### PR TITLE
Use forked tikv-jemallocator to support musl fully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6433,8 +6433,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-sys"
 version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+source = "git+https://github.com/restatedev/jemallocator?branch=musl-targets#2277a229bdcf602c5642a21efd430b8ea58d7687"
 dependencies = [
  "cc",
  "libc",
@@ -6443,8 +6442,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemallocator"
 version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+source = "git+https://github.com/restatedev/jemallocator?branch=musl-targets#2277a229bdcf602c5642a21efd430b8ea58d7687"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,8 @@ serde_yaml = "0.9"
 sync_wrapper = "0.1.2"
 tempfile = "3.6.0"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tikv-jemallocator = { version = "0.5" }
+# we need tikv-jemallocator to support fully musl targets. We use this branch until proposed changes are merged upstream
+tikv-jemallocator = { git = "https://github.com/restatedev/jemallocator", branch = "musl-targets", default-features = false }
 thiserror = "1.0"
 tokio = { version = "1.29", default-features = false, features = [ "rt-multi-thread", "signal", "macros", ] }
 tokio-util = { version = "0.7.10" }


### PR DESCRIPTION
This library has an ancient restriction against overriding global malloc in musl targets. This is no longer necessary, so we fork to remove it until upstream considers our change

https://github.com/tikv/jemallocator/pull/70