### PR TITLE
[storage] Enable Jemalloc for RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,6 +3143,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -6423,6 +6424,16 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/crates/storage-rocksdb/Cargo.toml
+++ b/crates/storage-rocksdb/Cargo.toml
@@ -27,7 +27,7 @@ futures = { workspace = true }
 futures-util = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true }
-rocksdb = { workspace = true }
+rocksdb = { workspace = true , features = [ "default", "jemalloc"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 sync_wrapper = { workspace = true }


### PR DESCRIPTION
Enable the Jemalloc feature for rocksdb.
Lets see how the memory usage would look like after this is applied, and potentially followup with enabling Jemalloc for the entire process.
 