### PR TITLE
Implement DefaultServiceInvocationFactory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,6 +2733,7 @@ dependencies = [
  "journal",
  "network",
  "pin-project",
+ "service_key_extractor",
  "service_protocol",
  "storage_api",
  "storage_rocksdb",

--- a/src/common/src/types.rs
+++ b/src/common/src/types.rs
@@ -98,26 +98,29 @@ pub struct ServiceInvocation {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("failed creating the service invocation: {source:?}")]
-pub struct ServiceInvocationFactoryError {
-    source: Option<GenericError>,
+pub enum ServiceInvocationFactoryError {
+    #[error("service method '{service_name}/{method_name}' is unknown")]
+    UnknownServiceMethod {
+        service_name: String,
+        method_name: String,
+    },
+    #[error("failed extracting the key from the request payload: {0}")]
+    KeyExtraction(GenericError),
 }
 
 impl ServiceInvocationFactoryError {
-    pub fn new() -> Self {
-        Self { source: None }
-    }
-
-    pub fn from(source: impl Into<GenericError>) -> Self {
-        Self {
-            source: Some(source.into()),
+    pub fn unknown_service_method(
+        service_name: impl Into<String>,
+        method_name: impl Into<String>,
+    ) -> Self {
+        ServiceInvocationFactoryError::UnknownServiceMethod {
+            service_name: service_name.into(),
+            method_name: method_name.into(),
         }
     }
-}
 
-impl Default for ServiceInvocationFactoryError {
-    fn default() -> Self {
-        Self::new()
+    pub fn key_extraction_error(source: impl Into<GenericError>) -> Self {
+        ServiceInvocationFactoryError::KeyExtraction(source.into())
     }
 }
 

--- a/src/service_key_extractor/src/lib.rs
+++ b/src/service_key_extractor/src/lib.rs
@@ -45,9 +45,9 @@ pub trait KeyExtractor {
 }
 
 /// This struct holds the key extractors for each known method of each known service.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct KeyExtractorsRegistry {
-    services: ArcSwap<HashMap<String, ServiceInstanceType>>,
+    services: Arc<ArcSwap<HashMap<String, ServiceInstanceType>>>,
 }
 
 impl KeyExtractorsRegistry {

--- a/src/worker/Cargo.toml
+++ b/src/worker/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+service_key_extractor = { workspace = true }
 service_protocol = { workspace = true }
 storage_api = { workspace = true}
 storage_rocksdb = { workspace = true}

--- a/src/worker/src/ingress_integration.rs
+++ b/src/worker/src/ingress_integration.rs
@@ -1,13 +1,16 @@
 use bytes::Bytes;
 use common::types::{
-    ServiceInvocation, ServiceInvocationFactory, ServiceInvocationFactoryError,
-    ServiceInvocationResponseSink, SpanRelation,
+    InvocationId, ServiceInvocation, ServiceInvocationFactory, ServiceInvocationFactoryError,
+    ServiceInvocationId, ServiceInvocationResponseSink, SpanRelation,
 };
 use ingress_grpc::{HyperServerIngress, InMemoryMethodDescriptorRegistry, ResponseDispatcherLoop};
+use service_key_extractor::{KeyExtractor, KeyExtractorsRegistry};
 use tokio::select;
 
-type ExternalClientIngress =
-    HyperServerIngress<InMemoryMethodDescriptorRegistry, DefaultServiceInvocationFactory>;
+type ExternalClientIngress = HyperServerIngress<
+    InMemoryMethodDescriptorRegistry,
+    DefaultServiceInvocationFactory<KeyExtractorsRegistry>,
+>;
 
 pub(super) struct ExternalClientIngressRunner {
     response_dispatcher_loop: ResponseDispatcherLoop,
@@ -38,18 +41,64 @@ impl ExternalClientIngressRunner {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub(super) struct DefaultServiceInvocationFactory;
+#[derive(Debug, Clone)]
+pub(super) struct DefaultServiceInvocationFactory<K> {
+    key_extractor: K,
+}
 
-impl ServiceInvocationFactory for DefaultServiceInvocationFactory {
+impl<K> DefaultServiceInvocationFactory<K>
+where
+    K: KeyExtractor + Clone,
+{
+    pub(super) fn new(key_extractor: K) -> Self {
+        Self { key_extractor }
+    }
+
+    fn extract_key(
+        &self,
+        service_name: impl AsRef<str>,
+        method_name: impl AsRef<str>,
+        request_payload: Bytes,
+    ) -> Result<Bytes, ServiceInvocationFactoryError> {
+        self.key_extractor
+            .extract(service_name.as_ref(), method_name.as_ref(), request_payload)
+            .map_err(|err| match err {
+                service_key_extractor::Error::NotFound => {
+                    ServiceInvocationFactoryError::unknown_service_method(
+                        service_name.as_ref(),
+                        method_name.as_ref(),
+                    )
+                }
+                err => ServiceInvocationFactoryError::key_extraction_error(err),
+            })
+    }
+}
+
+impl<K> ServiceInvocationFactory for DefaultServiceInvocationFactory<K>
+where
+    K: KeyExtractor + Clone,
+{
     fn create(
         &self,
-        _service_name: &str,
-        _method_name: &str,
-        _request_payload: Bytes,
-        _response_sink: ServiceInvocationResponseSink,
-        _span_relation: SpanRelation,
+        service_name: &str,
+        method_name: &str,
+        request_payload: Bytes,
+        response_sink: ServiceInvocationResponseSink,
+        span_relation: SpanRelation,
     ) -> Result<ServiceInvocation, ServiceInvocationFactoryError> {
-        todo!("https://github.com/restatedev/restate/issues/133")
+        let key = self.extract_key(service_name, method_name, request_payload.clone())?;
+
+        let invocation_id = InvocationId::now_v7();
+        let id = ServiceInvocationId::new(service_name, key, invocation_id);
+
+        let service_invocation = ServiceInvocation {
+            id,
+            method_name: method_name.into(),
+            response_sink,
+            argument: request_payload,
+            span_relation,
+        };
+
+        Ok(service_invocation)
     }
 }

--- a/src/worker/src/lib.rs
+++ b/src/worker/src/lib.rs
@@ -9,6 +9,7 @@ use invoker::{EndpointMetadata, Invoker, RetryPolicy, UnboundedInvokerInputSende
 use network::UnboundedNetworkHandle;
 use partition::shuffle;
 use partition::RocksDBJournalReader;
+use service_key_extractor::KeyExtractorsRegistry;
 use service_protocol::codec::ProtobufRawEntryCodec;
 use std::collections::HashMap;
 use storage_rocksdb::RocksDBStorage;
@@ -95,7 +96,8 @@ impl Worker {
         );
 
         let method_descriptor_registry = InMemoryMethodDescriptorRegistry::default();
-        let invocation_factory = DefaultServiceInvocationFactory::default();
+        let key_extractor_registry = KeyExtractorsRegistry::default();
+        let invocation_factory = DefaultServiceInvocationFactory::new(key_extractor_registry);
 
         let external_client_ingress = external_client_ingress.build(
             // TODO replace with proper network address once we have a distributed runtime


### PR DESCRIPTION
This commit adds the implementation of the default service invocation factory. It uses the KeyExtractorsRegistry for creating a ServiceInvocation for a given external client request.

This fixes #133.