### PR TITLE
Run e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           RUST_LOG: "info"
 
       - uses: actions/upload-artifact@v3
-        if: ${{ runner.os == 'Linux' && runner.arch	== 'X64' }}
+        if: ${{ runner.os == 'Linux' && runner.arch == 'X64' }}
         with:
           name: restate
           path: target/debug/restate


### PR DESCRIPTION
- Upload binary with 1 day retention; so it can be used in e2e jobs
- Cross repo workflow call to e2e repo

As part of https://github.com/restatedev/e2e/issues/110

Fixes https://github.com/restatedev/restate/issues/454