### PR TITLE
Remove partial state flag

### DIFF
--- a/src/service_protocol/src/message/header.rs
+++ b/src/service_protocol/src/message/header.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 const CUSTOM_MESSAGE_MASK: u16 = 0xFC00;
-const PARTIAL_STATE_MASK: u64 = 0x0400_0000_0000;
 const VERSION_MASK: u64 = 0x03FF_0000_0000;
 const COMPLETED_MASK: u64 = 0x0001_0000_0000;
 const REQUIRES_ACK_MASK: u64 = 0x0001_0000_0000;
@@ -77,10 +76,6 @@ impl MessageType {
     }
 
     fn has_protocol_version(&self) -> bool {
-        *self == MessageType::Start
-    }
-
-    fn has_partial_state_flag(&self) -> bool {
         *self == MessageType::Start
     }
 
@@ -161,8 +156,6 @@ pub struct MessageHeader {
     length: u32,
 
     // --- Flags
-    /// Only `StartMessage` has `PARTIAL_STATE`.
-    partial_state_flag: Option<bool>,
     /// Only `StartMessage` has protocol_version.
     protocol_version: Option<u16>,
 
@@ -175,14 +168,13 @@ pub struct MessageHeader {
 impl MessageHeader {
     #[inline]
     pub fn new(ty: MessageType, length: u32) -> Self {
-        Self::_new(ty, None, None, None, None, length)
+        Self::_new(ty, None, None, None, length)
     }
 
     #[inline]
-    pub fn new_start(partial_state: bool, protocol_version: u16, length: u32) -> Self {
+    pub fn new_start(protocol_version: u16, length: u32) -> Self {
         Self::_new(
             MessageType::Start,
-            Some(partial_state),
             Some(protocol_version),
             None,
             None,
@@ -203,7 +195,6 @@ impl MessageHeader {
         MessageHeader {
             ty,
             length,
-            partial_state_flag: None,
             protocol_version: None,
             completed_flag,
             requires_ack_flag,
@@ -213,7 +204,6 @@ impl MessageHeader {
     #[inline]
     fn _new(
         ty: MessageType,
-        partial_state_flag: Option<bool>,
         protocol_version: Option<u16>,
         completed_flag: Option<bool>,
         requires_ack_flag: Option<bool>,
@@ -222,7 +212,6 @@ impl MessageHeader {
         MessageHeader {
             ty,
             length,
-            partial_state_flag,
             protocol_version,
             completed_flag,
             requires_ack_flag,
@@ -237,11 +226,6 @@ impl MessageHeader {
     #[inline]
     pub fn message_type(&self) -> MessageType {
         self.ty
-    }
-
-    #[inline]
-    pub fn partial_state(&self) -> Option<bool> {
-        self.partial_state_flag
     }
 
     #[inline]
@@ -283,8 +267,6 @@ impl TryFrom<u64> for MessageHeader {
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         let ty_code = (value >> 48) as u16;
         let ty: MessageType = ty_code.try_into()?;
-        let partial_state_flag =
-            read_flag_if!(ty.has_partial_state_flag(), value, PARTIAL_STATE_MASK);
         let protocol_version = if ty.has_protocol_version() {
             Some(((value & VERSION_MASK) >> 32) as u16)
         } else {
@@ -296,7 +278,6 @@ impl TryFrom<u64> for MessageHeader {
 
         Ok(MessageHeader::_new(
             ty,
-            partial_state_flag,
             protocol_version,
             completed_flag,
             requires_ack_flag,
@@ -320,11 +301,6 @@ impl From<MessageHeader> for u64 {
         let mut res =
             ((u16::from(message_header.ty) as u64) << 48) | (message_header.length as u64);
 
-        write_flag!(
-            message_header.partial_state_flag,
-            &mut res,
-            PARTIAL_STATE_MASK
-        );
         if let Some(protocol_version) = message_header.protocol_version {
             res |= (protocol_version as u64) << 32;
         }
@@ -408,16 +384,7 @@ mod tests {
 
     roundtrip_test!(
         start,
-        MessageHeader::new_start(false, 1, 25),
-        Start,
-        Core,
-        25,
-        version: 1
-    );
-
-    roundtrip_test!(
-        start_with_partial_state,
-        MessageHeader::new_start(true, 1, 25),
+        MessageHeader::new_start(1, 25),
         Start,
         Core,
         25,
@@ -470,7 +437,7 @@ mod tests {
 
     roundtrip_test!(
         custom_entry_with_requires_ack,
-        MessageHeader::_new(MessageType::Custom(0xFC00), None, None, None, Some(true), 10341),
+        MessageHeader::_new(MessageType::Custom(0xFC00), None, None, Some(true), 10341),
         MessageType::Custom(0xFC00),
         MessageKind::Custom,
         10341,

--- a/src/service_protocol/src/message/mod.rs
+++ b/src/service_protocol/src/message/mod.rs
@@ -29,10 +29,7 @@ pub use header::{MessageHeader, MessageKind, MessageType};
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProtocolMessage {
     // Core
-    Start {
-        partial_state: bool,
-        inner: pb::protocol::StartMessage,
-    },
+    Start(pb::protocol::StartMessage),
     Completion(pb::protocol::CompletionMessage),
     Suspension(pb::protocol::SuspensionMessage),
     Error(pb::protocol::ErrorMessage),
@@ -49,24 +46,21 @@ impl ProtocolMessage {
         partial_state: bool,
         state_map_entries: impl IntoIterator<Item = (Bytes, Bytes)>,
     ) -> Self {
-        Self::Start {
+        Self::Start(pb::protocol::StartMessage {
+            id,
+            debug_id,
+            known_entries,
             partial_state,
-            inner: pb::protocol::StartMessage {
-                id,
-                debug_id,
-                known_entries,
-                partial_state,
-                state_map: state_map_entries
-                    .into_iter()
-                    .map(|(key, value)| pb::protocol::start_message::StateEntry { key, value })
-                    .collect(),
-            },
-        }
+            state_map: state_map_entries
+                .into_iter()
+                .map(|(key, value)| pb::protocol::start_message::StateEntry { key, value })
+                .collect(),
+        })
     }
 
     pub(crate) fn encoded_len(&self) -> usize {
         match self {
-            ProtocolMessage::Start { inner, .. } => inner.encoded_len(),
+            ProtocolMessage::Start(m) => m.encoded_len(),
             ProtocolMessage::Completion(m) => m.encoded_len(),
 
             ProtocolMessage::Suspension(m) => m.encoded_len(),

--- a/src/worker/src/partition/services/non_deterministic/remote_context.rs
+++ b/src/worker/src/partition/services/non_deterministic/remote_context.rs
@@ -981,13 +981,11 @@ mod tests {
                             invocation_status: some(pat!(
                                 start_response::InvocationStatus::Executing(
                                     decoded_as_protocol_messages(elements_are![
-                                        pat!(ProtocolMessage::Start {
-                                            inner: pat!(
-                                        restate_service_protocol::pb::protocol::StartMessage {
-                                            known_entries: eq(1)
-                                        }
-                                    )
-                                        }),
+                                        pat!(ProtocolMessage::Start(pat!(
+                                            restate_service_protocol::pb::protocol::StartMessage {
+                                                known_entries: eq(1)
+                                            }
+                                        ))),
                                         pat!(ProtocolMessage::UnparsedEntry(property!(
                                             PlainRawEntry.ty(),
                                             eq(EntryType::PollInputStream)
@@ -1165,13 +1163,11 @@ mod tests {
                             invocation_status: some(pat!(
                                 start_response::InvocationStatus::Executing(
                                     decoded_as_protocol_messages(elements_are![
-                                        pat!(ProtocolMessage::Start {
-                                            inner: pat!(
-                                        restate_service_protocol::pb::protocol::StartMessage {
-                                            known_entries: eq(2)
-                                        }
-                                    )
-                                        }),
+                                        pat!(ProtocolMessage::Start(pat!(
+                                            restate_service_protocol::pb::protocol::StartMessage {
+                                                known_entries: eq(2)
+                                            }
+                                        ))),
                                         pat!(ProtocolMessage::UnparsedEntry(property!(
                                             PlainRawEntry.ty(),
                                             eq(EntryType::PollInputStream)

--- a/tools/service_protocol_wireshark_dissector/dissector.lua
+++ b/tools/service_protocol_wireshark_dissector/dissector.lua
@@ -25,10 +25,6 @@ local f_requires_ack = ProtoField.bool("restate_service_protocol.requires_ack", 
     "Requires ack",
     "Doesn't require ack"
 })
-local f_partial_state = ProtoField.bool("restate_service_protocol.partial_state", "PARTIAL_STATE", base.NONE, {
-    "Partial state",
-    "Complete state"
-})
 local f_len = ProtoField.uint16("restate_service_protocol.length", "Length", base.DEC)
 local f_message = ProtoField.string("restate_service_protocol.message", "Message", base.UNICODE)
 
@@ -37,7 +33,6 @@ p_service_protocol.fields = {
     f_protocol_version,
     f_completed,
     f_requires_ack,
-    f_partial_state,
     f_len,
     f_message
 }
@@ -63,9 +58,6 @@ function p_service_protocol.dissector(buf, pkt, tree)
         end
         if msg.requires_ack ~= nil then
             subtree:add(f_requires_ack, msg.requires_ack)
-        end
-        if msg.partial_state ~= nil then
-            subtree:add(f_partial_state, msg.partial_state)
         end
         subtree:add(f_message, buf(8), msg.message, msg.message)
     end

--- a/tools/service_protocol_wireshark_dissector/src/lib.rs
+++ b/tools/service_protocol_wireshark_dissector/src/lib.rs
@@ -51,8 +51,8 @@ fn decode_packages<'lua>(lua: &'lua Lua, buf_lua: Value<'lua>) -> LuaResult<Tabl
             "ty_name" => format_message_type(header.message_type()),
             "len" => header.frame_length(),
             "message" => match message {
-                ProtocolMessage::Start{ inner, .. } => {
-                    format!("{:#?}", inner)
+                ProtocolMessage::Start(m) => {
+                    format!("{:#?}", m)
                 }
                 ProtocolMessage::Completion(c) => {
                     format!("{:#?}", c)
@@ -78,9 +78,6 @@ fn decode_packages<'lua>(lua: &'lua Lua, buf_lua: Value<'lua>) -> LuaResult<Tabl
         }
         if let Some(requires_ack) = header.requires_ack() {
             set_table_values!(message_table, "requires_ack" => requires_ack);
-        }
-        if let Some(partial_state) = header.partial_state() {
-            set_table_values!(message_table, "partial_state" => partial_state);
         }
 
         result_messages.push(message_table)?;


### PR DESCRIPTION
This is a cleanup after 0.3:

* Removed all the code related to the partial state flag, as we now pass this information in the StartMessage