### PR TITLE
Make ProtoSymbols::add_service and ::remove_service idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5251,6 +5251,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "codederror",
+ "googletest",
  "http 0.2.11",
  "itertools 0.11.0",
  "once_cell",

--- a/crates/schema-impl/Cargo.toml
+++ b/crates/schema-impl/Cargo.toml
@@ -34,6 +34,7 @@ restate-pb = { workspace = true, features = ["mocks"] }
 restate-schema-api = { workspace = true, features = ["mocks"] }
 restate-test-util = { workspace = true }
 
+googletest = { workspace = true }
 prost-reflect = { workspace = true }
 test-log = { workspace = true }
 tracing = { workspace = true }

--- a/crates/schema-impl/src/schemas_impl/service.rs
+++ b/crates/schema-impl/src/schemas_impl/service.rs
@@ -26,8 +26,7 @@ impl SchemasInner {
 
         // Update proto_symbols
         if let ServiceLocation::Deployment {
-            latest_deployment,
-            ..
+            latest_deployment, ..
         } = &schemas.location
         {
             if new_public_value {

--- a/crates/schema-impl/src/schemas_impl/service.rs
+++ b/crates/schema-impl/src/schemas_impl/service.rs
@@ -26,20 +26,16 @@ impl SchemasInner {
 
         // Update proto_symbols
         if let ServiceLocation::Deployment {
-            public: old_public_value,
             latest_deployment,
+            ..
         } = &schemas.location
         {
-            match (*old_public_value, new_public_value) {
-                (true, false) => {
-                    self.proto_symbols
-                        .remove_service(schemas.service_descriptor());
-                }
-                (false, true) => {
-                    self.proto_symbols
-                        .add_service(latest_deployment, schemas.service_descriptor());
-                }
-                _ => {}
+            if new_public_value {
+                self.proto_symbols
+                    .add_service(latest_deployment, schemas.service_descriptor());
+            } else {
+                self.proto_symbols
+                    .remove_service(schemas.service_descriptor());
             }
         }
 


### PR DESCRIPTION
This commit changes the ProtoSymbols to support idempotent calls instead of panicking if a service already exists when adding a new service or when removing a non-existent one. The latter caused problems when re- discovering a deployment which contained some private services.

This fixes #1205.