### PR TITLE
[1/n] Move my node ID to metadata and metadata-manager related fixes

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,10 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod metadata;
-
+mod metadata;
 mod task_center;
 mod task_center_types;
 
+pub use metadata::{spawn_metadata_manager, Metadata, MetadataManager, MetadataWriter};
 pub use task_center::*;
 pub use task_center_types::*;

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::info;
 
@@ -22,8 +23,8 @@ use super::MetadataInner;
 use super::MetadataKind;
 use super::MetadataWriter;
 
-pub(super) type CommandSender = tokio::sync::mpsc::UnboundedSender<Command>;
-pub(super) type CommandReceiver = tokio::sync::mpsc::UnboundedReceiver<Command>;
+pub(super) type CommandSender = mpsc::UnboundedSender<Command>;
+pub(super) type CommandReceiver = mpsc::UnboundedReceiver<Command>;
 
 pub(super) enum Command {
     UpdateMetadata(MetadataContainer, Option<oneshot::Sender<()>>),
@@ -70,11 +71,11 @@ impl MetadataManager {
     }
 
     pub fn writer(&self) -> MetadataWriter {
-        MetadataWriter::new(self.self_sender.clone())
+        MetadataWriter::new(self.self_sender.clone(), self.inner.clone())
     }
 
     /// Start and wait for shutdown signal.
-    pub async fn run(mut self /*, network_sender: NetworkSender*/) -> anyhow::Result<()> {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         info!("Metadata manager started");
 
         loop {

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -20,7 +20,7 @@ use futures::Future;
 use tokio::task::JoinHandle;
 use tokio::task_local;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::metadata::{spawn_metadata_manager, Metadata, MetadataManager};
 use crate::{TaskId, TaskKind};
@@ -52,10 +52,15 @@ impl TaskCenterFactory {
 
 #[cfg(any(test, feature = "test-util"))]
 pub fn create_test_task_center() -> TaskCenter {
+    use restate_types::GenerationalNodeId;
+
     let tc = TaskCenterFactory::create(tokio::runtime::Handle::current());
 
     let metadata_manager = MetadataManager::build();
     let metadata = metadata_manager.metadata();
+    metadata_manager
+        .writer()
+        .set_my_node_id(GenerationalNodeId::new(1, 1));
     tc.try_set_global_metadata(metadata);
 
     spawn_metadata_manager(&tc, metadata_manager).expect("metadata manager should start");
@@ -140,7 +145,12 @@ impl TaskCenter {
         });
 
         inner.tasks.lock().unwrap().insert(id, Arc::clone(&task));
-        let metadata = inner.global_metadata.get().cloned();
+        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
+        let metadata = METADATA
+            .try_with(|m| m.clone())
+            .ok()
+            .flatten()
+            .or_else(|| inner.global_metadata.get().cloned());
 
         let mut handle_mut = task.join_handle.lock().unwrap();
 
@@ -324,7 +334,7 @@ impl TaskCenter {
         future: F,
     ) -> O
     where
-        F: Future<Output = O> + Send + 'static,
+        F: Future<Output = O> + Send,
     {
         let cancel_token = CancellationToken::new();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
@@ -336,10 +346,19 @@ impl TaskCenter {
             cancel: cancel_token.clone(),
             join_handle: Mutex::new(None),
         });
-        CURRENT_TASK_CENTER
+        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
+        let metadata = METADATA
+            .try_with(|m| m.clone())
+            .ok()
+            .flatten()
+            .or_else(|| self.inner.global_metadata.get().cloned());
+        METADATA
             .scope(
-                self.clone(),
-                CANCEL_TOKEN.scope(cancel_token, CURRENT_TASK.scope(task, future)),
+                metadata,
+                CURRENT_TASK_CENTER.scope(
+                    self.clone(),
+                    CANCEL_TOKEN.scope(cancel_token, CURRENT_TASK.scope(task, future)),
+                ),
             )
             .await
     }
@@ -365,8 +384,16 @@ impl TaskCenter {
             cancel: cancel_token.clone(),
             join_handle: Mutex::new(None),
         });
-        CURRENT_TASK_CENTER.sync_scope(self.clone(), || {
-            CANCEL_TOKEN.sync_scope(cancel_token, || CURRENT_TASK.sync_scope(task, f))
+        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
+        let metadata = METADATA
+            .try_with(|m| m.clone())
+            .ok()
+            .flatten()
+            .or_else(|| self.inner.global_metadata.get().cloned());
+        METADATA.sync_scope(metadata, || {
+            CURRENT_TASK_CENTER.sync_scope(self.clone(), || {
+                CANCEL_TOKEN.sync_scope(cancel_token, || CURRENT_TASK.sync_scope(task, f))
+            })
         })
     }
 
@@ -425,7 +452,7 @@ impl TaskCenter {
         {
             match result {
                 Ok(Ok(())) => {
-                    debug!(kind = ?kind, name = ?task.name, "Task {} exited normally", task_id);
+                    trace!(kind = ?kind, name = ?task.name, "Task {} exited normally", task_id);
                 }
                 Ok(Err(err)) => {
                     if err.root_cause().downcast_ref::<ShutdownError>().is_some() {
@@ -550,7 +577,8 @@ pub fn current_task_id() -> Option<TaskId> {
     CURRENT_TASK.try_with(|ct| ct.id).ok()
 }
 
-/// Access to global metadata handle. This available in task-center tasks only!
+/// Accepss to global metadata handle. This available in task-center tasks only!
+#[track_caller]
 pub fn metadata() -> Metadata {
     METADATA
         .try_with(|m| m.clone())

--- a/crates/node-services/src/lib.rs
+++ b/crates/node-services/src/lib.rs
@@ -65,4 +65,13 @@ pub mod common {
             }
         }
     }
+
+    impl From<restate_types::GenerationalNodeId> for NodeId {
+        fn from(node_id: restate_types::GenerationalNodeId) -> Self {
+            NodeId {
+                id: node_id.raw_id(),
+                generation: Some(node_id.generation()),
+            }
+        }
+    }
 }

--- a/crates/node/src/network_server/handler/cluster_ctrl.rs
+++ b/crates/node/src/network_server/handler/cluster_ctrl.rs
@@ -11,7 +11,6 @@
 use tonic::{async_trait, Request, Response, Status};
 use tracing::debug;
 
-use restate_core::metadata::Metadata;
 use restate_meta::MetaReader;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_server::ClusterCtrlSvc;
 use restate_node_services::cluster_ctrl::{AttachmentRequest, AttachmentResponse};
@@ -21,15 +20,11 @@ use crate::network_server::AdminDependencies;
 
 pub struct ClusterCtrlSvcHandler {
     admin_deps: AdminDependencies,
-    _metadata: Metadata,
 }
 
 impl ClusterCtrlSvcHandler {
-    pub fn new(admin_deps: AdminDependencies, metadata: Metadata) -> Self {
-        Self {
-            admin_deps,
-            _metadata: metadata,
-        }
+    pub fn new(admin_deps: AdminDependencies) -> Self {
+        Self { admin_deps }
     }
 }
 

--- a/crates/node/src/network_server/handler/node.rs
+++ b/crates/node/src/network_server/handler/node.rs
@@ -12,36 +12,28 @@ use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::error::FlightError;
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
-use restate_core::metadata::{Metadata, MetadataWriter};
+use restate_core::{metadata, TaskCenter};
 use restate_node_services::node::node_svc_server::NodeSvc;
-use restate_node_services::node::{IdentResponse, NodeStatus};
 use restate_node_services::node::{
-    StateMutationRequest, StorageQueryRequest, StorageQueryResponse, TerminationRequest,
-    UpdateSchemaRequest,
+    IdentResponse, NodeStatus, StateMutationRequest, StorageQueryRequest, StorageQueryResponse,
+    TerminationRequest, UpdateSchemaRequest,
 };
 use restate_schema_impl::SchemasUpdateCommand;
-use restate_types::NodeId;
 use restate_worker_api::Handle;
 use tonic::{Request, Response, Status};
 
 use crate::network_server::WorkerDependencies;
 
 pub struct NodeSvcHandler {
+    task_center: TaskCenter,
     worker: Option<WorkerDependencies>,
-    _metadata_writer: MetadataWriter,
-    _metadata: Metadata,
 }
 
 impl NodeSvcHandler {
-    pub fn new(
-        worker: Option<WorkerDependencies>,
-        metadata_writer: MetadataWriter,
-        metadata: Metadata,
-    ) -> Self {
+    pub fn new(task_center: TaskCenter, worker: Option<WorkerDependencies>) -> Self {
         Self {
+            task_center,
             worker,
-            _metadata: metadata,
-            _metadata_writer: metadata_writer,
         }
     }
 }
@@ -50,10 +42,12 @@ impl NodeSvcHandler {
 impl NodeSvc for NodeSvcHandler {
     async fn get_ident(&self, _request: Request<()>) -> Result<Response<IdentResponse>, Status> {
         // STUB IMPLEMENTATION
-        return Ok(Response::new(IdentResponse {
-            status: NodeStatus::Alive.into(),
-            node_id: NodeId::my_node_id().map(Into::into),
-        }));
+        self.task_center.run_in_scope_sync("get_ident", None, || {
+            Ok(Response::new(IdentResponse {
+                status: NodeStatus::Alive.into(),
+                node_id: Some(metadata().my_node_id().into()),
+            }))
+        })
     }
 
     async fn terminate_invocation(
@@ -111,15 +105,18 @@ impl NodeSvc for NodeSvcHandler {
         let Some(ref worker) = self.worker else {
             return Err(Status::failed_precondition("Not a worker node"));
         };
-
         let query = request.into_inner().query;
 
-        let record_stream = worker.query_context.execute(&query).await.map_err(|err| {
-            Status::internal(format!("failed executing the query '{}': {}", query, err))
-        })?;
+        let record_stream = self
+            .task_center
+            .run_in_scope("query-storage", None, async move {
+                worker.query_context.execute(&query).await.map_err(|err| {
+                    Status::internal(format!("failed executing the query '{}': {}", query, err))
+                })
+            })
+            .await?;
 
         let schema = record_stream.schema();
-
         let response_stream =
             FlightDataEncoderBuilder::new()
                 // CLI is expecting schema information
@@ -132,7 +129,6 @@ impl NodeSvc for NodeSvcHandler {
                     data: flight_data.data_body,
                 })
                 .map_err(Status::from);
-
         Ok(Response::new(Box::pin(response_stream)))
     }
 
@@ -151,15 +147,19 @@ impl NodeSvc for NodeSvcHandler {
             )
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
-        crate::roles::update_schemas(
-            &worker.schemas,
-            worker.subscription_controller.as_ref(),
-            schema_updates,
-        )
-        .await
-        .map_err(|err| {
-            Status::internal(format!("failed updating the schema information: {err}"))
-        })?;
+        self.task_center
+            .run_in_scope("update-schema", None, async move {
+                crate::roles::update_schemas(
+                    &worker.schemas,
+                    worker.subscription_controller.as_ref(),
+                    schema_updates,
+                )
+                .await
+                .map_err(|err| {
+                    Status::internal(format!("failed updating the schema information: {err}"))
+                })
+            })
+            .await?;
 
         Ok(Response::new(()))
     }

--- a/crates/node/src/network_server/options.rs
+++ b/crates/node/src/network_server/options.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 
 use serde_with::serde_as;
 
-use restate_core::metadata::{Metadata, MetadataWriter};
 use restate_types::nodes_config::AdvertisedAddress;
 
 use crate::network_server::service::{AdminDependencies, NetworkServer, WorkerDependencies};
@@ -59,11 +58,9 @@ impl Default for Options {
 impl Options {
     pub fn build(
         self,
-        metadata: Metadata,
-        metadata_writer: MetadataWriter,
         node_deps: Option<WorkerDependencies>,
         admin_deps: Option<AdminDependencies>,
     ) -> NetworkServer {
-        NetworkServer::new(self, metadata, metadata_writer, node_deps, admin_deps)
+        NetworkServer::new(self, node_deps, admin_deps)
     }
 }

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -27,7 +27,6 @@ use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_rocksdb::RocksDBStorage;
 use restate_types::nodes_config::AdvertisedAddress;
 use restate_types::retries::RetryPolicy;
-use restate_types::NodeId;
 use restate_worker::{SubscriptionControllerHandle, Worker, WorkerCommandSender};
 use restate_worker_api::SubscriptionController;
 use tracing::info;
@@ -169,7 +168,7 @@ impl WorkerRole {
                 cc_client
                     .clone()
                     .attach_node(AttachmentRequest {
-                        node_id: NodeId::my_node_id().map(Into::into),
+                        node_id: Some(metadata().my_node_id().into()),
                     })
                     .await
             })

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -13,9 +13,9 @@ serde = ["dep:serde", "dep:bincode", "enum-map/serde", "bytestring/serde", "rest
 options_schema = ["dep:schemars"]
 
 [dependencies]
-restate-types = { workspace = true }
-restate-storage-api = { workspace = true }
 restate-invoker-api = { workspace = true }
+restate-storage-api = { workspace = true }
+restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 assert2 = { workspace = true }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -34,7 +34,6 @@ use restate_storage_query_postgres::service::PostgresQueryService;
 use restate_storage_rocksdb::{RocksDBStorage, RocksDBWriter};
 use restate_types::identifiers::{PartitionKey, PeerId};
 use restate_types::message::PartitionTarget;
-use restate_types::NodeId;
 use std::ops::RangeInclusive;
 use tokio::sync::mpsc;
 use tracing::debug;
@@ -384,7 +383,6 @@ impl Worker {
 
     pub async fn run(self) -> anyhow::Result<()> {
         let tc = task_center();
-        let my_node_id = NodeId::my_node_id().expect("my node ID is set");
         let shutdown = cancellation_watcher();
         let (shutdown_signal, shutdown_watch) = drain::channel();
 
@@ -403,7 +401,7 @@ impl Worker {
             "ingress-dispatcher",
             None,
             self.ingress_dispatcher_service
-                .run(my_node_id, self.network_ingress_sender),
+                .run(self.network_ingress_sender),
         )?;
 
         // Ingress RPC server

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -10,8 +10,8 @@
 
 use super::leadership::ActionEffect;
 use crate::partition::ConsensusWriter;
+use restate_core::metadata;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey};
-use restate_types::NodeId;
 use restate_wal_protocol::effects::BuiltinServiceEffects;
 use restate_wal_protocol::{AckMode, Command, Destination, Envelope, Header, Source};
 use std::ops::RangeInclusive;
@@ -114,7 +114,7 @@ impl ActionEffectHandler {
                 leader_epoch: self.leader_epoch,
                 // todo: Add support for deduplicating self proposals
                 sequence_number: None,
-                node_id: NodeId::my_node_id().expect("NodeId should be set").id(),
+                node_id: metadata().my_node_id().as_plain(),
             },
         }
     }

--- a/crates/worker/src/partition/leadership/action_collector.rs
+++ b/crates/worker/src/partition/leadership/action_collector.rs
@@ -19,13 +19,13 @@ use crate::partition::{shuffle, ConsensusWriter};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use prost::Message;
+use restate_core::metadata;
 use restate_errors::NotRunningError;
 use restate_ingress_dispatcher::{IngressDispatcherInput, IngressDispatcherInputSender};
 use restate_invoker_api::ServiceHandle;
 use restate_types::identifiers::{FullInvocationId, PartitionLeaderEpoch, WithPartitionKey};
 use restate_types::invocation::{ServiceInvocation, Source, SpanRelation};
 use restate_types::journal::CompletionResult;
-use restate_types::NodeId;
 use restate_wal_protocol::effects::BuiltinServiceEffects;
 use restate_wal_protocol::timer::TimerValue;
 use restate_wal_protocol::{AckMode, Command, Destination, Envelope, Header};
@@ -261,7 +261,7 @@ where
                 leader_epoch: partition_leader_epoch.1,
                 // todo: Add support for deduplicating self proposals
                 sequence_number: None,
-                node_id: NodeId::my_node_id().expect("NodeId should be set").id(),
+                node_id: metadata().my_node_id().as_plain(),
             },
         };
 

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -12,6 +12,7 @@ use crate::partition::shuffle::{HintSender, Shuffle, ShuffleMetadata};
 use crate::partition::{shuffle, storage, ConsensusWriter};
 use assert2::let_assert;
 use futures::{future, StreamExt};
+use restate_core::metadata;
 use restate_invoker_api::InvokeInputJournal;
 use restate_timer::TokioClock;
 use std::fmt::Debug;
@@ -37,7 +38,6 @@ use restate_storage_rocksdb::RocksDBStorage;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch, PeerId};
 use restate_types::journal::EntryType;
-use restate_types::NodeId;
 use restate_wal_protocol::timer::TimerValue;
 use restate_wal_protocol::Envelope;
 
@@ -199,7 +199,7 @@ where
                     follower_state.peer_id,
                     follower_state.partition_id,
                     leader_epoch,
-                    NodeId::my_node_id().expect("NodeId should be set"),
+                    metadata().my_node_id().into(),
                 ),
                 partition_storage.clone(),
                 follower_state.network_handle.create_shuffle_sender(),


### PR DESCRIPTION
[1/n] Move my node ID to metadata and metadata-manager related fixes

Removes `NodeId::my_node_id()` and introduces `metadata().my_node_id()`. Along with various fixes to allow automatic propagation of metadata between tasks

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1240).
* #1245
* #1244
* #1243
* #1242
* __->__ #1240