### PR TITLE
Clean GA runner by removing unnecessary software

### DIFF
--- a/.github/actions/clean-runner/action.yml
+++ b/.github/actions/clean-runner/action.yml
@@ -1,0 +1,14 @@
+name: "Clean runner"
+description: "Cleans the GA runner by removing unnecessary software"
+runs:
+  using: "composite"
+  steps:
+    - name: Remove unnecessary software
+      run: |
+        # .Net
+        sudo rm -rf /usr/share/dotnet
+        # Android
+        sudo rm -rf /usr/local/lib/android
+        # Haskell
+        sudo rm -rf /usr/local/.ghcup
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: ./.github/actions/clean-runner
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
This commit removes unnecessary software from the GA runner which gives us additional disk space.

This fixes #458.