### PR TITLE
Partition Table is not async and routing is based on partition id

### DIFF
--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [features]
 options_schema = ["dep:schemars"]
+memory_loglet = []
 
 [dependencies]
 restate-types = { workspace = true }

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -17,6 +17,8 @@ use std::sync::{Arc, Mutex};
 
 use enum_map::EnumMap;
 use once_cell::sync::OnceCell;
+#[cfg(any(test, feature = "memory_loglet"))]
+use tokio::task::JoinHandle;
 
 use restate_types::logs::{LogId, LogsVersion, Lsn, Payload, SequenceNumber};
 
@@ -39,6 +41,24 @@ pub struct Bifrost {
 impl Bifrost {
     pub(crate) fn new(inner: Arc<BifrostInner>) -> Self {
         Self { inner }
+    }
+
+    #[cfg(any(test, feature = "memory_loglet"))]
+    pub async fn new_in_memory(
+        num_logs: u64,
+        shutdown_watch: drain::Watch,
+    ) -> (Self, JoinHandle<Result<(), Error>>) {
+        let bifrost_svc = Options::memory().build(num_logs);
+        let bifrost = bifrost_svc.handle();
+
+        // start bifrost service in the background
+        (
+            bifrost,
+            bifrost_svc
+                .start(shutdown_watch)
+                .await
+                .expect("in memory loglet must start"),
+        )
     }
 
     /// Appends a single record to a log. The log id must exist, otherwise the
@@ -70,7 +90,7 @@ impl Bifrost {
         LogReadStream::new(self.inner.clone(), log_id, after)
     }
 
-    /// Finds the current readable tail LSN of a log.  
+    /// Finds the current readable tail LSN of a log.
     /// Returns `None` if there are no readable records in the log (e.g. trimmed or empty)
     pub async fn find_tail(
         &self,
@@ -261,17 +281,10 @@ mod tests {
         // start a simple bifrost service with 5 logs.
         let num_partitions = 5;
         let (shutdown_signal, shutdown_watch) = drain::channel();
+        let (mut bifrost, svc_handle) =
+            Bifrost::new_in_memory(num_partitions, shutdown_watch).await;
 
-        let bifrost_opts = Options {
-            default_provider: ProviderKind::Memory,
-            ..Options::default()
-        };
-        let bifrost_svc = bifrost_opts.build(num_partitions);
-        let mut bifrost = bifrost_svc.handle();
         let mut clean_bifrost_clone = bifrost.clone();
-
-        // start bifrost service in the background
-        let svc_handle = bifrost_svc.start(shutdown_watch).await?;
 
         let mut max_lsn = Lsn::INVALID;
         for i in 1..=5 {

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -36,14 +36,14 @@ use crate::{Error, LogRecord, LsnExt, Options};
 pub enum ProviderKind {
     /// A file-backed loglet.
     File,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "memory_loglet"))]
     Memory,
 }
 
 pub fn provider_default_config(kind: ProviderKind) -> serde_json::Value {
     match kind {
         ProviderKind::File => crate::loglets::file_loglet::default_config(),
-        #[cfg(test)]
+        #[cfg(any(test, feature = "memory_loglet"))]
         ProviderKind::Memory => crate::loglets::memory_loglet::default_config(),
     }
 }
@@ -51,7 +51,7 @@ pub fn provider_default_config(kind: ProviderKind) -> serde_json::Value {
 pub fn create_provider(kind: ProviderKind, options: &Options) -> Arc<dyn LogletProvider> {
     match kind {
         ProviderKind::File => crate::loglets::file_loglet::FileLogletProvider::new(options),
-        #[cfg(test)]
+        #[cfg(any(test, feature = "memory_loglet"))]
         ProviderKind::Memory => crate::loglets::memory_loglet::MemoryLogletProvider::new(),
     }
 }

--- a/crates/bifrost/src/loglets/memory_loglet.rs
+++ b/crates/bifrost/src/loglets/memory_loglet.rs
@@ -35,6 +35,7 @@ pub struct MemoryLogletProvider {
     init_delay: Option<Duration>,
 }
 
+#[allow(dead_code)]
 impl MemoryLogletProvider {
     pub fn new() -> Arc<Self> {
         Arc::default()

--- a/crates/bifrost/src/loglets/mod.rs
+++ b/crates/bifrost/src/loglets/mod.rs
@@ -9,5 +9,5 @@
 // by the Apache License, Version 2.0.
 
 pub mod file_loglet;
-#[cfg(test)]
+#[cfg(any(test, feature = "memory_loglet"))]
 pub mod memory_loglet;

--- a/crates/bifrost/src/options.rs
+++ b/crates/bifrost/src/options.rs
@@ -48,4 +48,16 @@ impl Options {
     pub fn build(self, num_partitions: u64) -> BifrostService {
         BifrostService::new(self, num_partitions)
     }
+
+    #[cfg(any(test, feature = "memory_loglet"))]
+    pub fn memory() -> Self {
+        let mut providers_config = EnumMap::default();
+        let kind = ProviderKind::Memory;
+        providers_config[kind] = provider_default_config(kind);
+
+        Self {
+            default_provider: ProviderKind::Memory,
+            providers_config,
+        }
+    }
 }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -13,7 +13,7 @@ use crate::sender::StateMachineSender;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use restate_types::identifiers::{LeaderEpoch, PeerId};
-use restate_types::message::PeerTarget;
+use restate_types::message::PartitionTarget;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use tokio::sync::mpsc;
@@ -43,16 +43,16 @@ pub struct Consensus<Cmd> {
     cmd_logs: HashMap<PeerId, CommandLog<Cmd>>,
 
     /// Receiver of proposals from all associated state machines
-    proposal_rx: mpsc::Receiver<PeerTarget<Cmd>>,
+    proposal_rx: mpsc::Receiver<PartitionTarget<Cmd>>,
 
     /// Receiver of incoming raft messages
-    raft_rx: mpsc::Receiver<PeerTarget<Cmd>>,
+    raft_rx: mpsc::Receiver<PartitionTarget<Cmd>>,
 
     /// Sender for outgoing raft messages
-    _raft_tx: mpsc::Sender<PeerTarget<Cmd>>,
+    _raft_tx: mpsc::Sender<PartitionTarget<Cmd>>,
 
     // used to create the ProposalSenders
-    proposal_tx: mpsc::Sender<PeerTarget<Cmd>>,
+    proposal_tx: mpsc::Sender<PartitionTarget<Cmd>>,
 }
 
 impl<Cmd> Consensus<Cmd>
@@ -60,8 +60,8 @@ where
     Cmd: Debug + Send + Sync + 'static,
 {
     pub fn new(
-        raft_rx: mpsc::Receiver<PeerTarget<Cmd>>,
-        raft_tx: mpsc::Sender<PeerTarget<Cmd>>,
+        raft_rx: mpsc::Receiver<PartitionTarget<Cmd>>,
+        raft_tx: mpsc::Sender<PartitionTarget<Cmd>>,
         proposal_channel_size: usize,
     ) -> Self {
         let (proposal_tx, proposal_rx) = mpsc::channel(proposal_channel_size);
@@ -75,7 +75,7 @@ where
         }
     }
 
-    pub fn create_proposal_sender(&self) -> ProposalSender<PeerTarget<Cmd>> {
+    pub fn create_proposal_sender(&self) -> ProposalSender<PartitionTarget<Cmd>> {
         self.proposal_tx.clone()
     }
 

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use restate_errors::NotRunningError;
-use restate_types::identifiers::{PartitionKey, PeerId};
+use restate_types::identifiers::{PartitionId, PartitionKey, PeerId};
 use std::fmt::Debug;
 use std::future::Future;
 use tokio::sync::mpsc;
@@ -62,7 +62,7 @@ pub enum ConsensusOrIngressTarget<C, I> {
 pub trait TargetConsensusOrIngress<C, I> {
     /// Returns the target of a message. It can either be an ingress
     /// or the consensus module.
-    fn target(self) -> ConsensusOrIngressTarget<C, I>;
+    fn into_target(self) -> ConsensusOrIngressTarget<C, I>;
 }
 
 pub enum ConsensusOrShuffleTarget<C, S> {
@@ -74,7 +74,7 @@ pub enum ConsensusOrShuffleTarget<C, S> {
 pub trait TargetConsensusOrShuffle<C, S> {
     /// Returns the target of a message. It can either be the consensus module
     /// or a shuffle
-    fn target(self) -> ConsensusOrShuffleTarget<C, S>;
+    fn into_target(self) -> ConsensusOrShuffleTarget<C, S>;
 }
 
 /// Trait for messages that are sent to a shuffle component or an ingress
@@ -85,15 +85,16 @@ pub enum ShuffleOrIngressTarget<S, I> {
 
 pub trait TargetShuffleOrIngress<S, I> {
     /// Returns the target of a message. It can either be a shuffle or an ingress.
-    fn target(self) -> ShuffleOrIngressTarget<S, I>;
+    fn into_target(self) -> ShuffleOrIngressTarget<S, I>;
 }
 
 #[derive(Debug, thiserror::Error)]
 #[error("Cannot find target peer for partition key {0}")]
 pub struct PartitionTableError(PartitionKey);
 
-pub trait PartitionTable {
-    type Future: Future<Output = Result<PeerId, PartitionTableError>>;
-
-    fn partition_key_to_target_peer(&self, partition_key: PartitionKey) -> Self::Future;
+pub trait FindPartition {
+    fn find_partition_id(
+        &self,
+        partition_key: PartitionKey,
+    ) -> Result<PartitionId, PartitionTableError>;
 }

--- a/crates/network/src/routing/partition_processor.rs
+++ b/crates/network/src/routing/partition_processor.rs
@@ -58,7 +58,7 @@ where
 
     pub(super) async fn run(mut self) -> Result<(), PartitionProcessorRouterError<IngressMsg>> {
         while let Some(message) = self.receiver.recv().await {
-            match message.target() {
+            match message.into_target() {
                 ShuffleOrIngressTarget::Shuffle(msg) => {
                     send_to_shuffle(msg, &self.shuffle_txs).await
                 }

--- a/crates/types/src/message.rs
+++ b/crates/types/src/message.rs
@@ -10,10 +10,10 @@
 
 //! This module defines types used for the internal messaging between Restate components.
 
-use crate::identifiers::PeerId;
+use crate::identifiers::PartitionId;
 
 /// Wrapper that extends a message with its target peer to which the message should be sent.
-pub type PeerTarget<Msg> = (PeerId, Msg);
+pub type PartitionTarget<Msg> = (PartitionId, Msg);
 
 /// Index type used messages in the runtime
 pub type MessageIndex = u64;

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -33,7 +33,7 @@ use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_query_postgres::service::PostgresQueryService;
 use restate_storage_rocksdb::{RocksDBStorage, RocksDBWriter};
 use restate_types::identifiers::{PartitionKey, PeerId};
-use restate_types::message::PeerTarget;
+use restate_types::message::PartitionTarget;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::GenerationalNodeId;
 use std::ops::RangeInclusive;
@@ -87,7 +87,7 @@ pub use restate_storage_query_postgres::{
 
 type PartitionProcessorCommand = partition::StateMachineAckCommand;
 type ConsensusCommand = restate_consensus::Command<PartitionProcessorCommand>;
-type ConsensusMsg = PeerTarget<PartitionProcessorCommand>;
+type ConsensusMsg = PartitionTarget<PartitionProcessorCommand>;
 type PartitionProcessor = partition::PartitionProcessor<
     ProtobufRawEntryCodec,
     InvokerChannelServiceHandle,

--- a/crates/worker/src/network_integration.rs
+++ b/crates/worker/src/network_integration.rs
@@ -45,7 +45,7 @@ mod ingress_integration {
     impl TargetConsensusOrShuffle<IngressToConsensus, IngressToShuffle>
         for restate_ingress_dispatcher::IngressDispatcherOutput
     {
-        fn target(self) -> ConsensusOrShuffleTarget<IngressToConsensus, IngressToShuffle> {
+        fn into_target(self) -> ConsensusOrShuffleTarget<IngressToConsensus, IngressToShuffle> {
             match self {
                 restate_ingress_dispatcher::IngressDispatcherOutput::Invocation {
                     service_invocation,
@@ -213,7 +213,7 @@ mod shuffle_integration {
     }
 
     impl TargetConsensusOrIngress<ShuffleToConsensus, ShuffleToIngress> for shuffle::ShuffleOutput {
-        fn target(self) -> ConsensusOrIngressTarget<ShuffleToConsensus, ShuffleToIngress> {
+        fn into_target(self) -> ConsensusOrIngressTarget<ShuffleToConsensus, ShuffleToIngress> {
             let (shuffle_id, partition_id, msg_index, target) = self.into_inner();
 
             match target {
@@ -280,7 +280,7 @@ mod partition_integration {
             partition::StateMachineIngressAckResponse,
         > for partition::StateMachineAckResponse
     {
-        fn target(
+        fn into_target(
             self,
         ) -> ShuffleOrIngressTarget<
             partition::StateMachineShuffleDeduplicationResponse,

--- a/crates/worker/src/util.rs
+++ b/crates/worker/src/util.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use restate_types::identifiers::PeerId;
-use restate_types::message::PeerTarget;
+use restate_types::message::PartitionTarget;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
 
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::error::SendError;
 #[derive(Debug)]
 pub(super) struct IdentitySender<T> {
     id: PeerId,
-    sender: mpsc::Sender<PeerTarget<T>>,
+    sender: mpsc::Sender<PartitionTarget<T>>,
 }
 
 impl<T> Clone for IdentitySender<T> {
@@ -30,7 +30,7 @@ impl<T> Clone for IdentitySender<T> {
 }
 
 impl<T> IdentitySender<T> {
-    pub(super) fn new(id: PeerId, sender: mpsc::Sender<PeerTarget<T>>) -> Self {
+    pub(super) fn new(id: PeerId, sender: mpsc::Sender<PartitionTarget<T>>) -> Self {
         Self { id, sender }
     }
 


### PR DESCRIPTION
Partition Table is not async and routing is based on partition id

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1178).
* __->__ #1178
* #1177