### PR TITLE
[CLI] Include Trace ID in invocation information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,6 +4966,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-panic",
  "vergen",
 ]
 
@@ -6515,6 +6516,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log 0.1.4",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf80030ce049691c9922d75be63cadf345110a245cd4581833c66f87c02ad25"
+dependencies = [
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/cli/src/commands/invocations/describe.rs
+++ b/cli/src/commands/invocations/describe.rs
@@ -69,6 +69,11 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     }
     table.add_kv_row("Method:", &inv.method);
     add_invocation_to_kv_table(&mut table, &inv);
+    table.add_kv_row_if(
+        || inv.state_modified_at.is_some(),
+        "Modified at:",
+        format!("{}", &inv.state_modified_at.unwrap()),
+    );
 
     c_title!("📜", "Invocation Information");
     c_println!("{}", table);

--- a/crates/storage-query-datafusion/src/inbox/row.rs
+++ b/crates/storage-query-datafusion/src/inbox/row.rs
@@ -12,7 +12,7 @@ use super::schema::InboxBuilder;
 use crate::table_util::format_using;
 use restate_storage_api::inbox_table::InboxEntry;
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
-use restate_types::invocation::{ServiceInvocation, Source};
+use restate_types::invocation::{ServiceInvocation, Source, TraceId};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -65,7 +65,9 @@ pub(crate) fn append_inbox_row(
     }
     if row.is_trace_id_defined() {
         let tid = span_context.trace_id();
-        row.trace_id(format_using(output, &tid));
+        if tid != TraceId::INVALID {
+            row.trace_id(format_using(output, &tid));
+        }
     }
 
     if row.is_created_at_defined() {

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -16,13 +16,14 @@ use crate::identifiers::{
 };
 use bytes::Bytes;
 use bytestring::ByteString;
-use opentelemetry_api::trace::{
-    SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
-};
+use opentelemetry_api::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceState};
 use opentelemetry_api::Context;
 use std::fmt;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+// Re-exporting opentelemetry [`TraceId`] to avoid having to import opentelemetry in all crates.
+pub use opentelemetry_api::trace::TraceId;
 
 /// Struct representing an invocation to a service. This struct is processed by Restate to execute the invocation.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,6 +46,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-panic = { version = "0.1.1" }
 
 [build-dependencies]
 vergen = { version = "8.0.0", default-features = false, features = [

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -107,6 +107,14 @@ fn main() {
             .init("Restate binary", std::process::id())
             .expect("failed to instrument logging and tracing!");
 
+        // Log panics as tracing errors if possible
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            tracing_panic::panic_hook(panic_info);
+            // run original hook if any.
+            prev_hook(panic_info);
+        }));
+
         info!("Starting Restate Server {}", build_info::build_info());
         info!(
             "Loading configuration file from {}",


### PR DESCRIPTION
[CLI] Include Trace ID in invocation information

Summary:

This introduces the _Trace ID_ (if set) in invocation list and describe commands. Additionally, it adds an explicit `Modified at` field to show when the status of an invocation was last updated.

Note that we also won't send invalid trace ids through datafusion after this commit. If TraceId is INVALID, the field will be returned with a null value.

This PR also includes some minor cosmetic changes


Test Plan:

```
  ❯ [2024-01-08 12:53:34.717 +00:00] PE_ArNvGvDYAYzpIrN9fXmB1xzSimZgMA [interpreter.CommandInterpreter @ 45-20-7-5000-cat4]::Call
     Status:      pending
     Invoked by:  interpreter.CommandInterpreter
                  hcahrcz7aBUAYzpIqihdAil7i0yDcBsGg
     Trace ID:    018ce922a8a17408a5ee2d320dc06c1a
```
