### PR TITLE
Allow node server to bind to unix domain socket

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -115,7 +115,7 @@ impl Node {
 
             admin_address
         } else if admin_role.is_some() {
-            NetworkAddress::DnsName(format!("127.0.0.1:{}", server.port()))
+            server.address().clone()
         } else {
             return Err(BuildError::UnknownClusterController);
         };
@@ -199,13 +199,12 @@ impl Node {
         );
         // Temporary: nodes configuration from current node.
         let mut nodes_config = NodesConfiguration::default();
-        let address: NetworkAddress = NetworkAddress::TcpSocketAddr(options.server.bind_address);
         let node = NodeConfig::new(
             options.node_name,
             my_node_id
                 .as_generational()
                 .expect("my NodeId is generational"),
-            address,
+            options.server.bind_address,
             options.roles,
         );
         nodes_config.upsert_node(node);

--- a/crates/node/src/net_utils.rs
+++ b/crates/node/src/net_utils.rs
@@ -35,9 +35,9 @@ fn create_channel_from_network_address(
     let channel = match network_address {
         NetworkAddress::Uds(uds_path) => {
             let uds_path = uds_path.clone();
-            // dummy endpoint required to specify an uds connector, it is not used anywhere
-            Endpoint::try_from("/")
-                .expect("/ should be a valid Uri")
+            // We need to specify a valid URI with scheme and authority since tower's AddOrigin expects it
+            Endpoint::try_from("http://127.0.0.1")
+                .expect("http://127.0.0.1 should be a valid Uri")
                 .connect_with_connector_lazy(service_fn(move |_: Uri| {
                     UnixStream::connect(uds_path.clone())
                 }))

--- a/crates/node/src/net_utils.rs
+++ b/crates/node/src/net_utils.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::Uri;
+use restate_types::nodes_config::NetworkAddress;
+use std::time::Duration;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint};
+use tower::service_fn;
+
+pub trait NetworkAddressExt {
+    fn network_address(&self) -> &NetworkAddress;
+
+    fn connect_lazy(&self) -> Result<Channel, http::Error> {
+        create_channel_from_network_address(self.network_address())
+    }
+}
+
+impl NetworkAddressExt for NetworkAddress {
+    fn network_address(&self) -> &NetworkAddress {
+        self
+    }
+}
+
+fn create_channel_from_network_address(
+    network_address: &NetworkAddress,
+) -> Result<Channel, http::Error> {
+    let channel = match network_address {
+        NetworkAddress::Uds(uds_path) => {
+            let uds_path = uds_path.clone();
+            // dummy endpoint required to specify an uds connector, it is not used anywhere
+            Endpoint::try_from("/")
+                .expect("/ should be a valid Uri")
+                .connect_with_connector_lazy(service_fn(move |_: Uri| {
+                    UnixStream::connect(uds_path.clone())
+                }))
+        }
+        NetworkAddress::TcpSocketAddr(socket_addr) => {
+            let uri = create_uri(socket_addr)?;
+            create_lazy_channel_from_uri(uri)
+        }
+        NetworkAddress::DnsName(dns_name) => {
+            let uri = create_uri(dns_name)?;
+            create_lazy_channel_from_uri(uri)
+        }
+    };
+    Ok(channel)
+}
+
+fn create_uri(authority: impl ToString) -> Result<Uri, http::Error> {
+    Uri::builder()
+        // todo: Make the scheme configurable
+        .scheme("http")
+        .authority(authority.to_string())
+        .path_and_query("/")
+        .build()
+}
+
+fn create_lazy_channel_from_uri(uri: Uri) -> Channel {
+    // todo: Make the channel settings configurable
+    Channel::builder(uri)
+        .connect_timeout(Duration::from_secs(5))
+        .connect_lazy()
+}

--- a/crates/node/src/server/options.rs
+++ b/crates/node/src/server/options.rs
@@ -8,9 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::SocketAddr;
-
 use crate::server::service::{ClusterControllerDependencies, NodeServer, WorkerDependencies};
+use restate_types::nodes_config::NetworkAddress;
 use serde_with::serde_as;
 
 /// # Node server options
@@ -21,7 +20,8 @@ use serde_with::serde_as;
 #[cfg_attr(feature = "options_schema", schemars(default))]
 pub struct Options {
     /// Address to bind for the Node server.
-    pub bind_address: SocketAddr,
+    #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
+    pub bind_address: NetworkAddress,
 
     /// Timeout for idle histograms.
     ///

--- a/crates/node/src/server/options.rs
+++ b/crates/node/src/server/options.rs
@@ -20,6 +20,7 @@ use serde_with::serde_as;
 #[cfg_attr(feature = "options_schema", schemars(default))]
 pub struct Options {
     /// Address to bind for the Node server.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
     pub bind_address: NetworkAddress,
 


### PR DESCRIPTION
This PR updates the node server to support binding to an unix domain socket. As part of this PR, I've updated the `server.bind_address` to accept a `NetworkAddress` instead of a `SocketAddr`.

Passing the `admin_address` to the `admin_role` and `worker_role` is temporary until we have put the proper `NodesConfiguration` mechanism in place.