### PR TITLE
ServiceEndpoint -> Deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "codederror"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "codederror-derive",
  "thiserror",
@@ -4494,14 +4494,14 @@ dependencies = [
 
 [[package]]
 name = "restate-base64-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64 0.21.5",
 ]
 
 [[package]]
 name = "restate-benchmarks"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "restate-consensus"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "restate-errors"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "codederror",
  "paste",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "restate-fs-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "restate-futures-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "futures",
  "pin-project",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "restate-ingress-dispatcher"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "bytestring",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "restate-ingress-grpc"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "restate-ingress-kafka"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "restate-invoker-api"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "restate-invoker-impl"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "restate-meta"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "axum",
  "bincode",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "restate-meta-rest-model"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "http",
  "humantime",
@@ -4825,7 +4825,7 @@ dependencies = [
 
 [[package]]
 name = "restate-network"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "restate-pb"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "restate-queue"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "restate-schema-api"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -4894,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "restate-schema-impl"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "restate-serde-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "restate-server"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "clap",
  "codederror",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "restate-service-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "aws-config",
@@ -4994,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "restate-service-protocol"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-api"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-proto"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-query-datafusion"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "async-trait",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-query-http"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "axum",
  "base64 0.21.5",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-query-postgres"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-rocksdb"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "restate-test-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "assert2",
  "googletest",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "restate-timer"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "derive_builder",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "restate-timer-queue"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "futures",
  "tokio",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "restate-tracing-instrumentation"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "console-subscriber",
  "derive_builder",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "restate-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "restate-worker"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert2",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "restate-worker-api"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "restate-schema-api",
  "restate-types",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "service-protocol-wireshark-dissector"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "mlua",
@@ -7095,7 +7095,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "drain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 authors = ["restate.dev"]
 edition = "2021"
 rust-version = "1.72"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ RUST_LOG=info,restate=debug just run --bin restate-server --release
 After the runtime is running on `localhost:9070`, you can register a service running on `localhost:9080` via `curl`:
 
 ```shell
-curl -X POST localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
+curl -X POST localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
 ```
 
 For more information check [how to register services](https://docs.restate.dev/services/registration).

--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -17,22 +17,22 @@ use std::str::FromStr;
 use super::DataFusionHttpClient;
 
 use arrow::array::{as_string_array, Array, AsArray};
-use restate_meta_rest_model::endpoints::EndpointId;
+use restate_meta_rest_model::deployments::DeploymentId;
 
 use anyhow::Result;
 use chrono::{DateTime, Duration, Local, TimeZone};
 
 pub async fn count_deployment_active_inv(
     client: &DataFusionHttpClient,
-    endpoint_id: &EndpointId,
+    deployment_id: &DeploymentId,
 ) -> Result<i64> {
     Ok(client
         .run_count_agg_query(format!(
             "SELECT COUNT(id) AS inv_count \
             FROM sys_status \
-            WHERE pinned_endpoint_id = '{}' \
-            GROUP BY pinned_endpoint_id",
-            endpoint_id
+            WHERE pinned_deployment_id = '{}' \
+            GROUP BY pinned_deployment_id",
+            deployment_id
         ))
         .await?)
 }
@@ -45,14 +45,14 @@ pub struct ServiceMethodUsage {
 
 pub async fn count_deployment_active_inv_by_method(
     client: &DataFusionHttpClient,
-    endpoint_id: &EndpointId,
+    deployment_id: &DeploymentId,
 ) -> Result<Vec<ServiceMethodUsage>> {
     let query = format!(
         "SELECT service, method, COUNT(id) AS inv_count \
             FROM sys_status \
-            WHERE pinned_endpoint_id = '{}' \
-            GROUP BY pinned_endpoint_id, service, method",
-        endpoint_id
+            WHERE pinned_deployment_id = '{}' \
+            GROUP BY pinned_deployment_id, service, method",
+        deployment_id
     );
 
     let resp = client.run_query(query).await?;
@@ -464,10 +464,10 @@ pub async fn get_locked_keys_status(
                 ss.id,
                 ss.created_at,
                 ss.modified_at,
-                ss.pinned_endpoint_id,
+                ss.pinned_deployment_id,
                 sis.retry_count,
                 sis.last_failure,
-                sis.last_attempt_endpoint_id,
+                sis.last_attempt_deployment_id,
                 sis.next_retry_at,
                 sis.last_start_at
             FROM sys_status ss
@@ -482,8 +482,8 @@ pub async fn get_locked_keys_status(
                 first_value(method),
                 first_value(created_at),
                 first_value(modified_at),
-                first_value(pinned_endpoint_id),
-                first_value(last_attempt_endpoint_id),
+                first_value(pinned_deployment_id),
+                first_value(last_attempt_deployment_id),
                 first_value(last_failure),
                 first_value(next_retry_at),
                 first_value(last_start_at),

--- a/cli/src/clients/metas_interface.rs
+++ b/cli/src/clients/metas_interface.rs
@@ -11,7 +11,7 @@
 use super::metas_client::Envelope;
 use super::MetasClient;
 
-use restate_meta_rest_model::endpoints::*;
+use restate_meta_rest_model::deployments::*;
 use restate_meta_rest_model::services::*;
 
 use async_trait::async_trait;
@@ -22,17 +22,17 @@ pub trait MetaClientInterface {
     async fn health(&self) -> reqwest::Result<Envelope<()>>;
     async fn get_services(&self) -> reqwest::Result<Envelope<ListServicesResponse>>;
     async fn get_service(&self, name: &str) -> reqwest::Result<Envelope<ServiceMetadata>>;
-    async fn get_endpoints(&self) -> reqwest::Result<Envelope<ListServiceEndpointsResponse>>;
-    async fn get_endpoint(
+    async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentResponse>>;
+    async fn get_deployment(
         &self,
         id: &str,
-    ) -> reqwest::Result<Envelope<DetailedServiceEndpointResponse>>;
-    async fn remove_endpoint(&self, id: &str, force: bool) -> reqwest::Result<Envelope<()>>;
+    ) -> reqwest::Result<Envelope<DetailedDeploymentResponse>>;
+    async fn remove_deployment(&self, id: &str, force: bool) -> reqwest::Result<Envelope<()>>;
 
-    async fn discover_endpoint(
+    async fn discover_deployment(
         &self,
-        body: RegisterServiceEndpointRequest,
-    ) -> reqwest::Result<Envelope<RegisterServiceEndpointResponse>>;
+        body: RegisterDeploymentRequest,
+    ) -> reqwest::Result<Envelope<RegisterDeploymentResponse>>;
 }
 
 #[async_trait]
@@ -56,34 +56,34 @@ impl MetaClientInterface for MetasClient {
         Ok(self.run(reqwest::Method::GET, url).await?)
     }
 
-    async fn get_endpoints(&self) -> reqwest::Result<Envelope<ListServiceEndpointsResponse>> {
-        let url = self.base_url.join("/endpoints").expect("Bad url!");
+    async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentResponse>> {
+        let url = self.base_url.join("/deployments").expect("Bad url!");
         Ok(self.run(reqwest::Method::GET, url).await?)
     }
 
-    async fn get_endpoint(
+    async fn get_deployment(
         &self,
         id: &str,
-    ) -> reqwest::Result<Envelope<DetailedServiceEndpointResponse>> {
+    ) -> reqwest::Result<Envelope<DetailedDeploymentResponse>> {
         let url = self
             .base_url
-            .join(&format!("/endpoints/{}", id))
+            .join(&format!("/deployments/{}", id))
             .expect("Bad url!");
         Ok(self.run(reqwest::Method::GET, url).await?)
     }
 
-    async fn discover_endpoint(
+    async fn discover_deployment(
         &self,
-        body: RegisterServiceEndpointRequest,
-    ) -> reqwest::Result<Envelope<RegisterServiceEndpointResponse>> {
-        let url = self.base_url.join("/endpoints").expect("Bad url!");
+        body: RegisterDeploymentRequest,
+    ) -> reqwest::Result<Envelope<RegisterDeploymentResponse>> {
+        let url = self.base_url.join("/deployments").expect("Bad url!");
         Ok(self.run_with_body(reqwest::Method::POST, url, body).await?)
     }
 
-    async fn remove_endpoint(&self, id: &str, force: bool) -> reqwest::Result<Envelope<()>> {
+    async fn remove_deployment(&self, id: &str, force: bool) -> reqwest::Result<Envelope<()>> {
         let mut url = self
             .base_url
-            .join(&format!("/endpoints/{}", id))
+            .join(&format!("/deployments/{}", id))
             .expect("Bad url!");
 
         url.set_query(Some(&format!("force={}", force)));

--- a/cli/src/clients/metas_interface.rs
+++ b/cli/src/clients/metas_interface.rs
@@ -22,7 +22,7 @@ pub trait MetaClientInterface {
     async fn health(&self) -> reqwest::Result<Envelope<()>>;
     async fn get_services(&self) -> reqwest::Result<Envelope<ListServicesResponse>>;
     async fn get_service(&self, name: &str) -> reqwest::Result<Envelope<ServiceMetadata>>;
-    async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentResponse>>;
+    async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentsResponse>>;
     async fn get_deployment(
         &self,
         id: &str,
@@ -56,7 +56,7 @@ impl MetaClientInterface for MetasClient {
         Ok(self.run(reqwest::Method::GET, url).await?)
     }
 
-    async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentResponse>> {
+    async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentsResponse>> {
         let url = self.base_url.join("/deployments").expect("Bad url!");
         Ok(self.run(reqwest::Method::GET, url).await?)
     }

--- a/cli/src/commands/deployments/mod.rs
+++ b/cli/src/commands/deployments/mod.rs
@@ -20,7 +20,7 @@ use cling::prelude::*;
 pub enum Deployments {
     /// List the registered deployments
     List(list::List),
-    /// Add or update deployments through endpoint discovery
+    /// Add or update deployments through deployment discovery
     Register(register::Register),
     /// Prints detailed information about a given deployment
     Describe(describe::Describe),

--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -16,7 +16,7 @@ use crate::cli_env::CliEnv;
 use crate::clients::{MetaClientInterface, MetasClient, MetasClientError};
 use crate::console::c_println;
 use crate::ui::console::{confirm_or_exit, Styled, StyledTable};
-use crate::ui::deployments::render_endpoint_url;
+use crate::ui::deployments::render_deployment_url;
 use crate::ui::service_methods::{
     create_service_methods_table, create_service_methods_table_diff, icon_for_service_flavor,
 };
@@ -24,8 +24,8 @@ use crate::ui::stylesheet::Style;
 use crate::{c_eprintln, c_error, c_indent_table, c_indentln, c_success, c_warn};
 
 use http::{HeaderName, HeaderValue, StatusCode, Uri};
-use restate_meta_rest_model::endpoints::{
-    LambdaARN, RegisterServiceEndpointMetadata, RegisterServiceEndpointRequest, ServiceEndpoint,
+use restate_meta_rest_model::deployments::{
+    Deployment, LambdaARN, RegisterDeploymentMetadata, RegisterDeploymentRequest,
 };
 
 use anyhow::Result;
@@ -58,8 +58,8 @@ pub struct Register {
     ///
     /// The URL must be network-accessible from Restate server. In case of using
     /// Lambda ARN, the ARN should include the function version.
-    #[clap(value_parser = parse_endpoint)]
-    endpoint: Endpoint,
+    #[clap(value_parser = parse_deployment)]
+    deployment: DeploymentEndpoint,
 }
 
 #[derive(Clone)]
@@ -69,16 +69,16 @@ struct HeaderKeyValue {
 }
 
 #[derive(Clone, Debug)]
-enum Endpoint {
+enum DeploymentEndpoint {
     Uri(Uri),
     Lambda(LambdaARN),
 }
 
-impl Display for Endpoint {
+impl Display for DeploymentEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Endpoint::Uri(uri) => write!(f, "URL {}", uri),
-            Endpoint::Lambda(arn) => write!(f, "AWS Lambda ARN {}", arn),
+            DeploymentEndpoint::Uri(uri) => write!(f, "URL {}", uri),
+            DeploymentEndpoint::Lambda(arn) => write!(f, "AWS Lambda ARN {}", arn),
         }
     }
 }
@@ -99,12 +99,12 @@ fn parse_header(
     })
 }
 
-// Needed as a function to allow clap to parse to [`Endpoint`]
-fn parse_endpoint(
+// Needed as a function to allow clap to parse to [`Deployment`]
+fn parse_deployment(
     raw: &str,
-) -> Result<Endpoint, Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let endpoint = if raw.starts_with("arn:") {
-        Endpoint::Lambda(LambdaARN::from_str(raw)?)
+) -> Result<DeploymentEndpoint, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let deployment = if raw.starts_with("arn:") {
+        DeploymentEndpoint::Lambda(LambdaARN::from_str(raw)?)
     } else {
         let mut uri = Uri::from_str(raw).map_err(|e| format!("invalid URL({e})"))?;
         let mut parts = uri.into_parts();
@@ -115,9 +115,9 @@ fn parse_endpoint(
             parts.path_and_query = Some(http::uri::PathAndQuery::from_str("/")?);
         }
         uri = Uri::from_parts(parts)?;
-        Endpoint::Uri(uri)
+        DeploymentEndpoint::Uri(uri)
     };
-    Ok(endpoint)
+    Ok(deployment)
 }
 
 // NOTE: Without parsing the proto descriptor, we can't detect the details of the
@@ -130,16 +130,16 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
 
     // Preparing the discovery request
     let client = crate::clients::MetasClient::new(&env)?;
-    let endpoint_metadata = match &discover_opts.endpoint {
-        Endpoint::Uri(uri) => RegisterServiceEndpointMetadata::Http { uri: uri.clone() },
-        Endpoint::Lambda(arn) => RegisterServiceEndpointMetadata::Lambda {
+    let endpoint_metadata = match &discover_opts.deployment {
+        DeploymentEndpoint::Uri(uri) => RegisterDeploymentMetadata::Http { uri: uri.clone() },
+        DeploymentEndpoint::Lambda(arn) => RegisterDeploymentMetadata::Lambda {
             arn: arn.to_string(),
             assume_role_arn: discover_opts.assume_role_arn.clone(),
         },
     };
 
-    let mk_request_body = |force, dry_run| RegisterServiceEndpointRequest {
-        endpoint_metadata: endpoint_metadata.clone(),
+    let mk_request_body = |force, dry_run| RegisterDeploymentRequest {
+        deployment_metadata: endpoint_metadata.clone(),
         additional_headers: headers.clone().map(Into::into),
         force,
         dry_run,
@@ -152,14 +152,14 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
 
     progress.set_message(format!(
         "Asking restate server at {} for a dry-run discovery of {}",
-        env.meta_base_url, discover_opts.endpoint
+        env.meta_base_url, discover_opts.deployment
     ));
 
     // This fails if the endpoint exists and --force is not set.
     let dry_run_result = client
         // We use force in the dry-run to make sure we get the result of the discovery
         // even if there is it's an existing endpoint
-        .discover_endpoint(mk_request_body(
+        .discover_deployment(mk_request_body(
             /* force = */ true, /* dry_run = */ true,
         ))
         .await?
@@ -170,7 +170,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
 
     // Is this an existing endpoint?
     let existing_endpoint = match client
-        .get_endpoint(&dry_run_result.id)
+        .get_deployment(&dry_run_result.id)
         .await?
         .into_body()
         .await
@@ -252,7 +252,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
     if !updated.is_empty() {
         c_println!();
         // used to resolving old endpoints.
-        let mut endpoint_cache: HashMap<String, ServiceEndpoint> = HashMap::new();
+        let mut deployment_cache: HashMap<String, Deployment> = HashMap::new();
         // A single spinner spans all requests.
         let progress = ProgressBar::new_spinner();
         progress.set_style(
@@ -303,17 +303,20 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
                     &existing_svc.revision,
                     Styled(Style::Success, &svc.revision),
                 );
-                if existing_svc.endpoint_id != dry_run_result.id {
-                    let maybe_old_endpoint =
-                        resolve_endpoint(&client, &mut endpoint_cache, &existing_svc.endpoint_id)
-                            .await;
-                    let old_endpoint_message =
-                        maybe_old_endpoint.map(|old_endpoint| render_endpoint_url(&old_endpoint));
+                if existing_svc.deployment_id != dry_run_result.id {
+                    let maybe_old_deployment = resolve_deployment(
+                        &client,
+                        &mut deployment_cache,
+                        &existing_svc.deployment_id,
+                    )
+                    .await;
+                    let old_deployment_message = maybe_old_deployment
+                        .map(|old_endpoint| render_deployment_url(&old_endpoint));
                     c_indentln!(
                         2,
                         "Old Deployment: {} (at {})",
-                        old_endpoint_message.as_deref().unwrap_or("<UNKNOWN>"),
-                        &existing_svc.endpoint_id,
+                        old_deployment_message.as_deref().unwrap_or("<UNKNOWN>"),
+                        &existing_svc.deployment_id,
                     );
                 }
 
@@ -366,11 +369,11 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
 
     progress.set_message(format!(
         "Asking restate server {} to confirm this deployment (at {})",
-        env.meta_base_url, discover_opts.endpoint
+        env.meta_base_url, discover_opts.deployment
     ));
 
     let dry_run_result = client
-        .discover_endpoint(mk_request_body(
+        .discover_deployment(mk_request_body(
             /* force = */ discover_opts.force,
             /* dry_run = */ false,
         ))
@@ -391,13 +394,13 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
     Ok(())
 }
 
-async fn resolve_endpoint(
+async fn resolve_deployment(
     client: &MetasClient,
-    cache: &mut HashMap<String, ServiceEndpoint>,
-    endpoint_id: &str,
-) -> Option<ServiceEndpoint> {
-    if cache.contains_key(endpoint_id) {
-        return cache.get(endpoint_id).cloned();
+    cache: &mut HashMap<String, Deployment>,
+    deployment_id: &str,
+) -> Option<Deployment> {
+    if cache.contains_key(deployment_id) {
+        return cache.get(deployment_id).cloned();
     }
 
     let progress = ProgressBar::new_spinner();
@@ -407,22 +410,22 @@ async fn resolve_endpoint(
 
     progress.set_message(format!(
         "Fetching information about existing deployments at {}",
-        endpoint_id,
+        deployment_id,
     ));
 
-    let endpoint = client
-        .get_endpoint(endpoint_id)
+    let deployment = client
+        .get_deployment(deployment_id)
         .await
         .ok()?
         .into_body()
         .await
         .ok()
         .map(|endpoint| {
-            let service_endpoint = endpoint.service_endpoint;
-            cache.insert(endpoint_id.to_string(), service_endpoint.clone());
+            let service_endpoint = endpoint.deployment;
+            cache.insert(deployment_id.to_string(), service_endpoint.clone());
             Some(service_endpoint)
         })?;
     progress.finish_and_clear();
 
-    endpoint
+    deployment
 }

--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -168,27 +168,27 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
 
     progress.finish_and_clear();
 
-    // Is this an existing endpoint?
-    let existing_endpoint = match client
+    // Is this an existing deployment?
+    let existing_deployment = match client
         .get_deployment(&dry_run_result.id)
         .await?
         .into_body()
         .await
     {
-        Ok(existing_endpoint) => {
+        Ok(existing_deployment) => {
             // Appears to be an existing endpoint.
-            Some(existing_endpoint)
+            Some(existing_deployment)
         }
         Err(MetasClientError::Api(err)) if err.http_status_code == StatusCode::NOT_FOUND => None,
-        // We cannot get existing endpoint details. This is a problem.
+        // We cannot get existing deployment details. This is a problem.
         Err(err) => return Err(err.into()),
     };
 
-    if let Some(ref existing_endpoint) = existing_endpoint {
+    if let Some(ref existing_deployment) = existing_deployment {
         if !discover_opts.force {
             c_error!(
                 "A deployment already exists that uses this endpoint (ID: {}). Use --force to overwrite it.",
-                existing_endpoint.id,
+                existing_deployment.id,
             );
             return Ok(());
         } else {
@@ -201,7 +201,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
                 \n\nThis is a DANGEROUS operation! \n
                 In production, we recommend creating a new deployment with a unique endpoint while \
                 keeping the old one active until the old deployment is drained.",
-                existing_endpoint.id
+                existing_deployment.id
             );
             c_eprintln!();
         }
@@ -251,7 +251,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
     // The following services will be updated:
     if !updated.is_empty() {
         c_println!();
-        // used to resolving old endpoints.
+        // used to resolving old deployments.
         let mut deployment_cache: HashMap<String, Deployment> = HashMap::new();
         // A single spinner spans all requests.
         let progress = ProgressBar::new_spinner();
@@ -340,7 +340,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
     }
 
     // The following services will be removed/forgotten:
-    if let Some(existing_endpoint) = existing_endpoint {
+    if let Some(existing_endpoint) = existing_deployment {
         // The following services will be removed/forgotten:
         let services_removed = existing_endpoint
             .services

--- a/crates/benchmarks/benches/throughput_parallel.rs
+++ b/crates/benchmarks/benches/throughput_parallel.rs
@@ -31,7 +31,7 @@ fn throughput_benchmark(criterion: &mut Criterion) {
         .build()
         .expect("current thread runtime must build");
 
-    restate_benchmarks::discover_endpoint(
+    restate_benchmarks::discover_deployment(
         &current_thread_rt,
         Uri::from_static("http://localhost:9080"),
     );

--- a/crates/benchmarks/benches/throughput_sequential.rs
+++ b/crates/benchmarks/benches/throughput_sequential.rs
@@ -27,7 +27,7 @@ fn throughput_benchmark(criterion: &mut Criterion) {
         .build()
         .expect("current thread runtime must build");
 
-    restate_benchmarks::discover_endpoint(
+    restate_benchmarks::discover_deployment(
         &current_thread_rt,
         Uri::from_static("http://localhost:9080"),
     );

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -27,14 +27,14 @@ pub mod counter {
     include!(concat!(env!("OUT_DIR"), "/counter.rs"));
 }
 
-pub fn discover_endpoint(current_thread_rt: &Runtime, address: Uri) {
+pub fn discover_deployment(current_thread_rt: &Runtime, address: Uri) {
     let discovery_payload = serde_json::json!({"uri": address.to_string()}).to_string();
     let discovery_result = current_thread_rt.block_on(async {
         RetryPolicy::fixed_delay(Duration::from_millis(200), 50)
             .retry_operation(|| {
                 hyper::Client::new()
                     .request(
-                        hyper::Request::post("http://localhost:9070/endpoints")
+                        hyper::Request::post("http://localhost:9070/deployments")
                             .header(CONTENT_TYPE, "application/json")
                             .body(Body::from(discovery_payload.clone()))
                             .expect("building discovery request should not fail"),

--- a/crates/errors/src/error_codes/META0003.md
+++ b/crates/errors/src/error_codes/META0003.md
@@ -1,8 +1,8 @@
 ## META0003
 
-Cannot reach the endpoint to execute service discovery. Make sure:
+Cannot reach the deployment to execute service discovery. Make sure:
 
-* The provided `uri` is correct
-* The service endpoint is up and running
-* The Restate runtime can reach the service endpoint through the configured `uri`
+* The provided `uri`/`arn` is correct
+* The deployment is up and running
+* Restate can reach the deployment through the configured `uri`/`arn`
 * If additional authentication is required, make sure it's configured through `additional_headers`

--- a/crates/errors/src/error_codes/META0004.md
+++ b/crates/errors/src/error_codes/META0004.md
@@ -1,9 +1,9 @@
 ## META0004
 
-Cannot register the provided service endpoint, because it conflicts with the uri of an already registered service endpoint.
+Cannot register the provided deployment, because it conflicts with the uri of an already registered deployment.
 
-In Restate service endpoints have a unique uri and are immutable, thus it's not possible to discover the same endpoint uri twice. 
-Make sure, when updating a service endpoint, to assign it a new uri. 
+In Restate deployments have a unique uri/arn and are immutable, thus it's not possible to discover the same deployment twice. 
+Make sure, when updating a deployment, to assign it a new uri/arn. 
 
 You can force the override using the `"force": true` field in the discover request, but beware that this can lead in-flight invocations to an unrecoverable error state.  
 

--- a/crates/errors/src/error_codes/META0005.md
+++ b/crates/errors/src/error_codes/META0005.md
@@ -1,5 +1,5 @@
 ## META0005
 
-Cannot propagate endpoint/service metadata to Restate components. If you see this error when starting Restate, this might indicate a corrupted Meta storage.
+Cannot propagate deployment/service metadata to Restate components. If you see this error when starting Restate, this might indicate a corrupted Meta storage.
 
-We recommend wiping the Meta storage and recreate it by registering endpoints in the same order they were registered before.
+We recommend wiping the Meta storage and recreate it by registering deployments in the same order they were registered before.

--- a/crates/errors/src/error_codes/META0006.md
+++ b/crates/errors/src/error_codes/META0006.md
@@ -1,6 +1,6 @@
 ## META0006
 
-Cannot register the newly discovered service revision in the provided service endpoint, because it conflicts with an already existing service revision.
+Cannot register the newly discovered service revision in the provided deployment, because it conflicts with an already existing service revision.
 
 When implementing a new service revision, make sure that:
 

--- a/crates/errors/src/error_codes/RT0003.md
+++ b/crates/errors/src/error_codes/RT0003.md
@@ -1,6 +1,6 @@
 ## RT0003
 
-The invocation failed because the invoker received a message from a service endpoint larger than the `worker.invoker.message_size_limit`.
+The invocation failed because the invoker received a message from a service larger than the `worker.invoker.message_size_limit`.
 
 Suggestions:
 

--- a/crates/errors/src/error_codes/RT0006.md
+++ b/crates/errors/src/error_codes/RT0006.md
@@ -1,11 +1,11 @@
 ## RT0006
 
-An error occurred while invoking the service endpoint. 
+An error occurred while invoking the service deployment. 
 This is a generic error which can be caused by many reasons, including:
 
 * Transient network or storage errors
-* Misconfiguration of the service endpoint and/or of the Restate runtime
+* Misconfiguration of the deployment and/or of the Restate runtime
 * Non-deterministic user code execution
 * Restate runtime and/or SDK bug
 
-We suggest checking the service endpoint logs as well to get any hint on the error cause.
+We suggest checking the service and/or deployment logs as well to get any hint on the error cause.

--- a/crates/errors/src/error_codes/RT0007.md
+++ b/crates/errors/src/error_codes/RT0007.md
@@ -1,8 +1,8 @@
 ## RT0007
 
-A retry-able error was received from the service endpoint while processing the invocation.
+A retry-able error was received from the service deployment while processing the invocation.
 
 Suggestions:
 
-* Check the service endpoint logs to get more info about the error cause, like the stacktrace.
+* Check the service/deployment logs to get more info about the error cause, like the stacktrace.
 * Look at the https://docs.restate.dev/services/sdk/error-handling for more info about error handling in services.

--- a/crates/ingress-grpc/src/lib.rs
+++ b/crates/ingress-grpc/src/lib.rs
@@ -105,7 +105,7 @@ impl ConnectInfo {
 // Contains some mocks we use in unit tests in this crate
 #[cfg(test)]
 mod mocks {
-    use restate_schema_api::endpoint::{DeliveryOptions, EndpointMetadata, ProtocolType};
+    use restate_schema_api::deployment::{DeliveryOptions, DeploymentMetadata, ProtocolType};
     use restate_schema_impl::Schemas;
 
     pub(super) fn test_schemas() -> Schemas {
@@ -114,8 +114,8 @@ mod mocks {
         schemas
             .apply_updates(
                 schemas
-                    .compute_new_endpoint(
-                        EndpointMetadata::new_http(
+                    .compute_new_deployment(
+                        DeploymentMetadata::new_http(
                             "http://localhost:9080".parse().unwrap(),
                             ProtocolType::BidiStream,
                             DeliveryOptions::default(),

--- a/crates/invoker-api/src/effects.rs
+++ b/crates/invoker-api/src/effects.rs
@@ -10,7 +10,7 @@
 
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::FullInvocationId;
-use restate_types::identifiers::{EndpointId, EntryIndex};
+use restate_types::identifiers::{DeploymentId, EntryIndex};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use std::collections::HashSet;
 
@@ -22,8 +22,8 @@ pub struct Effect {
 
 #[derive(Debug)]
 pub enum EffectKind {
-    /// This is sent before any new entry is created by the invoker. This won't be sent if the endpoint_id is already set.
-    SelectedEndpoint(EndpointId),
+    /// This is sent before any new entry is created by the invoker. This won't be sent if the deployment_id is already set.
+    SelectedDeployment(DeploymentId),
     JournalEntry {
         entry_index: EntryIndex,
         entry: EnrichedRawEntry,

--- a/crates/invoker-api/src/entry_enricher.rs
+++ b/crates/invoker-api/src/entry_enricher.rs
@@ -66,7 +66,7 @@ pub mod mocks {
                             }),
                         }
                     } else {
-                        // No need to service resolution if the entry was completed by the service endpoint
+                        // No need to service resolution if the entry was completed by the service
                         EnrichedEntryHeader::Invoke {
                             is_completed,
                             resolution_result: None,

--- a/crates/invoker-api/src/journal_reader.rs
+++ b/crates/invoker-api/src/journal_reader.rs
@@ -10,7 +10,7 @@
 
 use bytestring::ByteString;
 use futures::Stream;
-use restate_types::identifiers::{EndpointId, FullInvocationId};
+use restate_types::identifiers::{DeploymentId, FullInvocationId};
 use restate_types::invocation::ServiceInvocationSpanContext;
 use restate_types::journal::raw::PlainRawEntry;
 use restate_types::journal::EntryIndex;
@@ -22,7 +22,7 @@ pub struct JournalMetadata {
     pub length: EntryIndex,
     pub span_context: ServiceInvocationSpanContext,
     pub method: ByteString,
-    pub endpoint_id: Option<EndpointId>,
+    pub deployment_id: Option<DeploymentId>,
 }
 
 impl JournalMetadata {
@@ -30,10 +30,10 @@ impl JournalMetadata {
         length: EntryIndex,
         span_context: ServiceInvocationSpanContext,
         method: ByteString,
-        endpoint_id: Option<String>,
+        deployment_id: Option<String>,
     ) -> Self {
         Self {
-            endpoint_id,
+            deployment_id,
             method,
             span_context,
             length,

--- a/crates/invoker-api/src/status_handle.rs
+++ b/crates/invoker-api/src/status_handle.rs
@@ -10,7 +10,7 @@
 
 use codederror::Code;
 use restate_types::errors::{InvocationError, InvocationErrorCode};
-use restate_types::identifiers::{EndpointId, FullInvocationId, PartitionKey};
+use restate_types::identifiers::{DeploymentId, FullInvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
 use std::fmt;
 use std::future::Future;
@@ -26,7 +26,7 @@ pub struct InvocationStatusReportInner {
     pub last_start_at: SystemTime,
     pub last_retry_attempt_failure: Option<InvocationErrorReport>,
     pub next_retry_at: Option<SystemTime>,
-    pub last_attempt_endpoint_id: Option<EndpointId>,
+    pub last_attempt_deployment_id: Option<DeploymentId>,
 }
 
 impl Default for InvocationStatusReportInner {
@@ -37,7 +37,7 @@ impl Default for InvocationStatusReportInner {
             last_start_at: SystemTime::now(),
             last_retry_attempt_failure: None,
             next_retry_at: None,
-            last_attempt_endpoint_id: None,
+            last_attempt_deployment_id: None,
         }
     }
 }
@@ -90,8 +90,8 @@ impl InvocationStatusReport {
         self.2.last_retry_attempt_failure.as_ref()
     }
 
-    pub fn last_attempt_endpoint_id(&self) -> Option<&EndpointId> {
-        self.2.last_attempt_endpoint_id.as_ref()
+    pub fn last_attempt_deployment_id(&self) -> Option<&DeploymentId> {
+        self.2.last_attempt_deployment_id.as_ref()
     }
 }
 

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -17,7 +17,7 @@ restate-fs-util = { workspace = true }
 restate-futures-util = { workspace = true }
 restate-invoker-api = { workspace = true }
 restate-queue = { workspace = true }
-restate-schema-api = { workspace = true, features = ["endpoint"] }
+restate-schema-api = { workspace = true, features = ["deployment"] }
 restate-service-client = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["message"] }
 restate-timer-queue = { workspace = true }

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 
-use restate_types::identifiers::EndpointId;
+use restate_types::identifiers::DeploymentId;
 use restate_types::journal::Completion;
 use restate_types::retries;
 use std::fmt;
@@ -81,8 +81,8 @@ enum InvocationState {
         journal_tracker: JournalTracker,
         abort_handle: AbortHandle,
 
-        // If Some, we need to notify the endpoint id to the partition processor
-        chosen_endpoint: Option<EndpointId>,
+        // If Some, we need to notify the deployment id to the partition processor
+        chosen_deployment: Option<DeploymentId>,
     },
 
     WaitingRetry {
@@ -146,7 +146,7 @@ impl InvocationStateMachine {
             completions_tx: Some(completions_tx),
             journal_tracker: Default::default(),
             abort_handle,
-            chosen_endpoint: None,
+            chosen_deployment: None,
         };
     }
 
@@ -156,34 +156,34 @@ impl InvocationStateMachine {
         }
     }
 
-    pub(super) fn notify_chosen_endpoint(&mut self, endpoint_id: EndpointId) {
+    pub(super) fn notify_chosen_deployment(&mut self, endpoint_id: DeploymentId) {
         debug_assert!(matches!(
             &self.invocation_state,
             InvocationState::InFlight {
-                chosen_endpoint: None,
+                chosen_deployment: None,
                 ..
             }
         ));
 
         if let InvocationState::InFlight {
-            chosen_endpoint, ..
+            chosen_deployment, ..
         } = &mut self.invocation_state
         {
-            *chosen_endpoint = Some(endpoint_id);
+            *chosen_deployment = Some(endpoint_id);
         }
     }
 
-    pub(super) fn chosen_endpoint_to_notify(&mut self) -> Option<EndpointId> {
+    pub(super) fn chosen_deployment_to_notify(&mut self) -> Option<DeploymentId> {
         debug_assert!(matches!(
             &self.invocation_state,
             InvocationState::InFlight { .. }
         ));
 
         if let InvocationState::InFlight {
-            chosen_endpoint, ..
+            chosen_deployment, ..
         } = &mut self.invocation_state
         {
-            chosen_endpoint.take()
+            chosen_deployment.take()
         } else {
             None
         }

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -24,17 +24,17 @@ use restate_errors::warn_it;
 use restate_invoker_api::{
     EagerState, EntryEnricher, InvokeInputJournal, JournalReader, StateReader,
 };
-use restate_schema_api::endpoint::{
-    EndpointMetadata, EndpointMetadataResolver, EndpointType, ProtocolType,
+use restate_schema_api::deployment::{
+    DeploymentMetadata, DeploymentMetadataResolver, DeploymentType, ProtocolType,
 };
-use restate_service_client::{
-    Parts, Request, ServiceClient, ServiceClientError, ServiceEndpointAddress,
-};
+use restate_service_client::{Endpoint, Parts, Request, ServiceClient, ServiceClientError};
 use restate_service_protocol::message::{
     Decoder, Encoder, EncodingError, MessageHeader, MessageType, ProtocolMessage,
 };
 use restate_types::errors::InvocationError;
-use restate_types::identifiers::{EndpointId, EntryIndex, FullInvocationId, PartitionLeaderEpoch};
+use restate_types::identifiers::{
+    DeploymentId, EntryIndex, FullInvocationId, PartitionLeaderEpoch,
+};
 use restate_types::invocation::ServiceInvocationSpanContext;
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::raw::{EntryHeader, PlainRawEntry, RawEntryHeader};
@@ -62,10 +62,10 @@ const APPLICATION_RESTATE: HeaderValue = HeaderValue::from_static("application/r
 #[derive(Debug, thiserror::Error, codederror::CodedError)]
 #[code(restate_errors::RT0006)]
 pub(crate) enum InvocationTaskError {
-    #[error("no endpoint was found to process the invocation")]
-    NoEndpointForService,
-    #[error("the invocation has an endpoint id associated, but it was not found in the registry. This might indicate that an endpoint was forcefully removed from the registry, but there are still in-flight invocations for that endpoint")]
-    UnknownEndpoint(EndpointId),
+    #[error("no deployment was found to process the invocation")]
+    NoDeploymentForService,
+    #[error("the invocation has a deployment id associated, but it was not found in the registry. This might indicate that a deployment was forcefully removed from the registry, but there are still in-flight invocations pinned to it")]
+    UnknownDeployment(DeploymentId),
     #[error("unexpected http status code: {0}")]
     UnexpectedResponse(http::StatusCode),
     #[error("unexpected content type: {0:?}")]
@@ -170,7 +170,7 @@ pub(super) struct InvocationTaskOutput {
 
 pub(super) enum InvocationTaskOutputInner {
     // `has_changed` indicates if we believe this is a freshly selected endpoint or not.
-    SelectedEndpoint(EndpointId, /* has_changed: */ bool),
+    SelectedDeployment(DeploymentId, /* has_changed: */ bool),
     NewEntry {
         entry_index: EntryIndex,
         entry: EnrichedRawEntry,
@@ -202,7 +202,7 @@ pub(super) struct InvocationTask<JR, SR, EE, EMR> {
     journal_reader: JR,
     state_reader: SR,
     entry_enricher: EE,
-    endpoint_metadata_resolver: EMR,
+    deployment_metadata_resolver: EMR,
     invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
     invoker_rx: mpsc::UnboundedReceiver<Completion>,
 
@@ -251,7 +251,7 @@ where
     SR: StateReader + Clone + Send + Sync + 'static,
     <SR as StateReader>::StateIter: Send,
     EE: EntryEnricher,
-    EMR: EndpointMetadataResolver,
+    EMR: DeploymentMetadataResolver,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -267,7 +267,7 @@ where
         journal_reader: JR,
         state_reader: SR,
         entry_enricher: EE,
-        endpoint_metadata_resolver: EMR,
+        deployment_metadata_resolver: EMR,
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
         invoker_rx: mpsc::UnboundedReceiver<Completion>,
     ) -> Self {
@@ -282,7 +282,7 @@ where
             journal_reader,
             state_reader,
             entry_enricher,
-            endpoint_metadata_resolver,
+            deployment_metadata_resolver,
             invoker_tx,
             invoker_rx,
             encoder: Encoder::new(protocol_version),
@@ -291,7 +291,7 @@ where
         }
     }
 
-    /// Loop opening the request to service endpoint and consuming the stream
+    /// Loop opening the request to deployment and consuming the stream
     #[instrument(level = "debug", name = "invoker_invocation_task", fields(rpc.system = "restate", rpc.service = %self.full_invocation_id.service_id.service_name, restate.invocation.id = %self.full_invocation_id), skip_all)]
     pub async fn run(mut self, input_journal: InvokeInputJournal) {
         // Execute the task
@@ -369,34 +369,34 @@ where
         let ((journal_metadata, journal_stream), state_iter) =
             shortcircuit!(tokio::try_join!(read_journal_future, read_state_future));
 
-        // Resolve the endpoint metadata
-        let (endpoint_metadata, endpoint_changed) =
-            if let Some(endpoint_id) = journal_metadata.endpoint_id {
-                // We have a pinned endpoint that we can't change even if newer
-                // endpoints have been registered for the same service.
-                let endpoint_metadata = shortcircuit!(self
-                    .endpoint_metadata_resolver
-                    .get_endpoint(&endpoint_id)
-                    .ok_or_else(|| InvocationTaskError::UnknownEndpoint(endpoint_id.clone())));
-                (endpoint_metadata, /* has_changed= */ false)
+        // Resolve the deployment metadata
+        let (deployment_metadata, deployment_changed) =
+            if let Some(deployment_id) = journal_metadata.deployment_id {
+                // We have a pinned deployment that we can't change even if newer
+                // deployments have been registered for the same service.
+                let deployment_metadata = shortcircuit!(self
+                    .deployment_metadata_resolver
+                    .get_deployment(&deployment_id)
+                    .ok_or_else(|| InvocationTaskError::UnknownDeployment(deployment_id.clone())));
+                (deployment_metadata, /* has_changed= */ false)
             } else {
-                // We can choose the freshest endpoint for the latest revision
+                // We can choose the freshest deployment for the latest revision
                 // of the registered service.
-                let endpoint_metadata = shortcircuit!(self
-                    .endpoint_metadata_resolver
-                    .resolve_latest_endpoint_for_service(
+                let deployment_metadata = shortcircuit!(self
+                    .deployment_metadata_resolver
+                    .resolve_latest_deployment_for_service(
                         &self.full_invocation_id.service_id.service_name
                     )
-                    .ok_or(InvocationTaskError::NoEndpointForService));
-                (endpoint_metadata, /* has_changed= */ true)
+                    .ok_or(InvocationTaskError::NoDeploymentForService));
+                (deployment_metadata, /* has_changed= */ true)
             };
 
         let _ = self.invoker_tx.send(InvocationTaskOutput {
             partition: self.partition,
             full_invocation_id: self.full_invocation_id.clone(),
-            inner: InvocationTaskOutputInner::SelectedEndpoint(
-                endpoint_metadata.id(),
-                endpoint_changed,
+            inner: InvocationTaskOutputInner::SelectedDeployment(
+                deployment_metadata.id(),
+                deployment_changed,
             ),
         });
 
@@ -404,7 +404,7 @@ where
         let protocol_type = if self.inactivity_timeout.is_zero() {
             ProtocolType::RequestResponse
         } else {
-            endpoint_metadata.protocol_type()
+            deployment_metadata.protocol_type()
         };
 
         // Close the invoker_rx in case it's request response, this avoids further buffering of messages in this channel.
@@ -434,9 +434,9 @@ where
             .attach_to_span(&invocation_task_span);
 
         info!(
-            endpoint.address = %endpoint_metadata.address_display(),
+            deployment.address = %deployment_metadata.address_display(),
             path = %path,
-            "Executing invocation at service endpoint"
+            "Executing invocation at deployment"
         );
 
         // Create an arc of the parent SpanContext.
@@ -444,7 +444,7 @@ where
         let service_invocation_span_context = journal_metadata.span_context;
 
         // Prepare the request and send start message
-        let (mut http_stream_tx, request) = self.prepare_request(path, endpoint_metadata);
+        let (mut http_stream_tx, request) = self.prepare_request(path, deployment_metadata);
         shortcircuit!(
             self.write_start(&mut http_stream_tx, journal_size, state_iter)
                 .await
@@ -475,7 +475,7 @@ where
             );
         } else {
             // Drop the http_stream_tx.
-            // This is required in HTTP/1.1 to let the service endpoint send the headers back
+            // This is required in HTTP/1.1 to let the deployment send the headers back
             drop(http_stream_tx)
         }
 
@@ -627,7 +627,7 @@ where
 
         if let Err(hyper_err) = http_stream_tx.send_data(buf).await {
             // is_closed() is try only if the request channel (Sender) has been closed.
-            // This can happen if the service endpoint is suspending.
+            // This can happen if the deployment is suspending.
             if !hyper_err.is_closed() {
                 return Err(InvocationTaskError::Client(ServiceClientError::Http(
                     hyper_err.into(),
@@ -719,7 +719,7 @@ where
     fn prepare_request(
         &mut self,
         path: PathAndQuery,
-        endpoint_metadata: EndpointMetadata,
+        deployment_metadata: DeploymentMetadata,
     ) -> (Sender, Request<Body>) {
         let (http_stream_tx, req_body) = Body::channel();
 
@@ -734,15 +734,15 @@ where
             &mut HeaderInjector(&mut headers),
         );
 
-        let address = match endpoint_metadata.ty {
-            EndpointType::Lambda {
+        let address = match deployment_metadata.ty {
+            DeploymentType::Lambda {
                 arn,
                 assume_role_arn,
-            } => ServiceEndpointAddress::Lambda(arn, assume_role_arn),
-            EndpointType::Http {
+            } => Endpoint::Lambda(arn, assume_role_arn),
+            DeploymentType::Http {
                 address,
                 protocol_type,
-            } => ServiceEndpointAddress::Http(
+            } => Endpoint::Http(
                 address,
                 match protocol_type {
                     ProtocolType::RequestResponse => http::Version::default(),
@@ -751,7 +751,7 @@ where
             ),
         };
 
-        headers.extend(endpoint_metadata.delivery_options.additional_headers);
+        headers.extend(deployment_metadata.delivery_options.additional_headers);
 
         (
             http_stream_tx,

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -187,7 +187,7 @@ impl From<InvocationTaskError> for InvocationTaskOutputInner {
 }
 
 /// Represents an open invocation stream
-pub(super) struct InvocationTask<JR, SR, EE, EMR> {
+pub(super) struct InvocationTask<JR, SR, EE, DMR> {
     // Shared client
     client: ServiceClient,
 
@@ -202,7 +202,7 @@ pub(super) struct InvocationTask<JR, SR, EE, EMR> {
     journal_reader: JR,
     state_reader: SR,
     entry_enricher: EE,
-    deployment_metadata_resolver: EMR,
+    deployment_metadata_resolver: DMR,
     invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
     invoker_rx: mpsc::UnboundedReceiver<Completion>,
 
@@ -244,14 +244,14 @@ macro_rules! shortcircuit {
     };
 }
 
-impl<JR, SR, EE, EMR> InvocationTask<JR, SR, EE, EMR>
+impl<JR, SR, EE, DMR> InvocationTask<JR, SR, EE, DMR>
 where
     JR: JournalReader + Clone + Send + Sync + 'static,
     <JR as JournalReader>::JournalStream: Unpin + Send + 'static,
     SR: StateReader + Clone + Send + Sync + 'static,
     <SR as StateReader>::StateIter: Send,
     EE: EntryEnricher,
-    EMR: DeploymentMetadataResolver,
+    DMR: DeploymentMetadataResolver,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -267,7 +267,7 @@ where
         journal_reader: JR,
         state_reader: SR,
         entry_enricher: EE,
-        deployment_metadata_resolver: EMR,
+        deployment_metadata_resolver: DMR,
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
         invoker_rx: mpsc::UnboundedReceiver<Completion>,
     ) -> Self {

--- a/crates/invoker-impl/src/options.rs
+++ b/crates/invoker-impl/src/options.rs
@@ -71,12 +71,12 @@ pub struct Options {
 
     /// # Message size warning
     ///
-    /// Threshold to log a warning in case protocol messages coming from service are larger than the specified amount.
+    /// Threshold to log a warning in case protocol messages coming from a service are larger than the specified amount.
     message_size_warning: usize,
 
     /// # Message size limit
     ///
-    /// Threshold to fail the invocation in case protocol messages coming from service are larger than the specified amount.
+    /// Threshold to fail the invocation in case protocol messages coming from a service are larger than the specified amount.
     message_size_limit: Option<usize>,
 
     /// # Temporary directory

--- a/crates/invoker-impl/src/options.rs
+++ b/crates/invoker-impl/src/options.rs
@@ -12,7 +12,7 @@ use super::Service;
 
 use futures::Stream;
 use restate_invoker_api::{EntryEnricher, JournalReader};
-use restate_schema_api::endpoint::EndpointMetadataResolver;
+use restate_schema_api::deployment::DeploymentMetadataResolver;
 use restate_service_client::AssumeRoleCacheMode;
 use restate_types::journal::raw::PlainRawEntry;
 use restate_types::retries::RetryPolicy;
@@ -71,12 +71,12 @@ pub struct Options {
 
     /// # Message size warning
     ///
-    /// Threshold to log a warning in case protocol messages coming from service endpoint are larger than the specified amount.
+    /// Threshold to log a warning in case protocol messages coming from service are larger than the specified amount.
     message_size_warning: usize,
 
     /// # Message size limit
     ///
-    /// Threshold to fail the invocation in case protocol messages coming from service endpoint are larger than the specified amount.
+    /// Threshold to fail the invocation in case protocol messages coming from service are larger than the specified amount.
     message_size_limit: Option<usize>,
 
     /// # Temporary directory
@@ -119,23 +119,23 @@ impl Default for Options {
 }
 
 impl Options {
-    pub fn build<JR, JS, SR, EE, EMR>(
+    pub fn build<JR, JS, SR, EE, DMR>(
         self,
         journal_reader: JR,
         state_reader: SR,
         entry_enricher: EE,
-        service_endpoint_registry: EMR,
-    ) -> Service<JR, SR, EE, EMR>
+        deployment_registry: DMR,
+    ) -> Service<JR, SR, EE, DMR>
     where
         JR: JournalReader<JournalStream = JS> + Clone + Send + Sync + 'static,
         JS: Stream<Item = PlainRawEntry> + Unpin + Send + 'static,
         EE: EntryEnricher,
-        EMR: EndpointMetadataResolver,
+        DMR: DeploymentMetadataResolver,
     {
         let client = self.service_client.build(AssumeRoleCacheMode::Unbounded);
 
         Service::new(
-            service_endpoint_registry,
+            deployment_registry,
             self.retry_policy,
             *self.inactivity_timeout,
             *self.abort_timeout,

--- a/crates/invoker-impl/src/status_store.rs
+++ b/crates/invoker-impl/src/status_store.rs
@@ -49,15 +49,15 @@ impl InvocationStatusStore {
         report.in_flight = true;
     }
 
-    pub(super) fn on_endpoint_chosen(
+    pub(super) fn on_deployment_chosen(
         &mut self,
         partition: &PartitionLeaderEpoch,
         fid: &FullInvocationId,
-        endpoint_id: EndpointId,
+        deployment_id: DeploymentId,
     ) {
         if let Some(inner) = self.0.get_mut(partition) {
             if let Some(report) = inner.get_mut(fid) {
-                report.last_attempt_endpoint_id = Some(endpoint_id);
+                report.last_attempt_deployment_id = Some(deployment_id);
             }
         }
     }

--- a/crates/invoker-impl/tests/counter_test.rs
+++ b/crates/invoker-impl/tests/counter_test.rs
@@ -20,8 +20,8 @@ use prost::Message;
 use restate_invoker_api::entry_enricher::mocks::MockEntryEnricher;
 use restate_invoker_api::{Effect, EffectKind};
 use restate_invoker_impl::{ChannelServiceHandle, Service};
-use restate_schema_api::endpoint::mocks::MockEndpointMetadataRegistry;
-use restate_schema_api::endpoint::{DeliveryOptions, EndpointMetadata, ProtocolType};
+use restate_schema_api::deployment::mocks::MockDeploymentMetadataRegistry;
+use restate_schema_api::deployment::{DeliveryOptions, DeploymentMetadata, ProtocolType};
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_test_util::{assert, assert_eq, let_assert, test};
 use restate_types::identifiers::FullInvocationId;
@@ -138,10 +138,10 @@ async fn bidi_stream() {
     // Mock journal reader
     let journal_reader = InMemoryJournalStorage::default();
 
-    let mut endpoint_metadata_registry = MockEndpointMetadataRegistry::default();
-    endpoint_metadata_registry.mock_service_with_metadata(
+    let mut deployment_metadata_registry = MockDeploymentMetadataRegistry::default();
+    deployment_metadata_registry.mock_service_with_metadata(
         &fid.service_id.service_name,
-        EndpointMetadata::new_http(
+        DeploymentMetadata::new_http(
             Uri::from_static("http://localhost:9080"),
             ProtocolType::BidiStream,
             DeliveryOptions::default(),
@@ -154,12 +154,12 @@ async fn bidi_stream() {
         InMemoryJournalStorage,
         InMemoryStateStorage,
         MockEntryEnricher,
-        MockEndpointMetadataRegistry,
+        MockDeploymentMetadataRegistry,
     > = options.build(
         journal_reader.clone(),
         InMemoryStateStorage::default(),
         MockEntryEnricher,
-        endpoint_metadata_registry,
+        deployment_metadata_registry,
     );
 
     // Build the partition processor simulator

--- a/crates/invoker-impl/tests/mocks.rs
+++ b/crates/invoker-impl/tests/mocks.rs
@@ -219,7 +219,7 @@ impl InMemoryJournalStorage {
             fid,
             (
                 JournalMetadata {
-                    endpoint_id: None,
+                    deployment_id: None,
                     method: method.into().into(),
                     span_context,
                     length: 0,

--- a/crates/meta-rest-model/Cargo.toml
+++ b/crates/meta-rest-model/Cargo.toml
@@ -13,7 +13,7 @@ schema = ["dep:schemars", "restate-schema-api/serde_schema", "restate-serde-util
 
 [dependencies]
 restate-types = { workspace = true, features = ["serde"] }
-restate-schema-api = { workspace = true, features = [ "service", "endpoint", "serde", "subscription" ] }
+restate-schema-api = { workspace = true, features = [ "service", "deployment", "serde", "subscription" ] }
 restate-serde-util = { workspace = true }
 
 http = { workspace = true }

--- a/crates/meta-rest-model/src/deployments.rs
+++ b/crates/meta-rest-model/src/deployments.rs
@@ -21,14 +21,14 @@ use serde_with::serde_as;
 
 // Export schema types to be used by other crates without exposing the fact
 // that we are using proxying to restate-schema-api or restate-types
-use restate_schema_api::endpoint::EndpointType;
-pub use restate_schema_api::endpoint::{EndpointMetadata, ProtocolType};
-pub use restate_types::identifiers::{EndpointId, LambdaARN};
+use restate_schema_api::deployment::DeploymentType;
+pub use restate_schema_api::deployment::{DeploymentMetadata, ProtocolType};
+pub use restate_types::identifiers::{DeploymentId, LambdaARN};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServiceEndpoint {
+pub enum Deployment {
     Http {
         #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
         #[cfg_attr(feature = "schema", schemars(with = "String"))]
@@ -55,10 +55,10 @@ pub enum ServiceEndpoint {
     },
 }
 
-impl From<EndpointMetadata> for ServiceEndpoint {
-    fn from(value: EndpointMetadata) -> Self {
+impl From<DeploymentMetadata> for Deployment {
+    fn from(value: DeploymentMetadata) -> Self {
         match value.ty {
-            EndpointType::Http {
+            DeploymentType::Http {
                 address,
                 protocol_type,
             } => Self::Http {
@@ -67,7 +67,7 @@ impl From<EndpointMetadata> for ServiceEndpoint {
                 additional_headers: value.delivery_options.additional_headers.into(),
                 created_at: SystemTime::from(value.created_at).into(),
             },
-            EndpointType::Lambda {
+            DeploymentType::Lambda {
                 arn,
                 assume_role_arn,
             } => Self::Lambda {
@@ -82,16 +82,18 @@ impl From<EndpointMetadata> for ServiceEndpoint {
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RegisterServiceEndpointRequest {
+pub struct RegisterDeploymentRequest {
     #[serde(flatten)]
-    pub endpoint_metadata: RegisterServiceEndpointMetadata,
+    pub deployment_metadata: RegisterDeploymentMetadata,
+
     /// # Additional headers
     ///
-    /// Additional headers added to the discover/invoke requests to the service endpoint.
+    /// Additional headers added to the discover/invoke requests to the deployment.
+    ///
     pub additional_headers: Option<SerdeableHeaderHashMap>,
     /// # Force
     ///
-    /// If `true`, it will override, if existing, any endpoint using the same `uri`.
+    /// If `true`, it will override, if existing, any deployment using the same `uri`.
     /// Beware that this can lead in-flight invocations to an unrecoverable error state.
     ///
     /// By default, this is `true` but it might change in future to `false`.
@@ -102,8 +104,8 @@ pub struct RegisterServiceEndpointRequest {
 
     /// # Dry-run mode
     ///
-    /// If `true`, discovery will run but the endpoint will not be registered.
-    /// This is useful to see the impact of a new endpoint before registering it.
+    /// If `true`, discovery will run but the deployment will not be registered.
+    /// This is useful to see the impact of a new deployment before registering it.
     #[serde(default = "restate_serde_util::default::bool::<false>")]
     pub dry_run: bool,
 }
@@ -112,11 +114,11 @@ pub struct RegisterServiceEndpointRequest {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum RegisterServiceEndpointMetadata {
+pub enum RegisterDeploymentMetadata {
     Http {
         /// # Uri
         ///
-        /// Uri to use to discover/invoke the http service endpoint.
+        /// Uri to use to discover/invoke the http deployment.
         #[serde_as(as = "serde_with::DisplayFromStr")]
         #[cfg_attr(feature = "schema", schemars(with = "String"))]
         uri: Uri,
@@ -124,11 +126,11 @@ pub enum RegisterServiceEndpointMetadata {
     Lambda {
         /// # ARN
         ///
-        /// ARN to use to discover/invoke the lambda service endpoint.
+        /// ARN to use to discover/invoke the lambda deployment.
         arn: String,
         /// # Assume role ARN
         ///
-        /// Optional ARN of a role to assume when invoking this endpoint, to support role chaining
+        /// Optional ARN of a role to assume when invoking the addressed Lambda, to support role chaining
         assume_role_arn: Option<String>,
     },
 }
@@ -142,37 +144,41 @@ pub struct ServiceNameRevPair {
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RegisterServiceEndpointResponse {
-    pub id: EndpointId,
+pub struct RegisterDeploymentResponse {
+    pub id: DeploymentId,
     pub services: Vec<ServiceMetadata>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ListServiceEndpointsResponse {
-    pub endpoints: Vec<ServiceEndpointResponse>,
+pub struct ListDeploymentResponse {
+    pub deployments: Vec<DeploymentResponse>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ServiceEndpointResponse {
-    pub id: EndpointId,
+pub struct DeploymentResponse {
+    pub id: DeploymentId,
+
     #[serde(flatten)]
-    pub service_endpoint: ServiceEndpoint,
+    pub deployment: Deployment,
+
     /// # Services
     ///
-    /// List of services exposed by this service endpoint.
+    /// List of services exposed by this deployment.
     pub services: Vec<ServiceNameRevPair>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct DetailedServiceEndpointResponse {
-    pub id: EndpointId,
+pub struct DetailedDeploymentResponse {
+    pub id: DeploymentId,
+
     #[serde(flatten)]
-    pub service_endpoint: ServiceEndpoint,
+    pub deployment: Deployment,
+
     /// # Services
     ///
-    /// List of services exposed by this service endpoint.
+    /// List of services exposed by this deployment.
     pub services: Vec<ServiceMetadata>,
 }

--- a/crates/meta-rest-model/src/deployments.rs
+++ b/crates/meta-rest-model/src/deployments.rs
@@ -80,41 +80,12 @@ impl From<DeploymentMetadata> for Deployment {
     }
 }
 
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RegisterDeploymentRequest {
-    #[serde(flatten)]
-    pub deployment_metadata: RegisterDeploymentMetadata,
-
-    /// # Additional headers
-    ///
-    /// Additional headers added to the discover/invoke requests to the deployment.
-    ///
-    pub additional_headers: Option<SerdeableHeaderHashMap>,
-    /// # Force
-    ///
-    /// If `true`, it will override, if existing, any deployment using the same `uri`.
-    /// Beware that this can lead in-flight invocations to an unrecoverable error state.
-    ///
-    /// By default, this is `true` but it might change in future to `false`.
-    ///
-    /// See the [versioning documentation](https://docs.restate.dev/services/upgrades-removal) for more information.
-    #[serde(default = "restate_serde_util::default::bool::<true>")]
-    pub force: bool,
-
-    /// # Dry-run mode
-    ///
-    /// If `true`, discovery will run but the deployment will not be registered.
-    /// This is useful to see the impact of a new deployment before registering it.
-    #[serde(default = "restate_serde_util::default::bool::<false>")]
-    pub dry_run: bool,
-}
-
+// This enum could be a struct with a nested enum to avoid repeating some fields, but serde(flatten) unfortunately breaks the openapi code generation
 #[serde_as]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum RegisterDeploymentMetadata {
+pub enum RegisterDeploymentRequest {
     Http {
         /// # Uri
         ///
@@ -122,16 +93,63 @@ pub enum RegisterDeploymentMetadata {
         #[serde_as(as = "serde_with::DisplayFromStr")]
         #[cfg_attr(feature = "schema", schemars(with = "String"))]
         uri: Uri,
+
+        /// # Additional headers
+        ///
+        /// Additional headers added to the discover/invoke requests to the deployment.
+        ///
+        additional_headers: Option<SerdeableHeaderHashMap>,
+        /// # Force
+        ///
+        /// If `true`, it will override, if existing, any deployment using the same `uri`.
+        /// Beware that this can lead in-flight invocations to an unrecoverable error state.
+        ///
+        /// By default, this is `true` but it might change in future to `false`.
+        ///
+        /// See the [versioning documentation](https://docs.restate.dev/services/upgrades-removal) for more information.
+        #[serde(default = "restate_serde_util::default::bool::<true>")]
+        force: bool,
+
+        /// # Dry-run mode
+        ///
+        /// If `true`, discovery will run but the deployment will not be registered.
+        /// This is useful to see the impact of a new deployment before registering it.
+        #[serde(default = "restate_serde_util::default::bool::<false>")]
+        dry_run: bool,
     },
     Lambda {
         /// # ARN
         ///
         /// ARN to use to discover/invoke the lambda deployment.
         arn: String,
+
         /// # Assume role ARN
         ///
         /// Optional ARN of a role to assume when invoking the addressed Lambda, to support role chaining
         assume_role_arn: Option<String>,
+
+        /// # Additional headers
+        ///
+        /// Additional headers added to the discover/invoke requests to the deployment.
+        ///
+        additional_headers: Option<SerdeableHeaderHashMap>,
+        /// # Force
+        ///
+        /// If `true`, it will override, if existing, any deployment using the same `uri`.
+        /// Beware that this can lead in-flight invocations to an unrecoverable error state.
+        ///
+        /// By default, this is `true` but it might change in future to `false`.
+        ///
+        /// See the [versioning documentation](https://docs.restate.dev/services/upgrades-removal) for more information.
+        #[serde(default = "restate_serde_util::default::bool::<true>")]
+        force: bool,
+
+        /// # Dry-run mode
+        ///
+        /// If `true`, discovery will run but the deployment will not be registered.
+        /// This is useful to see the impact of a new deployment before registering it.
+        #[serde(default = "restate_serde_util::default::bool::<false>")]
+        dry_run: bool,
     },
 }
 

--- a/crates/meta-rest-model/src/deployments.rs
+++ b/crates/meta-rest-model/src/deployments.rs
@@ -151,7 +151,7 @@ pub struct RegisterDeploymentResponse {
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ListDeploymentResponse {
+pub struct ListDeploymentsResponse {
     pub deployments: Vec<DeploymentResponse>,
 }
 

--- a/crates/meta-rest-model/src/lib.rs
+++ b/crates/meta-rest-model/src/lib.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod endpoints;
+pub mod deployments;
 pub mod methods;
 pub mod services;
 pub mod subscriptions;

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -38,7 +38,7 @@ prost-reflect = { workspace = true }
 restate-fs-util = { workspace = true }
 restate-meta-rest-model = { workspace = true, features = ["schema"] }
 restate-pb = { workspace = true }
-restate-schema-api = { workspace = true, features = ["service", "endpoint", "serde", "serde_schema"] }
+restate-schema-api = { workspace = true, features = ["service", "deployment", "serde", "serde_schema"] }
 restate-schema-impl = { workspace = true }
 restate-service-client = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["discovery"] }

--- a/crates/meta/src/rest_api/deployments.rs
+++ b/crates/meta/src/rest_api/deployments.rs
@@ -158,8 +158,8 @@ pub async fn get_deployment_descriptors<S: DeploymentMetadataResolver, W>(
 )]
 pub async fn list_deployments<S: DeploymentMetadataResolver, W>(
     State(state): State<Arc<RestEndpointState<S, W>>>,
-) -> Json<ListDeploymentResponse> {
-    ListDeploymentResponse {
+) -> Json<ListDeploymentsResponse> {
+    ListDeploymentsResponse {
         deployments: state
             .schemas()
             .get_deployments()

--- a/crates/meta/src/rest_api/error.rs
+++ b/crates/meta/src/rest_api/error.rs
@@ -28,8 +28,8 @@ use crate::service::MetaError;
 pub enum MetaApiError {
     #[error("The request field '{0}' is invalid. Reason: {1}")]
     InvalidField(&'static str, String),
-    #[error("The requested service endpoint '{0}' does not exist")]
-    ServiceEndpointNotFound(String),
+    #[error("The requested deployment '{0}' does not exist")]
+    DeploymentNotFound(String),
     #[error("The requested service '{0}' does not exist")]
     ServiceNotFound(String),
     #[error("The requested method '{method_name}' on service '{service_name}' does not exist")]
@@ -62,13 +62,13 @@ impl IntoResponse for MetaApiError {
         let status_code = match &self {
             MetaApiError::ServiceNotFound(_)
             | MetaApiError::MethodNotFound { .. }
-            | MetaApiError::ServiceEndpointNotFound(_)
+            | MetaApiError::DeploymentNotFound(_)
             | MetaApiError::SubscriptionNotFound(_) => StatusCode::NOT_FOUND,
             MetaApiError::Meta(MetaError::SchemaRegistry(SchemasUpdateError::BadDescriptor(_))) => {
                 StatusCode::BAD_REQUEST
             }
             MetaApiError::Meta(MetaError::SchemaRegistry(
-                SchemasUpdateError::OverrideEndpoint(_),
+                SchemasUpdateError::OverrideDeployment(_),
             ))
             | MetaApiError::Meta(MetaError::SchemaRegistry(
                 SchemasUpdateError::IncompatibleServiceChange(_),
@@ -76,9 +76,9 @@ impl IntoResponse for MetaApiError {
             MetaApiError::Meta(MetaError::SchemaRegistry(SchemasUpdateError::UnknownService(
                 _,
             ))) => StatusCode::NOT_FOUND,
-            MetaApiError::Meta(MetaError::SchemaRegistry(SchemasUpdateError::UnknownEndpoint(
-                _,
-            ))) => StatusCode::NOT_FOUND,
+            MetaApiError::Meta(MetaError::SchemaRegistry(
+                SchemasUpdateError::UnknownDeployment(_),
+            )) => StatusCode::NOT_FOUND,
             MetaApiError::Meta(MetaError::SchemaRegistry(
                 SchemasUpdateError::ModifyInternalService(_),
             )) => StatusCode::FORBIDDEN,

--- a/crates/meta/src/rest_api/mod.rs
+++ b/crates/meta/src/rest_api/mod.rs
@@ -10,7 +10,7 @@
 
 //! This module implements the Meta API endpoint.
 
-mod endpoints;
+mod deployments;
 mod error;
 mod health;
 mod invocations;
@@ -26,7 +26,7 @@ use futures::FutureExt;
 use hyper::Server;
 use okapi_operation::axum_integration::{delete, get, patch, post};
 use okapi_operation::*;
-use restate_schema_api::endpoint::EndpointMetadataResolver;
+use restate_schema_api::deployment::DeploymentMetadataResolver;
 use restate_schema_api::service::ServiceMetadataResolver;
 use restate_schema_api::subscription::SubscriptionResolver;
 use std::net::SocketAddr;
@@ -65,7 +65,7 @@ impl MetaRestEndpoint {
 
     pub async fn run<
         S: ServiceMetadataResolver
-            + EndpointMetadataResolver
+            + DeploymentMetadataResolver
             + SubscriptionResolver
             + Send
             + Sync
@@ -87,26 +87,24 @@ impl MetaRestEndpoint {
         // Setup the router
         let meta_api = axum_integration::Router::new()
             .route(
-                "/endpoints",
-                get(openapi_handler!(endpoints::list_service_endpoints)),
+                "/deployments",
+                get(openapi_handler!(deployments::list_deployments)),
             )
             .route(
-                "/endpoints",
-                post(openapi_handler!(endpoints::create_service_endpoint)),
+                "/deployments",
+                post(openapi_handler!(deployments::create_deployment)),
             )
             .route(
-                "/endpoints/:endpoint",
-                get(openapi_handler!(endpoints::get_service_endpoint)),
+                "/deployments/:deployment",
+                get(openapi_handler!(deployments::get_deployment)),
             )
             .route(
-                "/endpoints/:endpoint/descriptors",
-                get(openapi_handler!(
-                    endpoints::get_service_endpoint_descriptors
-                )),
+                "/deployments/:deployment/descriptors",
+                get(openapi_handler!(deployments::get_deployment_descriptors)),
             )
             .route(
-                "/endpoints/:endpoint",
-                delete(openapi_handler!(endpoints::delete_service_endpoint)),
+                "/deployments/:deployment",
+                delete(openapi_handler!(deployments::delete_deployment)),
             )
             .route("/services", get(openapi_handler!(services::list_services)))
             .route(

--- a/crates/meta/src/storage.rs
+++ b/crates/meta/src/storage.rs
@@ -157,7 +157,7 @@ mod tests {
     use super::*;
 
     use restate_pb::mocks;
-    use restate_schema_api::endpoint::EndpointMetadata;
+    use restate_schema_api::deployment::DeploymentMetadata;
     use restate_schema_impl::Schemas;
     use restate_test_util::test;
     use tempfile::tempdir;
@@ -168,10 +168,10 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let mut file_storage = FileMetaStorage::new(temp_dir.path().to_path_buf());
 
-        // Generate some commands for a new endpoint, with new services
+        // Generate some commands for a new deployment, with new services
         let commands_1 = schemas
-            .compute_new_endpoint(
-                EndpointMetadata::mock_with_uri("http://localhost:9080"),
+            .compute_new_deployment(
+                DeploymentMetadata::mock_with_uri("http://localhost:9080"),
                 vec![mocks::GREETER_SERVICE_NAME.to_owned()],
                 mocks::DESCRIPTOR_POOL.clone(),
                 false,
@@ -180,12 +180,12 @@ mod tests {
 
         file_storage.store(commands_1.clone()).await.unwrap();
 
-        // Generate some commands for a new endpoint, with a new and old service
+        // Generate some commands for a new deployment, with a new and old service
         // We need to apply updates to generate a new command list
         schemas.apply_updates(commands_1.clone()).unwrap();
         let commands_2 = schemas
-            .compute_new_endpoint(
-                EndpointMetadata::mock_with_uri("http://localhost:9081"),
+            .compute_new_deployment(
+                DeploymentMetadata::mock_with_uri("http://localhost:9081"),
                 vec![
                     mocks::GREETER_SERVICE_NAME.to_owned(),
                     mocks::ANOTHER_GREETER_SERVICE_NAME.to_owned(),
@@ -233,12 +233,12 @@ mod tests {
         fn eq(&self, other: &Self) -> bool {
             match (&self.0, &other.0) {
                 (
-                    SchemasUpdateCommand::InsertEndpoint {
+                    SchemasUpdateCommand::InsertDeployment {
                         metadata: self_metadata,
                         services: self_services,
                         ..
                     },
-                    SchemasUpdateCommand::InsertEndpoint {
+                    SchemasUpdateCommand::InsertDeployment {
                         metadata: other_metadata,
                         services: other_services,
                         ..

--- a/crates/schema-api/Cargo.toml
+++ b/crates/schema-api/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [features]
 default = []
 
-endpoint = ["dep:restate-types", "dep:http", "dep:base64", "dep:restate-base64-util", "dep:bytestring"]
+deployment = ["dep:restate-types", "dep:http", "dep:base64", "dep:restate-base64-util", "dep:bytestring"]
 json_conversion = ["dep:prost-reflect", "prost-reflect?/serde", "dep:anyhow", "dep:serde_json"]
 json_key_conversion = ["key_extraction", "key_expansion", "dep:serde_json", "dep:thiserror"]
 key_expansion = ["dep:bytes", "dep:thiserror", "dep:prost", "dep:prost-reflect", "dep:anyhow"]

--- a/crates/schema-api/src/lib.rs
+++ b/crates/schema-api/src/lib.rs
@@ -114,7 +114,7 @@ pub mod deployment {
         }
 
         // address_display returns a Displayable identifier for the endpoint; for http endpoints this is a URI,
-        // and for Lambda Deployments its the ARN
+        // and for Lambda deployments its the ARN
         pub fn address_display(&self) -> impl Display + '_ {
             struct Wrapper<'a>(&'a DeploymentType);
             impl<'a> Display for Wrapper<'a> {
@@ -141,7 +141,7 @@ pub mod deployment {
             match &self.ty {
                 DeploymentType::Http { address, .. } => {
                     // For the time being we generate this from the URI
-                    // We use only authority and path, as those uniquely identify the Deployment.
+                    // We use only authority and path, as those uniquely identify the deployment.
                     let authority_and_path = format!(
                         "{}{}",
                         address.authority().expect("Must have authority"),

--- a/crates/schema-api/src/lib.rs
+++ b/crates/schema-api/src/lib.rs
@@ -10,14 +10,14 @@
 
 //! This crate contains all the different APIs for accessing schemas.
 
-#[cfg(feature = "endpoint")]
-pub mod endpoint {
+#[cfg(feature = "deployment")]
+pub mod deployment {
     use super::service::ServiceMetadata;
     use bytes::Bytes;
     use bytestring::ByteString;
     use http::header::{HeaderName, HeaderValue};
     use http::Uri;
-    use restate_types::identifiers::{EndpointId, LambdaARN, ServiceRevision};
+    use restate_types::identifiers::{DeploymentId, LambdaARN, ServiceRevision};
     use restate_types::time::MillisSinceEpoch;
     use std::collections::HashMap;
     use std::fmt;
@@ -55,8 +55,8 @@ pub mod endpoint {
     #[cfg_attr(feature = "serde", serde_with::serde_as)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde_schema", derive(schemars::JsonSchema))]
-    pub struct EndpointMetadata {
-        pub ty: EndpointType,
+    pub struct DeploymentMetadata {
+        pub ty: DeploymentType,
         pub delivery_options: DeliveryOptions,
         pub created_at: MillisSinceEpoch,
     }
@@ -65,7 +65,7 @@ pub mod endpoint {
     #[cfg_attr(feature = "serde", serde_with::serde_as)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde_schema", derive(schemars::JsonSchema))]
-    pub enum EndpointType {
+    pub enum DeploymentType {
         Http {
             #[cfg_attr(
                 feature = "serde",
@@ -82,14 +82,14 @@ pub mod endpoint {
         },
     }
 
-    impl EndpointMetadata {
+    impl DeploymentMetadata {
         pub fn new_http(
             address: Uri,
             protocol_type: ProtocolType,
             delivery_options: DeliveryOptions,
         ) -> Self {
             Self {
-                ty: EndpointType::Http {
+                ty: DeploymentType::Http {
                     address,
                     protocol_type,
                 },
@@ -104,7 +104,7 @@ pub mod endpoint {
             delivery_options: DeliveryOptions,
         ) -> Self {
             Self {
-                ty: EndpointType::Lambda {
+                ty: DeploymentType::Lambda {
                     arn,
                     assume_role_arn,
                 },
@@ -114,14 +114,14 @@ pub mod endpoint {
         }
 
         // address_display returns a Displayable identifier for the endpoint; for http endpoints this is a URI,
-        // and for Lambda endpoints its the ARN
+        // and for Lambda Deployments its the ARN
         pub fn address_display(&self) -> impl Display + '_ {
-            struct Wrapper<'a>(&'a EndpointType);
+            struct Wrapper<'a>(&'a DeploymentType);
             impl<'a> Display for Wrapper<'a> {
                 fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                     match self {
-                        Wrapper(EndpointType::Http { address, .. }) => address.fmt(f),
-                        Wrapper(EndpointType::Lambda { arn, .. }) => arn.fmt(f),
+                        Wrapper(DeploymentType::Http { address, .. }) => address.fmt(f),
+                        Wrapper(DeploymentType::Lambda { arn, .. }) => arn.fmt(f),
                     }
                 }
             }
@@ -130,18 +130,18 @@ pub mod endpoint {
 
         pub fn protocol_type(&self) -> ProtocolType {
             match &self.ty {
-                EndpointType::Http { protocol_type, .. } => *protocol_type,
-                EndpointType::Lambda { .. } => ProtocolType::RequestResponse,
+                DeploymentType::Http { protocol_type, .. } => *protocol_type,
+                DeploymentType::Lambda { .. } => ProtocolType::RequestResponse,
             }
         }
 
-        pub fn id(&self) -> EndpointId {
+        pub fn id(&self) -> DeploymentId {
             use base64::Engine;
 
             match &self.ty {
-                EndpointType::Http { address, .. } => {
+                DeploymentType::Http { address, .. } => {
                     // For the time being we generate this from the URI
-                    // We use only authority and path, as those uniquely identify the endpoint.
+                    // We use only authority and path, as those uniquely identify the Deployment.
                     let authority_and_path = format!(
                         "{}{}",
                         address.authority().expect("Must have authority"),
@@ -149,7 +149,7 @@ pub mod endpoint {
                     );
                     restate_base64_util::URL_SAFE.encode(authority_and_path.as_bytes())
                 }
-                EndpointType::Lambda { arn, .. } => {
+                DeploymentType::Lambda { arn, .. } => {
                     restate_base64_util::URL_SAFE.encode(arn.to_string().as_bytes())
                 }
             }
@@ -160,22 +160,22 @@ pub mod endpoint {
         }
     }
 
-    pub trait EndpointMetadataResolver {
-        fn resolve_latest_endpoint_for_service(
+    pub trait DeploymentMetadataResolver {
+        fn resolve_latest_deployment_for_service(
             &self,
             service_name: impl AsRef<str>,
-        ) -> Option<EndpointMetadata>;
+        ) -> Option<DeploymentMetadata>;
 
-        fn get_endpoint(&self, endpoint_id: &EndpointId) -> Option<EndpointMetadata>;
+        fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<DeploymentMetadata>;
 
-        fn get_endpoint_descriptor_pool(&self, endpoint_id: &EndpointId) -> Option<Bytes>;
+        fn get_deployment_descriptor_pool(&self, deployment_id: &DeploymentId) -> Option<Bytes>;
 
-        fn get_endpoint_and_services(
+        fn get_deployment_and_services(
             &self,
-            endpoint_id: &EndpointId,
-        ) -> Option<(EndpointMetadata, Vec<ServiceMetadata>)>;
+            deployment_id: &DeploymentId,
+        ) -> Option<(DeploymentMetadata, Vec<ServiceMetadata>)>;
 
-        fn get_endpoints(&self) -> Vec<(EndpointMetadata, Vec<(String, ServiceRevision)>)>;
+        fn get_deployments(&self) -> Vec<(DeploymentMetadata, Vec<(String, ServiceRevision)>)>;
     }
 
     #[cfg(feature = "mocks")]
@@ -184,17 +184,17 @@ pub mod endpoint {
 
         use std::collections::HashMap;
 
-        impl EndpointMetadata {
-            pub fn mock() -> EndpointMetadata {
-                EndpointMetadata::new_http(
+        impl DeploymentMetadata {
+            pub fn mock() -> DeploymentMetadata {
+                DeploymentMetadata::new_http(
                     "http://localhost:9080".parse().unwrap(),
                     ProtocolType::BidiStream,
                     Default::default(),
                 )
             }
 
-            pub fn mock_with_uri(uri: &str) -> EndpointMetadata {
-                EndpointMetadata::new_http(
+            pub fn mock_with_uri(uri: &str) -> DeploymentMetadata {
+                DeploymentMetadata::new_http(
                     uri.parse().unwrap(),
                     ProtocolType::BidiStream,
                     Default::default(),
@@ -203,52 +203,55 @@ pub mod endpoint {
         }
 
         #[derive(Default, Clone)]
-        pub struct MockEndpointMetadataRegistry {
-            pub endpoints: HashMap<EndpointId, EndpointMetadata>,
-            pub latest_endpoint: HashMap<String, EndpointId>,
+        pub struct MockDeploymentMetadataRegistry {
+            pub deployments: HashMap<DeploymentId, DeploymentMetadata>,
+            pub latest_deployment: HashMap<String, DeploymentId>,
         }
 
-        impl MockEndpointMetadataRegistry {
+        impl MockDeploymentMetadataRegistry {
             pub fn mock_service(&mut self, name: &str) {
-                self.mock_service_with_metadata(name, EndpointMetadata::mock());
+                self.mock_service_with_metadata(name, DeploymentMetadata::mock());
             }
 
-            pub fn mock_service_with_metadata(&mut self, name: &str, meta: EndpointMetadata) {
-                self.latest_endpoint.insert(name.to_string(), meta.id());
-                self.endpoints.insert(meta.id(), meta);
+            pub fn mock_service_with_metadata(&mut self, name: &str, meta: DeploymentMetadata) {
+                self.latest_deployment.insert(name.to_string(), meta.id());
+                self.deployments.insert(meta.id(), meta);
             }
         }
 
-        impl EndpointMetadataResolver for MockEndpointMetadataRegistry {
-            fn resolve_latest_endpoint_for_service(
+        impl DeploymentMetadataResolver for MockDeploymentMetadataRegistry {
+            fn resolve_latest_deployment_for_service(
                 &self,
                 service_name: impl AsRef<str>,
-            ) -> Option<EndpointMetadata> {
-                self.latest_endpoint
+            ) -> Option<DeploymentMetadata> {
+                self.latest_deployment
                     .get(service_name.as_ref())
-                    .and_then(|endpoint_id| self.get_endpoint(endpoint_id))
+                    .and_then(|deployment_id| self.get_deployment(deployment_id))
             }
 
-            fn get_endpoint(&self, endpoint_id: &EndpointId) -> Option<EndpointMetadata> {
-                self.endpoints.get(endpoint_id).cloned()
+            fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<DeploymentMetadata> {
+                self.deployments.get(deployment_id).cloned()
             }
 
-            fn get_endpoint_descriptor_pool(&self, _endpoint_id: &EndpointId) -> Option<Bytes> {
+            fn get_deployment_descriptor_pool(
+                &self,
+                _deployment_id: &DeploymentId,
+            ) -> Option<Bytes> {
                 todo!()
             }
 
-            fn get_endpoint_and_services(
+            fn get_deployment_and_services(
                 &self,
-                endpoint_id: &EndpointId,
-            ) -> Option<(EndpointMetadata, Vec<ServiceMetadata>)> {
-                self.endpoints
-                    .get(endpoint_id)
+                deployment_id: &DeploymentId,
+            ) -> Option<(DeploymentMetadata, Vec<ServiceMetadata>)> {
+                self.deployments
+                    .get(deployment_id)
                     .cloned()
                     .map(|e| (e, vec![]))
             }
 
-            fn get_endpoints(&self) -> Vec<(EndpointMetadata, Vec<(String, ServiceRevision)>)> {
-                self.endpoints
+            fn get_deployments(&self) -> Vec<(DeploymentMetadata, Vec<(String, ServiceRevision)>)> {
+                self.deployments
                     .values()
                     .map(|e| (e.clone(), vec![]))
                     .collect()
@@ -260,7 +263,7 @@ pub mod endpoint {
 #[cfg(feature = "service")]
 pub mod service {
     use bytes::Bytes;
-    use restate_types::identifiers::{EndpointId, ServiceRevision};
+    use restate_types::identifiers::{DeploymentId, ServiceRevision};
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -278,11 +281,11 @@ pub mod service {
         pub name: String,
         pub methods: Vec<MethodMetadata>,
         pub instance_type: InstanceType,
-        /// # Endpoint Id
+        /// # Deployment Id
         ///
-        /// Endpoint exposing the latest revision of the service.
+        /// Deployment exposing the latest revision of the service.
         #[cfg_attr(feature = "serde_schema", schemars(with = "String"))]
-        pub endpoint_id: EndpointId,
+        pub deployment_id: DeploymentId,
         /// # Revision
         ///
         /// Latest revision of the service.

--- a/crates/schema-impl/Cargo.toml
+++ b/crates/schema-impl/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 restate-errors = { workspace = true }
 restate-pb = { workspace = true }
-restate-schema-api = { workspace = true, features = ["key_extraction", "key_expansion", "json_key_conversion", "endpoint", "service", "subscription", "json_conversion", "proto_symbol", "serde"] }
+restate-schema-api = { workspace = true, features = ["key_extraction", "key_expansion", "json_key_conversion", "deployment", "service", "subscription", "json_conversion", "proto_symbol", "serde"] }
 restate-serde-util = { workspace = true }
 restate-types = { workspace = true }
 

--- a/crates/schema-impl/src/deployment.rs
+++ b/crates/schema-impl/src/deployment.rs
@@ -12,59 +12,59 @@ use super::Schemas;
 use bytes::Bytes;
 
 use crate::schemas_impl::ServiceLocation;
-use restate_schema_api::endpoint::{EndpointMetadata, EndpointMetadataResolver};
+use restate_schema_api::deployment::{DeploymentMetadata, DeploymentMetadataResolver};
 use restate_schema_api::service::ServiceMetadata;
-use restate_types::identifiers::{EndpointId, ServiceRevision};
+use restate_types::identifiers::{DeploymentId, ServiceRevision};
 
-impl EndpointMetadataResolver for Schemas {
-    fn resolve_latest_endpoint_for_service(
+impl DeploymentMetadataResolver for Schemas {
+    fn resolve_latest_deployment_for_service(
         &self,
         service_name: impl AsRef<str>,
-    ) -> Option<EndpointMetadata> {
+    ) -> Option<DeploymentMetadata> {
         let schemas = self.0.load();
         let service = schemas.services.get(service_name.as_ref())?;
         match &service.location {
             ServiceLocation::BuiltIn { .. } => None,
-            ServiceLocation::ServiceEndpoint {
-                latest_endpoint, ..
+            ServiceLocation::Deployment {
+                latest_deployment, ..
             } => schemas
-                .endpoints
-                .get(latest_endpoint)
+                .deployments
+                .get(latest_deployment)
                 .map(|schemas| schemas.metadata.clone()),
         }
     }
 
-    fn get_endpoint(&self, endpoint_id: &EndpointId) -> Option<EndpointMetadata> {
+    fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<DeploymentMetadata> {
         let schemas = self.0.load();
         schemas
-            .endpoints
-            .get(endpoint_id)
+            .deployments
+            .get(deployment_id)
             .map(|schemas| schemas.metadata.clone())
     }
 
-    fn get_endpoint_descriptor_pool(&self, endpoint_id: &EndpointId) -> Option<Bytes> {
+    fn get_deployment_descriptor_pool(&self, deployment_id: &DeploymentId) -> Option<Bytes> {
         let schemas = self.0.load();
         schemas
-            .endpoints
-            .get(endpoint_id)
+            .deployments
+            .get(deployment_id)
             .map(|schemas| schemas.descriptor_pool.encode_to_vec().into())
     }
 
-    fn get_endpoint_and_services(
+    fn get_deployment_and_services(
         &self,
-        endpoint_id: &EndpointId,
-    ) -> Option<(EndpointMetadata, Vec<ServiceMetadata>)> {
+        deployment_id: &DeploymentId,
+    ) -> Option<(DeploymentMetadata, Vec<ServiceMetadata>)> {
         let schemas = self.0.load();
         schemas
-            .endpoints
-            .get(endpoint_id)
+            .deployments
+            .get(deployment_id)
             .map(|schemas| (schemas.metadata.clone(), schemas.services.clone()))
     }
 
-    fn get_endpoints(&self) -> Vec<(EndpointMetadata, Vec<(String, ServiceRevision)>)> {
+    fn get_deployments(&self) -> Vec<(DeploymentMetadata, Vec<(String, ServiceRevision)>)> {
         let schemas = self.0.load();
         schemas
-            .endpoints
+            .deployments
             .values()
             .map(|schemas| {
                 (

--- a/crates/schema-impl/src/json.rs
+++ b/crates/schema-impl/src/json.rs
@@ -131,8 +131,8 @@ mod tests {
                 .into_iter()
                 .collect(),
                 instance_type: InstanceTypeMetadata::Unkeyed,
-                location: ServiceLocation::ServiceEndpoint {
-                    latest_endpoint: "".to_string(),
+                location: ServiceLocation::Deployment {
+                    latest_deployment: "".to_string(),
                     public: true,
                 },
             },

--- a/crates/schema-impl/src/schemas_impl/service.rs
+++ b/crates/schema-impl/src/schemas_impl/service.rs
@@ -25,9 +25,9 @@ impl SchemasInner {
             .ok_or_else(|| SchemasUpdateError::UnknownService(name.clone()))?;
 
         // Update proto_symbols
-        if let ServiceLocation::ServiceEndpoint {
+        if let ServiceLocation::Deployment {
             public: old_public_value,
-            latest_endpoint,
+            latest_deployment,
         } = &schemas.location
         {
             match (*old_public_value, new_public_value) {
@@ -37,14 +37,14 @@ impl SchemasInner {
                 }
                 (false, true) => {
                     self.proto_symbols
-                        .add_service(latest_endpoint, schemas.service_descriptor());
+                        .add_service(latest_deployment, schemas.service_descriptor());
                 }
                 _ => {}
             }
         }
 
         // Update the public field
-        if let ServiceLocation::ServiceEndpoint {
+        if let ServiceLocation::Deployment {
             public: old_public_value,
             ..
         } = &mut schemas.location

--- a/crates/schema-impl/src/service.rs
+++ b/crates/schema-impl/src/service.rs
@@ -54,8 +54,8 @@ pub(crate) fn map_to_service_metadata(
 ) -> Option<ServiceMetadata> {
     match &service_schemas.location {
         ServiceLocation::BuiltIn { .. } => None, // We filter out from this interface ingress only services
-        ServiceLocation::ServiceEndpoint {
-            latest_endpoint,
+        ServiceLocation::Deployment {
+            latest_deployment,
             public,
         } => Some(ServiceMetadata {
             name: service_name.to_string(),
@@ -79,7 +79,7 @@ pub(crate) fn map_to_service_metadata(
             instance_type: (&service_schemas.instance_type)
                 .try_into()
                 .expect("Checked in the line above whether this is a built-in service or not"),
-            endpoint_id: latest_endpoint.clone(),
+            deployment_id: latest_deployment.clone(),
             revision: service_schemas.revision,
             public: *public,
         }),

--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -39,7 +39,7 @@ pub struct Options {
     keep_alive_options: Option<Http2KeepAliveOptions>,
     /// # Proxy URI
     ///
-    /// A URI, such as `http://127.0.0.1:10001`, of a server to which all invocations should be sent, with the `Host` header set to the service endpoint URI.
+    /// A URI, such as `http://127.0.0.1:10001`, of a server to which all invocations should be sent, with the `Host` header set to the deployment URI.
     /// HTTPS proxy URIs are supported, but only HTTP endpoint traffic will be proxied currently.
     /// Can be overridden by the `HTTP_PROXY` environment variable.
     #[cfg_attr(feature = "options_schema", schemars(with = "Option<String>"))]
@@ -84,7 +84,7 @@ impl Options {
 /// Configuration for the HTTP/2 keep-alive mechanism, using PING frames.
 ///
 /// Please note: most gateways don't propagate the HTTP/2 keep-alive between downstream and upstream hosts.
-/// In those environments, you need to make sure the gateway can detect a broken connection to the upstream service endpoint(s).
+/// In those environments, you need to make sure the gateway can detect a broken connection to the upstream deployment(s).
 #[serde_as]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -20,7 +20,7 @@ protocol = []
 [dependencies]
 restate-base64-util = { workspace = true, optional = true }
 restate-errors = { workspace = true, optional = true }
-restate-schema-api = { workspace = true, optional = true, features = ["endpoint"] }
+restate-schema-api = { workspace = true, optional = true, features = ["deployment"] }
 restate-service-client =  { workspace = true, optional = true }
 restate-types = { workspace = true, optional = true }
 

--- a/crates/service-protocol/src/discovery.rs
+++ b/crates/service-protocol/src/discovery.rs
@@ -24,10 +24,8 @@ use prost_reflect::{DescriptorError, DescriptorPool};
 
 use codederror::CodedError;
 use restate_errors::{warn_it, META0003};
-use restate_schema_api::endpoint::ProtocolType;
-use restate_service_client::{
-    Parts, Request, ServiceClient, ServiceClientError, ServiceEndpointAddress,
-};
+use restate_schema_api::deployment::ProtocolType;
+use restate_service_client::{Endpoint, Parts, Request, ServiceClient, ServiceClientError};
 
 use restate_types::retries::{RetryIter, RetryPolicy};
 
@@ -93,21 +91,18 @@ impl ServiceDiscovery {
 }
 
 #[derive(Clone)]
-pub struct DiscoverEndpoint(ServiceEndpointAddress, HashMap<HeaderName, HeaderValue>);
+pub struct DiscoverEndpoint(Endpoint, HashMap<HeaderName, HeaderValue>);
 
 impl DiscoverEndpoint {
-    pub fn new(
-        address: ServiceEndpointAddress,
-        additional_headers: HashMap<HeaderName, HeaderValue>,
-    ) -> Self {
+    pub fn new(address: Endpoint, additional_headers: HashMap<HeaderName, HeaderValue>) -> Self {
         Self(address, additional_headers)
     }
 
-    pub fn into_inner(self) -> (ServiceEndpointAddress, HashMap<HeaderName, HeaderValue>) {
+    pub fn into_inner(self) -> (Endpoint, HashMap<HeaderName, HeaderValue>) {
         (self.0, self.1)
     }
 
-    pub fn address(&self) -> &ServiceEndpointAddress {
+    pub fn address(&self) -> &Endpoint {
         &self.0
     }
 
@@ -239,13 +234,13 @@ impl ServiceDiscovery {
             if let Some(next_retry_interval) = retry_iter.next() {
                 warn_it!(
                     e,
-                    "Error when discovering service endpoint at address '{}'. Retrying in {} seconds",
+                    "Error when discovering deployment at address '{}'. Retrying in {} seconds",
                     address,
                     next_retry_interval.as_secs()
                 );
                 tokio::time::sleep(next_retry_interval).await;
             } else {
-                warn_it!(e, "Error when discovering service endpoint '{}'", address);
+                warn_it!(e, "Error when discovering deployment '{}'", address);
                 return Err(e);
             }
         }

--- a/crates/service-protocol/tests/counter_test.rs
+++ b/crates/service-protocol/tests/counter_test.rs
@@ -14,9 +14,7 @@
 //! [Counter example](https://github.com/restatedev/sdk-java/blob/main/examples/src/main/java/dev/restate/sdk/examples/BlockingCounter.java) in sdk-java.
 
 use hyper::Uri;
-use restate_service_client::{
-    AssumeRoleCacheMode, Options as ServiceClientOptions, ServiceEndpointAddress,
-};
+use restate_service_client::{AssumeRoleCacheMode, Endpoint, Options as ServiceClientOptions};
 use restate_service_protocol::discovery::*;
 use restate_test_util::test;
 use restate_types::retries::RetryPolicy;
@@ -31,7 +29,7 @@ async fn counter_discovery() {
 
     let discovered_metadata = discovery
         .discover(&DiscoverEndpoint::new(
-            ServiceEndpointAddress::Http(
+            Endpoint::Http(
                 Uri::from_static("http://localhost:9080"),
                 Default::default(),
             ),

--- a/crates/storage-api/src/status_table/mod.rs
+++ b/crates/storage-api/src/status_table/mod.rs
@@ -11,7 +11,7 @@
 use crate::{GetFuture, GetStream, PutFuture};
 use bytestring::ByteString;
 use restate_types::identifiers::{
-    EndpointId, EntryIndex, FullInvocationId, InvocationUuid, PartitionKey, ServiceId,
+    DeploymentId, EntryIndex, FullInvocationId, InvocationUuid, PartitionKey, ServiceId,
 };
 use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
 use restate_types::time::MillisSinceEpoch;
@@ -178,7 +178,7 @@ impl JournalMetadata {
 pub struct InvocationMetadata {
     pub invocation_uuid: InvocationUuid,
     pub journal_metadata: JournalMetadata,
-    pub endpoint_id: Option<EndpointId>,
+    pub deployment_id: Option<DeploymentId>,
     pub method: ByteString,
     pub response_sink: Option<ServiceInvocationResponseSink>,
     pub timestamps: StatusTimestamps,
@@ -188,7 +188,7 @@ impl InvocationMetadata {
     pub fn new(
         invocation_uuid: InvocationUuid,
         journal_metadata: JournalMetadata,
-        endpoint_id: Option<String>,
+        deployment_id: Option<String>,
         method: ByteString,
         response_sink: Option<ServiceInvocationResponseSink>,
         timestamps: StatusTimestamps,
@@ -196,7 +196,7 @@ impl InvocationMetadata {
         Self {
             invocation_uuid,
             journal_metadata,
-            endpoint_id,
+            deployment_id,
             method,
             response_sink,
             timestamps,

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -32,7 +32,7 @@ message InvocationStatus {
         uint64 creation_time = 4;
         uint64 modification_time = 5;
         bytes method_name = 6;
-        oneof endpoint_id {
+        oneof deployment_id {
             google.protobuf.Empty none = 7;
             string value = 8;
         }
@@ -46,7 +46,7 @@ message InvocationStatus {
         uint64 modification_time = 5;
         repeated uint32 waiting_for_completed_entries = 6;
         bytes method_name = 7;
-        oneof endpoint_id {
+        oneof deployment_id {
             google.protobuf.Empty none = 8;
             string value = 9;
         }

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -183,13 +183,12 @@ pub mod storage {
                             "Cannot decode method_name string {e}"
                         ))
                     })?;
-                    let endpoint_id =
-                        value
-                            .endpoint_id
-                            .and_then(|one_of_endpoint_id| match one_of_endpoint_id {
-                                invocation_status::invoked::EndpointId::None(_) => None,
-                                invocation_status::invoked::EndpointId::Value(id) => Some(id),
-                            });
+                    let deployment_id = value.deployment_id.and_then(|one_of_deployment_id| {
+                        match one_of_deployment_id {
+                            invocation_status::invoked::DeploymentId::None(_) => None,
+                            invocation_status::invoked::DeploymentId::Value(id) => Some(id),
+                        }
+                    });
 
                     let journal_metadata =
                         restate_storage_api::status_table::JournalMetadata::try_from(
@@ -208,7 +207,7 @@ pub mod storage {
                     Ok(restate_storage_api::status_table::InvocationMetadata::new(
                         invocation_uuid,
                         journal_metadata,
-                        endpoint_id,
+                        deployment_id,
                         method_name,
                         response_sink,
                         restate_storage_api::status_table::StatusTimestamps::new(
@@ -223,7 +222,7 @@ pub mod storage {
                 fn from(value: restate_storage_api::status_table::InvocationMetadata) -> Self {
                     let restate_storage_api::status_table::InvocationMetadata {
                         invocation_uuid,
-                        endpoint_id,
+                        deployment_id: deployment_id,
                         method,
                         response_sink,
                         journal_metadata,
@@ -234,10 +233,10 @@ pub mod storage {
                         response_sink: Some(ServiceInvocationResponseSink::from(response_sink)),
                         invocation_uuid: invocation_uuid_to_bytes(&invocation_uuid),
                         method_name: method.into_bytes(),
-                        endpoint_id: Some(match endpoint_id {
-                            None => invocation_status::invoked::EndpointId::None(()),
-                            Some(endpoint_id) => {
-                                invocation_status::invoked::EndpointId::Value(endpoint_id)
+                        deployment_id: Some(match deployment_id {
+                            None => invocation_status::invoked::DeploymentId::None(()),
+                            Some(deployment_id) => {
+                                invocation_status::invoked::DeploymentId::Value(deployment_id)
                             }
                         }),
                         journal_meta: Some(JournalMeta::from(journal_metadata)),
@@ -263,13 +262,12 @@ pub mod storage {
                             "Cannot decode method_name string {e}"
                         ))
                     })?;
-                    let endpoint_id =
-                        value
-                            .endpoint_id
-                            .and_then(|one_of_endpoint_id| match one_of_endpoint_id {
-                                invocation_status::suspended::EndpointId::None(_) => None,
-                                invocation_status::suspended::EndpointId::Value(id) => Some(id),
-                            });
+                    let deployment_id = value.deployment_id.and_then(|one_of_deployment_id| {
+                        match one_of_deployment_id {
+                            invocation_status::suspended::DeploymentId::None(_) => None,
+                            invocation_status::suspended::DeploymentId::Value(id) => Some(id),
+                        }
+                    });
 
                     let journal_metadata =
                         restate_storage_api::status_table::JournalMetadata::try_from(
@@ -292,7 +290,7 @@ pub mod storage {
                         restate_storage_api::status_table::InvocationMetadata::new(
                             invocation_uuid,
                             journal_metadata,
-                            endpoint_id,
+                            deployment_id,
                             method_name,
                             response_sink,
                             restate_storage_api::status_table::StatusTimestamps::new(
@@ -328,10 +326,10 @@ pub mod storage {
                         response_sink: Some(response_sink),
                         journal_meta: Some(journal_meta),
                         method_name: metadata.method.into_bytes(),
-                        endpoint_id: Some(match metadata.endpoint_id {
-                            None => invocation_status::suspended::EndpointId::None(()),
-                            Some(endpoint_id) => {
-                                invocation_status::suspended::EndpointId::Value(endpoint_id)
+                        deployment_id: Some(match metadata.deployment_id {
+                            None => invocation_status::suspended::DeploymentId::None(()),
+                            Some(deployment_id) => {
+                                invocation_status::suspended::DeploymentId::Value(deployment_id)
                             }
                         }),
                         creation_time: metadata.timestamps.creation_time().as_u64(),

--- a/crates/storage-query-datafusion/src/invocation_state/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/row.rs
@@ -35,8 +35,8 @@ pub(crate) fn append_state_row(
     row.in_flight(status_row.in_flight());
     row.retry_count(status_row.retry_count() as u64);
     row.last_start_at(MillisSinceEpoch::as_u64(&status_row.last_start_at().into()) as i64);
-    if let Some(last_attempt_endpoint_id) = status_row.last_attempt_endpoint_id() {
-        row.last_attempt_endpoint_id(last_attempt_endpoint_id);
+    if let Some(last_attempt_deployment_id) = status_row.last_attempt_deployment_id() {
+        row.last_attempt_deployment_id(last_attempt_deployment_id);
     }
 
     if let Some(next_retry_at) = status_row.next_retry_at() {

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -22,10 +22,10 @@ define_table!(state(
     in_flight: DataType::Boolean,
     retry_count: DataType::UInt64,
     last_start_at: DataType::Date64,
-    // The endpoint that was selected in the last invocation attempt. This is
+    // The deployment that was selected in the last invocation attempt. This is
     // guaranteed to be set unlike in `sys_status` table which require that the
-    // endpoint to be committed before it is set.
-    last_attempt_endpoint_id: DataType::LargeUtf8,
+    // deployment to be committed before it is set.
+    last_attempt_deployment_id: DataType::LargeUtf8,
     next_retry_at: DataType::Date64,
     last_failure: DataType::LargeUtf8,
     last_error_code: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/status/row.rs
+++ b/crates/storage-query-datafusion/src/status/row.rs
@@ -83,8 +83,8 @@ fn fill_invocation_metadata(
 ) {
     // journal_metadata and stats are filled by other functions
     row.method(meta.method);
-    if let Some(endpoint_id) = meta.endpoint_id {
-        row.pinned_endpoint_id(endpoint_id);
+    if let Some(deployment_id) = meta.deployment_id {
+        row.pinned_deployment_id(deployment_id);
     }
     match meta.response_sink {
         Some(ServiceInvocationResponseSink::PartitionProcessor { caller, .. }) => {

--- a/crates/storage-query-datafusion/src/status/schema.rs
+++ b/crates/storage-query-datafusion/src/status/schema.rs
@@ -24,7 +24,7 @@ define_table!(status(
     invoked_by: DataType::LargeUtf8,
     invoked_by_service: DataType::LargeUtf8,
     invoked_by_id: DataType::LargeUtf8,
-    pinned_endpoint_id: DataType::LargeUtf8,
+    pinned_deployment_id: DataType::LargeUtf8,
     trace_id: DataType::LargeUtf8,
     journal_size: DataType::UInt32,
     created_at: DataType::Date64,

--- a/crates/storage-query-http/Cargo.toml
+++ b/crates/storage-query-http/Cargo.toml
@@ -13,7 +13,7 @@ options_schema = []
 
 [dependencies]
 restate-errors = { workspace = true }
-restate-schema-api = { workspace = true, features = [ "service", "endpoint", "serde", "serde_schema", ] }
+restate-schema-api = { workspace = true, features = [ "service", "deployment", "serde", "serde_schema", ] }
 restate-storage-query-datafusion = { workspace = true }
 restate-worker-api = { workspace = true }
 

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -263,7 +263,7 @@ impl InvocationError {
     pub fn service_not_found(service: impl Display) -> Self {
         Self {
             code: UserErrorCode::NotFound.into(),
-            message: Cow::Owned(format!("Service '{}' not found. Check whether the service endpoint containing the service is registered.", service)),
+            message: Cow::Owned(format!("Service '{}' not found. Check whether the deployment containing the service is registered.", service)),
             description: None,
         }
     }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -37,10 +37,10 @@ pub type PartitionLeaderEpoch = (PartitionId, LeaderEpoch);
 // Just an alias
 pub type EntryIndex = u32;
 
-/// Unique Id of an endpoint.
+/// Unique Id of a deployment.
 ///
-/// Currently this will contain the endpoint url authority and path base64 encoded, but this might change in future.
-pub type EndpointId = String;
+/// Currently this will contain the deployment url authority and path base64 encoded, or alternatively the ARN for Lambda, but this might change in future.
+pub type DeploymentId = String;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/types/src/journal/enriched.rs
+++ b/crates/types/src/journal/enriched.rs
@@ -45,7 +45,7 @@ pub enum EnrichedEntryHeader {
     },
     Invoke {
         is_completed: bool,
-        // None if invoke entry is completed by service endpoint
+        // None if invoke entry is completed by deployment
         resolution_result: Option<ResolutionResult>,
     },
     BackgroundInvoke {

--- a/crates/worker/src/invoker_integration.rs
+++ b/crates/worker/src/invoker_integration.rs
@@ -123,7 +123,7 @@ where
                         resolution_result: Some(resolution_result),
                     }
                 } else {
-                    // No need to service resolution if the entry was completed by the service endpoint
+                    // No need to service resolution if the entry was completed by the deployment
                     EnrichedEntryHeader::Invoke {
                         is_completed,
                         resolution_result: None,

--- a/crates/worker/src/partition/services/non_deterministic/ingress.rs
+++ b/crates/worker/src/partition/services/non_deterministic/ingress.rs
@@ -123,7 +123,7 @@ mod tests {
     use googletest::{all, pat};
     use prost::Message;
     use prost_reflect::DynamicMessage;
-    use restate_schema_api::endpoint::EndpointMetadata;
+    use restate_schema_api::deployment::DeploymentMetadata;
     use restate_test_util::matchers::*;
     use restate_test_util::test;
     use restate_types::invocation::ServiceInvocation;
@@ -134,8 +134,8 @@ mod tests {
         schemas
             .apply_updates(
                 schemas
-                    .compute_new_endpoint(
-                        EndpointMetadata::mock(),
+                    .compute_new_deployment(
+                        DeploymentMetadata::mock(),
                         vec![restate_pb::mocks::GREETER_SERVICE_NAME.to_owned()],
                         restate_pb::mocks::DESCRIPTOR_POOL.clone(),
                         false,

--- a/crates/worker/src/partition/services/non_deterministic/remote_context.rs
+++ b/crates/worker/src/partition/services/non_deterministic/remote_context.rs
@@ -1071,7 +1071,7 @@ mod tests {
     use restate_pb::mocks::GREETER_SERVICE_NAME;
     use restate_pb::restate::internal::{get_result_response, start_response, CleanupRequest};
     use restate_pb::REMOTE_CONTEXT_SERVICE_NAME;
-    use restate_schema_api::endpoint::EndpointMetadata;
+    use restate_schema_api::deployment::DeploymentMetadata;
     use restate_service_protocol::codec::ProtobufRawEntryCodec;
     use restate_test_util::matchers::*;
     use restate_test_util::{assert_eq, test};
@@ -2607,8 +2607,8 @@ mod tests {
         schemas
             .apply_updates(
                 schemas
-                    .compute_new_endpoint(
-                        EndpointMetadata::mock_with_uri("http://localhost:8080"),
+                    .compute_new_deployment(
+                        DeploymentMetadata::mock_with_uri("http://localhost:8080"),
                         vec![restate_pb::mocks::GREETER_SERVICE_NAME.to_owned()],
                         restate_pb::mocks::DESCRIPTOR_POOL.clone(),
                         false,

--- a/crates/worker/src/partition/state_machine/command_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter.rs
@@ -594,10 +594,10 @@ where
             .as_parent();
 
         match kind {
-            InvokerEffectKind::SelectedEndpoint(endpoint_id) => {
-                effects.store_chosen_endpoint(
+            InvokerEffectKind::SelectedDeployment(deployment_id) => {
+                effects.store_chosen_deployment(
                     full_invocation_id.service_id,
-                    endpoint_id,
+                    deployment_id,
                     invocation_metadata,
                 );
             }
@@ -868,7 +868,7 @@ where
                         effects,
                     );
                 } else {
-                    // no action needed for an invoke entry that has been completed by the service endpoint
+                    // no action needed for an invoke entry that has been completed by the deployment
                 }
             }
             EnrichedEntryHeader::BackgroundInvoke {
@@ -1242,7 +1242,7 @@ mod tests {
                         length: u32::try_from(journal.len()).unwrap(),
                         span_context: ServiceInvocationSpanContext::empty(),
                     },
-                    endpoint_id: None,
+                    deployment_id: None,
                     method: ByteString::from("".to_string()),
                     response_sink: None,
                     timestamps: StatusTimestamps::now(),

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -319,18 +319,18 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                     .delete_timer(full_invocation_id, wake_up_time, entry_index)
                     .await?;
             }
-            Effect::StoreEndpointId {
+            Effect::StoreDeploymentId {
                 service_id,
-                endpoint_id,
+                deployment_id,
                 mut metadata,
             } => {
                 debug_assert_eq!(
-                    metadata.endpoint_id, None,
-                    "No endpoint_id should be fixed for the current invocation"
+                    metadata.deployment_id, None,
+                    "No deployment_id should be fixed for the current invocation"
                 );
-                metadata.endpoint_id = Some(endpoint_id);
+                metadata.deployment_id = Some(deployment_id);
                 // We recreate the InvocationStatus in Invoked state as the invoker can notify the
-                // chosen endpoint_id only when the invocation is in-flight.
+                // chosen deployment_id only when the invocation is in-flight.
                 state_storage
                     .store_invocation_status(&service_id, InvocationStatus::Invoked(metadata))
                     .await?;

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -282,7 +282,7 @@ mod tests {
         //   But this means that once the awakeable entry X is received, it will be merged with completion X and thus X is resumable,
         //   contradicting the condition to end up in the Suspended state.
 
-        // * In case of a crash of the service endpoint:
+        // * In case of a crash of the deployment:
         //   * If the awakeable entry has been received, everything goes through the regular flow of the journal reader.
         //   * If the awakeable entry has not been received yet, when receiving it the completion will be sent through.
 

--- a/crates/worker/src/partition/storage/invoker.rs
+++ b/crates/worker/src/partition/storage/invoker.rs
@@ -58,7 +58,7 @@ where
                     invoked_status.journal_metadata.length,
                     invoked_status.journal_metadata.span_context,
                     invoked_status.method,
-                    invoked_status.endpoint_id,
+                    invoked_status.deployment_id,
                 );
                 let journal_stream = transaction
                     .get_journal(&fid.service_id, journal_metadata.length)


### PR DESCRIPTION
Based on #987, fixes #989 

Includes:

* Renaming of the admin API endpoints (this will fail the e2e tests now)
* Renaming of the various columns in datafusion
* Renaming of internal schema registry APIs and data models 