### PR TITLE
Make the worker role optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,6 +5235,7 @@ dependencies = [
  "codederror",
  "derive_builder",
  "drain",
+ "enumset",
  "futures",
  "http",
  "restate-admin",
@@ -5248,9 +5249,11 @@ dependencies = [
  "restate-worker",
  "schemars",
  "serde",
+ "serde_with",
  "thiserror",
  "tokio",
  "tonic 0.10.2",
+ "tower",
  "tracing",
 ]
 
@@ -5405,6 +5408,7 @@ dependencies = [
  "codederror",
  "derive_builder",
  "drain",
+ "enumset",
  "figment",
  "futures-util",
  "humantime",

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -15,14 +15,13 @@ use futures_util::{future, TryFutureExt};
 use hyper::header::CONTENT_TYPE;
 use hyper::{Body, Uri};
 use pprof::flamegraph::Options;
-use restate_node::{ClusterControllerLocation, Node};
+use restate_node::Node;
 use restate_node::{
     MetaOptionsBuilder, NodeOptionsBuilder, RocksdbOptionsBuilder, WorkerOptionsBuilder,
 };
 use restate_server::config::ConfigurationBuilder;
 use restate_server::Configuration;
 use restate_types::retries::RetryPolicy;
-use restate_types::PlainNodeId;
 use std::time::Duration;
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
@@ -72,12 +71,7 @@ pub fn spawn_restate(
     let (signal, drain) = drain::channel();
 
     let node_handle = rt.block_on(async move {
-        let node = Node::new(
-            PlainNodeId::from(1),
-            ClusterControllerLocation::Local,
-            config.node,
-        )
-        .expect("Restate node must build");
+        let node = Node::new(config.node).expect("Restate node must build");
         tokio::task::spawn(node.run(drain))
     });
 

--- a/crates/node-ctrl-proto/build.rs
+++ b/crates/node-ctrl-proto/build.rs
@@ -29,5 +29,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &["./proto/cluster_controller.proto"],
             &["proto", "../pb/proto"],
         )?;
+
+    tonic_build::configure()
+        .bytes(["."])
+        .file_descriptor_set_path(out_dir.join("worker_descriptor.bin"))
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&["./proto/worker.proto"], &["proto", "../pb/proto"])?;
     Ok(())
 }

--- a/crates/node-ctrl-proto/proto/node_ctrl.proto
+++ b/crates/node-ctrl-proto/proto/node_ctrl.proto
@@ -1,3 +1,12 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -16,12 +25,6 @@ enum NodeStatus {
 service NodeCtrl {
   // Get identity information from this node.
   rpc GetIdent(google.protobuf.Empty) returns (IdentResponse);
-  // Get the current known version of bifrost metadata on this node
-  rpc GetBifrostVersion(google.protobuf.Empty) returns (BifrostVersion);
-}
-
-message BifrostVersion {
-  uint64 version = 1;
 }
 
 message IdentResponse {

--- a/crates/node-ctrl-proto/proto/worker.proto
+++ b/crates/node-ctrl-proto/proto/worker.proto
@@ -9,20 +9,15 @@
 
 syntax = "proto3";
 
-import "dev/restate/common/common.proto";
+import "google/protobuf/empty.proto";
 
-package dev.restate.cluster_controller;
+package dev.restate.worker;
 
-service ClusterController {
-  // Attach node at cluster controller
-  rpc AttachNode(AttachmentRequest) returns (AttachmentResponse);
+service Worker {
+  // Get the current known version of bifrost metadata on this node
+  rpc GetBifrostVersion(google.protobuf.Empty) returns (BifrostVersion);
 }
 
-message AttachmentRequest {
-  dev.restate.common.NodeId node_id = 1;
+message BifrostVersion {
+  uint64 version = 1;
 }
-
-message AttachmentResponse {
-}
-
-

--- a/crates/node-ctrl-proto/src/lib.rs
+++ b/crates/node-ctrl-proto/src/lib.rs
@@ -31,3 +31,13 @@ pub mod cluster_controller {
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("cluster_controller_descriptor");
 }
+
+pub mod worker {
+    #![allow(warnings)]
+    #![allow(clippy::all)]
+    #![allow(unknown_lints)]
+
+    tonic::include_proto!("dev.restate.worker");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("worker_descriptor");
+}

--- a/crates/node-ctrl/src/handler/mod.rs
+++ b/crates/node-ctrl/src/handler/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod cluster_controller;
 pub mod node_ctrl;
+pub mod worker;
 
 use std::fmt::Write;
 use std::iter::once;

--- a/crates/node-ctrl/src/handler/node_ctrl.rs
+++ b/crates/node-ctrl/src/handler/node_ctrl.rs
@@ -8,20 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::state::HandlerState;
 use restate_node_ctrl_proto::node_ctrl::node_ctrl_server::NodeCtrl;
-use restate_node_ctrl_proto::node_ctrl::{BifrostVersion, IdentResponse, NodeStatus};
+use restate_node_ctrl_proto::node_ctrl::{IdentResponse, NodeStatus};
 use tonic::{Request, Response, Status};
 
 // -- GRPC Service Handlers --
-pub struct NodeCtrlHandler {
-    #[allow(dead_code)]
-    state: HandlerState,
-}
+pub struct NodeCtrlHandler {}
 
 impl NodeCtrlHandler {
-    pub fn new(state: HandlerState) -> Self {
-        Self { state }
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
@@ -31,16 +27,6 @@ impl NodeCtrl for NodeCtrlHandler {
         // STUB IMPLEMENTATION
         return Ok(Response::new(IdentResponse {
             status: NodeStatus::Alive.into(),
-        }));
-    }
-
-    async fn get_bifrost_version(
-        &self,
-        _request: Request<()>,
-    ) -> Result<Response<BifrostVersion>, Status> {
-        let version = self.state.bifrost.metadata_version();
-        return Ok(Response::new(BifrostVersion {
-            version: version.into(),
         }));
     }
 }

--- a/crates/node-ctrl/src/handler/worker.rs
+++ b/crates/node-ctrl/src/handler/worker.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_bifrost::Bifrost;
+use restate_node_ctrl_proto::worker::worker_server::Worker;
+use restate_node_ctrl_proto::worker::BifrostVersion;
+use tonic::{Request, Response, Status};
+
+// -- GRPC Service Handlers --
+pub struct WorkerHandler {
+    bifrost: Bifrost,
+}
+
+impl WorkerHandler {
+    pub fn new(bifrost: Bifrost) -> Self {
+        Self { bifrost }
+    }
+}
+
+#[async_trait::async_trait]
+impl Worker for WorkerHandler {
+    async fn get_bifrost_version(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<BifrostVersion>, Status> {
+        let version = self.bifrost.metadata_version();
+        return Ok(Response::new(BifrostVersion {
+            version: version.into(),
+        }));
+    }
+}

--- a/crates/node-ctrl/src/options.rs
+++ b/crates/node-ctrl/src/options.rs
@@ -52,10 +52,9 @@ impl Default for Options {
 impl Options {
     pub fn build(
         self,
-        rocksdb_storage: Option<RocksDBStorage>,
-        bifrost: Bifrost,
+        worker: Option<(RocksDBStorage, Bifrost)>,
         cluster_controller: Option<ClusterControllerHandle>,
     ) -> NodeCtrlService {
-        NodeCtrlService::new(self, rocksdb_storage, bifrost, cluster_controller)
+        NodeCtrlService::new(self, worker, cluster_controller)
     }
 }

--- a/crates/node-ctrl/src/state.rs
+++ b/crates/node-ctrl/src/state.rs
@@ -9,12 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use metrics_exporter_prometheus::PrometheusHandle;
-use restate_bifrost::Bifrost;
 use restate_storage_rocksdb::RocksDBStorage;
 
 #[derive(Clone, derive_builder::Builder)]
 pub struct HandlerState {
+    #[builder(default)]
     pub prometheus_handle: Option<PrometheusHandle>,
+    #[builder(default)]
     pub rocksdb_storage: Option<RocksDBStorage>,
-    pub bifrost: Bifrost,
 }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -32,11 +32,14 @@ restate-worker = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
+enumset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_with = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }

--- a/crates/node/src/options.rs
+++ b/crates/node/src/options.rs
@@ -8,17 +8,50 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use enumset::EnumSet;
+use restate_types::nodes_config::{NetworkAddress, Role};
+use restate_types::PlainNodeId;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, derive_builder::Builder)]
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "options_schema", schemars(default))]
 #[builder(default)]
 pub struct Options {
+    pub node_id: PlainNodeId,
+
     pub meta: restate_meta::Options,
     pub worker: restate_worker::Options,
     pub node_ctrl: restate_node_ctrl::Options,
     pub admin: restate_admin::Options,
     pub bifrost: restate_bifrost::Options,
     pub cluster_controller: restate_cluster_controller::Options,
+
+    /// Defines the roles which this Restate node should run
+    #[cfg_attr(feature = "options_schema", schemars(with = "Vec<String>"))]
+    pub roles: EnumSet<Role>,
+
+    /// Configures the cluster controller address. If it is not specified, then this
+    /// node needs to run the cluster controller
+    #[serde_as(as = "serde_with::NoneAsEmptyString")]
+    #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
+    pub cluster_controller_address: Option<NetworkAddress>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            node_id: PlainNodeId::from(1),
+            meta: Default::default(),
+            worker: Default::default(),
+            node_ctrl: Default::default(),
+            admin: Default::default(),
+            bifrost: Default::default(),
+            cluster_controller: Default::default(),
+            roles: Role::Worker | Role::ClusterController,
+            cluster_controller_address: None,
+        }
+    }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -39,6 +39,7 @@ clap = { version = "4.1", features = ["derive", "env"] }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
+enumset = { workspace = true }
 figment = { version = "0.10.8", features = ["env", "yaml"] }
 futures-util = { workspace = true }
 humantime = { workspace = true }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -138,7 +138,7 @@ fn main() {
             config.node.worker.storage_path().into()
         ).await.expect("Error when trying to wipe the configured storage path");
 
-        let node = Node::new(config.node_id, config.cluster_controller_endpoint.into(), config.node);
+        let node = Node::new(config.node);
 
         if let Err(err) = node {
             handle_error(err);


### PR DESCRIPTION
This commit changes the Node implementation to make the worker role optional. This also includes the node-ctrl service which can run a worker grpc service if the worker role is configured. If a node does not run the cluster controller role locally, then one needs to configure it with a cluster_controller_address.