### PR TITLE
Panics now emit error traces and renames restate threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,6 +4966,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-panic",
  "vergen",
 ]
 
@@ -6515,6 +6516,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log 0.1.4",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf80030ce049691c9922d75be63cadf345110a245cd4581833c66f87c02ad25"
+dependencies = [
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,6 +46,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-panic = { version = "0.1.1" }
 
 [build-dependencies]
 vergen = { version = "8.0.0", default-features = false, features = [

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -107,6 +107,14 @@ fn main() {
             .init("Restate binary", std::process::id())
             .expect("failed to instrument logging and tracing!");
 
+        // Log panics as tracing errors if possible
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            tracing_panic::panic_hook(panic_info);
+            // run original hook if any.
+            prev_hook(panic_info);
+        }));
+
         info!("Starting Restate Server {}", build_info::build_info());
         info!(
             "Loading configuration file from {}",


### PR DESCRIPTION
Panics now emit error traces and renames restate threads


This adds a panic handler that attempts to log the panic info to via tracing error (if possible). It'll fallback to existing panic handlers if any.

This sets restate tokio thread names to unique names that becomes handy when debugging `rs:worker-X` where X is a counter.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1041).
* #1046
* __->__ #1041