### PR TITLE
[CLI] BackgroundInvoke icon fix

### DIFF
--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -203,7 +203,6 @@ impl JournalEntryType {
             self,
             JournalEntryType::Sleep { .. }
                 | JournalEntryType::Invoke(_)
-                | JournalEntryType::BackgroundInvoke(_)
                 | JournalEntryType::Awakeable(_)
                 | JournalEntryType::GetState
         )


### PR DESCRIPTION
[CLI] BackgroundInvoke icon fix

At the moment, the CLI shows the Background invoke with "paused" icon, background invoke is a non-completable entry and it should appear as "done" when it's journalled.
