### PR TITLE
Relax the type checking for bytes/string keys

### DIFF
--- a/src/errors/src/error_codes/META0002.md
+++ b/src/errors/src/error_codes/META0002.md
@@ -5,7 +5,8 @@ When a service is keyed, for each method the input message must have a field ann
 When defining the key field, make sure:
 
 * The field type is either a primitive or a custom message, and not a repeated field nor a map.
-* The field type is the same for every method input message of the same service.
+* If the field type is not `string` nor `bytes`, then the same key field type must be used across all the methods input message.
+* If the field type is `string` or `bytes`, then the other methods input message must use either `string` or `bytes` as key field type.
 
 Example:
 


### PR DESCRIPTION
Fix #751

With this change one can define a service like the following:

```protobuf
service PersonService {
 option (dev.restate.ext.service_type) = KEYED;

 rpc Get(GetPersonRequest) returns (Person);
 // [..] Other methods 
 rpc HandleEvent(KeyedEvent) returns (Empty);
}

message GetPersonRequest {
 string id = 1 [(dev.restate.ext.field) = KEY];
}

message KeyedEvent {
  // Payload
  bytes key = 1 [(dev.restate.ext.field) = KEY];
  bytes payload = 2;

  // Metadata
  string source = 3;
  map<string, string> attributes = 15;
}
```

This change makes sense because on the wire bytes and strings are encoded in the same way, the difference is only during deserialization where with string types an additional check is performed to see if the bytes are UTF-8 conformant.