### PR TITLE
Rename cluster controller role into admin role

### DIFF
--- a/crates/node/src/options.rs
+++ b/crates/node/src/options.rs
@@ -35,11 +35,11 @@ pub struct Options {
     #[cfg_attr(feature = "options_schema", schemars(with = "Vec<String>"))]
     pub roles: EnumSet<Role>,
 
-    /// Configures the cluster controller address. If it is not specified, then this
-    /// node needs to run the cluster controller
+    /// Configures the admin address. If it is not specified, then this
+    /// node needs to run the admin role
     #[serde_as(as = "serde_with::NoneAsEmptyString")]
     #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
-    pub cluster_controller_address: Option<NetworkAddress>,
+    pub admin_address: Option<NetworkAddress>,
 }
 
 impl Default for Options {
@@ -53,8 +53,8 @@ impl Default for Options {
             admin: Default::default(),
             bifrost: Default::default(),
             cluster_controller: Default::default(),
-            roles: Role::Worker | Role::ClusterController,
-            cluster_controller_address: None,
+            roles: Role::Worker | Role::Admin,
+            admin_address: None,
         }
     }
 }

--- a/crates/node/src/roles/mod.rs
+++ b/crates/node/src/roles/mod.rs
@@ -8,8 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod cluster_controller;
+mod admin;
 mod worker;
 
-pub use cluster_controller::{ClusterControllerRole, ClusterControllerRoleBuildError};
+pub use admin::{AdminRole, AdminRoleBuildError};
 pub use worker::{update_schemas, WorkerRole, WorkerRoleBuildError};

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -40,7 +40,7 @@ pub enum NodesConfigError {
 #[cfg_attr(feature = "serde", enumset(serialize_repr = "list"))]
 pub enum Role {
     Worker,
-    ClusterController,
+    Admin,
 }
 
 #[derive(


### PR DESCRIPTION
Rename cluster controller role into admin role

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1198).
* #1200
* __->__ #1198