### PR TITLE
Implement ingress gRPC layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -719,6 +719,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -762,6 +774,29 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "ingress_grpc"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "common",
+ "futures",
+ "http",
+ "http-body",
+ "hyper",
+ "ingress_common",
+ "opentelemetry",
+ "opentelemetry-http",
+ "pin-project",
+ "prost-reflect",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tonic-web",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -1262,6 +1297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1542,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d378290cd658b119ce87621931ef448017ef1a0044d7b681159d779e7e07b8f6"
+dependencies = [
+ "base64",
+ "once_cell",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.0",
+ "serde",
 ]
 
 [[package]]
@@ -1944,7 +2013,7 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "log",
- "ordered-float",
+ "ordered-float 1.1.1",
  "threadpool",
 ]
 
@@ -1965,6 +2034,16 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2020,16 +2099,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
+ "axum",
  "base64",
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
+ "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project",
+ "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9213351ad53b0dcf1c9cf7c372a47533446b1114928a9177bedc6c551e14b7cf"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project",
+ "tonic",
+ "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2043,9 +2149,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2114,6 +2224,16 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.25"
 futures-sink = "0.3.25"
 futures-util = "0.3.25"
 drain = "0.1.1"
+hyper = { version = "0.14.24", default-features = false }
 paste = "1.0"
 pin-project = "1.0"
 prost = "0.11"
@@ -40,6 +41,7 @@ tokio-util = "0.7.4"
 tonic = { version = "0.8.3", default-features = false }
 opentelemetry_api = { version = "0.18" }
 opentelemetry = { version = "0.18" }
+opentelemetry-http = { version = "0.7" }
 tracing-opentelemetry = { version = "0.18" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 
@@ -48,6 +50,7 @@ config = { path = "src/config" }
 common = { path = "src/common" }
 consensus = { path = "src/consensus" }
 ingress_common = { path = "src/ingress_common" }
+ingress_grpc = { path = "src/ingress_grpc" }
 invoker = { path = "src/invoker" }
 journal = { path = "src/journal" }
 meta = { path = "src/meta" }

--- a/src/ingress_common/src/lib.rs
+++ b/src/ingress_common/src/lib.rs
@@ -18,6 +18,17 @@ pub struct IngressRequestHeaders {
     method_name: String,
     tracing_context: Context,
 }
+
+impl IngressRequestHeaders {
+    pub fn new(service_name: String, method_name: String, tracing_context: Context) -> Self {
+        Self {
+            service_name,
+            method_name,
+            tracing_context,
+        }
+    }
+}
+
 pub type IngressRequest = (IngressRequestHeaders, Bytes);
 pub type IngressResponse = Bytes;
 pub type IngressError = Status;

--- a/src/ingress_grpc/Cargo.toml
+++ b/src/ingress_grpc/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ingress_grpc"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+# Restate
+common = { workspace = true }
+ingress_common = { workspace = true }
+
+# Encoding/Decoding
+bytes = { workspace = true }
+serde_json = "1.0"
+prost-reflect = { workspace = true, features = ["serde", "reflect-well-known-types"] }
+
+# Futures
+pin-project = { workspace = true }
+futures = { workspace = true }
+
+# Tower + Hyper + Tonic + Tokio
+tower = { version = "0.4", features = ["util"] }
+http = "0.2"
+http-body = "0.4"
+hyper = { workspace = true, features = ["http1", "http2", "server", "tcp", "stream", "runtime"] }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tonic-web = "0.5"
+
+# Tracing
+opentelemetry = { workspace = true }
+opentelemetry-http = { workspace = true }
+tracing = { workspace = true }

--- a/src/ingress_grpc/src/grpc/mod.rs
+++ b/src/ingress_grpc/src/grpc/mod.rs
@@ -1,0 +1,192 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, BufMut, Bytes};
+use futures::future::{ok, BoxFuture};
+use futures::ready;
+use http::{Request, Response};
+use ingress_common::{
+    IngressError, IngressRequest, IngressRequestHeaders, IngressResponse, IngressResult,
+};
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::sdk::propagation::TraceContextPropagator;
+use pin_project::pin_project;
+use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use tonic::server::{Grpc, UnaryService};
+use tonic::Status;
+use tonic_web::GrpcWebService;
+use tower::{BoxError, Layer, Service};
+use tracing::debug;
+
+/// This layer converts a grpc or grpc-web request/response in a Restate ingress request/response internally using tonic.
+#[derive(Clone)]
+pub(super) struct GrpcLayer {}
+
+impl<S> Layer<S> for GrpcLayer
+where
+    S: Service<IngressRequest, Response = IngressResponse, Error = IngressError>
+        + Send
+        + Clone
+        + 'static,
+    S::Future: Send,
+{
+    type Service = GrpcWebService<GrpcIngressService<S>>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        tonic_web::GrpcWebLayer::new().layer(GrpcIngressService { inner: Some(inner) })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GrpcIngressService<S> {
+    inner: Option<S>,
+}
+
+impl<S> Service<Request<hyper::Body>> for GrpcIngressService<S>
+where
+    S: Service<IngressRequest, Response = IngressResponse, Error = IngressError> + Send + 'static,
+    S::Future: Send,
+{
+    type Response = Response<tonic::body::BoxBody>;
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Response<tonic::body::BoxBody>, BoxError>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner
+            .as_mut()
+            .expect("Invoked poll_ready after consuming the service")
+            .poll_ready(cx)
+            .map_err(|e| BoxError::from(e.message()))
+    }
+
+    fn call(&mut self, request: Request<hyper::Body>) -> Self::Future {
+        let inner = self
+            .inner
+            .take()
+            .expect("This service cannot be used twice");
+
+        debug!(?request, "Receiving request");
+
+        // Parse service_name and method_name
+        let mut path_parts: Vec<&str> = request.uri().path().split('/').collect();
+        if path_parts.len() != 3 {
+            // Let's immediately reply with a status code not found
+            debug!(
+                "Cannot parse the request path '{}' into a valid GRPC request path. \
+                Allowed format is '/Service-Name/Method-Name'",
+                request.uri().path()
+            );
+            return Box::pin(ok(Status::not_found(format!(
+                "Request path {} invalid",
+                request.uri().path()
+            ))
+            .to_http()));
+        }
+        let method_name = path_parts.remove(2).to_string();
+        let service_name = path_parts.remove(1).to_string();
+
+        // Unfortunately we can't get rid of this Box, because unary is an async fn
+        Box::pin(async move {
+            Ok(Grpc::new(NoopCodec)
+                .unary(
+                    HandlerAdapter {
+                        service_name: Some(service_name),
+                        method_name: Some(method_name),
+                        inner,
+                    },
+                    request,
+                )
+                .await)
+        })
+    }
+}
+
+// --- Adapters for tonic
+
+struct HandlerAdapter<S> {
+    service_name: Option<String>,
+    method_name: Option<String>,
+    inner: S,
+}
+
+impl<S> UnaryService<Bytes> for HandlerAdapter<S>
+where
+    S: Service<IngressRequest, Response = IngressResponse, Error = IngressError> + 'static,
+    S::Future: Send,
+{
+    type Response = Bytes;
+    type Future = AdapterResponseFuture<S::Future>;
+
+    fn call(&mut self, request: tonic::Request<Bytes>) -> Self::Future {
+        // Extract tracing context and payload
+        let (metadata, _, payload) = request.into_parts();
+        let headers = metadata.into_headers();
+        let tracing_context =
+            TraceContextPropagator::new().extract(&opentelemetry_http::HeaderExtractor(&headers));
+
+        let request = (
+            IngressRequestHeaders::new(
+                self.service_name.take().unwrap(),
+                self.method_name.take().unwrap(),
+                tracing_context,
+            ),
+            payload,
+        );
+
+        AdapterResponseFuture(self.inner.call(request))
+    }
+}
+
+#[pin_project]
+struct AdapterResponseFuture<F>(#[pin] F);
+
+impl<F> Future for AdapterResponseFuture<F>
+where
+    F: Future<Output = IngressResult>,
+{
+    type Output = Result<tonic::Response<Bytes>, Status>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        Poll::Ready(ready!(this.0.poll(cx)).map(tonic::Response::new))
+    }
+}
+
+// --- Noop codec to skip encode/decode in tonic
+
+struct NoopCodec;
+
+impl Codec for NoopCodec {
+    type Encode = Bytes;
+    type Decode = Bytes;
+    type Encoder = Self;
+    type Decoder = Self;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        NoopCodec
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        NoopCodec
+    }
+}
+
+impl Encoder for NoopCodec {
+    type Item = Bytes;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        dst.put(item);
+        Ok(())
+    }
+}
+
+impl Decoder for NoopCodec {
+    type Item = Bytes;
+    type Error = Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        Ok(Some(src.copy_to_bytes(src.remaining())))
+    }
+}

--- a/src/ingress_grpc/src/lib.rs
+++ b/src/ingress_grpc/src/lib.rs
@@ -1,0 +1,1 @@
+mod grpc;

--- a/src/invoker/Cargo.toml
+++ b/src/invoker/Cargo.toml
@@ -15,7 +15,7 @@ bytes-utils = { workspace = true }
 common = { workspace = true }
 drain = { workspace = true }
 futures = { workspace = true }
-hyper = { version = "0.14.23", features = ["http1", "http2", "client", "tcp", "stream", "runtime"] }
+hyper = { workspace = true, features = ["http1", "http2", "client", "tcp", "stream", "runtime"] }
 hyper-tls = "0.5"
 h2 = { version = "0.3.15", features = ["unstable"] }
 paste = { workspace = true }
@@ -26,7 +26,7 @@ tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 opentelemetry = { workspace = true }
-opentelemetry-http = "0.7"
+opentelemetry-http = { workspace = true }
 
 journal = { workspace = true }
 service_protocol = { workspace = true }


### PR DESCRIPTION
Depends on #108. Fix #51

This PR introduces the gRPC layer of the ingress, converting a Hyper req/res to Ingress req/res using `tonic`.