### PR TITLE
Add InboxTable::contains method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5113,6 +5113,7 @@ dependencies = [
  "futures",
  "futures-util",
  "num-bigint",
+ "once_cell",
  "paste",
  "prost 0.12.3",
  "restate-errors",

--- a/crates/storage-rocksdb/Cargo.toml
+++ b/crates/storage-rocksdb/Cargo.toml
@@ -33,8 +33,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 uuid = { workspace = true }
+once_cell = "1.18.0"
 
 [dev-dependencies]
+restate-types = { workspace = true, features = ["mocks"] }
+
 criterion = { workspace = true, features = ["async_tokio"] }
 num-bigint = "0.4"
 tempfile = { workspace = true }

--- a/crates/storage-rocksdb/tests/inbox_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/inbox_table_test/mod.rs
@@ -13,22 +13,13 @@ use once_cell::sync::Lazy;
 use restate_storage_api::inbox_table::{InboxEntry, InboxTable};
 use restate_storage_api::Transaction;
 use restate_storage_rocksdb::RocksDBStorage;
-use restate_types::identifiers::ServiceId;
+use restate_types::identifiers::{InvocationId, ServiceId};
 
 static INBOX_ENTRIES: Lazy<Vec<InboxEntry>> = Lazy::new(|| {
     vec![
-        InboxEntry::new(
-            7,
-            mock_service_invocation(ServiceId::new( "svc-1", "key-1")),
-        ),
-        InboxEntry::new(
-            8,
-            mock_service_invocation(ServiceId::new("svc-1", "key-1")),
-        ),
-        InboxEntry::new(
-            9,
-            mock_service_invocation(ServiceId::new("svc-2", "key-1")),
-        ),
+        InboxEntry::new(7, mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
+        InboxEntry::new(8, mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
+        InboxEntry::new(9, mock_service_invocation(ServiceId::new("svc-2", "key-1"))),
     ]
 });
 
@@ -41,23 +32,15 @@ async fn populate_data<T: InboxTable>(table: &mut T) {
 }
 
 async fn find_the_next_message_in_an_inbox<T: InboxTable>(table: &mut T) {
-    let result = table
-        .peek_inbox(INBOX_ENTRIES[0].service_id())
-        .await;
+    let result = table.peek_inbox(INBOX_ENTRIES[0].service_id()).await;
 
-    assert_eq!(
-        result.unwrap(),
-        Some(INBOX_ENTRIES[0].clone())
-    );
+    assert_eq!(result.unwrap(), Some(INBOX_ENTRIES[0].clone()));
 }
 
 async fn get_svc_inbox<T: InboxTable>(table: &mut T) {
     let stream = table.inbox(INBOX_ENTRIES[0].service_id());
 
-    let vec = vec![
-        INBOX_ENTRIES[0].clone(),
-        INBOX_ENTRIES[1].clone(),
-    ];
+    let vec = vec![INBOX_ENTRIES[0].clone(), INBOX_ENTRIES[1].clone()];
 
     assert_stream_eq(stream, vec).await;
 }
@@ -69,14 +52,65 @@ async fn delete_entry<T: InboxTable>(table: &mut T) {
 }
 
 async fn peek_after_delete<T: InboxTable>(table: &mut T) {
-    let result = table
-        .peek_inbox(INBOX_ENTRIES[0].service_id())
-        .await;
+    let result = table.peek_inbox(INBOX_ENTRIES[0].service_id()).await;
 
-    assert_eq!(
-        result.unwrap(),
-        Some(INBOX_ENTRIES[1].clone())
-    );
+    assert_eq!(result.unwrap(), Some(INBOX_ENTRIES[1].clone()));
+}
+
+async fn contains_inbox_entries<T: InboxTable>(table: &mut T) {
+    for inbox_entry in INBOX_ENTRIES.iter() {
+        let (service_id, index) = table
+            .contains(inbox_entry.fid().clone())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(service_id, inbox_entry.service_id().clone());
+        assert_eq!(index, inbox_entry.inbox_sequence_number);
+
+        let (service_id, index) = table
+            .contains(InvocationId::from(inbox_entry.fid()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(service_id, inbox_entry.service_id().clone());
+        assert_eq!(index, inbox_entry.inbox_sequence_number);
+    }
+
+    let not_existing_entry = table.contains(InvocationId::mock_random()).await.unwrap();
+
+    assert!(not_existing_entry.is_none());
+}
+
+async fn contains_inbox_entries_after_delete<T: InboxTable>(table: &mut T) {
+    let mut inbox_entries_iterator = INBOX_ENTRIES.iter();
+
+    let not_existing_entry = table
+        .contains(inbox_entries_iterator.next().unwrap().fid().clone())
+        .await
+        .unwrap();
+    assert!(not_existing_entry.is_none());
+
+    for inbox_entry in inbox_entries_iterator {
+        let (service_id, index) = table
+            .contains(inbox_entry.fid().clone())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(service_id, inbox_entry.service_id().clone());
+        assert_eq!(index, inbox_entry.inbox_sequence_number);
+
+        let (service_id, index) = table
+            .contains(InvocationId::from(inbox_entry.fid()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(service_id, inbox_entry.service_id().clone());
+        assert_eq!(index, inbox_entry.inbox_sequence_number);
+    }
 }
 
 pub(crate) async fn run_tests(rocksdb: RocksDBStorage) {
@@ -87,6 +121,7 @@ pub(crate) async fn run_tests(rocksdb: RocksDBStorage) {
     let mut txn = rocksdb.transaction();
     find_the_next_message_in_an_inbox(&mut txn).await;
     get_svc_inbox(&mut txn).await;
+    contains_inbox_entries(&mut txn).await;
 
     let mut txn = rocksdb.transaction();
     delete_entry(&mut txn).await;
@@ -94,4 +129,5 @@ pub(crate) async fn run_tests(rocksdb: RocksDBStorage) {
 
     let mut txn = rocksdb.transaction();
     peek_after_delete(&mut txn).await;
+    contains_inbox_entries_after_delete(&mut txn).await;
 }

--- a/crates/storage-rocksdb/tests/integration_test.rs
+++ b/crates/storage-rocksdb/tests/integration_test.rs
@@ -11,7 +11,7 @@
 use bytes::Bytes;
 use bytestring::ByteString;
 use restate_storage_api::GetStream;
-use restate_types::identifiers::FullInvocationId;
+use restate_types::identifiers::{FullInvocationId, InvocationUuid, ServiceId};
 use restate_types::invocation::{ServiceInvocation, SpanRelation};
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -61,13 +61,19 @@ pub(crate) fn uuid_str(uuid: &str) -> Uuid {
     Uuid::from_str(uuid).expect("")
 }
 
-pub(crate) fn mock_service_invocation() -> ServiceInvocation {
+pub(crate) fn mock_service_invocation(service_id: ServiceId) -> ServiceInvocation {
     ServiceInvocation::new(
-        FullInvocationId::new(
-            ByteString::from_static("service"),
-            Bytes::new(),
-            uuid_str("018756fa-3f7f-7854-a76b-42c59a3d7f2d"),
-        ),
+        FullInvocationId::with_service_id(service_id, InvocationUuid::now_v7()),
+        ByteString::from_static("service"),
+        Bytes::new(),
+        None,
+        SpanRelation::None,
+    )
+}
+
+pub(crate) fn mock_random_service_invocation() -> ServiceInvocation {
+    ServiceInvocation::new(
+        FullInvocationId::mock_random(),
         ByteString::from_static("service"),
         Bytes::new(),
         None,

--- a/crates/storage-rocksdb/tests/outbox_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/outbox_table_test/mod.rs
@@ -8,13 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mock_service_invocation;
+use crate::mock_random_service_invocation;
 use restate_storage_api::outbox_table::{OutboxMessage, OutboxTable};
 use restate_storage_api::Transaction;
 use restate_storage_rocksdb::RocksDBStorage;
 
 fn mock_outbox_message() -> OutboxMessage {
-    OutboxMessage::ServiceInvocation(mock_service_invocation())
+    OutboxMessage::ServiceInvocation(mock_random_service_invocation())
 }
 
 pub(crate) async fn populate_data<T: OutboxTable>(txn: &mut T) {

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -65,6 +65,18 @@ pub enum MaybeFullInvocationId {
     Full(FullInvocationId),
 }
 
+impl From<InvocationId> for MaybeFullInvocationId {
+    fn from(value: InvocationId) -> Self {
+        MaybeFullInvocationId::Partial(value)
+    }
+}
+
+impl From<FullInvocationId> for MaybeFullInvocationId {
+    fn from(value: FullInvocationId) -> Self {
+        MaybeFullInvocationId::Full(value)
+    }
+}
+
 impl WithPartitionKey for MaybeFullInvocationId {
     fn partition_key(&self) -> PartitionKey {
         match self {


### PR DESCRIPTION
This commit introduces the InboxTable::contains method which allows
to scan the inbox for the presence of a ServiceInvocation specified
either via an InvocationId or a FullInvocationId.

This fixes https://github.com/restatedev/restate/issues/941.