### PR TITLE
Jaeger JSON exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,6 +1674,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-contrib"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6171a92e47498eb95845189db332ab85721a51ba924349243192b28141d3fd8"
+dependencies = [
+ "async-trait",
+ "futures",
+ "opentelemetry",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +2640,7 @@ dependencies = [
  "console-subscriber",
  "nu-ansi-term",
  "opentelemetry",
+ "opentelemetry-contrib",
  "opentelemetry-jaeger",
  "opentelemetry-semantic-conventions",
  "schemars",

--- a/src/tracing_instrumentation/Cargo.toml
+++ b/src/tracing_instrumentation/Cargo.toml
@@ -21,6 +21,7 @@ console-subscriber = { version = "0.1.8", optional = true }
 opentelemetry = { workspace = true, features = ["rt-tokio-current-thread", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio-current-thread", "rt-tokio"] }
 opentelemetry-semantic-conventions = "0.10"
+opentelemetry-contrib = { version = "0.10", features = ["jaeger_json_exporter", "rt-tokio"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }


### PR DESCRIPTION
Part of #300 

This adds a new config to enable exporting spans as json using the jeager format, in order to collect traces without having an up and running jaeger.