### PR TITLE
Allow timers to be removed from running TimerService

### DIFF
--- a/crates/timer/src/lib.rs
+++ b/crates/timer/src/lib.rs
@@ -11,6 +11,7 @@
 extern crate core;
 
 use restate_types::time::MillisSinceEpoch;
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::future::Future;
 use std::hash::Hash;
@@ -22,15 +23,15 @@ pub use options::{Options, OptionsBuilder, OptionsBuilderError};
 pub use service::clock::{Clock, TokioClock};
 pub use service::TimerService;
 
-pub trait Timer: Hash + Eq {
+pub trait Timer: Hash + Eq + Borrow<Self::TimerKey> {
     type TimerKey: TimerKey + Send;
 
-    fn timer_key(&self) -> Self::TimerKey;
+    fn timer_key(&self) -> &Self::TimerKey;
 }
 
 /// Timer key establishes an absolute order on [`Timer`]. Naturally, this should be key under
 /// which the timer value is stored and can be retrieved.
-pub trait TimerKey: Ord + Clone + Debug {
+pub trait TimerKey: Ord + Clone + Hash + Debug {
     fn wake_up_time(&self) -> MillisSinceEpoch;
 }
 

--- a/crates/worker/src/partition/leadership/action_collector.rs
+++ b/crates/worker/src/partition/leadership/action_collector.rs
@@ -117,6 +117,9 @@ where
                 message,
             } => shuffle_hint_tx.send(shuffle::NewOutboxMessage::new(seq_number, message)),
             Action::RegisterTimer { timer_value } => timer_service.as_mut().add_timer(timer_value),
+            Action::DeleteTimer { timer_key } => {
+                timer_service.as_mut().remove_timer(timer_key.into())
+            }
             Action::AckStoredEntry {
                 full_invocation_id,
                 entry_index,

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -14,6 +14,7 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use restate_invoker_api::InvokeInputJournal;
 use restate_storage_api::outbox_table::OutboxMessage;
+use restate_storage_api::timer_table::TimerKey;
 use restate_types::identifiers::{EntryIndex, FullInvocationId, InvocationUuid, ServiceId};
 use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
 use restate_types::journal::Completion;
@@ -49,6 +50,9 @@ pub enum Action {
     },
     RegisterTimer {
         timer_value: TimerValue,
+    },
+    DeleteTimer {
+        timer_key: TimerKey,
     },
     AckStoredEntry {
         full_invocation_id: FullInvocationId,

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -303,6 +303,7 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
             }
             Effect::DeleteTimer(timer_key) => {
                 state_storage.delete_timer(&timer_key).await?;
+                collector.collect(Action::DeleteTimer { timer_key });
             }
             Effect::StoreDeploymentId {
                 service_id,

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -18,6 +18,7 @@ use restate_types::invocation::{
     ServiceInvocationResponseSink, Source, SpanRelation,
 };
 use restate_types::time::MillisSinceEpoch;
+use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -112,6 +113,12 @@ impl PartialEq for TimerValue {
 
 impl Eq for TimerValue {}
 
+impl Borrow<TimerKeyWrapper> for TimerValue {
+    fn borrow(&self) -> &TimerKeyWrapper {
+        &self.timer_key
+    }
+}
+
 /// New type wrapper to implement [`restate_timer::TimerKey`] for [`TimerKey`].
 ///
 /// # Important
@@ -131,14 +138,20 @@ impl TimerKeyWrapper {
 impl restate_timer::Timer for TimerValue {
     type TimerKey = TimerKeyWrapper;
 
-    fn timer_key(&self) -> Self::TimerKey {
-        self.timer_key.clone()
+    fn timer_key(&self) -> &Self::TimerKey {
+        &self.timer_key
     }
 }
 
 impl restate_timer::TimerKey for TimerKeyWrapper {
     fn wake_up_time(&self) -> MillisSinceEpoch {
         MillisSinceEpoch::from(self.0.timestamp)
+    }
+}
+
+impl From<TimerKey> for TimerKeyWrapper {
+    fn from(timer_key: TimerKey) -> Self {
+        TimerKeyWrapper(timer_key)
     }
 }
 


### PR DESCRIPTION
This commit adds timer::Service::remove_timer which allows to remove a
timer from the TimerService while it is running. Moreover, when cancelling
a timer, we also issue a timer deletion from RocksDB and removal from the
TimerService.

If the TimerService is currently loading new timers, we need to remember the
removed timer for the time of loading new timers to filter them out. After
leaving this state, we can forget the removed timers.

If the TimerSerivce is currently processing timers, we can directly remove
timers from the internal timer queue. If the removed timer is the last timer
in the current batch, then we need to update the batch end to reflect the
new state.

This PR is based on #1034 and fixes https://github.com/restatedev/restate/issues/1029.