### PR TITLE
Support gRPC health check service

### DIFF
--- a/src/pb/build.rs
+++ b/src/pb/build.rs
@@ -16,10 +16,15 @@ fn main() -> std::io::Result<()> {
         )
         .compile_protos(
             &[
+                "proto/grpc/health/v1/health.proto",
                 "proto/grpc/reflection/v1alpha/reflection.proto",
                 "proto/dev/restate/services.proto",
             ],
-            &["proto/grpc/reflection/v1alpha", "proto/dev/restate"],
+            &[
+                "proto/grpc/health/v1",
+                "proto/grpc/reflection/v1alpha",
+                "proto/dev/restate",
+            ],
         )?;
 
     prost_build::Config::new()

--- a/src/pb/proto/grpc/health/v1/health.proto
+++ b/src/pb/proto/grpc/health/v1/health.proto
@@ -1,0 +1,63 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  // If the requested service is unknown, the call will fail with status
+  // NOT_FOUND.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status.  It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/src/pb/src/lib.rs
+++ b/src/pb/src/lib.rs
@@ -5,6 +5,12 @@ use prost_reflect::DescriptorPool;
 use std::convert::AsRef;
 
 pub mod grpc {
+    pub mod health {
+        #![allow(warnings)]
+        #![allow(clippy::all)]
+        #![allow(unknown_lints)]
+        include!(concat!(env!("OUT_DIR"), "/grpc.health.v1.rs"));
+    }
     pub mod reflection {
         #![allow(warnings)]
         #![allow(clippy::all)]
@@ -30,6 +36,7 @@ pub static DESCRIPTOR_POOL: Lazy<DescriptorPool> = Lazy::new(|| {
 
 pub const INGRESS_SERVICE_NAME: &str = "dev.restate.Ingress";
 pub const REFLECTION_SERVICE_NAME: &str = "grpc.reflection.v1alpha.ServerReflection";
+pub const HEALTH_SERVICE_NAME: &str = "grpc.health.v1.Health";
 
 #[cfg(feature = "mocks")]
 pub mod mocks;

--- a/src/schema_impl/src/lib.rs
+++ b/src/schema_impl/src/lib.rs
@@ -319,6 +319,14 @@ pub(crate) mod schemas_impl {
                         .expect("The built-in descriptor pool should contain the ingress service"),
                 ),
             );
+            inner.services.insert(
+                restate_pb::HEALTH_SERVICE_NAME.to_string(),
+                ServiceSchemas::new_ingress_only(
+                    &restate_pb::DESCRIPTOR_POOL
+                        .get_service_by_name(restate_pb::HEALTH_SERVICE_NAME)
+                        .expect("The built-in descriptor pool should contain the ingress service"),
+                ),
+            );
 
             inner
         }

--- a/src/schema_impl/src/proto_symbol.rs
+++ b/src/schema_impl/src/proto_symbol.rs
@@ -235,6 +235,12 @@ impl Default for ProtoSymbols {
                 .get_service_by_name(restate_pb::INGRESS_SERVICE_NAME)
                 .expect("Service ingress should exist"),
         );
+        symbols.add_service(
+            &"self_ingress".to_string(),
+            &restate_pb::DESCRIPTOR_POOL
+                .get_service_by_name(restate_pb::HEALTH_SERVICE_NAME)
+                .expect("Service ingress should exist"),
+        );
 
         symbols
     }


### PR DESCRIPTION
Fix #544.

The service can also be used with connect:

```
!10154 ➜ http localhost:9090/grpc.health.v1.Health/Check
HTTP/1.1 200 OK
access-control-allow-credentials: true
content-length: 20
content-type: application/json
date: Mon, 24 Jul 2023 10:37:35 GMT
vary: origin
vary: access-control-request-method
vary: access-control-request-headers

{
    "status": "SERVING"
}


!10156 ➜ http localhost:9090/grpc.health.v1.Health/Check service=counter.Counter
HTTP/1.1 200 OK
access-control-allow-credentials: true
content-length: 20
content-type: application/json
date: Mon, 24 Jul 2023 10:37:45 GMT
vary: origin
vary: access-control-request-method
vary: access-control-request-headers

{
    "status": "SERVING"
}


!10157 ➜ http localhost:9090/grpc.health.v1.Health/Check service=counter.bwah  
HTTP/1.1 404 Not Found
access-control-allow-credentials: true
content-length: 63
content-type: application/json
date: Mon, 24 Jul 2023 10:37:50 GMT
vary: origin
vary: access-control-request-method
vary: access-control-request-headers

{
    "code": "not_found",
    "message": "Service counter.bwah not found"
}
``` 