### PR TITLE
Support MEMORY_LIMIT global setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5252,6 +5252,7 @@ dependencies = [
  "restate-fs-util",
  "restate-meta",
  "restate-node-ctrl",
+ "restate-storage-rocksdb",
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-worker",

--- a/crates/storage-rocksdb/src/lib.rs
+++ b/crates/storage-rocksdb/src/lib.rs
@@ -141,6 +141,8 @@ pub struct Options {
     /// # Write Buffer size
     ///
     /// The size of a single memtable. Once memtable exceeds this size, it is marked immutable and a new one is created.
+    /// The default is set such that 3 column families per table will use a total of 50% of the global memory limit
+    /// (`MEMORY_LIMIT`), which defaults to 3GiB, leading to a value of 64MiB with 8 tables.
     pub write_buffer_size: usize,
 
     /// # Maximum total WAL size
@@ -151,6 +153,7 @@ pub struct Options {
     /// # Maximum cache size
     ///
     /// The memory size used for rocksdb caches.
+    /// The default is roughly 33% of the global memory limit (set with `MEMORY_LIMIT`), which defaults to 3GiB, leading to a value of 1GiB.
     pub cache_size: usize,
 
     /// Disable rocksdb statistics collection
@@ -164,7 +167,7 @@ impl Default for Options {
             threads: 10,
             write_buffer_size: 0,
             max_total_wal_size: 2 * (1 << 30), // 2 GiB
-            cache_size: 1 << 30,               // 1 GB
+            cache_size: 0,
             disable_statistics: false,
         }
     }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,6 +34,7 @@ restate-node-ctrl = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
 restate-types = { workspace = true }
 restate-worker = { workspace = true }
+restate-storage-rocksdb = { workspace = true }
 
 clap = { version = "4.1", features = ["derive", "env"] }
 codederror = { workspace = true }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -12,6 +12,7 @@ use figment::providers::{Env, Format, Serialized, Yaml};
 use figment::Figment;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::ops::Div;
 use std::path::Path;
 use std::time::Duration;
 
@@ -25,6 +26,7 @@ pub use restate_meta::{
     OptionsBuilderError as MetaOptionsBuilderError,
 };
 pub use restate_node_ctrl::Options as NodeCtrlOptions;
+use restate_storage_rocksdb::TableKind;
 pub use restate_tracing_instrumentation::{
     LogOptions, LogOptionsBuilder, LogOptionsBuilderError, Options as ObservabilityOptions,
     OptionsBuilder as ObservabilityOptionsBuilder,
@@ -86,6 +88,51 @@ impl Default for Configuration {
     }
 }
 
+/// Global memory options. These may only be set by environment variable
+#[derive(Serialize, Deserialize)]
+pub struct MemoryOptions {
+    /// Global memory limit, configured with `MEMORY_LIMIT` environment variable only.
+    /// This controls rocksdb cache size defaults
+    limit: usize,
+}
+
+impl Default for MemoryOptions {
+    fn default() -> Self {
+        Self {
+            limit: 3 * (1 << 30), // 3 GiB
+        }
+    }
+}
+
+impl MemoryOptions {
+    fn apply_defaults(self, figment: Figment) -> Figment {
+        let table_count = TableKind::all().count();
+
+        let write_buffer_size = self
+            .limit
+            // target 50% usage
+            .div(2)
+            // split across all the tables
+            .div(table_count)
+            // where there's at most 3 column families per table
+            .div(3)
+            // with 8 MiB min and 256 MiB max
+            .clamp(8 * (1 << 20), 256 * (1 << 20));
+
+        let cache_size = self.limit.div(3); // target 33% usage, no min or max
+
+        figment
+            .merge(Figment::from(Serialized::default(
+                "worker.storage_rocksdb.write_buffer_size",
+                write_buffer_size,
+            )))
+            .merge(Figment::from(Serialized::default(
+                "worker.storage_rocksdb.cache_size",
+                cache_size,
+            )))
+    }
+}
+
 #[derive(Debug, thiserror::Error, codederror::CodedError)]
 #[code(restate_errors::RT0002)]
 #[error("configuration error: {0}")]
@@ -104,6 +151,12 @@ impl Configuration {
         config_file: Option<&Path>,
     ) -> Result<Self, Error> {
         let figment = Figment::from(Serialized::defaults(default_configuration));
+
+        // get memory options separately, and use them to set certain defaults
+        let memory: MemoryOptions = Figment::from(Serialized::defaults(MemoryOptions::default()))
+            .merge(Env::prefixed("MEMORY_").split("__"))
+            .extract()?;
+        let figment = memory.apply_defaults(figment);
 
         let figment = if let Some(config_file) = config_file {
             figment.merge(Yaml::file(config_file))


### PR DESCRIPTION
- Add a new memory options struct at the top level which is a bit of a special case; it needs to load before all other config sources in order to change the defaults for rocksdb caches without overriding user-specified values.
- Add a limit field to this memory options, and default it to 3GiB. We may one day also care about a memory request value here.
- Do math to calculate the two in memory rocksdb caches such that at 3GiB, the values are the same as they were previously hardcoded, but they otherwise scale linearly with the global memory limit