### PR TITLE
Move Meta's rest model to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4285,8 +4285,7 @@ dependencies = [
  "is-terminal",
  "once_cell",
  "reqwest",
- "restate-meta",
- "restate-schema-api",
+ "restate-meta-rest-model",
  "restate-serde-util",
  "serde",
  "serde_json",
@@ -4519,6 +4518,7 @@ dependencies = [
  "restate-errors",
  "restate-fs-util",
  "restate-futures-util",
+ "restate-meta-rest-model",
  "restate-pb",
  "restate-schema-api",
  "restate-schema-impl",
@@ -4539,6 +4539,20 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "restate-meta-rest-model"
+version = "0.5.0"
+dependencies = [
+ "http",
+ "restate-schema-api",
+ "restate-serde-util",
+ "restate-types",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ restate-ingress-kafka = { path = "crates/ingress-kafka" }
 restate-invoker-api = { path = "crates/invoker-api" }
 restate-invoker-impl = { path = "crates/invoker-impl" }
 restate-meta = { path = "crates/meta" }
+restate-meta-rest-model = { path = "crates/meta-rest-model" }
 restate-network = { path = "crates/network" }
 restate-pb = { path = "crates/pb" }
 restate-queue = { path = "crates/queue" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,8 +14,7 @@ build = "build.rs"
 default = []
 
 [dependencies]
-restate-meta = { workspace = true }
-restate-schema-api = { workspace = true }
+restate-meta-rest-model = { workspace = true }
 restate-serde-util = { workspace = true }
 
 anyhow = { workspace = true }

--- a/cli/src/commands/services/describe.rs
+++ b/cli/src/commands/services/describe.rs
@@ -18,7 +18,8 @@ use crate::console::c_println;
 use crate::meta_client::{MetaClient, MetaClientInterface};
 use crate::ui::console::{Styled, StyledTable};
 use crate::ui::stylesheet::Style;
-use restate_meta::rest_api::endpoints::{ServiceEndpoint, ServiceEndpointResponse};
+
+use restate_meta_rest_model::endpoints::{ProtocolType, ServiceEndpoint, ServiceEndpointResponse};
 
 use anyhow::Result;
 
@@ -89,8 +90,8 @@ fn add_endpoint(endpoint: &ServiceEndpointResponse, table: &mut Table) {
             table.add_row(vec!["Endpoint Type:", "HTTP"]);
             table.add_row(vec!["Endpoint URL:", &uri.to_string()]);
             let protocol_type = match protocol_type {
-                restate_schema_api::endpoint::ProtocolType::RequestResponse => "RequestResponse",
-                restate_schema_api::endpoint::ProtocolType::BidiStream => "BidiStream",
+                ProtocolType::RequestResponse => "RequestResponse",
+                ProtocolType::BidiStream => "BidiStream",
             }
             .to_string();
             table.add_row(vec!["Endpoint Protocol:", &protocol_type]);

--- a/cli/src/commands/services/list.rs
+++ b/cli/src/commands/services/list.rs
@@ -14,12 +14,13 @@ use crate::cli_env::CliEnv;
 use crate::console::{c_println, Icon};
 use crate::meta_client::MetaClientInterface;
 use crate::ui::console::StyledTable;
+
+use restate_meta_rest_model::endpoints::{ProtocolType, ServiceEndpoint, ServiceEndpointResponse};
+use restate_meta_rest_model::services::{InstanceType, MethodMetadata};
+
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::{Attribute, Cell, Table};
-use restate_meta::rest_api::endpoints::{ServiceEndpoint, ServiceEndpointResponse};
-use restate_schema_api::endpoint::ProtocolType;
-use restate_schema_api::service::{InstanceType, MethodMetadata};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[clap(visible_alias = "ls")]

--- a/cli/src/meta_client/meta_interface.rs
+++ b/cli/src/meta_client/meta_interface.rs
@@ -8,15 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
-use restate_meta::rest_api::endpoints::ListServiceEndpointsResponse;
-use restate_meta::rest_api::endpoints::ServiceEndpointResponse;
-
-use restate_meta::rest_api::services::ListServicesResponse;
-use restate_schema_api::service::ServiceMetadata;
-
 use super::client::Envelope;
 use super::MetaClient;
+
+use restate_meta_rest_model::endpoints::*;
+use restate_meta_rest_model::services::*;
+
+use async_trait::async_trait;
 
 #[async_trait]
 pub trait MetaClientInterface {

--- a/crates/meta-rest-model/Cargo.toml
+++ b/crates/meta-rest-model/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "restate-meta-rest-model"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+schema = ["dep:schemars", "restate-schema-api/serde_schema", "restate-serde-util/schema", "restate-types/serde_schema"]
+
+[dependencies]
+restate-types = { workspace = true, features = ["serde"] }
+restate-schema-api = { workspace = true, features = [ "service", "endpoint", "discovery", "serde", "subscription" ] }
+restate-serde-util = { workspace = true }
+
+http = { workspace = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }

--- a/crates/meta-rest-model/src/endpoints.rs
+++ b/crates/meta-rest-model/src/endpoints.rs
@@ -1,0 +1,150 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::services::ServiceRevision;
+
+use restate_serde_util::SerdeableHeaderHashMap;
+
+use http::Uri;
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+// Export schema types to be used by other crates without exposing the fact
+// that we are using proxying to restate-schema-api or restate-types
+pub use restate_schema_api::endpoint::{EndpointMetadata, ProtocolType};
+pub use restate_types::identifiers::{EndpointId, LambdaARN};
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServiceEndpoint {
+    Http {
+        #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+        #[cfg_attr(feature = "schema", schemars(with = "String"))]
+        uri: Uri,
+        protocol_type: ProtocolType,
+        #[serde(skip_serializing_if = "SerdeableHeaderHashMap::is_empty")]
+        #[serde(default)]
+        additional_headers: SerdeableHeaderHashMap,
+    },
+    Lambda {
+        arn: LambdaARN,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        assume_role_arn: Option<String>,
+        #[serde(skip_serializing_if = "SerdeableHeaderHashMap::is_empty")]
+        #[serde(default)]
+        additional_headers: SerdeableHeaderHashMap,
+    },
+}
+
+impl From<EndpointMetadata> for ServiceEndpoint {
+    fn from(value: EndpointMetadata) -> Self {
+        match value {
+            EndpointMetadata::Http {
+                address,
+                protocol_type,
+                delivery_options,
+            } => Self::Http {
+                uri: address,
+                protocol_type,
+                additional_headers: delivery_options.additional_headers.into(),
+            },
+            EndpointMetadata::Lambda {
+                arn,
+                assume_role_arn,
+                delivery_options,
+            } => Self::Lambda {
+                arn,
+                assume_role_arn: assume_role_arn.map(Into::into),
+                additional_headers: delivery_options.additional_headers.into(),
+            },
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterServiceEndpointRequest {
+    #[serde(flatten)]
+    pub endpoint_metadata: RegisterServiceEndpointMetadata,
+    /// # Additional headers
+    ///
+    /// Additional headers added to the discover/invoke requests to the service endpoint.
+    pub additional_headers: Option<SerdeableHeaderHashMap>,
+    /// # Force
+    ///
+    /// If `true`, it will override, if existing, any endpoint using the same `uri`.
+    /// Beware that this can lead in-flight invocations to an unrecoverable error state.
+    ///
+    /// By default, this is `true` but it might change in future to `false`.
+    ///
+    /// See the [versioning documentation](https://docs.restate.dev/services/upgrades-removal) for more information.
+    #[serde(default = "restate_serde_util::default::bool::<true>")]
+    pub force: bool,
+}
+
+#[serde_as]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RegisterServiceEndpointMetadata {
+    Http {
+        /// # Uri
+        ///
+        /// Uri to use to discover/invoke the http service endpoint.
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[cfg_attr(feature = "schema", schemars(with = "String"))]
+        uri: Uri,
+    },
+    Lambda {
+        /// # ARN
+        ///
+        /// ARN to use to discover/invoke the lambda service endpoint.
+        arn: String,
+        /// # Assume role ARN
+        ///
+        /// Optional ARN of a role to assume when invoking this endpoint, to support role chaining
+        assume_role_arn: Option<String>,
+    },
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterServiceResponse {
+    pub name: String,
+    pub revision: ServiceRevision,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterServiceEndpointResponse {
+    pub id: EndpointId,
+    pub services: Vec<RegisterServiceResponse>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListServiceEndpointsResponse {
+    pub endpoints: Vec<ServiceEndpointResponse>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServiceEndpointResponse {
+    pub id: EndpointId,
+    #[serde(flatten)]
+    pub service_endpoint: ServiceEndpoint,
+    /// # Services
+    ///
+    /// List of services exposed by this service endpoint.
+    pub services: Vec<RegisterServiceResponse>,
+}

--- a/crates/meta-rest-model/src/lib.rs
+++ b/crates/meta-rest-model/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod endpoints;
+pub mod methods;
+pub mod services;
+pub mod subscriptions;

--- a/crates/meta-rest-model/src/methods.rs
+++ b/crates/meta-rest-model/src/methods.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::{Deserialize, Serialize};
+
+// Export schema types to be used by other crates without exposing the fact
+// that we are using proxying to restate-schema-api or restate-types
+pub use restate_schema_api::service::MethodMetadata;
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListServiceMethodsResponse {
+    pub methods: Vec<MethodMetadata>,
+}

--- a/crates/meta-rest-model/src/services.rs
+++ b/crates/meta-rest-model/src/services.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::{Deserialize, Serialize};
+
+// Export schema types to be used by other crates without exposing the fact
+// that we are using proxying to restate-schema-api or restate-types
+pub use restate_schema_api::service::{InstanceType, MethodMetadata, ServiceMetadata};
+pub use restate_types::identifiers::ServiceRevision;
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListServicesResponse {
+    pub services: Vec<ServiceMetadata>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModifyServiceRequest {
+    /// # Public
+    ///
+    /// If true, the service can be invoked through the ingress.
+    /// If false, the service can be invoked only from another Restate service.
+    pub public: bool,
+}

--- a/crates/meta-rest-model/src/subscriptions.rs
+++ b/crates/meta-rest-model/src/subscriptions.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use http::Uri;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+// Export schema types to be used by other crates without exposing the fact
+// that we are using proxying to restate-schema-api or restate-types
+pub use restate_schema_api::subscription::{ListSubscriptionFilter, Subscription};
+
+#[serde_as]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateSubscriptionRequest {
+    /// # Identifier
+    ///
+    /// Identifier of the subscription. If not specified, one will be auto-generated.
+    pub id: Option<String>,
+    /// # Source
+    ///
+    /// Source uri. Accepted forms:
+    ///
+    /// * `kafka://<cluster_name>/<topic_name>`, e.g. `service://my-cluster/my-topic`
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    pub source: Uri,
+    /// # Sink
+    ///
+    /// Sink uri. Accepted forms:
+    ///
+    /// * `service://<service_name>/<method_name>`, e.g. `service://com.example.MySvc/MyMethod`
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schema", schemars(with = "String"))]
+    pub sink: Uri,
+    /// # Options
+    ///
+    /// Additional options to apply to the subscription.
+    pub options: Option<HashMap<String, String>>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubscriptionResponse {
+    pub id: String,
+    pub source: String,
+    pub sink: String,
+    pub options: HashMap<String, String>,
+}
+
+impl From<Subscription> for SubscriptionResponse {
+    fn from(value: Subscription) -> Self {
+        Self {
+            id: value.id().to_string(),
+            source: value.source().to_string(),
+            sink: value.sink().to_string(),
+            options: value.metadata().clone(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ListSubscriptionsParams {
+    pub sink: Option<String>,
+    pub source: Option<String>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ListSubscriptionsResponse {
+    pub subscriptions: Vec<SubscriptionResponse>,
+}

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -36,8 +36,9 @@ serde_with = { workspace = true }
 prost = { workspace = true }
 prost-reflect = { workspace = true }
 restate-fs-util = { workspace = true }
+restate-meta-rest-model = { workspace = true, features = ["schema"] }
 restate-pb = { workspace = true }
-restate-schema-api = { workspace = true, features = [ "service", "endpoint", "discovery", "serde", "serde_schema", ] }
+restate-schema-api = { workspace = true, features = ["service", "endpoint", "discovery", "serde", "serde_schema"] }
 restate-schema-impl = { workspace = true }
 restate-service-client = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["discovery"] }

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// TODO: FIX ME
-pub mod rest_api;
+mod rest_api;
 mod service;
 mod storage;
 

--- a/crates/meta/src/rest_api/methods.rs
+++ b/crates/meta/src/rest_api/methods.rs
@@ -8,20 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use super::error::*;
 use super::state::*;
+
+use restate_meta_rest_model::methods::*;
+use restate_schema_api::service::ServiceMetadataResolver;
+
 use axum::extract::{Path, State};
 use axum::Json;
 use okapi_operation::*;
-use restate_schema_api::service::{MethodMetadata, ServiceMetadataResolver};
-use schemars::JsonSchema;
-use serde::Serialize;
-use std::sync::Arc;
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListServiceMethodsResponse {
-    methods: Vec<MethodMetadata>,
-}
 
 /// List discovered methods for service
 #[openapi(

--- a/crates/meta/src/rest_api/mod.rs
+++ b/crates/meta/src/rest_api/mod.rs
@@ -10,14 +10,12 @@
 
 //! This module implements the Meta API endpoint.
 
-// TODO: FIX ME
-pub mod endpoints;
+mod endpoints;
 mod error;
 mod health;
 mod invocations;
 mod methods;
-// TODO: FIX ME
-pub mod services;
+mod services;
 mod state;
 mod subscriptions;
 

--- a/crates/meta/src/rest_api/services.rs
+++ b/crates/meta/src/rest_api/services.rs
@@ -10,6 +10,13 @@
 
 use std::sync::Arc;
 
+use super::error::*;
+use super::state::*;
+
+use restate_meta_rest_model::services::*;
+use restate_pb::grpc::reflection::FileDescriptorResponse;
+use restate_schema_api::service::ServiceMetadataResolver;
+
 use axum::extract::{Path, State};
 use axum::http::{header, HeaderValue};
 use axum::response::{IntoResponse, Response};
@@ -18,19 +25,6 @@ use okapi_operation::okapi::openapi3::MediaType;
 use okapi_operation::okapi::Map;
 use okapi_operation::*;
 use prost::Message;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-use restate_pb::grpc::reflection::FileDescriptorResponse;
-use restate_schema_api::service::{ServiceMetadata, ServiceMetadataResolver};
-
-use super::error::*;
-use super::state::*;
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ListServicesResponse {
-    pub services: Vec<ServiceMetadata>,
-}
 
 /// List services
 #[openapi(
@@ -69,15 +63,6 @@ pub async fn get_service<S: ServiceMetadataResolver, W>(
         .resolve_latest_service_metadata(&service_name)
         .map(Into::into)
         .ok_or_else(|| MetaApiError::ServiceNotFound(service_name))
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ModifyServiceRequest {
-    /// # Public
-    ///
-    /// If true, the service can be invoked through the ingress.
-    /// If false, the service can be invoked only from another Restate service.
-    pub public: bool,
 }
 
 /// Modify a service

--- a/crates/meta/src/rest_api/subscriptions.rs
+++ b/crates/meta/src/rest_api/subscriptions.rs
@@ -8,69 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use super::error::*;
 use super::state::*;
 
+use restate_meta_rest_model::subscriptions::*;
+use restate_schema_api::subscription::SubscriptionResolver;
+
 use axum::extract::Query;
 use axum::extract::{Path, State};
-use axum::http::{StatusCode, Uri};
+use axum::http::StatusCode;
 use axum::{http, Json};
 use okapi_operation::*;
-use restate_schema_api::subscription::{
-    ListSubscriptionFilter, Subscription, SubscriptionResolver,
-};
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use std::collections::HashMap;
-use std::sync::Arc;
-
-#[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateSubscriptionRequest {
-    /// # Identifier
-    ///
-    /// Identifier of the subscription. If not specified, one will be auto-generated.
-    pub id: Option<String>,
-    /// # Source
-    ///
-    /// Source uri. Accepted forms:
-    ///
-    /// * `kafka://<cluster_name>/<topic_name>`, e.g. `service://my-cluster/my-topic`
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    #[schemars(with = "String")]
-    pub source: Uri,
-    /// # Sink
-    ///
-    /// Sink uri. Accepted forms:
-    ///
-    /// * `service://<service_name>/<method_name>`, e.g. `service://com.example.MySvc/MyMethod`
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    #[schemars(with = "String")]
-    pub sink: Uri,
-    /// # Options
-    ///
-    /// Additional options to apply to the subscription.
-    pub options: Option<HashMap<String, String>>,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct SubscriptionResponse {
-    id: String,
-    source: String,
-    sink: String,
-    options: HashMap<String, String>,
-}
-
-impl From<Subscription> for SubscriptionResponse {
-    fn from(value: Subscription) -> Self {
-        Self {
-            id: value.id().to_string(),
-            source: value.source().to_string(),
-            sink: value.sink().to_string(),
-            options: value.metadata().clone(),
-        }
-    }
-}
 
 /// Create subscription.
 #[openapi(
@@ -135,17 +85,6 @@ where
         .ok_or_else(|| MetaApiError::SubscriptionNotFound(subscription_id.clone()))?;
 
     Ok(SubscriptionResponse::from(subscription).into())
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListSubscriptionsParams {
-    sink: Option<String>,
-    source: Option<String>,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListSubscriptionsResponse {
-    subscriptions: Vec<SubscriptionResponse>,
 }
 
 /// List subscriptions.

--- a/crates/schema-api/Cargo.toml
+++ b/crates/schema-api/Cargo.toml
@@ -20,7 +20,7 @@ mocks = []
 proto_symbol = ["dep:bytes"]
 serde = ["dep:serde", "dep:serde_with", "restate-types?/serde", "dep:restate-serde-util"]
 serde_schema = ["serde", "dep:schemars", "restate-types?/serde_schema", "restate-serde-util?/schema"]
-service = ["dep:restate-types"]
+service = ["dep:bytes", "dep:restate-types"]
 subscription = ["dep:anyhow"]
 
 [dependencies]

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 
 awakeable-id = ["dep:base64", "dep:restate-base64-util", "dep:restate-types", "dep:thiserror"]
 codec = ["protocol", "dep:restate-types", "dep:thiserror", "dep:paste"]
-discovery = ["dep:thiserror", "dep:codederror", "dep:restate-errors", "dep:restate-schema-api", "dep:hyper", "dep:restate-service-client", "dep:prost-reflect", "dep:restate-types", "dep:tokio"]
+discovery = ["dep:tracing", "dep:thiserror", "dep:codederror", "dep:restate-errors", "dep:restate-schema-api", "dep:hyper", "dep:restate-service-client", "dep:prost-reflect", "dep:restate-types", "dep:tokio"]
 message = ["protocol", "dep:restate-types", "dep:bytes-utils", "dep:codederror", "dep:restate-errors", "dep:size", "dep:tracing"]
 mocks = ["awakeable-id"]
 protocol = []


### PR DESCRIPTION
Move Meta's rest model to a separate crate

Tiny bonus: crate imports are re-organised in a more uniform way (std, local, restate, third-party)
