### PR TITLE
Use consistent seeds in verification test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: just test
 
       - name: Run verification test
-        run: just verification-test
+        run: just verification-test $${{ github.run_id }}
         env:
           TMPDIR: ${{ runner.temp }}
           RUST_LOG: "info"

--- a/justfile
+++ b/justfile
@@ -109,8 +109,8 @@ run *flags: (_target-installed target)
 test: (_target-installed target)
     cargo test {{ _target-option }} --workspace --all-features
 
-verification-test: (_target-installed target)
-    cargo test {{ _target-option }} --package restate verification --all-features -- --ignored --exact --nocapture
+verification-test seed='': (_target-installed target)
+    SEED={{seed}} cargo test {{ _target-option }} --package restate verification --all-features -- --ignored --exact --nocapture
 
 # Runs lints and tests
 verify: lint test

--- a/src/restate/tests/verification_test.rs
+++ b/src/restate/tests/verification_test.rs
@@ -26,7 +26,14 @@ impl Drop for SafeChild {
 #[test(tokio::test)]
 #[ignore = "Ignored because it requires the verification service running on localhost:8000. See .github/workflows/ci.yaml and https://github.com/restatedev/restate-verification for more details."]
 async fn verification() -> Result<(), Box<dyn std::error::Error>> {
-    let seed = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+    let seed = {
+        let seed = std::env::var("SEED").unwrap_or("".to_string());
+        if seed.is_empty() {
+            Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
+        } else {
+            seed
+        }
+    };
     let seed = seed.as_str();
     let width = 10;
     let depth = 4;


### PR DESCRIPTION
Use the github run id to ensure that for a given run, we use the same seed - even across reruns

Also make it so that you can `just verification-test <seed>`