### PR TITLE
Update server to work with new service protocol contract 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7141,18 +7141,18 @@ checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/service-protocol/service-protocol/dev/restate/service/protocol.proto
+++ b/crates/service-protocol/service-protocol/dev/restate/service/protocol.proto
@@ -100,7 +100,10 @@ message ErrorMessage {
 // Fallible: No
 // Type: 0x0400 + 0
 message PollInputStreamEntryMessage {
-  bytes value = 14;
+  oneof result {
+    bytes value = 14;
+    Failure failure = 15;
+  }
 }
 
 // Completable: No
@@ -124,6 +127,7 @@ message GetStateEntryMessage {
   oneof result {
     google.protobuf.Empty empty = 13;
     bytes value = 14;
+    Failure failure = 15;
   };
 }
 
@@ -152,7 +156,10 @@ message SleepEntryMessage {
   // The time is set as duration since UNIX Epoch.
   uint64 wake_up_time = 1;
 
-  google.protobuf.Empty result = 13;
+  oneof result {
+    google.protobuf.Empty empty = 13;
+    Failure failure = 15;
+  }
 }
 
 // Completable: Yes


### PR DESCRIPTION
This PR requires restatedev/service-protocol#58 to be merged first.

This commit pulls in the latest service protocol changes.
It updates the server to handle GetState, Sleep and
PollInputStreamEntryMessage as fallible (having an error case).

This fixes https://github.com/restatedev/restate/issues/999.