### PR TITLE
Remove public repositories from collaborator workflow

### DIFF
--- a/.github/workflows/collaborators.yml
+++ b/.github/workflows/collaborators.yml
@@ -29,11 +29,8 @@ jobs:
           # make sure that restatedev-ci is an admin for all collaborator repositories.
           COLLABORATOR_REPOS: |
             restatedev/restate-dist
-            restatedev/documentation
             restatedev/sdk-typescript
             restatedev/node-template-generator
-            restatedev/tour-of-restate-typescript
-            restatedev/examples
           GITHUB_TOKEN: ${{ secrets.COLLABORATOR_ADMIN_ACCESS }}
         run: |
           collaborator_repos="${{ env.COLLABORATOR_REPOS }}"


### PR DESCRIPTION
Since we make

* documentation
* examples
* tour-of-restate-typescript

public, we no longer need to add collaborators to them.