### PR TITLE
Automatic generation of configuration JSON Schema 

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[alias]
+xtask = "run --package xtask --"
+
 [build]
 rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2132,7 @@ dependencies = [
  "restate_test_utils",
  "restate_tracing_instrumentation",
  "restate_worker",
+ "schemars",
  "serde",
  "serde_with",
  "serde_yaml",
@@ -2144,6 +2151,7 @@ dependencies = [
  "bytestring",
  "humantime",
  "opentelemetry_api",
+ "schemars",
  "serde",
  "serde_with",
  "thiserror",
@@ -2220,6 +2228,7 @@ dependencies = [
  "restate_futures_util",
  "restate_service_metadata",
  "restate_test_utils",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -2245,6 +2254,7 @@ dependencies = [
  "drain",
  "futures",
  "h2",
+ "humantime",
  "hyper",
  "hyper-rustls",
  "opentelemetry",
@@ -2258,7 +2268,9 @@ dependencies = [
  "restate_service_protocol",
  "restate_test_utils",
  "restate_timer_queue",
+ "schemars",
  "serde",
+ "serde_with",
  "thiserror",
  "tokio",
  "tonic",
@@ -2296,6 +2308,7 @@ dependencies = [
  "restate_service_key_extractor",
  "restate_service_metadata",
  "restate_service_protocol",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with",
@@ -2424,6 +2437,7 @@ dependencies = [
  "restate_storage_api",
  "restate_storage_proto",
  "rocksdb",
+ "schemars",
  "serde",
  "tempfile",
  "tokio",
@@ -2451,6 +2465,7 @@ dependencies = [
  "priority-queue",
  "restate_common",
  "restate_test_utils",
+ "schemars",
  "serde",
  "thiserror",
  "tokio",
@@ -2475,6 +2490,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-semantic-conventions",
+ "schemars",
  "serde",
  "thiserror",
  "tokio",
@@ -2508,6 +2524,7 @@ dependencies = [
  "restate_storage_rocksdb",
  "restate_test_utils",
  "restate_timer",
+ "schemars",
  "serde",
  "thiserror",
  "tokio",
@@ -2625,6 +2642,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "bytes",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2739,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.14",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3689,6 +3742,16 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "restate",
+ "schemars",
+ "serde_json",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "src/*",
-    "src/codederror/impl"
+    "src/codederror/impl",
+    "tools/xtask"
 ]
 exclude = ["src/service_protocol_wireshark_dissector"]
 
@@ -34,6 +35,7 @@ prost = "0.11"
 prost-types = "0.11"
 prost-reflect = "0.11.1"
 prost-build = "0.11"
+schemars = { version = "0.8", features = ["bytes"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.2"
 thiserror = "1.0"
@@ -52,6 +54,7 @@ uuid = { version = "1.3.0", features = ["v7", "serde"] }
 
 # Own crates
 codederror = { path = "src/codederror" }
+restate = { path = "src/restate" }
 restate_common = { path = "src/common" }
 restate_consensus = { path = "src/consensus" }
 restate_errors = { path = "src/errors" }

--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -108,3 +108,23 @@ Next you can install Knative via:
 ```shell
 KNATIVE_VERSION=1.8.0 curl -sL https://raw.githubusercontent.com/csantanapr/knative-minikube/master/install.sh | bash
 ```
+
+### Build the configuration documentation
+
+Requirements:
+
+* [`generate-schema-doc`](https://github.com/coveooss/json-schema-for-humans#installation)
+
+To generate the JSON schema:
+
+```shell
+$ cargo xtask generate-config-schema > restate_config_schema.json 
+```
+
+To generate the HTML documentation:
+
+```shell
+$ generate-schema-doc --minify restate_config_schema.json restate_config_doc.html 
+```
+
+The schema can be associated to `restate.yaml` in Jetbrains IDEs to enable autocompletion: https://www.jetbrains.com/help/idea/json.html#ws_json_using_schemas

--- a/justfile
+++ b/justfile
@@ -78,6 +78,9 @@ docker:
 notice-file:
     cargo license -d -a --avoid-build-deps --avoid-dev-deps {{ _features }} | (echo "Restate Runtime\nCopyright (c) 2023 Restate GmbH <stephan@restate.dev>\n" && cat) > NOTICE
 
+generate-config-schema:
+    cargo xtask generate-config-schema > restate_config_schema.json
+
 check-deny:
     cargo deny check
 

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -12,10 +12,12 @@ publish = false
 [features]
 default = []
 serde = ["dep:serde", "dep:serde_with"]
+options_schema = ["serde", "dep:schemars"]
 
 [dependencies]
 bytes = { workspace = true }
 bytestring = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 humantime = { workspace = true }

--- a/src/common/src/retry_policy.rs
+++ b/src/common/src/retry_policy.rs
@@ -38,14 +38,34 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "options_schema",
+    schemars(title = "Retry policy", description = "Definition of a retry policy")
+)]
 pub enum RetryPolicy {
+    /// # None
+    ///
+    /// No retries strategy.
     None,
+    /// # Fixed delay
+    ///
+    /// Retry with a fixed delay strategy.
     FixedDelay {
+        /// # Interval
+        ///
+        /// Interval between retries.
+        ///
+        /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format.
         #[cfg_attr(
             feature = "serde",
             serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
         )]
+        #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
         interval: humantime::Duration,
+        /// # Max attempts
+        ///
+        /// Number of maximum attempts before giving up.
         max_attempts: usize,
     },
 }

--- a/src/ingress_grpc/Cargo.toml
+++ b/src/ingress_grpc/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = []
+options_schema = ["dep:schemars"]
+
 [dependencies]
 # Restate
 restate_common = { workspace = true }
@@ -45,6 +49,7 @@ tracing-opentelemetry = { workspace = true }
 drain = { workspace = true }
 arc-swap = { workspace = true }
 thiserror = { workspace = true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 hyper = { workspace = true, features = ["client"] }

--- a/src/ingress_grpc/src/options.rs
+++ b/src/ingress_grpc/src/options.rs
@@ -7,22 +7,47 @@ use restate_service_metadata::MethodDescriptorRegistry;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
+/// # Ingress options
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "IngressOptions"))]
 pub struct Options {
+    /// # Bind address
+    ///
+    /// The address to bind for the ingress.
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_bind_address")
+    )]
     bind_address: SocketAddr,
+    /// # Concurrency limit
+    ///
+    /// Local concurrency limit to use to limit the amount of concurrent requests. If exceeded, the ingress will reply immediately with an appropriate status code.
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_concurrency_limit")
+    )]
     concurrency_limit: usize,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
-            bind_address: "0.0.0.0:9090".parse().unwrap(),
-            concurrency_limit: 1000,
+            bind_address: Options::default_bind_address(),
+            concurrency_limit: Options::default_concurrency_limit(),
         }
     }
 }
 
 impl Options {
+    fn default_bind_address() -> SocketAddr {
+        "0.0.0.0:9090".parse().unwrap()
+    }
+
+    fn default_concurrency_limit() -> usize {
+        1000
+    }
+
     pub fn build<DescriptorRegistry, InvocationFactory, ReflectionService>(
         self,
         ingress_id: IngressId,

--- a/src/invoker/Cargo.toml
+++ b/src/invoker/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = []
+options_schema = ["dep:schemars", "restate_common/options_schema"]
+
 [dependencies]
 bytes = { workspace = true }
 bytes-utils = { workspace = true }
@@ -15,10 +19,13 @@ drain = { workspace = true }
 futures = { workspace = true }
 hyper = { workspace = true, features = ["http1", "http2", "client", "tcp", "stream", "runtime"] }
 hyper-rustls = { workspace = true }
+humantime = { workspace = true }
 h2 = { version = "0.3.15", features = ["unstable"] }
 paste = { workspace = true }
 prost = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_with = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -7,7 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+options_schema = ["dep:schemars"]
 
 [dependencies]
 # Async
@@ -25,6 +27,7 @@ tower = { workspace = true, features = ["load-shed", "limit"] }
 serde = { workspace = true }
 serde_with = { workspace = true }
 serde_json = "1.0"
+schemars = { workspace = true, optional = true }
 
 # Service discovery and metadata
 restate_common = { workspace = true, features = ["serde"] }

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -13,29 +13,62 @@ use storage::FileMetaStorage;
 use tokio::join;
 use tracing::{debug, error};
 
+/// # Meta options
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "MetaOptions"))]
 pub struct Options {
-    /// Address of the REST endpoint
+    /// # Rest endpoint address
+    ///
+    /// Address to bind for the Meta Operational REST APIs.
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_rest_address")
+    )]
     rest_address: SocketAddr,
 
-    /// Concurrency limit for the Meta Operational REST APIs
+    /// # Rest concurrency limit
+    ///
+    /// Concurrency limit for the Meta Operational REST APIs.
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_rest_concurrency_limit")
+    )]
     rest_concurrency_limit: usize,
 
-    /// Root path for Meta storage
+    /// # Storage path
+    ///
+    /// Root path for Meta storage.
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_storage_path")
+    )]
     storage_path: String,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
-            rest_address: "0.0.0.0:8081".parse().unwrap(),
-            rest_concurrency_limit: 1000,
-            storage_path: "target/meta/".to_string(),
+            rest_address: Options::default_rest_address(),
+            rest_concurrency_limit: Options::default_rest_concurrency_limit(),
+            storage_path: Options::default_storage_path(),
         }
     }
 }
 
 impl Options {
+    fn default_rest_address() -> SocketAddr {
+        "0.0.0.0:8081".parse().unwrap()
+    }
+
+    fn default_rest_concurrency_limit() -> usize {
+        1000
+    }
+
+    fn default_storage_path() -> String {
+        "target/meta/".to_string()
+    }
+
     pub fn build(self) -> Meta {
         let key_extractors_registry = KeyExtractorsRegistry::default();
         let method_descriptors_registry = InMemoryMethodDescriptorRegistry::default();

--- a/src/restate/Cargo.toml
+++ b/src/restate/Cargo.toml
@@ -7,13 +7,18 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 description.workspace = true
+default-run = "restate"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+console = ["tokio/full", "tokio/tracing", "restate_tracing_instrumentation/console-subscriber"]
+options_schema = ["dep:schemars", "restate_tracing_instrumentation/options_schema", "restate_meta/options_schema", "restate_worker/options_schema"]
 
 [dependencies]
 clap = { version = "4.1", features = ["derive", "env"] }
 drain = { workspace = true }
 figment = { version = "0.10.8", features = ["env", "yaml"] }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_with = "2.2"
 serde_yaml = "0.9"
@@ -35,6 +40,3 @@ tempfile = "3.4.0"
 restate_test_utils = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { workspace = true }
-
-[features]
-console = ["tokio/full", "tokio/tracing", "restate_tracing_instrumentation/console-subscriber"]

--- a/src/restate/src/config.rs
+++ b/src/restate/src/config.rs
@@ -5,21 +5,46 @@ use serde_with::serde_as;
 use std::path::Path;
 use std::time::Duration;
 
-/// This is the entrypoint struct for configuring the Restate single-binary deployment.
+/// # Restate configuration file
+///
+/// Configuration for the Restate single binary deployment.
+///
+/// You can specify the configuration file to use through the `--config-file <PATH>` argument or
+/// with `RESTATE_CONFIG=<PATH>` environment variable.
+///
+/// Each configuration entry can be overridden using environment variables,
+/// prefixing them with `RESTATE_` and separating nested structs with `__` (double underscore).
+/// For example, to configure `meta.rest_address`, the corresponding environment variable is `RESTATE_META__REST_ADDRESS`.
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
 pub struct Configuration {
+    /// # Shutdown grace timeout
+    ///
+    /// This timeout is used when shutting down the various Restate components to drain all the internal queues.
+    ///
+    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format.
     #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(
+            with = "String",
+            default = "Configuration::default_shutdown_grace_period"
+        )
+    )]
     pub shutdown_grace_period: humantime::Duration,
+    #[cfg_attr(feature = "options_schema", schemars(default))]
     pub tracing: restate_tracing_instrumentation::Options,
+    #[cfg_attr(feature = "options_schema", schemars(default))]
     pub meta: restate_meta::Options,
+    #[cfg_attr(feature = "options_schema", schemars(default))]
     pub worker: restate_worker::Options,
 }
 
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            shutdown_grace_period: Duration::from_secs(60).into(),
+            shutdown_grace_period: Configuration::default_shutdown_grace_period(),
             tracing: Default::default(),
             meta: Default::default(),
             worker: Default::default(),
@@ -28,7 +53,13 @@ impl Default for Configuration {
 }
 
 impl Configuration {
-    pub fn load<P: AsRef<Path>>(config_file: P) -> Configuration {
+    fn default_shutdown_grace_period() -> humantime::Duration {
+        Duration::from_secs(60).into()
+    }
+
+    /// Load [`Configuration`] from yaml with overrides from environment variables.
+    #[allow(dead_code)]
+    pub fn load<P: AsRef<Path>>(config_file: P) -> Self {
         Figment::from(Serialized::defaults(Configuration::default()))
             .merge(Yaml::file(config_file))
             .merge(Env::prefixed("RESTATE_").split("__"))

--- a/src/restate/src/lib.rs
+++ b/src/restate/src/lib.rs
@@ -1,0 +1,3 @@
+mod config;
+
+pub use config::Configuration;

--- a/src/restate/src/main.rs
+++ b/src/restate/src/main.rs
@@ -1,6 +1,6 @@
 use app::Application;
 use clap::Parser;
-use config::Configuration;
+use restate::Configuration;
 use std::path::PathBuf;
 use tracing::{info, warn};
 

--- a/src/storage_rocksdb/Cargo.toml
+++ b/src/storage_rocksdb/Cargo.toml
@@ -7,7 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+options_schema = ["dep:schemars"]
 
 [dependencies]
 restate_common = {workspace = true}
@@ -17,6 +19,7 @@ uuid = { workspace = true }
 futures = {workspace = true}
 futures-util = {workspace = true}
 prost = {workspace = true}
+schemars = { workspace = true, optional = true }
 restate_storage_proto = { workspace = true, features = ["conversion"] }
 restate_storage_api = { workspace = true }
 serde = {workspace = true}

--- a/src/storage_rocksdb/src/lib.rs
+++ b/src/storage_rocksdb/src/lib.rs
@@ -69,35 +69,72 @@ pub enum TableKind {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
 pub enum CompressionType {
+    /// No compression
     None,
+    /// Compression using lz4
     Lz4,
+    /// Compression using zlib
     Zstd,
 }
 
+/// # Storage options
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "StorageOptions"))]
 pub struct Options {
-    /// Storage path
+    /// # Storage path
+    ///
+    /// The root path to use for the Rocksdb storage
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_path")
+    )]
     pub path: String,
 
-    /// threads for rocksdb background tasks
+    /// # Threads
+    ///
+    /// The number of threads to reserve to Rocksdb background tasks
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_threads")
+    )]
     pub threads: usize,
 
-    /// compression type
+    /// # Compression type
+    ///
+    /// The type of compression to use
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "Options::default_compression")
+    )]
     pub compression: CompressionType,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
-            path: "target/db/".to_string(),
-            threads: 4,
-            compression: CompressionType::Zstd,
+            path: Options::default_path(),
+            threads: Options::default_threads(),
+            compression: Options::default_compression(),
         }
     }
 }
 
 impl Options {
+    fn default_path() -> String {
+        "target/db/".to_string()
+    }
+
+    fn default_threads() -> usize {
+        4
+    }
+
+    fn default_compression() -> CompressionType {
+        CompressionType::Zstd
+    }
+
     pub fn build(self) -> RocksDBStorage {
         RocksDBStorage::new(self)
     }

--- a/src/timer/Cargo.toml
+++ b/src/timer/Cargo.toml
@@ -7,7 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+options_schema = ["dep:schemars"]
 
 [dependencies]
 ahash = "0.8.3"
@@ -19,6 +21,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/src/timer/src/options.rs
+++ b/src/timer/src/options.rs
@@ -2,8 +2,14 @@ use crate::{Output, TimerService};
 use std::fmt::Debug;
 use tokio::sync::mpsc;
 
+/// # Timer options
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "TimerOptions"))]
 pub struct Options {
+    /// # Num timers in memory limit
+    ///
+    /// The number of timers in memory limit is used to bound the amount of timers loaded in memory. If this limit is set, when exceeding it, the timers farther in the future will be spilled to disk.
     num_timers_in_memory_limit: Option<usize>,
 }
 

--- a/src/tracing_instrumentation/Cargo.toml
+++ b/src/tracing_instrumentation/Cargo.toml
@@ -9,7 +9,12 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+options_schema = ["dep:schemars"]
+
 [dependencies]
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 console-subscriber = { version = "0.1.8", optional = true }
 opentelemetry = { workspace = true, features = ["rt-tokio-current-thread", "rt-tokio"] }

--- a/src/tracing_instrumentation/src/lib.rs
+++ b/src/tracing_instrumentation/src/lib.rs
@@ -15,12 +15,20 @@ pub struct Error {
 
 pub type TracingResult<T> = Result<T, Error>;
 
+/// # Tracing options
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "TracingOptions"))]
 pub struct Options {
-    /// Specify to expose OTEL spans to Jaeger
+    /// # Jaeger endpoint
+    ///
+    /// Specify the Jaeger endpoint to use to send traces. Traces will be exported using the [Jaeger Agent UDP protocol](https://www.jaegertracing.io/docs/1.6/deployment/#agent) through [opentelemetry_jaeger](https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/config/agent/struct.AgentPipeline.html).
     jaeger_endpoint: Option<String>,
 
-    /// Disable ANSI colors for formatted output
+    /// # Disable ANSI log
+    ///
+    /// Disable ANSI terminal codes for logs. This is useful when the log collector doesn't support processing ANSI terminal codes.
+    #[cfg_attr(feature = "options_schema", schemars(default))]
     disable_ansi_log: bool,
 }
 

--- a/src/worker/Cargo.toml
+++ b/src/worker/Cargo.toml
@@ -7,7 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+options_schema = ["dep:schemars", "restate_timer/options_schema", "restate_storage_rocksdb/options_schema", "restate_ingress_grpc/options_schema", "restate_invoker/options_schema"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -29,6 +31,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 opentelemetry_api = { workspace = true }
 tracing = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 restate_service_key_extractor = { workspace = true }
 restate_service_metadata = { workspace = true }

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "xtask"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+restate = { workspace = true, features = ["options_schema"] }
+serde_json = "1.0"
+schemars = { workspace = true }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -1,0 +1,34 @@
+use anyhow::bail;
+use schemars::schema_for;
+use std::env;
+
+fn generate_config_schema() -> anyhow::Result<()> {
+    let schema = schema_for!(restate::Configuration);
+    println!("{}", serde_json::to_string_pretty(&schema)?);
+    Ok(())
+}
+
+fn print_help() {
+    println!(
+        "
+Usage: Run with `cargo xtask <task>`, eg. `cargo xtask generate-config-schema`.
+Tasks:
+    generate-config-schema: Generate config schema for restate configuration.
+"
+    );
+}
+
+fn main() -> anyhow::Result<()> {
+    let task = env::args().nth(1);
+    match task {
+        None => print_help(),
+        Some(t) => match t.as_str() {
+            "generate-config-schema" => generate_config_schema()?,
+            invalid => {
+                print_help();
+                bail!("Invalid task name: {}", invalid)
+            }
+        },
+    };
+    Ok(())
+}


### PR DESCRIPTION
Fix #269.

This PR introduces automatic generation of the JSON schema describing how to configure Restate. The reason to choose JSON Schema is because we can generate documentation out of it and it can be used by IDEs to provide syntax highlighting.

Example using it with Intellij:

![Screenshot from 2023-04-13 18-43-29](https://user-images.githubusercontent.com/6706544/231835809-959e6368-8498-4817-a7b6-4b7fc51c5aa7.png)

Example generated doc:

![Screenshot 2023-04-13 at 19-19-07 Restate configuration file](https://user-images.githubusercontent.com/6706544/231835969-b9204690-25de-4caf-b5bd-b28e67c1a7f8.png)

Note: I haven't really chosen a tool to generate the HTML out of the JSON Schema, I just tried https://github.com/coveooss/json-schema-for-humans, and it seems to work fine, but happy to try something better. An incomplete list of those tools can be found here: https://json-schema.org/implementations.html#documentation-generators