### PR TITLE
Run debug assertions in release build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@ xtask = "run --package xtask --"
 [build]
 rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
+    "-C" , "debug-assertions", # Enable debug assertions in release builds to have more safeguards in place
     "--cfg", "uuid_unstable", # Enable unstable Uuid
     "--cfg", "tokio_unstable", # Enable unstable tokio
 ]


### PR DESCRIPTION
Since we are still in the early development phase, we should also run the debug assertions in our release builds to gain a bit of extra safety.

This fixes #373.