### PR TITLE
Correct logging of invoking invocations when popping the inbox

### DIFF
--- a/src/worker/src/partition/state_machine/mod.rs
+++ b/src/worker/src/partition/state_machine/mod.rs
@@ -734,8 +734,8 @@ where
                 service_invocation_id.service_id,
                 inbox_sequence_number,
                 journal_length,
+                service_invocation,
             );
-            effects.invoke_service(service_invocation);
         } else {
             effects.drop_journal_and_free_service(service_invocation_id.service_id, journal_length);
         }


### PR DESCRIPTION
With this commit, we invoke the new invocation as part of the Effect:: DropJournalAndPopInbox instead via a separate Effect::InvokeService. That way, we can log the correct sid of the invoked service.

This fixes #530.