### PR TITLE
External ingress invocation traces now have client socket info

### DIFF
--- a/src/ingress_grpc/src/lib.rs
+++ b/src/ingress_grpc/src/lib.rs
@@ -14,6 +14,9 @@ mod protocol;
 mod reflection;
 mod server;
 
+use std::net::{IpAddr, SocketAddr};
+
+use hyper::server::conn::AddrStream;
 pub use options::{Options, OptionsBuilder, OptionsBuilderError};
 pub use server::{HyperServerIngress, IngressServerError, StartSignal};
 
@@ -76,6 +79,28 @@ impl From<Bytes> for HandlerResponse {
 }
 
 type HandlerResult = Result<HandlerResponse, Status>;
+
+// --- Extensions injected into request/response
+
+/// Client connection information for a given RPC request
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ConnectInfo {
+    remote: SocketAddr,
+}
+
+impl ConnectInfo {
+    fn new(socket: &AddrStream) -> Self {
+        Self {
+            remote: socket.remote_addr(),
+        }
+    }
+    fn address(&self) -> IpAddr {
+        self.remote.ip()
+    }
+    fn port(&self) -> u16 {
+        self.remote.port()
+    }
+}
 
 // Contains some mocks we use in unit tests in this crate
 #[cfg(test)]


### PR DESCRIPTION
Open telemetry traces now include `client.socket.address` and `client.socket.port` following [OTel spec](https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/span-general/#client-attributes) 

Testing:
The new attributes appear both on the log:
```
2023-10-11T13:18:00.176865Z INFO restate_ingress_grpc::handler
  Processing ingress request
  in restate_ingress_grpc::handler::ingress_invoke
    otel.name: "ingress_invoke addTicket"
    rpc.system: "grpc"
    rpc.service: UserSession
    rpc.method: addTicket
    client.socket.address: 127.0.0.1
    client.socket.port: 59130
```

and in jaeger traces UI as expected 
<img width="1098" alt="image" src="https://github.com/restatedev/restate/assets/59670/2a350f58-e6f8-41a2-9534-4686e74488df">

As we grow this, we can create a new dedicated MakeService instead of using `make_service_fn`, but that'll do for now.