### PR TITLE
Make build information available in server and cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,11 +4052,12 @@ dependencies = [
 
 [[package]]
 name = "restate-cli"
-version = "0.5.0"
+version = "0.0.1-dev"
 dependencies = [
  "clap",
  "tokio",
  "tracing",
+ "vergen",
 ]
 
 [[package]]
@@ -4435,6 +4436,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "vergen",
 ]
 
 [[package]]
@@ -6058,6 +6060,17 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "restate-cli"
+version = "0.0.1-dev"
 authors = { workspace = true }
 description = { workspace = true }
-edition = {workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
-version = { workspace = true }
 publish = false
 default-run = "restate"
+build = "build.rs"
 
 [features]
 default = []
@@ -16,6 +17,14 @@ default = []
 clap = { version = "4.1", features = ["derive", "env"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[build-dependencies]
+vergen = { version = "8.0.0", default-features = false, features = [
+    "build",
+    "git",
+    "gitcl",
+    "cargo",
+] }
 
 [lib]
 bench = false

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder()
+        .build_date()
+        .build_timestamp()
+        .cargo_features()
+        .cargo_opt_level()
+        .cargo_target_triple()
+        .cargo_debug()
+        .git_branch()
+        .git_commit_date()
+        .git_commit_timestamp()
+        .git_sha(true)
+        .emit()?;
+    Ok(())
+}

--- a/cli/src/build_info.rs
+++ b/cli/src/build_info.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Build information
+
+/// The version of restate CLI.
+pub const RESTATE_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const RESTATE_CLI_VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
+pub const RESTATE_CLI_VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+pub const RESTATE_CLI_VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
+/// Pre-release version of restate.
+pub const RESTATE_CLI_VERSION_PRE: &str = env!("CARGO_PKG_VERSION_PRE");
+
+pub const RESTATE_CLI_BUILD_DATE: &str = env!("VERGEN_BUILD_DATE");
+pub const RESTATE_CLI_BUILD_TIME: &str = env!("VERGEN_BUILD_TIMESTAMP");
+pub const RESTATE_CLI_COMMIT_SHA: &str = env!("VERGEN_GIT_SHA");
+pub const RESTATE_CLI_COMMIT_DATE: &str = env!("VERGEN_GIT_COMMIT_DATE");
+pub const RESTATE_CLI_BRANCH: &str = env!("VERGEN_GIT_BRANCH");
+// /// The target triple.
+pub const RESTATE_CLI_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
+// /// The profile used in build.
+pub const RESTATE_CLI_DEBUG: &str = env!("VERGEN_CARGO_DEBUG");

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod build_info;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-fn main() {
-    println!("Restate cli placeholder, run restate-server if you need to run the server!");
+use restate_cli::build_info;
+
+#[tokio::main]
+async fn main() {
+    println!(
+        "Restate cli {} placeholder, run restate-server if you need to run the server!",
+        build_info::RESTATE_CLI_VERSION
+    );
 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -169,7 +169,7 @@ where
                                 leadership_state = message_collector.send().await?;
                             }
                             restate_consensus::Command::BecomeLeader(leader_epoch) => {
-                                info!(restate.partition.peer = %peer_id, restate.partition.id = %partition_id, restate.partition.leader_epoch = %leader_epoch, "Become leader");
+                                debug!(restate.partition.peer = %peer_id, restate.partition.id = %partition_id, restate.partition.leader_epoch = %leader_epoch, "Become leader");
 
                                 (actuator_stream, leadership_state) = leadership_state.become_leader(
                                     leader_epoch,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 description.workspace = true
+build = "build.rs"
 
 [features]
 default = []
@@ -45,3 +46,11 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[build-dependencies]
+vergen = { version = "8.0.0", default-features = false, features = [
+    "build",
+    "git",
+    "gitcl",
+    "cargo",
+] }

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder()
+        .build_date()
+        .build_timestamp()
+        .cargo_features()
+        .cargo_opt_level()
+        .cargo_target_triple()
+        .cargo_debug()
+        .git_branch()
+        .git_commit_date()
+        .git_commit_timestamp()
+        .git_sha(true)
+        .emit()?;
+    Ok(())
+}

--- a/server/src/build_info.rs
+++ b/server/src/build_info.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Build information
+#![allow(dead_code)]
+
+/// The version of restate server.
+pub const RESTATE_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const RESTATE_SERVER_VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
+pub const RESTATE_SERVER_VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+pub const RESTATE_SERVER_VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
+/// Pre-release version of restate.
+pub const RESTATE_SERVER_VERSION_PRE: &str = env!("CARGO_PKG_VERSION_PRE");
+
+pub const RESTATE_SERVER_BUILD_DATE: &str = env!("VERGEN_BUILD_DATE");
+pub const RESTATE_SERVER_BUILD_TIME: &str = env!("VERGEN_BUILD_TIMESTAMP");
+pub const RESTATE_SERVER_COMMIT_SHA: &str = env!("VERGEN_GIT_SHA");
+pub const RESTATE_SERVER_COMMIT_DATE: &str = env!("VERGEN_GIT_COMMIT_DATE");
+pub const RESTATE_SERVER_BRANCH: &str = env!("VERGEN_GIT_BRANCH");
+// The target triple.
+pub const RESTATE_SERVER_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
+/// The profile used in build.
+pub const RESTATE_SERVER_DEBUG: &str = env!("VERGEN_CARGO_DEBUG");
+
+/// Returns build information, e.g: 0.5.0-dev (debug) (2ba1491 aarch64-apple-darwin 2023-11-21)
+pub fn build_info() -> String {
+    format!(
+        "{RESTATE_SERVER_VERSION}{} ({RESTATE_SERVER_COMMIT_SHA} {RESTATE_SERVER_TARGET_TRIPLE} {RESTATE_SERVER_BUILD_DATE})",
+        if RESTATE_SERVER_DEBUG == "true" {
+            " (debug)"
+        } else {
+            ""
+        }
+    )
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod app;
+pub mod build_info;
 pub mod config;
 pub mod future_util;
 pub mod rt;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -11,6 +11,7 @@
 use clap::Parser;
 use codederror::CodedError;
 use restate_errors::fmt::RestateCode;
+use restate_server::build_info;
 use restate_server::Application;
 use restate_server::Configuration;
 use restate_tracing_instrumentation::TracingGuard;
@@ -86,8 +87,8 @@ fn main() {
         Ok(c) => c,
         Err(e) => {
             // We cannot use tracing here as it's not configured yet
-            println!("{}", e.decorate());
-            println!("{:#?}", RestateCode::from(&e));
+            eprintln!("{}", e.decorate());
+            eprintln!("{:#?}", RestateCode::from(&e));
             std::process::exit(EXIT_CODE_FAILURE);
         }
     };
@@ -106,7 +107,7 @@ fn main() {
             .init("Restate binary", std::process::id())
             .expect("failed to instrument logging and tracing!");
 
-        info!("Starting Restate");
+        info!("Starting Restate Server {}", build_info::build_info());
         info!(
             "Loading configuration file from {}",
             cli_args.config_file.display()


### PR DESCRIPTION
Make build information available in server and cli

Summary:
The build_info module contains build-time constants that will be used to print build
information in server and the command-line.

Bonus:
- The PR reduces the startup logging noise by reducing the log levels for the configuration
dump and the "Become Leader" notice.
- Premature errors on startup is now printed on stderr as they should be.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/901).
* #903
* #902
* __->__ #901