### PR TITLE
Include sid in log event for a failing invocation

### DIFF
--- a/src/invoker_impl/src/lib.rs
+++ b/src/invoker_impl/src/lib.rs
@@ -781,7 +781,10 @@ where
         error: E,
         mut ism: InvocationStateMachine,
     ) {
-        warn_it!(error, "Error when executing the invocation");
+        warn_it!(
+            error,
+            restate.invocation.sid = %service_invocation_id,
+            "Error when executing the invocation");
 
         match ism.handle_task_error() {
             Some(next_retry_timer_duration) if error.is_transient() => {


### PR DESCRIPTION
For log levels lower or equal than DEBUG, this will duplicate the sid information since it is logged as part of the event as well as part of the associated span.

This fixes #670.