### PR TITLE
Move common to node-services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5188,7 +5188,6 @@ dependencies = [
  "bytes",
  "prost 0.12.3",
  "prost-types",
- "restate-pb",
  "restate-types",
  "thiserror",
  "tonic 0.10.2",

--- a/crates/node-services/Cargo.toml
+++ b/crates/node-services/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 default = []
 
 [dependencies]
-restate-pb = { workspace = true, features = ["common"] }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true, optional = true }

--- a/crates/node-services/build.rs
+++ b/crates/node-services/build.rs
@@ -13,22 +13,27 @@ use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    tonic_build::configure()
+        .bytes(["."])
+        .file_descriptor_set_path(out_dir.join("common_descriptor.bin"))
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&["./proto/common.proto"], &["proto"])?;
+
     tonic_build::configure()
         .bytes(["."])
         .file_descriptor_set_path(out_dir.join("cluster_ctrl_svc_descriptor.bin"))
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile(
-            &["./proto/cluster_ctrl_svc.proto"],
-            &["proto", "../pb/proto"],
-        )?;
+        .compile(&["./proto/cluster_ctrl_svc.proto"], &["proto"])?;
 
     tonic_build::configure()
         .bytes(["."])
         .file_descriptor_set_path(out_dir.join("node_svc_descriptor.bin"))
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile(&["./proto/node_svc.proto"], &["proto", "../pb/proto"])?;
+        .compile(&["./proto/node_svc.proto"], &["proto"])?;
 
     Ok(())
 }

--- a/crates/node-services/proto/cluster_ctrl_svc.proto
+++ b/crates/node-services/proto/cluster_ctrl_svc.proto
@@ -9,7 +9,7 @@
 
 syntax = "proto3";
 
-import "dev/restate/common/common.proto";
+import "common.proto";
 
 package dev.restate.cluster_ctrl;
 

--- a/crates/node-services/proto/common.proto
+++ b/crates/node-services/proto/common.proto
@@ -11,6 +11,12 @@ syntax = "proto3";
 
 package dev.restate.common;
 
+enum ProtocolVersion {
+  ProtocolVersion_UNKNOWN = 0;
+  BASIC_HANDSHAKE = 1;
+  MAX_PROTOCOL_VERSION = 2;
+}
+
 message NodeId {
   uint32 id = 1;
   optional uint32 generation = 2;

--- a/crates/node-services/proto/node_svc.proto
+++ b/crates/node-services/proto/node_svc.proto
@@ -10,7 +10,7 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
-import "dev/restate/common/common.proto";
+import "common.proto";
 
 package dev.restate.node;
 

--- a/crates/node-services/src/lib.rs
+++ b/crates/node-services/src/lib.rs
@@ -8,13 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_pb::restate::common;
-
 pub mod cluster_ctrl {
-    #![allow(warnings)]
-    #![allow(clippy::all)]
-    #![allow(unknown_lints)]
-
     tonic::include_proto!("dev.restate.cluster_ctrl");
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
@@ -22,12 +16,53 @@ pub mod cluster_ctrl {
 }
 
 pub mod node {
-    #![allow(warnings)]
-    #![allow(clippy::all)]
-    #![allow(unknown_lints)]
-
     tonic::include_proto!("dev.restate.node");
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("node_svc_descriptor");
+}
+
+pub mod common {
+    tonic::include_proto!("dev.restate.common");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("common_descriptor");
+
+    impl From<Version> for restate_types::Version {
+        fn from(version: Version) -> Self {
+            restate_types::Version::from(version.value)
+        }
+    }
+
+    impl From<restate_types::Version> for Version {
+        fn from(version: restate_types::Version) -> Self {
+            Version {
+                value: version.into(),
+            }
+        }
+    }
+
+    impl From<NodeId> for restate_types::NodeId {
+        fn from(node_id: NodeId) -> Self {
+            restate_types::NodeId::new(node_id.id, node_id.generation)
+        }
+    }
+
+    impl From<restate_types::NodeId> for NodeId {
+        fn from(node_id: restate_types::NodeId) -> Self {
+            NodeId {
+                id: node_id.id().into(),
+                generation: node_id.as_generational().map(|g| g.generation()),
+            }
+        }
+    }
+
+    impl From<restate_types::PlainNodeId> for NodeId {
+        fn from(node_id: restate_types::PlainNodeId) -> Self {
+            let id: u32 = node_id.into();
+            NodeId {
+                id,
+                generation: None,
+            }
+        }
+    }
 }

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -19,7 +19,7 @@ use restate_cluster_controller::ClusterControllerHandle;
 use restate_meta::FileMetaReader;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_server::ClusterCtrlSvcServer;
 use restate_node_services::node::node_svc_server::NodeSvcServer;
-use restate_node_services::{cluster_ctrl, node};
+use restate_node_services::{cluster_ctrl, common, node};
 use restate_schema_impl::Schemas;
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_rocksdb::RocksDBStorage;
@@ -106,7 +106,8 @@ impl NetworkServer {
 
         // -- GRPC Service Setup
         let mut reflection_service_builder = tonic_reflection::server::Builder::configure()
-            .register_encoded_file_descriptor_set(node::FILE_DESCRIPTOR_SET);
+            .register_encoded_file_descriptor_set(node::FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(common::FILE_DESCRIPTOR_SET);
 
         if self.admin_deps.is_some() {
             reflection_service_builder = reflection_service_builder

--- a/crates/pb/Cargo.toml
+++ b/crates/pb/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [features]
 default = []
 builtin-service = ["restate-types"]
-common = ["restate-types"]
 mocks = []
 
 [dependencies]

--- a/crates/pb/build.rs
+++ b/crates/pb/build.rs
@@ -348,7 +348,6 @@ fn main() -> std::io::Result<()> {
                 "proto/dev/restate/internal/services.proto",
                 "proto/dev/restate/events.proto",
                 "proto/dev/restate/internal/messages.proto",
-                "proto/dev/restate/common/common.proto",
             ],
             &["proto"],
         )?;

--- a/crates/pb/src/lib.rs
+++ b/crates/pb/src/lib.rs
@@ -70,54 +70,6 @@ pub mod restate {
             }
         }
     }
-
-    #[cfg(feature = "common")]
-    pub mod common {
-        #![allow(warnings)]
-        #![allow(clippy::all)]
-        #![allow(unknown_lints)]
-
-        include!(concat!(env!("OUT_DIR"), "/dev.restate.common.rs"));
-
-        impl From<Version> for restate_types::Version {
-            fn from(version: Version) -> Self {
-                restate_types::Version::from(version.value)
-            }
-        }
-
-        impl From<restate_types::Version> for Version {
-            fn from(version: restate_types::Version) -> Self {
-                Version {
-                    value: version.into(),
-                }
-            }
-        }
-
-        impl From<NodeId> for restate_types::NodeId {
-            fn from(node_id: NodeId) -> Self {
-                restate_types::NodeId::new(node_id.id, node_id.generation)
-            }
-        }
-
-        impl From<restate_types::NodeId> for NodeId {
-            fn from(node_id: restate_types::NodeId) -> Self {
-                NodeId {
-                    id: node_id.id().into(),
-                    generation: node_id.as_generational().map(|g| g.generation()),
-                }
-            }
-        }
-
-        impl From<restate_types::PlainNodeId> for NodeId {
-            fn from(node_id: restate_types::PlainNodeId) -> Self {
-                let id: u32 = node_id.into();
-                NodeId {
-                    id,
-                    generation: None,
-                }
-            }
-        }
-    }
 }
 
 pub static DESCRIPTOR_POOL: Lazy<DescriptorPool> = Lazy::new(|| {


### PR DESCRIPTION
Move common to node-services

node-services protocol is meant for internal restate communication. pb/ appears to go beyond the internal cluster scope.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1211).
* #1214
* #1213
* #1212
* __->__ #1211