### PR TITLE
Cross compilation + NPM publish

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -128,6 +128,10 @@ jobs:
             export node_version
             # set the package name
             export node_pkg="${bin}-${node_os}-${node_arch}"
+            if npm view "@restatedev/${node_pkg}@${node_version}"
+            then
+              continue
+            fi
             # create the package directory
             mkdir -p "${node_pkg}/bin"
             # generate package.json from the template
@@ -164,6 +168,10 @@ jobs:
           cd npm
           for bin in restate restate-server
           do
+            if npm view "@restatedev/${bin}@${node_version}"
+            then
+              continue
+            fi
             pushd "${bin}"
             sed -i "s/0.5.1/${node_version}/" package.json
             npm install

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -19,20 +19,24 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.build.os }}
     strategy:
       matrix:
         build:
           - target: aarch64-apple-darwin
+            os: macos-12
             node_arch: arm64
             node_os: darwin
           - target: x86_64-apple-darwin
+            os: macos-12
             node_arch: x64
             node_os: darwin
           - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
             node_arch: x64
             node_os: linux
           - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
             node_arch: arm64
             node_os: linux
     env:
@@ -42,13 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: ./.github/actions/clean-runner
 
       - name: Install Rust toolchain
@@ -56,6 +53,11 @@ jobs:
         with:
           # need to provide a toolchain version because this action cannot read rust-toolchain.toml. See https://github.com/actions-rs/toolchain/issues/126
           toolchain: stable
+
+      # necessary because the toolchain@v1 action would install this target for stable only
+      - name: Install aarch64-apple-darwin Rust toolchain
+        if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
+        run: rustup target add aarch64-apple-darwin
 
       - uses: actions/setup-node@v3
         with:
@@ -68,17 +70,12 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
 
-      - name: Install Cross
-        run: cargo install cross
-
       - name: Install cargo-license
         run: cargo install cargo-license
 
-      - name: Install ldid for signing
-        if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
-        run: |
-          curl -L https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_linux_x86_64 -o ldid
-          chmod +x ldid
+      - name: Install protoc
+        if: ${{ matrix.build.os == 'macos-12' }} # installed in cross docker image in linux builds
+        uses: ./.github/actions/install-protoc
 
       - name: Setup just
         uses: extractions/setup-just@v1
@@ -88,16 +85,33 @@ jobs:
       - name: Generate notice
         run: just notice-file
 
-      - name: Compile binaries
+      - name: Compile Mac binaries
+        if: ${{ matrix.build.os == 'macos-12' }}
+        uses: actions-rs/cargo@v1
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.14.0
+          CC: sccache clang -target ${{ matrix.build.target }}
+          CXX: sccache clang++ -target ${{ matrix.build.target }}
+        with:
+          command: build
+          args: --release --bins --target ${{ matrix.build.target }}
+          use-cross: ${{ matrix.build.os == 'ubuntu-22.04' }}
+
+      - name: Compile Linux binaries
+        if: ${{ matrix.build.os == 'ubuntu-22.04' }}
+        uses: actions-rs/cargo@v1
         env:
           RUSTC_WRAPPER: "" # Cross.toml sets it back
-        run: just target=${{ matrix.build.target }} cross-build --bins --release
+        with:
+          command: build
+          args: --release --bins --target ${{ matrix.build.target }}
+          use-cross: true
 
-      - name: Sign binary with ldid
-        if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
+      - name: Sign binaries
+        if: ${{ matrix.build.os == 'macos-12' }}
         run: |
-          ./ldid -S target/${{ matrix.build.target }}/release/restate-server
-          ./ldid -S target/${{ matrix.build.target }}/release/restate
+          codesign -s - target/${{ matrix.build.target }}/release/restate-server
+          codesign -s - target/${{ matrix.build.target }}/release/restate
 
       - name: Move binary
         run: cp target/${{ matrix.build.target }}/release/restate-server target/${{ matrix.build.target }}/release/restate .
@@ -150,7 +164,7 @@ jobs:
 
   publish-npm-base:
     needs: build-and-npm-publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -44,9 +44,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           # need to provide a toolchain version because this action cannot read rust-toolchain.toml. See https://github.com/actions-rs/toolchain/issues/126
+          # note, however, that this does not just install stable but also whatever is in rust-toolchain.toml, which is what we will use
           toolchain: stable
 
-      # necessary because the toolchain@v1 action would install this target for stable only
+      # necessary because the toolchain@v1 action would install this target for stable only, whereas this command respects rust-toolchain.toml
       - name: Install aarch64-apple-darwin Rust toolchain
         if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
         run: rustup target add aarch64-apple-darwin
@@ -77,12 +78,12 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.14.0
+          # -target seems to be needed here, or librdkafka will always be built for amd64
           CC: sccache clang -target ${{ matrix.build.target }}
           CXX: sccache clang++ -target ${{ matrix.build.target }}
         with:
           command: build
           args: --release --bins --target ${{ matrix.build.target }}
-          use-cross: false
 
       - name: Compile Linux binaries
         if: ${{ matrix.build.os == 'ubuntu-latest' }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -187,7 +187,7 @@ jobs:
               continue
             fi
             pushd "${bin}"
-            sed -i "s/0.5.1/${node_version}/" package.json
+            sed -i "s/\"version\": \".*\",/\"version\": \"${node_version}\",/" package.json
             npm install
             npm run build
             npm publish --access public

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 jobs:
-  build-and-npm-publish:
+  build:
     permissions:
       contents: read
       packages: read
@@ -25,20 +25,12 @@ jobs:
         build:
           - target: aarch64-apple-darwin
             os: macos-12
-            node_arch: arm64
-            node_os: darwin
           - target: x86_64-apple-darwin
             os: macos-12
-            node_arch: x64
-            node_os: darwin
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
-            node_arch: x64
-            node_os: linux
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
-            node_arch: arm64
-            node_os: linux
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: "sccache"
@@ -58,11 +50,6 @@ jobs:
       - name: Install aarch64-apple-darwin Rust toolchain
         if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
         run: rustup target add aarch64-apple-darwin
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
@@ -125,73 +112,3 @@ jobs:
           path: restate.${{ matrix.build.target }}.tar.gz
           retention-days: 1
           if-no-files-found: error
-
-      - name: Publish to NPM
-        shell: bash
-        run: |
-          cd npm
-          for bin in restate restate-server
-          do
-            export node_os="${{ matrix.build.node_os }}"
-            export node_os
-            node_arch="${{ matrix.build.node_arch }}"
-            export node_arch
-            # set the version
-            node_version="${{ inputs.version }}"
-            node_version="${node_version#v}"
-            export node_version
-            # set the package name
-            export node_pkg="${bin}-${node_os}-${node_arch}"
-            if npm view "@restatedev/${node_pkg}@${node_version}"
-            then
-              continue
-            fi
-            # create the package directory
-            mkdir -p "${node_pkg}/bin"
-            # generate package.json from the template
-            envsubst < package.json.tmpl > "${node_pkg}/package.json"
-            # copy the binary into the package
-            cp "../target/${{ matrix.build.target }}/release/${bin}" "${node_pkg}/bin"
-            cp ../NOTICE "${node_pkg}"
-            cp ../LICENSE "${node_pkg}"
-            # publish the package
-            pushd "${node_pkg}"
-            npm publish --access public
-            popd
-          done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-npm-base:
-    needs: build-and-npm-publish
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.x"
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Publish to npm
-        shell: bash
-        run: |
-          node_version="${{ inputs.version }}"
-          node_version="${node_version#v}"
-          cd npm
-          for bin in restate restate-server
-          do
-            if npm view "@restatedev/${bin}@${node_version}"
-            then
-              continue
-            fi
-            pushd "${bin}"
-            sed -i "s/\"version\": \".*\",/\"version\": \"${node_version}\",/" package.json
-            npm install
-            npm run build
-            npm publish --access public
-            popd
-          done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -134,6 +134,8 @@ jobs:
             envsubst < package.json.tmpl > "${node_pkg}/package.json"
             # copy the binary into the package
             cp "../target/${{ matrix.build.target }}/release/${bin}" "${node_pkg}/bin"
+            cp ../NOTICE "${node_pkg}"
+            cp ../LICENSE "${node_pkg}"
             # publish the package
             pushd "${node_pkg}"
             npm publish --access public

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -24,13 +24,13 @@ jobs:
       matrix:
         build:
           - target: aarch64-apple-darwin
-            os: macos-12
+            os: macos-latest
           - target: x86_64-apple-darwin
-            os: macos-12
+            os: macos-latest
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-latest
     env:
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: "sccache"
@@ -61,7 +61,7 @@ jobs:
         run: cargo install cargo-license
 
       - name: Install protoc
-        if: ${{ matrix.build.os == 'macos-12' }} # installed in cross docker image in linux builds
+        if: ${{ matrix.build.os == 'macos-latest' }} # installed in cross docker image in linux builds
         uses: ./.github/actions/install-protoc
 
       - name: Setup just
@@ -73,7 +73,7 @@ jobs:
         run: just notice-file
 
       - name: Compile Mac binaries
-        if: ${{ matrix.build.os == 'macos-12' }}
+        if: ${{ matrix.build.os == 'macos-latest' }}
         uses: actions-rs/cargo@v1
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.14.0
@@ -82,10 +82,10 @@ jobs:
         with:
           command: build
           args: --release --bins --target ${{ matrix.build.target }}
-          use-cross: ${{ matrix.build.os == 'ubuntu-22.04' }}
+          use-cross: false
 
       - name: Compile Linux binaries
-        if: ${{ matrix.build.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.build.os == 'ubuntu-latest' }}
         uses: actions-rs/cargo@v1
         env:
           RUSTC_WRAPPER: "" # Cross.toml sets it back
@@ -95,7 +95,7 @@ jobs:
           use-cross: true
 
       - name: Sign binaries
-        if: ${{ matrix.build.os == 'macos-12' }}
+        if: ${{ matrix.build.os == 'macos-latest' }}
         run: |
           codesign -s - target/${{ matrix.build.target }}/release/restate-server
           codesign -s - target/${{ matrix.build.target }}/release/restate

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,173 @@
+name: Build binaries
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'version to label binaries'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version to label binaries'
+        required: true
+        type: string
+
+jobs:
+  build-and-npm-publish:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        build:
+          - target: aarch64-apple-darwin
+            node_arch: arm64
+            node_os: darwin
+          - target: x86_64-apple-darwin
+            node_arch: x64
+            node_os: darwin
+          - target: x86_64-unknown-linux-gnu
+            node_arch: x64
+            node_os: linux
+          - target: aarch64-unknown-linux-gnu
+            node_arch: arm64
+            node_os: linux
+    env:
+      RUST_BACKTRACE: full
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/clean-runner
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          # need to provide a toolchain version because this action cannot read rust-toolchain.toml. See https://github.com/actions-rs/toolchain/issues/126
+          toolchain: stable
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Cross
+        run: cargo install cross
+
+      - name: Install cargo-license
+        run: cargo install cargo-license
+
+      - name: Install ldid for signing
+        if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
+        run: |
+          curl -L https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_linux_x86_64 -o ldid
+          chmod +x ldid
+
+      - name: Setup just
+        uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate notice
+        run: just notice-file
+
+      - name: Compile binaries
+        env:
+          RUSTC_WRAPPER: "" # Cross.toml sets it back
+        run: just target=${{ matrix.build.target }} cross-build --bins --release
+
+      - name: Sign binary with ldid
+        if: ${{ matrix.build.target == 'aarch64-apple-darwin' }}
+        run: |
+          ./ldid -S target/${{ matrix.build.target }}/release/restate-server
+          ./ldid -S target/${{ matrix.build.target }}/release/restate
+
+      - name: Move binary
+        run: cp target/${{ matrix.build.target }}/release/restate-server target/${{ matrix.build.target }}/release/restate .
+
+      - name: Create tar
+        run: tar -cvzf restate.${{ matrix.build.target }}.tar.gz LICENSE NOTICE restate-server restate
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: restate.${{ matrix.build.target }}.tar.gz
+          path: restate.${{ matrix.build.target }}.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Publish to NPM
+        shell: bash
+        run: |
+          cd npm
+          for bin in restate restate-server
+          do
+            export node_os="${{ matrix.build.node_os }}"
+            export node_os
+            node_arch="${{ matrix.build.node_arch }}"
+            export node_arch
+            # set the version
+            node_version="${{ inputs.version }}"
+            node_version="${node_version#v}"
+            export node_version
+            # set the package name
+            export node_pkg="${bin}-${node_os}-${node_arch}"
+            # create the package directory
+            mkdir -p "${node_pkg}/bin"
+            # generate package.json from the template
+            envsubst < package.json.tmpl > "${node_pkg}/package.json"
+            # copy the binary into the package
+            cp "../target/${{ matrix.build.target }}/release/${bin}" "${node_pkg}/bin"
+            # publish the package
+            pushd "${node_pkg}"
+            npm publish --access public
+            popd
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-npm-base:
+    needs: build-and-npm-publish
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        shell: bash
+        run: |
+          node_version="${{ inputs.version }}"
+          node_version="${node_version#v}"
+          cd npm
+          for bin in restate restate-server
+          do
+            pushd "${bin}"
+            sed -i "s/0.5.1/${node_version}/" package.json
+            npm install
+            npm run build
+            npm publish --access public
+            popd
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         build:
@@ -67,6 +67,7 @@ jobs:
             cp "${bin}" "${node_pkg}/bin"
             cp NOTICE "${node_pkg}"
             cp LICENSE "${node_pkg}"
+            cp README.md "${node_pkg}"
             # publish the package
             pushd "${node_pkg}"
             npm publish --access public
@@ -77,7 +78,7 @@ jobs:
 
   publish-npm-base:
     needs: build-and-npm-publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -101,6 +102,7 @@ jobs:
             fi
             pushd "${bin}"
             sed -i "s/\"version\": \".*\",/\"version\": \"${node_version}\",/" package.json
+            curl https://raw.githubusercontent.com/restatedev/restate/main/README.md -o README.md
             npm install
             npm run build
             npm publish --access public

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,110 @@
+name: Publish npm binary packages
+
+on:
+  workflow_call:
+
+jobs:
+  publish-npm-binaries:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        build:
+          - target: aarch64-apple-darwin
+            node_arch: arm64
+            node_os: darwin
+          - target: x86_64-apple-darwin
+            node_arch: x64
+            node_os: darwin
+          - target: x86_64-unknown-linux-gnu
+            node_arch: x64
+            node_os: linux
+          - target: aarch64-unknown-linux-gnu
+            node_arch: arm64
+            node_os: linux
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download binary build from in-progress workflow
+        uses: actions/download-artifact@v3
+        with:
+          name: restate.${{ matrix.build.target }}.tar.gz
+          path: restate.${{ matrix.build.target }}.tar.gz
+
+      - name: Extract binaries
+        run: tar -xvzf restate.${{ matrix.build.target }}.tar.gz
+
+      - name: Publish to NPM
+        shell: bash
+        run: |
+          cd npm
+          for bin in restate restate-server
+          do
+            export node_os="${{ matrix.build.node_os }}"
+            export node_os
+            node_arch="${{ matrix.build.node_arch }}"
+            export node_arch
+            # set the version
+            node_version="${{ inputs.version }}"
+            node_version="${node_version#v}"
+            export node_version
+            # set the package name
+            export node_pkg="${bin}-${node_os}-${node_arch}"
+            if npm view "@restatedev/${node_pkg}@${node_version}"
+            then
+              continue
+            fi
+            # create the package directory
+            mkdir -p "${node_pkg}/bin"
+            # generate package.json from the template
+            envsubst < package.json.tmpl > "${node_pkg}/package.json"
+            # copy the binary into the package
+            cp "${bin}" "${node_pkg}/bin"
+            cp NOTICE "${node_pkg}"
+            cp LICENSE "${node_pkg}"
+            # publish the package
+            pushd "${node_pkg}"
+            npm publish --access public
+            popd
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-npm-base:
+    needs: build-and-npm-publish
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        shell: bash
+        run: |
+          node_version="${{ inputs.version }}"
+          node_version="${node_version#v}"
+          cd npm
+          for bin in restate restate-server
+          do
+            if npm view "@restatedev/${bin}@${node_version}"
+            then
+              continue
+            fi
+            pushd "${bin}"
+            sed -i "s/\"version\": \".*\",/\"version\": \"${node_version}\",/" package.json
+            npm install
+            npm run build
+            npm publish --access public
+            popd
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,15 +1253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codederror"
 version = "0.5.0"
 dependencies = [
@@ -4038,7 +4029,6 @@ version = "4.7.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
 dependencies = [
- "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,76 @@
+[build]
+pre-build = [
+    "apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*",
+    "curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip",
+    "unzip -o protoc-21.12-linux-x86_64.zip -d /usr/local bin/protoc",
+    "unzip -o protoc-21.12-linux-x86_64.zip -d /usr/local 'include/*'",
+    "rm -f protoc-21.12-linux-x86_64.zip",
+    "chmod +x /usr/local/bin/protoc",
+    "cd $(mktemp -d) && curl -LSfs https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-unknown-linux-musl.tar.gz -o sccache.tar.gz && tar -xvf sccache.tar.gz && rm sccache.tar.gz && cp sccache-v0.7.4-x86_64-unknown-linux-musl/sccache /usr/bin/sccache",
+]
+
+[target.aarch64-apple-darwin]
+image = "ghcr.io/jackkleeman/cross:aarch64-apple-darwin"
+
+[target.aarch64-apple-darwin.env]
+passthrough = [
+    "BINDGEN_EXTRA_CLANG_ARGS=--sysroot /opt/osxcross",
+    "MACOSX_DEPLOYMENT_TARGET=10.14.0",
+    "CC=/usr/bin/sccache oa64-clang",
+    "CXX=/usr/bin/sccache oa64-clang++",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RUNTIME_TOKEN",
+    "SCCACHE_PATH",
+    "SCCACHE_DIR",
+    "SCCACHE_GHA_ENABLED",
+    "RUSTC_WRAPPER=/usr/bin/sccache"
+]
+
+[target.x86_64-apple-darwin]
+image = "ghcr.io/jackkleeman/cross:x86_64-apple-darwin"
+
+[target.x86_64-apple-darwin.env]
+passthrough = [
+    "BINDGEN_EXTRA_CLANG_ARGS=--sysroot=/opt/osxcross",
+    "MACOSX_DEPLOYMENT_TARGET=10.14.0",
+    "CC=/usr/bin/sccache o64-clang",
+    "CXX=/usr/bin/sccache o64-clang++",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RUNTIME_TOKEN",
+    "SCCACHE_PATH",
+    "SCCACHE_DIR",
+    "SCCACHE_GHA_ENABLED",
+    "RUSTC_WRAPPER=/usr/bin/sccache"
+]
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = [
+    "CC_aarch64_unknown_linux_gnu=/usr/bin/sccache aarch64-linux-gnu-gcc",
+    "CXX_aarch64_unknown_linux_gnu=/usr/bin/sccache aarch64-linux-gnu-g++",
+    "CC=/usr/bin/sccache aarch64-linux-gnu-gcc",
+    "CXX=/usr/bin/sccache aarch64-linux-gnu-g++",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RUNTIME_TOKEN",
+    "SCCACHE_PATH",
+    "SCCACHE_DIR",
+    "SCCACHE_GHA_ENABLED",
+    "RUSTC_WRAPPER=/usr/bin/sccache"
+]
+
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
+
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = [
+    "CC=/usr/bin/sccache gcc",
+    "CXX=/usr/bin/sccache g++",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RUNTIME_TOKEN",
+    "SCCACHE_PATH",
+    "SCCACHE_DIR",
+    "SCCACHE_GHA_ENABLED",
+    "RUSTC_WRAPPER=/usr/bin/sccache"
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -9,40 +9,6 @@ pre-build = [
     "cd $(mktemp -d) && curl -LSfs https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-unknown-linux-musl.tar.gz -o sccache.tar.gz && tar -xvf sccache.tar.gz && rm sccache.tar.gz && cp sccache-v0.7.4-x86_64-unknown-linux-musl/sccache /usr/bin/sccache",
 ]
 
-[target.aarch64-apple-darwin]
-image = "ghcr.io/restatedev/cross:aarch64-apple-darwin"
-
-[target.aarch64-apple-darwin.env]
-passthrough = [
-    "BINDGEN_EXTRA_CLANG_ARGS=--sysroot /opt/osxcross",
-    "MACOSX_DEPLOYMENT_TARGET=10.14.0",
-    "CC=/usr/bin/sccache oa64-clang",
-    "CXX=/usr/bin/sccache oa64-clang++",
-    "ACTIONS_CACHE_URL",
-    "ACTIONS_RUNTIME_TOKEN",
-    "SCCACHE_PATH",
-    "SCCACHE_DIR",
-    "SCCACHE_GHA_ENABLED",
-    "RUSTC_WRAPPER=/usr/bin/sccache"
-]
-
-[target.x86_64-apple-darwin]
-image = "ghcr.io/restatedev/cross:x86_64-apple-darwin"
-
-[target.x86_64-apple-darwin.env]
-passthrough = [
-    "BINDGEN_EXTRA_CLANG_ARGS=--sysroot=/opt/osxcross",
-    "MACOSX_DEPLOYMENT_TARGET=10.14.0",
-    "CC=/usr/bin/sccache o64-clang",
-    "CXX=/usr/bin/sccache o64-clang++",
-    "ACTIONS_CACHE_URL",
-    "ACTIONS_RUNTIME_TOKEN",
-    "SCCACHE_PATH",
-    "SCCACHE_DIR",
-    "SCCACHE_GHA_ENABLED",
-    "RUSTC_WRAPPER=/usr/bin/sccache"
-]
-
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -10,7 +10,7 @@ pre-build = [
 ]
 
 [target.aarch64-apple-darwin]
-image = "ghcr.io/jackkleeman/cross:aarch64-apple-darwin"
+image = "ghcr.io/restatedev/cross:aarch64-apple-darwin"
 
 [target.aarch64-apple-darwin.env]
 passthrough = [
@@ -27,7 +27,7 @@ passthrough = [
 ]
 
 [target.x86_64-apple-darwin]
-image = "ghcr.io/jackkleeman/cross:x86_64-apple-darwin"
+image = "ghcr.io/restatedev/cross:x86_64-apple-darwin"
 
 [target.x86_64-apple-darwin.env]
 passthrough = [

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -25,7 +25,7 @@ derive_builder = { workspace = true }
 drain = { workspace = true }
 opentelemetry_api = { workspace = true }
 prost = { workspace = true }
-rdkafka = { version = "0.34", features = ["cmake-build"] }
+rdkafka = { version = "0.34", features = ["libz-static"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -88,21 +88,8 @@ build-tools *flags: (_target-installed target)
     cd {{justfile_directory()}}/tools/xtask; cargo build {{ _target-option }} {{ _features }} {{ flags }}
     cd {{justfile_directory()}}/tools/service-protocol-wireshark-dissector; cargo build {{ _target-option }} {{ _features }} {{ flags }}
 
-# Might be able to use cross-rs at some point but for now it could not handle a container image that
-# has a rust toolchain installed. Alternatively, we can create a separate cross-rs builder image.
 cross-build *flags:
-    #!/usr/bin/env bash
-    if [[ {{ target }} =~ "linux" ]]; then
-      docker run --rm -v `pwd`:/restate:Z -w /restate {{ dev_tools_image }} just _resolved_target={{ target }} features={{ features }} build {{ flags }}
-    elif [[ {{ target }} =~ "darwin" ]]; then
-      if [[ {{ os() }} != "macos" ]]; then
-        echo "Cannot built macos target on non-macos host";
-      else
-        just _resolved_target={{ target }} features={{ features }} build {{ flags }};
-      fi
-    else
-      echo "Unsupported target: {{ target }}";
-    fi
+    cross build --target {{ target }} {{ _features }} {{ flags }}
 
 print-target:
     @echo {{ _resolved_target }}

--- a/justfile
+++ b/justfile
@@ -88,8 +88,21 @@ build-tools *flags: (_target-installed target)
     cd {{justfile_directory()}}/tools/xtask; cargo build {{ _target-option }} {{ _features }} {{ flags }}
     cd {{justfile_directory()}}/tools/service-protocol-wireshark-dissector; cargo build {{ _target-option }} {{ _features }} {{ flags }}
 
+# Might be able to use cross-rs at some point but for now it could not handle a container image that
+# has a rust toolchain installed. Alternatively, we can create a separate cross-rs builder image.
 cross-build *flags:
-    cross build --target {{ target }} {{ _features }} {{ flags }}
+    #!/usr/bin/env bash
+    if [[ {{ target }} =~ "linux" ]]; then
+      docker run --rm -v `pwd`:/restate:Z -w /restate {{ dev_tools_image }} just _resolved_target={{ target }} features={{ features }} build {{ flags }}
+    elif [[ {{ target }} =~ "darwin" ]]; then
+      if [[ {{ os() }} != "macos" ]]; then
+        echo "Cannot built macos target on non-macos host";
+      else
+        just _resolved_target={{ target }} features={{ features }} build {{ flags }};
+      fi
+    else
+      echo "Unsupported target: {{ target }}";
+    fi
 
 print-target:
     @echo {{ _resolved_target }}

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+lib

--- a/npm/package.json.tmpl
+++ b/npm/package.json.tmpl
@@ -3,7 +3,7 @@
   "version": "${node_version}",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/restate/restate.git"
+    "url": "git+https://github.com/restatedev/restate.git"
   },
   "publishConfig": {
     "@restatedev:registry": "https://registry.npmjs.org"

--- a/npm/package.json.tmpl
+++ b/npm/package.json.tmpl
@@ -1,0 +1,21 @@
+{
+  "name": "@restatedev/${node_pkg}",
+  "version": "${node_version}",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/restate/restate.git"
+  },
+  "publishConfig": {
+    "@restatedev:registry": "https://registry.npmjs.org"
+  },
+  "author": "Restate Developers",
+  "license": "BSL",
+  "email": "code@restate.dev",
+  "homepage": "https://github.com/restatedev/restate#readme",
+  "os": [
+    "${node_os}"
+  ],
+  "cpu": [
+    "${node_arch}"
+  ]
+}

--- a/npm/restate-server/package.json
+++ b/npm/restate-server/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@restatedev/restate-server",
+  "description": "The Restate runtime",
+  "version": "0.5.1",
+  "bin": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/restate/restate.git"
+  },
+  "publishConfig": {
+    "@restatedev:registry": "https://registry.npmjs.org"
+  },
+  "author": "Restate Developers",
+  "license": "BSL",
+  "email": "code@restate.dev",
+  "homepage": "https://github.com/restatedev/restate#readme",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "build": "tsc",
+    "dev": "npm run build && node lib/index.js"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.48.0",
+    "@typescript-eslint/parser": "^5.48.0",
+    "eslint": "^8.31.0",
+    "typescript": "^4.9.4"
+  },
+  "optionalDependencies": {
+    "@restatedev/restate-server-linux-x86_64": "0.5.1",
+    "@restatedev/restate-server-linux-arm64": "0.5.1",
+    "@restatedev/restate-server-darwin-x86_64": "0.5.1",
+    "@restatedev/restate-server-darwin-arm64": "0.5.1"
+  }
+}

--- a/npm/restate-server/package.json
+++ b/npm/restate-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/restate-server",
-  "description": "The Restate runtime",
+  "description": "The Restate server",
   "version": "0.5.1",
   "bin": "lib/index.js",
   "repository": {

--- a/npm/restate-server/package.json
+++ b/npm/restate-server/package.json
@@ -5,7 +5,7 @@
   "bin": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/restate/restate.git"
+    "url": "git+https://github.com/restatedev/restate.git"
   },
   "publishConfig": {
     "@restatedev:registry": "https://registry.npmjs.org"

--- a/npm/restate-server/src/index.ts
+++ b/npm/restate-server/src/index.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "child_process";
+import os from 'node:os';
+
+function getExePath() {
+  const arch = os.arch();
+  const op = os.platform();
+
+  try {
+    return require.resolve(`@restatedev/restate-server-${op}-${arch}/bin/restate-server`);
+  } catch (e) {
+    throw new Error(
+      `Couldn't find application binary inside node_modules for ${op}-${arch}`
+    );
+  }
+}
+
+function run() {
+  const args = process.argv.slice(2);
+  const processResult = spawnSync(getExePath(), args, { stdio: "inherit" });
+  process.exit(processResult.status ?? 0);
+}
+
+run();

--- a/npm/restate-server/tsconfig.json
+++ b/npm/restate-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "baseUrl": "./",
+    "outDir": "lib",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/npm/restate/package.json
+++ b/npm/restate/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@restatedev/restate",
+  "description": "The Restate CLI",
+  "version": "0.5.1",
+  "bin": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/restate/restate.git"
+  },
+  "publishConfig": {
+    "@restatedev:registry": "https://registry.npmjs.org"
+  },
+  "author": "Restate Developers",
+  "license": "BSL",
+  "email": "code@restate.dev",
+  "homepage": "https://github.com/restatedev/restate#readme",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "build": "tsc",
+    "dev": "npm run build && node lib/index.js"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.48.0",
+    "@typescript-eslint/parser": "^5.48.0",
+    "eslint": "^8.31.0",
+    "typescript": "^4.9.4"
+  },
+  "optionalDependencies": {
+    "@restatedev/restate-linux-x86_64": "0.5.1",
+    "@restatedev/restate-linux-arm64": "0.5.1",
+    "@restatedev/restate-darwin-x86_64": "0.5.1",
+    "@restatedev/restate-darwin-arm64": "0.5.1"
+  }
+}

--- a/npm/restate/package.json
+++ b/npm/restate/package.json
@@ -5,7 +5,7 @@
   "bin": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/restate/restate.git"
+    "url": "git+https://github.com/restatedev/restate.git"
   },
   "publishConfig": {
     "@restatedev:registry": "https://registry.npmjs.org"

--- a/npm/restate/src/index.ts
+++ b/npm/restate/src/index.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "child_process";
+import os from 'node:os';
+
+function getExePath() {
+  const arch = os.arch();
+  const op = os.platform();
+
+  try {
+    return require.resolve(`@restatedev/restate-${op}-${arch}/bin/restate`);
+  } catch (e) {
+    throw new Error(
+      `Couldn't find application binary inside node_modules for ${op}-${arch}`
+    );
+  }
+}
+
+function run() {
+  const args = process.argv.slice(2);
+  const processResult = spawnSync(getExePath(), args, { stdio: "inherit" });
+  process.exit(processResult.status ?? 0);
+}
+
+run();

--- a/npm/restate/tsconfig.json
+++ b/npm/restate/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "baseUrl": "./",
+    "outDir": "lib",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Adds npm packages for each target for cli and server, and base packages that import these using optional dependencies (https://blog.orhun.dev/packaging-rust-for-npm/)

Cross.toml had to be set with some particular env vars to get cross compiles working properly (and sccached), and also had to disabvle the experimental cmake build for rdkafka, and ensure libz is statically compiled there too

Will plumb this into the release process as a followup