### PR TITLE
Reject schema updates that would remove defined service methods

### DIFF
--- a/crates/errors/src/error_codes/META0006.md
+++ b/crates/errors/src/error_codes/META0006.md
@@ -4,7 +4,8 @@ Cannot register the newly discovered service revision in the provided service en
 
 When implementing a new service revision, make sure that:
 
-* The service instance type and the key definition, if any, is exactly the same as of the previous revisions.
+* The service instance type and the key definition, if any, are exactly the same as of the previous revisions.
 * The Protobuf contract and message definitions are backward compatible.
+  * The new revision must implement all the methods of the previous revisions.
 
 See the [versioning documentation](https://docs.restate.dev/services/upgrades-removal) for more information.

--- a/crates/meta/src/rest_api/error.rs
+++ b/crates/meta/src/rest_api/error.rs
@@ -69,7 +69,10 @@ impl IntoResponse for MetaApiError {
             }
             MetaApiError::Meta(MetaError::SchemaRegistry(RegistrationError::OverrideEndpoint(
                 _,
-            ))) => StatusCode::CONFLICT,
+            )))
+            | MetaApiError::Meta(MetaError::SchemaRegistry(
+                RegistrationError::IncompatibleSchemaMissingMethod(_, _),
+            )) => StatusCode::CONFLICT,
             MetaApiError::Meta(MetaError::SchemaRegistry(RegistrationError::UnknownService(_))) => {
                 StatusCode::NOT_FOUND
             }

--- a/crates/pb/build.rs
+++ b/crates/pb/build.rs
@@ -328,5 +328,22 @@ fn main() -> std::io::Result<()> {
             &["proto", "tests/proto"],
         )?;
 
+    prost_build::Config::new()
+        // TODO: figure out a cleaner way of discarding the Rust byproducts
+        .out_dir(PathBuf::from(
+            env::var("TMPDIR").expect("OUT_DIR environment variable not set"),
+        ))
+        .file_descriptor_set_path(
+            PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
+                .join("file_descriptor_set_test-v2_incompatible.bin"),
+        )
+        .bytes(["."])
+        .service_generator(tonic_build::configure().service_generator())
+        .extern_path(".dev.restate", "crate::restate")
+        .compile_protos(
+            &["tests/proto/greeter-v2_incompatible.proto"],
+            &["proto", "tests/proto"],
+        )?;
+
     Ok(())
 }

--- a/crates/pb/src/mocks.rs
+++ b/crates/pb/src/mocks.rs
@@ -39,6 +39,17 @@ pub static DESCRIPTOR_POOL: Lazy<DescriptorPool> = Lazy::new(|| {
     .expect("The built-in descriptor pool should be valid")
 });
 
+pub static DESCRIPTOR_POOL_V2_INCOMPATIBLE: Lazy<DescriptorPool> = Lazy::new(|| {
+    DescriptorPool::decode(
+        include_bytes!(concat!(
+            env!("OUT_DIR"),
+            "/file_descriptor_set_test-v2_incompatible.bin"
+        ))
+        .as_ref(),
+    )
+    .expect("The built-in descriptor pool should be valid")
+});
+
 pub const GREETER_SERVICE_NAME: &str = "greeter.Greeter";
 pub const ANOTHER_GREETER_SERVICE_NAME: &str = "greeter.AnotherGreeter";
 

--- a/crates/pb/tests/proto/greeter-v2_incompatible.proto
+++ b/crates/pb/tests/proto/greeter-v2_incompatible.proto
@@ -5,9 +5,11 @@ import "google/protobuf/empty.proto";
 package greeter;
 
 service Greeter {
-  rpc Greetings(GreetingRequest) returns (GreetingResponse); // Renamed from "Greet" - incompatible change
-  // rpc GetCount(google.protobuf.Empty) returns (CountResponse);
-  // rpc GreetStream(GreetingRequest) returns (stream CountResponse);
+  // Simulate renaming "Greet" to "Greetings" - this represents a backwards-incompatible change
+  // rpc Greet(GreetingRequest) returns (GreetingResponse);
+  rpc Greetings(GreetingRequest) returns (GreetingResponse);
+  rpc GetCount(google.protobuf.Empty) returns (CountResponse);
+  rpc GreetStream(GreetingRequest) returns (stream CountResponse);
 }
 
 message GreetingRequest {

--- a/crates/pb/tests/proto/greeter-v2_incompatible.proto
+++ b/crates/pb/tests/proto/greeter-v2_incompatible.proto
@@ -5,7 +5,7 @@ import "google/protobuf/empty.proto";
 package greeter;
 
 service Greeter {
-  rpc Greet(GreetingRequest) returns (GreetingResponse);
+  rpc Greetings(GreetingRequest) returns (GreetingResponse); // Renamed from "Greet" - incompatible change
   // rpc GetCount(google.protobuf.Empty) returns (CountResponse);
   // rpc GreetStream(GreetingRequest) returns (stream CountResponse);
 }

--- a/crates/pb/tests/proto/greeter.proto
+++ b/crates/pb/tests/proto/greeter.proto
@@ -6,8 +6,8 @@ package greeter;
 
 service Greeter {
   rpc Greet(GreetingRequest) returns (GreetingResponse);
-  // rpc GetCount(google.protobuf.Empty) returns (CountResponse);
-  // rpc GreetStream(GreetingRequest) returns (stream CountResponse);
+  rpc GetCount(google.protobuf.Empty) returns (CountResponse);
+  rpc GreetStream(GreetingRequest) returns (stream CountResponse);
 }
 
 message GreetingRequest {

--- a/crates/schema-impl/src/lib.rs
+++ b/crates/schema-impl/src/lib.rs
@@ -60,8 +60,9 @@ pub enum RegistrationError {
     InvalidSubscription(anyhow::Error),
     #[error("a subscription with the same id {0} already exists in the registry")]
     OverrideSubscription(EndpointId),
-    #[error("a schema update is not backwards compatible with the existing definition")]
-    IncompatibleSchemaEvolution(String, Vec<String>),
+    #[error("schema update removes methods from an existing service endpoint")]
+    #[code(restate_errors::META0006)]
+    IncompatibleSchemaMissingMethod(String, Vec<String>),
 }
 
 /// Insert (or replace) service
@@ -139,13 +140,13 @@ impl Schemas {
         endpoint_metadata: EndpointMetadata,
         services: Vec<ServiceRegistrationRequest>,
         descriptor_pool: DescriptorPool,
-        allow_overwrite: bool,
+        force: bool,
     ) -> Result<Vec<SchemasUpdateCommand>, RegistrationError> {
         self.0.load().compute_new_endpoint_updates(
             endpoint_metadata,
             services,
             descriptor_pool,
-            allow_overwrite,
+            force,
         )
     }
 

--- a/crates/schema-impl/src/lib.rs
+++ b/crates/schema-impl/src/lib.rs
@@ -60,6 +60,8 @@ pub enum RegistrationError {
     InvalidSubscription(anyhow::Error),
     #[error("a subscription with the same id {0} already exists in the registry")]
     OverrideSubscription(EndpointId),
+    #[error("a schema update is not backwards compatible with the existing definition")]
+    IncompatibleSchemaEvolution(String, Vec<String>),
 }
 
 /// Insert (or replace) service


### PR DESCRIPTION
**WIP**

Re-opened https://github.com/restatedev/restate/pull/879/ with no changes other than rebase on `main`.

- [ ] Fix using the TMPDIR for unwanted protobuf build byproducts
- [ ] Validate input/output messages for backwards compatibility
- [ ] Revisit how we build up mock `DescriptorPool`s - or at least add some sanity checks that the shape of the service definition matches what we expect in terms of methods

Related: https://github.com/restatedev/restate/issues/226, https://github.com/restatedev/restate/issues/930