### PR TITLE
Awakeable ID versioning

### DIFF
--- a/cli/src/ui/invocations.rs
+++ b/cli/src/ui/invocations.rs
@@ -263,7 +263,7 @@ pub fn format_entry_type_details(entry_type: &JournalEntryType) -> String {
             )
         }
         JournalEntryType::Awakeable(awakeable_id) => {
-            format!("{}", style(awakeable_id.encode()).cyan())
+            format!("{}", style(awakeable_id.to_string()).cyan())
         }
         _ => String::new(),
     }

--- a/crates/service-protocol/src/awakeable_id.rs
+++ b/crates/service-protocol/src/awakeable_id.rs
@@ -11,9 +11,11 @@
 use base64::Engine as _;
 use bytes::{BufMut, BytesMut};
 use restate_types::errors::IdDecodeError;
-use restate_types::identifiers::{EncodedInvocationId, EntryIndex, InvocationId};
+use restate_types::identifiers::{EncodedInvocationId, EntryIndex, InvocationId, ResourceId};
+use restate_types::{IdDecoder, IdEncoder, IdResourceType};
 use std::fmt::Display;
 use std::mem::size_of;
+use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub struct AwakeableIdentifier {
@@ -21,14 +23,21 @@ pub struct AwakeableIdentifier {
     entry_index: EntryIndex,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("cannot parse the awakeable id, bad length")]
-    BadLength,
-    #[error("cannot parse the invocation id within the awakeable id: {0}")]
-    BadInvocationId(#[from] IdDecodeError),
-    #[error("cannot parse the awakeable identifier id encoded as base64: {0}")]
-    Base64(#[from] base64::DecodeError),
+impl ResourceId for AwakeableIdentifier {
+    const SIZE_IN_BYTES: usize = InvocationId::SIZE_IN_BYTES + size_of::<EntryIndex>();
+    const RESOURCE_TYPE: IdResourceType = IdResourceType::Awakeable;
+    const STRING_CAPACITY_HINT: usize = 0; /* Not needed since encoding is custom */
+
+    /// We use a custom strategy for awakeable identifiers since they need to be encoded as base64
+    /// for wider language support.
+    fn push_contents_to_encoder(&self, encoder: &mut IdEncoder<Self>) {
+        let mut input_buf =
+            BytesMut::with_capacity(size_of::<EncodedInvocationId>() + size_of::<EntryIndex>());
+        input_buf.put_slice(&self.invocation_id.to_bytes());
+        input_buf.put_u32(self.entry_index);
+        let encoded_base64 = restate_base64_util::URL_SAFE.encode(input_buf.freeze());
+        encoder.push_str(encoded_base64);
+    }
 }
 
 impl AwakeableIdentifier {
@@ -39,41 +48,51 @@ impl AwakeableIdentifier {
         }
     }
 
-    pub fn decode<T: AsRef<[u8]>>(id: T) -> Result<Self, Error> {
-        let buffer = restate_base64_util::URL_SAFE.decode(id)?;
+    pub fn into_inner(self) -> (InvocationId, EntryIndex) {
+        (self.invocation_id, self.entry_index)
+    }
+}
+
+impl FromStr for AwakeableIdentifier {
+    type Err = IdDecodeError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let decoder = IdDecoder::new(input)?;
+        // Ensure we are decoding the right type
+        if decoder.resource_type != Self::RESOURCE_TYPE {
+            return Err(IdDecodeError::TypeMismatch);
+        }
+        let remaining = decoder.cursor.take_remaining()?;
+
+        let buffer = restate_base64_util::URL_SAFE
+            .decode(remaining)
+            .map_err(|_| IdDecodeError::Codec)?;
+
         if buffer.len() != size_of::<EncodedInvocationId>() + size_of::<EntryIndex>() {
-            return Err(Error::BadLength);
+            return Err(IdDecodeError::Length);
         }
 
         let invocation_id: InvocationId =
             InvocationId::from_slice(&buffer[..size_of::<EncodedInvocationId>()])?;
-
-        let mut encoded_entry_index: [u8; size_of::<EntryIndex>()] = Default::default();
-        encoded_entry_index.copy_from_slice(&buffer[size_of::<EncodedInvocationId>()..]);
-        let entry_index = EntryIndex::from_be_bytes(encoded_entry_index);
+        let entry_index = EntryIndex::from_be_bytes(
+            buffer[size_of::<EncodedInvocationId>()..]
+                .try_into()
+                // Unwrap is safe because we check the size above.
+                .unwrap(),
+        );
 
         Ok(Self {
             invocation_id,
             entry_index,
         })
     }
-
-    pub fn encode(&self) -> String {
-        let mut input_buf =
-            BytesMut::with_capacity(size_of::<EncodedInvocationId>() + size_of::<EntryIndex>());
-        input_buf.put_slice(&self.invocation_id.to_bytes());
-        input_buf.put_u32(self.entry_index);
-        restate_base64_util::URL_SAFE.encode(input_buf.freeze())
-    }
-
-    pub fn into_inner(self) -> (InvocationId, EntryIndex) {
-        (self.invocation_id, self.entry_index)
-    }
 }
 
 impl Display for AwakeableIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.encode())
+        let mut encoder = IdEncoder::<Self>::new();
+        self.push_contents_to_encoder(&mut encoder);
+        std::fmt::Display::fmt(&encoder.finalize(), f)
     }
 }
 
@@ -92,9 +111,10 @@ mod tests {
             invocation_id: expected_invocation_id.clone(),
             entry_index: expected_entry_index,
         }
-        .encode();
+        .to_string();
+        dbg!(&input_str);
 
-        let actual = AwakeableIdentifier::decode(input_str).unwrap();
+        let actual = AwakeableIdentifier::from_str(&input_str).unwrap();
         let (actual_invocation_id, actual_entry_index) = actual.into_inner();
 
         assert_eq!(expected_invocation_id, actual_invocation_id);

--- a/crates/service-protocol/src/codec.rs
+++ b/crates/service-protocol/src/codec.rs
@@ -117,6 +117,8 @@ impl RawEntryCodec for ProtobufRawEntryCodec {
 
 #[cfg(feature = "mocks")]
 mod mocks {
+    use std::str::FromStr;
+
     use super::*;
 
     use crate::awakeable_id::AwakeableIdentifier;
@@ -253,8 +255,9 @@ mod mocks {
                     Self::serialize_poll_input_stream_entry(entry),
                 ),
                 Entry::CompleteAwakeable(entry) => {
-                    let (invocation_id, entry_index) =
-                        AwakeableIdentifier::decode(&entry.id).unwrap().into_inner();
+                    let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&entry.id)
+                        .unwrap()
+                        .into_inner();
 
                     EnrichedRawEntry::new(
                         EnrichedEntryHeader::CompleteAwakeable {

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -44,6 +44,7 @@ prefixed_ids! {
         Invocation("inv"),
         Deployment("dp"),
         Subscription("sub"),
+        Awakeable("prom"),
     }
 }
 
@@ -112,6 +113,12 @@ impl<'a> IdStrCursor<'a> {
             .get(self.offset..self.offset + length)
             .ok_or(IdDecodeError::Length)?;
         self.offset += length;
+        Ok(out)
+    }
+
+    /// Reads remaining bytes as string slice without decoding
+    pub fn take_remaining(self) -> Result<&'a str, IdDecodeError> {
+        let out = self.inner.get(self.offset..).ok_or(IdDecodeError::Length)?;
         Ok(out)
     }
 
@@ -207,6 +214,14 @@ impl<T: ResourceId + ?Sized> IdEncoder<T> {
     /// Estimates the capacity of string buffer needed to encode this ResourceId
     pub const fn estimate_buf_capacity() -> usize {
         T::RESOURCE_TYPE.as_str().len() + /* separator =*/1 + /* version =*/ 1 + T::STRING_CAPACITY_HINT
+    }
+
+    /// Adds the given string to the end of the buffer
+    pub fn push_str<S>(&mut self, i: S)
+    where
+        S: AsRef<str>,
+    {
+        self.buf.push_str(i.as_ref());
     }
 
     pub fn finalize(self) -> String {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -14,6 +14,8 @@ mod base62_util;
 mod id_util;
 mod macros;
 
+pub use id_util::{IdDecoder, IdEncoder, IdResourceType, IdStrCursor};
+
 pub mod deployment;
 pub mod errors;
 pub mod identifiers;

--- a/crates/worker/src/invoker_integration.rs
+++ b/crates/worker/src/invoker_integration.rs
@@ -22,6 +22,7 @@ use restate_types::journal::raw::{PlainEntryHeader, PlainRawEntry, RawEntry, Raw
 use restate_types::journal::{BackgroundInvokeEntry, CompleteAwakeableEntry, Entry, InvokeEntry};
 use restate_types::journal::{EntryType, InvokeRequest};
 use std::marker::PhantomData;
+use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub(super) struct EntryEnricher<KeyExtractor, Codec> {
@@ -161,7 +162,7 @@ where
                         .map_err(InvocationError::internal)?;
                 let_assert!(Entry::CompleteAwakeable(CompleteAwakeableEntry { id, .. }) = entry);
 
-                let (invocation_id, entry_index) = AwakeableIdentifier::decode(id)
+                let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&id)
                     .map_err(|e| {
                         InvocationError::new(
                             UserErrorCode::InvalidArgument,

--- a/crates/worker/src/partition/services/deterministic/awakeables.rs
+++ b/crates/worker/src/partition/services/deterministic/awakeables.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::str::FromStr;
+
 use crate::partition::services::deterministic::*;
 
 use prost_reflect::ReflectMessage;
@@ -18,7 +20,7 @@ use restate_types::invocation::ResponseResult;
 
 impl AwakeablesBuiltInService for &mut ServiceInvoker<'_> {
     async fn resolve(&mut self, req: ResolveAwakeableRequest) -> Result<(), InvocationError> {
-        let (invocation_id, entry_index) = AwakeableIdentifier::decode(req.id)
+        let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&req.id)
             .map_err(|e| InvocationError::new(UserErrorCode::InvalidArgument, e.to_string()))?
             .into_inner();
 
@@ -46,7 +48,7 @@ impl AwakeablesBuiltInService for &mut ServiceInvoker<'_> {
     }
 
     async fn reject(&mut self, req: RejectAwakeableRequest) -> Result<(), InvocationError> {
-        let (invocation_id, entry_index) = AwakeableIdentifier::decode(req.id)
+        let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&req.id)
             .map_err(|e| InvocationError::new(UserErrorCode::InvalidArgument, e.to_string()))?
             .into_inner();
 

--- a/crates/worker/src/partition/services/non_deterministic/remote_context.rs
+++ b/crates/worker/src/partition/services/non_deterministic/remote_context.rs
@@ -46,6 +46,7 @@ use restate_types::journal::{
 use restate_types::journal::{Completion, CompletionResult};
 use serde::{Deserialize, Serialize};
 use std::iter;
+use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use tracing::{debug, instrument, trace, warn};
 
@@ -365,7 +366,7 @@ impl<'a, State: StateReader> InvocationContext<'a, State> {
                         .map_err(InvocationError::internal)?
                 );
 
-                let (invocation_id, entry_index) = AwakeableIdentifier::decode(id)
+                let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&id)
                     .map_err(InvocationError::internal)?
                     .into_inner();
 
@@ -2126,7 +2127,7 @@ mod tests {
 
         let (_, _, _, _, effects) = send_test(
             ProtobufRawEntryCodec::serialize(Entry::complete_awakeable(
-                awakeable_id.encode(),
+                awakeable_id.to_string(),
                 entry_result.clone(),
             ))
             .into(),

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -257,7 +257,7 @@ async fn awakeable_with_success() {
     let entry = ProtobufRawEntryCodec::serialize_enriched(Entry::CompleteAwakeable(
         CompleteAwakeableEntry {
             id: AwakeableIdentifier::new(sid_callee.clone().into(), 1)
-                .encode()
+                .to_string()
                 .into(),
             result: EntryResult::Success(Bytes::default()),
         },
@@ -312,7 +312,7 @@ async fn awakeable_with_failure() {
     let entry = ProtobufRawEntryCodec::serialize_enriched(Entry::CompleteAwakeable(
         CompleteAwakeableEntry {
             id: AwakeableIdentifier::new(sid_callee.clone().into(), 1)
-                .encode()
+                .to_string()
                 .into(),
             result: EntryResult::Failure(UserErrorCode::FailedPrecondition, "Some failure".into()),
         },


### PR DESCRIPTION
Awakeable ID versioning

Awakeable IDs have special encoding but the prefix now follows the standard `ResourceId` prefix formatting.
The ID is still base64 after the prefix (`prom_1` which includes the version)

Example for how the awakeable id looks like: `prom_1AAAAAAAAAFwBjUHUt83u10Ef50OZUpB9AAAAAg`


Note, this is breaking change and both Java and JavaScript SDKs will be updated accordingly
