### PR TITLE
Introduce max batch size and duration for PartitionProcessor

### DIFF
--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -109,6 +109,7 @@ pub struct Options {
     ingress_grpc: IngressOptions,
     kafka: KafkaIngressOptions,
     invoker: InvokerOptions,
+    partition_processor: partition::Options,
 
     /// # Partitions
     ///
@@ -130,6 +131,7 @@ impl Default for Options {
             ingress_grpc: Default::default(),
             kafka: Default::default(),
             invoker: Default::default(),
+            partition_processor: Default::default(),
             partitions: 1024,
         }
     }
@@ -244,6 +246,7 @@ impl Worker {
             storage_query_datafusion,
             storage_query_postgres,
             storage_rocksdb,
+            partition_processor: partition_processor_options,
             ..
         } = opts;
 
@@ -327,6 +330,7 @@ impl Worker {
                     network.create_partition_processor_sender(),
                     rocksdb_storage.clone(),
                     schemas.clone(),
+                    partition_processor_options.clone(),
                 )
             })
             .unzip();
@@ -370,6 +374,7 @@ impl Worker {
         ack_sender: PartitionProcessorSender<partition::StateMachineAckResponse>,
         rocksdb_storage: RocksDBStorage,
         schemas: Schemas,
+        partition_processor_options: partition::Options,
     ) -> ((PeerId, mpsc::Sender<ConsensusCommand>), PartitionProcessor) {
         let (command_tx, command_rx) = mpsc::channel(channel_size);
         let processor = PartitionProcessor::new(
@@ -385,6 +390,7 @@ impl Worker {
             ack_sender,
             rocksdb_storage,
             schemas,
+            partition_processor_options,
         );
 
         ((peer_id, command_tx), processor)

--- a/crates/worker/src/partition/options.rs
+++ b/crates/worker/src/partition/options.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde_with::serde_as;
+use std::time::Duration;
+
+/// Partition processor options
+#[serde_as]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "options_schema",
+    schemars(rename = "PartitionProcessorOptions", default)
+)]
+#[builder(default)]
+pub struct Options {
+    /// # Maximum batch duration
+    ///
+    /// The maximum duration the partition processor can spend on batching commands before
+    /// checking for signals from its actuators. The larger the value, the fewer disk writes
+    /// are being performed which can improve overall throughput at the cost of potentially
+    /// longer invocation latencies.
+    #[serde_as(as = "serde_with::NoneAsEmptyString")]
+    #[cfg_attr(feature = "options_schema", schemars(with = "Option<String>"))]
+    pub max_batch_duration: Option<humantime::Duration>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            max_batch_duration: Some(Duration::from_millis(50).into()),
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces an upper limit for the size of command batches that the PartitionProcessor can create and the maximum duration the batching can take before checking again the actuators for signals. This prevents the situation where the PartitionProcessor is starved because of too many commands being applied.

This fixes #1051.