### PR TITLE
Abort Restate process on panic

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+# Include full unwind tables when aborting on panic
+rustflags = ["-C", "force-unwind-tables"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["profile-rustflags"]
+
 [workspace]
 members = [
     "src/*"]
@@ -35,4 +37,10 @@ worker = { path = "src/worker" }
 opt-level = 3
 lto = "thin"
 codegen-units = 1
+# Let's be defensive and abort on every panic
+panic = "abort"
+
+[profile.dev]
+# Let's be defensive and abort on every panic
+panic = "abort"
 


### PR DESCRIPTION
Additionally, include full unwind tables so that stack traces contain helpful information in case of a panic.

This fixes #10.