### PR TITLE
Add optional Bearer Token auth and a default HTTP request timeout

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -46,11 +46,21 @@ pub enum TableStyle {
     Borders,
 }
 
+const DEFAULT_CONNECT_TIMEOUT: u64 = 5_000;
+
 #[derive(Args, Collect, Clone, Default)]
 pub struct GlobalOpts {
     /// Auto answer "yes" to confirmation prompts
     #[arg(long, short, global = true)]
     pub yes: bool,
+
+    /// Connection timeout for service interactions, in milliseconds.
+    #[arg(long, default_value_t = DEFAULT_CONNECT_TIMEOUT, global = true)]
+    pub connect_timeout: u64,
+
+    /// Overall request timeout for service interactions, in milliseconds.
+    #[arg(long, global = true)]
+    pub request_timeout: Option<u64>,
 
     #[clap(flatten)]
     pub ui_config: UiConfig,

--- a/cli/src/cli_env.rs
+++ b/cli/src/cli_env.rs
@@ -29,8 +29,6 @@ pub const RESTATE_HOST_SCHEME_ENV: &str = "RESTATE_HOST_SCHEME";
 // The default is localhost unless the CLI configuration states a different default.
 pub const RESTATE_HOST_DEFAULT: &str = "localhost";
 pub const RESTATE_HOST_SCHEME_DEFAULT: &str = "http";
-// Default request timeout.
-pub const REQUEST_TIMEOUT_DEFAULT: Duration = Duration::from_secs(10);
 
 /// Environment variable to override the default config dir path
 pub const CLI_CONFIG_HOME_ENV: &str = "RESTATE_CLI_CONFIG_HOME";
@@ -54,11 +52,14 @@ pub struct CliEnv {
     pub meta_base_url: Url,
     pub datafusion_http_base_url: Url,
     pub bearer_token: Option<String>,
-    pub request_timeout: Duration,
     /// Should we use colors and emojis or not?
     pub colorful: bool,
     /// Auto answer yes to prompts that asks for confirmation
     pub auto_confirm: bool,
+    /// Timeout for the connect phase of the request.
+    pub connect_timeout: Duration,
+    /// Overall request timeout.
+    pub request_timeout: Option<Duration>,
     /// UI Configuration
     pub ui_config: UiConfig,
 }
@@ -171,7 +172,8 @@ impl CliEnv {
             meta_base_url,
             datafusion_http_base_url,
             bearer_token,
-            request_timeout: REQUEST_TIMEOUT_DEFAULT,
+            connect_timeout: Duration::from_millis(global_opts.connect_timeout),
+            request_timeout: global_opts.request_timeout.map(Duration::from_millis),
             colorful,
             auto_confirm: global_opts.yes,
             ui_config: global_opts.ui_config.clone(),
@@ -337,9 +339,14 @@ mod tests {
 
     #[test]
     fn test_default_timeout_applied() {
-        let os_env = OsEnv::default();
-        let cli_env = CliEnv::load_from_env(&os_env, &GlobalOpts::default()).unwrap();
-        assert_eq!(cli_env.request_timeout, REQUEST_TIMEOUT_DEFAULT);
+        let opts = &GlobalOpts {
+            connect_timeout: 1000,
+            request_timeout: Some(5000),
+            ..GlobalOpts::default()
+        };
+        let cli_env = CliEnv::load_from_env(&OsEnv::default(), opts).unwrap();
+        assert_eq!(cli_env.connect_timeout, Duration::from_millis(1000));
+        assert_eq!(cli_env.request_timeout, Some(Duration::from_millis(5000)));
     }
 
     #[test]

--- a/cli/src/clients/metas_client.rs
+++ b/cli/src/clients/metas_client.rs
@@ -10,10 +10,9 @@
 
 //! A wrapper client for meta HTTP service.
 
-use std::time::Duration;
-
 use http::StatusCode;
 use serde::{de::DeserializeOwned, Serialize};
+use std::time::Duration;
 use thiserror::Error;
 use tracing::{debug, info};
 use url::Url;
@@ -106,6 +105,8 @@ pub struct MetasClient {
     pub(crate) request_timeout: Duration,
 }
 
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 impl MetasClient {
     pub fn new(env: &CliEnv) -> reqwest::Result<Self> {
         let raw_client = reqwest::Client::builder()
@@ -116,13 +117,14 @@ impl MetasClient {
                 std::env::consts::OS,
                 std::env::consts::ARCH,
             ))
+            .connect_timeout(env.connect_timeout)
             .build()?;
 
         Ok(Self {
             inner: raw_client,
             base_url: env.meta_base_url.clone(),
             bearer_token: env.bearer_token.clone(),
-            request_timeout: env.request_timeout.clone(),
+            request_timeout: env.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 

--- a/cli/src/commands/whoami.rs
+++ b/cli/src/commands/whoami.rs
@@ -32,6 +32,11 @@ pub async fn run(State(env): State<CliEnv>) {
     table.add_row(vec!["Ingress base URL", env.ingress_base_url.as_ref()]);
 
     table.add_row(vec!["Meta URL", env.meta_base_url.as_ref()]);
+
+    if env.bearer_token.is_some() {
+        table.add_row(vec!["Authentication Token", "(set)"]);
+    }
+
     c_println!("{}", table);
 
     c_println!();


### PR DESCRIPTION
These are not entirely unrelated, but happy to split into two PRs if we'd rather reflect on how to do auth some more.

I didn't make the request timeout configurable. It seems like this should be passed in via the config file and/or a CLI switch override, but it seems that config file parsing is not implemented yet. Does it seem reasonable to add timeout as another member of `GlobalOpts`?

Should we have separate timeouts for meta requests vs. DataFusion queries? Seems reasonable and we might legitimately have longer-running DataFusion queries (though the open-ended nature of this is concerning in itself).


Auth tokens: it seems reasonable that in any future development, we would have some form of auth. Token auth passed as a bearer token is widespread and likely to continue being in use regardless of endpoint tenancy. So it seems reasonable to me to add this in now, even if we change our mind about some auth details in the future – but a reasonable person may disagree!

---

Sanity testing:

HTTP request against HTTPS endpoint – this times out, expectedly:

```
     Running `target/debug/restate whoami`

     →↓→↓
    →↓→↓→↓→→→               →→→→
    ↓→↓→↓→↓↓→↓→→           →↓↓→↓→↓→
    →↓→↓→↓→↓→↓↓→↓→↓       →↓→↓→↓→↓→↓→
    →↓→↓→↓→↓→↓→↓→↓→↓→→      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→ →↓→↓→↓→↓→↓→↓→      →↓→↓→↓→↓↓→↓→↗
    →↓→↓→↓→    →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓↓→↓→
    →↓→↓→↓→       →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓→↓→→
    →↓→↓→↓→          →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓↓→↓→
    →↓→↓→↓→             →↓→↓→↓→↓→↓→       →→↓→↓→↓→↓→↓
    →↓→↓→↓→             →↓→↓→↓→↓→↓→      →→↓→↓→↓→↓→↓→
    →↓→↓→↓→          →↓→↓→↓→↓→↓→↓      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→       →→↓→↓→↓→↓→↓→→     →↓→↓→↓→↓→↓→→
    →↓→↓→↓→      →↓→↓→↓→↓→↓→     →↓→↓→↓→↓→↓→↓
    →↓→↓→↓→     →↓→↓→↓→↓→     →↓→↓→↓→↓→↓→↓→
    →↓→↓→↓→      ↓→↓→→      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→               →↓→↓→↓→↓→↓→
    →↓→↓→↓→                →↓→↓→↓→
    ↓→↓→↓→↓
     →↓→→

            Restate
       https://restate.dev/

 Ingress base URL  http://pcholakov.dev.restate.cloud:8080/
 Meta URL          http://pcholakov.dev.restate.cloud:9070/

Local Environment
 Config Dir        /Users/pavel/.config/restate (exists)
 Config File       /Users/pavel/.config/restate/config.yaml (exists)
 Loaded .env file  (NONE)

Build Information
 Version            0.0.1-dev
 Target             aarch64-apple-darwin
 Debug Build?       true
 Build Time         2024-01-02T13:17:43.817018000Z
 Build Features     default
 Git SHA            72628ef
 Git Commit Date    2024-01-02
 Git Commit Branch  token-auth

❌ Meta Service 'http://pcholakov.dev.restate.cloud:9070/' is unhealthy:
   >> error sending request for url (http://pcholakov.dev.restate.cloud:9070/health): operation timed out
```

Successful authenticated request against Managed Cluster endpoint:

```
     Running `target/debug/restate whoami`

     →↓→↓
    →↓→↓→↓→→→               →→→→
    ↓→↓→↓→↓↓→↓→→           →↓↓→↓→↓→
    →↓→↓→↓→↓→↓↓→↓→↓       →↓→↓→↓→↓→↓→
    →↓→↓→↓→↓→↓→↓→↓→↓→→      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→ →↓→↓→↓→↓→↓→↓→      →↓→↓→↓→↓↓→↓→↗
    →↓→↓→↓→    →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓↓→↓→
    →↓→↓→↓→       →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓→↓→→
    →↓→↓→↓→          →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓↓→↓→
    →↓→↓→↓→             →↓→↓→↓→↓→↓→       →→↓→↓→↓→↓→↓
    →↓→↓→↓→             →↓→↓→↓→↓→↓→      →→↓→↓→↓→↓→↓→
    →↓→↓→↓→          →↓→↓→↓→↓→↓→↓      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→       →→↓→↓→↓→↓→↓→→     →↓→↓→↓→↓→↓→→
    →↓→↓→↓→      →↓→↓→↓→↓→↓→     →↓→↓→↓→↓→↓→↓
    →↓→↓→↓→     →↓→↓→↓→↓→     →↓→↓→↓→↓→↓→↓→
    →↓→↓→↓→      ↓→↓→→      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→               →↓→↓→↓→↓→↓→
    →↓→↓→↓→                →↓→↓→↓→
    ↓→↓→↓→↓
     →↓→→

            Restate
       https://restate.dev/

 Ingress base URL      https://pcholakov.dev.restate.cloud:8080/
 Meta URL              https://pcholakov.dev.restate.cloud:9070/
 Authentication Token  (set)

Local Environment
 Config Dir        /Users/pavel/.config/restate (exists)
 Config File       /Users/pavel/.config/restate/config.yaml (exists)
 Loaded .env file  (NONE)

Build Information
 Version            0.0.1-dev
 Target             aarch64-apple-darwin
 Debug Build?       true
 Build Time         2024-01-02T13:36:01.705865000Z
 Build Features     default
 Git SHA            a7a6e84
 Git Commit Date    2024-01-02
 Git Commit Branch  token-auth

✅ Meta Service 'https://pcholakov.dev.restate.cloud:9070/' is healthy!
```

This is what the help screen looks like now:

```
     Running `target/debug/restate`
Restate makes distributed applications easy!

Usage: restate [OPTIONS] <COMMAND>

Commands:
  whoami       Prints general information about the configured environment
  services     Manage Restate's service registry [aliases: svc]
  deployments  Manages your service deployments [aliases: dp]
  invocations  Manage active invocations
  example      Download one of Restate's examples in this directory
  help         Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...                         More output per occurrence
  -q, --quiet...                           Less output per occurrence
  -y, --yes                                Auto answer "yes" to confirmation prompts
      --connect-timeout <CONNECT_TIMEOUT>  Connection timeout for service interactions, in milliseconds [default: 5000]
      --request-timeout <REQUEST_TIMEOUT>  Overall request timeout for service interactions, in milliseconds
      --table-style <TABLE_STYLE>          Which table output style to use [default: compact] [possible values: compact, borders]
  -h, --help                               Print help (see more with '--help')
  -V, --version                            Print version
```