### PR TITLE
Log storage_query errors on debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,6 +3951,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/src/storage_query/Cargo.toml
+++ b/src/storage_query/Cargo.toml
@@ -35,3 +35,4 @@ paste = { workspace = true}
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }


### PR DESCRIPTION
Logging the storage_query errors on warn allows better insights into why a connection might be rejected by a client. Currently, a user of Restate runs into the problem that the connection gets rejected but it is unclear why.

This fixes #740.