### PR TITLE
Node-ctrl Server Basics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -95,9 +95,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -115,37 +115,37 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arc-swap"
@@ -321,7 +321,7 @@ dependencies = [
  "arrow-data 49.0.0",
  "arrow-schema 49.0.0",
  "arrow-select 49.0.0",
- "base64 0.21.5",
+ "base64 0.21.6",
  "chrono",
  "comfy-table",
  "half 2.3.1",
@@ -624,18 +624,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -683,7 +683,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "ring 0.17.6",
+ "ring 0.17.7",
  "time",
  "tokio",
  "tracing",
@@ -1060,9 +1060,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
 
 [[package]]
 name = "base64-simd"
@@ -1116,7 +1116,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76"
+checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.10"
+version = "4.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
+checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1397,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fdbb015d790cfb378aca82caf9cc52a38be96a7eecdb92f31b4366a8afc019"
+checksum = "3c90e95e5bd4e8ac34fa6f37c774b0c6f8ed06ea90c79931fd448fcf941a9767"
 dependencies = [
  "clap",
  "log",
@@ -1407,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.9"
+version = "4.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
+checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1427,7 +1427,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1464,7 +1464,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1522,15 +1522,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1572,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -1709,11 +1709,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -1723,56 +1722,46 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
@@ -1854,12 +1843,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix 0.27.1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1907,7 +1896,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1929,7 +1918,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2079,7 +2068,7 @@ dependencies = [
  "arrow-array 46.0.0",
  "arrow-buffer 46.0.0",
  "arrow-schema 46.0.0",
- "base64 0.21.5",
+ "base64 0.21.6",
  "blake2",
  "blake3",
  "chrono",
@@ -2137,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2287,6 +2276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,9 +2332,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "figment"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649f3e5d826594057e9a519626304d8da859ea8a0b18ce99500c586b8d45faee"
+checksum = "7629b8c7bcd214a072c2c88b263b5bb3ceb54c34365d8c41c1665461aeae0993"
 dependencies = [
  "atomic 0.6.0",
  "pear",
@@ -2410,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2425,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2435,15 +2430,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2452,38 +2447,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2509,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2563,7 +2558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005e4cb962c56efd249bdeeb4ac232b11e1c45a2e49793bba2b2982dcc3f2e9d"
 dependencies = [
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2610,6 +2605,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -2624,7 +2628,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "byteorder",
  "flate2",
  "nom",
@@ -2660,11 +2664,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2680,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -2725,9 +2729,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2740,7 +2744,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2777,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2920,13 +2924,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2949,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
@@ -2977,10 +2981,10 @@ version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "js-sys",
- "pem 3.0.2",
- "ring 0.17.6",
+ "pem 3.0.3",
+ "ring 0.17.7",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -3064,18 +3068,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3112,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
 dependencies = [
  "cc",
  "libc",
@@ -3139,6 +3143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee33defb27b106378a6efcfcde4dda6226dfdac8ba7a2904f5bc93363cb88557"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,9 +3156,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lua-src"
-version = "546.0.1"
+version = "546.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c26d4af78361e025a3d03a2b964cd1592aff7495f4d4f7947218c084c6fdca8"
+checksum = "2da0daa7eee611a4c30c8f5ee31af55266e26e573971ba9336d2993e2da129b2"
 dependencies = [
  "cc",
 ]
@@ -3227,26 +3237,79 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.0"
+name = "metrics"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "77b9e10a211c839210fd7f99954bda26e5f8e26ec686ad68da6a32df7c80e782"
 dependencies = [
- "autocfg",
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a4c4718a371ddfb7806378f23617876eea8b82e5ff1324516bcd283249d9ea"
+dependencies = [
+ "base64 0.21.6",
+ "hyper",
+ "indexmap 1.9.3",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "metrics-tracing-context"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
+dependencies = [
+ "indexmap 2.1.0",
+ "itoa",
+ "lockfree-object-pool",
+ "metrics",
+ "metrics-util",
+ "once_cell",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2670b8badcc285d486261e2e9f1615b506baff91427b61bd336a472b65bbf5ed"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "indexmap 1.9.3",
+ "metrics",
+ "num_cpus",
+ "ordered-float 4.2.0",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -3281,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
@@ -3328,6 +3391,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -3506,9 +3578,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -3542,7 +3614,7 @@ checksum = "abfeeafb5fa0da7046229ec3c7b3bd2981aae05c549871192c408d59fc0fffd5"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "cfg-if",
  "chrono",
@@ -3618,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -3777,6 +3849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,7 +3912,7 @@ dependencies = [
  "arrow-ipc 46.0.0",
  "arrow-schema 46.0.0",
  "arrow-select 46.0.0",
- "base64 0.21.5",
+ "base64 0.21.6",
  "brotli",
  "bytes",
  "chrono",
@@ -3891,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "pear"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
 dependencies = [
  "inlinable_string",
  "pear_codegen",
@@ -3902,14 +3983,14 @@ dependencies = [
 
 [[package]]
 name = "pear_codegen"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3924,17 +4005,17 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "serde",
 ]
 
 [[package]]
 name = "pem"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "serde",
 ]
 
@@ -3961,7 +4042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2de42ee35f9694def25c37c15f564555411d9904b48e33680618ee7359080dc"
 dependencies = [
  "async-trait",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "chrono",
  "derive-new",
@@ -4037,7 +4118,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4054,9 +4135,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plotters"
@@ -4088,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postgres-protocol"
@@ -4098,7 +4179,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -4168,12 +4249,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4222,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -4237,7 +4318,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
@@ -4279,7 +4360,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types",
  "regex",
- "syn 2.0.39",
+ "syn 2.0.48",
  "tempfile",
  "which",
 ]
@@ -4307,7 +4388,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4316,7 +4397,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "once_cell",
  "prost 0.12.3",
  "prost-types",
@@ -4334,6 +4415,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,11 +4440,21 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -4379,6 +4485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.4.1",
 ]
 
 [[package]]
@@ -4504,11 +4619,11 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4546,7 +4661,7 @@ dependencies = [
 name = "restate-base64-util"
 version = "0.7.0"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
 ]
 
 [[package]]
@@ -4630,6 +4745,7 @@ dependencies = [
  "pin-project",
  "restate-test-util",
  "restate-types",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -4644,6 +4760,7 @@ dependencies = [
  "paste",
  "restate-test-util",
  "termimad",
+ "test-log",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -4665,6 +4782,7 @@ dependencies = [
  "futures",
  "pin-project",
  "restate-test-util",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -4685,6 +4803,7 @@ dependencies = [
  "restate-schema-api",
  "restate-test-util",
  "restate-types",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -4706,6 +4825,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "metrics",
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
@@ -4723,6 +4843,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "test-log",
  "thiserror",
  "tokio",
  "tonic 0.10.2",
@@ -4739,7 +4860,7 @@ dependencies = [
 name = "restate-ingress-kafka"
 version = "0.7.0"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "derive_builder",
  "drain",
@@ -4795,6 +4916,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.11.0",
+ "metrics",
  "opentelemetry",
  "opentelemetry-http",
  "prost 0.12.3",
@@ -4813,6 +4935,7 @@ dependencies = [
  "serde",
  "serde_with",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -4854,6 +4977,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "tower",
@@ -4889,10 +5013,55 @@ dependencies = [
  "restate-errors",
  "restate-test-util",
  "restate-types",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "restate-node-ctrl"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "codederror",
+ "derive_builder",
+ "drain",
+ "futures",
+ "http",
+ "humantime",
+ "hyper",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-tracing-context",
+ "metrics-util",
+ "restate-errors",
+ "restate-node-ctrl-proto",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tonic 0.10.2",
+ "tonic-reflection",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "restate-node-ctrl-proto"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "prost 0.12.3",
+ "prost-types",
+ "thiserror",
+ "tonic 0.10.2",
+ "tonic-build",
 ]
 
 [[package]]
@@ -4929,7 +5098,7 @@ name = "restate-schema-api"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "bytestring",
  "http",
@@ -4967,6 +5136,7 @@ dependencies = [
  "restate-types",
  "serde",
  "serde_json",
+ "test-log",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -4977,7 +5147,7 @@ dependencies = [
 name = "restate-serde-util"
 version = "0.7.0"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "http",
  "prost 0.12.3",
@@ -5003,6 +5173,7 @@ dependencies = [
  "restate-errors",
  "restate-fs-util",
  "restate-meta",
+ "restate-node-ctrl",
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-worker",
@@ -5027,7 +5198,7 @@ dependencies = [
  "aws-sdk-lambda",
  "aws-sdk-sts",
  "aws-smithy-runtime",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytestring",
  "derive_builder",
  "futures",
@@ -5050,7 +5221,7 @@ dependencies = [
 name = "restate-service-protocol"
 version = "0.7.0"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "bytes-utils",
  "codederror",
@@ -5067,6 +5238,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "size",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -5138,7 +5310,7 @@ name = "restate-storage-query-http"
 version = "0.7.0"
 dependencies = [
  "axum",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "codederror",
  "datafusion",
@@ -5251,6 +5423,7 @@ dependencies = [
  "restate-types",
  "schemars",
  "serde",
+ "test-log",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5273,6 +5446,7 @@ version = "0.7.0"
 dependencies = [
  "console-subscriber",
  "derive_builder",
+ "metrics-tracing-context",
  "nu-ansi-term",
  "once_cell",
  "opentelemetry",
@@ -5293,7 +5467,7 @@ name = "restate-types"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "bytestring",
  "http",
@@ -5330,6 +5504,7 @@ dependencies = [
  "futures",
  "googletest",
  "humantime",
+ "metrics",
  "opentelemetry_api",
  "pin-project",
  "prost 0.12.3",
@@ -5362,6 +5537,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5406,9 +5582,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
  "getrandom",
@@ -5450,9 +5626,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -5463,12 +5639,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.17.6",
+ "ring 0.17.7",
  "rustls-webpki",
  "sct",
 ]
@@ -5491,7 +5667,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
 ]
 
 [[package]]
@@ -5500,7 +5676,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.6",
+ "ring 0.17.7",
  "untrusted 0.9.0",
 ]
 
@@ -5512,9 +5688,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -5527,11 +5703,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5572,7 +5748,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.6",
+ "ring 0.17.7",
  "untrusted 0.9.0",
 ]
 
@@ -5610,9 +5786,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "seq-macro"
@@ -5622,9 +5798,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -5641,13 +5817,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5663,9 +5839,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -5674,9 +5850,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
 dependencies = [
  "itoa",
  "serde",
@@ -5719,14 +5895,14 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
 dependencies = [
  "indexmap 2.1.0",
  "itoa",
@@ -5852,6 +6028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fed904c7fb2856d868b92464fc8fa597fce366edea1a9cbfaa8cb5fe080bd6d"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5891,19 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "snap"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -6012,7 +6184,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6057,9 +6229,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6095,15 +6267,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6141,33 +6313,43 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66edd6b6cd810743c0c71e1d085e92b01ce6a72782032e3f794c8284fe4bcdd"
+checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+dependencies = [
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6193,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -6215,9 +6397,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -6267,9 +6449,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6279,7 +6461,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -6303,7 +6485,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6366,7 +6548,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6395,7 +6577,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "h2",
  "http",
@@ -6423,7 +6605,20 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
+dependencies = [
+ "prost 0.12.3",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -6432,7 +6627,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddb2a37b247e6adcb9f239f4e5cefdcc5ed526141a416b943929f13aea2cce"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "bytes",
  "http",
  "http-body",
@@ -6519,7 +6714,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6613,9 +6808,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -6644,9 +6839,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -6809,7 +7004,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -6843,7 +7038,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6915,20 +7110,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -6947,21 +7133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6996,12 +7167,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7011,12 +7176,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7032,12 +7191,6 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -7047,12 +7200,6 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7068,12 +7215,6 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -7083,12 +7224,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7104,12 +7239,6 @@ checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -7122,9 +7251,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
 dependencies = [
  "memchr",
 ]
@@ -7183,9 +7312,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "xz2"
@@ -7210,22 +7339,22 @@ checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ restate-invoker-impl = { path = "crates/invoker-impl" }
 restate-meta = { path = "crates/meta" }
 restate-meta-rest-model = { path = "crates/meta-rest-model" }
 restate-network = { path = "crates/network" }
+restate-node-ctrl = { path = "crates/node-ctrl" }
+restate-node-ctrl-proto = { path = "crates/node-ctrl-proto" }
 restate-pb = { path = "crates/pb" }
 restate-queue = { path = "crates/queue" }
 restate-schema-api = { path = "crates/schema-api" }
@@ -71,13 +73,14 @@ arc-swap = "1.6"
 assert2 = "0.3.11"
 async-channel = "2.1.1"
 async-trait = "0.1.73"
+axum = "0.6.18"
 base64 = "0.21"
 bincode = { version = "2.0.0-rc", default-features = false, features = [ "std", "serde", ] }
 bytes = { version = "1.3", features = ["serde"] }
 bytes-utils = "0.1.3"
 bytestring = { version = "1.2", features = ["serde"] }
-criterion = "0.5"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+criterion = "0.5"
 datafusion = { version = "31.0.0" }
 datafusion-expr = { version = "31.0.0" }
 derive_builder = "0.12.0"
@@ -91,6 +94,7 @@ humantime = "2.1.0"
 hyper = { version = "0.14.24", default-features = false }
 hyper-rustls = { version = "0.24.1", features = ["http2"] }
 itertools = "0.11.0"
+metrics = { version = "0.22" }
 once_cell = "1.18"
 opentelemetry = { version = "0.20.0" }
 opentelemetry-http = { version = "0.9.0" }
@@ -112,6 +116,7 @@ serde_with = "2.2"
 serde_yaml = "0.9"
 sync_wrapper = "0.1.2"
 tempfile = "3.6.0"
+test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 thiserror = "1.0"
 tokio = { version = "1.29", default-features = false, features = [ "rt-multi-thread", "signal", "macros", ] }
 tokio-util = { version = "0.7.10" }
@@ -119,9 +124,10 @@ tokio-stream = "0.1.14"
 tonic = { version = "0.10.2", default-features = false }
 tonic-build = "0.10.2"
 tower = "0.4"
+tower-http = { version = "0.4", default-features = false }
 tracing = "0.1"
 tracing-opentelemetry = { version = "0.21.0" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 
 

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -68,7 +68,8 @@ pub fn spawn_restate(
 
     let (signal, drain) = drain::channel();
     let app_handle = rt.block_on(async move {
-        let app = Application::new(config.meta, config.worker).expect("Application must build");
+        let app = Application::new(config.node_ctrl, config.meta, config.worker)
+            .expect("Application must build");
         tokio::task::spawn(app.run(drain))
     });
 

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -21,5 +21,5 @@ tracing = { workspace = true }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
-

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -21,5 +21,6 @@ tracing = { workspace = true }
 restate-test-util = { workspace = true }
 
 thiserror = { workspace = true }
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/futures-util/Cargo.toml
+++ b/crates/futures-util/Cargo.toml
@@ -16,5 +16,6 @@ tokio = { workspace = true, features = ["sync"] }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
+test-log = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/ingress-dispatcher/Cargo.toml
+++ b/crates/ingress-dispatcher/Cargo.toml
@@ -32,5 +32,6 @@ restate-test-util = { workspace = true, features = ["prost"] }
 restate-types = { workspace = true, features = ["mocks"] }
 
 googletest = { workspace = true }
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/ingress-grpc/Cargo.toml
+++ b/crates/ingress-grpc/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { workspace = true }
 tonic = { workspace = true, features = ["codegen", "prost", "transport"] }
 tonic-web = "0.10.2"
 tower = { workspace = true, features = ["util"] }
-tower-http = { version = "0.4", default-features = false, features = ["cors"] }
+tower-http = { workspace = true, features = ["cors"] }
 
 # Tracing
 opentelemetry = { workspace = true }
@@ -54,6 +54,7 @@ arc-swap = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
+metrics = { workspace = true }
 once_cell = { workspace = true }
 schemars = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -66,6 +67,7 @@ restate-test-util = { workspace = true }
 restate-types = { workspace = true, features = ["mocks"] }
 
 hyper = { workspace = true, features = ["client"] }
+test-log = { workspace = true }
 tonic = { workspace = true, features = ["default"] }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ingress-grpc/src/lib.rs
+++ b/crates/ingress-grpc/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod handler;
+mod metric_definitions;
 mod options;
 mod protocol;
 mod reflection;

--- a/crates/ingress-grpc/src/metric_definitions.rs
+++ b/crates/ingress-grpc/src/metric_definitions.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Optional to have but adds description/help message to the metrics emitted to
+/// the metrics' sink.
+use metrics::{describe_counter, describe_histogram, Unit};
+
+pub const INGRESS_REQUEST_CREATED: &str = "ingress.request_created.total";
+pub const INGRESS_REQUEST_DURATION: &str = "ingress.request_duration.seconds";
+
+pub(crate) fn describe_metrics() {
+    describe_counter!(
+        INGRESS_REQUEST_CREATED,
+        Unit::Count,
+        "Number of ingress requests created"
+    );
+    describe_histogram!(
+        INGRESS_REQUEST_DURATION,
+        Unit::Seconds,
+        "Total latency of Ingress request processing in seconds"
+    );
+}

--- a/crates/ingress-grpc/src/options.rs
+++ b/crates/ingress-grpc/src/options.rs
@@ -146,6 +146,7 @@ impl Options {
             json,
         } = self;
 
+        crate::metric_definitions::describe_metrics();
         let (hyper_ingress_server, _) =
             HyperServerIngress::new(bind_address, concurrency_limit, json, schemas, request_tx);
 

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -33,6 +33,7 @@ h2 = { version = "0.3.20" }
 humantime = { workspace = true }
 hyper = { workspace = true, features = ["http1", "http2", "client", "tcp", "stream", "runtime"] }
 itertools = { workspace = true }
+metrics = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true }
 schemars = { workspace = true, optional = true }
@@ -53,5 +54,6 @@ restate-types = { workspace = true }
 googletest = { workspace = true }
 prost = { workspace = true }
 tempfile = { workspace = true }
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/crates/invoker-impl/src/metric_definitions.rs
+++ b/crates/invoker-impl/src/metric_definitions.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Optional to have but adds description/help message to the metrics emitted to
+/// the metrics' sink.
+use metrics::{describe_counter, describe_gauge, Unit};
+
+pub const INVOKER_ENQUEUE: &str = "invoker.enqueue.total";
+pub const INVOKER_INVOCATION_TASK_STARTED: &str = "invoker.invocation_task_started.total";
+pub const INVOKER_INVOCATION_TASK_FAILED: &str = "invoker.invocation_task_failed.total";
+pub const INVOKER_INVOCATION_TASK_SUSPENDED: &str = "invoker.invocation_task_suspended.total";
+pub const INVOKER_INFLIGHT_INVOCATIONS: &str = "invoker.inflight_invocations.total";
+
+pub(crate) fn describe_metrics() {
+    describe_counter!(
+        INVOKER_ENQUEUE,
+        Unit::Count,
+        "Number of invocations that were added to the queue"
+    );
+
+    describe_counter!(
+        INVOKER_INVOCATION_TASK_STARTED,
+        Unit::Count,
+        "Number of active invocation tasks started"
+    );
+
+    describe_counter!(
+        INVOKER_INVOCATION_TASK_FAILED,
+        Unit::Count,
+        "Number of active invocation tasks failed"
+    );
+
+    describe_counter!(
+        INVOKER_INVOCATION_TASK_SUSPENDED,
+        Unit::Count,
+        "Number of active invocation tasks suspended"
+    );
+
+    describe_gauge!(
+        INVOKER_INFLIGHT_INVOCATIONS,
+        Unit::Count,
+        "Number of actively executing invocation tasks"
+    );
+}

--- a/crates/invoker-impl/src/options.rs
+++ b/crates/invoker-impl/src/options.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::metric_definitions;
+
 use super::Service;
 
 use futures::Stream;
@@ -132,6 +134,7 @@ impl Options {
         EE: EntryEnricher,
         DMR: DeploymentMetadataResolver,
     {
+        metric_definitions::describe_metrics();
         let client = self.service_client.build(AssumeRoleCacheMode::Unbounded);
 
         Service::new(

--- a/crates/invoker-impl/src/state_machine_manager.rs
+++ b/crates/invoker-impl/src/state_machine_manager.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::metric_definitions::INVOKER_INFLIGHT_INVOCATIONS;
+
 use super::*;
 use std::ops::RangeInclusive;
 
@@ -60,11 +62,13 @@ impl InvocationStateMachineManager {
         partition: PartitionLeaderEpoch,
         full_invocation_id: &FullInvocationId,
     ) -> Option<(&mpsc::Sender<Effect>, InvocationStateMachine)> {
-        self.resolve_partition(partition).and_then(|p| {
+        let ret = self.resolve_partition(partition).and_then(|p| {
             p.invocation_state_machines
                 .remove(full_invocation_id)
                 .map(|ism| (&p.output_tx, ism))
-        })
+        });
+        gauge!(INVOKER_INFLIGHT_INVOCATIONS).decrement(1.0);
+        ret
     }
 
     #[inline]
@@ -105,6 +109,7 @@ impl InvocationStateMachineManager {
             .expect("Cannot register an invocation on an unknown partition")
             .invocation_state_machines
             .insert(fid, ism);
+        gauge!(INVOKER_INFLIGHT_INVOCATIONS).increment(1.0);
     }
 
     #[inline]

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -19,7 +19,7 @@ restate-futures-util = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 # Rest API
-axum = "0.6.18"
+axum = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 okapi-operation = { version = "0.2.2", features = ["axum-integration"] }
 tower = { workspace = true, features = ["load-shed", "limit"] }
@@ -60,5 +60,6 @@ restate-schema-api = { workspace = true, features = ["mocks"] }
 restate-test-util = { workspace = true }
 
 tempfile = { workspace = true }
+test-log = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -23,5 +23,5 @@ tracing = { workspace = true }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
-

--- a/crates/node-ctrl-proto/Cargo.toml
+++ b/crates/node-ctrl-proto/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "restate-node-ctrl-proto"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+
+[dependencies]
+anyhow = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+thiserror = { workspace = true, optional = true }
+tonic = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }

--- a/crates/node-ctrl-proto/build.rs
+++ b/crates/node-ctrl-proto/build.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    tonic_build::configure()
+        .bytes(["."])
+        .file_descriptor_set_path(out_dir.join("node_ctrl_descriptor.bin"))
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&["./proto/node_ctrl.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/node-ctrl-proto/proto/node_ctrl.proto
+++ b/crates/node-ctrl-proto/proto/node_ctrl.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package dev.restate.node_ctrl;
+
+enum NodeStatus {
+  NodeStatus_UNKNOWN = 0;
+  ALIVE = 1;
+  // The node is not fully running yet.
+  STARTING_UP = 2;
+  // The node is performing a graceful shutdown.
+  SHUTTING_DOWN = 3;
+}
+
+service NodeCtrl {
+  // Get identity information from this node.
+  rpc GetIdent(google.protobuf.Empty) returns (IdentResponse);
+}
+
+message IdentResponse {
+  NodeStatus status = 1;
+}
+
+

--- a/crates/node-ctrl-proto/src/lib.rs
+++ b/crates/node-ctrl-proto/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod proto {
+    #![allow(warnings)]
+    #![allow(clippy::all)]
+    #![allow(unknown_lints)]
+    tonic::include_proto!("dev.restate.node_ctrl");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("node_ctrl_descriptor");
+}

--- a/crates/node-ctrl/Cargo.toml
+++ b/crates/node-ctrl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "restate-storage-query-http"
+name = "restate-node-ctrl"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -9,28 +9,32 @@ publish = false
 
 [features]
 default = []
-options_schema = []
+options_schema = ["dep:schemars"]
 
 [dependencies]
 restate-errors = { workspace = true }
-restate-schema-api = { workspace = true, features = [ "service", "deployment", "serde", "serde_schema", ] }
-restate-storage-query-datafusion = { workspace = true }
-restate-worker-api = { workspace = true }
+restate-node-ctrl-proto = { workspace = true }
 
 axum = { workspace = true }
-base64 = { workspace = true }
-bytes = { workspace = true }
+async-trait = { workspace = true }
 codederror = { workspace = true }
-datafusion = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
 futures = { workspace = true }
+http = { workspace = true }
+humantime = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
-okapi-operation = { version = "0.2.1", features = ["axum-integration"] }
-schemars = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { version = "0.13", default-features = false, features = ["async-runtime"] }
+metrics-tracing-context = { version = "0.15.0" }
+metrics-util = { version = "0.16.0" }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
+tonic = { workspace = true, features = ["codegen", "prost", "transport"] }
+tonic-reflection = { version = "0.10.2" }
 tower = { workspace = true, features = ["load-shed", "limit"] }
+tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }

--- a/crates/node-ctrl/src/handler.rs
+++ b/crates/node-ctrl/src/handler.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use axum::extract::State;
+use tonic::{Request, Response, Status};
+
+use restate_node_ctrl_proto::proto::node_ctrl_server::NodeCtrl;
+use restate_node_ctrl_proto::proto::{IdentResponse, NodeStatus};
+
+use crate::state::HandlerState;
+
+// -- Direct HTTP Handlers --
+pub async fn render_metrics(State(state): State<HandlerState>) -> (http::StatusCode, String) {
+    // Response content type is plain/text and that's expected.
+    if let Some(prometheus_handle) = state.prometheus_handle {
+        (http::StatusCode::OK, prometheus_handle.render())
+    } else {
+        // We want to fail scraping to prevent silent failures.
+        (
+            // We respond with 422 since this is technically not a server error.
+            // We indicate that that the request is valid but cannot process this
+            // request due to semantic errors (i.e. not enabled in this case).
+            http::StatusCode::UNPROCESSABLE_ENTITY,
+            "Prometheus metric collection is not enabled.".to_string(),
+        )
+    }
+}
+
+// -- GRPC Service Handlers --
+pub struct Handler {
+    #[allow(dead_code)]
+    state: HandlerState,
+}
+
+impl Handler {
+    pub fn new(state: HandlerState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait::async_trait]
+impl NodeCtrl for Handler {
+    async fn get_ident(&self, _request: Request<()>) -> Result<Response<IdentResponse>, Status> {
+        // STUB IMPLEMENTATION
+        return Ok(Response::new(IdentResponse {
+            status: NodeStatus::Alive.into(),
+        }));
+    }
+}

--- a/crates/node-ctrl/src/lib.rs
+++ b/crates/node-ctrl/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod handler;
+mod metrics;
+mod multiplex;
+mod options;
+pub mod service;
+mod state;
+
+pub use crate::options::{Options, OptionsBuilder, OptionsBuilderError};
+pub use service::Error;

--- a/crates/node-ctrl/src/metrics.rs
+++ b/crates/node-ctrl/src/metrics.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_tracing_context::TracingContextLayer;
+use metrics_util::{layers::Layer, MetricKindMask};
+
+use crate::Options;
+
+/// The set of labels that are allowed to be extracted from tracing context to be used in metrics.
+/// Be mindful when adding new labels, the number of time series(es) is directly propotional
+/// to cardinality of the chosen labels. Avoid using labels with potential high cardinality
+/// as much as possible (e.g. `restate.invocation.id`)
+static ALLOWED_LABELS: &[&str] = &[
+    "partition_id",
+    "rpc.method",
+    "rpc.service",
+    "command",
+    "service",
+];
+
+pub(crate) fn install_global_prometheus_recorder(opts: &Options) -> PrometheusHandle {
+    let builder = PrometheusBuilder::default()
+        // Remove a metric from registry if it was not updated for that duration
+        .idle_timeout(
+            MetricKindMask::HISTOGRAM,
+            opts.histogram_inactivity_timeout.map(Into::into),
+        );
+    let recorder = builder.build_recorder();
+    let prometheus_handle = recorder.handle();
+    let recorder = TracingContextLayer::only_allow(ALLOWED_LABELS).layer(recorder);
+
+    // We do not expect this to fail except due to atomic CAS failure
+    // which should never happen in practice.
+    metrics::set_global_recorder(recorder).expect("no global metrics recorder should be installed");
+    prometheus_handle
+}

--- a/crates/node-ctrl/src/multiplex.rs
+++ b/crates/node-ctrl/src/multiplex.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+//
+//
+
+//! Mostly copied from axum example: https://github.com/tokio-rs/axum/blob/791d5038a927add3f8ff1d5c1010cd0b24fdda77/examples/rest-grpc-multiplex/src/multiplex_service.rs
+//! License MIT
+
+use axum::{
+    http::header::CONTENT_TYPE,
+    response::{IntoResponse, Response},
+};
+use futures::{future::BoxFuture, ready};
+use hyper::Request;
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
+use tower::Service;
+
+pub struct MultiplexService<A, B> {
+    base: A,
+    base_ready: bool,
+    grpc: B,
+    grpc_ready: bool,
+}
+
+impl<A, B> MultiplexService<A, B> {
+    pub fn new(base: A, grpc: B) -> Self {
+        Self {
+            base,
+            base_ready: false,
+            grpc,
+            grpc_ready: false,
+        }
+    }
+}
+
+impl<A, B> Clone for MultiplexService<A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            base: self.base.clone(),
+            grpc: self.grpc.clone(),
+            // the cloned services probably wont be ready
+            base_ready: false,
+            grpc_ready: false,
+        }
+    }
+}
+
+impl<A, B> Service<Request<hyper::Body>> for MultiplexService<A, B>
+where
+    A: Service<Request<hyper::Body>, Error = Infallible>,
+    A::Response: IntoResponse,
+    A::Future: Send + 'static,
+    B: Service<Request<hyper::Body>>,
+    B::Response: IntoResponse,
+    B::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = B::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // drive readiness for each inner service and record which is ready
+        loop {
+            match (self.base_ready, self.grpc_ready) {
+                (true, true) => {
+                    return Ok(()).into();
+                }
+                (false, _) => {
+                    ready!(self.base.poll_ready(cx)).map_err(|err| match err {})?;
+                    self.base_ready = true;
+                }
+                (_, false) => {
+                    ready!(self.grpc.poll_ready(cx))?;
+                    self.grpc_ready = true;
+                }
+            }
+        }
+    }
+
+    fn call(&mut self, req: Request<hyper::Body>) -> Self::Future {
+        // require users to call `poll_ready` first, if they don't we're allowed to panic
+        // as per the `tower::Service` contract
+        assert!(
+            self.grpc_ready,
+            "grpc service not ready. Did you forget to call `poll_ready`?"
+        );
+        assert!(
+            self.base_ready,
+            "http service not ready. Did you forget to call `poll_ready`?"
+        );
+
+        // if we get a grpc request call the grpc service, otherwise call the http service
+        // when calling a service it becomes not-ready so we have drive readiness again
+        if is_grpc_request(&req) {
+            self.grpc_ready = false;
+            let future = self.grpc.call(req);
+            Box::pin(async move {
+                let res = future.await?;
+                Ok(res.into_response())
+            })
+        } else {
+            self.base_ready = false;
+            let future = self.base.call(req);
+            Box::pin(async move {
+                let res = future.await.map_err(|err| match err {})?;
+                Ok(res.into_response())
+            })
+        }
+    }
+}
+
+fn is_grpc_request<B>(req: &Request<B>) -> bool {
+    req.headers()
+        .get(CONTENT_TYPE)
+        .map(|content_type| content_type.as_bytes())
+        .filter(|content_type| content_type.starts_with(b"application/grpc"))
+        .is_some()
+}

--- a/crates/node-ctrl/src/options.rs
+++ b/crates/node-ctrl/src/options.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::SocketAddr;
+
+use serde_with::serde_as;
+
+use crate::service::NodeCtrlService;
+
+/// # Node ctrl service options
+#[serde_as]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "options_schema", schemars(rename = "NodeCtrlOptions"))]
+#[cfg_attr(feature = "options_schema", schemars(default))]
+pub struct Options {
+    /// Address to bind for the Node ctrl Service.
+    pub bind_address: SocketAddr,
+
+    /// Timeout for idle histograms.
+    ///
+    /// The duration after which a histogram is considered idle and will be removed from
+    /// metric responses to save memory. Unsetting means that histograms will never be removed.
+    #[serde(with = "serde_with::As::<Option<serde_with::DisplayFromStr>>")]
+    #[cfg_attr(feature = "options_schema", schemars(with = "Option<String>"))]
+    pub histogram_inactivity_timeout: Option<humantime::Duration>,
+
+    /// Disable prometheus metric recording and reporting. Default is `false`.
+    pub disable_prometheus: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            bind_address: "0.0.0.0:5122".parse().unwrap(),
+            histogram_inactivity_timeout: None,
+            disable_prometheus: false,
+        }
+    }
+}
+
+impl Options {
+    pub fn build(self) -> NodeCtrlService {
+        NodeCtrlService::new(self)
+    }
+}

--- a/crates/node-ctrl/src/service.rs
+++ b/crates/node-ctrl/src/service.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::SocketAddr;
+
+use axum::routing::get;
+use codederror::CodedError;
+use futures::FutureExt;
+use tower_http::trace::TraceLayer;
+use tracing::info;
+
+use restate_node_ctrl_proto::proto::node_ctrl_server::NodeCtrlServer;
+use restate_node_ctrl_proto::proto::FILE_DESCRIPTOR_SET;
+
+use crate::handler::Handler;
+use crate::multiplex::MultiplexService;
+use crate::state::HandlerStateBuilder;
+use crate::Options;
+
+#[derive(Debug, thiserror::Error, CodedError)]
+pub enum Error {
+    #[error("failed binding to address '{address}' specified in 'node_ctrl.bind_address'")]
+    #[code(restate_errors::RT0004)]
+    Binding {
+        address: SocketAddr,
+        #[source]
+        source: hyper::Error,
+    },
+    #[error("error while running node-ctrl service: {0}")]
+    #[code(unknown)]
+    Running(hyper::Error),
+    #[error("error while running node-ctrl server grpc reflection service: {0}")]
+    #[code(unknown)]
+    Grpc(#[from] tonic_reflection::server::Error),
+}
+
+pub struct NodeCtrlService {
+    opts: Options,
+}
+
+impl NodeCtrlService {
+    pub fn new(opts: Options) -> Self {
+        Self { opts }
+    }
+
+    pub async fn run(self, drain: drain::Watch) -> Result<(), Error> {
+        // Configure Metric Exporter
+        let mut state_builder = HandlerStateBuilder::default();
+
+        if !self.opts.disable_prometheus {
+            state_builder.prometheus_handle(Some(
+                crate::metrics::install_global_prometheus_recorder(&self.opts),
+            ));
+        }
+
+        let shared_state = state_builder.build().unwrap();
+        // Trace layer
+        let span_factory = tower_http::trace::DefaultMakeSpan::new()
+            .include_headers(true)
+            .level(tracing::Level::ERROR);
+
+        // -- HTTP service (for prometheus et al.)
+        let router = axum::Router::new()
+            .route("/metrics", get(crate::handler::render_metrics))
+            .with_state(shared_state.clone())
+            .layer(TraceLayer::new_for_http().make_span_with(span_factory.clone()))
+            .fallback(handler_404);
+
+        // -- GRPC Service Setup
+        let tonic_reflection_service = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build()?;
+
+        // Build the NodeCtrl grpc service
+        let grpc = tonic::transport::Server::builder()
+            .layer(TraceLayer::new_for_grpc().make_span_with(span_factory))
+            .add_service(NodeCtrlServer::new(Handler::new(shared_state)))
+            .add_service(tonic_reflection_service)
+            .into_service();
+
+        // Multiplex both grpc and http based on content-type
+        let service = MultiplexService::new(router, grpc);
+
+        // Bind and serve
+        let server = hyper::Server::try_bind(&self.opts.bind_address)
+            .map_err(|err| Error::Binding {
+                address: self.opts.bind_address,
+                source: err,
+            })?
+            .serve(tower::make::Shared::new(service));
+
+        info!(
+            net.host.addr = %server.local_addr().ip(),
+            net.host.port = %server.local_addr().port(),
+            "Node-ctrl service listening"
+        );
+
+        // Wait server graceful shutdown
+        server
+            .with_graceful_shutdown(drain.signaled().map(|_| ()))
+            .await
+            .map_err(Error::Running)
+    }
+}
+
+// handle 404
+async fn handler_404() -> (http::StatusCode, &'static str) {
+    (
+        http::StatusCode::NOT_FOUND,
+        "Are you lost? Maybe visit https://restate.dev instead!",
+    )
+}

--- a/crates/node-ctrl/src/state.rs
+++ b/crates/node-ctrl/src/state.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics_exporter_prometheus::PrometheusHandle;
+
+#[derive(Clone, derive_builder::Builder)]
+pub struct HandlerState {
+    pub prometheus_handle: Option<PrometheusHandle>,
+}

--- a/crates/schema-impl/Cargo.toml
+++ b/crates/schema-impl/Cargo.toml
@@ -35,6 +35,7 @@ restate-schema-api = { workspace = true, features = ["mocks"] }
 restate-test-util = { workspace = true }
 
 prost-reflect = { workspace = true }
+test-log = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { workspace = true, optional = true }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
+test-log = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -12,7 +12,7 @@ assert2 = { workspace = true }
 googletest = { workspace = true }
 pretty_assertions = "1.3"
 prost = { workspace = true, optional = true }
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+test-log = { workspace = true }
 
 [dev-dependencies]
 prost-types = { workspace = true }

--- a/crates/timer/Cargo.toml
+++ b/crates/timer/Cargo.toml
@@ -32,4 +32,5 @@ restate-test-util = { workspace = true }
 
 futures-util = { workspace = true }
 tracing-subscriber = { workspace = true }
+test-log = { workspace = true }
 

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
+metrics-tracing-context = { version = "0.15.0" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -56,6 +56,7 @@ derive_builder = { workspace = true }
 drain = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
+metrics =  { workspace = true }
 opentelemetry_api = { workspace = true }
 pin-project = { workspace = true }
 prost = { workspace = true }
@@ -81,4 +82,5 @@ restate-types = { workspace = true, features = ["mocks"] }
 
 googletest = { workspace = true }
 tempfile = { workspace = true }
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -41,6 +41,7 @@ use util::IdentitySender;
 
 mod ingress_integration;
 mod invoker_integration;
+mod metric_definitions;
 mod network_integration;
 mod partition;
 mod partitioning_scheme;
@@ -163,6 +164,7 @@ impl Options {
     }
 
     pub fn build(self, schemas: Schemas) -> Result<Worker, BuildError> {
+        metric_definitions::describe_metrics();
         Worker::new(self, schemas)
     }
 }

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Optional to have but adds description/help message to the metrics emitted to
+/// the metrics' sink.
+use metrics::{describe_counter, Unit};
+
+pub const PARTITION_APPLY_COMMAND: &str = "partition.apply_command.total";
+pub const PARTITION_ACTUATOR_HANDLED: &str = "partition.actuator_handled.total";
+pub const PARTITION_TIMER_DUE_HANDLED: &str = "partition.timer_due_handled.total";
+pub const PARTITION_STORAGE_TX_CREATED: &str = "partition.storage_tx_created.total";
+pub const PARTITION_STORAGE_TX_COMMITTED: &str = "partition.storage_tx_committed.total";
+
+pub(crate) fn describe_metrics() {
+    describe_counter!(
+        PARTITION_APPLY_COMMAND,
+        Unit::Count,
+        "Total consensus commands processed by partition processor"
+    );
+    describe_counter!(
+        PARTITION_ACTUATOR_HANDLED,
+        Unit::Count,
+        "Number of actuator operation outputs processed"
+    );
+    describe_counter!(
+        PARTITION_TIMER_DUE_HANDLED,
+        Unit::Count,
+        "Number of due timer instances processed"
+    );
+    describe_counter!(
+        PARTITION_STORAGE_TX_CREATED,
+        Unit::Count,
+        "Storage transactions created by from processing state machine commands"
+    );
+    describe_counter!(
+        PARTITION_STORAGE_TX_COMMITTED,
+        Unit::Count,
+        "Storage transactions committed by applying partition state machine commands"
+    );
+}

--- a/crates/worker/src/partition/state_machine/commands.rs
+++ b/crates/worker/src/partition/state_machine/commands.rs
@@ -210,3 +210,17 @@ pub enum Command {
     Response(InvocationResponse),
     BuiltInInvoker(NBISEffects),
 }
+
+impl Command {
+    pub fn type_human(&self) -> &'static str {
+        match self {
+            Command::TerminateInvocation(_) => "InvocationTermination",
+            Command::Invoker(_) => "InvokerEffect",
+            Command::Timer(_) => "TimerValue",
+            Command::OutboxTruncation(_) => "OutboxTruncation",
+            Command::Invocation(_) => "ServiceInvocation",
+            Command::Response(_) => "InvocationResponse",
+            Command::BuiltInInvoker(_) => "NBISEffects",
+        }
+    }
+}

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -8,11 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::metric_definitions::{PARTITION_STORAGE_TX_COMMITTED, PARTITION_STORAGE_TX_CREATED};
 use crate::partition::shuffle::{OutboxReader, OutboxReaderError};
 use crate::partition::types::TimerKeyWrapper;
 use crate::partition::{CommitError, Committable, TimerValue};
 use bytes::{Buf, Bytes};
 use futures::{Stream, StreamExt, TryStreamExt};
+use metrics::counter;
 use restate_storage_api::deduplication_table::SequenceNumberSource;
 use restate_storage_api::fsm_table::ReadOnlyFsmTable;
 use restate_storage_api::inbox_table::InboxEntry;
@@ -67,6 +69,7 @@ where
     Storage: restate_storage_api::Storage,
 {
     pub(super) fn create_transaction(&mut self) -> Transaction<Storage::TransactionType<'_>> {
+        counter!(PARTITION_STORAGE_TX_CREATED).increment(1);
         Transaction::new(
             self.partition_id,
             self.partition_key_range.clone(),
@@ -208,8 +211,10 @@ where
         }
     }
 
-    pub(super) fn commit(self) -> impl Future<Output = Result<(), StorageError>> + Send {
-        self.inner.commit()
+    pub(super) async fn commit(self) -> Result<(), StorageError> {
+        let res = self.inner.commit().await;
+        counter!(PARTITION_STORAGE_TX_COMMITTED).increment(1);
+        res
     }
 
     async fn store_seq_number(

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,6 +20,7 @@ options_schema = [
     "dep:schemars",
     "restate-tracing-instrumentation/options_schema",
     "restate-meta/options_schema",
+    "restate-node-ctrl/options_schema",
     "restate-worker/options_schema",
 ]
 
@@ -27,6 +28,7 @@ options_schema = [
 restate-errors = { workspace = true, features = ["include_doc"] }
 restate-fs-util = { workspace = true }
 restate-meta = { workspace = true }
+restate-node-ctrl = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
 restate-types = { workspace = true }
 restate-worker = { workspace = true }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -23,6 +23,7 @@ pub use restate_meta::{
     Options as MetaOptions, OptionsBuilder as MetaOptionsBuilder,
     OptionsBuilderError as MetaOptionsBuilderError,
 };
+pub use restate_node_ctrl::Options as NodeCtrlOptions;
 pub use restate_tracing_instrumentation::{
     LogOptions, LogOptionsBuilder, LogOptionsBuilderError, Options as ObservabilityOptions,
     OptionsBuilder as ObservabilityOptionsBuilder,
@@ -65,6 +66,7 @@ pub struct Configuration {
     pub observability: restate_tracing_instrumentation::Options,
     pub meta: restate_meta::Options,
     pub worker: WorkerOptions,
+    pub node_ctrl: NodeCtrlOptions,
     pub tokio_runtime: crate::rt::Options,
 }
 
@@ -73,6 +75,7 @@ impl Default for Configuration {
         Self {
             shutdown_grace_period: Duration::from_secs(60).into(),
             observability: Default::default(),
+            node_ctrl: Default::default(),
             meta: Default::default(),
             worker: Default::default(),
             tokio_runtime: Default::default(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -131,7 +131,9 @@ fn main() {
             config.worker.storage_path().into()
         ).await.expect("Error when trying to wipe the configured storage path");
 
-        let app = Application::new(config.meta, config.worker);
+        let app = Application::new(
+            config.node_ctrl,
+            config.meta, config.worker);
 
         if let Err(err) = app {
             handle_error(err);


### PR DESCRIPTION
Node-ctrl Server Basics

Introduces a node-level control service listening on port 5121 (to pair with the future node-to-node port will be on 5122)
The node-ctrl service also initializes and exposes prometheus metrics. Components are advised to collect metrics with
the `metrics` crate, and the recorder will automatically inject labels from the current `tracing` span (merged with parent spans).

To avoid an explosion of time series on high-cardinality span attributes, an allow list is defined in `node-ctrl/src/metrics.rs`
that will be expanded over time.

For every crate, we should create `src/metric_definitions.rs` that defines `describe_metrics()`. This function describes the metrics
so that it appears in prometheus metric explorer with help messages. Note that it's not a requirement to describe metrics before using
but it helps to centralize all metrics maintained by every crate in a single place as demonstrated in this PR.

Features:
- Node-ctrl configuration is under `node_ctrl` key in config file. Most notably, `node_ctrl.disable_prometheus` will stop prometheus recording.
- `node_ctrl.histogram_inactivity_timeout` (disabled by default) will evict idle histograms if idle after certain timeout to reclaim memory.
- Prometheus scraping is supported on `GET http://localhost:5122/metrics` (try with curl).
- A stub NodeCtrl GRPC service is put in place multiplexing on the same port based on content-type.

Side Notes:
 - The changes in Cargo.toml files are due to a newer version of test-log that requires every macro user to have `test-log` crate available.
 - The current defined metrics are meant to act as an example and will _almost certainly_ change in the future.

Example:
```
❯ http localhost:5122/metrics
HTTP/1.1 200 OK
content-length: 1167
content-type: text/plain; charset=utf-8
date: Wed, 10 Jan 2024 11:43:13 GMT

# TYPE partition_storage_tx_created_total counter
partition_storage_tx_created_total{partition_id="690"} 1

# TYPE invoker_invocation_task_started_total counter
invoker_invocation_task_started_total{rpc_service="interpreter.CommandInterpreter"} 5
invoker_invocation_task_started_total{rpc_service="verifier.CommandVerifier"} 30

# TYPE invoker_invocation_task_failed_total counter
invoker_invocation_task_failed_total{rpc_service="interpreter.CommandInterpreter",transient="true"} 5
invoker_invocation_task_failed_total{rpc_service="verifier.CommandVerifier",transient="true"} 30

# TYPE ingress_request_created_total counter
ingress_request_created_total{rpc_service="verifier.CommandVerifier",rpc_method="Execute"} 1

# TYPE partition_apply_command_total counter
partition_apply_command_total{partition_id="690",command="ServiceInvocation"} 1

# TYPE partition_storage_tx_committed_total counter
partition_storage_tx_committed_total{partition_id="690"} 1

# TYPE invoker_inflight_invocations_total gauge
invoker_inflight_invocations_total{rpc_service="verifier.CommandVerifier"} 0
invoker_inflight_invocations_total{rpc_service="interpreter.CommandInterpreter"} 0

```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1050).
* #1063
* #1062
* __->__ #1050