### PR TITLE
[types] Add StateMutationVersion type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,6 +5531,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_with",
+ "sha2",
  "sync_wrapper",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ rand = "0.8.5"
 rocksdb = { git = "https://github.com/restatedev/rust-rocksdb.git", branch = "next"}
 rustls = "0.21.6"
 schemars = { version = "0.8", features = ["bytes"] }
+sha2 = "0.10.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -29,6 +29,7 @@ rand = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
+sha2 = {workspace = true}
 sync_wrapper = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["time", "sync"]}

--- a/crates/types/src/state_mut.rs
+++ b/crates/types/src/state_mut.rs
@@ -9,9 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use crate::identifiers::ServiceId;
+use base64::Engine;
 use bytes::Bytes;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-
+use std::fmt::{Display, Formatter};
 /// ExternalStateMutation
 ///
 /// represents an external request to mutate a user's state.
@@ -20,4 +22,90 @@ pub struct ExternalStateMutation {
     pub service_id: ServiceId,
     pub version: Option<String>,
     pub state: HashMap<Bytes, Bytes>,
+}
+
+/// # StateMutationVersion
+///
+/// This type represents a user state version. This implementation hashes canonically the raw key-value
+/// and hands out an opaque string representation of that version, to be used for exact comparisons.
+///
+#[derive(Eq, PartialEq, Debug, Ord, PartialOrd)]
+pub struct StateMutationVersion(String);
+
+impl StateMutationVersion {
+    pub fn from_raw<S: Into<String>>(raw: S) -> StateMutationVersion {
+        StateMutationVersion(raw.into())
+    }
+
+    pub fn from_user_state(state: &[(Bytes, Bytes)]) -> StateMutationVersion {
+        let mut kvs: Vec<_> = state.iter().collect();
+        kvs.sort_by_key(|(k, _)| k);
+
+        let mut hasher = Sha256::new();
+        for (i, (k, v)) in kvs.iter().enumerate() {
+            hasher.update(i.to_be_bytes());
+            hasher.update([0x1u8]);
+            hasher.update(k);
+            hasher.update([0x2u8]);
+            hasher.update(v);
+            hasher.update([0x3u8]);
+        }
+        let result = hasher.finalize();
+        let str = restate_base64_util::URL_SAFE.encode(result);
+        StateMutationVersion(str)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl Display for StateMutationVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn example_usage() {
+        let state = vec![(Bytes::from("name"), Bytes::from("bob"))];
+        let version = StateMutationVersion::from_user_state(&state);
+
+        let expected =
+            StateMutationVersion::from_raw("tDqA04Lj3_qJ-PgNPTecXDGZgpwy6jm2Ni2BYqJIthM");
+
+        assert_eq!(version, expected);
+    }
+
+    #[test]
+    fn multipule_kvs() {
+        let state = vec![
+            (Bytes::from("b"), Bytes::from("bbb")),
+            (Bytes::from("a"), Bytes::from("aaa")),
+        ];
+        let version = StateMutationVersion::from_user_state(&state);
+
+        let expected =
+            StateMutationVersion::from_raw("RVM17P6x18Wp-JnzQ01BzmqCvhAunTOQI_az6Px3Zyk");
+
+        assert_eq!(version, expected);
+    }
+
+    #[test]
+    fn empty_state() {
+        let state = vec![];
+        let version = StateMutationVersion::from_user_state(&state);
+        let expected =
+            StateMutationVersion::from_raw("47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU");
+
+        assert_eq!(version, expected);
+    }
 }


### PR DESCRIPTION
This PR adds a StateMutationVersion type that represents a user state version. This implementation hashes canonically the raw key-value and hands out an opaque string representation of that version, to be used for exact comparisons.