### PR TITLE
Let PartitionProcessor apply Command::ExternalStateMutation commands 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,6 +5065,7 @@ dependencies = [
 name = "restate-meta-rest-model"
 version = "0.7.1"
 dependencies = [
+ "bytes",
  "http",
  "humantime",
  "restate-schema-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,6 +5438,7 @@ dependencies = [
  "restate-errors",
  "restate-storage-api",
  "restate-storage-proto",
+ "restate-test-util",
  "restate-types",
  "rocksdb",
  "schemars",

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -62,6 +62,10 @@ pub fn create_router<W: restate_worker_api::Handle + Send + Sync + 'static>(
             get(openapi_handler!(services::list_service_descriptors)),
         )
         .route(
+            "/services/:service/state",
+            post(openapi_handler!(services::modify_service_state)),
+        )
+        .route(
             "/services/:service/methods",
             get(openapi_handler!(methods::list_service_methods)),
         )

--- a/crates/meta-rest-model/Cargo.toml
+++ b/crates/meta-rest-model/Cargo.toml
@@ -16,6 +16,7 @@ restate-types = { workspace = true, features = ["serde"] }
 restate-schema-api = { workspace = true, features = [ "service", "deployment", "serde", "subscription" ] }
 restate-serde-util = { workspace = true }
 
+bytes = { workspace = true }
 http = { workspace = true }
 humantime = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/meta-rest-model/src/services.rs
+++ b/crates/meta-rest-model/src/services.rs
@@ -8,7 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // Export schema types to be used by other crates without exposing the fact
 // that we are using proxying to restate-schema-api or restate-types
@@ -29,4 +31,24 @@ pub struct ModifyServiceRequest {
     /// If true, the service can be invoked through the ingress.
     /// If false, the service can be invoked only from another Restate service.
     pub public: bool,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModifyServiceStateRequest {
+    /// # Version
+    ///
+    /// If set, the latest version of the state is compared with this value and the operation will fail
+    /// when the versions differ.
+    pub version: Option<String>,
+
+    /// # Service key
+    ///
+    /// To what service key to apply this change
+    pub service_key: String,
+
+    /// # New State
+    ///
+    /// The new state to replace the previous state with
+    pub new_state: HashMap<String, Bytes>,
 }

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -58,6 +58,11 @@ pub trait InboxTable {
         service_id: &ServiceId,
     ) -> impl Future<Output = Result<Option<InboxEntry>>> + Send;
 
+    fn pop_inbox(
+        &mut self,
+        service_id: &ServiceId,
+    ) -> impl Future<Output = Result<Option<InboxEntry>>> + Send;
+
     fn inbox(&mut self, service_id: &ServiceId) -> impl Stream<Item = Result<InboxEntry>> + Send;
 
     fn all_inboxes(

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -10,44 +10,81 @@
 
 use crate::Result;
 use futures_util::Stream;
-use restate_types::identifiers::{FullInvocationId, PartitionKey, ServiceId};
+use restate_types::identifiers::{PartitionKey, ServiceId};
 use restate_types::invocation::{MaybeFullInvocationId, ServiceInvocation};
 use restate_types::message::MessageIndex;
+use restate_types::state_mut::ExternalStateMutation;
 use std::future::Future;
 use std::ops::RangeInclusive;
 
-/// Entry of the inbox
 #[derive(Debug, Clone, PartialEq)]
-pub struct InboxEntry {
-    pub inbox_sequence_number: MessageIndex,
-    pub service_invocation: ServiceInvocation,
+pub enum InboxEntry {
+    Invocation(ServiceInvocation),
+    StateMutation(ExternalStateMutation),
 }
 
 impl InboxEntry {
-    pub fn new(inbox_sequence_number: MessageIndex, service_invocation: ServiceInvocation) -> Self {
+    pub fn service_id(&self) -> &ServiceId {
+        match self {
+            InboxEntry::Invocation(invocation) => &invocation.fid.service_id,
+            InboxEntry::StateMutation(state_mutation) => &state_mutation.service_id,
+        }
+    }
+}
+
+/// Entry of the inbox
+#[derive(Debug, Clone, PartialEq)]
+pub struct SequenceNumberInboxEntry {
+    pub inbox_sequence_number: MessageIndex,
+    pub inbox_entry: InboxEntry,
+}
+
+impl SequenceNumberInboxEntry {
+    pub fn new(inbox_sequence_number: MessageIndex, inbox_entry: InboxEntry) -> Self {
         Self {
             inbox_sequence_number,
-            service_invocation,
+            inbox_entry,
+        }
+    }
+    pub fn from_invocation(
+        inbox_sequence_number: MessageIndex,
+        service_invocation: ServiceInvocation,
+    ) -> Self {
+        Self {
+            inbox_sequence_number,
+            inbox_entry: InboxEntry::Invocation(service_invocation),
+        }
+    }
+
+    pub fn from_state_mutation(
+        inbox_sequence_number: MessageIndex,
+        state_mutation: ExternalStateMutation,
+    ) -> Self {
+        Self {
+            inbox_sequence_number,
+            inbox_entry: InboxEntry::StateMutation(state_mutation),
         }
     }
 
     pub fn service_id(&self) -> &ServiceId {
-        &self.service_invocation.fid.service_id
-    }
-
-    pub fn fid(&self) -> &FullInvocationId {
-        &self.service_invocation.fid
+        self.inbox_entry.service_id()
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SequenceNumberInvocation {
+    pub inbox_sequence_number: MessageIndex,
+    pub invocation: ServiceInvocation,
+}
+
 pub trait InboxTable {
-    fn put_invocation(
+    fn put_inbox_entry(
         &mut self,
         service_id: &ServiceId,
-        inbox_entry: InboxEntry,
+        inbox_entry: SequenceNumberInboxEntry,
     ) -> impl Future<Output = ()> + Send;
 
-    fn delete_invocation(
+    fn delete_inbox_entry(
         &mut self,
         service_id: &ServiceId,
         sequence_number: u64,
@@ -56,26 +93,29 @@ pub trait InboxTable {
     fn peek_inbox(
         &mut self,
         service_id: &ServiceId,
-    ) -> impl Future<Output = Result<Option<InboxEntry>>> + Send;
+    ) -> impl Future<Output = Result<Option<SequenceNumberInboxEntry>>> + Send;
 
     fn pop_inbox(
         &mut self,
         service_id: &ServiceId,
-    ) -> impl Future<Output = Result<Option<InboxEntry>>> + Send;
+    ) -> impl Future<Output = Result<Option<SequenceNumberInboxEntry>>> + Send;
 
-    fn inbox(&mut self, service_id: &ServiceId) -> impl Stream<Item = Result<InboxEntry>> + Send;
+    fn inbox(
+        &mut self,
+        service_id: &ServiceId,
+    ) -> impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send;
 
     fn all_inboxes(
         &mut self,
         range: RangeInclusive<PartitionKey>,
-    ) -> impl Stream<Item = Result<InboxEntry>> + Send;
+    ) -> impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send;
 
-    /// Gets an inbox entry for the given invocation id.
+    /// Gets an invocation for the given invocation id.
     ///
     /// Important: This method can be quite costly if it is invoked with an `InvocationId` because
     /// it needs to scan all inboxes for the given partition key to match the given invocation uuid.
-    fn get_inbox_entry(
+    fn get_invocation(
         &mut self,
         maybe_fid: impl Into<MaybeFullInvocationId>,
-    ) -> impl Future<Output = Result<Option<InboxEntry>>> + Send;
+    ) -> impl Future<Output = Result<Option<SequenceNumberInvocation>>> + Send;
 }

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -8,6 +8,11 @@ package dev.restate.storage.domain.v1;
 // Common
 // ---------------------------------------------------------------------
 
+message ServiceId {
+    bytes service_name = 1;
+    bytes service_key = 2;
+}
+
 message FullInvocationId {
     bytes service_name = 1;
     bytes service_key = 2;
@@ -19,6 +24,11 @@ message MaybeFullInvocationId {
         FullInvocationId full_invocation_id = 1;
         bytes invocation_id = 2;
     }
+}
+
+message KvPair {
+    bytes key = 1;
+    bytes value = 2;
 }
 
 // ---------------------------------------------------------------------
@@ -160,8 +170,21 @@ message ServiceInvocation {
     Source source = 6;
 }
 
+message StateMutation {
+    ServiceId service_id = 1;
+    optional string version = 2;
+    repeated KvPair kv_pairs = 3;
+}
+
 message InboxEntry {
+    // Kept for backwards compatibility, should be removed once no more migrations are needed
     ServiceInvocation service_invocation = 2;
+
+    // All new InboxEntries should have an entry starting from Restate >= 0.7.1
+    oneof entry {
+        ServiceInvocation invocation = 3;
+        StateMutation state_mutation = 4;
+    }
 }
 
 message InvocationResolutionResult {

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -37,20 +37,20 @@ pub mod storage {
                 Ingress, NewInvocation, PartitionProcessor, ResponseSink,
             };
             use crate::storage::v1::{
-                enriched_entry_header, invocation_resolution_result, invocation_status,
-                maybe_full_invocation_id, outbox_message, response_result, source, span_relation,
-                timer, BackgroundCallResolutionResult, EnrichedEntryHeader, FullInvocationId,
-                InboxEntry, InvocationResolutionResult, InvocationStatus, JournalEntry,
-                JournalMeta, MaybeFullInvocationId, OutboxMessage, ResponseResult,
-                ServiceInvocation, ServiceInvocationResponseSink, SocketAddr, Source, SpanContext,
-                SpanRelation, Timer,
+                enriched_entry_header, inbox_entry, invocation_resolution_result,
+                invocation_status, maybe_full_invocation_id, outbox_message, response_result,
+                source, span_relation, timer, BackgroundCallResolutionResult, EnrichedEntryHeader,
+                FullInvocationId, InboxEntry, InvocationResolutionResult, InvocationStatus,
+                JournalEntry, JournalMeta, KvPair, MaybeFullInvocationId, OutboxMessage,
+                ResponseResult, ServiceId, ServiceInvocation, ServiceInvocationResponseSink,
+                SocketAddr, Source, SpanContext, SpanRelation, StateMutation, Timer,
             };
             use anyhow::anyhow;
             use bytes::{Buf, Bytes};
             use bytestring::ByteString;
             use opentelemetry_api::trace::TraceState;
             use restate_storage_api::StorageError;
-            use restate_types::identifiers::{IngressDispatcherId, ServiceId};
+            use restate_types::identifiers::IngressDispatcherId;
             use restate_types::invocation::{InvocationTermination, TerminationFlavor};
             use restate_types::journal::enriched::AwakeableEnrichmentResult;
             use restate_types::time::MillisSinceEpoch;
@@ -373,7 +373,7 @@ pub mod storage {
                         )?;
                     let completion_notification_target =
                         restate_storage_api::status_table::NotificationTarget {
-                            service: ServiceId::new(
+                            service: restate_types::identifiers::ServiceId::new(
                                 value.completion_notification_target_service_name,
                                 value.completion_notification_target_service_key,
                             ),
@@ -381,7 +381,7 @@ pub mod storage {
                         };
                     let kill_notification_target =
                         restate_storage_api::status_table::NotificationTarget {
-                            service: ServiceId::new(
+                            service: restate_types::identifiers::ServiceId::new(
                                 value.kill_notification_target_service_name,
                                 value.kill_notification_target_service_key,
                             ),
@@ -520,27 +520,58 @@ pub mod storage {
                 }
             }
 
-            impl TryFrom<InboxEntry> for restate_types::invocation::ServiceInvocation {
+            impl TryFrom<InboxEntry> for restate_storage_api::inbox_table::InboxEntry {
                 type Error = ConversionError;
 
                 fn try_from(value: InboxEntry) -> Result<Self, Self::Error> {
-                    let service_invocation =
-                        restate_types::invocation::ServiceInvocation::try_from(
-                            value
-                                .service_invocation
-                                .ok_or(ConversionError::missing_field("service_invocation"))?,
-                        )?;
+                    // Backwards compatibility to support Restate <= 0.7
+                    let inbox_entry = if let Some(service_invocation) = value.service_invocation {
+                        restate_storage_api::inbox_table::InboxEntry::Invocation(
+                            restate_types::invocation::ServiceInvocation::try_from(
+                                service_invocation,
+                            )?,
+                        )
+                    } else {
+                        // All InboxEntries starting with Restate >= 0.7.1 should have the entry field set
+                        match value.entry.ok_or(ConversionError::missing_field("entry"))? {
+                            inbox_entry::Entry::Invocation(service_invocation) => {
+                                restate_storage_api::inbox_table::InboxEntry::Invocation(
+                                    restate_types::invocation::ServiceInvocation::try_from(
+                                        service_invocation,
+                                    )?,
+                                )
+                            }
+                            inbox_entry::Entry::StateMutation(state_mutation) => {
+                                restate_storage_api::inbox_table::InboxEntry::StateMutation(
+                                    restate_types::state_mut::ExternalStateMutation::try_from(
+                                        state_mutation,
+                                    )?,
+                                )
+                            }
+                        }
+                    };
 
-                    Ok(service_invocation)
+                    Ok(inbox_entry)
                 }
             }
 
-            impl From<restate_types::invocation::ServiceInvocation> for InboxEntry {
-                fn from(value: restate_types::invocation::ServiceInvocation) -> Self {
-                    let service_invocation = ServiceInvocation::from(value);
+            impl From<restate_storage_api::inbox_table::InboxEntry> for InboxEntry {
+                fn from(inbox_entry: restate_storage_api::inbox_table::InboxEntry) -> Self {
+                    let inbox_entry = match inbox_entry {
+                        restate_storage_api::inbox_table::InboxEntry::Invocation(
+                            service_invocation,
+                        ) => inbox_entry::Entry::Invocation(ServiceInvocation::from(
+                            service_invocation,
+                        )),
+                        restate_storage_api::inbox_table::InboxEntry::StateMutation(
+                            state_mutation,
+                        ) => inbox_entry::Entry::StateMutation(StateMutation::from(state_mutation)),
+                    };
 
                     InboxEntry {
-                        service_invocation: Some(service_invocation),
+                        // Backwards compatibility to support Restate <= 0.7
+                        service_invocation: None,
+                        entry: Some(inbox_entry),
                     }
                 }
             }
@@ -606,6 +637,67 @@ pub mod storage {
                         method_name,
                         argument: value.argument,
                         source: Some(source),
+                    }
+                }
+            }
+
+            impl TryFrom<StateMutation> for restate_types::state_mut::ExternalStateMutation {
+                type Error = ConversionError;
+
+                fn try_from(state_mutation: StateMutation) -> Result<Self, Self::Error> {
+                    let service_id = restate_types::identifiers::ServiceId::try_from(
+                        state_mutation
+                            .service_id
+                            .ok_or(ConversionError::missing_field("service_id"))?,
+                    )?;
+                    let state = state_mutation
+                        .kv_pairs
+                        .into_iter()
+                        .map(|kv| (kv.key, kv.value))
+                        .collect();
+
+                    Ok(restate_types::state_mut::ExternalStateMutation {
+                        service_id,
+                        version: state_mutation.version,
+                        state,
+                    })
+                }
+            }
+
+            impl From<restate_types::state_mut::ExternalStateMutation> for StateMutation {
+                fn from(state_mutation: restate_types::state_mut::ExternalStateMutation) -> Self {
+                    let service_id = ServiceId::from(state_mutation.service_id);
+                    let kv_pairs = state_mutation
+                        .state
+                        .into_iter()
+                        .map(|(key, value)| KvPair { key, value })
+                        .collect();
+
+                    StateMutation {
+                        service_id: Some(service_id),
+                        version: state_mutation.version,
+                        kv_pairs,
+                    }
+                }
+            }
+
+            impl TryFrom<ServiceId> for restate_types::identifiers::ServiceId {
+                type Error = ConversionError;
+
+                fn try_from(service_id: ServiceId) -> Result<Self, Self::Error> {
+                    Ok(restate_types::identifiers::ServiceId::new(
+                        ByteString::try_from(service_id.service_name)
+                            .map_err(ConversionError::invalid_data)?,
+                        service_id.service_key,
+                    ))
+                }
+            }
+
+            impl From<restate_types::identifiers::ServiceId> for ServiceId {
+                fn from(service_id: restate_types::identifiers::ServiceId) -> Self {
+                    ServiceId {
+                        service_key: service_id.key,
+                        service_name: service_id.service_name.into_bytes(),
                     }
                 }
             }
@@ -1568,7 +1660,8 @@ pub mod storage {
                 fn try_from(value: Timer) -> Result<Self, Self::Error> {
                     let service_name = ByteString::try_from(value.service_name)
                         .map_err(ConversionError::invalid_data)?;
-                    let service_id = ServiceId::new(service_name, value.service_key);
+                    let service_id =
+                        restate_types::identifiers::ServiceId::new(service_name, value.service_key);
 
                     Ok(
                         match value.value.ok_or(ConversionError::missing_field("value"))? {

--- a/crates/storage-query-datafusion/src/inbox/row.rs
+++ b/crates/storage-query-datafusion/src/inbox/row.rs
@@ -10,7 +10,7 @@
 
 use super::schema::InboxBuilder;
 use crate::table_util::format_using;
-use restate_storage_api::inbox_table::InboxEntry;
+use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
 use restate_types::invocation::{ServiceInvocation, Source, TraceId};
 use std::time::Duration;
@@ -20,61 +20,67 @@ use uuid::Uuid;
 pub(crate) fn append_inbox_row(
     builder: &mut InboxBuilder,
     output: &mut String,
-    inbox_entry: InboxEntry,
+    inbox_entry: SequenceNumberInboxEntry,
 ) {
-    let InboxEntry {
+    let SequenceNumberInboxEntry {
         inbox_sequence_number,
-        service_invocation:
-            ServiceInvocation {
-                fid,
-                method_name,
-                source: caller,
-                span_context,
-                ..
-            },
+        inbox_entry,
     } = inbox_entry;
 
-    let mut row = builder.row();
-    row.partition_key(fid.partition_key());
+    if let InboxEntry::Invocation(ServiceInvocation {
+        fid,
+        method_name,
+        source: caller,
+        span_context,
+        ..
+    }) = inbox_entry
+    {
+        let mut row = builder.row();
+        row.partition_key(fid.partition_key());
 
-    row.service(&fid.service_id.service_name);
-    row.method(&method_name);
+        row.service(&fid.service_id.service_name);
+        row.method(&method_name);
 
-    row.service_key(std::str::from_utf8(&fid.service_id.key).expect("The key must be a string!"));
+        row.service_key(
+            std::str::from_utf8(&fid.service_id.key).expect("The key must be a string!"),
+        );
 
-    if row.is_id_defined() {
-        row.id(format_using(output, &InvocationId::from(&fid)));
-    }
+        if row.is_id_defined() {
+            row.id(format_using(output, &InvocationId::from(&fid)));
+        }
 
-    row.sequence_number(inbox_sequence_number);
+        row.sequence_number(inbox_sequence_number);
 
-    match caller {
-        Source::Service(caller) => {
-            row.invoked_by("service");
-            row.invoked_by_service(&caller.service_id.service_name);
-            if row.is_invoked_by_id_defined() {
-                row.invoked_by_id(format_using(output, &caller));
+        match caller {
+            Source::Service(caller) => {
+                row.invoked_by("service");
+                row.invoked_by_service(&caller.service_id.service_name);
+                if row.is_invoked_by_id_defined() {
+                    row.invoked_by_id(format_using(output, &caller));
+                }
+            }
+            Source::Ingress => {
+                row.invoked_by("ingress");
+            }
+            Source::Internal => {
+                row.invoked_by("restate");
             }
         }
-        Source::Ingress => {
-            row.invoked_by("ingress");
+        if row.is_trace_id_defined() {
+            let tid = span_context.trace_id();
+            if tid != TraceId::INVALID {
+                row.trace_id(format_using(output, &tid));
+            }
         }
-        Source::Internal => {
-            row.invoked_by("restate");
-        }
-    }
-    if row.is_trace_id_defined() {
-        let tid = span_context.trace_id();
-        if tid != TraceId::INVALID {
-            row.trace_id(format_using(output, &tid));
-        }
-    }
 
-    if row.is_created_at_defined() {
-        let (secs, nanos) = Uuid::from(fid.invocation_uuid)
-            .get_timestamp()
-            .expect("The UUID must be a v7 uuid")
-            .to_unix();
-        row.created_at(Duration::new(secs, nanos).as_millis() as i64);
+        if row.is_created_at_defined() {
+            let (secs, nanos) = Uuid::from(fid.invocation_uuid)
+                .get_timestamp()
+                .expect("The UUID must be a v7 uuid")
+                .to_unix();
+            row.created_at(Duration::new(secs, nanos).as_millis() as i64);
+        }
+    } else {
+        // todo think about how to present other inbox entries via datafusion: https://github.com/restatedev/restate/issues/1101
     }
 }

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -23,7 +23,7 @@ use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
 pub use datafusion_expr::UserDefinedLogicalNode;
 use futures::{Stream, StreamExt};
-use restate_storage_api::inbox_table::{InboxEntry, InboxTable};
+use restate_storage_api::inbox_table::{InboxTable, SequenceNumberInboxEntry};
 use restate_storage_api::StorageError;
 use restate_storage_rocksdb::RocksDBStorage;
 use restate_types::identifiers::PartitionKey;
@@ -66,7 +66,7 @@ impl RangeScanner for InboxScanner {
 async fn for_each_state(
     schema: SchemaRef,
     tx: Sender<datafusion::common::Result<RecordBatch>>,
-    rows: impl Stream<Item = Result<InboxEntry, StorageError>>,
+    rows: impl Stream<Item = Result<SequenceNumberInboxEntry, StorageError>>,
 ) {
     let mut builder = InboxBuilder::new(schema.clone());
     let mut temp = String::new();

--- a/crates/storage-rocksdb/Cargo.toml
+++ b/crates/storage-rocksdb/Cargo.toml
@@ -39,11 +39,12 @@ once_cell = "1.18.0"
 log = "0.4.20"
 
 [dev-dependencies]
-rand = { workspace = true }
+restate-test-util = { workspace = true }
 restate-types = { workspace = true, features = ["mocks"] }
 
 criterion = { workspace = true, features = ["async_tokio"] }
 num-bigint = "0.4"
+rand = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/crates/storage-rocksdb/src/inbox_table/mod.rs
+++ b/crates/storage-rocksdb/src/inbox_table/mod.rs
@@ -21,11 +21,13 @@ use std::future::Future;
 use futures::Stream;
 use futures_util::stream;
 use prost::Message;
-use restate_storage_api::inbox_table::{InboxEntry, InboxTable};
+use restate_storage_api::inbox_table::{
+    InboxEntry, InboxTable, SequenceNumberInboxEntry, SequenceNumberInvocation,
+};
 use restate_storage_api::{Result, StorageError};
 use restate_storage_proto::storage;
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
-use restate_types::invocation::{MaybeFullInvocationId, ServiceInvocation};
+use restate_types::invocation::MaybeFullInvocationId;
 use std::io::Cursor;
 use std::ops::RangeInclusive;
 
@@ -40,13 +42,13 @@ define_table_key!(
 );
 
 impl<'a> InboxTable for RocksDBTransaction<'a> {
-    async fn put_invocation(
+    async fn put_inbox_entry(
         &mut self,
         service_id: &ServiceId,
-        InboxEntry {
+        SequenceNumberInboxEntry {
             inbox_sequence_number,
-            service_invocation,
-        }: InboxEntry,
+            inbox_entry,
+        }: SequenceNumberInboxEntry,
     ) {
         let key = InboxKey::default()
             .partition_key(service_id.partition_key())
@@ -54,13 +56,10 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
             .service_key(service_id.key.clone())
             .sequence_number(inbox_sequence_number);
 
-        self.put_kv(
-            key,
-            ProtoValue(storage::v1::InboxEntry::from(service_invocation)),
-        );
+        self.put_kv(key, ProtoValue(storage::v1::InboxEntry::from(inbox_entry)));
     }
 
-    async fn delete_invocation(&mut self, service_id: &ServiceId, sequence_number: u64) {
+    async fn delete_inbox_entry(&mut self, service_id: &ServiceId, sequence_number: u64) {
         let key = InboxKey::default()
             .partition_key(service_id.partition_key())
             .service_name(service_id.service_name.clone())
@@ -70,7 +69,10 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
         self.delete_key(&key);
     }
 
-    async fn peek_inbox(&mut self, service_id: &ServiceId) -> Result<Option<InboxEntry>> {
+    async fn peek_inbox(
+        &mut self,
+        service_id: &ServiceId,
+    ) -> Result<Option<SequenceNumberInboxEntry>> {
         let key = InboxKey::default()
             .partition_key(service_id.partition_key())
             .service_name(service_id.service_name.clone())
@@ -85,18 +87,24 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
         })
     }
 
-    async fn pop_inbox(&mut self, service_id: &ServiceId) -> Result<Option<InboxEntry>> {
+    async fn pop_inbox(
+        &mut self,
+        service_id: &ServiceId,
+    ) -> Result<Option<SequenceNumberInboxEntry>> {
         let result = self.peek_inbox(service_id).await;
 
         if let Ok(Some(inbox_entry)) = &result {
-            self.delete_invocation(service_id, inbox_entry.inbox_sequence_number)
+            self.delete_inbox_entry(service_id, inbox_entry.inbox_sequence_number)
                 .await
         }
 
         result
     }
 
-    fn inbox(&mut self, service_id: &ServiceId) -> impl Stream<Item = Result<InboxEntry>> + Send {
+    fn inbox(
+        &mut self,
+        service_id: &ServiceId,
+    ) -> impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send {
         let key = InboxKey::default()
             .partition_key(service_id.partition_key())
             .service_name(service_id.service_name.clone())
@@ -113,7 +121,7 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
     fn all_inboxes(
         &mut self,
         range: RangeInclusive<PartitionKey>,
-    ) -> impl Stream<Item = Result<InboxEntry>> + Send {
+    ) -> impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send {
         stream::iter(self.for_each_key_value_in_place(
             TableScan::PartitionKeyRange::<InboxKey>(range),
             |k, v| {
@@ -123,10 +131,10 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
         ))
     }
 
-    fn get_inbox_entry(
+    fn get_invocation(
         &mut self,
         maybe_fid: impl Into<MaybeFullInvocationId>,
-    ) -> impl Future<Output = Result<Option<InboxEntry>>> + Send {
+    ) -> impl Future<Output = Result<Option<SequenceNumberInvocation>>> + Send {
         let (inbox_key, invocation_uuid) = match maybe_fid.into() {
             MaybeFullInvocationId::Partial(invocation_id) => (
                 InboxKey::default().partition_key(invocation_id.partition_key()),
@@ -147,11 +155,18 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
 
                 match inbox_entry {
                     Ok(inbox_entry) => {
-                        if inbox_entry.service_invocation.fid.invocation_uuid == invocation_uuid {
-                            TableScanIterationDecision::BreakWith(Ok(inbox_entry))
-                        } else {
-                            TableScanIterationDecision::Continue
+                        if let InboxEntry::Invocation(invocation) = inbox_entry.inbox_entry {
+                            if invocation.fid.invocation_uuid == invocation_uuid {
+                                return TableScanIterationDecision::BreakWith(Ok(
+                                    SequenceNumberInvocation {
+                                        inbox_sequence_number: inbox_entry.inbox_sequence_number,
+                                        invocation,
+                                    },
+                                ));
+                            }
                         }
+
+                        TableScanIterationDecision::Continue
                     }
                     Err(err) => TableScanIterationDecision::BreakWith(Err(err)),
                 }
@@ -167,15 +182,15 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
     }
 }
 
-fn decode_inbox_key_value(k: &[u8], v: &[u8]) -> Result<InboxEntry> {
+fn decode_inbox_key_value(k: &[u8], v: &[u8]) -> Result<SequenceNumberInboxEntry> {
     let key = InboxKey::deserialize_from(&mut Cursor::new(k))?;
     let sequence_number = *key.sequence_number_ok_or()?;
 
-    let inbox_entry = ServiceInvocation::try_from(
+    let inbox_entry = InboxEntry::try_from(
         storage::v1::InboxEntry::decode(v).map_err(|error| StorageError::Generic(error.into()))?,
     )?;
 
-    Ok(InboxEntry::new(sequence_number, inbox_entry))
+    Ok(SequenceNumberInboxEntry::new(sequence_number, inbox_entry))
 }
 
 #[cfg(test)]

--- a/crates/storage-rocksdb/src/inbox_table/mod.rs
+++ b/crates/storage-rocksdb/src/inbox_table/mod.rs
@@ -85,6 +85,17 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
         })
     }
 
+    async fn pop_inbox(&mut self, service_id: &ServiceId) -> Result<Option<InboxEntry>> {
+        let result = self.peek_inbox(service_id).await;
+
+        if let Ok(Some(inbox_entry)) = &result {
+            self.delete_invocation(service_id, inbox_entry.inbox_sequence_number)
+                .await
+        }
+
+        result
+    }
+
     fn inbox(&mut self, service_id: &ServiceId) -> impl Stream<Item = Result<InboxEntry>> + Send {
         let key = InboxKey::default()
             .partition_key(service_id.partition_key())

--- a/crates/storage-rocksdb/tests/inbox_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/inbox_table_test/mod.rs
@@ -8,25 +8,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{assert_stream_eq, mock_service_invocation};
+use crate::{assert_stream_eq, mock_service_invocation, mock_state_mutation};
 use once_cell::sync::Lazy;
-use restate_storage_api::inbox_table::{InboxEntry, InboxTable};
+use restate_storage_api::inbox_table::{InboxEntry, InboxTable, SequenceNumberInboxEntry};
 use restate_storage_api::Transaction;
 use restate_storage_rocksdb::RocksDBStorage;
+use restate_test_util::let_assert;
 use restate_types::identifiers::{InvocationId, ServiceId};
 
-static INBOX_ENTRIES: Lazy<Vec<InboxEntry>> = Lazy::new(|| {
+static INBOX_ENTRIES: Lazy<Vec<SequenceNumberInboxEntry>> = Lazy::new(|| {
     vec![
-        InboxEntry::new(7, mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
-        InboxEntry::new(8, mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
-        InboxEntry::new(9, mock_service_invocation(ServiceId::new("svc-2", "key-1"))),
+        SequenceNumberInboxEntry::new(
+            7,
+            InboxEntry::Invocation(mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
+        ),
+        SequenceNumberInboxEntry::new(
+            8,
+            InboxEntry::StateMutation(mock_state_mutation(ServiceId::new("svc-1", "key-1"))),
+        ),
+        SequenceNumberInboxEntry::new(
+            9,
+            InboxEntry::Invocation(mock_service_invocation(ServiceId::new("svc-2", "key-1"))),
+        ),
+        SequenceNumberInboxEntry::new(
+            10,
+            InboxEntry::Invocation(mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
+        ),
     ]
 });
 
 async fn populate_data<T: InboxTable>(table: &mut T) {
     for inbox_entry in INBOX_ENTRIES.iter() {
         table
-            .put_invocation(inbox_entry.service_id(), inbox_entry.clone())
+            .put_inbox_entry(inbox_entry.service_id(), inbox_entry.clone())
             .await;
     }
 }
@@ -40,14 +54,18 @@ async fn find_the_next_message_in_an_inbox<T: InboxTable>(table: &mut T) {
 async fn get_svc_inbox<T: InboxTable>(table: &mut T) {
     let stream = table.inbox(INBOX_ENTRIES[0].service_id());
 
-    let vec = vec![INBOX_ENTRIES[0].clone(), INBOX_ENTRIES[1].clone()];
+    let vec = vec![
+        INBOX_ENTRIES[0].clone(),
+        INBOX_ENTRIES[1].clone(),
+        INBOX_ENTRIES[3].clone(),
+    ];
 
     assert_stream_eq(stream, vec).await;
 }
 
 async fn delete_entry<T: InboxTable>(table: &mut T) {
     table
-        .delete_invocation(INBOX_ENTRIES[0].service_id(), 7)
+        .delete_inbox_entry(INBOX_ENTRIES[0].service_id(), 7)
         .await;
 }
 
@@ -57,58 +75,79 @@ async fn peek_after_delete<T: InboxTable>(table: &mut T) {
     assert_eq!(result.unwrap(), Some(INBOX_ENTRIES[1].clone()));
 }
 
-async fn get_inbox_entries<T: InboxTable>(table: &mut T) {
+async fn get_invocations<T: InboxTable>(table: &mut T) {
     for expected_inbox_entry in INBOX_ENTRIES.iter() {
-        let actual_inbox_entry = table
-            .get_inbox_entry(expected_inbox_entry.fid().clone())
-            .await
-            .unwrap()
-            .unwrap();
+        if let InboxEntry::Invocation(expected_invocation) = &expected_inbox_entry.inbox_entry {
+            let actual_inbox_entry = table
+                .get_invocation(expected_invocation.fid.clone())
+                .await
+                .unwrap()
+                .unwrap();
 
-        assert_eq!(actual_inbox_entry, *expected_inbox_entry);
+            assert_eq!(
+                actual_inbox_entry.inbox_sequence_number,
+                expected_inbox_entry.inbox_sequence_number
+            );
+            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
 
-        let actual_inbox_entry = table
-            .get_inbox_entry(InvocationId::from(expected_inbox_entry.fid()))
-            .await
-            .unwrap()
-            .unwrap();
+            let actual_inbox_entry = table
+                .get_invocation(InvocationId::from(&expected_invocation.fid))
+                .await
+                .unwrap()
+                .unwrap();
 
-        assert_eq!(actual_inbox_entry, *expected_inbox_entry);
+            assert_eq!(
+                actual_inbox_entry.inbox_sequence_number,
+                expected_inbox_entry.inbox_sequence_number
+            );
+            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
+        }
     }
 
     let not_existing_entry = table
-        .get_inbox_entry(InvocationId::mock_random())
+        .get_invocation(InvocationId::mock_random())
         .await
         .unwrap();
 
     assert!(not_existing_entry.is_none());
 }
 
-async fn get_inbox_entries_after_delete<T: InboxTable>(table: &mut T) {
+async fn get_invocations_after_delete<T: InboxTable>(table: &mut T) {
     let mut inbox_entries_iterator = INBOX_ENTRIES.iter();
 
-    let not_existing_entry = table
-        .get_inbox_entry(inbox_entries_iterator.next().unwrap().fid().clone())
-        .await
-        .unwrap();
+    let inbox_entry = inbox_entries_iterator.next().unwrap();
+
+    let_assert!(InboxEntry::Invocation(invocation) = &inbox_entry.inbox_entry);
+
+    let not_existing_entry = table.get_invocation(invocation.fid.clone()).await.unwrap();
     assert!(not_existing_entry.is_none());
 
     for expected_inbox_entry in inbox_entries_iterator {
-        let actual_inbox_entry = table
-            .get_inbox_entry(expected_inbox_entry.fid().clone())
-            .await
-            .unwrap()
-            .unwrap();
+        if let InboxEntry::Invocation(expected_invocation) = &expected_inbox_entry.inbox_entry {
+            let actual_inbox_entry = table
+                .get_invocation(expected_invocation.fid.clone())
+                .await
+                .unwrap()
+                .unwrap();
 
-        assert_eq!(actual_inbox_entry, *expected_inbox_entry);
+            assert_eq!(
+                actual_inbox_entry.inbox_sequence_number,
+                expected_inbox_entry.inbox_sequence_number
+            );
+            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
 
-        let actual_inbox_entry = table
-            .get_inbox_entry(InvocationId::from(expected_inbox_entry.fid()))
-            .await
-            .unwrap()
-            .unwrap();
+            let actual_inbox_entry = table
+                .get_invocation(InvocationId::from(&expected_invocation.fid))
+                .await
+                .unwrap()
+                .unwrap();
 
-        assert_eq!(actual_inbox_entry, *expected_inbox_entry);
+            assert_eq!(
+                actual_inbox_entry.inbox_sequence_number,
+                expected_inbox_entry.inbox_sequence_number
+            );
+            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
+        }
     }
 }
 
@@ -118,12 +157,12 @@ pub(crate) async fn run_tests(mut rocksdb: RocksDBStorage) {
 
     find_the_next_message_in_an_inbox(&mut txn).await;
     get_svc_inbox(&mut txn).await;
-    get_inbox_entries(&mut txn).await;
+    get_invocations(&mut txn).await;
     delete_entry(&mut txn).await;
 
     txn.commit().await.expect("should not fail");
 
     let mut txn = rocksdb.transaction();
     peek_after_delete(&mut txn).await;
-    get_inbox_entries_after_delete(&mut txn).await;
+    get_invocations_after_delete(&mut txn).await;
 }

--- a/crates/storage-rocksdb/tests/integration_test.rs
+++ b/crates/storage-rocksdb/tests/integration_test.rs
@@ -14,6 +14,8 @@ use futures::Stream;
 use restate_storage_api::StorageError;
 use restate_types::identifiers::{FullInvocationId, InvocationUuid, ServiceId};
 use restate_types::invocation::{ServiceInvocation, Source, SpanRelation};
+use restate_types::state_mut::ExternalStateMutation;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::pin::pin;
 use std::str::FromStr;
@@ -79,6 +81,14 @@ pub(crate) fn mock_service_invocation(service_id: ServiceId) -> ServiceInvocatio
         None,
         SpanRelation::None,
     )
+}
+
+pub(crate) fn mock_state_mutation(service_id: ServiceId) -> ExternalStateMutation {
+    ExternalStateMutation {
+        service_id,
+        version: None,
+        state: HashMap::default(),
+    }
 }
 
 pub(crate) fn mock_random_service_invocation() -> ServiceInvocation {

--- a/crates/types/src/state_mut.rs
+++ b/crates/types/src/state_mut.rs
@@ -8,13 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! This crate contains the core types used by various Restate components.
+use crate::identifiers::ServiceId;
+use bytes::Bytes;
+use std::collections::HashMap;
 
-pub mod errors;
-pub mod identifiers;
-pub mod invocation;
-pub mod journal;
-pub mod message;
-pub mod retries;
-pub mod state_mut;
-pub mod time;
+/// ExternalStateMutation
+///
+/// represents an external request to mutate a user's state.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ExternalStateMutation {
+    pub service_id: ServiceId,
+    pub version: Option<String>,
+    pub state: HashMap<Bytes, Bytes>,
+}

--- a/crates/worker-api/src/lib.rs
+++ b/crates/worker-api/src/lib.rs
@@ -10,6 +10,7 @@
 
 use restate_schema_api::subscription::{Subscription, SubscriptionValidator};
 use restate_types::invocation::InvocationTermination;
+use restate_types::state_mut::ExternalStateMutation;
 use std::future::Future;
 
 #[derive(Debug, thiserror::Error)]
@@ -38,6 +39,12 @@ pub trait Handle: Clone {
     fn terminate_invocation(
         &self,
         invocation_termination: InvocationTermination,
+    ) -> impl Future<Output = Result<(), Error>> + Send;
+
+    /// Send a command to mutate a state. This command is best-effort.
+    fn external_state_mutation(
+        &self,
+        mutation: ExternalStateMutation,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 
     fn subscription_controller_handle(&self) -> Self::SubscriptionControllerHandle;

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -197,6 +197,9 @@ where
                 self.try_built_in_invoker_effect(effects, state, nbis_effects)
                     .await
             }
+            Command::ExternalStateMutation(_mutation) => {
+                todo!("handle an external state mutation command")
+            }
         }
     }
 

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -158,15 +158,6 @@ impl StateReader for StateReaderMock {
         ))
     }
 
-    async fn peek_inbox(&mut self, service_id: &ServiceId) -> StorageResult<Option<InboxEntry>> {
-        let result = self
-            .inboxes
-            .get(service_id)
-            .and_then(|inbox| inbox.first().cloned());
-
-        Ok(result)
-    }
-
     fn get_inbox_entry(
         &mut self,
         maybe_fid: impl Into<MaybeFullInvocationId>,
@@ -489,7 +480,7 @@ async fn kill_call_tree() -> Result<(), Error> {
         effects,
         all!(
             contains(pat!(Effect::AbortInvocation(eq(fid.clone())))),
-            contains(pat!(Effect::DropJournalAndFreeService {
+            contains(pat!(Effect::DropJournalAndPopInbox {
                 service_id: eq(fid.service_id.clone()),
             })),
             contains(terminate_invocation_outbox_message_matcher(

--- a/crates/worker/src/partition/state_machine/commands.rs
+++ b/crates/worker/src/partition/state_machine/commands.rs
@@ -13,6 +13,7 @@ use crate::partition::types::{InvokerEffect, TimerValue};
 use restate_types::identifiers::{IngressDispatcherId, PartitionId, PeerId};
 use restate_types::invocation::{InvocationResponse, InvocationTermination, ServiceInvocation};
 use restate_types::message::{AckKind, MessageIndex};
+use restate_types::state_mut::ExternalStateMutation;
 
 /// Envelope for [`partition::Command`] that might require an explicit acknowledge.
 #[derive(Debug)]
@@ -202,6 +203,7 @@ pub struct IngressAckResponse {
 /// State machine input commands
 #[derive(Debug)]
 pub enum Command {
+    ExternalStateMutation(ExternalStateMutation),
     TerminateInvocation(InvocationTermination),
     Invoker(InvokerEffect),
     Timer(TimerValue),
@@ -221,6 +223,7 @@ impl Command {
             Command::Invocation(_) => "ServiceInvocation",
             Command::Response(_) => "InvocationResponse",
             Command::BuiltInInvoker(_) => "NBISEffects",
+            Command::ExternalStateMutation(_) => "ExternalStateMutation",
         }
     }
 }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -84,10 +84,11 @@ impl<Codec: RawEntryCodec> StateMachine<Codec> {
 mod tests {
     use super::*;
 
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use bytes::Bytes;
     use bytestring::ByteString;
+    use futures::{StreamExt, TryStreamExt};
     use googletest::matcher::Matcher;
     use googletest::{all, assert_that, pat, property};
     use tempfile::tempdir;
@@ -102,6 +103,7 @@ mod tests {
     use restate_storage_api::inbox_table::InboxTable;
     use restate_storage_api::journal_table::{JournalEntry, ReadOnlyJournalTable};
     use restate_storage_api::outbox_table::OutboxTable;
+    use restate_storage_api::state_table::ReadOnlyStateTable;
     use restate_storage_api::status_table::{
         InvocationMetadata, JournalMetadata, NotificationTarget, ReadOnlyStatusTable,
     };
@@ -120,6 +122,7 @@ mod tests {
     use restate_types::journal::enriched::EnrichedRawEntry;
     use restate_types::journal::{Completion, CompletionResult};
     use restate_types::journal::{Entry, EntryType};
+    use restate_types::state_mut::ExternalStateMutation;
 
     type VecActionCollector = Vec<Action>;
 
@@ -345,7 +348,7 @@ mod tests {
         let result = state_machine
             .storage()
             .transaction()
-            .get_inbox_entry(inboxed_fid.clone())
+            .get_invocation(inboxed_fid.clone())
             .await?;
 
         // assert that inboxed invocation is in inbox
@@ -360,7 +363,7 @@ mod tests {
         let result = state_machine
             .storage()
             .transaction()
-            .get_inbox_entry(inboxed_fid.clone())
+            .get_invocation(inboxed_fid.clone())
             .await?;
 
         // assert that inboxed invocation has been removed
@@ -403,6 +406,68 @@ mod tests {
         );
 
         state_machine.shutdown().await
+    }
+
+    #[test(tokio::test)]
+    async fn mutate_state() -> anyhow::Result<()> {
+        let mut state_machine = MockStateMachine::default();
+        let fid = mock_start_invocation(&mut state_machine).await;
+
+        let first_state_mutation: HashMap<Bytes, Bytes> = [
+            (Bytes::from_static(b"foobar"), Bytes::from_static(b"foobar")),
+            (Bytes::from_static(b"bar"), Bytes::from_static(b"bar")),
+        ]
+        .into_iter()
+        .collect();
+
+        let second_state_mutation: HashMap<Bytes, Bytes> =
+            [(Bytes::from_static(b"bar"), Bytes::from_static(b"foo"))]
+                .into_iter()
+                .collect();
+
+        // state should be empty
+        assert_eq!(
+            state_machine
+                .rocksdb_storage
+                .get_all_user_states(&fid.service_id)
+                .count()
+                .await,
+            0
+        );
+
+        state_machine
+            .apply(Command::ExternalStateMutation(ExternalStateMutation {
+                service_id: fid.service_id.clone(),
+                version: None,
+                state: first_state_mutation,
+            }))
+            .await;
+        state_machine
+            .apply(Command::ExternalStateMutation(ExternalStateMutation {
+                service_id: fid.service_id.clone(),
+                version: None,
+                state: second_state_mutation.clone(),
+            }))
+            .await;
+
+        // terminating the ongoing invocation should trigger popping from the inbox until the
+        // next invocation is found
+        state_machine
+            .apply(Command::Invoker(InvokerEffect {
+                full_invocation_id: fid.clone(),
+                kind: InvokerEffectKind::End,
+            }))
+            .await;
+
+        let all_states: HashMap<_, _> = state_machine
+            .rocksdb_storage
+            .get_all_user_states(&fid.service_id)
+            .try_collect()
+            .await?;
+
+        assert_eq!(all_states, second_state_mutation);
+
+        Ok(())
     }
 
     mod virtual_invocation {

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -288,11 +288,6 @@ where
         ))
     }
 
-    async fn peek_inbox(&mut self, service_id: &ServiceId) -> StorageResult<Option<InboxEntry>> {
-        self.assert_partition_key(service_id);
-        self.inner.peek_inbox(service_id).await
-    }
-
     fn get_inbox_entry(
         &mut self,
         maybe_fid: impl Into<MaybeFullInvocationId>,
@@ -487,15 +482,8 @@ where
         Ok(())
     }
 
-    async fn truncate_inbox(
-        &mut self,
-        service_id: &ServiceId,
-        inbox_sequence_number: MessageIndex,
-    ) -> StorageResult<()> {
-        self.inner
-            .delete_invocation(service_id, inbox_sequence_number)
-            .await;
-        Ok(())
+    async fn pop_inbox(&mut self, service_id: &ServiceId) -> StorageResult<Option<InboxEntry>> {
+        self.inner.pop_inbox(service_id).await
     }
 
     async fn delete_inbox_entry(&mut self, service_id: &ServiceId, sequence_number: MessageIndex) {

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -13,6 +13,8 @@ use reqwest::header::ACCEPT;
 use restate_schema_api::subscription::Subscription;
 use restate_types::invocation::InvocationTermination;
 use restate_types::retries::RetryPolicy;
+use restate_types::state_mut::ExternalStateMutation;
+use restate_worker_api::Error;
 use schemars::gen::SchemaSettings;
 use std::env;
 use std::time::Duration;
@@ -44,6 +46,10 @@ impl restate_worker_api::Handle for Mock {
         &self,
         _: InvocationTermination,
     ) -> Result<(), restate_worker_api::Error> {
+        Ok(())
+    }
+
+    async fn external_state_mutation(&self, _mutation: ExternalStateMutation) -> Result<(), Error> {
         Ok(())
     }
 


### PR DESCRIPTION
This commit adds support for applying Command::ExternalStateMutation commands
in the PP's state machine. The way it works is the following: Upon receiving
the command, the CommandInterpreter checks whether the service instance is
currently locked. If so, then the ExternalStateMutation is enqueued into the
inbox. If not, then the ExternalStateMutation is directly applied by the
EffectInterpreter. Upon completing an invocation, the EffectInterpreter will
now drain the inbox until it finds the next ServiceInvocation. All encountered
ExternalStateMutations will be applied when searching for the next
ServiceInvocation.

The inbox now needs to be able to store ExternalStateMutations and
ServiceInvocations. That's why this commit updates the InboxEntry type to
support both variants. The underlying storage Protobufs of the InboxEntry
were changed in a backward compatible way by introducing a new field called
entry and keeping the service_invocation field.

The storage-query-datafusion inbox table has not been update wrt to the new
inbox entry types. Instead, all state mutations are being filtered out when
querying the inbox. This is something that needs to be done as a follow-up (https://github.com/restatedev/restate/issues/1101).

Other things that need to be done as a follow up are the proper computation of
state version before applying state mutations in the `EffectInterpreter` 
(https://github.com/restatedev/restate/issues/1079) and support for deleting/clearing state entries (https://github.com/restatedev/restate/issues/1102).

This fixes https://github.com/restatedev/restate/issues/1099.