### PR TITLE
Introduce new API to resolve `ComponentMetadata`

### DIFF
--- a/crates/meta-rest-model/src/deployments.rs
+++ b/crates/meta-rest-model/src/deployments.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::services::ServiceRevision;
+use super::services::ComponentRevision;
 use std::time::SystemTime;
 
 use restate_schema_api::service::ServiceMetadata;
@@ -157,7 +157,7 @@ pub enum RegisterDeploymentRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServiceNameRevPair {
     pub name: String,
-    pub revision: ServiceRevision,
+    pub revision: ComponentRevision,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/meta-rest-model/src/services.rs
+++ b/crates/meta-rest-model/src/services.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 // Export schema types to be used by other crates without exposing the fact
 // that we are using proxying to restate-schema-api or restate-types
 pub use restate_schema_api::service::{InstanceType, MethodMetadata, ServiceMetadata};
-pub use restate_types::identifiers::ServiceRevision;
+pub use restate_types::identifiers::ComponentRevision;
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/schema-api/Cargo.toml
+++ b/crates/schema-api/Cargo.toml
@@ -20,6 +20,7 @@ proto_symbol = ["dep:bytes"]
 serde = ["dep:serde", "dep:serde_with", "restate-types?/serde", "dep:restate-serde-util"]
 serde_schema = ["serde", "dep:schemars", "restate-types?/serde_schema", "restate-serde-util?/schema"]
 service = ["dep:bytes", "dep:restate-types"]
+component = ["dep:bytes", "dep:restate-types"]
 subscription = ["dep:anyhow", "dep:restate-types"]
 
 [dependencies]

--- a/crates/schema-impl/src/deployment.rs
+++ b/crates/schema-impl/src/deployment.rs
@@ -14,7 +14,7 @@ use bytes::Bytes;
 use crate::schemas_impl::ServiceLocation;
 use restate_schema_api::deployment::{Deployment, DeploymentResolver};
 use restate_schema_api::service::ServiceMetadata;
-use restate_types::identifiers::{DeploymentId, ServiceRevision};
+use restate_types::identifiers::{ComponentRevision, DeploymentId};
 
 impl DeploymentResolver for Schemas {
     fn resolve_latest_deployment_for_service(
@@ -72,7 +72,7 @@ impl DeploymentResolver for Schemas {
         })
     }
 
-    fn get_deployments(&self) -> Vec<(Deployment, Vec<(String, ServiceRevision)>)> {
+    fn get_deployments(&self) -> Vec<(Deployment, Vec<(String, ComponentRevision)>)> {
         let schemas = self.0.load();
         schemas
             .deployments

--- a/crates/schema-impl/src/lib.rs
+++ b/crates/schema-impl/src/lib.rs
@@ -15,7 +15,7 @@ use prost_reflect::{DescriptorPool, ServiceDescriptor};
 use restate_schema_api::deployment::DeploymentMetadata;
 use restate_schema_api::service::ServiceMetadata;
 use restate_schema_api::subscription::{Subscription, SubscriptionValidator};
-use restate_types::identifiers::{DeploymentId, ServiceRevision, SubscriptionId};
+use restate_types::identifiers::{ComponentRevision, DeploymentId, SubscriptionId};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -66,7 +66,7 @@ pub struct DiscoveredMethodMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InsertServiceUpdateCommand {
     pub name: String,
-    pub revision: ServiceRevision,
+    pub revision: ComponentRevision,
     pub instance_type: DiscoveredInstanceType,
     pub methods: HashMap<String, DiscoveredMethodMetadata>,
 }
@@ -107,7 +107,7 @@ pub enum SchemasUpdateCommand {
     /// Remove only if the revision is matching
     RemoveService {
         name: String,
-        revision: ServiceRevision,
+        revision: ComponentRevision,
     },
     ModifyService {
         name: String,
@@ -310,7 +310,7 @@ mod tests {
         }
 
         #[track_caller]
-        pub(crate) fn assert_service_revision(&self, svc_name: &str, revision: ServiceRevision) {
+        pub(crate) fn assert_service_revision(&self, svc_name: &str, revision: ComponentRevision) {
             assert_eq!(
                 self.resolve_latest_service_metadata(svc_name)
                     .unwrap()

--- a/crates/schema-impl/src/schemas_impl/mod.rs
+++ b/crates/schema-impl/src/schemas_impl/mod.rs
@@ -18,7 +18,7 @@ use restate_schema_api::service::InstanceType;
 use restate_schema_api::subscription::{
     EventReceiverServiceInstanceType, FieldRemapType, InputEventRemap, Sink, Source,
 };
-use restate_types::identifiers::{DeploymentId, ServiceRevision};
+use restate_types::identifiers::{ComponentRevision, DeploymentId};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
@@ -116,7 +116,7 @@ impl MethodSchemas {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServiceSchemas {
-    pub(crate) revision: ServiceRevision,
+    pub(crate) revision: ComponentRevision,
     pub(crate) methods: HashMap<String, MethodSchemas>,
     pub(crate) instance_type: InstanceTypeMetadata,
     pub(crate) location: ServiceLocation,
@@ -191,7 +191,7 @@ impl TryFrom<&InstanceTypeMetadata> for InstanceType {
 
 impl ServiceSchemas {
     pub(crate) fn new(
-        revision: ServiceRevision,
+        revision: ComponentRevision,
         methods: HashMap<String, MethodSchemas>,
         instance_type: InstanceTypeMetadata,
         latest_deployment: DeploymentId,

--- a/crates/schema-impl/src/schemas_impl/service.rs
+++ b/crates/schema-impl/src/schemas_impl/service.rs
@@ -53,7 +53,7 @@ impl SchemasInner {
     pub(crate) fn apply_remove_service(
         &mut self,
         name: String,
-        revision: ServiceRevision,
+        revision: ComponentRevision,
     ) -> Result<(), SchemasUpdateError> {
         let entry = self.services.entry(name);
         match entry {

--- a/crates/storage-query-datafusion/src/deployment/table.rs
+++ b/crates/storage-query-datafusion/src/deployment/table.rs
@@ -19,7 +19,7 @@ use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
 pub use datafusion_expr::UserDefinedLogicalNode;
 use restate_schema_api::deployment::{Deployment, DeploymentResolver};
-use restate_types::identifiers::{PartitionKey, ServiceRevision};
+use restate_types::identifiers::{ComponentRevision, PartitionKey};
 use std::fmt::Debug;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
@@ -68,7 +68,7 @@ impl<DMR: DeploymentResolver + Debug + Sync + Send + 'static> RangeScanner
 async fn for_each_state(
     schema: SchemaRef,
     tx: Sender<datafusion::common::Result<RecordBatch>>,
-    rows: Vec<(Deployment, Vec<(String, ServiceRevision)>)>,
+    rows: Vec<(Deployment, Vec<(String, ComponentRevision)>)>,
 ) {
     let mut builder = DeploymentBuilder::new(schema.clone());
     let mut temp = String::new();

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -532,7 +532,7 @@ impl From<FullInvocationId> for EncodedInvocationId {
 }
 
 /// Incremental id defining the service revision.
-pub type ServiceRevision = u32;
+pub type ComponentRevision = u32;
 
 mod partitioner {
     use super::PartitionKey;


### PR DESCRIPTION
Fix #1218

`ComponentMetadataResolver#resolve_latest_component_handler` will replace key extraction from now on, and will be used by invoker and ingress to build the `ServiceInvocation` struct.