### PR TITLE
Kill child invocations when killing an invocation

### DIFF
--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -14,7 +14,7 @@ use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::CompletionResult;
 
 /// Different types of journal entries persisted by the runtime
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum JournalEntry {
     Entry(EnrichedRawEntry),
     Completion(CompletionResult),

--- a/crates/storage-api/src/outbox_table/mod.rs
+++ b/crates/storage-api/src/outbox_table/mod.rs
@@ -28,6 +28,9 @@ pub enum OutboxMessage {
         full_invocation_id: FullInvocationId,
         response: ResponseResult,
     },
+
+    /// Kill command to send to another partition processor
+    Kill(FullInvocationId),
 }
 
 pub trait OutboxTable {

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -302,10 +302,15 @@ message OutboxMessage {
         ResponseResult response_result = 3;
     }
 
+    message OutboxKill {
+        FullInvocationId full_invocation_id = 1;
+    }
+
     oneof outbox_message {
         OutboxServiceInvocation service_invocation_case = 1;
         OutboxServiceInvocationResponse service_invocation_response = 2;
         OutboxIngressResponse ingress_response = 3;
+        OutboxKill kill = 4;
     }
 
 }

--- a/crates/worker/src/partition/state_machine/command_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter.rs
@@ -20,7 +20,9 @@ use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::future::BoxFuture;
+use futures::stream::BoxStream;
 use restate_storage_api::inbox_table::InboxEntry;
+use restate_storage_api::journal_table::JournalEntry;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::status_table::{InvocationMetadata, InvocationStatus};
 use restate_storage_api::timer_table::Timer;
@@ -89,6 +91,12 @@ pub trait StateReader {
         service_id: &'a ServiceId,
         entry_index: EntryIndex,
     ) -> BoxFuture<Result<Option<CompletionResult>, restate_storage_api::StorageError>>;
+
+    fn get_journal<'a>(
+        &'a mut self,
+        service_id: &'a ServiceId,
+        length: EntryIndex,
+    ) -> BoxStream<'a, Result<JournalEntry, restate_storage_api::StorageError>>;
 }
 
 pub(crate) struct CommandInterpreter<Codec> {
@@ -1264,6 +1272,14 @@ mod tests {
             _service_id: &'a ServiceId,
             _entry_index: EntryIndex,
         ) -> BoxFuture<Result<Option<CompletionResult>, StorageError>> {
+            todo!()
+        }
+
+        fn get_journal<'a>(
+            &'a mut self,
+            _service_id: &'a ServiceId,
+            _length: EntryIndex,
+        ) -> BoxStream<'a, Result<JournalEntry, StorageError>> {
             todo!()
         }
     }

--- a/crates/worker/src/partition/state_machine/command_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter.rs
@@ -1291,9 +1291,14 @@ mod tests {
 
         fn peek_inbox<'a>(
             &'a mut self,
-            _service_id: &'a ServiceId,
+            service_id: &'a ServiceId,
         ) -> BoxFuture<'a, Result<Option<InboxEntry>, restate_storage_api::StorageError>> {
-            todo!()
+            let result = self
+                .inboxes
+                .get(service_id)
+                .and_then(|inbox| inbox.first().cloned());
+
+            ok(result).boxed()
         }
 
         fn get_inbox_entry(

--- a/crates/worker/src/partition/state_machine/commands.rs
+++ b/crates/worker/src/partition/state_machine/commands.rs
@@ -10,8 +10,8 @@
 
 use crate::partition::services::non_deterministic::Effects as NBISEffects;
 use crate::partition::types::{InvokerEffect, TimerValue};
-use restate_types::identifiers::{IngressDispatcherId, InvocationId, PartitionId, PeerId};
-use restate_types::invocation::{InvocationResponse, ServiceInvocation};
+use restate_types::identifiers::{IngressDispatcherId, PartitionId, PeerId};
+use restate_types::invocation::{InvocationResponse, MaybeFullInvocationId, ServiceInvocation};
 use restate_types::message::{AckKind, MessageIndex};
 
 /// Envelope for [`partition::Command`] that might require an explicit acknowledge.
@@ -202,7 +202,7 @@ pub struct IngressAckResponse {
 /// State machine input commands
 #[derive(Debug)]
 pub enum Command {
-    Kill(InvocationId),
+    Kill(MaybeFullInvocationId),
     Invoker(InvokerEffect),
     Timer(TimerValue),
     OutboxTruncation(MessageIndex),

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -285,6 +285,16 @@ impl Effect {
             ),
             Effect::EnqueueIntoOutbox {
                 seq_number,
+                message: OutboxMessage::Kill(fid),
+            } => debug_if_leader!(
+                is_leader,
+                rpc.service = %fid.service_id.service_name,
+                restate.invocation.id = %fid,
+                restate.outbox.seq = seq_number,
+                "Effect: Send kill command to partition processor",
+            ),
+            Effect::EnqueueIntoOutbox {
+                seq_number,
                 message:
                     OutboxMessage::ServiceResponse(InvocationResponse {
                         result: ResponseResult::Failure(failure_code, failure_msg),

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -103,8 +103,7 @@ mod tests {
     use restate_test_util::test;
     use restate_types::errors::UserErrorCode;
     use restate_types::identifiers::{
-        FullInvocationId, InvocationId, InvocationUuid, PartitionId, PartitionKey, ServiceId,
-        WithPartitionKey,
+        FullInvocationId, InvocationUuid, PartitionId, PartitionKey, ServiceId, WithPartitionKey,
     };
     use restate_types::invocation::{
         InvocationResponse, MaybeFullInvocationId, ResponseResult, ServiceInvocation,
@@ -378,7 +377,9 @@ mod tests {
         assert!(result.is_some());
 
         let actions = state_machine
-            .apply_cmd(Command::Kill(InvocationId::from(inboxed_fid.clone())))
+            .apply_cmd(Command::Kill(MaybeFullInvocationId::from(
+                inboxed_fid.clone(),
+            )))
             .await;
 
         let result = state_machine

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -292,6 +292,14 @@ where
     ) -> BoxFuture<Result<Option<CompletionResult>, StorageError>> {
         super::state_machine::StateStorage::load_completion_result(self, service_id, entry_index)
     }
+
+    fn get_journal<'a>(
+        &'a mut self,
+        service_id: &'a ServiceId,
+        length: EntryIndex,
+    ) -> BoxStream<'a, Result<JournalEntry, StorageError>> {
+        self.inner.get_journal(service_id, length)
+    }
 }
 
 impl<TransactionType> super::state_machine::StateStorage for Transaction<TransactionType>

--- a/crates/worker/src/services.rs
+++ b/crates/worker/src/services.rs
@@ -17,6 +17,7 @@ use restate_consensus::ProposalSender;
 use restate_network::PartitionTableError;
 use restate_types::identifiers::InvocationId;
 use restate_types::identifiers::WithPartitionKey;
+use restate_types::invocation::MaybeFullInvocationId;
 use restate_types::message::PeerTarget;
 use tokio::sync::mpsc;
 use tracing::debug;
@@ -130,7 +131,7 @@ where
                             let target_peer_id = partition_table
                                 .partition_key_to_target_peer(invocation_id.partition_key())
                                 .await?;
-                            let msg = StateMachineAckCommand::no_ack(StateMachineCommand::Kill(invocation_id));
+                            let msg = StateMachineAckCommand::no_ack(StateMachineCommand::Kill(MaybeFullInvocationId::from(invocation_id)));
                             proposal_tx.send((target_peer_id, msg)).await.map_err(|_| Error::ConsensusClosed)?
                         }
                     }


### PR DESCRIPTION
This commit introduces the killing of child invocations when killing
an invocation. The way it works is by scanning the journal for un-
completed calls and then sending for these calls a kill command to
the corresponding PartitionProcessor.

This fixes https://github.com/restatedev/restate/issues/942.

This PR is based on #951 and #969.