### PR TITLE
Eks pod identity implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,8 +511,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-config"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af266887e24cd5f6d2ea7433cacd25dcd4773b7f70e488701968a7cdf51df57"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -541,8 +540,7 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d56f287a9e65e4914bfedb5b22c056b65e4c232fca512d5509a9df36386759f"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -553,8 +551,7 @@ dependencies = [
 [[package]]
 name = "aws-runtime"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6a29eca8ea8982028a4df81883e7001e250a21d323b86418884b5345950a4b"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -576,8 +573,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-lambda"
 version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6253a6dd3ed34c605408deb75ebc9e655f97ede58930c9c6324a5aea72183e"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -598,8 +594,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sso"
 version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d7f527c7b28af1a641f7d89f9e6a4863e8ec00f39d2b731b056fc5ec5ce829"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -620,8 +615,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-ssooidc"
 version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0be3224cd574ee8ab5fd7c32087876f25c134c27ac603fcb38669ed8d346b0"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -642,8 +636,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sts"
 version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3167c60d82a13bbaef569da06041644ff41e85c6377e5dad53fa2526ccfe9d"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -665,8 +658,7 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b1cbe0eee57a213039088dbdeca7be9352f24e0d72332d961e8a1cb388f82d"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -688,8 +680,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-async"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426a5bc369ca7c8d3686439e46edc727f397a47ab3696b13f3ae8c81b3b36132"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -699,8 +690,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.60.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d6a0619f7b67183067fa3b558f94f90753da2df8c04aeb7336d673f804b0b8"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -719,8 +709,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-json"
 version = "0.60.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c1b5186b6f5c579bf0de1bcca9dd3d946d6d51361ea1d18131f6a0b64e13ae"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -728,8 +717,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-query"
 version = "0.60.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0a2ce65882e788d2cf83ff28b9b16918de0460c47bf66c5da4f6c17b4c9694"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -738,8 +726,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4cb6b3afa5fc9825a75675975dcc3e21764b5476bc91dbc63df4ea3d30a576e"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -763,8 +750,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23165433e80c04e8c09cee66d171292ae7234bae05fa9d5636e33095eae416b2"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -779,8 +765,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-types"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94a5bec34850b92c9a054dad57b95c1d47f25125f55973e19f6ad788f0381ff"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -802,8 +787,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-xml"
 version = "0.60.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16f94c9673412b7a72e3c3efec8de89081c320bf59ea12eed34c417a62ad600"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "xmlparser",
 ]
@@ -811,8 +795,7 @@ dependencies = [
 [[package]]
 name = "aws-types"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff7e122ee50ca962e9de91f5850cc37e2184b1219611eef6d44aa85929b54f6"
+source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,12 +510,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.100.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14044e9a7e7ae811d99e71d35e3698113ec27eb618445863b611c60811574cc6"
+checksum = "7af266887e24cd5f6d2ea7433cacd25dcd4773b7f70e488701968a7cdf51df57"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
@@ -530,7 +529,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http",
+ "http 0.2.11",
  "hyper",
  "ring 0.17.7",
  "time",
@@ -541,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "0.58.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1eca93b9b017fab7c53a2d1518efc7f03de631e32f420298440acbfef146d21"
+checksum = "2d56f287a9e65e4914bfedb5b22c056b65e4c232fca512d5509a9df36386759f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -552,50 +551,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-http"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31eca8162dedcccb0ff256a878689510763b9ffd5a2c0d51ee0199dc2ec593a"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http",
- "http-body",
- "pin-project-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-runtime"
-version = "0.58.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb1cd6bf27e01014e52b5b181d1e700841abd8adccee55055b1a86757f9afbb"
+checksum = "2d6a29eca8ea8982028a4df81883e7001e250a21d323b86418884b5345950a4b"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "bytes",
  "fastrand",
- "http",
+ "http 0.2.11",
+ "http-body",
  "percent-encoding",
+ "pin-project-lite",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "0.37.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587cbc5b5cd48a11448cbefbb58c3696fd504868314bd5e454474a1a9dbbc839"
+checksum = "5b6253a6dd3ed34c605408deb75ebc9e655f97ede58930c9c6324a5aea72183e"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -605,19 +589,19 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
- "regex",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.37.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73693581f8ad829c05e52738bdc44a650881e6bb2601d06a30bd67201228536b"
+checksum = "e2d7f527c7b28af1a641f7d89f9e6a4863e8ec00f39d2b731b056fc5ec5ce829"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -627,19 +611,19 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
- "regex",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "0.37.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c4f6ca50ff57ead33b8b5f89e01aefcd82a408b5b5d2a7c14385b9f93c88f"
+checksum = "0d0be3224cd574ee8ab5fd7c32087876f25c134c27ac603fcb38669ed8d346b0"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -649,19 +633,19 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
- "regex",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.37.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89064d7755ed95727f0ddb3e3aaab8191e37dd9c89fc38343a1604b9462fa583"
+checksum = "5b3167c60d82a13bbaef569da06041644ff41e85c6377e5dad53fa2526ccfe9d"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -672,16 +656,17 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "http",
- "regex",
+ "http 0.2.11",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "0.58.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b2ae7efc433aac9c367e6038484e604df711b9ae7ad1224a1db5e3caaab0f1"
+checksum = "54b1cbe0eee57a213039088dbdeca7be9352f24e0d72332d961e8a1cb388f82d"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -691,10 +676,10 @@ dependencies = [
  "form_urlencoded",
  "hex",
  "hmac",
- "http",
+ "http 0.2.11",
+ "http 1.0.0",
  "once_cell",
  "percent-encoding",
- "regex",
  "sha2",
  "time",
  "tracing",
@@ -702,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.100.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324538ebc89f2414c9c92d878fe7b0538d1dea8ebb72c45f8add0aa1002a3666"
+checksum = "426a5bc369ca7c8d3686439e46edc727f397a47ab3696b13f3ae8c81b3b36132"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -713,16 +698,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.58.0"
+version = "0.60.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03f240d3eafae9359943d0ccdabf96f507e2ce00d865578bb10fc21c6a08a72"
+checksum = "85d6a0619f7b67183067fa3b558f94f90753da2df8c04aeb7336d673f804b0b8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
- "http",
+ "http 0.2.11",
  "http-body",
  "once_cell",
  "percent-encoding",
@@ -733,18 +718,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.58.0"
+version = "0.60.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5593def1d50cab58bffa61483a66d369520ae8d95902562314bac9bad6aaa64d"
+checksum = "a1c1b5186b6f5c579bf0de1bcca9dd3d946d6d51361ea1d18131f6a0b64e13ae"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.58.0"
+version = "0.60.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71452a6f146914adf3c6b1d4e2fc8a9df6bf10a2d05bd5b982e152d62280e18c"
+checksum = "1c0a2ce65882e788d2cf83ff28b9b16918de0460c47bf66c5da4f6c17b4c9694"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -752,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "0.58.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ad73bc100c48acc09794914f06ae717f8d07132c2512a667e516f0c0a5fd4d"
+checksum = "b4cb6b3afa5fc9825a75675975dcc3e21764b5476bc91dbc63df4ea3d30a576e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -762,7 +747,8 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "http",
+ "h2",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -776,14 +762,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "0.100.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d354f37c2df3661338507bdb78d4ace08d3ff687c3ece9b0dca12f6fd5d09184"
+checksum = "23165433e80c04e8c09cee66d171292ae7234bae05fa9d5636e33095eae416b2"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -792,15 +778,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.100.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d66124208cd17da157b8603fee220187239caa3531a0c71260704a076281d8"
+checksum = "c94a5bec34850b92c9a054dad57b95c1d47f25125f55973e19f6ad788f0381ff"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
- "http",
+ "http 0.2.11",
  "http-body",
  "itoa",
  "num-integer",
@@ -815,24 +801,24 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.58.0"
+version = "0.60.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfe149c4afea01e25105c712d16295c0b604631e97914968e3f77af27d646f2"
+checksum = "d16f94c9673412b7a72e3c3efec8de89081c320bf59ea12eed34c417a62ad600"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.100.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bee3e0dfe1b104957a49f17b5a77b1e783deac4dfd829f2718ca0437ac7b814"
+checksum = "0ff7e122ee50ca962e9de91f5850cc37e2184b1219611eef6d44aa85929b54f6"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http",
+ "http 0.2.11",
  "rustc_version",
  "tracing",
 ]
@@ -848,7 +834,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "itoa",
@@ -878,7 +864,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "mime",
  "rustversion",
@@ -2563,7 +2549,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.2.2",
  "slab",
  "tokio",
@@ -2668,13 +2654,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
@@ -2690,7 +2687,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
 dependencies = [
- "http",
+ "http 0.2.11",
  "serde",
 ]
 
@@ -2723,7 +2720,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -2743,7 +2740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
  "rustls",
@@ -3620,7 +3617,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -3663,7 +3660,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bytes",
- "http",
+ "http 0.2.11",
  "okapi",
  "okapi-operation-macro",
  "paste",
@@ -3739,7 +3736,7 @@ checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 0.2.11",
  "opentelemetry_api",
 ]
 
@@ -3751,7 +3748,7 @@ checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
  "futures-core",
- "http",
+ "http 0.2.11",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_api",
@@ -4593,6 +4590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,7 +4619,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -4659,7 +4662,7 @@ dependencies = [
  "derive_builder",
  "drain",
  "futures",
- "http",
+ "http 0.2.11",
  "hyper",
  "okapi-operation",
  "prost 0.12.3",
@@ -4776,7 +4779,7 @@ dependencies = [
  "dirs",
  "dotenvy",
  "futures",
- "http",
+ "http 0.2.11",
  "indicatif",
  "indoc",
  "is-terminal",
@@ -4909,7 +4912,7 @@ dependencies = [
  "derive_builder",
  "drain",
  "futures",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "metrics",
@@ -5041,7 +5044,7 @@ dependencies = [
  "drain",
  "futures",
  "googletest",
- "http",
+ "http 0.2.11",
  "prost 0.12.3",
  "prost-reflect",
  "restate-errors",
@@ -5073,7 +5076,7 @@ name = "restate-meta-rest-model"
 version = "0.8.0"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "humantime",
  "restate-schema-api",
  "restate-serde-util",
@@ -5117,7 +5120,7 @@ dependencies = [
  "drain",
  "enumset",
  "futures",
- "http",
+ "http 0.2.11",
  "humantime",
  "hyper",
  "metrics",
@@ -5202,7 +5205,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "bytestring",
- "http",
+ "http 0.2.11",
  "prost 0.12.3",
  "prost-reflect",
  "restate-base64-util",
@@ -5223,7 +5226,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "codederror",
- "http",
+ "http 0.2.11",
  "itertools 0.11.0",
  "once_cell",
  "prost 0.12.3",
@@ -5250,7 +5253,7 @@ version = "0.8.0"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "http",
+ "http 0.2.11",
  "prost 0.12.3",
  "schemars",
  "serde",
@@ -5554,7 +5557,7 @@ dependencies = [
  "cfg_eval",
  "derive_more",
  "enumset",
- "http",
+ "http 0.2.11",
  "humantime",
  "num-traits",
  "once_cell",
@@ -6718,7 +6721,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -6745,7 +6748,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -6794,7 +6797,7 @@ checksum = "0fddb2a37b247e6adcb9f239f4e5cefdcc5ed526141a416b943929f13aea2cce"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "pin-project",
@@ -6836,7 +6839,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "http-range-header",
  "iri-string",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-config"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "aws-runtime"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-lambda"
 version = "1.13.0"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sso"
 version = "1.13.0"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-ssooidc"
 version = "1.13.0"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sts"
 version = "1.13.0"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-async"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.60.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-json"
 version = "0.60.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-query"
 version = "0.60.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-runtime-api"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-types"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-xml"
 version = "0.60.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "xmlparser",
 ]
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "aws-types"
 version = "1.1.5"
-source = "git+https://github.com/jackkleeman/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
+source = "git+https://github.com/restatedev/aws-sdk-rust#684ccb3c39808a3ad183adbba07a2daa3b9a5dae"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,11 +148,11 @@ uuid = { version = "1.3.0", features = ["v7", "serde"] }
 
 [patch.crates-io]
 # Patch these until https://github.com/smithy-lang/smithy-rs/pull/3416 merged and released
-aws-config = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
-aws-credential-types = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
-aws-sdk-lambda = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
-aws-sdk-sts = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
-aws-smithy-runtime = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-config = { git = "https://github.com/restatedev/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-credential-types = { git = "https://github.com/restatedev/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-sdk-lambda = { git = "https://github.com/restatedev/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-sdk-sts = { git = "https://github.com/restatedev/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-smithy-runtime = { git = "https://github.com/restatedev/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 ulid = { version = "1.1.0" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 
+[patch.crates-io]
+# Patch these until https://github.com/smithy-lang/smithy-rs/pull/3416 merged and released
+aws-config = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-credential-types = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-sdk-lambda = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-sdk-sts = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
+aws-smithy-runtime = { git = "https://github.com/jackkleeman/aws-sdk-rust", commit = "684ccb3c39808a3ad183adbba07a2daa3b9a5dae" }
 
 [profile.release]
 opt-level = 3

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -33,8 +33,8 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
 
-aws-config = { version = "0.100.0", features = ["sso"] }
-aws-credential-types = "0.58.0"
-aws-sdk-lambda = "0.37.0"
-aws-sdk-sts = "0.37.0"
-aws-smithy-runtime = "0.58.0"
+aws-config = { version = "1.1.5", features = ["sso"] }
+aws-credential-types = "1.1.5"
+aws-sdk-lambda = "1.13.0"
+aws-sdk-sts = "1.13.0"
+aws-smithy-runtime = "1.1.5"


### PR DESCRIPTION
Relies on a forked aws-sdk-rust to include https://github.com/smithy-lang/smithy-rs/pull/3416
Because aws-sdk-rust has a *massive* repo footprint, i have hosted a truncated-history fork at https://github.com/restatedev/aws-sdk-rust temporarily. It would be nice if Cargo supported shallow clones, but it does not