### PR TITLE
Store SocketAddr octets as bytes instead of String

### DIFF
--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -93,6 +93,11 @@ message InvocationStatus {
     }
 }
 
+message SocketAddr {
+    uint32 port = 1;
+    bytes ip = 2;
+}
+
 message ServiceInvocationResponseSink {
 
     message PartitionProcessor {
@@ -107,7 +112,7 @@ message ServiceInvocationResponseSink {
     }
 
     message Ingress {
-        string ingress_dispatcher_id = 1;
+        SocketAddr socket_addr = 1;
     }
 
     message None {
@@ -308,7 +313,7 @@ message OutboxMessage {
 
     message OutboxIngressResponse {
         FullInvocationId full_invocation_id = 1;
-        string ingress_dispatcher_id = 2;
+        SocketAddr socket_addr = 2;
         ResponseResult response_result = 3;
     }
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -17,7 +17,6 @@ use bytes::Bytes;
 use bytestring::ByteString;
 
 use std::fmt;
-use std::fmt::{Display, Formatter};
 use std::mem::size_of;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -459,8 +458,8 @@ impl schemars::JsonSchema for LambdaARN {
     }
 }
 
-impl Display for LambdaARN {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for LambdaARN {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let LambdaARN {
             partition,
             region,


### PR DESCRIPTION
Storing the SocketAddr as octets instead of Strings will avoid
extra serde costs of allocating and parsing Strings.

This fixes https://github.com/restatedev/restate/issues/1020.