### PR TITLE
Do not use padding in server-side base64 encoding

### DIFF
--- a/crates/base64-util/src/lib.rs
+++ b/crates/base64-util/src/lib.rs
@@ -14,6 +14,7 @@ use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
 // We have this custom configuration for padding because Node's base64url implementation will omit padding,
 // but the spec https://datatracker.ietf.org/doc/html/rfc4648#section-5 doesn't specify that padding MUST be omitted.
 // Hence, Other implementations might include it, so we keep this relaxed.
-pub const INDIFFERENT_PAD: GeneralPurposeConfig =
-    GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent);
+pub const INDIFFERENT_PAD: GeneralPurposeConfig = GeneralPurposeConfig::new()
+    .with_decode_padding_mode(DecodePaddingMode::Indifferent)
+    .with_encode_padding(false);
 pub const URL_SAFE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, INDIFFERENT_PAD);

--- a/crates/service-protocol/src/awakeable_id.rs
+++ b/crates/service-protocol/src/awakeable_id.rs
@@ -13,9 +13,10 @@ use bytes::{BufMut, BytesMut};
 use restate_types::identifiers::{
     EncodedInvocationId, EntryIndex, InvocationId, InvocationIdParseError,
 };
+use std::fmt::Display;
 use std::mem::size_of;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AwakeableIdentifier {
     invocation_id: InvocationId,
     entry_index: EntryIndex,
@@ -69,6 +70,12 @@ impl AwakeableIdentifier {
 
     pub fn into_inner(self) -> (InvocationId, EntryIndex) {
         (self.invocation_id, self.entry_index)
+    }
+}
+
+impl Display for AwakeableIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.encode())
     }
 }
 


### PR DESCRIPTION
Do not use padding in server-side base64 encoding

And make AwakeableId clone + display
