### PR TITLE
Subscription ID to follow resource ID scheme

### DIFF
--- a/crates/admin/src/rest_api/error.rs
+++ b/crates/admin/src/rest_api/error.rs
@@ -18,7 +18,7 @@ use okapi_operation::okapi::openapi3::Responses;
 use okapi_operation::{okapi, Components, ToMediaTypes, ToResponses};
 use restate_meta::Error as MetaError;
 use restate_schema_impl::SchemasUpdateError;
-use restate_types::identifiers::DeploymentId;
+use restate_types::identifiers::{DeploymentId, SubscriptionId};
 use schemars::JsonSchema;
 use serde::Serialize;
 
@@ -38,7 +38,7 @@ pub enum MetaApiError {
         method_name: String,
     },
     #[error("The requested subscription '{0}' does not exist")]
-    SubscriptionNotFound(String),
+    SubscriptionNotFound(SubscriptionId),
     #[error(transparent)]
     Meta(#[from] MetaError),
     #[error(transparent)]

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -22,6 +22,7 @@ use restate_pb::restate::Event;
 use restate_schema_api::subscription::{
     EventReceiverServiceInstanceType, KafkaOrderingKeyFormat, Sink, Source, Subscription,
 };
+use restate_types::identifiers::SubscriptionId;
 use restate_types::invocation::SpanRelation;
 use restate_types::message::MessageIndex;
 use std::collections::HashMap;
@@ -182,7 +183,7 @@ impl MessageSender {
 
     fn generate_events_attributes(
         msg: &impl Message,
-        subscription_id: &str,
+        subscription_id: SubscriptionId,
     ) -> HashMap<String, String> {
         let mut attributes = HashMap::with_capacity(3);
         attributes.insert("kafka.offset".to_string(), msg.offset().to_string());

--- a/crates/meta-rest-model/src/subscriptions.rs
+++ b/crates/meta-rest-model/src/subscriptions.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 
 use http::Uri;
+use restate_types::identifiers::SubscriptionId;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -23,9 +24,6 @@ pub use restate_schema_api::subscription::{ListSubscriptionFilter, Subscription}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateSubscriptionRequest {
     /// # Identifier
-    ///
-    /// Identifier of the subscription. If not specified, one will be auto-generated.
-    pub id: Option<String>,
     /// # Source
     ///
     /// Source uri. Accepted forms:
@@ -51,7 +49,7 @@ pub struct CreateSubscriptionRequest {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SubscriptionResponse {
-    pub id: String,
+    pub id: SubscriptionId,
     pub source: String,
     pub sink: String,
     pub options: HashMap<String, String>,
@@ -60,7 +58,7 @@ pub struct SubscriptionResponse {
 impl From<Subscription> for SubscriptionResponse {
     fn from(value: Subscription) -> Self {
         Self {
-            id: value.id().to_string(),
+            id: value.id(),
             source: value.source().to_string(),
             sink: value.sink().to_string(),
             options: value.metadata().clone(),

--- a/crates/schema-api/src/lib.rs
+++ b/crates/schema-api/src/lib.rs
@@ -549,6 +549,8 @@ pub mod subscription {
     use std::collections::HashMap;
     use std::fmt;
 
+    use restate_types::identifiers::SubscriptionId;
+
     #[derive(Debug, Clone, Eq, PartialEq, Default)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde_schema", derive(schemars::JsonSchema))]
@@ -653,7 +655,7 @@ pub mod subscription {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde_schema", derive(schemars::JsonSchema))]
     pub struct Subscription {
-        id: String,
+        id: SubscriptionId,
         source: Source,
         sink: Sink,
         metadata: HashMap<String, String>,
@@ -661,7 +663,7 @@ pub mod subscription {
 
     impl Subscription {
         pub fn new(
-            id: String,
+            id: SubscriptionId,
             source: Source,
             sink: Sink,
             metadata: HashMap<String, String>,
@@ -674,8 +676,8 @@ pub mod subscription {
             }
         }
 
-        pub fn id(&self) -> &str {
-            &self.id
+        pub fn id(&self) -> SubscriptionId {
+            self.id
         }
 
         pub fn source(&self) -> &Source {
@@ -710,7 +712,7 @@ pub mod subscription {
     }
 
     pub trait SubscriptionResolver {
-        fn get_subscription(&self, id: &str) -> Option<Subscription>;
+        fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription>;
 
         fn list_subscriptions(&self, filters: &[ListSubscriptionFilter]) -> Vec<Subscription>;
     }
@@ -723,12 +725,16 @@ pub mod subscription {
 
     #[cfg(feature = "mocks")]
     pub mod mocks {
+        use std::str::FromStr;
+
         use super::*;
 
         impl Subscription {
             pub fn mock() -> Self {
+                let id = SubscriptionId::from_str("sub_15VqmTOnXH3Vv2pl5HOG7Ua")
+                    .expect("stable valid subscription id");
                 Subscription {
-                    id: "my-sub".to_string(),
+                    id,
                     source: Source::Kafka {
                         cluster: "my-cluster".to_string(),
                         topic: "my-topic".to_string(),

--- a/crates/schema-impl/src/lib.rs
+++ b/crates/schema-impl/src/lib.rs
@@ -113,7 +113,7 @@ pub enum SchemasUpdateCommand {
         public: bool,
     },
     AddSubscription(Subscription),
-    RemoveSubscription(String),
+    RemoveSubscription(SubscriptionId),
 }
 
 mod descriptor_pool_serde {
@@ -240,7 +240,7 @@ impl Schemas {
     // Returns the [`Subscription`] id together with the update command
     pub fn compute_add_subscription<V: SubscriptionValidator>(
         &self,
-        id: Option<String>,
+        id: Option<SubscriptionId>,
         source: Uri,
         sink: Uri,
         metadata: Option<HashMap<String, String>>,
@@ -253,7 +253,7 @@ impl Schemas {
 
     pub fn compute_remove_subscription(
         &self,
-        id: String,
+        id: SubscriptionId,
     ) -> Result<SchemasUpdateCommand, SchemasUpdateError> {
         self.0.load().compute_remove_subscription(id)
     }

--- a/crates/schema-impl/src/schemas_impl/mod.rs
+++ b/crates/schema-impl/src/schemas_impl/mod.rs
@@ -42,7 +42,7 @@ impl Schemas {
 pub(crate) struct SchemasInner {
     pub(crate) services: HashMap<String, ServiceSchemas>,
     pub(crate) deployments: HashMap<DeploymentId, DeploymentSchemas>,
-    pub(crate) subscriptions: HashMap<String, Subscription>,
+    pub(crate) subscriptions: HashMap<SubscriptionId, Subscription>,
     pub(crate) proto_symbols: ProtoSymbols,
 }
 

--- a/crates/schema-impl/src/subscriptions.rs
+++ b/crates/schema-impl/src/subscriptions.rs
@@ -13,11 +13,12 @@ use super::Schemas;
 use restate_schema_api::subscription::{
     ListSubscriptionFilter, Subscription, SubscriptionResolver,
 };
+use restate_types::identifiers::SubscriptionId;
 
 impl SubscriptionResolver for Schemas {
-    fn get_subscription(&self, id: &str) -> Option<Subscription> {
+    fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription> {
         let schemas = self.0.load();
-        schemas.subscriptions.get(id).cloned()
+        schemas.subscriptions.get(&id).cloned()
     }
 
     fn list_subscriptions(&self, filters: &[ListSubscriptionFilter]) -> Vec<Subscription> {

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -18,6 +18,7 @@ use num_traits::PrimInt;
 use crate::base62_util::{base62_encode_fixed_width, base62_max_length_for_type};
 use crate::errors::IdDecodeError;
 use crate::identifiers::ResourceId;
+use crate::macros::prefixed_ids;
 
 pub const ID_RESOURCE_SEPARATOR: char = '_';
 
@@ -35,12 +36,15 @@ pub enum IdSchemeVersion {
     V1,
 }
 
-/// The set of resources that we can generate IDs for. Those resource IDs will
-/// follow the same encoding scheme according to the [default] version.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum IdResourceType {
-    Invocation,
-    Deployment,
+prefixed_ids! {
+    /// The set of resources that we can generate IDs for. Those resource IDs will
+    /// follow the same encoding scheme according to the [default] version.
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    pub enum IdResourceType {
+        Invocation("inv"),
+        Deployment("dp"),
+        Subscription("sub"),
+    }
 }
 
 impl IdSchemeVersion {
@@ -62,28 +66,6 @@ impl FromStr for IdSchemeVersion {
     }
 }
 
-impl IdResourceType {
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Invocation => "inv",
-            Self::Deployment => "dp",
-        }
-    }
-}
-
-impl FromStr for IdResourceType {
-    type Err = IdDecodeError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "inv" => Ok(Self::Invocation),
-            "dp" => Ok(Self::Deployment),
-            _ => Err(IdDecodeError::UnrecognizedType(value.to_string())),
-        }
-    }
-}
-
-/// A deserialization helper for resource ID tokens that walks the base62 encoded
 /// strings and extracts the next encoded token and tracks the buffer offset.
 pub struct IdStrCursor<'a> {
     inner: &'a str,

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -41,9 +41,6 @@ pub type PartitionLeaderEpoch = (PartitionId, LeaderEpoch);
 // Just an alias
 pub type EntryIndex = u32;
 
-// Temporary
-pub type SubscriptionId = String;
-
 /// Unique Id of a deployment.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
 #[cfg_attr(
@@ -68,15 +65,27 @@ impl Default for DeploymentId {
     }
 }
 
-// Passthrough json schema to the string
-#[cfg(feature = "serde_schema")]
-impl schemars::JsonSchema for DeploymentId {
-    fn schema_name() -> String {
-        <String as schemars::JsonSchema>::schema_name()
+/// Unique Id of a subscription.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+pub struct SubscriptionId(pub(crate) Ulid);
+
+impl SubscriptionId {
+    pub fn new() -> Self {
+        Self(Ulid::new())
     }
 
-    fn json_schema(g: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <String as schemars::JsonSchema>::json_schema(g)
+    pub const fn from_parts(timestamp_ms: u64, random: u128) -> Self {
+        Self(Ulid::from_parts(timestamp_ms, random))
+    }
+}
+
+impl Default for SubscriptionId {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod base62_util;
 mod id_util;
+mod macros;
 
 pub mod deployment;
 pub mod errors;
@@ -21,4 +22,5 @@ pub mod journal;
 pub mod message;
 pub mod retries;
 pub mod state_mut;
+pub mod subscription;
 pub mod time;

--- a/crates/types/src/macros.rs
+++ b/crates/types/src/macros.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Helper macros for restate-types crate.
+
+// Helper macro to generate serialization primitives back and forth for id types with well-defined prefixes.
+macro_rules! prefixed_ids {
+    (
+    $(#[$m:meta])*
+    $type_vis:vis enum $typename:ident {
+        $(
+            $(#[$variant_meta:meta])*
+            $variant:ident($variant_prefix:literal),
+        )+
+    }
+    ) => {
+        #[allow(clippy::all)]
+        $(#[$m])*
+        $type_vis enum $typename {
+            $(
+                $(#[$variant_meta])*
+                $variant,
+            )+
+        }
+
+        #[automatically_derived]
+        impl $typename {
+            #[doc = "The prefix string for this identifier"]
+            pub const fn as_str(&self) -> &'static str {
+                match self {
+                    $(
+                        $typename::$variant => $variant_prefix,
+                    )+
+                }
+            }
+            pub fn iter() -> ::core::slice::Iter<'static, $typename> {
+                static VARIANTS: &'static [$typename] = &[
+                    $(
+                        $typename::$variant,
+                    )+
+                ];
+                VARIANTS.iter()
+            }
+        }
+
+
+        #[automatically_derived]
+        impl ::core::str::FromStr for $typename {
+            type Err = crate::errors::IdDecodeError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                match value {
+                    $(
+                        $variant_prefix => Ok($typename::$variant),
+                    )+
+                    _ => Err(crate::errors::IdDecodeError::UnrecognizedType(value.to_string())),
+                }
+            }
+        }
+
+    };
+}
+
+pub(crate) use prefixed_ids;

--- a/crates/worker-api/src/lib.rs
+++ b/crates/worker-api/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use restate_schema_api::subscription::{Subscription, SubscriptionValidator};
+use restate_types::identifiers::SubscriptionId;
 use restate_types::invocation::InvocationTermination;
 use restate_types::state_mut::ExternalStateMutation;
 use std::future::Future;
@@ -28,7 +29,7 @@ pub trait SubscriptionController: SubscriptionValidator {
     ) -> impl Future<Output = Result<(), Error>> + Send;
     fn stop_subscription(
         &self,
-        subscription_id: String,
+        id: SubscriptionId,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 }
 

--- a/crates/worker/src/subscription_integration.rs
+++ b/crates/worker/src/subscription_integration.rs
@@ -10,6 +10,7 @@
 
 use restate_ingress_kafka::SubscriptionCommandSender;
 use restate_schema_api::subscription::{Subscription, SubscriptionValidator};
+use restate_types::identifiers::SubscriptionId;
 use restate_worker_api::SubscriptionController;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -50,14 +51,9 @@ impl SubscriptionController for SubscriptionControllerHandle {
             .map_err(|_| restate_worker_api::Error::Unreachable)
     }
 
-    async fn stop_subscription(
-        &self,
-        subscription_id: String,
-    ) -> Result<(), restate_worker_api::Error> {
+    async fn stop_subscription(&self, id: SubscriptionId) -> Result<(), restate_worker_api::Error> {
         self.1
-            .send(restate_ingress_kafka::Command::StopSubscription(
-                subscription_id,
-            ))
+            .send(restate_ingress_kafka::Command::StopSubscription(id))
             .await
             .map_err(|_| restate_worker_api::Error::Unreachable)
     }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -11,6 +11,7 @@
 use anyhow::bail;
 use reqwest::header::ACCEPT;
 use restate_schema_api::subscription::Subscription;
+use restate_types::identifiers::SubscriptionId;
 use restate_types::invocation::InvocationTermination;
 use restate_types::retries::RetryPolicy;
 use restate_types::state_mut::ExternalStateMutation;
@@ -63,7 +64,7 @@ impl restate_worker_api::SubscriptionController for Mock {
         Ok(())
     }
 
-    async fn stop_subscription(&self, _: String) -> Result<(), restate_worker_api::Error> {
+    async fn stop_subscription(&self, _: SubscriptionId) -> Result<(), restate_worker_api::Error> {
         Ok(())
     }
 }


### PR DESCRIPTION
Subscription ID to follow resource ID scheme

This introduces a formal format for subscription IDs and moves everything to use the `SubscriptionId` newtype (implements ResourceId)

An example subscription id: `sub_15VqmTOnXH3Vv2pl5HOG7Ua` which follows the same scheme.

The most notable change is that we now don't accept `id` from the user when creating subscriptions.

Closes #1117

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1119).
* #1121
* #1120
* __->__ #1119