### PR TITLE
Remove "unstable" feature from h2 dependency in restate_invoker_impl package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,9 +1822,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",

--- a/src/invoker_impl/Cargo.toml
+++ b/src/invoker_impl/Cargo.toml
@@ -18,7 +18,7 @@ codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
 futures = { workspace = true }
-h2 = { version = "0.3.15", features = ["unstable"] }
+h2 = { version = "0.3.20" }
 humantime = { workspace = true }
 hyper = { workspace = true, features = ["http1", "http2", "client", "tcp", "stream", "runtime"] }
 hyper-rustls = { workspace = true }


### PR DESCRIPTION
Remove "unstable" feature from h2 dependency in restate_invoker_impl package