### PR TITLE
Reorganize observability config options

### DIFF
--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -42,12 +42,8 @@ CMAKE_OSX_ARCHITECTURES = "arm64"
 
 ## Tracing
 
-Restate supports exposing tracing information via opentelemetry.
-
-### Using Jaeger
-
-In order publish tracing information to [Jaeger](https://www.jaegertracing.io/), you have to enable the feature `jaeger`.
-Moreover, you have to start Jaeger.
+It is useful to enable tracing when testing the runtime. 
+To set up the runtime to publish traces to Jaeger, refer to the observability documentation in the Restate official documentation.
 
 #### Starting Jaeger on Linux
 
@@ -78,16 +74,6 @@ Moreover, you have to set the maximum udp package size to 65536 via
 
 ```shell
 sudo sysctl net.inet.udp.maxdgram=65536
-```
-
-### Using Zipkin
-
-In order to publish tracing information to [Zipkin](https://zipkin.io/), you hae to enable the feature `zipkin`.
-
-Moreover, you have to start Zipkin via
-
-```shell
-docker run -d -p 9411:9411 --name zipkin openzipkin/zipkin
 ```
 
 ## Setting up Knative

--- a/src/restate/src/config.rs
+++ b/src/restate/src/config.rs
@@ -34,7 +34,7 @@ pub struct Configuration {
     )]
     pub shutdown_grace_period: humantime::Duration,
     #[cfg_attr(feature = "options_schema", schemars(default))]
-    pub tracing: restate_tracing_instrumentation::Options,
+    pub observability: restate_tracing_instrumentation::Options,
     #[cfg_attr(feature = "options_schema", schemars(default))]
     pub meta: restate_meta::Options,
     #[cfg_attr(feature = "options_schema", schemars(default))]
@@ -45,7 +45,7 @@ impl Default for Configuration {
     fn default() -> Self {
         Self {
             shutdown_grace_period: Configuration::default_shutdown_grace_period(),
-            tracing: Default::default(),
+            observability: Default::default(),
             meta: Default::default(),
             worker: Default::default(),
         }
@@ -70,7 +70,11 @@ impl Configuration {
                 .merge(Yaml::file(config_file))
                 .merge(Env::prefixed("RESTATE_").split("__"))
                 // Override tracing.log with RUST_LOG, if present
-                .merge(Env::raw().only(&["RUST_LOG"]).map(|_| "tracing.log".into()))
+                .merge(
+                    Env::raw()
+                        .only(&["RUST_LOG"])
+                        .map(|_| "observability.log.filter".into()),
+                )
                 .extract()?,
         )
     }

--- a/src/restate/src/main.rs
+++ b/src/restate/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
         // Apply tracing config globally
         // We need to apply this first to log correctly
         config
-            .tracing
+            .observability
             .init("Restate binary", std::process::id())
             .expect("failed to instrument logging and tracing!");
 

--- a/src/tracing_instrumentation/src/lib.rs
+++ b/src/tracing_instrumentation/src/lib.rs
@@ -6,7 +6,7 @@ use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonExporter;
 use pretty::Pretty;
 use std::fmt::Display;
 use tracing::Level;
-use tracing_subscriber::filter::ParseError;
+use tracing_subscriber::filter::{Filtered, ParseError};
 use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::layer::SubscriberExt;
@@ -25,156 +25,44 @@ pub enum Error {
     LogDirectiveParseError(#[from] ParseError),
 }
 
-pub type TracingResult<T> = Result<T, Error>;
-
-/// # Log format
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
-pub enum LogFormat {
-    /// # Pretty
-    ///
-    /// Enables verbose logging. Not recommended in production.
-    #[default]
-    Pretty,
-    /// # Compact
-    ///
-    /// Enables compact logging.
-    Compact,
-    /// # Json
-    ///
-    /// Enables json logging. You can use a json log collector to ingest these logs and further process them.
-    Json,
+fn default_filter() -> String {
+    "info".to_string()
 }
 
-/// # Tracing options
+/// # Jaeger Options
+///
+/// Configuration for the [Jaeger Agent exporter](https://www.jaegertracing.io/docs/1.6/deployment/#agent).
+///
+/// To configure the sampling, please refer to the [opentelemetry autoconfigure docs](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#sampler).
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "options_schema", schemars(rename = "TracingOptions"))]
-pub struct Options {
-    /// # Jaeger endpoint
+struct JaegerOptions {
+    /// # Endpoint
     ///
-    /// Specify the Jaeger endpoint to use to send traces. Traces will be exported using the [Jaeger Agent UDP protocol](https://www.jaegertracing.io/docs/1.6/deployment/#agent) through [opentelemetry_jaeger](https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/config/agent/struct.AgentPipeline.html).
-    jaeger_endpoint: Option<String>,
-
-    /// # Jaeger File Exporter Path
+    /// Specify the Jaeger endpoint to use to send traces.
+    /// Traces will be exported using the [Jaeger Agent UDP protocol](https://www.jaegertracing.io/docs/1.6/deployment/#agent)
+    /// through [opentelemetry_jaeger](https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/config/agent/struct.AgentPipeline.html).
+    endpoint: String,
+    /// # Filter
     ///
-    /// Specify the path where to export spans as JSON in the Jaeger format. This option allows you to export traces as JSON files and load them later in Jaeger for inspection.
-    jaeger_file_exporter_path: Option<String>,
-
-    /// # Log
-    ///
-    /// Log configuration. Can be overridden by the `RUST_LOG` environment variable.
+    /// Exporter filter configuration.
     /// Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
-    #[cfg_attr(feature = "options_schema", schemars(default = "Options::default_log"))]
-    log: String,
-
-    /// # Log format
-    ///
-    /// Format to use when logging.
-    #[cfg_attr(feature = "options_schema", schemars(default))]
-    log_format: LogFormat,
-
-    /// # Disable ANSI log
-    ///
-    /// Disable ANSI terminal codes for logs. This is useful when the log collector doesn't support processing ANSI terminal codes.
-    #[cfg_attr(feature = "options_schema", schemars(default))]
-    disable_ansi_log: bool,
+    #[serde(default = "default_filter")]
+    filter: String,
 }
 
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            jaeger_endpoint: None,
-            jaeger_file_exporter_path: None,
-            log: Options::default_log(),
-            log_format: Default::default(),
-            disable_ansi_log: false,
-        }
-    }
-}
-
-impl Options {
-    fn default_log() -> String {
-        "warn,restate=info".to_string()
-    }
-
-    /// Instruments the process with logging and tracing.
-    ///
-    /// The opentelemetry tracer provider is automatically shut down when this struct is being dropped.
-    ///
-    /// # Panics
-    /// This method will panic if there is already a global subscriber configured. Moreover, it will
-    /// panic if it is executed outside of a Tokio runtime.
-    pub fn init(&self, service_name: impl Display, instance_id: impl Display) -> TracingResult<()> {
-        let restate_service_name = format!("Restate service: {service_name}");
-
-        let fmt_layer = match self.log_format {
-            LogFormat::Pretty => tracing_subscriber::fmt::layer()
-                .event_format::<Pretty<SystemTime>>(Pretty::default())
-                .fmt_fields(PrettyFields::default())
-                .with_writer(
-                    // Write WARN and ERR to stderr, everything else to stdout
-                    std::io::stderr
-                        .with_max_level(Level::WARN)
-                        .or_else(std::io::stdout),
-                )
-                .with_ansi(!self.disable_ansi_log)
-                .boxed(),
-            LogFormat::Compact => tracing_subscriber::fmt::layer()
-                .compact()
-                .with_ansi(!self.disable_ansi_log)
-                .boxed(),
-            LogFormat::Json => tracing_subscriber::fmt::layer()
-                .json()
-                .with_ansi(!self.disable_ansi_log)
-                .boxed(),
-        };
-
-        let layers = tracing_subscriber::registry()
-            .with(EnvFilter::try_new(&self.log)?)
-            .with(fmt_layer);
-        #[cfg(feature = "console-subscriber")]
-        let layers = layers.with(console_subscriber::spawn());
-
-        let layers = layers.with(
-            self.jaeger_endpoint
-                .as_ref()
-                .map(|jaeger_endpoint| {
-                    self.try_init_jaeger_tracing(
-                        jaeger_endpoint,
-                        restate_service_name.clone(),
-                        instance_id,
-                    )
-                })
-                .transpose()?,
-        );
-
-        let layers = layers.with(self.jaeger_file_exporter_path.as_ref().map(
-            |jaeger_file_exporter_path| {
-                tracing_opentelemetry::layer().with_tracer(
-                    JaegerJsonExporter::new(
-                        jaeger_file_exporter_path.into(),
-                        "span".to_string(),
-                        restate_service_name,
-                        opentelemetry::runtime::Tokio,
-                    )
-                    .install_batch(),
-                )
-            },
-        ));
-
-        layers.init();
-
-        Ok(())
-    }
-
-    fn try_init_jaeger_tracing<S>(
+impl JaegerOptions {
+    pub(crate) fn build_layer<S>(
         &self,
-        jaeger_endpoint: impl AsRef<str>,
         service_name: String,
         instance_id: impl Display,
-    ) -> TracingResult<
-        tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry::sdk::trace::Tracer>,
+    ) -> Result<
+        Filtered<
+            tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry::sdk::trace::Tracer>,
+            EnvFilter,
+            S,
+        >,
+        Error,
     >
     where
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
@@ -195,7 +83,7 @@ impl Options {
             .with_trace_config(opentelemetry::sdk::trace::config().with_resource(resource));
 
         jaeger_pipeline = jaeger_pipeline
-            .with_endpoint(jaeger_endpoint.as_ref())
+            .with_endpoint(&self.endpoint)
             .with_auto_split_batch(true);
 
         let jaeger_tracer = jaeger_pipeline.install_batch(opentelemetry::runtime::Tokio)?;
@@ -204,7 +92,213 @@ impl Options {
             .with_location(false)
             .with_threads(false)
             .with_tracked_inactivity(false)
-            .with_tracer(jaeger_tracer))
+            .with_tracer(jaeger_tracer)
+            .with_filter(EnvFilter::try_new(&self.filter)?))
+    }
+}
+
+/// # Jaeger File Options
+///
+/// Configuration for the Jaeger file exporter. This exporter writes traces as JSON in the Jaeger format.
+///
+/// It can be used to export traces in a structured format without configuring a Jaeger agent.
+/// To inspect the traces, open the Jaeger UI and use the Upload JSON feature to load and inspect them.
+///
+/// All spans will be sampled.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+struct JaegerFileOptions {
+    /// # Path
+    ///
+    /// Specify the path where all the traces will be exported. Each trace file will start with the `trace` prefix.
+    path: String,
+    /// # Filter
+    ///
+    /// Exporter filter configuration.
+    /// Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
+    #[serde(default = "default_filter")]
+    filter: String,
+}
+
+impl JaegerFileOptions {
+    fn build_layer<S>(
+        &self,
+        restate_service_name: String,
+    ) -> Result<
+        Filtered<
+            tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry::sdk::trace::Tracer>,
+            EnvFilter,
+            S,
+        >,
+        Error,
+    >
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        Ok(tracing_opentelemetry::layer()
+            .with_tracer(
+                JaegerJsonExporter::new(
+                    self.path.clone().into(),
+                    "trace".to_string(),
+                    restate_service_name,
+                    opentelemetry::runtime::Tokio,
+                )
+                .install_batch(),
+            )
+            .with_filter(EnvFilter::try_new(&self.filter)?))
+    }
+}
+
+/// # Log format
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+pub enum LogFormat {
+    /// # Pretty
+    ///
+    /// Enables verbose logging. Not recommended in production.
+    #[default]
+    Pretty,
+    /// # Compact
+    ///
+    /// Enables compact logging.
+    Compact,
+    /// # Json
+    ///
+    /// Enables json logging. You can use a json log collector to ingest these logs and further process them.
+    Json,
+}
+
+/// # Log options
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+struct LogOptions {
+    /// # Filter
+    ///
+    /// Log filter configuration. Can be overridden by the `RUST_LOG` environment variable.
+    /// Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
+    #[cfg_attr(
+        feature = "options_schema",
+        schemars(default = "LogOptions::default_filter")
+    )]
+    filter: String,
+
+    /// # Log format
+    ///
+    /// Format to use when logging.
+    #[cfg_attr(feature = "options_schema", schemars(default))]
+    format: LogFormat,
+
+    /// # Disable ANSI log
+    ///
+    /// Disable ANSI terminal codes for logs. This is useful when the log collector doesn't support processing ANSI terminal codes.
+    #[cfg_attr(feature = "options_schema", schemars(default))]
+    disable_ansi_codes: bool,
+}
+
+impl Default for LogOptions {
+    fn default() -> Self {
+        Self {
+            filter: LogOptions::default_filter(),
+            format: Default::default(),
+            disable_ansi_codes: false,
+        }
+    }
+}
+
+impl LogOptions {
+    fn default_filter() -> String {
+        "warn,restate=info".to_string()
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn build_layer<S>(
+        &self,
+    ) -> Result<Filtered<Box<dyn Layer<S> + Send + Sync>, EnvFilter, S>, Error>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        let filter = EnvFilter::try_new(&self.filter)?;
+        Ok(match self.format {
+            LogFormat::Pretty => tracing_subscriber::fmt::layer()
+                .event_format::<Pretty<SystemTime>>(Pretty::default())
+                .fmt_fields(PrettyFields::default())
+                .with_writer(
+                    // Write WARN and ERR to stderr, everything else to stdout
+                    std::io::stderr
+                        .with_max_level(Level::WARN)
+                        .or_else(std::io::stdout),
+                )
+                .with_ansi(!self.disable_ansi_codes)
+                .boxed()
+                .with_filter(filter),
+            LogFormat::Compact => tracing_subscriber::fmt::layer()
+                .compact()
+                .with_ansi(!self.disable_ansi_codes)
+                .boxed()
+                .with_filter(filter),
+            LogFormat::Json => tracing_subscriber::fmt::layer()
+                .json()
+                .with_ansi(!self.disable_ansi_codes)
+                .boxed()
+                .with_filter(filter),
+        })
+    }
+}
+
+/// # Observability options
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "ObservabilityOptions"))]
+pub struct Options {
+    /// # Jaeger options
+    jaeger: Option<JaegerOptions>,
+
+    /// # Jaeger file exporter options
+    jaeger_file: Option<JaegerFileOptions>,
+
+    /// # Logging options
+    log: LogOptions,
+}
+
+impl Options {
+    /// Instruments the process with logging and tracing.
+    ///
+    /// The opentelemetry tracer provider is automatically shut down when this struct is being dropped.
+    ///
+    /// # Panics
+    /// This method will panic if there is already a global subscriber configured. Moreover, it will
+    /// panic if it is executed outside of a Tokio runtime.
+    pub fn init(&self, service_name: impl Display, instance_id: impl Display) -> Result<(), Error> {
+        let restate_service_name = format!("Restate service: {service_name}");
+
+        let layers = tracing_subscriber::registry();
+
+        // Logging layer
+        let layers = layers.with(self.log.build_layer()?);
+
+        // Console subscriber layer
+        #[cfg(feature = "console-subscriber")]
+        let layers = layers.with(console_subscriber::spawn());
+
+        // Jaeger layer
+        let layers = layers.with(
+            self.jaeger
+                .as_ref()
+                .map(|jaeger| jaeger.build_layer(restate_service_name.clone(), instance_id))
+                .transpose()?,
+        );
+
+        // Jaeger file layer
+        let layers = layers.with(
+            self.jaeger_file
+                .as_ref()
+                .map(|jaeger_file| jaeger_file.build_layer(restate_service_name))
+                .transpose()?,
+        );
+
+        layers.init();
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
While working on the observability documentation I've found out that the organization of those config options make little sense. 

This PR reorganizes the observability config options, expanding their docs as well.

Part of #319 and #312