### PR TITLE
Use error codes for service registration related failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,8 +1613,10 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64 0.21.0",
+ "codederror",
  "common",
  "drain",
+ "errors",
  "futures",
  "futures_util",
  "hyper",
@@ -2614,7 +2616,9 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "bytes-utils",
+ "codederror",
  "common",
+ "errors",
  "hyper",
  "hyper-rustls",
  "journal",

--- a/src/errors/src/error_codes/META0001.md
+++ b/src/errors/src/error_codes/META0001.md
@@ -1,0 +1,23 @@
+## META0001
+
+Bad service definition encountered while registering/updating a service.
+When defining a service, make sure:
+
+* The service has at least one method 
+* Use a fully qualified service name (`package_name.service_name`) that doesn't start with `dev.restate` or `grpc`
+* The service is annotated with the `dev.restate.ext.service_type` extension
+
+Example:
+
+```protobuf
+syntax = "proto3";
+import "dev/restate/ext.proto";
+
+package com.example;
+
+service HelloWorld {
+  option (dev.restate.ext.service_type) = KEYED;
+
+  rpc greet (GreetingRequest) returns (GreetingResponse);
+}
+```

--- a/src/errors/src/error_codes/META0002.md
+++ b/src/errors/src/error_codes/META0002.md
@@ -1,0 +1,22 @@
+## META0002
+
+Bad key definition encountered while registering/updating a service. 
+When a service is keyed, for each method the input message must have a field annotated with `dev.restate.ext.field`. 
+When defining the key field, make sure:
+
+* The field type is either a primitive or a custom message, and not a repeated field nor a map.
+* The field type is the same for every method input message of the same service.
+
+Example:
+
+```protobuf
+service HelloWorld {
+  option (dev.restate.ext.service_type) = KEYED;
+
+  rpc greet (GreetingRequest) returns (GreetingResponse);
+}
+
+message GreetingRequest {
+  Person person = 1 [(dev.restate.ext.field) = KEY];
+}
+```

--- a/src/errors/src/error_codes/META0003.md
+++ b/src/errors/src/error_codes/META0003.md
@@ -1,0 +1,8 @@
+## META0003
+
+Cannot reach the endpoint to execute service discovery. Make sure:
+
+* The provided `uri` is correct
+* The service endpoint is up and running
+* The Restate runtime can reach the service endpoint through the configured `uri`
+* If additional authentication is required, make sure it's configured through `additional_headers`

--- a/src/errors/src/lib.rs
+++ b/src/errors/src/lib.rs
@@ -21,4 +21,7 @@ pub mod fmt;
 #[macro_use]
 mod helper;
 
-declare_restate_error_codes!(RT0001);
+// RT are runtime related errors and can be used for both execution errors, or runtime configuration errors.
+// META are meta related errors.
+
+declare_restate_error_codes!(RT0001, META0001, META0002, META0003);

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -37,3 +37,5 @@ base64 = "0.21.0"
 # Others
 tracing = { workspace = true }
 thiserror = { workspace = true }
+codederror = { workspace = true }
+errors = { workspace = true, features = ["include_doc"] }

--- a/src/meta/src/rest_api/error.rs
+++ b/src/meta/src/rest_api/error.rs
@@ -1,6 +1,7 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use codederror::CodedError;
 use serde::Serialize;
 
 use crate::service::MetaError;
@@ -45,7 +46,10 @@ impl IntoResponse for MetaApiError {
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let body = Json(ErrorDescriptionResponse {
-            message: self.to_string(),
+            message: match &self {
+                MetaApiError::Meta(m) => m.decorate().to_string(),
+                e => e.to_string(),
+            },
         });
 
         (status_code, body).into_response()

--- a/src/service_protocol/Cargo.toml
+++ b/src/service_protocol/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 protocol = []
 message = ["protocol", "dep:bytes-utils"]
 codec = ["protocol", "dep:thiserror", "dep:journal", "dep:paste"]
-discovery = ["dep:thiserror", "dep:service_key_extractor", "dep:hyper", "dep:hyper-rustls", "dep:prost-reflect", "dep:common", "dep:service_metadata"]
+discovery = ["dep:thiserror", "dep:codederror", "dep:errors", "dep:service_key_extractor", "dep:hyper", "dep:hyper-rustls", "dep:prost-reflect", "dep:common", "dep:service_metadata"]
 
 [dependencies]
 bytes = { workspace = true }
@@ -31,6 +31,8 @@ hyper-rustls = { workspace = true, optional = true }
 common = { workspace = true, optional = true }
 prost-reflect = { workspace = true, optional = true }
 service_metadata = { workspace = true, optional = true }
+codederror = { workspace = true, optional = true }
+errors = { workspace = true, optional = true }
 
 [dev-dependencies]
 test_utils = { workspace = true }


### PR DESCRIPTION
Example output:

![Screenshot from 2023-04-13 14-12-52](https://user-images.githubusercontent.com/6706544/231754925-c58b7460-add8-4e79-9e26-23279a142005.png)
