### PR TITLE
Fix build for old protobuf compilers

### DIFF
--- a/src/pb/build.rs
+++ b/src/pb/build.rs
@@ -296,6 +296,8 @@ fn main() -> std::io::Result<()> {
                         .service_generator(),
                 ),
         ))
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &[
                 "proto/grpc/health/v1/health.proto",

--- a/src/storage_proto/build.rs
+++ b/src/storage_proto/build.rs
@@ -11,5 +11,7 @@
 fn main() -> std::io::Result<()> {
     prost_build::Config::new()
         .bytes(["."])
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&["proto/dev/restate/storage/v1/domain.proto"], &["proto"])
 }


### PR DESCRIPTION
Fix build for old protobuf compilers

Old protobuf compiler (before v3.15.0) require `--experimental_allow_proto4_optional` flag to be set in order to support `optional` keyword in proto3.
This fixes the build on Mint Linux (ships with v3.12.4)

Test Plan:
Cargo builds on both a modern libprotoc (v24) and v3.12.4.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/865).
* #866
* __->__ #865