### PR TITLE
Change PartitionKey to be u32

### DIFF
--- a/src/common/src/partitioner.rs
+++ b/src/common/src/partitioner.rs
@@ -8,6 +8,7 @@ impl HashPartitioner {
     pub fn compute_partition_key(value: &impl Hash) -> PartitionKey {
         let mut hasher = xxhash_rust::xxh3::Xxh3::default();
         value.hash(&mut hasher);
-        hasher.finish()
+        // Safe to only take the lower 32 bits: See https://github.com/Cyan4973/xxHash/issues/453#issuecomment-696838445
+        hasher.finish() as u32
     }
 }

--- a/src/common/src/types.rs
+++ b/src/common/src/types.rs
@@ -31,7 +31,7 @@ pub type EntryIndex = u32;
 
 /// Identifying to which partition a key belongs. This is unlike the [`PartitionId`]
 /// which identifies a consecutive range of partition keys.
-pub type PartitionKey = u64;
+pub type PartitionKey = u32;
 
 /// Discriminator for invocation instances
 pub type InvocationId = Uuid;

--- a/src/storage_grpc/proto/dev/restate/storage/v1/scan.proto
+++ b/src/storage_grpc/proto/dev/restate/storage/v1/scan.proto
@@ -34,14 +34,14 @@ message PartitionStateMachine {
 }
 
 message Inbox {
-  optional uint64 partition_key = 1;
+  optional uint32 partition_key = 1;
   optional string service_name = 2;
   optional bytes service_key = 3;
   optional uint64 sequence_number = 4;
 }
 
 message Journal {
-  optional uint64 partition_key = 1;
+  optional uint32 partition_key = 1;
   optional string service_name = 2;
   optional bytes service_key = 3;
   optional uint32 journal_index = 4;
@@ -53,14 +53,14 @@ message Outbox {
 }
 
 message State {
-  optional uint64 partition_key = 1;
+  optional uint32 partition_key = 1;
   optional string service_name = 2;
   optional bytes service_key = 3;
   optional bytes state_key = 4;
 }
 
 message Status {
-  optional uint64 partition_key = 1;
+  optional uint32 partition_key = 1;
   optional string service_name = 2;
   optional bytes service_key = 3;
 }

--- a/src/storage_rocksdb/tests/status_table_test/mod.rs
+++ b/src/storage_rocksdb/tests/status_table_test/mod.rs
@@ -57,7 +57,7 @@ async fn populate_data<T: StatusTable>(txn: &mut T) {
     .await;
 
     txn.put_invocation_status(
-        &ServiceId::with_partition_key(u64::MAX, "svc-u64", "key-0"),
+        &ServiceId::with_partition_key(u32::MAX, "svc-u64", "key-0"),
         invoked_status(uuid_str("218756fa-3f7f-7854-a76b-42c59a3d7f2d")),
     )
     .await;
@@ -99,9 +99,9 @@ async fn verify_all_svc_with_status_invoked<T: StatusTable>(txn: &mut T) {
 }
 
 async fn verify_last_partition_all_svc_with_status_invoked<T: StatusTable>(txn: &mut T) {
-    let stream = txn.invoked_invocations(4000..=u64::MAX);
+    let stream = txn.invoked_invocations(4000..=u32::MAX);
     let expected = vec![ServiceInvocationId::with_service_id(
-        ServiceId::with_partition_key(u64::MAX, "svc-u64", "key-0"),
+        ServiceId::with_partition_key(u32::MAX, "svc-u64", "key-0"),
         uuid_str("218756fa-3f7f-7854-a76b-42c59a3d7f2d"),
     )];
 

--- a/src/worker/src/lib.rs
+++ b/src/worker/src/lib.rs
@@ -78,7 +78,7 @@ pub struct Options {
         feature = "options_schema",
         schemars(default = "Options::default_partitions")
     )]
-    partitions: usize,
+    partitions: u32,
 }
 
 impl Default for Options {
@@ -108,7 +108,7 @@ impl Options {
         64
     }
 
-    fn default_partitions() -> usize {
+    fn default_partitions() -> u32 {
         1024
     }
 
@@ -206,7 +206,7 @@ impl Worker {
             ..
         } = opts;
 
-        let num_partition_processors = opts.partitions as u64;
+        let num_partition_processors = opts.partitions;
         let (raft_in_tx, raft_in_rx) = mpsc::channel(channel_size);
 
         let external_client_ingress_id = IngressId(

--- a/src/worker/src/network_integration.rs
+++ b/src/worker/src/network_integration.rs
@@ -25,11 +25,11 @@ pub(super) type Network = restate_network::Network<
 
 #[derive(Debug, Clone)]
 pub(super) struct FixedPartitionTable {
-    number_partitions: u64,
+    number_partitions: u32,
 }
 
 impl FixedPartitionTable {
-    pub(super) fn new(number_partitions: u64) -> Self {
+    pub(super) fn new(number_partitions: u32) -> Self {
         Self { number_partitions }
     }
 }
@@ -39,7 +39,7 @@ impl PartitionTable for FixedPartitionTable {
 
     fn partition_key_to_target_peer(&self, partition_key: PartitionKey) -> Self::Future {
         let target_partition = partition_key % self.number_partitions;
-        ok(target_partition)
+        ok(u64::from(target_partition))
     }
 }
 

--- a/src/worker/src/range_partitioner.rs
+++ b/src/worker/src/range_partitioner.rs
@@ -2,17 +2,17 @@ use restate_common::types::{PartitionKey, PeerId};
 use std::ops::RangeInclusive;
 
 pub(crate) struct RangePartitioner {
-    num_partitions: PeerId,
+    num_partitions: u32,
     partition_length: PartitionKey,
     partition_remainder: PartitionKey,
 
     current_remainder: PartitionKey,
-    next_partition: PeerId,
+    next_partition: u32,
     next_start_partition_key: PartitionKey,
 }
 
 impl RangePartitioner {
-    pub(crate) fn new(num_partitions: PeerId) -> Self {
+    pub(crate) fn new(num_partitions: u32) -> Self {
         Self {
             num_partitions,
             partition_length: PartitionKey::MAX / num_partitions,
@@ -44,7 +44,7 @@ impl Iterator for RangePartitioner {
                 self.next_start_partition_key..=(end_partition_key - 1)
             };
 
-            let result = Some((self.next_partition, partition_key_range));
+            let result = Some((u64::from(self.next_partition), partition_key_range));
 
             self.next_partition += 1;
             self.next_start_partition_key = end_partition_key;


### PR DESCRIPTION
This commit changes the PartitionKey to be a u32. This reduces the required bytes for the partition key while still keeping enough values to scale arbitrarily.

This fixes #279.