### PR TITLE
[Invoker] Implement request/response mode

### DIFF
--- a/src/invoker/src/invocation_task.rs
+++ b/src/invoker/src/invocation_task.rs
@@ -26,7 +26,7 @@ use tracing::trace;
 use super::message::{
     Decoder, Encoder, EncodingError, MessageHeader, MessageType, ProtocolMessage,
 };
-use super::{EndpointMetadata, InvokeInputJournal, JournalMetadata, JournalReader, ProtocolType};
+use super::{EndpointMetadata, InvokeInputJournal, JournalMetadata, JournalReader};
 
 // Clippy false positive, might be caused by Bytes contained within HeaderValue.
 // https://github.com/rust-lang/rust/issues/40543#issuecomment-1212981256
@@ -175,10 +175,6 @@ where
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
         invoker_rx: Option<mpsc::UnboundedReceiver<Completion>>,
     ) -> Self {
-        if endpoint_metadata.protocol_type == ProtocolType::RequestResponse {
-            // TODO https://github.com/restatedev/restate/issues/83
-            unimplemented!("Request response is not implemented yet");
-        }
         Self {
             partition,
             service_invocation_id: sid,


### PR DESCRIPTION
This PR implements the missing bits for the request/response mode. Fix #83

* Don't create the completion channel in request/response mode
* Propagate the suspension state from the invocation task to the invoker, and check protocol violations. This is part of #97, I still miss the suspension message decoding and propagation.