### PR TITLE
Fix clippy false positive with mutable_key_type

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# https://github.com/rust-lang/rust-clippy/issues/9801
+ignore-interior-mutability = ["bytes::Bytes", "http::header::HeaderName", "http::header::HeaderValue"]

--- a/src/ingress_grpc/src/dispatcher.rs
+++ b/src/ingress_grpc/src/dispatcher.rs
@@ -158,7 +158,6 @@ impl DispatcherLoopHandler {
         }
     }
 
-    #[allow(clippy::mutable_key_type)]
     fn handle_ingress_command(
         &mut self,
         cmd: Command<ServiceInvocation, IngressResult>,

--- a/src/meta/src/rest_api/endpoints.rs
+++ b/src/meta/src/rest_api/endpoints.rs
@@ -29,8 +29,6 @@ pub async fn discover_endpoint(
     State(state): State<Arc<RestEndpointState>>,
     Json(payload): Json<RegisterEndpointRequest>,
 ) -> Result<Json<RegisterEndpointResponse>, MetaApiError> {
-    // False positive with Bytes field
-    #[allow(clippy::mutable_key_type)]
     let headers = payload
         .additional_headers
         .unwrap_or_default()

--- a/src/meta/src/service.rs
+++ b/src/meta/src/service.rs
@@ -40,8 +40,6 @@ enum MetaHandleResponse {
 }
 
 impl MetaHandle {
-    // False positive with Bytes field
-    #[allow(clippy::mutable_key_type)]
     pub async fn register(
         &self,
         uri: Uri,
@@ -129,8 +127,6 @@ where
         }
     }
 
-    // False positive with Bytes field
-    #[allow(clippy::mutable_key_type)]
     async fn discover_endpoint(
         &mut self,
         uri: Uri,

--- a/src/service_metadata/src/lib.rs
+++ b/src/service_metadata/src/lib.rs
@@ -22,8 +22,6 @@ pub struct DeliveryOptions {
 }
 
 impl DeliveryOptions {
-    // false positive because of inner Bytes field of HeaderName
-    #[allow(clippy::mutable_key_type)]
     pub fn new(
         additional_headers: HashMap<HeaderName, HeaderValue>,
         retry_policy: Option<RetryPolicy>,
@@ -67,8 +65,6 @@ impl EndpointMetadata {
         self.delivery_options.retry_policy.as_ref()
     }
 
-    // false positive because of inner Bytes field of HeaderName
-    #[allow(clippy::mutable_key_type)]
     pub fn additional_headers(&self) -> &HashMap<HeaderName, HeaderValue> {
         &self.delivery_options.additional_headers
     }

--- a/src/service_protocol/src/discovery.rs
+++ b/src/service_protocol/src/discovery.rs
@@ -171,8 +171,6 @@ impl ServiceDiscoveryError {
 }
 
 impl ServiceDiscovery {
-    // False positive with Bytes field
-    #[allow(clippy::mutable_key_type)]
     pub async fn discover(
         &self,
         uri: &Uri,


### PR DESCRIPTION
Unfortunately this config fix still doesn't apply to all the lints related to interior mutability: https://github.com/rust-lang/rust-clippy/issues/10537