### PR TITLE
[CLI] Discover sets url scheme if unset

### DIFF
--- a/cli/src/commands/services/discover.rs
+++ b/cli/src/commands/services/discover.rs
@@ -106,7 +106,15 @@ fn parse_endpoint(
     let endpoint = if raw.starts_with("arn:") {
         Endpoint::Lambda(LambdaARN::from_str(raw)?)
     } else {
-        let uri = Uri::from_str(raw).map_err(|e| format!("invalid URL({e})"))?;
+        let mut uri = Uri::from_str(raw).map_err(|e| format!("invalid URL({e})"))?;
+        let mut parts = uri.into_parts();
+        if parts.scheme.is_none() {
+            parts.scheme = Some(http::uri::Scheme::HTTP);
+        }
+        if parts.path_and_query.is_none() {
+            parts.path_and_query = Some(http::uri::PathAndQuery::from_str("/")?);
+        }
+        uri = Uri::from_parts(parts)?;
         Endpoint::Uri(uri)
     };
     Ok(endpoint)


### PR DESCRIPTION
[CLI] Discover sets url scheme if unset

This closes #937 that reports that a missing URI scheme would fail discovery on the server. The proper solution should be on the side of the meta service
but for now, this patches the URI with `http` and a trailing `/` if unset.

Test Plan:

```sh
# All those options now work.

> restate svc discover localhost:8090
> restate svc discover http://localhost:8090
> restate svc discover http://localhost:8090/
```
