### PR TITLE
Task Center init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -327,7 +327,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "lexical-core",
  "num",
  "serde",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -473,7 +473,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -484,7 +484,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1018,15 +1018,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.2"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -1155,14 +1155,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1254,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57f73ca21b17a0352944b9bb61803b6007bd911b6cccfef7153f7f0600ac495"
+checksum = "bb9b20c0dd58e4c2e991c8d203bbeb76c11304d1011659686b5b644bc29aa478"
 dependencies = [
  "clap",
  "log",
@@ -1274,34 +1274,34 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cling"
@@ -1327,11 +1327,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f3e4ed7569e1ca05aacf00701393267944971e284a0f9cca0014e7326ce3fa4"
 dependencies = [
- "darling 0.20.5",
+ "darling 0.20.6",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1535,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1736,12 +1736,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
 dependencies = [
- "darling_core 0.20.5",
- "darling_macro 0.20.5",
+ "darling_core 0.20.6",
+ "darling_macro 0.20.6",
 ]
 
 [[package]]
@@ -1754,22 +1754,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn 2.0.48",
+ "strsim 0.10.0",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1785,13 +1785,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
 dependencies = [
- "darling_core 0.20.5",
+ "darling_core 0.20.6",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "glob",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.12.1",
  "log",
  "num_cpus",
@@ -1951,7 +1951,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "hex",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.12.1",
  "log",
  "md-5",
@@ -1984,7 +1984,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itertools 0.12.1",
  "log",
  "once_cell",
@@ -2173,9 +2173,9 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encode_unicode"
@@ -2216,7 +2216,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2235,10 +2235,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.5",
+ "darling 0.20.6",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2259,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2270,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -2419,7 +2419,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2518,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005e4cb962c56efd249bdeeb4ac232b11e1c45a2e49793bba2b2982dcc3f2e9d"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2533,7 +2533,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -2556,15 +2556,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2597,9 +2588,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -2796,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2806,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
 dependencies = [
  "console",
  "instant",
@@ -2830,7 +2821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "is-terminal",
  "itoa",
  "log",
@@ -2889,12 +2880,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -3225,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b9e10a211c839210fd7f99954bda26e5f8e26ec686ad68da6a32df7c80e782"
+checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -3235,13 +3226,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a4c4718a371ddfb7806378f23617876eea8b82e5ff1324516bcd283249d9ea"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
  "hyper",
- "indexmap 1.9.3",
+ "indexmap 2.2.3",
  "metrics",
  "metrics-util",
  "quanta",
@@ -3255,7 +3246,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -3268,15 +3259,15 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2670b8badcc285d486261e2e9f1615b506baff91427b61bd336a472b65bbf5ed"
+checksum = "ece71ab046dcf45604e573329966ec1db5ff4b81cfa170a924ff4c959ab5451a"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.13.1",
- "indexmap 1.9.3",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.3",
  "metrics",
  "num_cpus",
  "ordered-float 4.2.0",
@@ -3541,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
@@ -3969,7 +3960,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4005,7 +3996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -4091,7 +4082,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4108,9 +4099,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
@@ -4227,7 +4218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4291,7 +4282,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
@@ -4333,7 +4324,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.49",
  "tempfile",
  "which",
 ]
@@ -4361,7 +4352,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4635,6 +4626,7 @@ dependencies = [
 name = "restate-admin"
 version = "0.8.0"
 dependencies = [
+ "anyhow",
  "arrow-flight",
  "axum",
  "bincode",
@@ -4702,6 +4694,7 @@ dependencies = [
  "rand",
  "restate-node",
  "restate-server",
+ "restate-task-center",
  "restate-types",
  "serde_json",
  "tempfile",
@@ -4795,6 +4788,7 @@ dependencies = [
 name = "restate-cluster-controller"
 version = "0.8.0"
 dependencies = [
+ "anyhow",
  "codederror",
  "derive_builder",
  "drain",
@@ -5093,6 +5087,7 @@ dependencies = [
 name = "restate-node"
 version = "0.8.0"
 dependencies = [
+ "anyhow",
  "arrow-flight",
  "async-trait",
  "axum",
@@ -5103,6 +5098,7 @@ dependencies = [
  "drain",
  "enumset",
  "futures",
+ "googletest",
  "http 0.2.11",
  "humantime",
  "hyper",
@@ -5120,6 +5116,8 @@ dependencies = [
  "restate-schema-impl",
  "restate-storage-query-datafusion",
  "restate-storage-rocksdb",
+ "restate-task-center",
+ "restate-test-util",
  "restate-types",
  "restate-worker",
  "restate-worker-api",
@@ -5128,13 +5126,17 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "test-log",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic 0.10.2",
  "tonic-reflection",
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -5264,6 +5266,7 @@ dependencies = [
  "restate-meta",
  "restate-node",
  "restate-storage-rocksdb",
+ "restate-task-center",
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-worker",
@@ -5274,6 +5277,7 @@ dependencies = [
  "thiserror",
  "tikv-jemallocator",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-panic",
  "vergen",
@@ -5461,6 +5465,28 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "restate-task-center"
+version = "0.8.0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "futures",
+ "googletest",
+ "restate-test-util",
+ "restate-types",
+ "static_assertions",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
+ "test-log",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -5936,7 +5962,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6005,10 +6031,10 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.5",
+ "darling 0.20.6",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6017,7 +6043,7 @@ version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -6240,7 +6266,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6279,6 +6305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6303,7 +6335,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6316,7 +6348,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6361,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6460,27 +6492,27 @@ checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6636,7 +6668,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6686,7 +6718,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
@@ -6756,7 +6788,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -6865,7 +6897,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -7192,7 +7224,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-shared",
 ]
 
@@ -7226,7 +7258,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7449,9 +7481,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -7556,7 +7588,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ restate-admin = { path = "crates/admin" }
 restate-base64-util = { path = "crates/base64-util" }
 restate-benchmarks = { path = "crates/benchmarks" }
 restate-bifrost = { path = "crates/bifrost" }
+restate-cluster-controller = { path = "crates/cluster-controller" }
 restate-consensus = { path = "crates/consensus" }
 restate-errors = { path = "crates/errors" }
 restate-fs-util = { path = "crates/fs-util" }
 restate-futures-util = { path = "crates/futures-util" }
-restate-cluster-controller = { path = "crates/cluster-controller" }
 restate-ingress-dispatcher = { path = "crates/ingress-dispatcher" }
 restate-ingress-grpc = { path = "crates/ingress-grpc" }
 restate-ingress-kafka = { path = "crates/ingress-kafka" }
@@ -60,6 +60,7 @@ restate-storage-proto = { path = "crates/storage-proto" }
 restate-storage-query-datafusion = { path = "crates/storage-query-datafusion" }
 restate-storage-query-postgres = { path = "crates/storage-query-postgres" }
 restate-storage-rocksdb = { path = "crates/storage-rocksdb" }
+restate-task-center = { path = "crates/task-center" }
 restate-test-util = { path = "crates/test-util" }
 restate-timer = { path = "crates/timer" }
 restate-timer-queue = { path = "crates/timer-queue" }
@@ -143,6 +144,7 @@ tower-http = { version = "0.4", default-features = false }
 tracing = "0.1"
 tracing-opentelemetry = { version = "0.21.0" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-test = { version = "0.2.4" }
 ulid = { version = "1.1.0" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -27,6 +27,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-types = { workspace = true, features = ["serde", "serde_schema"] }
 restate-worker-api = { workspace = true }
 
+anyhow = { workspace = true }
 arrow-flight = { workspace = true }
 axum = { workspace = true }
 bincode = { workspace = true }

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -52,7 +52,7 @@ impl AdminService {
         drain: drain::Watch,
         worker_handle: impl restate_worker_api::Handle + Clone + Send + Sync + 'static,
         worker_svc_client: WorkerSvcClient<Channel>,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         let rest_state = state::AdminServiceState::new(
             self.meta_handle,
             self.schemas,
@@ -93,9 +93,9 @@ impl AdminService {
         );
 
         // Wait server graceful shutdown
-        server
+        Ok(server
             .with_graceful_shutdown(drain.signaled().map(|_| ()))
             .await
-            .map_err(Error::Running)
+            .map_err(Error::Running)?)
     }
 }

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -14,6 +14,7 @@ frame-pointer = ["pprof/frame-pointer"]
 [dependencies]
 restate-node = { workspace = true }
 restate-server = { workspace = true }
+restate-task-center = { workspace = true }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/benchmarks/benches/throughput_parallel.rs
+++ b/crates/benchmarks/benches/throughput_parallel.rs
@@ -25,7 +25,7 @@ use tonic::transport::Channel;
 
 fn throughput_benchmark(criterion: &mut Criterion) {
     let config = restate_benchmarks::restate_configuration();
-    let (_rt, signal, app_handle) = restate_benchmarks::spawn_restate(config);
+    let (tc, _rt) = restate_benchmarks::spawn_restate(config);
 
     let BenchmarkSettings {
         num_requests,
@@ -63,13 +63,7 @@ fn throughput_benchmark(criterion: &mut Criterion) {
             })
         });
 
-    current_thread_rt.block_on(async move {
-        signal.drain().await;
-        app_handle
-            .await
-            .expect("restate should not panic")
-            .expect("restate should not fail");
-    });
+    current_thread_rt.block_on(tc.shutdown_node("completed", 0));
 }
 
 async fn send_parallel_counter_requests(

--- a/crates/cluster-controller/Cargo.toml
+++ b/crates/cluster-controller/Cargo.toml
@@ -15,6 +15,7 @@ options_schema = ["dep:schemars"]
 restate-errors = { workspace = true }
 restate-types = { workspace = true }
 
+anyhow = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }

--- a/crates/cluster-controller/src/service.rs
+++ b/crates/cluster-controller/src/service.rs
@@ -36,7 +36,7 @@ impl Service {
         ClusterControllerHandle
     }
 
-    pub async fn run(self, shutdown_watch: drain::Watch) -> Result<(), Error> {
+    pub async fn run(self, shutdown_watch: drain::Watch) -> anyhow::Result<()> {
         let _ = shutdown_watch.signaled().await;
         Ok(())
     }

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -24,6 +24,7 @@ restate-service-client = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-types = { workspace = true, features = ["serde", "serde_schema"] }
 
+anyhow = { workspace = true }
 bincode = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }

--- a/crates/meta/src/service.rs
+++ b/crates/meta/src/service.rs
@@ -247,7 +247,7 @@ where
         self.reload_schemas().await
     }
 
-    pub async fn run(mut self, drain: drain::Watch) -> Result<(), Error> {
+    pub async fn run(mut self, drain: drain::Watch) -> anyhow::Result<()> {
         debug_assert!(
             self.reloaded,
             "The Meta service was not init-ed before running it"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -28,10 +28,12 @@ restate-schema-api = { workspace = true }
 restate-schema-impl = { workspace = true }
 restate-storage-query-datafusion = { workspace = true }
 restate-storage-rocksdb = { workspace = true }
+restate-task-center = { workspace = true }
 restate-types = { workspace = true }
 restate-worker = { workspace = true }
 restate-worker-api = { workspace = true }
 
+anyhow = { workspace = true }
 arrow-flight = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
@@ -56,8 +58,18 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+restate-test-util = { workspace = true }
+
+googletest = { workspace = true }
+test-log = { workspace = true }
+tracing-test = { workspace = true }
+tracing-subscriber = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/node/src/roles/mod.rs
+++ b/crates/node/src/roles/mod.rs
@@ -11,7 +11,5 @@
 mod cluster_controller;
 mod worker;
 
-pub use cluster_controller::{
-    ClusterControllerRole, ClusterControllerRoleBuildError, ClusterControllerRoleError,
-};
-pub use worker::{update_schemas, WorkerRole, WorkerRoleBuildError, WorkerRoleError};
+pub use cluster_controller::{ClusterControllerRole, ClusterControllerRoleBuildError};
+pub use worker::{update_schemas, WorkerRole, WorkerRoleBuildError};

--- a/crates/node/src/server/mod.rs
+++ b/crates/node/src/server/mod.rs
@@ -17,4 +17,4 @@ mod service;
 mod state;
 
 pub use options::Options;
-pub use service::{ClusterControllerDependencies, Error, NodeServer, WorkerDependencies};
+pub use service::{ClusterControllerDependencies, NodeServer, WorkerDependencies};

--- a/crates/node/src/server/service.rs
+++ b/crates/node/src/server/service.rs
@@ -12,19 +12,21 @@ use std::net::SocketAddr;
 
 use axum::routing::get;
 use codederror::CodedError;
-use futures::FutureExt;
+use tower_http::trace::TraceLayer;
+use tracing::info;
+
 use restate_bifrost::Bifrost;
 use restate_cluster_controller::ClusterControllerHandle;
 use restate_meta::FileMetaReader;
 use restate_storage_rocksdb::RocksDBStorage;
-use tower_http::trace::TraceLayer;
-use tracing::info;
+use restate_task_center::cancellation_watcher;
 
 use crate::server::handler;
 use crate::server::handler::cluster_controller::ClusterControllerHandler;
 use crate::server::handler::metadata::MetadataHandler;
 use crate::server::handler::node_ctrl::NodeCtrlHandler;
 use crate::server::handler::worker::WorkerHandler;
+// TODO cleanup
 use crate::server::metrics::install_global_prometheus_recorder;
 use restate_node_services::cluster_controller::cluster_controller_svc_server::ClusterControllerSvcServer;
 use restate_node_services::metadata::metadata_svc_server::MetadataSvcServer;
@@ -75,7 +77,7 @@ impl NodeServer {
         }
     }
 
-    pub async fn run(self, drain: drain::Watch) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), anyhow::Error> {
         // Configure Metric Exporter
         let mut state_builder = HandlerStateBuilder::default();
 
@@ -166,10 +168,10 @@ impl NodeServer {
         );
 
         // Wait server graceful shutdown
-        server
-            .with_graceful_shutdown(drain.signaled().map(|_| ()))
+        Ok(server
+            .with_graceful_shutdown(cancellation_watcher())
             .await
-            .map_err(Error::Running)
+            .map_err(Error::Running)?)
     }
 
     pub fn port(&self) -> u16 {

--- a/crates/task-center/Cargo.toml
+++ b/crates/task-center/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "restate-bifrost"
+name = "restate-task-center"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -8,30 +8,20 @@ license.workspace = true
 publish = false
 
 [features]
-options_schema = ["dep:schemars"]
-memory_loglet = []
+test-util = []
 
 [dependencies]
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }
-async-trait = { workspace = true }
-bytes = { workspace = true }
-bytestring = { workspace = true, features = ["serde"] }
-codederror = { workspace = true }
-derive_builder = { workspace = true }
 derive_more = { workspace = true }
-drain = { workspace = true }
-enum-map = { workspace = true, features = ["serde"] }
-once_cell = { workspace = true }
-schemars = { workspace = true, optional = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
+futures = { workspace = true }
 static_assertions = { workspace = true }
-strum_macros = { workspace = true }
 strum = { workspace = true }
+strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 
@@ -43,3 +33,4 @@ test-log = { workspace = true }
 tracing-test = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+

--- a/crates/task-center/src/lib.rs
+++ b/crates/task-center/src/lib.rs
@@ -1,0 +1,600 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod types;
+pub use types::*;
+
+use futures::FutureExt;
+use restate_types::identifiers::PartitionId;
+use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use futures::Future;
+use tokio::task::JoinHandle;
+use tokio::task_local;
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
+use tracing::{debug, error, info, instrument, warn};
+
+static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(0);
+const EXIT_CODE_FAILURE: i32 = 1;
+
+#[derive(Debug, thiserror::Error)]
+#[error("system is shutting down")]
+pub struct ShutdownError;
+
+/// Used to create a new task center. In practice, there should be a single task center for the
+/// entire process but we might need to create more than one in integration test scenarios.
+pub struct TaskCenterFactory {}
+impl TaskCenterFactory {
+    pub fn create(runtime: tokio::runtime::Handle) -> TaskCenter {
+        TaskCenter {
+            inner: Arc::new(TaskCenterInner {
+                runtime,
+                global_cancel_token: CancellationToken::new(),
+                shutdown_requested: AtomicBool::new(false),
+                current_exit_code: AtomicI32::new(0),
+                tasks: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+pub fn create_test_task_center() -> TaskCenter {
+    TaskCenterFactory::create(tokio::runtime::Handle::current())
+}
+
+/// Task center is used to manage long-running and background tasks and their lifecycle.
+#[derive(Clone)]
+pub struct TaskCenter {
+    inner: Arc<TaskCenterInner>,
+}
+
+static_assertions::assert_impl_all!(TaskCenter: Send, Sync, Clone);
+
+impl TaskCenter {
+    /// Used to monitor an on-going shutdown when requested
+    pub fn watch_shutdown(&self) -> WaitForCancellationFutureOwned {
+        self.inner.global_cancel_token.clone().cancelled_owned()
+    }
+
+    /// The exit code that the process should exit with.
+    pub fn exit_code(&self) -> i32 {
+        self.inner.current_exit_code.load(Ordering::Acquire)
+    }
+
+    /// Triggers a shutdown of the system. All running tasks will be asked gracefully
+    /// to cancel but we will only wait for tasks with a TaskKind that has the property
+    /// "OnCancel" set to "wait".
+    #[instrument(level = "error", skip(self, exit_code))]
+    pub async fn shutdown_node(&self, reason: &str, exit_code: i32) {
+        let inner = self.inner.clone();
+        if inner
+            .shutdown_requested
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .unwrap_or_else(|e| e)
+        {
+            // already shutting down....
+            return;
+        }
+        let start = Instant::now();
+        inner.current_exit_code.store(exit_code, Ordering::Release);
+
+        if exit_code != 0 {
+            warn!("** Shutdown requested");
+        } else {
+            info!("** Shutdown requested");
+        }
+        self.cancel_tasks(None, None).await;
+        // notify outer components that we have completed the shutdown.
+        self.inner.global_cancel_token.cancel();
+        info!("** Shutdown completed in {:?}", start.elapsed());
+    }
+
+    #[track_caller]
+    fn spawn_inner<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        cancel: CancellationToken,
+        future: F,
+    ) -> TaskId
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let inner = self.inner.clone();
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
+        let task = Arc::new(Task {
+            id,
+            name,
+            kind,
+            partition_id,
+            cancel: cancel.clone(),
+            join_handle: Mutex::new(None),
+        });
+
+        inner.tasks.lock().unwrap().insert(id, Arc::clone(&task));
+
+        let mut handle_mut = task.join_handle.lock().unwrap();
+
+        let task_cloned = Arc::clone(&task);
+        let join_handle =
+            inner
+                .runtime
+                .spawn(wrapper(self.clone(), id, kind, task_cloned, cancel, future));
+        *handle_mut = Some(join_handle);
+        drop(handle_mut);
+
+        // Task is ready
+        id
+    }
+
+    /// Launch a new task
+    #[track_caller]
+    pub fn spawn<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> Result<TaskId, ShutdownError>
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let inner = self.inner.clone();
+        if inner.shutdown_requested.load(Ordering::Acquire) {
+            return Err(ShutdownError);
+        }
+        Ok(self.spawn_unchecked(kind, name, partition_id, future))
+    }
+
+    // Allows for spawning a new task without checking if the system is shutting down. This means
+    // that this task might not be able to finish if the system is shutting down.
+    #[track_caller]
+    fn spawn_unchecked<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> TaskId
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let cancel = CancellationToken::new();
+        self.spawn_inner(kind, name, partition_id, cancel, future)
+    }
+
+    /// Spawn a new task that is a child of the current task. The child task will be cancelled if the parent
+    /// task is cancelled. At the moment, the parent task will not automatically wait for children tasks to
+    /// finish before completion, but this might change in the future if the need for that arises.
+    #[track_caller]
+    pub fn spawn_child<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> Result<TaskId, ShutdownError>
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let inner = self.inner.clone();
+        if inner.shutdown_requested.load(Ordering::Acquire) {
+            return Err(ShutdownError);
+        }
+
+        let parent_id =
+            current_task_id().expect("spawn_child called outside of a task-center task");
+        let parent_kind =
+            current_task_kind().expect("spawn_child called outside of a task-center task");
+        let parent_name = CURRENT_TASK
+            .try_with(|ct| ct.name)
+            .expect("spawn_child called outside of a task-center task");
+
+        let cancel = cancellation_token().child_token();
+        let result = self.spawn_inner(kind, name, partition_id, cancel, future);
+
+        debug!(
+            kind = ?parent_kind,
+            name = ?parent_name,
+            child_kind = ?kind,
+            "Task \"{}\" {} spawned \"{}\" {}",
+            parent_name, parent_id, name, result
+        );
+        Ok(result)
+    }
+
+    /// Cancelling the child will not cancel the parent. Note that parent task will not
+    /// wait for children tasks. The parent task is allowed to finish before children.
+    #[track_caller]
+    pub fn spawn_child_unchecked<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> TaskId
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let cancel = cancellation_token().child_token();
+        self.spawn_inner(kind, name, partition_id, cancel, future)
+    }
+
+    /// Signal and wait for tasks to stop.
+    ///
+    ///
+    /// You can select which tasks to cancel. Any None arguments are ignored.
+    /// For example, to shut down all MetadataBackgroundSync tasks:
+    ///
+    ///   cancel_tasks(Some(TaskKind::MetadataBackgroundSync), None)
+    ///
+    /// Or to shut down all tasks for a particular partition ID:
+    ///
+    ///   cancel_tasks(None, Some(partition_id))
+    ///
+    pub async fn cancel_tasks(&self, kind: Option<TaskKind>, partition_id: Option<PartitionId>) {
+        let inner = self.inner.clone();
+        let mut victims = Vec::new();
+
+        {
+            let tasks = inner.tasks.lock().unwrap();
+            for task in tasks.values() {
+                if (kind.is_none() || Some(task.kind) == kind)
+                    && (partition_id.is_none() || task.partition_id == partition_id)
+                {
+                    task.cancel.cancel();
+                    victims.push((Arc::clone(task), task.kind, task.partition_id));
+                }
+            }
+        }
+
+        for (task, task_kind, partition_id) in victims {
+            let join_handle = {
+                let mut task_mut = task.join_handle.lock().unwrap();
+                // Task is not running anymore or another cancel is waiting for it.
+                task_mut.take()
+            };
+            if let Some(mut join_handle) = join_handle {
+                if task_kind.should_abort_on_cancel() {
+                    // We should not wait, instead, just abort the tokio task.
+                    debug!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "task {} aborted!", task.id);
+                    join_handle.abort();
+                } else if task_kind.should_wait_on_cancel() {
+                    // Give the task a chance to finish before logging.
+                    if tokio::time::timeout(Duration::from_secs(1), &mut join_handle)
+                        .await
+                        .is_err()
+                    {
+                        info!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "waiting for task {} to shutdown", task.id);
+                        // Ignore join errors on cancel. on_finish already takes care
+                        let _ = join_handle.await;
+                        info!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "task {} completed", task.id);
+                    }
+                } else {
+                    // Ignore the task. the task will be dropped on tokio runtime drop.
+                }
+            } else {
+                // Possibly one of:
+                //  * The task had not even fully started yet.
+                //  * It was shut down concurrently and already exited (or failed)
+            }
+        }
+    }
+
+    /// Sets the current task_center but doesn't create a task. Use this when you need to run a
+    /// future within task_center scope.
+    pub async fn run_in_scope<F, O>(
+        &self,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> O
+    where
+        F: Future<Output = O> + Send + 'static,
+    {
+        let cancel_token = CancellationToken::new();
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
+        let task = Arc::new(Task {
+            id,
+            name,
+            kind: TaskKind::InPlace,
+            partition_id,
+            cancel: cancel_token.clone(),
+            join_handle: Mutex::new(None),
+        });
+        CURRENT_TASK_CENTER
+            .scope(
+                self.clone(),
+                CANCEL_TOKEN.scope(cancel_token, CURRENT_TASK.scope(task, future)),
+            )
+            .await
+    }
+
+    /// Sets the current task_center but doesn't create a task. Use this when you need to run a
+    /// closure within task_center scope.
+    pub fn run_in_scope_sync<F, O>(
+        &self,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        f: F,
+    ) -> O
+    where
+        F: FnOnce() -> O,
+    {
+        let cancel_token = CancellationToken::new();
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
+        let task = Arc::new(Task {
+            id,
+            name,
+            kind: TaskKind::InPlace,
+            partition_id,
+            cancel: cancel_token.clone(),
+            join_handle: Mutex::new(None),
+        });
+        CURRENT_TASK_CENTER.sync_scope(self.clone(), || {
+            CANCEL_TOKEN.sync_scope(cancel_token, || CURRENT_TASK.sync_scope(task, f))
+        })
+    }
+
+    /// Take control over the running task from task-center. This returns None if the task was not
+    /// found, completed, or has been cancelled.
+    pub fn take_task(&self, task_id: TaskId) -> Option<JoinHandle<()>> {
+        let inner = self.inner.clone();
+        let task = {
+            // find the task
+            let mut tasks = inner.tasks.lock().unwrap();
+            tasks.remove(&task_id)?
+        };
+
+        let mut task_mut = task.join_handle.lock().unwrap();
+        // Task is not running anymore or a cancellation is already in progress.
+        task_mut.take()
+    }
+
+    /// Request cancellation of a task. This returns the join handle if the task was found and was
+    /// not already cancelled or completed. The returned task will not be awaited by task-center on
+    /// shutdown, and it's the responsibility of the caller to join or abort.
+    pub fn cancel_task(&self, task_id: TaskId) -> Option<JoinHandle<()>> {
+        let inner = self.inner.clone();
+        let task = {
+            // find the task
+            let tasks = inner.tasks.lock().unwrap();
+            let task = tasks.get(&task_id)?;
+            // request cancellation
+            task.cancel.cancel();
+            Arc::clone(task)
+        };
+
+        let mut task_mut = task.join_handle.lock().unwrap();
+        // Task is not running anymore or a cancellation is already in progress.
+        task_mut.take()
+    }
+
+    async fn on_finish(
+        &self,
+        result: std::result::Result<
+            anyhow::Result<()>,
+            std::boxed::Box<dyn std::any::Any + std::marker::Send>,
+        >,
+        kind: TaskKind,
+        task_id: TaskId,
+    ) {
+        let inner = self.inner.clone();
+        // Remove our entry from the tasks map.
+        let Some(task) = inner.tasks.lock().unwrap().remove(&task_id) else {
+            // This can happen if the task ownership was taken by calling take_task(id);
+            return;
+        };
+
+        let should_shutdown_on_error = kind.should_shutdown_on_error();
+        let mut request_node_shutdown = false;
+        {
+            match result {
+                Ok(Ok(())) => {
+                    debug!(kind = ?kind, name = ?task.name, "Task {} exited normally", task_id);
+                }
+                Ok(Err(err)) => {
+                    if err.root_cause().downcast_ref::<ShutdownError>().is_some() {
+                        // The task failed to spawn other tasks because the system
+                        // is already shutting down, we ignore those errors.
+                        return;
+                    }
+                    if should_shutdown_on_error {
+                        error!(kind = ?kind, name = ?task.name,
+                            "Shutting down: task {} failed with: {:?}",
+                            task_id, err
+                        );
+                        request_node_shutdown = true;
+                    } else {
+                        error!(kind = ?kind, name = ?task.name, "Task {} failed with: {:?}", task_id, err);
+                    }
+                }
+                Err(err) => {
+                    if should_shutdown_on_error {
+                        error!(kind = ?kind, name = ?task.name, "Shutting down: task {} panicked: {:?}", task_id, err);
+                        request_node_shutdown = true;
+                    } else {
+                        error!(kind = ?kind, name = ?task.name, "Task {} panicked: {:?}", task_id, err);
+                    }
+                }
+            }
+        }
+
+        if request_node_shutdown {
+            // Note that the task itself has been already removed from the task map, so shutdown
+            // will not wait for its completion.
+            self.shutdown_node(
+                &format!("task {} failed and requested a shutdown", task.name),
+                EXIT_CODE_FAILURE,
+            )
+            .await;
+        }
+    }
+}
+
+struct TaskCenterInner {
+    runtime: tokio::runtime::Handle,
+    global_cancel_token: CancellationToken,
+    shutdown_requested: AtomicBool,
+    current_exit_code: AtomicI32,
+    tasks: Mutex<HashMap<TaskId, Arc<Task>>>,
+}
+
+pub struct Task {
+    /// It's nice to have a unique ID for each task.
+    id: TaskId,
+    name: &'static str,
+    kind: TaskKind,
+    /// cancel this token to request cancelling this task.
+    cancel: CancellationToken,
+
+    /// Tasks associated with a specific partition ID will have this set. This allows
+    /// for cancellation of tasks associated with that partition.
+    partition_id: Option<PartitionId>,
+    join_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+task_local! {
+    // This is a cancellation token which will be cancelled when a task needs to shut down.
+    static CANCEL_TOKEN: CancellationToken;
+
+    // Tasks have self-reference.
+    static CURRENT_TASK: Arc<Task>;
+
+    // Current task center
+    static CURRENT_TASK_CENTER: TaskCenter;
+}
+
+/// This wrapper function runs in a newly-spawned task. It initializes the
+/// task-local variables and calls the payload function.
+async fn wrapper<F>(
+    task_center: TaskCenter,
+    task_id: TaskId,
+    kind: TaskKind,
+    task: Arc<Task>,
+    cancel_token: CancellationToken,
+    future: F,
+) where
+    F: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    debug!(kind = ?kind, name = ?task.name, "Starting task {}", task_id);
+
+    let result = CURRENT_TASK_CENTER
+        .scope(
+            task_center.clone(),
+            CANCEL_TOKEN.scope(
+                cancel_token,
+                CURRENT_TASK.scope(task, {
+                    // We use AssertUnwindSafe here so that the wrapped function
+                    // doesn't need to be UnwindSafe. We should not do anything after
+                    // unwinding that'd risk us being in unwind-unsafe behavior.
+                    AssertUnwindSafe(future).catch_unwind()
+                }),
+            ),
+        )
+        .await;
+    task_center.on_finish(result, kind, task_id).await;
+}
+
+/// The current task-center task kind. This returns None if we are not in the scope
+/// of a task-center task.
+pub fn current_task_kind() -> Option<TaskKind> {
+    CURRENT_TASK.try_with(|ct| ct.kind).ok()
+}
+
+/// The current task-center task Id. This returns None if we are not in the scope
+/// of a task-center task.
+pub fn current_task_id() -> Option<TaskId> {
+    CURRENT_TASK.try_with(|ct| ct.id).ok()
+}
+
+/// The current partition Id associated to the running task-center task.
+pub fn current_task_partition_id() -> Option<PartitionId> {
+    CURRENT_TASK.try_with(|ct| ct.partition_id).ok().flatten()
+}
+
+/// Get the current task center. Use this to spawn tasks on the current task center.
+/// This must be called from within a task-center task.
+pub fn task_center() -> TaskCenter {
+    CURRENT_TASK_CENTER
+        .try_with(|t| t.clone())
+        .expect("task_center() called in a task-center task")
+}
+
+/// A Future that can be used to check if the current task has been requested to
+/// shut down.
+pub async fn cancellation_watcher() {
+    let token = cancellation_token();
+    token.cancelled().await;
+}
+
+/// Clones the current task's cancellation token, which can be moved across tasks.
+///
+/// When the system is shutting down, or the current task is being cancelled by a
+/// cancel_task() call, or if it's a child and the parent is being cancelled by a
+/// cancel_task() call, this cancellation token will be set to cancelled.
+pub fn cancellation_token() -> CancellationToken {
+    let res = CANCEL_TOKEN.try_with(|t| t.clone());
+
+    if cfg!(any(test, feature = "test-util")) {
+        // allow in tests to call from non-task-center tasks.
+        res.unwrap_or_default()
+    } else {
+        res.expect("cancellation_token() called in in a task-center task")
+    }
+}
+
+/// Has the current task been requested to cancel?
+pub fn is_cancellation_requested() -> bool {
+    if let Ok(cancel) = CANCEL_TOKEN.try_with(|t| t.clone()) {
+        cancel.is_cancelled()
+    } else {
+        if cfg!(any(test, feature = "test-util")) {
+            warn!("is_cancellation_requested() called in task-center task");
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use googletest::prelude::*;
+    use restate_test_util::assert_eq;
+    use tracing_test::traced_test;
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn test_basic_lifecycle() -> Result<()> {
+        let tc = TaskCenterFactory::create(tokio::runtime::Handle::current());
+        let start = tokio::time::Instant::now();
+        tc.spawn(TaskKind::RoleRunner, "worker-role", None, async {
+            info!("Hello async");
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            assert_eq!(TaskKind::RoleRunner, current_task_kind().unwrap());
+            info!("Bye async");
+            Ok(())
+        })
+        .unwrap();
+
+        tc.cancel_tasks(None, None).await;
+        assert!(logs_contain("Hello async"));
+        assert!(logs_contain("Bye async"));
+        assert!(start.elapsed() >= Duration::from_secs(10));
+        Ok(())
+    }
+}

--- a/crates/task-center/src/types.rs
+++ b/crates/task-center/src/types.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use strum::EnumProperty;
+
+#[derive(
+    Clone,
+    Debug,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    derive_more::Display,
+    derive_more::From,
+    derive_more::Into,
+)]
+pub struct TaskId(u64);
+
+/// Describes the types of tasks TaskCenter manages.
+///
+/// Properties can be assigned to task kinds:
+///   * `OnCancel` - What to do when the task is cancelled:
+///     - `ignore                 - Ignores the tokio task. The task will be dropped on tokio
+///                                 runtime drop.
+///     - `abort`                 - Aborts the tokio task (default)
+///     - `wait`  (default)       - Wait for graceful shutdown. The task must respond
+///                                  to cancellation_watcher() or check periodically for
+///                                  is_cancellation_requested()
+///
+///   * `OnError`  - What to do if the task returned Err(_)
+///     - `log`                   - Log an error
+///     - `shutdown` (default)    - Shutdown the node (task center global shutdown)
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::EnumProperty,
+    strum_macros::IntoStaticStr,
+    strum_macros::Display,
+)]
+pub enum TaskKind {
+    #[cfg(any(test, feature = "test-util"))]
+    TestRunner,
+    /// Do not use. This is a special task kind that indicate that work is running within
+    /// task_center but its lifecycle is not managed by it.
+    InPlace,
+    /// Tasks used during system initialization. Short lived but will shutdown the node if they
+    /// failed.
+    #[strum(props(OnCancel = "abort"))]
+    SystemBoot,
+    #[strum(props(OnCancel = "abort"))]
+    MetadataBackgroundSync,
+    RpcServer,
+    RoleRunner,
+    SystemService,
+    PartitionProcessor,
+    // -- Bifrost Tasks
+    /// A background task that the system needs for its operation. The task requires a system
+    /// shutdown on errors and the system will wait for its graceful cancellation on shutdown.
+    BifrostBackgroundHiPri,
+}
+
+impl TaskKind {
+    pub fn should_shutdown_on_error(&self) -> bool {
+        self.on_error() == "shutdown"
+    }
+
+    pub fn should_wait_on_cancel(&self) -> bool {
+        self.on_cancel() == "wait"
+    }
+
+    pub fn should_abort_on_cancel(&self) -> bool {
+        self.on_cancel() == "abort"
+    }
+
+    fn on_cancel(&self) -> &'static str {
+        self.get_str("OnCancel").unwrap_or("wait")
+    }
+
+    fn on_error(&self) -> &'static str {
+        self.get_str("OnError").unwrap_or("shutdown")
+    }
+}
+
+pub enum FailureBehaviour {
+    Shutdown,
+}

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -26,18 +26,16 @@ codederror = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 drain = { workspace = true }
-enum-map = { version = "2.7.3" }
-#futures = { workspace = true }
+enum-map = { workspace = true }
 once_cell = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
-strum_macros = { version = "0.26.1" }
-strum = { version = "0.26.1" }
+strum_macros = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-#tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 
@@ -46,6 +44,6 @@ restate-test-util = { workspace = true }
 
 googletest = { workspace = true }
 test-log = { workspace = true }
-tracing-test = { version = "0.2.4" }
+tracing-test = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -416,7 +416,7 @@ impl Worker {
         &self.rocksdb_storage
     }
 
-    pub async fn run(self, drain: drain::Watch) -> Result<(), Error> {
+    pub async fn run(self, drain: drain::Watch) -> anyhow::Result<()> {
         let (shutdown_signal, shutdown_watch) = drain::channel();
 
         let mut external_client_ingress_handle = tokio::spawn(

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ restate-fs-util = { workspace = true }
 restate-meta = { workspace = true }
 restate-node = { workspace = true }
 restate-storage-rocksdb = { workspace = true }
+restate-task-center = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
 restate-types = { workspace = true }
 restate-worker = { workspace = true }
@@ -49,6 +50,7 @@ serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-panic = { version = "0.1.1" }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,12 +13,14 @@ use codederror::CodedError;
 use restate_errors::fmt::RestateCode;
 use restate_server::build_info;
 use restate_server::Configuration;
+use restate_task_center::TaskCenterFactory;
 use restate_tracing_instrumentation::TracingGuard;
 use std::error::Error;
 use std::ops::Div;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::io;
+use tracing::error;
 use tracing::{info, trace, warn};
 
 mod signal;
@@ -106,76 +108,89 @@ fn main() {
         .build()
         .expect("failed to build Tokio runtime!");
 
-    runtime.block_on(async move {
-        // Apply tracing config globally
-        // We need to apply this first to log correctly
-        let tracing_guard = config
-            .observability
-            .init("Restate binary", std::process::id())
-            .expect("failed to instrument logging and tracing!");
+    let tc = TaskCenterFactory::create(runtime.handle().clone());
 
-        // Log panics as tracing errors if possible
-        let prev_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |panic_info| {
-            tracing_panic::panic_hook(panic_info);
-            // run original hook if any.
-            prev_hook(panic_info);
-        }));
+    runtime.block_on({
+        let tc = tc.clone();
+        async move {
+            // Apply tracing config globally
+            // We need to apply this first to log correctly
+            let tracing_guard = config
+                .observability
+                .init("Restate binary", std::process::id())
+                .expect("failed to instrument logging and tracing!");
 
-        info!("Starting Restate Server {}", build_info::build_info());
-        info!(
-            "Loading configuration file from {}",
-            cli_args.config_file.display()
-        );
-        info!(
-            "Configuration dump (MAY CONTAIN SENSITIVE DATA!):\n{}",
-            serde_yaml::to_string(&config).unwrap()
-        );
+            // Log panics as tracing errors if possible
+            let prev_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |panic_info| {
+                tracing_panic::panic_hook(panic_info);
+                // run original hook if any.
+                prev_hook(panic_info);
+            }));
 
-        WipeMode::wipe(
-            cli_args.wipe.as_ref(),
-            config.node.meta.storage_path().into(),
-            config.node.worker.storage_path().into()
-        ).await.expect("Error when trying to wipe the configured storage path");
+            info!("Starting Restate Server {}", build_info::build_info());
+            info!(
+                "Loading configuration file from {}",
+                cli_args.config_file.display()
+            );
+            info!(
+                "Configuration dump (MAY CONTAIN SENSITIVE DATA!):\n{}",
+                serde_yaml::to_string(&config).unwrap()
+            );
 
-        let node = Node::new(config.node);
+            WipeMode::wipe(
+                cli_args.wipe.as_ref(),
+                config.node.meta.storage_path().into(),
+                config.node.worker.storage_path().into(),
+            )
+            .await
+            .expect("Error when trying to wipe the configured storage path");
 
-        if let Err(err) = node {
-            handle_error(err);
-        }
-        let node = node.unwrap();
-
-        let (shutdown_signal, shutdown_watch) = drain::channel();
-        let node = node.run(shutdown_watch);
-        tokio::pin!(node);
-
-        tokio::select! {
-            _ = signal::shutdown() => {
-                info!("Received shutdown signal.");
-
-                let shutdown_tasks = futures_util::future::join(shutdown_signal.drain(), node);
-                let shutdown_with_timeout = tokio::time::timeout(config.shutdown_grace_period.into(), shutdown_tasks);
-
-                // ignore the result because we are shutting down
-                let shutdown_result = shutdown_with_timeout.await;
-
-                if shutdown_result.is_err() {
-                    warn!("Could not gracefully shut down Restate, terminating now.");
-                } else {
-                    info!("Restate has been gracefully shut down.");
-                }
-            },
-            result = &mut node => {
-                if let Err(err) = result {
-                    handle_error(err);
-                } else {
-                    panic!("Unexpected termination of restate application. Please contact the Restate developers.");
-                }
+            let task_center_watch = tc.watch_shutdown();
+            let node = Node::new(config.node);
+            if let Err(err) = node {
+                handle_error(err);
             }
-        }
+            // We ignore errors since we will wait for shutdown below anyway.
+            // This starts node roles and the rest of the system async under tasks managed by
+            // the TaskCenter.
+            let _ = node.unwrap().boot(&tc);
 
-        shutdown_tracing(config.shutdown_grace_period.div(2), tracing_guard).await;
+            tokio::select! {
+                signal_name = signal::shutdown() => {
+                    info!("Received shutdown signal.");
+                    let signal_reason = format!("received signal {}", signal_name);
+
+                    let shutdown_with_timeout = tokio::time::timeout(
+                        config.shutdown_grace_period.into(),
+                        tc.shutdown_node(&signal_reason, 0)
+                    );
+
+                    // ignore the result because we are shutting down
+                    let shutdown_result = shutdown_with_timeout.await;
+
+                    if shutdown_result.is_err() {
+                        warn!("Could not gracefully shut down Restate, terminating now.");
+                    } else {
+                        info!("Restate has been gracefully shut down.");
+                    }
+                },
+                _ = task_center_watch => {
+                    // Shutdown was requested by task center and it has completed.
+                },
+            };
+
+            shutdown_tracing(config.shutdown_grace_period.div(2), tracing_guard).await;
+        }
     });
+    let exit_code = tc.exit_code();
+    if exit_code != 0 {
+        error!("Restate terminated with exit code {}!", exit_code);
+    } else {
+        info!("Restate terminated");
+    }
+    // The process terminates with the task center requested exit code
+    std::process::exit(exit_code);
 }
 
 async fn shutdown_tracing(grace_period: Duration, tracing_guard: TracingGuard) {

--- a/server/src/signal.rs
+++ b/server/src/signal.rs
@@ -11,13 +11,14 @@
 use tokio::signal::unix::{signal, SignalKind};
 use tracing::info;
 
-pub(super) async fn shutdown() {
+pub(super) async fn shutdown() -> &'static str {
     let signal = tokio::select! {
         () = await_signal(SignalKind::interrupt()) => "SIGINT",
         () = await_signal(SignalKind::terminate()) => "SIGTERM"
     };
 
-    info!(%signal, "Received signal, starting shutdown.")
+    info!(%signal, "Received signal, starting shutdown.");
+    signal
 }
 
 async fn await_signal(kind: SignalKind) {


### PR DESCRIPTION
Task Center init

This introduces a central system to manage long-running and background restate async tasks.
The core of this proposal is to help us lean more towards spawning self-contained tasks that
are addressable, trackable, and cancellable, than current deep future poll trees.

It also allows nice possibilities like:
- Limited structured concurrency (no auto-waiting for children though)
- Graceful cancellations/shutdown reduces the risk of cancellation-unsafe drops
- Potentially less memory, deep nested future state machines become shallower.
- A single place where we can auto-propagate tracing context, flag tasks by priority, schedule tasks on different runtime, provide observability of what kind of tasks are running, etc.
- Scoped tasks allow scoped cancellation. (cooperatively cancel all tasks for a partition id, or a specific tenant in the future, or be specific and filter specific kinds of tasks)
- Limit concurrency of certain tasks by kind, partition, or tenant, etc.
- Distributing tasks among multiple tokio runtimes based on the task kind
- Support for different abort-policy based on the task kind.

A the moment, I only migrated a small pieces of our code to this system to make the merging with #1180 easier.
Once #1180 is merged, I'll move the rest of our services and bifrost to use it.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1181).
* #1196
* #1195
* #1194
* __->__ #1181