### PR TITLE
Send welcome mail when adding collaborators

### DIFF
--- a/.github/welcome_mail.md
+++ b/.github/welcome_mail.md
@@ -5,7 +5,6 @@ The main repositories you need in the beginning are:
 * [restate-dist](https://github.com/restatedev/restate-dist): your starting point to set up registry access (docker, npm)
 * [node-template-generator](https://github.com/restatedev/node-template-generator): your "hello world" and "getting started" for Restate
 * [sdk-typescript](https://github.com/restatedev/sdk-typescript): main SDK
-* [documentation](https://github.com/restatedev/documentation): this invite also unlocks the auth for https://docs.restate.dev/
 
 If you want, [join Discord](https://discord.gg/skW3AZ6uGd) to connect with other users.
 
@@ -13,7 +12,7 @@ Here is a quick set of steps to get started:
 
 **(1) Get access (one-time Access Token setup while Restate is still closed access)**
 
-* We share the code by **adding you as a collaborator to the Restate Github repositories**. You'll receive a few invite emails, for the repositories.
+* We share the code by **adding you as a collaborator to the Restate GitHub repositories**. You'll receive a few invite emails, for the repositories.
 * You should then be able to access https://docs.restate.dev/, which is behind a GitHub auth wall.
 * Core repos of interest are [restate-dist](https://github.com/restatedev/restate-dist) (runtime docker image), [sdk-typescript](https://github.com/restatedev/sdk-typescript), [node-template-generator](https://github.com/restatedev/node-template-generator). The remainder are examples that are just FYI.
 * The same credentials that give you access to the repos also let you pull the **npm packages** and **docker images**.
@@ -40,6 +39,6 @@ We are pushing updates regularly, so stay tuned. We usually post this on Discord
 
 Looking forward to hearing your feedback. Would be fun if we end up using each other's tech!
 
-If you should encounter any problems then respond to this mail, write to [info@restate.dev](mailto:info@restate.dev) or contact us on [Discord](https://discord.gg/skW3AZ6uGd).
+If you should encounter any problems then write me or contact us on [Discord](https://discord.gg/skW3AZ6uGd).
 
-Best regards, The Restate team
+Best regards, Stephan

--- a/.github/workflows/collaborators.yml
+++ b/.github/workflows/collaborators.yml
@@ -77,7 +77,6 @@ jobs:
         if: ${{ inputs.email != '' && inputs.operation == 'add' }}
         uses: dawidd6/action-send-mail@v3
         with:
-          #connection_url: ${{secrets.MAIL_CONNECTION}}
           server_address: smtp.gmail.com
           server_port: 465
           username: ${{secrets.MAIL_USERNAME}}
@@ -85,8 +84,8 @@ jobs:
           secure: true
           subject: Welcome to Restate
           to: ${{ inputs.email }}
-          from: Restate
+          from: Stephan and the Restate team
           html_body: file://.github/welcome_mail.md
-          reply_to: info@restate.dev
+          reply_to: stephan@restate.dev
           ignore_cert: true
           convert_markdown: true


### PR DESCRIPTION
The current setup uses Till's email account to send the welcome mails. The app password is stored under MAIL_PASSWORD. The email text is stored as markdown under .github/welcome_mail.md. Replies to this email
will go to info@restate.dev.

This fixes #742.

If you want to try this feature out, then run the collaborator workflow for the branch `issue#742`.