### PR TITLE
Reject schema updates that would remove previously defined methods

### DIFF
--- a/src/pb/build.rs
+++ b/src/pb/build.rs
@@ -328,5 +328,22 @@ fn main() -> std::io::Result<()> {
             &["proto", "tests/proto"],
         )?;
 
+    prost_build::Config::new()
+        // TODO: figure out a cleaner way of discarding the Rust byproducts
+        .out_dir(PathBuf::from(
+            env::var("TMPDIR").expect("OUT_DIR environment variable not set"),
+        ))
+        .file_descriptor_set_path(
+            PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
+                .join("file_descriptor_set_test-v2_incompatible.bin"),
+        )
+        .bytes(["."])
+        .service_generator(tonic_build::configure().service_generator())
+        .extern_path(".dev.restate", "crate::restate")
+        .compile_protos(
+            &["tests/proto/greeter-v2_incompatible.proto"],
+            &["proto", "tests/proto"],
+        )?;
+
     Ok(())
 }

--- a/src/pb/src/mocks.rs
+++ b/src/pb/src/mocks.rs
@@ -39,6 +39,17 @@ pub static DESCRIPTOR_POOL: Lazy<DescriptorPool> = Lazy::new(|| {
     .expect("The built-in descriptor pool should be valid")
 });
 
+pub static DESCRIPTOR_POOL_V2_INCOMPATIBLE: Lazy<DescriptorPool> = Lazy::new(|| {
+    DescriptorPool::decode(
+        include_bytes!(concat!(
+            env!("OUT_DIR"),
+            "/file_descriptor_set_test-v2_incompatible.bin"
+        ))
+        .as_ref(),
+    )
+    .expect("The built-in descriptor pool should be valid")
+});
+
 pub const GREETER_SERVICE_NAME: &str = "greeter.Greeter";
 pub const ANOTHER_GREETER_SERVICE_NAME: &str = "greeter.AnotherGreeter";
 

--- a/src/pb/tests/proto/greeter-v2_incompatible.proto
+++ b/src/pb/tests/proto/greeter-v2_incompatible.proto
@@ -5,7 +5,7 @@ import "google/protobuf/empty.proto";
 package greeter;
 
 service Greeter {
-  rpc Greet(GreetingRequest) returns (GreetingResponse);
+  rpc Greetings(GreetingRequest) returns (GreetingResponse); // Renamed from "Greet" - incompatible change
   // rpc GetCount(google.protobuf.Empty) returns (CountResponse);
   // rpc GreetStream(GreetingRequest) returns (stream CountResponse);
 }

--- a/src/schema_impl/src/lib.rs
+++ b/src/schema_impl/src/lib.rs
@@ -60,6 +60,8 @@ pub enum RegistrationError {
     InvalidSubscription(anyhow::Error),
     #[error("a subscription with the same id {0} already exists in the registry")]
     OverrideSubscription(EndpointId),
+    #[error("a schema update is not backwards compatible with the existing definition")]
+    IncompatibleSchemaEvolution(String, Vec<String>),
 }
 
 /// Insert (or replace) service


### PR DESCRIPTION
**WIP**

- [ ] Fix using the TMPDIR for unwanted protobuf build byproducts
- [ ] Validate input/output messages for backwards compatibility
- [ ] Revisit how we build up mock `DescriptorPool`s - or at least add some sanity checks that the shape of the service definition matches what we expect in terms of methods

https://github.com/restatedev/restate/issues/226