### PR TITLE
Fix span relation assert

### DIFF
--- a/src/types/src/invocation.rs
+++ b/src/types/src/invocation.rs
@@ -274,8 +274,7 @@ impl SpanRelation {
 
     fn is_sampled(&self) -> bool {
         match self {
-            // we only expect this in tests where we always sample
-            SpanRelation::None => true,
+            SpanRelation::None => false,
             SpanRelation::Parent(span_context) => span_context.is_sampled(),
             SpanRelation::Linked(span_context) => span_context.is_sampled(),
         }

--- a/src/worker/src/partition/state_machine/mod.rs
+++ b/src/worker/src/partition/state_machine/mod.rs
@@ -570,10 +570,6 @@ where
                     }) = Codec::deserialize(&journal_entry)?
                 );
 
-                let_assert!(
-                    Some(SpanRelationCause::Linked(_, pointer_span_id)) = span_context.span_cause()
-                );
-
                 let method = request.method_name.to_string();
 
                 let service_invocation = Self::create_service_invocation(
@@ -584,11 +580,16 @@ where
                     span_context.clone(),
                 );
 
+                let pointer_span_id = match span_context.span_cause() {
+                    Some(SpanRelationCause::Linked(_, span_id)) => Some(*span_id),
+                    _ => None,
+                };
+
                 effects.background_invoke(
                     service_invocation.id.clone(),
                     method,
                     invocation_metadata.journal_metadata.span_context.clone(),
-                    *pointer_span_id,
+                    pointer_span_id,
                 );
 
                 // 0 is equal to not set, meaning execute now


### PR DESCRIPTION
This assert is too bold; the relation *can* be None, eg if the span wasn't sampled. Just make the pointer span id optional - we can still try and emit a span without it, so let's not panic.