### PR TITLE
Use musl for binaries in docker containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,11 +35,11 @@ ARG SCCACHE_GHA_ENABLED=''
 ARG CARGO_PROFILE_RELEASE_DEBUG=false
 # Caching layer if nothing has changed
 # Only build restate binary to avoid compiling unneeded crates
-RUN just arch=$TARGETARCH chef-cook --release --bin restate-server
+RUN just arch=$TARGETARCH libc=musl chef-cook --release --bin restate-server
 COPY . .
-RUN just arch=$TARGETARCH build --release --bin restate-server && \
+RUN just arch=$TARGETARCH libc=musl build --release --bin restate-server && \
     just notice-file && \
-    mv target/$(just arch=$TARGETARCH print-target)/release/restate-server target/restate-server
+    mv target/$(just arch=$TARGETARCH libc=musl print-target)/release/restate-server target/restate-server
 
 # We do not need the Rust toolchain to run the server binary!
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
We do not want to have differences between binary releases and docker releases, because we will be more likely to miss bugs that only occur in glibc or musl. One such bug re atomics has already been found!