### PR TITLE
[Meta] Dry-run discovery and richer discovery response

### DIFF
--- a/crates/meta-rest-model/src/endpoints.rs
+++ b/crates/meta-rest-model/src/endpoints.rs
@@ -10,6 +10,7 @@
 
 use super::services::ServiceRevision;
 
+use restate_schema_api::service::ServiceMetadata;
 use restate_serde_util::SerdeableHeaderHashMap;
 
 use http::Uri;
@@ -90,11 +91,18 @@ pub struct RegisterServiceEndpointRequest {
     /// See the [versioning documentation](https://docs.restate.dev/services/upgrades-removal) for more information.
     #[serde(default = "restate_serde_util::default::bool::<true>")]
     pub force: bool,
+
+    /// # Dry-run mode
+    ///
+    /// If `true`, discovery will run but the endpoint will not be registered.
+    /// This is useful to see the impact of a new endpoint before registering it.
+    #[serde(default = "restate_serde_util::default::bool::<false>")]
+    pub dry_run: bool,
 }
 
 #[serde_as]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RegisterServiceEndpointMetadata {
     Http {
@@ -119,7 +127,7 @@ pub enum RegisterServiceEndpointMetadata {
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RegisterServiceResponse {
+pub struct ServiceNameRevPair {
     pub name: String,
     pub revision: ServiceRevision,
 }
@@ -128,7 +136,7 @@ pub struct RegisterServiceResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RegisterServiceEndpointResponse {
     pub id: EndpointId,
-    pub services: Vec<RegisterServiceResponse>,
+    pub services: Vec<ServiceMetadata>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -146,5 +154,5 @@ pub struct ServiceEndpointResponse {
     /// # Services
     ///
     /// List of services exposed by this service endpoint.
-    pub services: Vec<RegisterServiceResponse>,
+    pub services: Vec<ServiceNameRevPair>,
 }

--- a/crates/schema-impl/src/schemas_impl.rs
+++ b/crates/schema-impl/src/schemas_impl.rs
@@ -150,7 +150,7 @@ impl TryFrom<&InstanceTypeMetadata> for InstanceType {
 }
 
 impl ServiceSchemas {
-    fn new(
+    pub(crate) fn new(
         revision: ServiceRevision,
         methods: HashMap<String, MethodSchemas>,
         instance_type: InstanceTypeMetadata,
@@ -191,7 +191,7 @@ impl ServiceSchemas {
         }
     }
 
-    fn compute_service_methods(
+    pub(crate) fn compute_service_methods(
         svc_desc: &ServiceDescriptor,
         method_meta: &HashMap<String, DiscoveredMethodMetadata>,
     ) -> HashMap<String, MethodSchemas> {

--- a/crates/schema-impl/src/service.rs
+++ b/crates/schema-impl/src/service.rs
@@ -49,7 +49,7 @@ impl ServiceMetadataResolver for Schemas {
     }
 }
 
-fn map_to_service_metadata(
+pub(crate) fn map_to_service_metadata(
     service_name: &str,
     service_schemas: &ServiceSchemas,
 ) -> Option<ServiceMetadata> {


### PR DESCRIPTION
[Meta] Dry-run discovery and richer discovery response

Summary:
This introduces two important changes to the meta's REST API:
- A new `dry_run` attribute in `POST /endpoints` body to allow discovery without application.
- Response format of discovery to include the set of discovered methods, using the same structure that is returned in `GET services/{name}/`.


The updated response type unblocks the CLI work which visualizes the changes that a potential endpoint discovery will cause.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/928).
* #933
* __->__ #928