### PR TITLE
Support killing of inboxed service invocations

### DIFF
--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -49,12 +49,12 @@ pub trait InboxTable {
 
     fn all_inboxes(&mut self, range: RangeInclusive<PartitionKey>) -> GetStream<InboxEntry>;
 
-    /// Scans the inbox for an inbox entry with the given invocation id.
+    /// Gets an inbox entry for the given invocation id.
     ///
     /// Important: This method can be quite costly if it is invoked with an `InvocationId` because
     /// it needs to scan all inboxes for the given partition key to match the given invocation uuid.
-    fn contains(
+    fn get_inbox_entry(
         &mut self,
         maybe_fid: impl Into<MaybeFullInvocationId>,
-    ) -> GetFuture<Option<(ServiceId, u64)>>;
+    ) -> GetFuture<Option<InboxEntry>>;
 }

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -369,3 +369,20 @@ impl SpanRelation {
         }
     }
 }
+
+#[cfg(any(test, feature = "mocks"))]
+mod mocks {
+    use super::*;
+
+    impl ServiceInvocation {
+        pub fn mock() -> Self {
+            Self {
+                fid: FullInvocationId::mock_random(),
+                method_name: "mock".into(),
+                argument: Default::default(),
+                response_sink: None,
+                span_context: Default::default(),
+            }
+        }
+    }
+}

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -65,6 +65,15 @@ pub enum MaybeFullInvocationId {
     Full(FullInvocationId),
 }
 
+impl From<MaybeFullInvocationId> for InvocationId {
+    fn from(value: MaybeFullInvocationId) -> Self {
+        match value {
+            MaybeFullInvocationId::Partial(iid) => iid,
+            MaybeFullInvocationId::Full(fid) => InvocationId::from(fid),
+        }
+    }
+}
+
 impl From<InvocationId> for MaybeFullInvocationId {
     fn from(value: InvocationId) -> Self {
         MaybeFullInvocationId::Partial(value)

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -125,6 +125,12 @@ impl From<InvocationError> for ResponseResult {
     }
 }
 
+impl From<&InvocationError> for ResponseResult {
+    fn from(e: &InvocationError) -> Self {
+        ResponseResult::Failure(e.code().into(), e.message().into())
+    }
+}
+
 /// Definition of the sink where to send the result of a service invocation.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/worker/src/partition/state_machine/command_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter.rs
@@ -569,14 +569,13 @@ where
         invocation_metadata: InvocationMetadata,
         error: InvocationError,
     ) -> Result<(), Error> {
-        let code = error.code();
         if let Some(response_sink) = &invocation_metadata.response_sink {
             // TODO: We probably only need to send the response if we haven't send a response before
             self.send_message(
                 OutboxMessage::from_response_sink(
                     &full_invocation_id,
                     response_sink.clone(),
-                    ResponseResult::Failure(code.into(), error.message().into()),
+                    ResponseResult::from(&error),
                 ),
                 effects,
             );
@@ -587,7 +586,7 @@ where
             &full_invocation_id,
             invocation_metadata,
             effects,
-            Err((code, error.to_string())),
+            Err((error.code(), error.to_string())),
         );
         self.complete_invocation(full_invocation_id, state, length, effects)
             .await

--- a/crates/worker/src/partition/state_machine/command_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter.rs
@@ -841,7 +841,7 @@ where
                     _ => None,
                 };
 
-                effects.background_invoke(
+                effects.trace_background_invoke(
                     service_invocation.fid.clone(),
                     method,
                     invocation_metadata.journal_metadata.span_context.clone(),
@@ -1042,7 +1042,7 @@ where
         result: Result<(), (InvocationErrorCode, String)>,
         effects: &mut Effects,
     ) {
-        effects.notify_invocation_result(
+        effects.trace_invocation_result(
             full_invocation_id.clone(),
             service_method,
             span_context,

--- a/crates/worker/src/partition/state_machine/command_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter.rs
@@ -826,7 +826,7 @@ where
                     }) = Codec::deserialize(&journal_entry)?
                 );
 
-                let method = request.method_name.to_string();
+                let service_method = request.method_name.clone();
 
                 let service_invocation = Self::create_service_invocation(
                     *invocation_id,
@@ -843,7 +843,7 @@ where
 
                 effects.trace_background_invoke(
                     service_invocation.fid.clone(),
-                    method,
+                    service_method,
                     invocation_metadata.journal_metadata.span_context.clone(),
                     pointer_span_id,
                 );

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -430,7 +430,7 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                     .await?;
                 Self::invoke_service(state_storage, collector, service_invocation).await?;
             }
-            Effect::NotifyInvocationResult { .. } | Effect::BackgroundInvoke { .. } => {
+            Effect::TraceInvocationResult { .. } | Effect::TraceBackgroundInvoke { .. } => {
                 // these effects are only needed for span creation
             }
             Effect::SendAckResponse(ack_response) => {

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -113,6 +113,12 @@ pub trait StateStorage {
         inbox_sequence_number: MessageIndex,
     ) -> BoxFuture<Result<(), restate_storage_api::StorageError>>;
 
+    fn delete_inbox_entry<'a>(
+        &'a mut self,
+        service_id: &'a ServiceId,
+        sequence_number: MessageIndex,
+    ) -> BoxFuture<()>;
+
     // State
     fn store_state<'a>(
         &'a mut self,
@@ -253,6 +259,14 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                     .await?;
                 // need to store the next inbox sequence number
                 state_storage.store_inbox_seq_number(seq_number + 1).await?;
+            }
+            Effect::DeleteInboxEntry {
+                service_id,
+                sequence_number,
+            } => {
+                state_storage
+                    .delete_inbox_entry(&service_id, sequence_number)
+                    .await;
             }
             Effect::EnqueueIntoOutbox {
                 seq_number,

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -993,3 +993,15 @@ impl Effects {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Effect;
+    use super::Effects;
+
+    impl Effects {
+        pub(crate) fn into_inner(self) -> Vec<Effect> {
+            self.effects
+        }
+    }
+}

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -151,13 +151,13 @@ pub(crate) enum Effect {
     },
 
     // Effects used only for tracing purposes
-    BackgroundInvoke {
+    TraceBackgroundInvoke {
         full_invocation_id: FullInvocationId,
         service_method: String,
         span_context: ServiceInvocationSpanContext,
         pointer_span_id: Option<SpanId>,
     },
-    NotifyInvocationResult {
+    TraceInvocationResult {
         full_invocation_id: FullInvocationId,
         creation_time: MillisSinceEpoch,
         service_method: ByteString,
@@ -550,7 +550,7 @@ impl Effect {
                     method_name
                 )
             }
-            Effect::BackgroundInvoke {
+            Effect::TraceBackgroundInvoke {
                 full_invocation_id,
                 service_method,
                 span_context,
@@ -586,7 +586,7 @@ impl Effect {
                     );
                 }
             }
-            Effect::NotifyInvocationResult {
+            Effect::TraceInvocationResult {
                 full_invocation_id,
                 creation_time,
                 service_method,
@@ -901,14 +901,14 @@ impl Effects {
         });
     }
 
-    pub(crate) fn background_invoke(
+    pub(crate) fn trace_background_invoke(
         &mut self,
         full_invocation_id: FullInvocationId,
         service_method: String,
         span_context: ServiceInvocationSpanContext,
         pointer_span_id: Option<SpanId>,
     ) {
-        self.effects.push(Effect::BackgroundInvoke {
+        self.effects.push(Effect::TraceBackgroundInvoke {
             full_invocation_id,
             service_method,
             span_context,
@@ -916,7 +916,7 @@ impl Effects {
         })
     }
 
-    pub(crate) fn notify_invocation_result(
+    pub(crate) fn trace_invocation_result(
         &mut self,
         full_invocation_id: FullInvocationId,
         service_method: ByteString,
@@ -924,7 +924,7 @@ impl Effects {
         creation_time: MillisSinceEpoch,
         result: Result<(), (InvocationErrorCode, String)>,
     ) {
-        self.effects.push(Effect::NotifyInvocationResult {
+        self.effects.push(Effect::TraceInvocationResult {
             full_invocation_id,
             creation_time,
             service_method,

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -153,7 +153,7 @@ pub(crate) enum Effect {
     // Effects used only for tracing purposes
     TraceBackgroundInvoke {
         full_invocation_id: FullInvocationId,
-        service_method: String,
+        service_method: ByteString,
         span_context: ServiceInvocationSpanContext,
         pointer_span_id: Option<SpanId>,
     },
@@ -569,7 +569,7 @@ impl Effect {
                         "background_invoke",
                         otel.name = format!("background_invoke {service_method}"),
                         rpc.service = %full_invocation_id.service_id.service_name,
-                        rpc.method = service_method,
+                        rpc.method = %service_method,
                         restate.invocation.id = %full_invocation_id,
                         restate.internal.span_id = %pointer_span_id,
                     );
@@ -581,7 +581,7 @@ impl Effect {
                         "background_invoke",
                         otel.name = format!("background_invoke {service_method}"),
                         rpc.service = %full_invocation_id.service_id.service_name,
-                        rpc.method = service_method,
+                        rpc.method = %service_method,
                         restate.invocation.id = %full_invocation_id,
                     );
                 }
@@ -904,7 +904,7 @@ impl Effects {
     pub(crate) fn trace_background_invoke(
         &mut self,
         full_invocation_id: FullInvocationId,
-        service_method: String,
+        service_method: ByteString,
         span_context: ServiceInvocationSpanContext,
         pointer_span_id: Option<SpanId>,
     ) {


### PR DESCRIPTION
This PR adds the functionality to kill an inboxed service invocation. The way it works is the following:

1. Check whether an invocation is currently invoked.
2. If not, then check the inbox for the corresponding service invocation
3. If the inbox contains the service invocation, then fail it with a `KILLED_INVOCATION_ERROR` and delete the service invocation from the inbox.

This PR is based on #949.

This fixes #951.