### PR TITLE
Global access to my NodeId and NodesConfiguration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,6 +5664,7 @@ name = "restate-types"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "base62",
  "base64 0.21.7",
  "bytes",
@@ -5674,6 +5675,7 @@ dependencies = [
  "http",
  "humantime",
  "num-traits",
+ "once_cell",
  "opentelemetry_api",
  "rand",
  "restate-base64-util",

--- a/crates/node-services/proto/cluster_controller.proto
+++ b/crates/node-services/proto/cluster_controller.proto
@@ -19,10 +19,8 @@ service ClusterController {
 }
 
 message AttachmentRequest {
-  dev.restate.common.NodeId node_id = 1;
+  string node_name = 1;
+  optional dev.restate.common.NodeId node_id = 2;
 }
 
-message AttachmentResponse {
-}
-
-
+message AttachmentResponse {}

--- a/crates/node-services/proto/node_ctrl.proto
+++ b/crates/node-services/proto/node_ctrl.proto
@@ -10,6 +10,7 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
+import "dev/restate/common/common.proto";
 
 package dev.restate.node_ctrl;
 
@@ -29,6 +30,8 @@ service NodeCtrl {
 
 message IdentResponse {
   NodeStatus status = 1;
+  dev.restate.common.NodeId node_id = 2;
+  uint32 nodes_config_version = 3;
 }
 
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -14,13 +14,14 @@ mod server;
 
 use codederror::CodedError;
 use futures::TryFutureExt;
-use restate_types::{NodeId, PlainNodeId};
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{MyNodeIdWriter, NodeId, PlainNodeId};
 use std::time::Duration;
 use tokio::net::UnixStream;
 use tokio::task::{JoinError, JoinSet};
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
-use tracing::{info, instrument, warn};
+use tracing::{info, warn};
 
 use crate::roles::{ClusterControllerRole, WorkerRole};
 use crate::server::NodeServer;
@@ -29,7 +30,9 @@ pub use restate_admin::OptionsBuilder as AdminOptionsBuilder;
 pub use restate_meta::OptionsBuilder as MetaOptionsBuilder;
 use restate_node_services::cluster_controller::cluster_controller_client::ClusterControllerClient;
 use restate_node_services::cluster_controller::AttachmentRequest;
-use restate_types::nodes_config::{NetworkAddress, Role};
+use restate_types::nodes_config::{
+    NetworkAddress, NodeConfig, NodesConfiguration, NodesConfigurationWriter, Role,
+};
 use restate_types::retries::RetryPolicy;
 pub use restate_worker::{OptionsBuilder as WorkerOptionsBuilder, RocksdbOptionsBuilder};
 
@@ -78,7 +81,7 @@ pub enum BuildError {
 }
 
 pub struct Node {
-    node_id: PlainNodeId,
+    options: Options,
     cluster_controller_address: NetworkAddress,
 
     cluster_controller_role: Option<ClusterControllerRole>,
@@ -88,6 +91,7 @@ pub struct Node {
 
 impl Node {
     pub fn new(options: Options) -> Result<Self, BuildError> {
+        let opts = options.clone();
         let cluster_controller_role = if options.roles.contains(Role::ClusterController) {
             Some(ClusterControllerRole::try_from(options.clone()).expect("should be infallible"))
         } else {
@@ -125,7 +129,7 @@ impl Node {
         };
 
         Ok(Node {
-            node_id: options.node_id,
+            options: opts,
             cluster_controller_address,
             cluster_controller_role,
             worker_role,
@@ -133,7 +137,6 @@ impl Node {
         })
     }
 
-    #[instrument(level = "debug", skip_all, fields(node.id = %self.node_id))]
     pub async fn run(self, shutdown_watch: drain::Watch) -> Result<(), Error> {
         let shutdown_signal = shutdown_watch.signaled();
         tokio::pin!(shutdown_signal);
@@ -169,7 +172,7 @@ impl Node {
                 let component_name = component_result.map_err(Error::ComponentPanic)??;
                 panic!("Unexpected termination of '{component_name}'");
             }
-            attachment_result = Self::attach_node(self.node_id, self.cluster_controller_address) => {
+            attachment_result = Self::attach_node(self.options, self.cluster_controller_address) => {
                 attachment_result?
             }
         }
@@ -201,29 +204,63 @@ impl Node {
     }
 
     async fn attach_node(
-        node_id: PlainNodeId,
+        options: Options,
         cluster_controller_address: NetworkAddress,
     ) -> Result<(), Error> {
-        info!("Attach to cluster controller at '{cluster_controller_address}'");
+        info!(
+            "Attaching '{}' (insist on ID?={:?}) to cluster controller at '{cluster_controller_address}'",
+            options.node_name,
+            options.node_id,
+        );
 
         let channel = Self::create_channel_from_network_address(&cluster_controller_address)
             .map_err(Error::InvalidClusterControllerAddress)?;
 
         let cc_client = ClusterControllerClient::new(channel);
 
-        let node_id = NodeId::from(node_id);
-        RetryPolicy::exponential(Duration::from_millis(50), 2.0, 10, None)
+        let _response = RetryPolicy::exponential(Duration::from_millis(50), 2.0, 10, None)
             .retry_operation(|| async {
                 cc_client
                     .clone()
                     .attach_node(AttachmentRequest {
-                        node_id: Some(node_id.into()),
+                        node_id: options.node_id.map(Into::into),
+                        node_name: options.node_name.clone(),
                     })
                     .await
             })
             .await
             .map_err(|err| Error::Attachment(cluster_controller_address, err))?;
 
+        // todo: Generational NodeId should come from attachment result
+        let now = MillisSinceEpoch::now();
+        let my_node_id: NodeId = options
+            .node_id
+            .unwrap_or(PlainNodeId::from(1))
+            .with_generation(now.as_u64() as u32)
+            .into();
+        // We are attached, we can set our own NodeId.
+        MyNodeIdWriter::set_as_my_node_id(my_node_id);
+        info!(
+            "Node attached to cluster controller. My Node ID is {}",
+            my_node_id
+        );
+        // Temporary: nodes configuration from current node.
+        let mut nodes_config = NodesConfiguration::default();
+        let address: NetworkAddress = NetworkAddress::TcpSocketAddr(options.server.bind_address);
+        let node = NodeConfig::new(
+            options.node_name,
+            my_node_id
+                .as_generational()
+                .expect("my NodeId is generational"),
+            address,
+            options.roles,
+        );
+        nodes_config.upsert_node(node);
+        NodesConfigurationWriter::set_as_current_unconditional(nodes_config);
+        info!(
+            "Loaded nodes configuration version {}",
+            NodesConfiguration::current_version()
+        );
         Ok(())
     }
 

--- a/crates/node/src/options.rs
+++ b/crates/node/src/options.rs
@@ -21,7 +21,8 @@ use serde_with::serde_as;
 #[cfg_attr(feature = "options_schema", schemars(default))]
 #[builder(default)]
 pub struct Options {
-    pub node_id: PlainNodeId,
+    pub node_name: String,
+    pub node_id: Option<PlainNodeId>,
 
     pub meta: restate_meta::Options,
     pub worker: restate_worker::Options,
@@ -44,7 +45,8 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Options {
-            node_id: PlainNodeId::from(1),
+            node_name: "LocalNode".to_owned(),
+            node_id: None,
             meta: Default::default(),
             worker: Default::default(),
             server: Default::default(),

--- a/crates/node/src/server/handler/cluster_controller.rs
+++ b/crates/node/src/server/handler/cluster_controller.rs
@@ -10,7 +10,6 @@
 
 use restate_node_services::cluster_controller::cluster_controller_server::ClusterController;
 use restate_node_services::cluster_controller::{AttachmentRequest, AttachmentResponse};
-use restate_types::NodeId;
 use tonic::{async_trait, Request, Response, Status};
 use tracing::debug;
 
@@ -28,8 +27,8 @@ impl ClusterController for ClusterControllerHandler {
         &self,
         request: Request<AttachmentRequest>,
     ) -> Result<Response<AttachmentResponse>, Status> {
-        let node_id = request.into_inner().node_id.expect("node_id must be set");
-        debug!("Register node '{}'", NodeId::from(node_id));
+        let node_name = request.into_inner().node_name;
+        debug!("Register node '{}'", node_name);
         Ok(Response::new(AttachmentResponse {}))
     }
 }

--- a/crates/node/src/server/handler/node_ctrl.rs
+++ b/crates/node/src/server/handler/node_ctrl.rs
@@ -10,6 +10,8 @@
 
 use restate_node_services::node_ctrl::node_ctrl_server::NodeCtrl;
 use restate_node_services::node_ctrl::{IdentResponse, NodeStatus};
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::NodeId;
 use tonic::{Request, Response, Status};
 
 // -- GRPC Service Handlers --
@@ -27,6 +29,8 @@ impl NodeCtrl for NodeCtrlHandler {
         // STUB IMPLEMENTATION
         return Ok(Response::new(IdentResponse {
             status: NodeStatus::Alive.into(),
+            node_id: NodeId::my_node_node().map(Into::into),
+            nodes_config_version: NodesConfiguration::current_version().into(),
         }));
     }
 }

--- a/crates/pb/src/lib.rs
+++ b/crates/pb/src/lib.rs
@@ -84,6 +84,16 @@ pub mod restate {
                 }
             }
         }
+
+        impl From<restate_types::PlainNodeId> for NodeId {
+            fn from(node_id: restate_types::PlainNodeId) -> Self {
+                let id: u32 = node_id.into();
+                NodeId {
+                    id,
+                    generation: None,
+                }
+            }
+        }
     }
 }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -20,12 +20,14 @@ test-utils = []
 restate-base64-util = { workspace = true }
 
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 enumset = { workspace = true }
 http = { workspace = true }
 humantime = { workspace = true }
+once_cell = { workspace = true }
 opentelemetry_api = { workspace = true }
 rand = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }

--- a/crates/types/src/logs.rs
+++ b/crates/types/src/logs.rs
@@ -22,9 +22,8 @@ use bytes::Bytes;
     derive_more::Display,
     derive_more::From,
     derive_more::Into,
-    serde::Serialize,
-    serde::Deserialize,
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LogId(u64);
 
 /// Index of an entry in the log
@@ -45,13 +44,12 @@ impl LogId {
     Hash,
     Ord,
     PartialOrd,
-    serde::Serialize,
-    serde::Deserialize,
     derive_more::Into,
     derive_more::From,
     derive_more::Add,
     derive_more::Display,
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Lsn(u64);
 
 impl SequenceNumber for Lsn {
@@ -91,9 +89,8 @@ impl SequenceNumber for Lsn {
     derive_more::Display,
     derive_more::From,
     derive_more::Into,
-    serde::Serialize,
-    serde::Deserialize,
 )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[display(fmt = "v{}", _0)]
 pub struct LogsVersion(u64);
 

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -8,6 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#[cfg(test)]
+use arc_swap::ArcSwap;
+use std::sync::OnceLock;
+
+#[cfg(not(test))]
+static MY_NODE_ID: OnceLock<NodeId> = OnceLock::new();
+#[cfg(test)]
+static MY_NODE_ID: OnceLock<ArcSwap<NodeId>> = OnceLock::new();
+
 /// A generational node identifier. Nodes with the same ID but different generations
 /// represent the same node across different instances (restarts) of its lifetime.
 ///
@@ -45,12 +54,41 @@ pub struct GenerationalNodeId(PlainNodeId, u32);
 #[display(fmt = "N{}", _0)]
 pub struct PlainNodeId(#[cfg_attr(feature = "serde_schema", schemars(default))] u32);
 
+pub struct MyNodeIdWriter {}
+impl MyNodeIdWriter {
+    #[cfg(not(test))]
+    pub fn set_as_my_node_id(node_id: NodeId) {
+        debug_assert!(node_id.as_generational().is_some());
+        if let Err(e) = MY_NODE_ID.set(node_id) {
+            panic!("My NodeId can only be set once, it's already set to {}", e);
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_as_my_node_id(node_id: NodeId) {
+        use std::sync::Arc;
+
+        let n = MY_NODE_ID.get_or_init(|| ArcSwap::from_pointee(node_id));
+        n.store(Arc::new(node_id))
+    }
+}
+
 impl NodeId {
     pub fn new(id: u32, generation: Option<u32>) -> NodeId {
         match generation {
             Some(generation) => Self::new_generational(id, generation),
             None => Self::new_plain(id),
         }
+    }
+
+    #[cfg(not(test))]
+    pub fn my_node_node() -> Option<NodeId> {
+        MY_NODE_ID.get().copied()
+    }
+
+    #[cfg(test)]
+    pub fn my_node_node() -> Option<NodeId> {
+        MY_NODE_ID.get().map(|n| *n.load().as_ref())
     }
 
     pub fn new_plain(id: u32) -> NodeId {


### PR DESCRIPTION
Global access to my NodeId and NodesConfiguration

`NodeId::my_node_id()` and `NodesConfiguration::current()` / `NodesConfiguration::current_version()`
- Stubs out the creation of nodes configuration after attachment until we move that to cluster controller.
- Addeded nodes_config_id and my_node_id in GetIdent

Test Plan:
Tests + grpcurl

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1179).
* #1181
* __->__ #1179