### PR TITLE
[storage] Make sure to delete status of freed services

### DIFF
--- a/src/storage_rocksdb/src/status_table/mod.rs
+++ b/src/storage_rocksdb/src/status_table/mod.rs
@@ -50,6 +50,10 @@ impl StatusTable for RocksDBTransaction {
             .partition_key(service_id.partition_key())
             .service_name(service_id.service_name.clone())
             .service_key(service_id.key.clone());
+        if status == InvocationStatus::Free {
+            self.delete_key(&key);
+            return ready();
+        }
 
         let value = ProtoValue(storage::v1::InvocationStatus::from(status));
 


### PR DESCRIPTION
This PR makes sure that services with a service invocation status - free, are deleted from storage (instead of persisted with status free)