### PR TITLE
New versioned deployment ID scheme

### DIFF
--- a/cli/src/clients/metas_interface.rs
+++ b/cli/src/clients/metas_interface.rs
@@ -7,6 +7,7 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use std::fmt::Display;
 
 use super::metas_client::Envelope;
 use super::MetasClient;
@@ -20,9 +21,9 @@ pub trait MetaClientInterface {
     async fn get_services(&self) -> reqwest::Result<Envelope<ListServicesResponse>>;
     async fn get_service(&self, name: &str) -> reqwest::Result<Envelope<ServiceMetadata>>;
     async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentsResponse>>;
-    async fn get_deployment(
+    async fn get_deployment<D: Display>(
         &self,
-        id: &str,
+        id: D,
     ) -> reqwest::Result<Envelope<DetailedDeploymentResponse>>;
     async fn remove_deployment(&self, id: &str, force: bool) -> reqwest::Result<Envelope<()>>;
 
@@ -59,9 +60,9 @@ impl MetaClientInterface for MetasClient {
         self.run(reqwest::Method::GET, url).await
     }
 
-    async fn get_deployment(
+    async fn get_deployment<D: Display>(
         &self,
-        id: &str,
+        id: D,
     ) -> reqwest::Result<Envelope<DetailedDeploymentResponse>> {
         let url = self
             .base_url

--- a/cli/src/commands/deployments/describe.rs
+++ b/cli/src/commands/deployments/describe.rs
@@ -84,7 +84,7 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     );
 
     let mut table = Table::new_styled(&env.ui_config);
-    table.add_kv_row("ID:", &deployment.id);
+    table.add_kv_row("ID:", deployment.id);
 
     add_deployment_to_kv_table(&deployment.deployment, &mut table);
     table.add_kv_row("Status:", render_deployment_status(status));

--- a/cli/src/commands/deployments/list.rs
+++ b/cli/src/commands/deployments/list.rs
@@ -29,6 +29,7 @@ use restate_meta_rest_model::services::ServiceMetadata;
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
+use restate_types::identifiers::DeploymentId;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[clap(visible_alias = "ls")]
@@ -112,7 +113,7 @@ async fn list(env: &CliEnv, list_opts: &List) -> Result<()> {
             Cell::new(render_deployment_type(&deployment.deployment)),
             render_deployment_status(status),
             render_active_invocations(active_inv),
-            Cell::new(&deployment.id),
+            Cell::new(deployment.id),
             Cell::new(match &deployment.deployment {
                 Deployment::Http { created_at, .. } => created_at,
                 Deployment::Lambda { created_at, .. } => created_at,
@@ -135,7 +136,7 @@ async fn list(env: &CliEnv, list_opts: &List) -> Result<()> {
 }
 
 fn render_services(
-    deployment_id: &str,
+    deployment_id: &DeploymentId,
     services: &[ServiceNameRevPair],
     latest_services: &HashMap<String, ServiceMetadata>,
 ) -> Cell {
@@ -144,7 +145,7 @@ fn render_services(
     let mut out = String::new();
     for svc in services {
         if let Some(latest_svc) = latest_services.get(&svc.name) {
-            let style = if latest_svc.deployment_id == deployment_id {
+            let style = if &latest_svc.deployment_id == deployment_id {
                 // We are hosting the latest revision of this service.
                 Style::Success
             } else {

--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -307,7 +307,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
                     let maybe_old_deployment = resolve_deployment(
                         &client,
                         &mut deployment_cache,
-                        &existing_svc.deployment_id,
+                        &existing_svc.deployment_id.to_string(),
                     )
                     .await;
                     let old_deployment_message = maybe_old_deployment

--- a/cli/src/commands/deployments/remove.rs
+++ b/cli/src/commands/deployments/remove.rs
@@ -85,7 +85,7 @@ pub async fn run_remove(State(env): State<CliEnv>, opts: &Remove) -> Result<()> 
     );
 
     let mut table = Table::new_styled(&env.ui_config);
-    table.add_kv_row("ID:", &deployment.id);
+    table.add_kv_row("ID:", deployment.id);
 
     add_deployment_to_kv_table(&deployment.deployment, &mut table);
     table.add_kv_row("Status:", render_deployment_status(status));

--- a/cli/src/commands/services/describe.rs
+++ b/cli/src/commands/services/describe.rs
@@ -54,7 +54,7 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     );
     table.add_kv_row("Revision:", svc.revision);
     table.add_kv_row("Public:", svc.public);
-    table.add_kv_row("Deployment ID:", &svc.deployment_id);
+    table.add_kv_row("Deployment ID:", svc.deployment_id);
 
     let deployment = client
         .get_deployment(&svc.deployment_id)

--- a/cli/src/commands/services/list.rs
+++ b/cli/src/commands/services/list.rs
@@ -25,6 +25,7 @@ use restate_meta_rest_model::services::MethodMetadata;
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::Table;
+use restate_types::identifiers::DeploymentId;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[clap(visible_alias = "ls")]
@@ -59,11 +60,11 @@ async fn list(env: &CliEnv, list_opts: &List) -> Result<()> {
 
     let deployments = client.get_deployments().await?.into_body().await?;
 
-    let mut deployment_cache: HashMap<String, DeploymentResponse> = HashMap::new();
+    let mut deployment_cache: HashMap<DeploymentId, DeploymentResponse> = HashMap::new();
 
     // Caching endpoints
-    for endpoint in deployments.deployments {
-        deployment_cache.insert(endpoint.id.to_string(), endpoint);
+    for deployment in deployments.deployments {
+        deployment_cache.insert(deployment.id, deployment);
     }
 
     let mut table = Table::new_styled(&env.ui_config);
@@ -100,7 +101,7 @@ async fn list(env: &CliEnv, list_opts: &List) -> Result<()> {
             svc.revision.to_string(),
             flavor.to_string(),
             render_deployment_type(&deployment.deployment),
-            deployment.id.clone(),
+            deployment.id.to_string(),
         ];
         if list_opts.extra {
             row.push(render_deployment_url(&deployment.deployment));

--- a/cli/src/ui/deployments.rs
+++ b/cli/src/ui/deployments.rs
@@ -14,6 +14,7 @@ use comfy_table::{Cell, Color, Table};
 
 use restate_meta_rest_model::deployments::{Deployment, ProtocolType, ServiceNameRevPair};
 use restate_meta_rest_model::services::ServiceMetadata;
+use restate_types::identifiers::DeploymentId;
 
 use super::console::StyledTable;
 
@@ -53,7 +54,7 @@ pub fn render_deployment_type(deployment: &Deployment) -> String {
 }
 
 pub fn calculate_deployment_status(
-    deployment_id: &str,
+    deployment_id: &DeploymentId,
     owned_services: &[ServiceNameRevPair],
     active_inv: i64,
     latest_services: &HashMap<String, ServiceMetadata>,
@@ -62,7 +63,7 @@ pub fn calculate_deployment_status(
 
     for svc in owned_services {
         if let Some(latest_svc) = latest_services.get(&svc.name) {
-            if latest_svc.deployment_id == deployment_id {
+            if &latest_svc.deployment_id == deployment_id {
                 status = DeploymentStatus::Active;
                 break;
             }

--- a/crates/admin/src/rest_api/error.rs
+++ b/crates/admin/src/rest_api/error.rs
@@ -18,6 +18,7 @@ use okapi_operation::okapi::openapi3::Responses;
 use okapi_operation::{okapi, Components, ToMediaTypes, ToResponses};
 use restate_meta::Error as MetaError;
 use restate_schema_impl::SchemasUpdateError;
+use restate_types::identifiers::DeploymentId;
 use schemars::JsonSchema;
 use serde::Serialize;
 
@@ -28,7 +29,7 @@ pub enum MetaApiError {
     #[error("The request field '{0}' is invalid. Reason: {1}")]
     InvalidField(&'static str, String),
     #[error("The requested deployment '{0}' does not exist")]
-    DeploymentNotFound(String),
+    DeploymentNotFound(DeploymentId),
     #[error("The requested service '{0}' does not exist")]
     ServiceNotFound(String),
     #[error("The requested method '{method_name}' on service '{service_name}' does not exist")]

--- a/crates/ingress-grpc/src/lib.rs
+++ b/crates/ingress-grpc/src/lib.rs
@@ -116,6 +116,7 @@ mod mocks {
             .apply_updates(
                 schemas
                     .compute_new_deployment(
+                        None, /* deployment_id */
                         DeploymentMetadata::new_http(
                             "http://localhost:9080".parse().unwrap(),
                             ProtocolType::BidiStream,

--- a/crates/invoker-api/src/journal_reader.rs
+++ b/crates/invoker-api/src/journal_reader.rs
@@ -30,7 +30,7 @@ impl JournalMetadata {
         length: EntryIndex,
         span_context: ServiceInvocationSpanContext,
         method: ByteString,
-        deployment_id: Option<String>,
+        deployment_id: Option<DeploymentId>,
     ) -> Self {
         Self {
             deployment_id,

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -25,7 +25,7 @@ use restate_invoker_api::{
     EagerState, EntryEnricher, InvokeInputJournal, JournalReader, StateReader,
 };
 use restate_schema_api::deployment::{
-    DeploymentMetadata, DeploymentMetadataResolver, DeploymentType, ProtocolType,
+    DeploymentMetadata, DeploymentResolver, DeploymentType, ProtocolType,
 };
 use restate_service_client::{Endpoint, Parts, Request, ServiceClient, ServiceClientError};
 use restate_service_protocol::message::{
@@ -252,7 +252,7 @@ where
     SR: StateReader + Clone + Send + Sync + 'static,
     <SR as StateReader>::StateIter: Send,
     EE: EntryEnricher,
-    DMR: DeploymentMetadataResolver,
+    DMR: DeploymentResolver,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -358,41 +358,38 @@ where
             shortcircuit!(tokio::try_join!(read_journal_future, read_state_future));
 
         // Resolve the deployment metadata
-        let (deployment_metadata, deployment_changed) =
+        let (deployment, deployment_changed) =
             if let Some(deployment_id) = journal_metadata.deployment_id {
                 // We have a pinned deployment that we can't change even if newer
                 // deployments have been registered for the same service.
                 let deployment_metadata = shortcircuit!(self
                     .deployment_metadata_resolver
                     .get_deployment(&deployment_id)
-                    .ok_or_else(|| InvocationTaskError::UnknownDeployment(deployment_id.clone())));
+                    .ok_or_else(|| InvocationTaskError::UnknownDeployment(deployment_id)));
                 (deployment_metadata, /* has_changed= */ false)
             } else {
                 // We can choose the freshest deployment for the latest revision
                 // of the registered service.
-                let deployment_metadata = shortcircuit!(self
+                let deployment = shortcircuit!(self
                     .deployment_metadata_resolver
                     .resolve_latest_deployment_for_service(
                         &self.full_invocation_id.service_id.service_name
                     )
                     .ok_or(InvocationTaskError::NoDeploymentForService));
-                (deployment_metadata, /* has_changed= */ true)
+                (deployment, /* has_changed= */ true)
             };
 
         let _ = self.invoker_tx.send(InvocationTaskOutput {
             partition: self.partition,
             full_invocation_id: self.full_invocation_id.clone(),
-            inner: InvocationTaskOutputInner::SelectedDeployment(
-                deployment_metadata.id(),
-                deployment_changed,
-            ),
+            inner: InvocationTaskOutputInner::SelectedDeployment(deployment.id, deployment_changed),
         });
 
         // Figure out the protocol type. Force RequestResponse if inactivity_timeout is zero
         let protocol_type = if self.inactivity_timeout.is_zero() {
             ProtocolType::RequestResponse
         } else {
-            deployment_metadata.protocol_type()
+            deployment.metadata.ty.protocol_type()
         };
 
         // Close the invoker_rx in case it's request response, this avoids further buffering of messages in this channel.
@@ -422,7 +419,7 @@ where
             .attach_to_span(&invocation_task_span);
 
         info!(
-            deployment.address = %deployment_metadata.address_display(),
+            deployment.address = %deployment.metadata.address_display(),
             path = %path,
             "Executing invocation at deployment"
         );
@@ -432,7 +429,7 @@ where
         let service_invocation_span_context = journal_metadata.span_context;
 
         // Prepare the request and send start message
-        let (mut http_stream_tx, request) = self.prepare_request(path, deployment_metadata);
+        let (mut http_stream_tx, request) = self.prepare_request(path, deployment.metadata);
         shortcircuit!(
             self.write_start(&mut http_stream_tx, journal_size, state_iter)
                 .await

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -30,7 +30,7 @@ use restate_invoker_api::{
     StateReader,
 };
 use restate_queue::SegmentQueue;
-use restate_schema_api::deployment::DeploymentMetadataResolver;
+use restate_schema_api::deployment::DeploymentResolver;
 use restate_timer_queue::TimerQueue;
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::{DeploymentId, FullInvocationId, PartitionKey, WithPartitionKey};
@@ -112,7 +112,7 @@ where
     SR: StateReader + Clone + Send + Sync + 'static,
     <SR as StateReader>::StateIter: Send,
     EE: EntryEnricher + Clone + Send + 'static,
-    DMR: DeploymentMetadataResolver + Clone + Send + 'static,
+    DMR: DeploymentResolver + Clone + Send + 'static,
 {
     fn start_invocation_task(
         &self,
@@ -218,7 +218,7 @@ where
     SR: StateReader + Clone + Send + Sync + 'static,
     <SR as StateReader>::StateIter: Send,
     EE: EntryEnricher + Clone + Send + 'static,
-    EMR: DeploymentMetadataResolver + Clone + Send + 'static,
+    EMR: DeploymentResolver + Clone + Send + 'static,
 {
     pub fn handle(&self) -> ChannelServiceHandle {
         ChannelServiceHandle {
@@ -520,11 +520,8 @@ where
                 ism.invocation_state_debug()
             );
 
-            self.status_store.on_deployment_chosen(
-                &partition,
-                &full_invocation_id,
-                deployment_id.clone(),
-            );
+            self.status_store
+                .on_deployment_chosen(&partition, &full_invocation_id, deployment_id);
             // If we think this selected deployment has been freshly picked, otherwise
             // we assume that we have stored it previously.
             if has_changed {

--- a/crates/invoker-impl/src/options.rs
+++ b/crates/invoker-impl/src/options.rs
@@ -14,7 +14,7 @@ use super::Service;
 
 use futures::Stream;
 use restate_invoker_api::{EntryEnricher, JournalReader};
-use restate_schema_api::deployment::DeploymentMetadataResolver;
+use restate_schema_api::deployment::DeploymentResolver;
 use restate_service_client::AssumeRoleCacheMode;
 use restate_types::journal::raw::PlainRawEntry;
 use restate_types::retries::RetryPolicy;
@@ -132,7 +132,7 @@ impl Options {
         JR: JournalReader<JournalStream = JS> + Clone + Send + Sync + 'static,
         JS: Stream<Item = PlainRawEntry> + Unpin + Send + 'static,
         EE: EntryEnricher,
-        DMR: DeploymentMetadataResolver,
+        DMR: DeploymentResolver,
     {
         metric_definitions::describe_metrics();
         let client = self.service_client.build(AssumeRoleCacheMode::Unbounded);

--- a/crates/meta/src/service.rs
+++ b/crates/meta/src/service.rs
@@ -354,6 +354,7 @@ where
 
         // Compute the diff with the current state of Schemas
         let schemas_update_commands = self.schemas.compute_new_deployment(
+            None, /* requested_deployment_id */
             deployment_metadata,
             discovered_metadata.services,
             discovered_metadata.descriptor_pool,
@@ -458,13 +459,14 @@ where
     ) -> DiscoverDeploymentResponse {
         for schema_update_command in commands {
             if let SchemasUpdateCommand::InsertDeployment {
-                metadata,
+                deployment_id,
+                metadata: _,
                 services,
                 descriptor_pool,
             } = schema_update_command
             {
                 return DiscoverDeploymentResponse {
-                    deployment: metadata.id(),
+                    deployment: *deployment_id,
                     services: services
                         .iter()
                         .map(|update_command| {
@@ -474,7 +476,7 @@ where
                                     "A service descriptor must be present in the descriptor pool",
                                 );
                             update_command
-                                .as_service_metadata(metadata.id(), &service_descriptor)
+                                .as_service_metadata(*deployment_id, &service_descriptor)
                                 .expect("Discovered services cannot be built-in services")
                         })
                         .collect(),

--- a/crates/schema-api/src/lib.rs
+++ b/crates/schema-api/src/lib.rs
@@ -52,6 +52,14 @@ pub mod deployment {
     }
 
     #[derive(Debug, Clone)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde_schema", derive(schemars::JsonSchema))]
+    pub struct Deployment {
+        pub id: DeploymentId,
+        pub metadata: DeploymentMetadata,
+    }
+
+    #[derive(Debug, Clone)]
     #[cfg_attr(feature = "serde", serde_with::serde_as)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde_schema", derive(schemars::JsonSchema))]
@@ -80,6 +88,29 @@ pub mod deployment {
             #[cfg_attr(feature = "serde_schema", schemars(with = "Option<String>"))]
             assume_role_arn: Option<ByteString>,
         },
+    }
+
+    impl DeploymentType {
+        pub fn protocol_type(&self) -> ProtocolType {
+            match self {
+                DeploymentType::Http { protocol_type, .. } => *protocol_type,
+                DeploymentType::Lambda { .. } => ProtocolType::RequestResponse,
+            }
+        }
+
+        pub fn normalized_address(&self) -> String {
+            match self {
+                DeploymentType::Http { address, .. } => {
+                    // We use only authority and path, as those uniquely identify the deployment.
+                    format!(
+                        "{}{}",
+                        address.authority().expect("Must have authority"),
+                        address.path()
+                    )
+                }
+                DeploymentType::Lambda { arn, .. } => arn.to_string(),
+            }
+        }
     }
 
     impl DeploymentMetadata {
@@ -128,54 +159,27 @@ pub mod deployment {
             Wrapper(&self.ty)
         }
 
-        pub fn protocol_type(&self) -> ProtocolType {
-            match &self.ty {
-                DeploymentType::Http { protocol_type, .. } => *protocol_type,
-                DeploymentType::Lambda { .. } => ProtocolType::RequestResponse,
-            }
-        }
-
-        pub fn id(&self) -> DeploymentId {
-            use base64::Engine;
-
-            match &self.ty {
-                DeploymentType::Http { address, .. } => {
-                    // For the time being we generate this from the URI
-                    // We use only authority and path, as those uniquely identify the deployment.
-                    let authority_and_path = format!(
-                        "{}{}",
-                        address.authority().expect("Must have authority"),
-                        address.path()
-                    );
-                    restate_base64_util::URL_SAFE.encode(authority_and_path.as_bytes())
-                }
-                DeploymentType::Lambda { arn, .. } => {
-                    restate_base64_util::URL_SAFE.encode(arn.to_string().as_bytes())
-                }
-            }
-        }
-
         pub fn created_at(&self) -> MillisSinceEpoch {
             self.created_at
         }
     }
 
-    pub trait DeploymentMetadataResolver {
+    pub trait DeploymentResolver {
         fn resolve_latest_deployment_for_service(
             &self,
             service_name: impl AsRef<str>,
-        ) -> Option<DeploymentMetadata>;
+        ) -> Option<Deployment>;
 
-        fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<DeploymentMetadata>;
+        fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<Deployment>;
 
         fn get_deployment_descriptor_pool(&self, deployment_id: &DeploymentId) -> Option<Bytes>;
 
         fn get_deployment_and_services(
             &self,
             deployment_id: &DeploymentId,
-        ) -> Option<(DeploymentMetadata, Vec<ServiceMetadata>)>;
+        ) -> Option<(Deployment, Vec<ServiceMetadata>)>;
 
-        fn get_deployments(&self) -> Vec<(DeploymentMetadata, Vec<(String, ServiceRevision)>)>;
+        fn get_deployments(&self) -> Vec<(Deployment, Vec<(String, ServiceRevision)>)>;
     }
 
     #[cfg(feature = "mocks")]
@@ -184,21 +188,28 @@ pub mod deployment {
 
         use std::collections::HashMap;
 
-        impl DeploymentMetadata {
-            pub fn mock() -> DeploymentMetadata {
-                DeploymentMetadata::new_http(
+        impl Deployment {
+            pub fn mock() -> Deployment {
+                let id = "dp_15VqmTOnXH3Vv2pl5HOG7UB"
+                    .parse()
+                    .expect("valid stable deployment id");
+                let metadata = DeploymentMetadata::new_http(
                     "http://localhost:9080".parse().unwrap(),
                     ProtocolType::BidiStream,
                     Default::default(),
-                )
+                );
+
+                Deployment { id, metadata }
             }
 
-            pub fn mock_with_uri(uri: &str) -> DeploymentMetadata {
-                DeploymentMetadata::new_http(
+            pub fn mock_with_uri(uri: &str) -> Deployment {
+                let id = DeploymentId::new();
+                let metadata = DeploymentMetadata::new_http(
                     uri.parse().unwrap(),
                     ProtocolType::BidiStream,
                     Default::default(),
-                )
+                );
+                Deployment { id, metadata }
             }
         }
 
@@ -210,27 +221,34 @@ pub mod deployment {
 
         impl MockDeploymentMetadataRegistry {
             pub fn mock_service(&mut self, name: &str) {
-                self.mock_service_with_metadata(name, DeploymentMetadata::mock());
+                self.mock_service_with_metadata(name, Deployment::mock());
             }
 
-            pub fn mock_service_with_metadata(&mut self, name: &str, meta: DeploymentMetadata) {
-                self.latest_deployment.insert(name.to_string(), meta.id());
-                self.deployments.insert(meta.id(), meta);
+            pub fn mock_service_with_metadata(&mut self, name: &str, deployment: Deployment) {
+                self.latest_deployment
+                    .insert(name.to_string(), deployment.id);
+                self.deployments.insert(deployment.id, deployment.metadata);
             }
         }
 
-        impl DeploymentMetadataResolver for MockDeploymentMetadataRegistry {
+        impl DeploymentResolver for MockDeploymentMetadataRegistry {
             fn resolve_latest_deployment_for_service(
                 &self,
                 service_name: impl AsRef<str>,
-            ) -> Option<DeploymentMetadata> {
+            ) -> Option<Deployment> {
                 self.latest_deployment
                     .get(service_name.as_ref())
                     .and_then(|deployment_id| self.get_deployment(deployment_id))
             }
 
-            fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<DeploymentMetadata> {
-                self.deployments.get(deployment_id).cloned()
+            fn get_deployment(&self, deployment_id: &DeploymentId) -> Option<Deployment> {
+                self.deployments
+                    .get(deployment_id)
+                    .cloned()
+                    .map(|metadata| Deployment {
+                        id: *deployment_id,
+                        metadata,
+                    })
             }
 
             fn get_deployment_descriptor_pool(
@@ -243,17 +261,33 @@ pub mod deployment {
             fn get_deployment_and_services(
                 &self,
                 deployment_id: &DeploymentId,
-            ) -> Option<(DeploymentMetadata, Vec<ServiceMetadata>)> {
+            ) -> Option<(Deployment, Vec<ServiceMetadata>)> {
                 self.deployments
                     .get(deployment_id)
                     .cloned()
-                    .map(|e| (e, vec![]))
+                    .map(|metadata| {
+                        (
+                            Deployment {
+                                id: *deployment_id,
+                                metadata,
+                            },
+                            vec![],
+                        )
+                    })
             }
 
-            fn get_deployments(&self) -> Vec<(DeploymentMetadata, Vec<(String, ServiceRevision)>)> {
+            fn get_deployments(&self) -> Vec<(Deployment, Vec<(String, ServiceRevision)>)> {
                 self.deployments
-                    .values()
-                    .map(|e| (e.clone(), vec![]))
+                    .iter()
+                    .map(|(id, metadata)| {
+                        (
+                            Deployment {
+                                id: *id,
+                                metadata: metadata.clone(),
+                            },
+                            vec![],
+                        )
+                    })
                     .collect()
             }
         }

--- a/crates/schema-impl/src/json.rs
+++ b/crates/schema-impl/src/json.rs
@@ -101,6 +101,7 @@ mod tests {
         InstanceTypeMetadata, MethodSchemas, ServiceLocation, ServiceSchemas,
     };
     use prost_reflect::{MethodDescriptor, ServiceDescriptor};
+    use restate_types::identifiers::DeploymentId;
     use serde::Serialize;
     use serde_json::json;
 
@@ -120,6 +121,9 @@ mod tests {
 
     fn schemas_mock() -> Schemas {
         let schemas = Schemas::default();
+        let latest_deployment: DeploymentId = "dp_134xwosaM2PKrh2dZTMbotj"
+            .parse()
+            .expect("valid stable deployment id");
         schemas.add_mock_service(
             "greeter.Greeter",
             ServiceSchemas {
@@ -132,7 +136,7 @@ mod tests {
                 .collect(),
                 instance_type: InstanceTypeMetadata::Unkeyed,
                 location: ServiceLocation::Deployment {
-                    latest_deployment: "".to_string(),
+                    latest_deployment,
                     public: true,
                 },
             },

--- a/crates/schema-impl/src/lib.rs
+++ b/crates/schema-impl/src/lib.rs
@@ -14,7 +14,7 @@ use prost_reflect::{DescriptorPool, ServiceDescriptor};
 use restate_schema_api::deployment::DeploymentMetadata;
 use restate_schema_api::service::ServiceMetadata;
 use restate_schema_api::subscription::{Subscription, SubscriptionValidator};
-use restate_types::identifiers::{DeploymentId, ServiceRevision};
+use restate_types::identifiers::{DeploymentId, ServiceRevision, SubscriptionId};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -94,6 +94,7 @@ impl InsertServiceUpdateCommand {
 pub enum SchemasUpdateCommand {
     /// Insert (or replace) deployment
     InsertDeployment {
+        deployment_id: DeploymentId,
         metadata: DeploymentMetadata,
         services: Vec<InsertServiceUpdateCommand>,
         #[serde(with = "descriptor_pool_serde")]
@@ -146,6 +147,14 @@ pub enum SchemasUpdateError {
     #[error("a deployment with the same id {0} already exists in the registry")]
     #[code(restate_errors::META0004)]
     OverrideDeployment(DeploymentId),
+    #[error(
+        "existing deployment id is different from requested (requested = {requested}, existing = {existing})"
+    )]
+    #[code(restate_errors::META0004)]
+    IncorrectDeploymentId {
+        requested: DeploymentId,
+        existing: DeploymentId,
+    },
     #[error("missing service {0} in descriptor")]
     #[code(restate_errors::META0005)]
     MissingServiceInDescriptor(String),
@@ -158,12 +167,12 @@ pub enum SchemasUpdateError {
     #[error("unknown deployment id {0}")]
     UnknownDeployment(DeploymentId),
     #[error("unknown subscription id {0}")]
-    UnknownSubscription(String),
+    UnknownSubscription(SubscriptionId),
     #[error("invalid subscription: {0}")]
     #[code(restate_errors::META0009)]
     InvalidSubscription(anyhow::Error),
     #[error("a subscription with the same id {0} already exists in the registry")]
-    OverrideSubscription(DeploymentId),
+    OverrideSubscription(SubscriptionId),
     #[error(transparent)]
     IncompatibleServiceChange(
         #[from]
@@ -186,18 +195,29 @@ impl Schemas {
     /// If `allow_override` is true, this method compares the deployment registered services with the given `services`,
     /// and generates remove commands for services no longer available at that deployment.
     ///
+    /// If `deployment_id` is set, it's assumed that:
+    ///   - This ID should be used if it's is a new deployment
+    ///   - or if conflicting/existing deployment exists, it must match.
+    /// Otherwise, a new deployment id is generated for this deployment, or the existing
+    /// deployment_id will be reused.
+    ///
     /// IMPORTANT: It is not safe to consecutively call this method several times and apply the updates all-together with a single [`Self::apply_updates`],
     /// as one change set might depend on the previously computed change set.
     pub fn compute_new_deployment(
         &self,
+        deployment_id: Option<DeploymentId>,
         deployment_metadata: DeploymentMetadata,
         services: Vec<String>,
         descriptor_pool: DescriptorPool,
         force: bool,
     ) -> Result<Vec<SchemasUpdateCommand>, SchemasUpdateError> {
-        self.0
-            .load()
-            .compute_new_deployment(deployment_metadata, services, descriptor_pool, force)
+        self.0.load().compute_new_deployment(
+            deployment_id,
+            deployment_metadata,
+            services,
+            descriptor_pool,
+            force,
+        )
     }
 
     pub fn compute_modify_service(
@@ -251,11 +271,17 @@ impl Schemas {
         for cmd in updates {
             match cmd {
                 SchemasUpdateCommand::InsertDeployment {
+                    deployment_id,
                     metadata,
                     services,
                     descriptor_pool,
                 } => {
-                    schemas_inner.apply_insert_deployment(metadata, services, descriptor_pool)?;
+                    schemas_inner.apply_insert_deployment(
+                        deployment_id,
+                        metadata,
+                        services,
+                        descriptor_pool,
+                    )?;
                 }
                 SchemasUpdateCommand::RemoveDeployment { deployment_id } => {
                     schemas_inner.apply_remove_deployment(deployment_id)?;
@@ -284,7 +310,7 @@ impl Schemas {
 mod tests {
     use super::*;
 
-    use restate_schema_api::deployment::DeploymentMetadataResolver;
+    use restate_schema_api::deployment::DeploymentResolver;
     use restate_schema_api::service::ServiceMetadataResolver;
     use restate_test_util::assert_eq;
 
@@ -297,6 +323,7 @@ mod tests {
             self.0.store(Arc::new(schemas_inner));
         }
 
+        #[track_caller]
         pub(crate) fn assert_service_revision(&self, svc_name: &str, revision: ServiceRevision) {
             assert_eq!(
                 self.resolve_latest_service_metadata(svc_name)
@@ -306,6 +333,7 @@ mod tests {
             );
         }
 
+        #[track_caller]
         pub(crate) fn assert_resolves_deployment(
             &self,
             svc_name: &str,
@@ -314,7 +342,7 @@ mod tests {
             assert_eq!(
                 self.resolve_latest_deployment_for_service(svc_name)
                     .unwrap()
-                    .id(),
+                    .id,
                 deployment_id
             );
         }

--- a/crates/schema-impl/src/proto_symbol.rs
+++ b/crates/schema-impl/src/proto_symbol.rs
@@ -328,14 +328,14 @@ impl ProtoSymbols {
 // to avoid collision between file names of unrelated deployments
 // TODO with schema checks in place,
 //  should we move this or remove this normalization of the file name?
-fn normalize_file_name(deployment_id: &str, file_name: &str) -> String {
+fn normalize_file_name(deployment_id: &DeploymentId, file_name: &str) -> String {
     // Because file_name is a path (either relative or absolute),
     // prepending deployment_id/ should always be fine
     format!("{deployment_id}/{file_name}")
 }
 
 fn normalize_self_and_dependencies_file_names(
-    deployment_id: &str,
+    deployment_id: &DeploymentId,
     mut file_desc_proto: FileDescriptorProto,
 ) -> FileDescriptorProto {
     file_desc_proto.name = file_desc_proto

--- a/crates/schema-impl/src/schemas_impl/deployment.rs
+++ b/crates/schema-impl/src/schemas_impl/deployment.rs
@@ -1,9 +1,13 @@
 use super::*;
 
-use crate::schemas_impl::service::check_service_name_reserved;
 use prost::DecodeError;
 use prost_reflect::{Cardinality, DescriptorError, ExtensionDescriptor, FieldDescriptor};
+
 use restate_errors::*;
+use restate_schema_api::deployment::DeploymentType;
+use restate_types::identifiers::DeploymentId;
+
+use crate::schemas_impl::service::check_service_name_reserved;
 
 const SERVICE_TYPE_EXT: &str = "dev.restate.ext.service_type";
 const FIELD_EXT: &str = "dev.restate.ext.field";
@@ -104,16 +108,32 @@ pub enum IncompatibleServiceChangeError {
 }
 
 impl SchemasInner {
+    /// Find existing deployment that knows about a particular endpoint
+    fn find_existing_deployment_by_endpoint(
+        &self,
+        endpoint: &DeploymentType,
+    ) -> Option<(&DeploymentId, &DeploymentSchemas)> {
+        self.deployments.iter().find(|(_, schemas)| {
+            schemas.metadata.ty.protocol_type() == endpoint.protocol_type()
+                && schemas.metadata.ty.normalized_address() == endpoint.normalized_address()
+        })
+    }
+
+    fn find_existing_deployment_by_id(
+        &self,
+        deployment_id: &DeploymentId,
+    ) -> Option<(&DeploymentId, &DeploymentSchemas)> {
+        self.deployments.iter().find(|(id, _)| deployment_id == *id)
+    }
     /// When `force` is set, allow incompatible service definition updates to existing services.
     pub(crate) fn compute_new_deployment(
         &self,
+        requested_deployment_id: Option<DeploymentId>,
         deployment_metadata: DeploymentMetadata,
         services: Vec<String>,
         descriptor_pool: DescriptorPool,
         force: bool,
     ) -> Result<Vec<SchemasUpdateCommand>, SchemasUpdateError> {
-        let deployment_id = deployment_metadata.id();
-
         let services: Vec<ServiceRegistrationRequest> =
             ServiceRegistrationRequest::infer_all_services_from_descriptor_pool(
                 services,
@@ -121,13 +141,29 @@ impl SchemasInner {
             )?;
 
         let mut result_commands = Vec::with_capacity(1 + services.len());
+        let deployment_id: Option<DeploymentId>;
 
-        if let Some(existing_deployment) = self.deployments.get(&deployment_id) {
+        // Did we find an existing deployment with same id or with a conflicting endpoint url?
+        let found_existing_deployment = requested_deployment_id
+            .and_then(|id| self.find_existing_deployment_by_id(&id))
+            .or_else(|| self.find_existing_deployment_by_endpoint(&deployment_metadata.ty));
+
+        if let Some((existing_deployment_id, existing_deployment)) = found_existing_deployment {
+            if requested_deployment_id.is_some_and(|dp| &dp != existing_deployment_id) {
+                // The deployment id is different from the existing one, we don't accept that even
+                // if force is used. It means that the user intended to update another deployment.
+                return Err(SchemasUpdateError::IncorrectDeploymentId {
+                    requested: requested_deployment_id.expect("must be set"),
+                    existing: *existing_deployment_id,
+                });
+            }
+
             if force {
+                deployment_id = Some(*existing_deployment_id);
                 // If we need to overwrite the deployment we need to remove old services
                 for svc in &existing_deployment.services {
                     warn!(
-                        restate.deployment.id = %deployment_id,
+                        restate.deployment.id = %existing_deployment_id,
                         restate.deployment.address = %deployment_metadata.address_display(),
                         "Going to remove service {} due to a forced deployment update",
                         svc.name
@@ -138,9 +174,17 @@ impl SchemasInner {
                     });
                 }
             } else {
-                return Err(SchemasUpdateError::OverrideDeployment(deployment_id));
+                return Err(SchemasUpdateError::OverrideDeployment(
+                    *existing_deployment_id,
+                ));
             }
+        } else {
+            // New deployment. Use the supplied deployment_id if passed, otherwise, generate one.
+            deployment_id = requested_deployment_id.or_else(|| Some(DeploymentId::new()));
         }
+
+        // We must have a deployment id by now, either a new or existing one.
+        let deployment_id = deployment_id.unwrap();
 
         // Compute service revision numbers
         let mut computed_revisions = HashMap::with_capacity(services.len());
@@ -209,6 +253,7 @@ impl SchemasInner {
 
         // Create the InsertDeployment command
         result_commands.push(SchemasUpdateCommand::InsertDeployment {
+            deployment_id,
             metadata: deployment_metadata,
             services: services
                 .into_iter()
@@ -231,11 +276,11 @@ impl SchemasInner {
 
     pub(crate) fn apply_insert_deployment(
         &mut self,
+        deployment_id: DeploymentId,
         metadata: DeploymentMetadata,
         services: Vec<InsertServiceUpdateCommand>,
         descriptor_pool: DescriptorPool,
     ) -> Result<(), SchemasUpdateError> {
-        let deployment_id = metadata.id();
         info!(
             restate.deployment.id = %deployment_id,
             restate.deployment.address = %metadata.address_display(),
@@ -288,7 +333,7 @@ impl SchemasInner {
                         latest_deployment, ..
                     } = &mut service_schemas.location
                     {
-                        *latest_deployment = deployment_id.clone();
+                        *latest_deployment = deployment_id;
                     }
 
                     // We need to remove the service from the proto_symbols.
@@ -303,7 +348,7 @@ impl SchemasInner {
                             instance_type.clone(),
                             &methods,
                         ),
-                        deployment_id.clone(),
+                        deployment_id,
                     )
                 });
 
@@ -658,7 +703,7 @@ mod tests {
 
     use test_log::test;
 
-    use restate_schema_api::deployment::DeploymentMetadataResolver;
+    use restate_schema_api::deployment::{Deployment, DeploymentResolver};
     use restate_schema_api::service::ServiceMetadataResolver;
     use restate_test_util::{assert, assert_eq, let_assert};
 
@@ -670,10 +715,11 @@ mod tests {
     fn register_new_deployment() {
         let schemas = Schemas::default();
 
-        let deployment = DeploymentMetadata::mock();
+        let deployment = Deployment::mock();
         let commands = schemas
             .compute_new_deployment(
-                deployment.clone(),
+                Some(deployment.id),
+                deployment.metadata.clone(),
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 DESCRIPTOR.clone(),
                 false,
@@ -681,14 +727,21 @@ mod tests {
             .unwrap();
 
         let_assert!(
-            Some(SchemasUpdateCommand::InsertDeployment { services, .. }) = commands.first()
+            Some(SchemasUpdateCommand::InsertDeployment {
+                deployment_id,
+                services,
+                ..
+            }) = commands.first()
         );
         assert_eq!(services.len(), 1);
+        // Ensure we are using the pre-determined id
+        assert_eq!(&deployment.id, deployment_id);
+        let deployment_id = *deployment_id;
 
         schemas.apply_updates(commands).unwrap();
 
         schemas.assert_service_revision(GREETER_SERVICE_NAME, 1);
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_id);
         assert_eq!(schemas.list_services().first().unwrap().methods.len(), 3);
     }
 
@@ -696,12 +749,13 @@ mod tests {
     fn register_new_deplooyment_add_unregistered_service() {
         let schemas = Schemas::default();
 
-        let deployment_1 = DeploymentMetadata::mock_with_uri("http://localhost:9080");
-        let deployment_2 = DeploymentMetadata::mock_with_uri("http://localhost:9081");
+        let deployment_1 = Deployment::mock_with_uri("http://localhost:9080");
+        let deployment_2 = Deployment::mock_with_uri("http://localhost:9081");
 
         let commands = schemas
             .compute_new_deployment(
-                deployment_1.clone(),
+                Some(deployment_1.id),
+                deployment_1.metadata.clone(),
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 DESCRIPTOR.clone(),
                 false,
@@ -715,14 +769,15 @@ mod tests {
 
         schemas.apply_updates(commands).unwrap();
 
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_1.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_1.id);
         assert!(schemas
             .resolve_latest_service_metadata(ANOTHER_GREETER_SERVICE_NAME)
             .is_none());
 
         let commands = schemas
             .compute_new_deployment(
-                deployment_2.clone(),
+                Some(deployment_2.id),
+                deployment_2.metadata.clone(),
                 vec![
                     GREETER_SERVICE_NAME.to_owned(),
                     ANOTHER_GREETER_SERVICE_NAME.to_owned(),
@@ -739,9 +794,9 @@ mod tests {
 
         schemas.apply_updates(commands).unwrap();
 
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_2.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_2.id);
         schemas.assert_service_revision(GREETER_SERVICE_NAME, 2);
-        schemas.assert_resolves_deployment(ANOTHER_GREETER_SERVICE_NAME, deployment_2.id());
+        schemas.assert_resolves_deployment(ANOTHER_GREETER_SERVICE_NAME, deployment_2.id);
         schemas.assert_service_revision(ANOTHER_GREETER_SERVICE_NAME, 1);
     }
 
@@ -765,14 +820,15 @@ mod tests {
         fn register_new_deployment_fails_changing_instance_type() {
             let schemas = Schemas::default();
 
-            let deployment_1 = DeploymentMetadata::mock_with_uri("http://localhost:9080");
-            let deployment_2 = DeploymentMetadata::mock_with_uri("http://localhost:9081");
+            let deployment_1 = Deployment::mock_with_uri("http://localhost:9080");
+            let deployment_2 = Deployment::mock_with_uri("http://localhost:9081");
 
             schemas
                 .apply_updates(
                     schemas
                         .compute_new_deployment(
-                            deployment_1.clone(),
+                            Some(deployment_1.id),
+                            deployment_1.metadata.clone(),
                             vec![GREETER_SERVICE_NAME.to_owned()],
                             CHANGE_INSTANCE_TYPE_DESCRIPTOR_V1.clone(),
                             false,
@@ -781,10 +837,11 @@ mod tests {
                 )
                 .unwrap();
 
-            schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_1.id());
+            schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_1.id);
 
             let compute_result = schemas.compute_new_deployment(
-                deployment_2,
+                Some(deployment_2.id),
+                deployment_2.metadata,
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 CHANGE_INSTANCE_TYPE_DESCRIPTOR_V2.clone(),
                 false,
@@ -798,10 +855,11 @@ mod tests {
     fn override_existing_deployment_removing_a_service() {
         let schemas = Schemas::default();
 
-        let deployment = DeploymentMetadata::mock();
+        let deployment = Deployment::mock();
         let commands = schemas
             .compute_new_deployment(
-                deployment.clone(),
+                Some(deployment.id),
+                deployment.metadata.clone(),
                 vec![
                     GREETER_SERVICE_NAME.to_owned(),
                     ANOTHER_GREETER_SERVICE_NAME.to_owned(),
@@ -812,12 +870,13 @@ mod tests {
             .unwrap();
         schemas.apply_updates(commands).unwrap();
 
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment.id());
-        schemas.assert_resolves_deployment(ANOTHER_GREETER_SERVICE_NAME, deployment.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment.id);
+        schemas.assert_resolves_deployment(ANOTHER_GREETER_SERVICE_NAME, deployment.id);
 
         let commands = schemas
             .compute_new_deployment(
-                deployment.clone(),
+                Some(deployment.id),
+                deployment.metadata.clone(),
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 DESCRIPTOR.clone(),
                 true,
@@ -825,21 +884,22 @@ mod tests {
             .unwrap();
         schemas.apply_updates(commands).unwrap();
 
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment.id);
         assert!(schemas
             .resolve_latest_deployment_for_service(ANOTHER_GREETER_SERVICE_NAME)
             .is_none());
     }
 
     #[test]
-    fn cannot_override_existing_deployment() {
+    fn cannot_override_existing_deployment_endpoint_conflict() {
         let schemas = Schemas::default();
 
-        let deployment = DeploymentMetadata::mock();
+        let deployment = Deployment::mock();
 
         let commands = schemas
             .compute_new_deployment(
-                deployment.clone(),
+                Some(deployment.id),
+                deployment.metadata.clone(),
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 DESCRIPTOR.clone(),
                 false,
@@ -848,7 +908,8 @@ mod tests {
         schemas.apply_updates(commands).unwrap();
 
         assert!(let Err(SchemasUpdateError::OverrideDeployment(_)) = schemas.compute_new_deployment(
-            deployment,
+            Some(deployment.id),
+            deployment.metadata,
             vec![GREETER_SERVICE_NAME.to_owned()],
             DESCRIPTOR.clone(),
             false)
@@ -856,17 +917,53 @@ mod tests {
     }
 
     #[test]
+    fn cannot_override_existing_deployment_existing_id_mismatch() {
+        let schemas = Schemas::default();
+
+        let deployment = Deployment::mock();
+
+        let commands = schemas
+            .compute_new_deployment(
+                Some(deployment.id),
+                deployment.metadata.clone(),
+                vec![GREETER_SERVICE_NAME.to_owned()],
+                DESCRIPTOR.clone(),
+                false,
+            )
+            .unwrap();
+        schemas.apply_updates(commands).unwrap();
+
+        let new_id = DeploymentId::new();
+
+        let_assert!(
+            Err(SchemasUpdateError::IncorrectDeploymentId {
+                requested,
+                existing
+            }) = schemas.compute_new_deployment(
+                Some(new_id),
+                deployment.metadata,
+                vec![GREETER_SERVICE_NAME.to_owned()],
+                DESCRIPTOR.clone(),
+                false
+            )
+        );
+        assert_eq!(new_id, requested);
+        assert_eq!(deployment.id, existing);
+    }
+
+    #[test]
     fn register_two_deployments_then_remove_first() {
         let schemas = Schemas::default();
 
-        let deployment_1 = DeploymentMetadata::mock_with_uri("http://localhost:9080");
-        let deployment_2 = DeploymentMetadata::mock_with_uri("http://localhost:9081");
+        let deployment_1 = Deployment::mock_with_uri("http://localhost:9080");
+        let deployment_2 = Deployment::mock_with_uri("http://localhost:9081");
 
         schemas
             .apply_updates(
                 schemas
                     .compute_new_deployment(
-                        deployment_1.clone(),
+                        Some(deployment_1.id),
+                        deployment_1.metadata.clone(),
                         vec![
                             GREETER_SERVICE_NAME.to_owned(),
                             ANOTHER_GREETER_SERVICE_NAME.to_owned(),
@@ -881,7 +978,8 @@ mod tests {
             .apply_updates(
                 schemas
                     .compute_new_deployment(
-                        deployment_2.clone(),
+                        Some(deployment_2.id),
+                        deployment_2.metadata.clone(),
                         vec![GREETER_SERVICE_NAME.to_owned()],
                         DESCRIPTOR.clone(),
                         false,
@@ -890,14 +988,12 @@ mod tests {
             )
             .unwrap();
 
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_2.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_2.id);
         schemas.assert_service_revision(GREETER_SERVICE_NAME, 2);
-        schemas.assert_resolves_deployment(ANOTHER_GREETER_SERVICE_NAME, deployment_1.id());
+        schemas.assert_resolves_deployment(ANOTHER_GREETER_SERVICE_NAME, deployment_1.id);
         schemas.assert_service_revision(ANOTHER_GREETER_SERVICE_NAME, 1);
 
-        let commands = schemas
-            .compute_remove_deployment(deployment_1.id())
-            .unwrap();
+        let commands = schemas.compute_remove_deployment(deployment_1.id).unwrap();
 
         assert!(
             let Some(SchemasUpdateCommand::RemoveService { .. }) = commands.first()
@@ -911,12 +1007,12 @@ mod tests {
 
         schemas.apply_updates(commands).unwrap();
 
-        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_2.id());
+        schemas.assert_resolves_deployment(GREETER_SERVICE_NAME, deployment_2.id);
         schemas.assert_service_revision(GREETER_SERVICE_NAME, 2);
         assert!(schemas
             .resolve_latest_deployment_for_service(ANOTHER_GREETER_SERVICE_NAME)
             .is_none());
-        assert!(schemas.get_deployment(&deployment_1.id()).is_none());
+        assert!(schemas.get_deployment(&deployment_1.id).is_none());
     }
 
     // Reproducer for issue where the service name is the same of the method name
@@ -925,12 +1021,13 @@ mod tests {
         let schemas = Schemas::default();
         let svc_name = "greeter.Greeter";
 
-        let deployment = DeploymentMetadata::mock();
+        let deployment = Deployment::mock();
         schemas
             .apply_updates(
                 schemas
                     .compute_new_deployment(
-                        deployment.clone(),
+                        Some(deployment.id),
+                        deployment.metadata.clone(),
                         vec![GREETER_SERVICE_NAME.to_owned()],
                         DESCRIPTOR.clone(),
                         false,
@@ -945,7 +1042,8 @@ mod tests {
             .apply_updates(
                 schemas
                     .compute_new_deployment(
-                        deployment,
+                        Some(deployment.id),
+                        deployment.metadata,
                         vec![GREETER_SERVICE_NAME.to_owned()],
                         DESCRIPTOR.clone(),
                         true,
@@ -970,11 +1068,12 @@ mod tests {
         fn reject_removing_existing_methods() {
             let schemas = Schemas::default();
 
-            let deployment_1 = DeploymentMetadata::mock_with_uri("http://localhost:9080");
-            let deployment_2 = DeploymentMetadata::mock_with_uri("http://localhost:9081");
+            let deployment_1 = Deployment::mock_with_uri("http://localhost:9080");
+            let deployment_2 = Deployment::mock_with_uri("http://localhost:9081");
 
             let commands = schemas.compute_new_deployment(
-                deployment_1,
+                Some(deployment_1.id),
+                deployment_1.metadata,
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 REMOVE_METHOD_DESCRIPTOR_V1.clone(),
                 false,
@@ -983,7 +1082,8 @@ mod tests {
             schemas.assert_service_revision(GREETER_SERVICE_NAME, 1);
 
             let rejection = schemas.compute_new_deployment(
-                deployment_2,
+                Some(deployment_2.id),
+                deployment_2.metadata,
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 REMOVE_METHOD_DESCRIPTOR_V2.clone(),
                 false,
@@ -1014,8 +1114,10 @@ mod tests {
         fn reject_bad_key_wrong_type() {
             let schemas = Schemas::default();
 
+            let deployment = Deployment::mock();
             let rejection = schemas.compute_new_deployment(
-                DeploymentMetadata::mock(),
+                Some(deployment.id),
+                deployment.metadata,
                 vec![GREETER_SERVICE_NAME.to_owned()],
                 BAD_KEY_WRONG_TYPE_DESCRIPTOR.clone(),
                 false,

--- a/crates/schema-impl/src/schemas_impl/mod.rs
+++ b/crates/schema-impl/src/schemas_impl/mod.rs
@@ -253,6 +253,8 @@ pub(crate) struct DeploymentSchemas {
 
 impl Default for SchemasInner {
     fn default() -> Self {
+        const INGRESS_DEPLOYMENT_ID: DeploymentId = DeploymentId::from_parts(0, 0);
+
         let mut inner = Self {
             services: Default::default(),
             deployments: Default::default(),
@@ -282,10 +284,9 @@ impl Default for SchemasInner {
                 ),
             );
             if matches!(visibility, Visibility::Public) {
-                inner.proto_symbols.add_service(
-                    &"self_ingress".to_string(),
-                    &restate_pb::get_service(svc_name),
-                )
+                inner
+                    .proto_symbols
+                    .add_service(&INGRESS_DEPLOYMENT_ID, &restate_pb::get_service(svc_name))
             }
         };
         register_built_in(

--- a/crates/schema-impl/src/service.rs
+++ b/crates/schema-impl/src/service.rs
@@ -79,7 +79,7 @@ pub(crate) fn map_to_service_metadata(
             instance_type: (&service_schemas.instance_type)
                 .try_into()
                 .expect("Checked in the line above whether this is a built-in service or not"),
-            deployment_id: latest_deployment.clone(),
+            deployment_id: *latest_deployment,
             revision: service_schemas.revision,
             public: *public,
         }),

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 [features]
 default = []
 
-awakeable-id = ["dep:base64", "dep:restate-base64-util", "dep:restate-types", "dep:thiserror"]
-codec = ["protocol", "dep:restate-types", "dep:thiserror", "dep:paste"]
-discovery = ["dep:tracing", "dep:thiserror", "dep:codederror", "dep:restate-errors", "dep:restate-schema-api", "dep:hyper", "dep:restate-service-client", "dep:prost-reflect", "dep:restate-types", "dep:tokio"]
+awakeable-id = ["dep:base64", "dep:restate-base64-util", "dep:restate-types"]
+codec = ["protocol", "dep:restate-types", "dep:paste"]
+discovery = ["dep:tracing", "dep:codederror", "dep:restate-errors", "dep:restate-schema-api", "dep:hyper", "dep:restate-service-client", "dep:prost-reflect", "dep:restate-types", "dep:tokio"]
 message = ["protocol", "dep:restate-types", "dep:bytes-utils", "dep:codederror", "dep:restate-errors", "dep:size", "dep:tracing"]
 mocks = ["awakeable-id"]
 protocol = []
@@ -34,7 +34,7 @@ prost = { workspace = true }
 prost-reflect = { workspace = true, optional = true }
 prost-types = { workspace = true }
 size = { version = "0.4.1", optional = true }
-thiserror = { workspace = true, optional = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["time"] }
 tracing = { workspace = true, optional = true }
 

--- a/crates/storage-api/src/status_table/mod.rs
+++ b/crates/storage-api/src/status_table/mod.rs
@@ -193,7 +193,7 @@ impl InvocationMetadata {
     pub fn new(
         invocation_uuid: InvocationUuid,
         journal_metadata: JournalMetadata,
-        deployment_id: Option<String>,
+        deployment_id: Option<DeploymentId>,
         method: ByteString,
         response_sink: Option<ServiceInvocationResponseSink>,
         timestamps: StatusTimestamps,

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -182,7 +182,9 @@ pub mod storage {
                     let deployment_id = value.deployment_id.and_then(|one_of_deployment_id| {
                         match one_of_deployment_id {
                             invocation_status::invoked::DeploymentId::None(_) => None,
-                            invocation_status::invoked::DeploymentId::Value(id) => Some(id),
+                            invocation_status::invoked::DeploymentId::Value(id) => {
+                                Some(id.parse().expect("valid deployment id"))
+                            }
                         }
                     });
 
@@ -239,9 +241,9 @@ pub mod storage {
                         method_name: method.into_bytes(),
                         deployment_id: Some(match deployment_id {
                             None => invocation_status::invoked::DeploymentId::None(()),
-                            Some(deployment_id) => {
-                                invocation_status::invoked::DeploymentId::Value(deployment_id)
-                            }
+                            Some(deployment_id) => invocation_status::invoked::DeploymentId::Value(
+                                deployment_id.to_string(),
+                            ),
                         }),
                         journal_meta: Some(JournalMeta::from(journal_metadata)),
                         creation_time: timestamps.creation_time().as_u64(),
@@ -301,7 +303,7 @@ pub mod storage {
                         restate_storage_api::status_table::InvocationMetadata::new(
                             invocation_uuid,
                             journal_metadata,
-                            deployment_id,
+                            deployment_id.map(|d| d.parse().expect("valid deployment id")),
                             method_name,
                             response_sink,
                             restate_storage_api::status_table::StatusTimestamps::new(
@@ -341,7 +343,9 @@ pub mod storage {
                         deployment_id: Some(match metadata.deployment_id {
                             None => invocation_status::suspended::DeploymentId::None(()),
                             Some(deployment_id) => {
-                                invocation_status::suspended::DeploymentId::Value(deployment_id)
+                                invocation_status::suspended::DeploymentId::Value(
+                                    deployment_id.to_string(),
+                                )
                             }
                         }),
                         creation_time: metadata.timestamps.creation_time().as_u64(),

--- a/crates/storage-query-datafusion/src/deployment/row.rs
+++ b/crates/storage-query-datafusion/src/deployment/row.rs
@@ -10,18 +10,18 @@
 
 use super::schema::DeploymentBuilder;
 use crate::table_util::format_using;
-use restate_schema_api::deployment::{DeploymentMetadata, DeploymentType};
+use restate_schema_api::deployment::{Deployment, DeploymentType};
 
 #[inline]
 pub(crate) fn append_deployment_row(
     builder: &mut DeploymentBuilder,
     output: &mut String,
-    deployment_metadata: DeploymentMetadata,
+    deployment: Deployment,
 ) {
     let mut row = builder.row();
-    row.id(format_using(output, &deployment_metadata.id()));
+    row.id(format_using(output, &deployment.id));
 
-    match deployment_metadata.ty {
+    match deployment.metadata.ty {
         DeploymentType::Http { .. } => {
             row.ty("http");
         }
@@ -30,6 +30,6 @@ pub(crate) fn append_deployment_row(
         }
     }
 
-    row.endpoint(format_using(output, &deployment_metadata.address_display()));
-    row.created_at(deployment_metadata.created_at.as_u64() as i64);
+    row.endpoint(format_using(output, &deployment.metadata.address_display()));
+    row.created_at(deployment.metadata.created_at.as_u64() as i64);
 }

--- a/crates/storage-query-datafusion/src/deployment/table.rs
+++ b/crates/storage-query-datafusion/src/deployment/table.rs
@@ -18,7 +18,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
 pub use datafusion_expr::UserDefinedLogicalNode;
-use restate_schema_api::deployment::{DeploymentMetadata, DeploymentMetadataResolver};
+use restate_schema_api::deployment::{Deployment, DeploymentResolver};
 use restate_types::identifiers::{PartitionKey, ServiceRevision};
 use std::fmt::Debug;
 use std::ops::RangeInclusive;
@@ -27,7 +27,7 @@ use tokio::sync::mpsc::Sender;
 
 pub(crate) fn register_self(
     ctx: &QueryContext,
-    resolver: impl DeploymentMetadataResolver + Send + Sync + Debug + 'static,
+    resolver: impl DeploymentResolver + Send + Sync + Debug + 'static,
 ) -> datafusion::common::Result<()> {
     let deployment_table = GenericTableProvider::new(
         DeploymentBuilder::schema(),
@@ -44,7 +44,7 @@ struct DeploymentMetadataScanner<DMR>(DMR);
 
 /// TODO This trait makes little sense for sys_deployment,
 ///  but it's fine nevertheless as the caller always uses the full range
-impl<DMR: DeploymentMetadataResolver + Debug + Sync + Send + 'static> RangeScanner
+impl<DMR: DeploymentResolver + Debug + Sync + Send + 'static> RangeScanner
     for DeploymentMetadataScanner<DMR>
 {
     fn scan(
@@ -67,7 +67,7 @@ impl<DMR: DeploymentMetadataResolver + Debug + Sync + Send + 'static> RangeScann
 async fn for_each_state(
     schema: SchemaRef,
     tx: Sender<datafusion::common::Result<RecordBatch>>,
-    rows: Vec<(DeploymentMetadata, Vec<(String, ServiceRevision)>)>,
+    rows: Vec<(Deployment, Vec<(String, ServiceRevision)>)>,
 ) {
     let mut builder = DeploymentBuilder::new(schema.clone());
     let mut temp = String::new();

--- a/crates/storage-query-datafusion/src/invocation_state/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/row.rs
@@ -36,7 +36,7 @@ pub(crate) fn append_state_row(
     row.retry_count(status_row.retry_count() as u64);
     row.last_start_at(MillisSinceEpoch::as_u64(&status_row.last_start_at().into()) as i64);
     if let Some(last_attempt_deployment_id) = status_row.last_attempt_deployment_id() {
-        row.last_attempt_deployment_id(last_attempt_deployment_id);
+        row.last_attempt_deployment_id(last_attempt_deployment_id.to_string());
     }
 
     if let Some(next_retry_at) = status_row.next_retry_at() {

--- a/crates/storage-query-datafusion/src/options.rs
+++ b/crates/storage-query-datafusion/src/options.rs
@@ -12,7 +12,7 @@ use crate::context::QueryContext;
 use codederror::CodedError;
 use datafusion::error::DataFusionError;
 use restate_invoker_api::StatusHandle;
-use restate_schema_api::deployment::DeploymentMetadataResolver;
+use restate_schema_api::deployment::DeploymentResolver;
 use restate_schema_api::service::ServiceMetadataResolver;
 use restate_storage_rocksdb::RocksDBStorage;
 use std::fmt::Debug;
@@ -47,7 +47,7 @@ impl Options {
         self,
         rocksdb: RocksDBStorage,
         status: impl StatusHandle + Send + Sync + Debug + Clone + 'static,
-        schemas: impl DeploymentMetadataResolver
+        schemas: impl DeploymentResolver
             + ServiceMetadataResolver
             + Send
             + Sync

--- a/crates/storage-query-datafusion/src/status/row.rs
+++ b/crates/storage-query-datafusion/src/status/row.rs
@@ -84,7 +84,7 @@ fn fill_invocation_metadata(
     // journal_metadata and stats are filled by other functions
     row.method(meta.method);
     if let Some(deployment_id) = meta.deployment_id {
-        row.pinned_deployment_id(deployment_id);
+        row.pinned_deployment_id(deployment_id.to_string());
     }
     match meta.source {
         Source::Service(caller) => {

--- a/crates/types/src/deployment.rs
+++ b/crates/types/src/deployment.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+use std::mem::size_of;
+use std::str::FromStr;
+
+use ulid::Ulid;
+
+use crate::base62_util::base62_max_length_for_type;
+use crate::errors::IdDecodeError;
+use crate::id_util::{IdDecoder, IdEncoder, IdResourceType};
+use crate::identifiers::{DeploymentId, ResourceId, TimestampAwareId};
+use crate::time::MillisSinceEpoch;
+
+impl ResourceId for DeploymentId {
+    const SIZE_IN_BYTES: usize = size_of::<u128>();
+    const RESOURCE_TYPE: IdResourceType = IdResourceType::Deployment;
+    const STRING_CAPACITY_HINT: usize = base62_max_length_for_type::<u128>();
+    fn push_contents_to_encoder(&self, encoder: &mut IdEncoder<Self>) {
+        let ulid_raw: u128 = self.0.into();
+        encoder.encode_fixed_width(ulid_raw);
+    }
+}
+
+impl TimestampAwareId for DeploymentId {
+    fn timestamp(&self) -> MillisSinceEpoch {
+        self.0.timestamp_ms().into()
+    }
+}
+
+impl FromStr for DeploymentId {
+    type Err = IdDecodeError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut decoder = IdDecoder::new(input)?;
+        // Ensure we are decoding the correct resource type
+        if decoder.resource_type != Self::RESOURCE_TYPE {
+            return Err(IdDecodeError::TypeMismatch);
+        }
+
+        // ulid (u128)
+        let raw_ulid: u128 = decoder.cursor.decode_next()?;
+        Ok(Self::from(raw_ulid))
+    }
+}
+
+impl fmt::Display for DeploymentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut encoder = IdEncoder::<Self>::new();
+        self.push_contents_to_encoder(&mut encoder);
+        fmt::Display::fmt(&encoder.finalize(), f)
+    }
+}
+
+impl From<u128> for DeploymentId {
+    fn from(value: u128) -> Self {
+        Self(Ulid::from(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deployment_id_format() {
+        let a = DeploymentId::new();
+        assert!(a.timestamp().as_u64() > 0);
+        let a_str = a.to_string();
+        assert!(a_str.starts_with("dp_"));
+        assert_eq!(DeploymentId::STRING_CAPACITY_HINT + 4, a_str.len());
+        assert_eq!(
+            a_str.len(),
+            IdEncoder::<DeploymentId>::estimate_buf_capacity()
+        );
+        assert_eq!(26, a_str.len());
+    }
+
+    #[test]
+    fn test_deployment_roundtrip() {
+        let a = DeploymentId::new();
+        let b: DeploymentId = a.to_string().parse().unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.to_string(), b.to_string());
+    }
+}

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -40,6 +40,7 @@ pub enum IdSchemeVersion {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum IdResourceType {
     Invocation,
+    Deployment,
 }
 
 impl IdSchemeVersion {
@@ -65,6 +66,7 @@ impl IdResourceType {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Invocation => "inv",
+            Self::Deployment => "dp",
         }
     }
 }
@@ -75,6 +77,7 @@ impl FromStr for IdResourceType {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "inv" => Ok(Self::Invocation),
+            "dp" => Ok(Self::Deployment),
             _ => Err(IdDecodeError::UnrecognizedType(value.to_string())),
         }
     }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -13,6 +13,7 @@
 mod base62_util;
 mod id_util;
 
+pub mod deployment;
 pub mod errors;
 pub mod identifiers;
 pub mod invocation;

--- a/crates/worker/src/partition/services/non_deterministic/ingress.rs
+++ b/crates/worker/src/partition/services/non_deterministic/ingress.rs
@@ -125,7 +125,7 @@ mod tests {
     use prost_reflect::DynamicMessage;
     use test_log::test;
 
-    use restate_schema_api::deployment::DeploymentMetadata;
+    use restate_schema_api::deployment::Deployment;
     use restate_test_util::matchers::*;
     use restate_types::invocation::ServiceInvocation;
 
@@ -134,11 +134,13 @@ mod tests {
     fn mock_schemas() -> Schemas {
         let schemas = Schemas::default();
 
+        let deployment = Deployment::mock();
         schemas
             .apply_updates(
                 schemas
                     .compute_new_deployment(
-                        DeploymentMetadata::mock(),
+                        Some(deployment.id),
+                        deployment.metadata,
                         vec![restate_pb::mocks::GREETER_SERVICE_NAME.to_owned()],
                         restate_pb::mocks::DESCRIPTOR_POOL.clone(),
                         false,

--- a/crates/worker/src/partition/services/non_deterministic/remote_context.rs
+++ b/crates/worker/src/partition/services/non_deterministic/remote_context.rs
@@ -1171,7 +1171,7 @@ mod tests {
     use restate_pb::mocks::GREETER_SERVICE_NAME;
     use restate_pb::restate::internal::{get_result_response, start_response, CleanupRequest};
     use restate_pb::REMOTE_CONTEXT_SERVICE_NAME;
-    use restate_schema_api::deployment::DeploymentMetadata;
+    use restate_schema_api::deployment::Deployment;
     use restate_service_protocol::codec::ProtobufRawEntryCodec;
     use restate_test_util::assert_eq;
     use restate_test_util::matchers::*;
@@ -2781,11 +2781,13 @@ mod tests {
     fn mock_schemas() -> Schemas {
         let schemas = Schemas::default();
 
+        let deployment = Deployment::mock_with_uri("http://localhost:8080");
         schemas
             .apply_updates(
                 schemas
                     .compute_new_deployment(
-                        DeploymentMetadata::mock_with_uri("http://localhost:8080"),
+                        Some(deployment.id),
+                        deployment.metadata,
                         vec![GREETER_SERVICE_NAME.to_owned()],
                         restate_pb::mocks::DESCRIPTOR_POOL.clone(),
                         false,


### PR DESCRIPTION
New versioned deployment ID scheme

**Note:** This is a _big_ refactoring that is hard to split, but many changes are mechanical. I'll highlight the key changes in the description to make it easier to review.


This change introduces new scheme for deployment IDs, the scheme follows the recently introduced `ResourceId` trait that aims to unify
the user-facing ID scheme in a versioned and copy-paste friendly format.

An example of the new IDs: `dp_134xwosaM2PKrh2dZTMbotj`. The prefix `dp_` is short for `deployment`.
The first character after the separator is the ID version scheme. The ID is lexographically sortable
which makes it easy to rough-order deployments by recency.

The most notable change in this PR is in `compute_new_deployment` function. The change introduces the ability
for the caller to specify a deployment-id for the new deployment, or leave it as None for an auto-generated one.

This is currently only being leveraged in tests but it can be used in future user-facing features that require editing existing deployments (adding new endpoints, etc.)
The logic is described in the code comment but the summary is:
> If the ID is set on request, we assume that the user wants to create a deployment with this ID, or if the deployment exists, the user _only_ accepts to overwrite this deployment **if** existing deployment matches with this ID.


Test Plan:
- Tests have been updated to validate the new logic and ID scheme
- System was tested manually with the CLI for a variety of cases (register, list, invocation, etc.)
- Verification/e2e tests

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1115).
* #1121
* #1120
* #1119
* __->__ #1115