### PR TITLE
restate examples command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,7 +1138,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -1330,6 +1341,16 @@ checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half 1.8.2",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1544,6 +1565,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -2423,8 +2450,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2786,6 +2815,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,6 +2843,16 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "iri-string"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -2857,6 +2905,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+dependencies = [
+ "base64 0.21.5",
+ "js-sys",
+ "pem 3.0.2",
+ "ring 0.17.6",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -3398,6 +3461,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "octocrab"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abfeeafb5fa0da7046229ec3c7b3bd2981aae05c549871192c408d59fc0fffd5"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.21.5",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "okapi"
 version = "0.7.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3680,10 +3781,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "pear"
@@ -3719,6 +3843,16 @@ name = "pem"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.5",
+ "serde",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
  "base64 0.21.5",
  "serde",
@@ -4370,12 +4504,15 @@ dependencies = [
  "clap-verbosity-flag",
  "cling",
  "comfy-table",
+ "convert_case",
  "dialoguer",
  "dirs",
  "dotenvy",
+ "futures",
  "http",
  "indicatif",
  "is-terminal",
+ "octocrab",
  "once_cell",
  "reqwest",
  "restate-meta-rest-model",
@@ -4391,6 +4528,8 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "vergen",
+ "zip",
+ "zip-extensions",
 ]
 
 [[package]]
@@ -5339,6 +5478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5500,6 +5648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5730,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,6 +5774,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
+ "backtrace",
  "doc-comment",
  "snafu-derive",
 ]
@@ -6209,9 +6381,12 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6419,6 +6594,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6866,7 +7042,7 @@ dependencies = [
  "chrono",
  "der",
  "hex",
- "pem",
+ "pem 2.0.1",
  "ring 0.16.20",
  "signature",
  "spki",
@@ -6951,6 +7127,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zip-extensions"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecf62554c4ff96bce01a7ef123d160c3ffe9180638820f8b4d545c65b221b8c"
+dependencies = [
+ "zip",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
 name = "zstd"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6966,6 +7180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
  "zstd-safe 7.0.0",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7102,18 +7102,18 @@ checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.28"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.28"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,13 +24,16 @@ bytes = { workspace = true }
 clap = { version = "4.1", features = ["derive", "env", "wrap_help", "color"] }
 clap-verbosity-flag = { version = "2.0.1" }
 cling = { version = "0.1.0", default-features = false, features = ["derive"] }
+convert_case = "0.6"
 comfy-table = "7.1"
 dialoguer = { version = "0.11.0" }
 dirs = { version = "5.0" }
 dotenvy = "0.15"
+futures = { workspace = true }
 http = { workspace = true }
 indicatif = "0.17.7"
 is-terminal = { version = "0.4.9" }
+octocrab = { version = "0.32.0", features = ["stream"] }
 once_cell = { workspace = true }
 reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls-tls"] }
 serde = { workspace = true }
@@ -38,12 +41,13 @@ serde_json = { workspace = true }
 termcolor = { version = "1.4.0" }
 thiserror = { workspace = true }
 tiny-gradient = { version = "0.1.0" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
 tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }
 url = { version = "2.4.1" }
-
+zip = "0.6"
+zip-extensions = "0.6"
 
 [build-dependencies]
 vergen = { version = "8.0.0", default-features = false, features = [

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -73,7 +73,7 @@ pub enum Command {
     #[clap(hide = true)]
     Sql(sql::Sql),
 
-    /// Download Restate's examples
+    /// Download one of Restate's examples in this directory.
     #[clap(name = "example", alias = "examples")]
     Examples(examples::Examples),
 }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -62,6 +62,8 @@ pub enum Command {
     #[clap(name = "whoami")]
     WhoAmiI(whoami::WhoAmI),
     /// Manages Restate's service registry
+
+    /// Manage Restate's service registry
     #[clap(subcommand)]
     Services(services::Services),
     /// Manages your service deployments
@@ -70,6 +72,10 @@ pub enum Command {
     /// Runs SQL queries against the data fusion service
     #[clap(hide = true)]
     Sql(sql::Sql),
+
+    /// Download Restate's examples
+    #[clap(name = "example", alias = "examples")]
+    Examples(examples::Examples),
 }
 
 fn init(

--- a/cli/src/commands/examples.rs
+++ b/cli/src/commands/examples.rs
@@ -162,7 +162,7 @@ async fn download_example(repo_handler: RepoHandler<'_>, asset: Asset) -> Result
     zip_out_file_path.push("temp.zip");
 
     // Download zip in the out_dir
-    let _ = match download_asset_to_file(&zip_out_file_path, repo_handler, asset).await {
+    match download_asset_to_file(&zip_out_file_path, repo_handler, asset).await {
         Ok(f) => f,
         Err(e) => {
             // Try to remove the directory, to avoid leaving a dirty user directory in case of a retry.
@@ -199,10 +199,7 @@ async fn download_asset_to_file(
     asset: Asset,
 ) -> Result<()> {
     let mut out_file = File::create(zip_out_file_path).await?;
-    let mut zip_stream = repo_handler
-        .releases()
-        .stream_asset(asset.id.clone())
-        .await?;
+    let mut zip_stream = repo_handler.releases().stream_asset(asset.id).await?;
     while let Some(res) = zip_stream.next().await {
         let mut buf = res?;
         out_file.write_buf(&mut buf).await?;
@@ -212,9 +209,9 @@ async fn download_asset_to_file(
     Ok(())
 }
 
-async fn unzip(zip_out_file: &PathBuf, out_name: &PathBuf) -> Result<()> {
-    let zip_out_file_copy = zip_out_file.clone();
-    let out_dir_copy = out_name.clone();
+async fn unzip(zip_out_file: &Path, out_name: &Path) -> Result<()> {
+    let zip_out_file_copy = zip_out_file.to_owned();
+    let out_dir_copy = out_name.to_owned();
     tokio::task::spawn_blocking(move || {
         let zip_file = std::fs::File::open(zip_out_file_copy)?;
         let mut archive = zip::ZipArchive::new(zip_file)?;

--- a/cli/src/commands/examples.rs
+++ b/cli/src/commands/examples.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::console::c_println;
+use anyhow::{anyhow, bail, Context, Result};
+use cling::prelude::*;
+use convert_case::{Case, Casing};
+use dialoguer::Select;
+use futures::StreamExt;
+use octocrab::models::repos::Asset;
+use octocrab::repos::RepoHandler;
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_examples")]
+pub struct Examples {
+    /// Example name
+    name: Option<String>,
+}
+
+pub async fn run_examples(example_opts: &Examples) -> Result<()> {
+    // Get latest release of the examples repo
+    let octocrab = octocrab::instance();
+    let examples_repo = octocrab.repos("restatedev", "examples");
+    let latest_release = examples_repo
+        .releases()
+        .get_latest()
+        .await
+        .context("Can't access the examples releases. Please retry later")?;
+
+    let example_asset = if let Some(example) = &example_opts.name {
+        // Check if the example exists
+        let example_lowercase = example.to_lowercase();
+        latest_release
+            .assets
+            .into_iter()
+            .find(|a| a.name.trim_end_matches(".zip") == example_lowercase)
+            .ok_or(anyhow!(
+                "Unknown example {}. Use `restate examples` to navigate the list of examples.",
+                example_lowercase
+            ))?
+    } else {
+        // Ask the example to download among the available examples
+        let mut languages = parse_available_examples(latest_release.assets);
+        let language_selection = Select::new()
+            .with_prompt("Which language?")
+            .items(&languages)
+            .interact()
+            .unwrap();
+        let example_selection = Select::new()
+            .with_prompt("Which example?")
+            .items(&languages[language_selection].examples)
+            .interact()
+            .unwrap();
+
+        languages
+            .remove(language_selection)
+            .examples
+            .remove(example_selection)
+            .asset
+    };
+
+    download_example(examples_repo, example_asset).await
+}
+
+struct Language {
+    display_name: String,
+    examples: Vec<Example>,
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display_name)
+    }
+}
+
+struct Example {
+    display_name: String,
+    asset: Asset,
+}
+
+impl fmt::Display for Example {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display_name)
+    }
+}
+
+fn parse_available_examples(assets: Vec<Asset>) -> Vec<Language> {
+    let mut languages_map = HashMap::new();
+
+    for asset in assets {
+        // Zip names have the format [language]-[example_name].zip
+
+        let asset_name = asset.name.clone();
+        let mut split_asset_name = asset_name.splitn(2, '-');
+
+        // First part is language
+        let language = if let Some(lang) = split_asset_name.next() {
+            lang.to_string()
+        } else {
+            // Bad name, just ignore it
+            continue;
+        };
+        let language_display_name = capitalize(&language);
+
+        // Second is example name
+        let example_display_name = if let Some(example) = split_asset_name.next() {
+            example
+                .to_string()
+                .from_case(Case::Kebab)
+                .to_case(Case::Title)
+        } else {
+            // Bad name, just ignore it
+            continue;
+        };
+        let example_display_name = example_display_name.trim_end_matches(".zip").to_string();
+
+        languages_map
+            .entry(language)
+            .or_insert_with(|| Language {
+                display_name: language_display_name,
+                examples: vec![],
+            })
+            .examples
+            .push(Example {
+                display_name: example_display_name,
+                asset,
+            });
+    }
+
+    languages_map.into_values().collect()
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+async fn download_example(repo_handler: RepoHandler<'_>, asset: Asset) -> Result<()> {
+    let out_dir_name = PathBuf::from(asset.name.trim_end_matches(".zip").to_string());
+    // This fails if the directory already exists.
+    tokio::fs::create_dir(&out_dir_name).await.context(format!(
+        "Cannot create the output directory {} for the example",
+        out_dir_name.display()
+    ))?;
+
+    let mut zip_out_file_path = PathBuf::from(&out_dir_name);
+    zip_out_file_path.push("temp.zip");
+
+    // Download zip in the out_dir
+    let _ = match download_asset_to_file(&zip_out_file_path, repo_handler, asset).await {
+        Ok(f) => f,
+        Err(e) => {
+            // Try to remove the directory, to avoid leaving a dirty user directory in case of a retry.
+            let _ = tokio::fs::remove_dir_all(&out_dir_name).await;
+            bail!(
+                "Error when downloading the zip {} for the example: {:#?}",
+                zip_out_file_path.display(),
+                e
+            );
+        }
+    };
+
+    // Unzip it
+    if let Err(e) = unzip(&zip_out_file_path, &out_dir_name).await {
+        // Try to remove the directory, to avoid leaving a dirty user directory in case of a retry.
+        println!("{:#?}", e);
+        let _ = tokio::fs::remove_dir_all(&out_dir_name).await;
+        return Err(e);
+    }
+
+    // Ready to rock!
+    c_println!(
+        "The example is ready in the directory {}",
+        out_dir_name.display()
+    );
+    c_println!("Look at the example README to get started!");
+
+    Ok(())
+}
+
+async fn download_asset_to_file(
+    zip_out_file_path: impl AsRef<Path>,
+    repo_handler: RepoHandler<'_>,
+    asset: Asset,
+) -> Result<()> {
+    let mut out_file = File::create(zip_out_file_path).await?;
+    let mut zip_stream = repo_handler
+        .releases()
+        .stream_asset(asset.id.clone())
+        .await?;
+    while let Some(res) = zip_stream.next().await {
+        let mut buf = res?;
+        out_file.write_buf(&mut buf).await?;
+    }
+    out_file.flush().await?;
+
+    Ok(())
+}
+
+async fn unzip(zip_out_file: &PathBuf, out_name: &PathBuf) -> Result<()> {
+    let zip_out_file_copy = zip_out_file.clone();
+    let out_dir_copy = out_name.clone();
+    tokio::task::spawn_blocking(move || {
+        let zip_file = std::fs::File::open(zip_out_file_copy)?;
+        let mut archive = zip::ZipArchive::new(zip_file)?;
+        archive.extract(out_dir_copy)?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await
+    .context(format!(
+        "Panic when trying to unzip {} in {}",
+        zip_out_file.display(),
+        out_name.display()
+    ))?
+    .context(format!(
+        "Error when trying to unzip {} in {}",
+        zip_out_file.display(),
+        out_name.display()
+    ))?;
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub mod examples;
 pub mod deployments;
 pub mod services;
 pub mod sql;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,8 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod examples;
 pub mod deployments;
+pub mod examples;
 pub mod services;
 pub mod sql;
 pub mod whoami;


### PR DESCRIPTION
Command to download examples from the https://github.com/restatedev/examples repo.

The command queries the github latest release of the examples repo, and either uses the example name you manually provide, or starts an interactive prompt to select the example.

For testing I added an artifact to the latest examples release.