### PR TITLE
NBIS/DBIS tracing passthrough

### DIFF
--- a/src/types/src/invocation.rs
+++ b/src/types/src/invocation.rs
@@ -152,6 +152,8 @@ impl ServiceInvocationSpanContext {
 
     /// Create a [`SpanContext`] for this invocation, a [`Span`] which will be created
     /// when the invocation completes.
+    ///
+    /// This function is **deterministic**.
     pub fn start(
         full_invocation_id: &FullInvocationId,
         related_span: SpanRelation,
@@ -160,10 +162,7 @@ impl ServiceInvocationSpanContext {
             // don't waste any time or storage space on unsampled traces
             // sampling based on parent is default otel behaviour; we do the same for the
             // non-parent background invoke relationship
-            return ServiceInvocationSpanContext {
-                span_context: SpanContext::empty_context(),
-                cause: None,
-            };
+            return ServiceInvocationSpanContext::empty();
         }
 
         let (cause, new_span_context) = match &related_span {
@@ -296,6 +295,12 @@ impl ServiceInvocationSpanContext {
 
     pub fn trace_id(&self) -> TraceId {
         self.span_context.trace_id()
+    }
+}
+
+impl Default for ServiceInvocationSpanContext {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 

--- a/src/worker/src/partition/effects/interpreter.rs
+++ b/src/worker/src/partition/effects/interpreter.rs
@@ -21,7 +21,9 @@ use restate_storage_api::timer_table::Timer;
 use crate::partition::services::non_deterministic;
 use bytestring::ByteString;
 use restate_types::identifiers::{EntryIndex, FullInvocationId, ServiceId};
-use restate_types::invocation::{ServiceInvocation, ServiceInvocationResponseSink};
+use restate_types::invocation::{
+    ServiceInvocation, ServiceInvocationResponseSink, ServiceInvocationSpanContext,
+};
 use restate_types::journal::enriched::{EnrichedEntryHeader, EnrichedRawEntry};
 use restate_types::journal::raw::{
     EntryHeader, PlainRawEntry, RawEntryCodec, RawEntryCodecError, RawEntryHeader,
@@ -48,8 +50,9 @@ pub(crate) enum ActuatorMessage {
     },
     InvokeBuiltInService {
         full_invocation_id: FullInvocationId,
-        response_sink: Option<ServiceInvocationResponseSink>,
         method: ByteString,
+        span_context: ServiceInvocationSpanContext,
+        response_sink: Option<ServiceInvocationResponseSink>,
         argument: Bytes,
     },
     NewOutboxMessage {
@@ -672,6 +675,7 @@ impl<Codec: RawEntryCodec> Interpreter<Codec> {
         ) {
             collector.collect(ActuatorMessage::InvokeBuiltInService {
                 full_invocation_id: service_invocation.fid,
+                span_context: service_invocation.span_context,
                 response_sink: service_invocation.response_sink,
                 method: service_invocation.method_name,
                 argument: service_invocation.argument.clone(),

--- a/src/worker/src/partition/leadership/actuator.rs
+++ b/src/worker/src/partition/leadership/actuator.rs
@@ -138,12 +138,19 @@ where
                 }
                 ActuatorMessage::InvokeBuiltInService {
                     full_invocation_id,
+                    span_context,
                     response_sink,
                     method,
                     argument,
                 } => {
                     non_deterministic_service_invoker
-                        .invoke(full_invocation_id, method.deref(), argument, response_sink)
+                        .invoke(
+                            full_invocation_id,
+                            method.deref(),
+                            span_context,
+                            response_sink,
+                            argument,
+                        )
                         .await;
                 }
             }

--- a/src/worker/src/partition/leadership/mod.rs
+++ b/src/worker/src/partition/leadership/mod.rs
@@ -288,7 +288,13 @@ where
             let response_sink = metadata.response_sink;
             let argument = input_entry.entry;
             built_in_service_invoker
-                .invoke(full_invocation_id, &method, argument, response_sink)
+                .invoke(
+                    full_invocation_id,
+                    &method,
+                    metadata.journal_metadata.span_context,
+                    response_sink,
+                    argument,
+                )
                 .await;
         }
 

--- a/src/worker/src/partition/services/deterministic/mod.rs
+++ b/src/worker/src/partition/services/deterministic/mod.rs
@@ -16,7 +16,7 @@ use restate_pb::restate::AwakeablesInvoker;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_types::errors::{InvocationError, UserErrorCode};
 use restate_types::identifiers::FullInvocationId;
-use restate_types::invocation::ServiceInvocationResponseSink;
+use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
 use std::ops::Deref;
 
 mod awakeables;
@@ -30,6 +30,8 @@ pub(crate) enum Effect {
 /// Deterministic built-in services are executed by both leaders and followers, hence they must generate the same output.
 pub(crate) struct ServiceInvoker<'a> {
     fid: &'a FullInvocationId,
+    span_context: &'a ServiceInvocationSpanContext,
+
     effects: Vec<Effect>,
 }
 
@@ -42,11 +44,13 @@ impl<'a> ServiceInvoker<'a> {
     pub(crate) async fn invoke(
         fid: &'a FullInvocationId,
         method: &'a str,
+        span_context: &'a ServiceInvocationSpanContext,
+        response_sink: Option<&'a ServiceInvocationResponseSink>,
         argument: Bytes,
-        response_sink: Option<&ServiceInvocationResponseSink>,
     ) -> Vec<Effect> {
         let mut this: ServiceInvoker<'a> = Self {
             fid,
+            span_context,
             effects: vec![],
         };
 

--- a/src/worker/src/partition/services/deterministic/proxy.rs
+++ b/src/worker/src/partition/services/deterministic/proxy.rs
@@ -12,7 +12,7 @@ use super::*;
 
 use restate_pb::restate::internal::*;
 use restate_types::identifiers::InvocationUuid;
-use restate_types::invocation::{ServiceInvocation, SpanRelation};
+use restate_types::invocation::ServiceInvocation;
 
 #[async_trait::async_trait]
 impl ProxyBuiltInService for &mut ServiceInvoker<'_> {
@@ -29,7 +29,7 @@ impl ProxyBuiltInService for &mut ServiceInvoker<'_> {
             req.target_method,
             req.input,
             None,
-            SpanRelation::None,
+            self.span_context.as_parent(),
         )));
 
         Ok(())

--- a/src/worker/src/partition/services/non_deterministic/ingress.rs
+++ b/src/worker/src/partition/services/non_deterministic/ingress.rs
@@ -16,7 +16,7 @@ use restate_pb::restate::*;
 use restate_schema_api::json::{JsonMapperResolver, JsonToProtobufMapper, ProtobufToJsonMapper};
 use restate_schema_api::key::KeyExtractor;
 use restate_types::identifiers::InvocationUuid;
-use restate_types::invocation::{ServiceInvocation, SpanRelation};
+use restate_types::invocation::ServiceInvocation;
 use serde::Serialize;
 use tracing::instrument;
 
@@ -143,7 +143,7 @@ impl<'a, State: StateReader + Send + Sync> IngressBuiltInService for InvocationC
             request.method,
             argument,
             None,
-            SpanRelation::None,
+            self.span_context.as_linked(),
         )));
 
         Ok(())

--- a/src/worker/src/partition/state_machine/mod.rs
+++ b/src/worker/src/partition/state_machine/mod.rs
@@ -896,8 +896,9 @@ where
         for effect in deterministic::ServiceInvoker::invoke(
             &invocation.fid,
             invocation.method_name.deref(),
-            invocation.argument.clone(),
+            &invocation.span_context,
             invocation.response_sink.as_ref(),
+            invocation.argument.clone(),
         )
         .await
         {


### PR DESCRIPTION
This PR implements:

* NBIS/DBIS tracing passthrough, that is `SpanRelation` is passed through the NBIS/DBIS infrastructure without adding additional info about built-in services (e.g. the span of built-in service). Fix #782
* Make sure we record the time for kafka ingress to propose the message


