### PR TITLE
[Observability] Extend sys_status and sys_invocation_state with endpoint_id

### DIFF
--- a/crates/invoker-api/src/status_handle.rs
+++ b/crates/invoker-api/src/status_handle.rs
@@ -10,7 +10,7 @@
 
 use codederror::Code;
 use restate_types::errors::{InvocationError, InvocationErrorCode};
-use restate_types::identifiers::{FullInvocationId, PartitionKey};
+use restate_types::identifiers::{EndpointId, FullInvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
 use std::fmt;
 use std::future::Future;
@@ -25,6 +25,8 @@ pub struct InvocationStatusReportInner {
     pub start_count: usize,
     pub last_start_at: SystemTime,
     pub last_retry_attempt_failure: Option<InvocationErrorReport>,
+    pub next_retry_at: Option<SystemTime>,
+    pub last_attempt_endpoint_id: Option<EndpointId>,
 }
 
 impl Default for InvocationStatusReportInner {
@@ -34,6 +36,8 @@ impl Default for InvocationStatusReportInner {
             start_count: 0,
             last_start_at: SystemTime::now(),
             last_retry_attempt_failure: None,
+            next_retry_at: None,
+            last_attempt_endpoint_id: None,
         }
     }
 }
@@ -78,8 +82,16 @@ impl InvocationStatusReport {
         self.2.last_start_at
     }
 
+    pub fn next_retry_at(&self) -> Option<SystemTime> {
+        self.2.next_retry_at
+    }
+
     pub fn last_retry_attempt_failure(&self) -> Option<&InvocationErrorReport> {
         self.2.last_retry_attempt_failure.as_ref()
+    }
+
+    pub fn last_attempt_endpoint_id(&self) -> Option<&EndpointId> {
+        self.2.last_attempt_endpoint_id.as_ref()
     }
 }
 

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -167,7 +167,8 @@ pub(super) struct InvocationTaskOutput {
 }
 
 pub(super) enum InvocationTaskOutputInner {
-    SelectedEndpoint(EndpointId),
+    // `has_changed` indicates if we believe this is a freshly selected endpoint or not.
+    SelectedEndpoint(EndpointId, /* has_changed: */ bool),
     NewEntry {
         entry_index: EntryIndex,
         entry: EnrichedRawEntry,
@@ -367,25 +368,35 @@ where
             shortcircuit!(tokio::try_join!(read_journal_future, read_state_future));
 
         // Resolve the endpoint metadata
-        let endpoint_metadata = if let Some(endpoint_id) = journal_metadata.endpoint_id {
-            shortcircuit!(self
-                .endpoint_metadata_resolver
-                .get_endpoint(&endpoint_id)
-                .ok_or_else(|| InvocationTaskError::UnknownEndpoint(endpoint_id.clone())))
-        } else {
-            let endpoint_meta = shortcircuit!(self
-                .endpoint_metadata_resolver
-                .resolve_latest_endpoint_for_service(
-                    &self.full_invocation_id.service_id.service_name
-                )
-                .ok_or(InvocationTaskError::NoEndpointForService));
-            let _ = self.invoker_tx.send(InvocationTaskOutput {
-                partition: self.partition,
-                full_invocation_id: self.full_invocation_id.clone(),
-                inner: InvocationTaskOutputInner::SelectedEndpoint(endpoint_meta.id()),
-            });
-            endpoint_meta
-        };
+        let (endpoint_metadata, endpoint_changed) =
+            if let Some(endpoint_id) = journal_metadata.endpoint_id {
+                // We have a pinned endpoint that we can't change even if newer
+                // endpoints have been registered for the same service.
+                let endpoint_metadata = shortcircuit!(self
+                    .endpoint_metadata_resolver
+                    .get_endpoint(&endpoint_id)
+                    .ok_or_else(|| InvocationTaskError::UnknownEndpoint(endpoint_id.clone())));
+                (endpoint_metadata, /* has_changed= */ false)
+            } else {
+                // We can choose the freshest endpoint for the latest revision
+                // of the registered service.
+                let endpoint_metadata = shortcircuit!(self
+                    .endpoint_metadata_resolver
+                    .resolve_latest_endpoint_for_service(
+                        &self.full_invocation_id.service_id.service_name
+                    )
+                    .ok_or(InvocationTaskError::NoEndpointForService));
+                (endpoint_metadata, /* has_changed= */ true)
+            };
+
+        let _ = self.invoker_tx.send(InvocationTaskOutput {
+            partition: self.partition,
+            full_invocation_id: self.full_invocation_id.clone(),
+            inner: InvocationTaskOutputInner::SelectedEndpoint(
+                endpoint_metadata.id(),
+                endpoint_changed,
+            ),
+        });
 
         // Figure out the protocol type. Force RequestResponse if inactivity_timeout is zero
         let protocol_type = if self.inactivity_timeout.is_zero() {

--- a/crates/storage-query-datafusion/src/invocation_state/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/row.rs
@@ -70,6 +70,13 @@ pub(crate) fn append_state_row(
     row.in_flight(status_row.in_flight());
     row.retry_count(status_row.retry_count() as u64);
     row.last_start_at(MillisSinceEpoch::as_u64(&status_row.last_start_at().into()) as i64);
+    if let Some(last_attempt_endpoint_id) = status_row.last_attempt_endpoint_id() {
+        row.last_attempt_endpoint_id(last_attempt_endpoint_id);
+    }
+
+    if let Some(next_retry_at) = status_row.next_retry_at() {
+        row.next_retry_at(MillisSinceEpoch::as_u64(&next_retry_at.into()) as i64);
+    }
     if let Some(last_retry_attempt_failure) = status_row.last_retry_attempt_failure() {
         row.last_failure(format_using(
             output,

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -26,6 +26,11 @@ define_table!(state(
     in_flight: DataType::Boolean,
     retry_count: DataType::UInt64,
     last_start_at: DataType::Date64,
+    // The endpoint that was selected in the last invocation attempt. This is
+    // guaranteed to be set unlike in `sys_status` table which require that the
+    // endpoint to be committed before it is set.
+    last_attempt_endpoint_id: DataType::LargeUtf8,
+    next_retry_at: DataType::Date64,
     last_failure: DataType::LargeUtf8,
     last_error_code: DataType::LargeUtf8,
 ));

--- a/crates/storage-query-datafusion/src/status/row.rs
+++ b/crates/storage-query-datafusion/src/status/row.rs
@@ -114,6 +114,9 @@ fn fill_invocation_metadata(
 ) {
     // journal_metadata and stats are filled by other functions
     row.method(meta.method);
+    if let Some(endpoint_id) = meta.endpoint_id {
+        row.pinned_endpoint_id(endpoint_id);
+    }
     match meta.response_sink {
         Some(ServiceInvocationResponseSink::PartitionProcessor { caller, .. }) => {
             row.invoked_by("service");

--- a/crates/storage-query-datafusion/src/status/schema.rs
+++ b/crates/storage-query-datafusion/src/status/schema.rs
@@ -28,6 +28,7 @@ define_table!(status(
     invoked_by: DataType::LargeUtf8,
     invoked_by_service: DataType::LargeUtf8,
     invoked_by_id: DataType::LargeUtf8,
+    pinned_endpoint_id: DataType::LargeUtf8,
     trace_id: DataType::LargeUtf8,
     journal_size: DataType::UInt32,
     created_at: DataType::Date64,


### PR DESCRIPTION
[Observability] Extend sys_status and sys_invocation_state with endpoint_id

Summary:
This introduces two new columns in `sys_invocation_state`:
  - `next_retry_at` Points to the next retry timestamp if a retry is scheduled for an invocation.
  - `last_attempt_endpoint_id` The endpoint ID that was used for the last invocation attempt.

Also, a new column was added in `sys_status`:
  - `pinned_endpoint_id` Indicates the endpoint ID that this invocation is _pinned_ to. If set, the invocation must continue to use this endpoint id even if other endpoints were installed that claim to host higher service revisions.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/913).
* #933
* #928
* __->__ #913