### PR TITLE
Fix npm automation

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -111,7 +111,7 @@ jobs:
             sed -i "s/\"version\": \".*\",/\"version\": \"${node_version}\",/" package.json
             for os in linux darwin
             do
-              for arch in x86 arm64
+              for arch in x64 arm64
               do
                 sed -i "s|\"@restatedev/${bin}-${os}-${arch}\": \".*\"|\"@restatedev/${bin}-${os}-${arch}\": \"${node_version}\"|" package.json
               done

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -109,6 +109,13 @@ jobs:
             fi
             pushd "${bin}"
             sed -i "s/\"version\": \".*\",/\"version\": \"${node_version}\",/" package.json
+            for os in linux darwin
+            do
+              for arch in x86 arm64
+              do
+                sed -i "s|\"@restatedev/${bin}-${os}-${arch}\": \".*\"|\"@restatedev/${bin}-${os}-${arch}\": \"${node_version}\"|" package.json
+              done
+            done
             curl https://raw.githubusercontent.com/restatedev/restate/main/README.md -o README.md
             npm install
             npm run build

--- a/npm/restate-server/package.json
+++ b/npm/restate-server/package.json
@@ -29,9 +29,9 @@
     "typescript": "^4.9.4"
   },
   "optionalDependencies": {
-    "@restatedev/restate-server-linux-x86_64": "0.5.1",
+    "@restatedev/restate-server-linux-x64": "0.5.1",
     "@restatedev/restate-server-linux-arm64": "0.5.1",
-    "@restatedev/restate-server-darwin-x86_64": "0.5.1",
+    "@restatedev/restate-server-darwin-x64": "0.5.1",
     "@restatedev/restate-server-darwin-arm64": "0.5.1"
   }
 }

--- a/npm/restate/package.json
+++ b/npm/restate/package.json
@@ -29,9 +29,9 @@
     "typescript": "^4.9.4"
   },
   "optionalDependencies": {
-    "@restatedev/restate-linux-x86_64": "0.5.1",
+    "@restatedev/restate-linux-x64": "0.5.1",
     "@restatedev/restate-linux-arm64": "0.5.1",
-    "@restatedev/restate-darwin-x86_64": "0.5.1",
+    "@restatedev/restate-darwin-x64": "0.5.1",
     "@restatedev/restate-darwin-arm64": "0.5.1"
   }
 }


### PR DESCRIPTION
Node uses x64, not x86_64, and we were neglecting to update the package imports