### PR TITLE
prefix metrics with restate_

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -321,7 +321,7 @@ dependencies = [
  "arrow-data 49.0.0",
  "arrow-schema 49.0.0",
  "arrow-select 49.0.0",
- "base64 0.21.6",
+ "base64 0.21.7",
  "chrono",
  "comfy-table",
  "half 2.3.1",
@@ -1060,9 +1060,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64-simd"
@@ -1082,9 +1082,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcder"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf16bec990f8ea25cab661199904ef452fcf11f565c404ce6cffbdf3f8cbbc47"
+checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
 dependencies = [
  "bytes",
  "smallvec",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.1"
+version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
+checksum = "a4c69fae65a523209d34240b60abe0c42d33d1045d445c0839d8a4894a736e2d"
 dependencies = [
  "bitflags 2.4.1",
  "cexpr",
@@ -1261,6 +1261,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "80932e03c33999b9235edb8655bc9df3204adc9887c2f95b50cb1deb9fd54253"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1407,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "d6c0db58c659eef1c73e444d298c27322a1b52f6927d2ad470c0c0f96fa7b8fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2068,7 +2100,7 @@ dependencies = [
  "arrow-array 46.0.0",
  "arrow-buffer 46.0.0",
  "arrow-schema 46.0.0",
- "base64 0.21.6",
+ "base64 0.21.7",
  "blake2",
  "blake3",
  "chrono",
@@ -2299,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "218a870470cce1469024e9fb66b901aa983929d81304a1cdb299f28118e550d5"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2563,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
 dependencies = [
  "bytes",
  "fnv",
@@ -2628,7 +2660,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "byteorder",
  "flate2",
  "nom",
@@ -2968,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2981,7 +3013,7 @@ version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "js-sys",
  "pem 3.0.3",
  "ring 0.17.7",
@@ -3101,8 +3133,8 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.15.0+8.9.1"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb.git?rev=66f04df013b6e6bd42b5a8c353406e09a7c7da2a#66f04df013b6e6bd42b5a8c353406e09a7c7da2a"
+version = "0.16.0+8.10.0"
+source = "git+https://github.com/restatedev/rust-rocksdb.git?branch=next#d29bccff916b8b41221ebb726f4e99bb5a65b5bf"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3266,7 +3298,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a4c4718a371ddfb7806378f23617876eea8b82e5ff1324516bcd283249d9ea"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "hyper",
  "indexmap 1.9.3",
  "metrics",
@@ -3614,7 +3646,7 @@ checksum = "abfeeafb5fa0da7046229ec3c7b3bd2981aae05c549871192c408d59fc0fffd5"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "cfg-if",
  "chrono",
@@ -3646,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "okapi"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce66b6366e049880a35c378123fddb630b1a1a3c37fa1ca70caaf4a09f6e2893"
+checksum = "9a64853d7ab065474e87696f7601cee817d200e86c42e04004e005cb3e20c3c5"
 dependencies = [
  "log",
  "schemars",
@@ -3912,7 +3944,7 @@ dependencies = [
  "arrow-ipc 46.0.0",
  "arrow-schema 46.0.0",
  "arrow-select 46.0.0",
- "base64 0.21.6",
+ "base64 0.21.7",
  "brotli",
  "bytes",
  "chrono",
@@ -4005,7 +4037,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -4015,7 +4047,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -4042,7 +4074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2de42ee35f9694def25c37c15f564555411d9904b48e33680618ee7359080dc"
 dependencies = [
  "async-trait",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "derive-new",
@@ -4179,7 +4211,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -4397,7 +4429,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "once_cell",
  "prost 0.12.3",
  "prost-types",
@@ -4623,7 +4655,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4707,7 +4739,7 @@ dependencies = [
 name = "restate-base64-util"
 version = "0.7.1"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4906,7 +4938,7 @@ dependencies = [
 name = "restate-ingress-kafka"
 version = "0.7.1"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "derive_builder",
  "drain",
@@ -5082,6 +5114,8 @@ dependencies = [
  "metrics-util",
  "restate-errors",
  "restate-node-ctrl-proto",
+ "restate-storage-rocksdb",
+ "rocksdb",
  "schemars",
  "serde",
  "serde_json",
@@ -5141,7 +5175,7 @@ name = "restate-schema-api"
 version = "0.7.1"
 dependencies = [
  "anyhow",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "bytestring",
  "http",
@@ -5190,7 +5224,7 @@ dependencies = [
 name = "restate-serde-util"
 version = "0.7.1"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "http",
  "prost 0.12.3",
@@ -5242,7 +5276,7 @@ dependencies = [
  "aws-sdk-lambda",
  "aws-sdk-sts",
  "aws-smithy-runtime",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytestring",
  "derive_builder",
  "futures",
@@ -5265,7 +5299,7 @@ dependencies = [
 name = "restate-service-protocol"
 version = "0.7.1"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "bytes-utils",
  "codederror",
@@ -5483,7 +5517,7 @@ name = "restate-types"
 version = "0.7.1"
 dependencies = [
  "anyhow",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "bytestring",
  "http",
@@ -5612,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.21.0"
-source = "git+https://github.com/rust-rocksdb/rust-rocksdb.git?rev=66f04df013b6e6bd42b5a8c353406e09a7c7da2a#66f04df013b6e6bd42b5a8c353406e09a7c7da2a"
+source = "git+https://github.com/restatedev/rust-rocksdb.git?branch=next#d29bccff916b8b41221ebb726f4e99bb5a65b5bf"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5641,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -5682,7 +5716,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -5804,6 +5838,9 @@ name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "seq-macro"
@@ -6059,9 +6096,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
 
 [[package]]
 name = "snafu"
@@ -6295,9 +6332,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -6563,7 +6600,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6592,7 +6629,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "h2",
  "http",
@@ -6642,7 +6679,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddb2a37b247e6adcb9f239f4e5cefdcc5ed526141a416b943929f13aea2cce"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "http",
  "http-body",
@@ -6952,11 +6989,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.2.6"
+version = "8.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1290fd64cc4e7d3c9b07d7f333ce0ce0007253e32870e632624835cc80b83939"
+checksum = "1a78365c3f8ca9dc5428a9f5c6349558c3f9f3eeb65e3fc00b6a981379462947"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
+ "regex",
  "rustversion",
  "time",
 ]
@@ -7000,9 +7039,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -7010,9 +7049,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -7025,9 +7064,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7037,9 +7076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7047,9 +7086,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7060,15 +7099,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7266,9 +7305,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.33"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,8 @@ prost-build = "0.12.1"
 prost-reflect = "0.12.0"
 prost-types = "0.12.1"
 rand = "0.8.5"
-# we need to use RocksDB >= 8.9.1 because it fixes https://github.com/facebook/rocksdb/pull/11680
-rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "66f04df013b6e6bd42b5a8c353406e09a7c7da2a" }
+# we need to use RocksDB with fine-grained statistics access. We use this branch until proposed changes are merged upstream
+rocksdb = { git = "https://github.com/restatedev/rust-rocksdb.git", branch = "next"}
 rustls = "0.21.6"
 schemars = { version = "0.8", features = ["bytes"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/ingress-grpc/src/metric_definitions.rs
+++ b/crates/ingress-grpc/src/metric_definitions.rs
@@ -12,8 +12,8 @@
 /// the metrics' sink.
 use metrics::{describe_counter, describe_histogram, Unit};
 
-pub const INGRESS_REQUEST_CREATED: &str = "ingress.request_created.total";
-pub const INGRESS_REQUEST_DURATION: &str = "ingress.request_duration.seconds";
+pub const INGRESS_REQUEST_CREATED: &str = "restate.ingress.request_created.total";
+pub const INGRESS_REQUEST_DURATION: &str = "restate.ingress.request_duration.seconds";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(

--- a/crates/invoker-impl/src/metric_definitions.rs
+++ b/crates/invoker-impl/src/metric_definitions.rs
@@ -10,13 +10,14 @@
 
 /// Optional to have but adds description/help message to the metrics emitted to
 /// the metrics' sink.
-use metrics::{describe_counter, describe_gauge, Unit};
+use metrics::{describe_counter, Unit};
 
-pub const INVOKER_ENQUEUE: &str = "invoker.enqueue.total";
-pub const INVOKER_INVOCATION_TASK_STARTED: &str = "invoker.invocation_task_started.total";
-pub const INVOKER_INVOCATION_TASK_FAILED: &str = "invoker.invocation_task_failed.total";
-pub const INVOKER_INVOCATION_TASK_SUSPENDED: &str = "invoker.invocation_task_suspended.total";
-pub const INVOKER_INFLIGHT_INVOCATIONS: &str = "invoker.inflight_invocations.total";
+pub const INVOKER_ENQUEUE: &str = "restate.invoker.enqueue.total";
+pub const INVOKER_INVOCATION_TASK: &str = "restate.invoker.invocation_task.total";
+
+pub const TASK_OP_STARTED: &str = "started";
+pub const TASK_OP_SUSPENDED: &str = "suspended";
+pub const TASK_OP_FAILED: &str = "failed";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(
@@ -26,26 +27,8 @@ pub(crate) fn describe_metrics() {
     );
 
     describe_counter!(
-        INVOKER_INVOCATION_TASK_STARTED,
+        INVOKER_INVOCATION_TASK,
         Unit::Count,
-        "Number of active invocation tasks started"
-    );
-
-    describe_counter!(
-        INVOKER_INVOCATION_TASK_FAILED,
-        Unit::Count,
-        "Number of active invocation tasks failed"
-    );
-
-    describe_counter!(
-        INVOKER_INVOCATION_TASK_SUSPENDED,
-        Unit::Count,
-        "Number of active invocation tasks suspended"
-    );
-
-    describe_gauge!(
-        INVOKER_INFLIGHT_INVOCATIONS,
-        Unit::Count,
-        "Number of actively executing invocation tasks"
+        "Invocation task operation"
     );
 }

--- a/crates/invoker-impl/src/state_machine_manager.rs
+++ b/crates/invoker-impl/src/state_machine_manager.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::metric_definitions::INVOKER_INFLIGHT_INVOCATIONS;
-
 use super::*;
 use std::ops::RangeInclusive;
 
@@ -62,13 +60,11 @@ impl InvocationStateMachineManager {
         partition: PartitionLeaderEpoch,
         full_invocation_id: &FullInvocationId,
     ) -> Option<(&mpsc::Sender<Effect>, InvocationStateMachine)> {
-        let ret = self.resolve_partition(partition).and_then(|p| {
+        self.resolve_partition(partition).and_then(|p| {
             p.invocation_state_machines
                 .remove(full_invocation_id)
                 .map(|ism| (&p.output_tx, ism))
-        });
-        gauge!(INVOKER_INFLIGHT_INVOCATIONS).decrement(1.0);
-        ret
+        })
     }
 
     #[inline]
@@ -109,7 +105,6 @@ impl InvocationStateMachineManager {
             .expect("Cannot register an invocation on an unknown partition")
             .invocation_state_machines
             .insert(fid, ism);
-        gauge!(INVOKER_INFLIGHT_INVOCATIONS).increment(1.0);
     }
 
     #[inline]

--- a/crates/node-ctrl/Cargo.toml
+++ b/crates/node-ctrl/Cargo.toml
@@ -14,9 +14,10 @@ options_schema = ["dep:schemars"]
 [dependencies]
 restate-errors = { workspace = true }
 restate-node-ctrl-proto = { workspace = true }
+restate-storage-rocksdb = { workspace = true }
 
-axum = { workspace = true }
 async-trait = { workspace = true }
+axum = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
@@ -28,6 +29,7 @@ metrics = { workspace = true }
 metrics-exporter-prometheus = { version = "0.13", default-features = false, features = ["async-runtime"] }
 metrics-tracing-context = { version = "0.15.0" }
 metrics-util = { version = "0.16.0" }
+rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/node-ctrl/src/handler.rs
+++ b/crates/node-ctrl/src/handler.rs
@@ -8,29 +8,227 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::Write;
+use std::iter::once;
+
 use axum::extract::State;
+use axum::response::IntoResponse;
+use metrics_exporter_prometheus::formatting;
+use restate_storage_rocksdb::{TableKind, DB};
+use rocksdb::statistics::{Histogram, Ticker};
+use rocksdb::AsColumnFamilyRef;
 use tonic::{Request, Response, Status};
 
 use restate_node_ctrl_proto::proto::node_ctrl_server::NodeCtrl;
 use restate_node_ctrl_proto::proto::{IdentResponse, NodeStatus};
 
+use crate::prometheus_helpers::{
+    format_rocksdb_histogram_for_prometheus, format_rocksdb_property_for_prometheus,
+    format_rocksdb_stat_ticker_for_prometheus, MetricUnit,
+};
 use crate::state::HandlerState;
 
+static ROCKSDB_TICKERS: &[Ticker] = &[
+    Ticker::BlockCacheDataBytesInsert,
+    Ticker::BlockCacheDataHit,
+    Ticker::BlockCacheDataMiss,
+    Ticker::BloomFilterUseful,
+    Ticker::BytesRead,
+    Ticker::BytesWritten,
+    Ticker::CompactReadBytes,
+    Ticker::CompactWriteBytes,
+    Ticker::FlushWriteBytes,
+    Ticker::MemtableHit,
+    Ticker::MemtableMiss,
+    Ticker::NoIteratorCreated,
+    Ticker::NoIteratorDeleted,
+    Ticker::NumberKeysRead,
+    Ticker::NumberKeysUpdated,
+    Ticker::NumberKeysWritten,
+    Ticker::StallMicros,
+    Ticker::WalFileBytes,
+    Ticker::WalFileSynced,
+    Ticker::WriteWithWal,
+];
+
+static ROCKSDB_HISTOGRAMS: &[(Histogram, &str, MetricUnit)] = &[
+    (Histogram::DbGet, "rocksdb.db.get", MetricUnit::Micros),
+    (
+        Histogram::DbMultiget,
+        "rocksdb.db.multiget",
+        MetricUnit::Micros,
+    ),
+    (Histogram::DbWrite, "rocksdb.db.write", MetricUnit::Micros),
+    (Histogram::DbSeek, "rocksdb.db.seek", MetricUnit::Micros),
+    (Histogram::FlushTime, "rocksdb.db.flush", MetricUnit::Micros),
+    (
+        Histogram::WalFileSyncMicros,
+        "rocksdb.wal.file.sync",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::CompactionTime,
+        "rocksdb.compaction.times",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::SstBatchSize,
+        Histogram::SstBatchSize.name(),
+        MetricUnit::Bytes,
+    ),
+    (
+        Histogram::BytesPerWrite,
+        Histogram::BytesPerWrite.name(),
+        MetricUnit::Bytes,
+    ),
+    (
+        Histogram::BytesPerRead,
+        Histogram::BytesPerRead.name(),
+        MetricUnit::Bytes,
+    ),
+    (
+        Histogram::BytesPerMultiget,
+        Histogram::BytesPerMultiget.name(),
+        MetricUnit::Bytes,
+    ),
+];
+
+// Per column-family properties
+static ROCKSDB_PROPERTIES: &[(&str, MetricUnit)] = &[
+    ("rocksdb.num-immutable-mem-table", MetricUnit::Count),
+    ("rocksdb.mem-table-flush-pending", MetricUnit::Count),
+    ("rocksdb.compaction-pending", MetricUnit::Count),
+    ("rocksdb.background-errors", MetricUnit::Count),
+    ("rocksdb.cur-size-active-mem-table", MetricUnit::Bytes),
+    ("rocksdb.cur-size-all-mem-tables", MetricUnit::Bytes),
+    ("rocksdb.size-all-mem-tables", MetricUnit::Bytes),
+    ("rocksdb.num-entries-active-mem-table", MetricUnit::Count),
+    ("rocksdb.num-entries-imm-mem-tables", MetricUnit::Count),
+    ("rocksdb.num-deletes-active-mem-table", MetricUnit::Count),
+    ("rocksdb.num-deletes-imm-mem-tables", MetricUnit::Count),
+    ("rocksdb.estimate-num-keys", MetricUnit::Count),
+    ("rocksdb.estimate-table-readers-mem", MetricUnit::Bytes),
+    ("rocksdb.num-live-versions", MetricUnit::Count),
+    ("rocksdb.estimate-live-data-size", MetricUnit::Bytes),
+    ("rocksdb.min-log-number-to-keep", MetricUnit::Count),
+    ("rocksdb.live-sst-files-size", MetricUnit::Bytes),
+    (
+        "rocksdb.estimate-pending-compaction-bytes",
+        MetricUnit::Bytes,
+    ),
+    ("rocksdb.num-running-compactions", MetricUnit::Count),
+    ("rocksdb.actual-delayed-write-rate", MetricUnit::Count),
+    ("rocksdb.block-cache-capacity", MetricUnit::Bytes),
+    ("rocksdb.block-cache-usage", MetricUnit::Bytes),
+    ("rocksdb.block-cache-pinned-usage", MetricUnit::Bytes),
+    ("rocksdb.num-files-at-level0", MetricUnit::Count),
+    ("rocksdb.num-files-at-level1", MetricUnit::Count),
+    // Add more as needed.
+    ("rocksdb.num-files-at-level2", MetricUnit::Count),
+];
+
 // -- Direct HTTP Handlers --
-pub async fn render_metrics(State(state): State<HandlerState>) -> (http::StatusCode, String) {
+pub async fn render_metrics(State(state): State<HandlerState>) -> String {
+    let mut out = String::new();
+
     // Response content type is plain/text and that's expected.
     if let Some(prometheus_handle) = state.prometheus_handle {
-        (http::StatusCode::OK, prometheus_handle.render())
-    } else {
-        // We want to fail scraping to prevent silent failures.
-        (
-            // We respond with 422 since this is technically not a server error.
-            // We indicate that that the request is valid but cannot process this
-            // request due to semantic errors (i.e. not enabled in this case).
-            http::StatusCode::UNPROCESSABLE_ENTITY,
-            "Prometheus metric collection is not enabled.".to_string(),
-        )
+        // Internal system metrics
+        let _ = write!(&mut out, "{}", prometheus_handle.render());
     }
+
+    // Load metrics from rocksdb (if the node runs rocksdb, and rocksdb
+    // stat collection is enabled)
+    let Some(db) = state.rocksdb_storage else {
+        return out;
+    };
+
+    let raw_db = db.inner();
+    let options = db.options();
+    // Tickers (Counters)
+    for ticker in ROCKSDB_TICKERS {
+        format_rocksdb_stat_ticker_for_prometheus(&mut out, &options, *ticker);
+    }
+    // Histograms
+    for (histogram, name, unit) in ROCKSDB_HISTOGRAMS {
+        format_rocksdb_histogram_for_prometheus(
+            &mut out,
+            name,
+            options.get_histogram_data(*histogram),
+            *unit,
+        );
+    }
+
+    // Properties (Gauges)
+    // For properties, we need to get them for each column family.
+    let all_cfs = TableKind::all()
+        .map(TableKind::cf_name)
+        // Include the default column family
+        .chain(once("default"));
+
+    for cf in all_cfs {
+        let Some(cf_handle) = raw_db.cf_handle(cf) else {
+            continue;
+        };
+        let sanitized_cf_name = formatting::sanitize_label_value(cf);
+        let labels = [format!("cf=\"{}\"", sanitized_cf_name)];
+        for (property, unit) in ROCKSDB_PROPERTIES {
+            format_rocksdb_property_for_prometheus(
+                &mut out,
+                &labels,
+                *unit,
+                property,
+                get_property(&raw_db, &cf_handle, property),
+            );
+        }
+    }
+
+    // Memory Usage Stats (Gauges)
+    let cache = db.cache();
+    let memory_usage =
+        get_memory_usage_stats(Some(&[&raw_db]), cache).expect("get_memory_usage_stats");
+
+    format_rocksdb_property_for_prometheus(
+        &mut out,
+        &[],
+        MetricUnit::Bytes,
+        "rocksdb.memory.approximate-cache",
+        memory_usage.approximate_cache_total(),
+    );
+
+    format_rocksdb_property_for_prometheus(
+        &mut out,
+        &[],
+        MetricUnit::Bytes,
+        "rocksdb.memory.approx-memtable",
+        memory_usage.approximate_mem_table_total(),
+    );
+
+    format_rocksdb_property_for_prometheus(
+        &mut out,
+        &[],
+        MetricUnit::Bytes,
+        "rocksdb.memory.approx-memtable-unflushed",
+        memory_usage.approximate_mem_table_unflushed(),
+    );
+
+    format_rocksdb_property_for_prometheus(
+        &mut out,
+        &[],
+        MetricUnit::Bytes,
+        "rocksdb.memory.approx-memtable-readers",
+        memory_usage.approximate_mem_table_readers_total(),
+    );
+    out
+}
+
+pub async fn rocksdb_stats(State(state): State<HandlerState>) -> impl IntoResponse {
+    let Some(db) = state.rocksdb_storage else {
+        return String::new();
+    };
+
+    let options = db.options();
+    options.get_statistics().unwrap_or_default()
 }
 
 // -- GRPC Service Handlers --
@@ -53,4 +251,27 @@ impl NodeCtrl for Handler {
             status: NodeStatus::Alive.into(),
         }));
     }
+}
+
+// -- Local Helpers
+#[inline]
+fn get_property(db: &DB, cf_handle: &impl AsColumnFamilyRef, name: &str) -> u64 {
+    db.property_int_value_cf(cf_handle, name)
+        .unwrap_or_default()
+        .unwrap_or_default()
+}
+
+fn get_memory_usage_stats(
+    dbs: Option<&[&DB]>,
+    cache: Option<rocksdb::Cache>,
+) -> Result<rocksdb::perf::MemoryUsage, rocksdb::Error> {
+    let mut builder = rocksdb::perf::MemoryUsageBuilder::new()?;
+    if let Some(dbs_) = dbs {
+        dbs_.iter().for_each(|db| builder.add_db(db));
+    }
+    if let Some(cache) = cache {
+        builder.add_cache(&cache);
+    }
+
+    builder.build()
 }

--- a/crates/node-ctrl/src/lib.rs
+++ b/crates/node-ctrl/src/lib.rs
@@ -12,6 +12,7 @@ mod handler;
 mod metrics;
 mod multiplex;
 mod options;
+mod prometheus_helpers;
 pub mod service;
 mod state;
 

--- a/crates/node-ctrl/src/options.rs
+++ b/crates/node-ctrl/src/options.rs
@@ -10,6 +10,7 @@
 
 use std::net::SocketAddr;
 
+use restate_storage_rocksdb::RocksDBStorage;
 use serde_with::serde_as;
 
 use crate::service::NodeCtrlService;
@@ -47,7 +48,7 @@ impl Default for Options {
 }
 
 impl Options {
-    pub fn build(self) -> NodeCtrlService {
-        NodeCtrlService::new(self)
+    pub fn build(self, rocksdb_storage: Option<RocksDBStorage>) -> NodeCtrlService {
+        NodeCtrlService::new(self, rocksdb_storage)
     }
 }

--- a/crates/node-ctrl/src/prometheus_helpers.rs
+++ b/crates/node-ctrl/src/prometheus_helpers.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Write;
+
+use metrics_exporter_prometheus::formatting;
+use rocksdb::statistics::{HistogramData, Ticker};
+
+static PREFIX: &str = "restate";
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MetricUnit {
+    Micros,
+    Bytes,
+    Count,
+}
+
+impl MetricUnit {
+    fn normalize_value(&self, value: f64) -> f64 {
+        match self {
+            // Prometheus recommends base units, so we convert micros to seconds
+            // (fractions) when convenient.
+            // See https://prometheus.io/docs/practices/naming/
+            MetricUnit::Micros => value / 1_000_000.0,
+            MetricUnit::Bytes => value,
+            MetricUnit::Count => value,
+        }
+    }
+    fn normalized_unit(&self) -> &str {
+        match self {
+            MetricUnit::Micros => "seconds",
+            MetricUnit::Bytes => "bytes",
+            MetricUnit::Count => "count",
+        }
+    }
+}
+
+pub fn format_rocksdb_stat_ticker_for_prometheus(
+    out: &mut String,
+    options: &rocksdb::Options,
+    ticker: Ticker,
+) {
+    let sanitized_name = format!(
+        "{}_{}_total",
+        PREFIX,
+        formatting::sanitize_metric_name(ticker.name())
+    );
+    formatting::write_type_line(out, &sanitized_name, "counter");
+    formatting::write_metric_line::<&str, u64>(
+        out,
+        &sanitized_name,
+        None,
+        &[],
+        None,
+        options.get_ticker_count(ticker),
+    );
+    let _ = writeln!(out);
+}
+
+pub fn format_rocksdb_property_for_prometheus(
+    out: &mut String,
+    labels: &[String],
+    unit: MetricUnit,
+    property_name: &str,
+    property_value: u64,
+) {
+    let sanitized_name = format!(
+        "{}_{}_{}",
+        PREFIX,
+        formatting::sanitize_metric_name(property_name),
+        unit.normalized_unit()
+    );
+
+    formatting::write_type_line(out, &sanitized_name, "gauge");
+    formatting::write_metric_line::<&str, u64>(
+        out,
+        &sanitized_name,
+        None,
+        labels,
+        None,
+        property_value,
+    );
+    let _ = writeln!(out);
+}
+
+//
+// Follows prometheus exposition format like following:
+//    rpc_duration_seconds{quantile="0.01"} 3102
+//    rpc_duration_seconds{quantile="0.05"} 3272
+//    rpc_duration_seconds{quantile="0.5"} 4773
+//    rpc_duration_seconds{quantile="0.9"} 9001
+//    rpc_duration_seconds{quantile="0.99"} 76656
+//    rpc_duration_seconds_sum 1.7560473e+07
+//    rpc_duration_seconds_count 2693
+//
+pub fn format_rocksdb_histogram_for_prometheus(
+    out: &mut String,
+    name: &str,
+    data: HistogramData,
+    unit: MetricUnit,
+) {
+    let base_sanitized_name = format!(
+        "{}_{}_{}",
+        PREFIX,
+        formatting::sanitize_metric_name(name),
+        unit.normalized_unit()
+    );
+    formatting::write_type_line(out, &base_sanitized_name, "summary");
+
+    formatting::write_metric_line::<&str, f64>(
+        out,
+        &base_sanitized_name,
+        None,
+        &[],
+        Some(("quantile", "0.5")),
+        unit.normalize_value(data.median()),
+    );
+    formatting::write_metric_line::<&str, f64>(
+        out,
+        &base_sanitized_name,
+        None,
+        &[],
+        Some(("quantile", "0.95")),
+        unit.normalize_value(data.p95()),
+    );
+    formatting::write_metric_line::<&str, f64>(
+        out,
+        &base_sanitized_name,
+        None,
+        &[],
+        Some(("quantile", "0.99")),
+        unit.normalize_value(data.p99()),
+    );
+    formatting::write_metric_line::<&str, f64>(
+        out,
+        &base_sanitized_name,
+        None,
+        &[],
+        Some(("quantile", "1.0")),
+        unit.normalize_value(data.max()),
+    );
+    formatting::write_metric_line::<&str, f64>(
+        out,
+        &base_sanitized_name,
+        Some("sum"),
+        &[],
+        None,
+        unit.normalize_value(data.sum() as f64),
+    );
+    formatting::write_metric_line::<&str, u64>(
+        out,
+        &base_sanitized_name,
+        Some("count"),
+        &[],
+        None,
+        data.count(),
+    );
+    let _ = writeln!(out);
+}

--- a/crates/node-ctrl/src/state.rs
+++ b/crates/node-ctrl/src/state.rs
@@ -9,8 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use metrics_exporter_prometheus::PrometheusHandle;
+use restate_storage_rocksdb::RocksDBStorage;
 
 #[derive(Clone, derive_builder::Builder)]
 pub struct HandlerState {
     pub prometheus_handle: Option<PrometheusHandle>,
+    pub rocksdb_storage: Option<RocksDBStorage>,
 }

--- a/crates/storage-rocksdb/src/lib.rs
+++ b/crates/storage-rocksdb/src/lib.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 pub use writer::JoinHandle as RocksDBWriterJoinHandle;
 pub use writer::Writer as RocksDBWriter;
 
-type DB = rocksdb::OptimisticTransactionDB<SingleThreaded>;
+pub type DB = rocksdb::OptimisticTransactionDB<SingleThreaded>;
 type TransactionDB<'a> = rocksdb::Transaction<'a, DB>;
 
 pub type DBIterator<'b> = DBRawIteratorWithThreadMode<'b, DB>;
@@ -74,7 +74,7 @@ pub enum TableScanIterationDecision<R> {
 }
 
 #[inline]
-fn cf_name(kind: TableKind) -> &'static str {
+const fn cf_name(kind: TableKind) -> &'static str {
     match kind {
         State => STATE_TABLE_NAME,
         Status => STATUS_TABLE_NAME,
@@ -97,6 +97,26 @@ pub enum TableKind {
     PartitionStateMachine,
     Timers,
     Journal,
+}
+
+impl TableKind {
+    pub const fn cf_name(&self) -> &'static str {
+        cf_name(*self)
+    }
+
+    pub fn all() -> core::slice::Iter<'static, TableKind> {
+        static VARIANTS: &[TableKind] = &[
+            State,
+            Status,
+            Inbox,
+            Outbox,
+            Deduplication,
+            PartitionStateMachine,
+            Timers,
+            Journal,
+        ];
+        VARIANTS.iter()
+    }
 }
 
 /// # Storage options
@@ -132,6 +152,9 @@ pub struct Options {
     ///
     /// The memory size used for rocksdb caches.
     pub cache_size: usize,
+
+    /// Disable rocksdb statistics collection
+    pub disable_statistics: bool,
 }
 
 impl Default for Options {
@@ -142,6 +165,7 @@ impl Default for Options {
             write_buffer_size: 0,
             max_total_wal_size: 2 * (1 << 30), // 2 GiB
             cache_size: 1 << 30,               // 1 GB
+            disable_statistics: false,
         }
     }
 }
@@ -176,12 +200,32 @@ impl BuildError {
     }
 }
 
-#[derive(Debug)]
 pub struct RocksDBStorage {
     db: Arc<DB>,
     writer_handle: WriterHandle,
     key_buffer: BytesMut,
     value_buffer: BytesMut,
+    cache: Option<Cache>,
+    options: Arc<rocksdb::Options>,
+}
+
+impl std::fmt::Debug for RocksDBStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RocksDBStorage")
+            .field("db", &self.db)
+            .field("writer_handle", &self.writer_handle)
+            .field("key_buffer", &self.key_buffer)
+            .field("value_buffer", &self.value_buffer)
+            .field(
+                "cache",
+                if self.cache.is_some() {
+                    &"<set>"
+                } else {
+                    &"<unset>"
+                },
+            )
+            .finish()
+    }
 }
 
 impl Clone for RocksDBStorage {
@@ -191,6 +235,8 @@ impl Clone for RocksDBStorage {
             writer_handle: self.writer_handle.clone(),
             key_buffer: BytesMut::default(),
             value_buffer: BytesMut::default(),
+            cache: self.cache.clone(),
+            options: self.options.clone(),
         }
     }
 }
@@ -202,6 +248,12 @@ fn db_options(opts: &Options) -> rocksdb::Options {
     if opts.threads > 0 {
         db_options.increase_parallelism(opts.threads as i32);
         db_options.set_max_background_jobs(opts.threads as i32);
+    }
+
+    if !opts.disable_statistics {
+        db_options.enable_statistics();
+        // Reasonable default, but we might expose this as a config in the future.
+        db_options.set_statistics_level(rocksdb::statistics::StatsLevel::ExceptDetailedTimers);
     }
 
     db_options.set_atomic_flush(true);
@@ -297,6 +349,22 @@ fn cf_options(opts: &Options, cache: Option<Cache>) -> rocksdb::Options {
 }
 
 impl RocksDBStorage {
+    /// Returns the raw rocksdb handle, this should only be used for node-ctrl operations that
+    /// require direct access to rocksdb.
+    pub fn inner(&self) -> Arc<DB> {
+        self.db.clone()
+    }
+    /// The database options object that was used at creation time, this can be used to extract
+    /// running statistics after the database is opened.
+    pub fn options(&self) -> Arc<rocksdb::Options> {
+        self.options.clone()
+    }
+
+    /// Block cache wrapper handle, It's set if block cache is enabled.
+    pub fn cache(&self) -> Option<Cache> {
+        self.cache.clone()
+    }
+
     fn new(opts: Options) -> std::result::Result<(Self, Writer), BuildError> {
         let cache = if opts.cache_size > 0 {
             Some(Cache::new_lru_cache(opts.cache_size))
@@ -304,7 +372,7 @@ impl RocksDBStorage {
             None
         };
 
-        let tables = [
+        let tables = vec![
             //
             // keyed by partition key + user key
             //
@@ -328,11 +396,12 @@ impl RocksDBStorage {
             // keyed by partition_id + u64
             rocksdb::ColumnFamilyDescriptor::new(
                 cf_name(PartitionStateMachine),
-                cf_options(&opts, cache),
+                cf_options(&opts, cache.clone()),
             ),
         ];
 
         let db_options = db_options(&opts);
+
         let rdb = DB::open_cf_descriptors(&db_options, opts.path, tables)
             .map_err(BuildError::from_rocksdb_error)?;
         let rdb = Arc::new(rdb);
@@ -347,6 +416,8 @@ impl RocksDBStorage {
                 writer_handle,
                 key_buffer: BytesMut::default(),
                 value_buffer: BytesMut::default(),
+                cache,
+                options: Arc::new(db_options),
             },
             writer,
         ))

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -234,6 +234,7 @@ pub struct Worker {
     ingress_kafka: IngressKafkaService,
     services: Services<FixedConsecutivePartitions>,
     rocksdb_writer: RocksDBWriter,
+    rocksdb_storage: RocksDBStorage,
 }
 
 impl Worker {
@@ -359,6 +360,7 @@ impl Worker {
             ingress_kafka,
             services,
             rocksdb_writer,
+            rocksdb_storage,
         })
     }
 
@@ -402,6 +404,10 @@ impl Worker {
 
     pub fn storage_query_context(&self) -> &QueryContext {
         &self.storage_query_context
+    }
+
+    pub fn rocksdb_storage(&self) -> &RocksDBStorage {
+        &self.rocksdb_storage
     }
 
     pub async fn run(self, drain: drain::Watch) -> Result<(), Error> {

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -12,11 +12,11 @@
 /// the metrics' sink.
 use metrics::{describe_counter, Unit};
 
-pub const PARTITION_APPLY_COMMAND: &str = "partition.apply_command.total";
-pub const PARTITION_ACTUATOR_HANDLED: &str = "partition.actuator_handled.total";
-pub const PARTITION_TIMER_DUE_HANDLED: &str = "partition.timer_due_handled.total";
-pub const PARTITION_STORAGE_TX_CREATED: &str = "partition.storage_tx_created.total";
-pub const PARTITION_STORAGE_TX_COMMITTED: &str = "partition.storage_tx_committed.total";
+pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command.total";
+pub const PARTITION_ACTUATOR_HANDLED: &str = "restate.partition.actuator_handled.total";
+pub const PARTITION_TIMER_DUE_HANDLED: &str = "restate.partition.timer_due_handled.total";
+pub const PARTITION_STORAGE_TX_CREATED: &str = "restate.partition.storage_tx_created.total";
+pub const PARTITION_STORAGE_TX_COMMITTED: &str = "restate.partition.storage_tx_committed.total";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(

--- a/server/src/app.rs
+++ b/server/src/app.rs
@@ -82,7 +82,7 @@ impl Application {
         // create worker service
         let worker = worker.build(meta.schemas())?;
 
-        let node_ctrl = node_ctrl.build();
+        let node_ctrl = node_ctrl.build(Some(worker.rocksdb_storage().clone()));
 
         Ok(Self {
             node_ctrl,


### PR DESCRIPTION
prefix metrics with restate_

We should namespace all our metrics with the application name, additionally, grouping invoker task counters and using status as label instead of a counter per status (better ergonomics)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1077).
* __->__ #1077
* #1073