### PR TITLE
Add PartitionTable metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,6 +5818,7 @@ dependencies = [
  "strum 0.26.1",
  "strum_macros 0.26.1",
  "sync_wrapper",
+ "test-log",
  "thiserror",
  "tokio",
  "tonic 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -149,9 +149,9 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
 name = "arrayref"
@@ -327,7 +327,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "lexical-core",
  "num",
  "serde",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "assert2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c2a406fdd319a14eccedbc8d1ef96b27e4d2101f19d997ac19fb307d919f39"
+checksum = "844ca3172d927ddd9d01f63b6c80f4ebd3e01c3f787c204626635450dfe3edba"
 dependencies = [
  "assert2-macros",
  "diff",
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "assert2-macros"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d83ae6bec6fbfa955b8ff04be5e63ae26ed2d9d068979d993142f13a2133344"
+checksum = "9ec0e42bd0fe1c8d72c7bde53ac8686764cea0fd86f412b92fcad20fea08b489"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,7 +474,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -485,7 +485,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -529,7 +529,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper 0.14.28",
  "ring 0.17.8",
  "time",
@@ -563,7 +563,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
@@ -586,7 +586,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -607,7 +607,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -628,7 +628,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -650,7 +650,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "regex-lite",
  "tracing",
@@ -669,8 +669,8 @@ dependencies = [
  "form_urlencoded",
  "hex",
  "hmac",
- "http 0.2.11",
- "http 1.0.0",
+ "http 0.2.12",
+ "http 1.1.0",
  "once_cell",
  "percent-encoding",
  "sha2",
@@ -698,7 +698,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
@@ -736,7 +736,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "h2 0.3.24",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
@@ -756,7 +756,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -772,7 +772,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "itoa",
  "num-integer",
@@ -802,7 +802,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.11",
+ "http 0.2.12",
  "rustc_version",
  "tracing",
 ]
@@ -818,7 +818,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "itoa",
@@ -848,7 +848,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "mime",
  "rustversion",
@@ -941,7 +941,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.1"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c764d619ca78fccbf3069b37bd7af92577f044bb15236036662d79b6559f25b7"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytemuck"
@@ -1125,9 +1125,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
  "jobserver",
  "libc",
@@ -1156,7 +1156,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1171,7 +1171,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1295,7 +1295,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1328,11 +1328,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f3e4ed7569e1ca05aacf00701393267944971e284a0f9cca0014e7326ce3fa4"
 dependencies = [
- "darling 0.20.6",
+ "darling 0.20.8",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1446,9 +1446,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1737,12 +1737,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.6",
- "darling_macro 0.20.6",
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -1761,16 +1761,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1786,13 +1786,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.6",
+ "darling_core 0.20.8",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1837,7 +1837,7 @@ dependencies = [
  "glob",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "itertools 0.12.1",
  "log",
  "num_cpus",
@@ -1952,7 +1952,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "hex",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "itertools 0.12.1",
  "log",
  "md-5",
@@ -1985,7 +1985,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "itertools 0.12.1",
  "log",
  "once_cell",
@@ -2168,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -2217,7 +2217,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2236,10 +2236,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.6",
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2420,7 +2420,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2519,7 +2519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005e4cb962c56efd249bdeeb4ac232b11e1c45a2e49793bba2b2982dcc3f2e9d"
 dependencies = [
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2533,8 +2533,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
- "indexmap 2.2.3",
+ "http 0.2.12",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2552,8 +2552,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 1.0.0",
- "indexmap 2.2.3",
+ "http 1.1.0",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2562,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -2617,9 +2617,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2658,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2669,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -2685,7 +2685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -2696,7 +2696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.0.0",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2707,7 +2707,7 @@ checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
 ]
@@ -2724,7 +2724,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
 dependencies = [
- "http 0.2.11",
+ "http 0.2.12",
  "serde",
 ]
 
@@ -2757,7 +2757,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.24",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
@@ -2780,7 +2780,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.2",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
  "httpdate",
@@ -2798,7 +2798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper 0.14.28",
  "log",
  "rustls",
@@ -2828,7 +2828,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "hyper 1.2.0",
  "pin-project-lite",
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2925,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "is-terminal",
  "itoa",
  "log",
@@ -3037,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3143,12 +3143,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "2caa5afb8bf9f3a2652760ce7d4f62d21c4d5a423e68466fca30df82f2330164"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3220,9 +3220,9 @@ checksum = "3a69c0481fc2424cb55795de7da41add33372ea75a94f9b6588ab6a2826dfebc"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lua-src"
@@ -3343,7 +3343,7 @@ checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
  "hyper 0.14.28",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "metrics",
  "metrics-util",
  "quanta",
@@ -3357,7 +3357,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -3378,7 +3378,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "metrics",
  "num_cpus",
  "ordered-float 4.2.0",
@@ -3419,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -3667,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d139f545f64630e2e3688fd9f81c470888ab01edeb72d13b4e86c566f1130000"
+checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3702,7 +3702,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
@@ -3745,7 +3745,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "okapi",
  "okapi-operation-macro",
  "paste",
@@ -3821,7 +3821,7 @@ checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
 dependencies = [
  "async-trait",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "opentelemetry_api",
 ]
 
@@ -3833,7 +3833,7 @@ checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 0.2.11",
+ "http 0.2.12",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_api",
@@ -4071,7 +4071,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4107,7 +4107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -4193,7 +4193,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4329,7 +4329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4393,7 +4393,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
@@ -4435,7 +4435,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types",
  "regex",
- "syn 2.0.50",
+ "syn 2.0.52",
  "tempfile",
  "which",
 ]
@@ -4463,7 +4463,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4573,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -4650,7 +4650,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -4665,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4724,7 +4724,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.24",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
@@ -4768,7 +4768,7 @@ dependencies = [
  "derive_builder",
  "drain",
  "futures",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper 0.14.28",
  "okapi-operation",
  "prost 0.12.3",
@@ -4888,7 +4888,7 @@ dependencies = [
  "dirs",
  "dotenvy",
  "futures",
- "http 0.2.11",
+ "http 0.2.12",
  "indicatif",
  "indoc",
  "is-terminal",
@@ -5053,7 +5053,7 @@ dependencies = [
  "derive_builder",
  "drain",
  "futures",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "metrics",
@@ -5096,7 +5096,7 @@ dependencies = [
  "codederror",
  "derive_builder",
  "futures",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
@@ -5226,7 +5226,7 @@ dependencies = [
  "drain",
  "futures",
  "googletest",
- "http 0.2.11",
+ "http 0.2.12",
  "prost 0.12.3",
  "prost-reflect",
  "restate-core",
@@ -5258,7 +5258,7 @@ name = "restate-meta-rest-model"
 version = "0.9.0"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "humantime",
  "restate-schema-api",
  "restate-serde-util",
@@ -5275,14 +5275,20 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "bytes",
  "drain",
+ "enum-map",
+ "enumset",
  "futures",
- "http 0.2.11",
+ "googletest",
+ "http 0.2.12",
  "pin-project",
+ "rand",
  "restate-core",
  "restate-errors",
  "restate-node-protocol",
+ "restate-node-services",
  "restate-test-util",
  "restate-types",
  "restate-wal-protocol",
@@ -5290,6 +5296,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic 0.10.2",
  "tower",
  "tracing",
@@ -5315,7 +5322,7 @@ dependencies = [
  "futures",
  "googletest",
  "hostname",
- "http 0.2.11",
+ "http 0.2.12",
  "humantime",
  "hyper 0.14.28",
  "metrics",
@@ -5349,6 +5356,7 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic 0.10.2",
  "tonic-reflection",
@@ -5428,7 +5436,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "bytestring",
- "http 0.2.11",
+ "http 0.2.12",
  "prost 0.12.3",
  "prost-reflect",
  "restate-base64-util",
@@ -5450,7 +5458,7 @@ dependencies = [
  "bytes",
  "codederror",
  "googletest",
- "http 0.2.11",
+ "http 0.2.12",
  "itertools 0.11.0",
  "once_cell",
  "prost 0.12.3",
@@ -5478,7 +5486,7 @@ version = "0.9.0"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "prost 0.12.3",
  "schemars",
  "serde",
@@ -5578,7 +5586,7 @@ dependencies = [
  "serde",
  "serde_json",
  "size",
- "syn 2.0.50",
+ "syn 2.0.52",
  "test-log",
  "thiserror",
  "tokio",
@@ -5795,7 +5803,7 @@ dependencies = [
  "derive_more",
  "enum-map",
  "enumset",
- "http 0.2.11",
+ "http 0.2.12",
  "humantime",
  "num-traits",
  "once_cell",
@@ -6196,7 +6204,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6240,7 +6248,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6277,10 +6285,10 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.6",
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6289,7 +6297,7 @@ version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -6464,12 +6472,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6512,7 +6520,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6581,7 +6589,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6594,7 +6602,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6639,9 +6647,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6677,9 +6685,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6722,9 +6730,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
@@ -6732,13 +6740,13 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6758,7 +6766,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6914,7 +6922,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6964,7 +6972,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -6982,7 +6990,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.24",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-timeout",
@@ -7009,7 +7017,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2 0.3.24",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-timeout",
@@ -7026,15 +7034,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7058,7 +7066,7 @@ checksum = "0fddb2a37b247e6adcb9f239f4e5cefdcc5ed526141a416b943929f13aea2cce"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "pin-project",
@@ -7100,7 +7108,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body 0.4.6",
  "http-range-header",
  "iri-string",
@@ -7143,7 +7151,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7303,7 +7311,7 @@ dependencies = [
  "regress 0.7.1",
  "schemars",
  "serde_json",
- "syn 2.0.50",
+ "syn 2.0.52",
  "thiserror",
  "unicode-ident",
 ]
@@ -7320,7 +7328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.50",
+ "syn 2.0.52",
  "typify-impl",
 ]
 
@@ -7470,9 +7478,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -7495,9 +7503,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -7505,24 +7513,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7532,9 +7540,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7542,28 +7550,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7571,9 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7634,7 +7642,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7652,7 +7660,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7672,17 +7680,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -7693,9 +7701,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7705,9 +7713,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7717,9 +7725,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7729,9 +7737,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7741,9 +7749,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7753,9 +7761,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7765,9 +7773,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -7879,7 +7887,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ tokio-util = { version = "0.7.10" }
 tokio-stream = "0.1.14"
 tonic = { version = "0.10.2", default-features = false }
 tonic-reflection = { version = "0.10.2" }
-tonic-build = "0.10.2"
+tonic-build = "0.11.0"
 tower = "0.4"
 tower-http = { version = "0.4", default-features = false }
 tracing = "0.1"

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use arc_swap::ArcSwapOption;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -18,8 +19,9 @@ use tracing::{debug, info, warn};
 use restate_node_protocol::metadata::{MetadataMessage, MetadataUpdate};
 use restate_node_protocol::MessageEnvelope;
 use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partition_table::FixedPartitionTable;
 use restate_types::GenerationalNodeId;
-use restate_types::Version;
+use restate_types::{Version, Versioned};
 
 use crate::cancellation_watcher;
 use crate::is_cancellation_requested;
@@ -219,52 +221,64 @@ where
     fn update_metadata(&mut self, value: MetadataContainer, callback: Option<oneshot::Sender<()>>) {
         match value {
             MetadataContainer::NodesConfiguration(config) => {
-                self.update_nodes_configuration(config, callback);
+                self.update_nodes_configuration(config);
             }
-        }
-    }
-
-    fn update_nodes_configuration(
-        &mut self,
-        config: NodesConfiguration,
-        callback: Option<oneshot::Sender<()>>,
-    ) {
-        let inner = &self.inner;
-        let current = inner.nodes_config.load();
-        let mut maybe_new_version = config.version();
-        match current.as_deref() {
-            None => {
-                inner.nodes_config.store(Some(Arc::new(config)));
-            }
-            Some(current) if config.version() > current.version() => {
-                inner.nodes_config.store(Some(Arc::new(config)));
-            }
-            Some(current) => {
-                /* Do nothing, current is already newer */
-                debug!(
-                    "Ignoring nodes config update {} because we are at {}",
-                    config.version(),
-                    current.version(),
-                );
-                maybe_new_version = current.version();
+            MetadataContainer::PartitionTable(partition_table) => {
+                self.update_partition_table(partition_table);
             }
         }
 
         if let Some(callback) = callback {
             let _ = callback.send(());
         }
+    }
 
+    fn update_nodes_configuration(&mut self, config: NodesConfiguration) {
+        let maybe_new_version = Self::update_internal(&self.inner.nodes_config, config);
+
+        self.notify_watches(maybe_new_version, MetadataKind::NodesConfiguration);
+    }
+
+    fn update_partition_table(&mut self, partition_table: FixedPartitionTable) {
+        let maybe_new_version = Self::update_internal(&self.inner.partition_table, partition_table);
+
+        self.notify_watches(maybe_new_version, MetadataKind::PartitionTable);
+    }
+
+    fn update_internal<T: Versioned>(container: &ArcSwapOption<T>, new_value: T) -> Version {
+        let current_value = container.load();
+        let mut maybe_new_version = new_value.version();
+        match current_value.as_deref() {
+            None => {
+                container.store(Some(Arc::new(new_value)));
+            }
+            Some(current_value) if new_value.version() > current_value.version() => {
+                container.store(Some(Arc::new(new_value)));
+            }
+            Some(current_value) => {
+                /* Do nothing, current is already newer */
+                debug!(
+                    "Ignoring update {} because we are at {}",
+                    new_value.version(),
+                    current_value.version(),
+                );
+                maybe_new_version = current_value.version();
+            }
+        }
+
+        maybe_new_version
+    }
+
+    fn notify_watches(&mut self, maybe_new_version: Version, kind: MetadataKind) {
         // notify watches.
-        self.inner.write_watches[MetadataKind::NodesConfiguration]
-            .sender
-            .send_if_modified(|v| {
-                if maybe_new_version > *v {
-                    *v = maybe_new_version;
-                    true
-                } else {
-                    false
-                }
-            });
+        self.inner.write_watches[kind].sender.send_if_modified(|v| {
+            if maybe_new_version > *v {
+                *v = maybe_new_version;
+                true
+            } else {
+                false
+            }
+        });
     }
 }
 
@@ -278,59 +292,58 @@ mod tests {
     use googletest::prelude::*;
     use restate_test_util::assert_eq;
     use restate_types::nodes_config::{AdvertisedAddress, NodeConfig, Role};
-    use restate_types::{GenerationalNodeId, NodeId, Version};
+    use restate_types::{GenerationalNodeId, Version};
 
     use crate::metadata::spawn_metadata_manager;
-    use crate::network::NetworkSendError;
+    use crate::test_env::MockNetworkSender;
     use crate::TaskCenterFactory;
-
-    // TEMPORARY. REMOVED IN NEXT PR(s)
-    #[derive(Clone)]
-    struct MockNetworkSender;
-
-    impl NetworkSender for MockNetworkSender {
-        async fn send<M>(
-            &self,
-            _to: NodeId,
-            _message: &M,
-        ) -> std::result::Result<(), NetworkSendError>
-        where
-            M: restate_node_protocol::codec::WireSerde
-                + restate_node_protocol::codec::Targeted
-                + Send
-                + Sync,
-        {
-            Ok(())
-        }
-    }
 
     #[tokio::test]
     async fn test_nodes_config_updates() -> Result<()> {
+        test_updates(
+            create_mock_nodes_config(),
+            MetadataKind::NodesConfiguration,
+            |metadata| metadata.nodes_config_version(),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_partition_table_updates() -> Result<()> {
+        test_updates(
+            FixedPartitionTable::new(Version::MIN, 42),
+            MetadataKind::PartitionTable,
+            |metadata| metadata.partition_table_version(),
+        )
+        .await
+    }
+
+    async fn test_updates<T, F>(value: T, kind: MetadataKind, config_version: F) -> Result<()>
+    where
+        T: Into<MetadataContainer> + Versioned + Clone,
+        F: Fn(&Metadata) -> Version,
+    {
         let network_sender = MockNetworkSender;
         let tc = TaskCenterFactory::create(tokio::runtime::Handle::current());
         let metadata_manager = MetadataManager::build(network_sender);
         let metadata_writer = metadata_manager.writer();
         let metadata = metadata_manager.metadata();
 
-        assert_eq!(Version::INVALID, metadata.nodes_config_version());
+        assert_eq!(Version::INVALID, config_version(&metadata));
 
-        let nodes_config = create_mock_nodes_config();
-        assert_eq!(Version::MIN, nodes_config.version());
+        assert_eq!(Version::MIN, value.version());
         // updates happening before metadata manager start should not get lost.
-        metadata_writer.submit(nodes_config.clone());
+        metadata_writer.submit(value.clone());
 
         // start metadata manager
         spawn_metadata_manager(&tc, metadata_manager)?;
 
-        let version = metadata
-            .wait_for_version(MetadataKind::NodesConfiguration, Version::MIN)
-            .await
-            .unwrap();
+        let version = metadata.wait_for_version(kind, Version::MIN).await.unwrap();
         assert_eq!(Version::MIN, version);
 
         // Wait should not block if waiting older version
         let version2 = metadata
-            .wait_for_version(MetadataKind::NodesConfiguration, Version::INVALID)
+            .wait_for_version(kind, Version::INVALID)
             .await
             .unwrap();
         assert_eq!(version, version2);
@@ -340,21 +353,19 @@ mod tests {
             let metadata = metadata.clone();
             let updated = Arc::clone(&updated);
             async move {
-                let _ = metadata
-                    .wait_for_version(MetadataKind::NodesConfiguration, Version::from(3))
-                    .await;
+                let _ = metadata.wait_for_version(kind, Version::from(3)).await;
                 updated.store(true, Ordering::Release);
             }
         });
 
         // let's bump the version a couple of times.
-        let mut nodes_config = nodes_config.clone();
-        nodes_config.increment_version();
-        nodes_config.increment_version();
-        nodes_config.increment_version();
-        nodes_config.increment_version();
+        let mut value = value.clone();
+        value.increment_version();
+        value.increment_version();
+        value.increment_version();
+        value.increment_version();
 
-        metadata_writer.update(nodes_config).await?;
+        metadata_writer.update(value).await?;
         assert_eq!(true, updated.load(Ordering::Acquire));
 
         tc.cancel_tasks(None, None).await;
@@ -362,42 +373,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_watchers() -> Result<()> {
+    async fn test_nodes_config_watchers() -> Result<()> {
+        test_watchers(
+            create_mock_nodes_config(),
+            MetadataKind::NodesConfiguration,
+            |metadata| metadata.nodes_config_version(),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_partition_table_watchers() -> Result<()> {
+        test_watchers(
+            FixedPartitionTable::new(Version::MIN, 42),
+            MetadataKind::PartitionTable,
+            |metadata| metadata.partition_table_version(),
+        )
+        .await
+    }
+
+    async fn test_watchers<T, F>(value: T, kind: MetadataKind, config_version: F) -> Result<()>
+    where
+        T: Into<MetadataContainer> + Versioned + Clone,
+        F: Fn(&Metadata) -> Version,
+    {
         let network_sender = MockNetworkSender;
         let tc = TaskCenterFactory::create(tokio::runtime::Handle::current());
         let metadata_manager = MetadataManager::build(network_sender);
         let metadata_writer = metadata_manager.writer();
         let metadata = metadata_manager.metadata();
 
-        assert_eq!(Version::INVALID, metadata.nodes_config_version());
+        assert_eq!(Version::INVALID, config_version(&metadata));
 
-        let nodes_config = create_mock_nodes_config();
-        assert_eq!(Version::MIN, nodes_config.version());
+        assert_eq!(Version::MIN, value.version());
 
         // start metadata manager
         spawn_metadata_manager(&tc, metadata_manager)?;
 
-        let mut watcher1 = metadata.watch(MetadataKind::NodesConfiguration);
+        let mut watcher1 = metadata.watch(kind);
         assert_eq!(Version::INVALID, *watcher1.borrow());
-        let mut watcher2 = metadata.watch(MetadataKind::NodesConfiguration);
+        let mut watcher2 = metadata.watch(kind);
         assert_eq!(Version::INVALID, *watcher2.borrow());
 
-        metadata_writer.update(nodes_config.clone()).await?;
+        metadata_writer.update(value.clone()).await?;
         watcher1.changed().await?;
 
         assert_eq!(Version::MIN, *watcher1.borrow());
         assert_eq!(Version::MIN, *watcher2.borrow());
 
         // let's push multiple updates
-        let mut nodes_config = nodes_config.clone();
-        nodes_config.increment_version();
-        metadata_writer.update(nodes_config.clone()).await?;
-        nodes_config.increment_version();
-        metadata_writer.update(nodes_config.clone()).await?;
-        nodes_config.increment_version();
-        metadata_writer.update(nodes_config.clone()).await?;
-        nodes_config.increment_version();
-        metadata_writer.update(nodes_config.clone()).await?;
+        let mut value = value.clone();
+        value.increment_version();
+        metadata_writer.update(value.clone()).await?;
+        value.increment_version();
+        metadata_writer.update(value.clone()).await?;
+        value.increment_version();
+        metadata_writer.update(value.clone()).await?;
+        value.increment_version();
+        metadata_writer.update(value.clone()).await?;
 
         // Watcher sees the latest value only.
         watcher2.changed().await?;

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -15,7 +15,6 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use futures::{Future, FutureExt};
-use restate_types::NodeId;
 use tokio::task::JoinHandle;
 use tokio::task_local;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
@@ -23,9 +22,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use restate_types::identifiers::PartitionId;
 
-use crate::metadata::Metadata;
-use crate::network::{NetworkSendError, NetworkSender};
-use crate::{TaskId, TaskKind};
+use crate::{Metadata, TaskId, TaskKind};
 
 static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(0);
 const EXIT_CODE_FAILURE: i32 = 1;
@@ -33,22 +30,6 @@ const EXIT_CODE_FAILURE: i32 = 1;
 #[derive(Debug, thiserror::Error)]
 #[error("system is shutting down")]
 pub struct ShutdownError;
-
-// TEMPORARY. REMOVED IN NEXT PR(s)
-#[derive(Clone)]
-struct MockNetworkSender;
-
-impl NetworkSender for MockNetworkSender {
-    async fn send<M>(&self, _to: NodeId, _message: &M) -> Result<(), NetworkSendError>
-    where
-        M: restate_node_protocol::codec::WireSerde
-            + restate_node_protocol::codec::Targeted
-            + Send
-            + Sync,
-    {
-        Ok(())
-    }
-}
 
 /// Used to create a new task center. In practice, there should be a single task center for the
 /// entire process but we might need to create more than one in integration test scenarios.

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -66,6 +66,8 @@ pub enum TaskKind {
     SystemService,
     Ingress,
     PartitionProcessor,
+    #[strum(props(OnError = "log"))]
+    ConnectionReactor,
     // -- Bifrost Tasks
     /// A background task that the system needs for its operation. The task requires a system
     /// shutdown on errors and the system will wait for its graceful cancellation on shutdown.

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,19 +11,25 @@ publish = false
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-node-protocol = { workspace = true }
+restate-node-services = { workspace = true, features = ["clients"] }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+bincode = { workspace = true }
 bytes = { workspace = true }
 drain = { workspace = true }
+enum-map = { workspace = true }
+enumset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 pin-project = { workspace = true }
+rand = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
@@ -32,5 +38,7 @@ tracing = { workspace = true }
 restate-core = { workspace = true, features = ["test-util"] }
 restate-test-util = { workspace = true }
 
+googletest = { workspace = true }
 test-log = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -9,8 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use restate_errors::NotRunningError;
-use restate_types::identifiers::{PartitionId, PartitionKey, PeerId};
-use std::fmt::Debug;
+use restate_types::identifiers::PeerId;
 use std::future::Future;
 use tokio::sync::mpsc;
 
@@ -66,15 +65,4 @@ pub enum ShuffleOrIngressTarget<S, I> {
 pub trait TargetShuffleOrIngress<S, I> {
     /// Returns the target of a message. It can either be a shuffle or an ingress.
     fn into_target(self) -> ShuffleOrIngressTarget<S, I>;
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("Cannot find target peer for partition key {0}")]
-pub struct PartitionTableError(PartitionKey);
-
-pub trait FindPartition {
-    fn find_partition_id(
-        &self,
-        partition_key: PartitionKey,
-    ) -> Result<PartitionId, PartitionTableError>;
 }

--- a/crates/network/src/routing/ingress.rs
+++ b/crates/network/src/routing/ingress.rs
@@ -8,9 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{FindPartition, PartitionTableError};
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::message::PartitionTarget;
+use restate_types::partition_table::{FindPartition, PartitionTableError};
 use std::fmt::Debug;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;

--- a/crates/network/src/routing/mod.rs
+++ b/crates/network/src/routing/mod.rs
@@ -16,6 +16,7 @@ use crate::{NetworkCommand, TargetShuffle, TargetShuffleOrIngress, UnboundedNetw
 use restate_core::cancellation_watcher;
 use restate_types::identifiers::PeerId;
 use restate_types::message::PartitionTarget;
+use restate_types::partition_table::FindPartition;
 use restate_wal_protocol::Envelope;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -101,7 +102,7 @@ where
     PPOut: TargetShuffleOrIngress<PPToShuffle, PPToIngress>,
     PPToShuffle: TargetShuffle + Into<ShuffleIn> + Debug,
     PPToIngress: Into<IngressIn> + Debug,
-    PartitionTable: crate::FindPartition + Clone,
+    PartitionTable: FindPartition + Clone,
 {
     pub fn new(
         consensus_tx: mpsc::Sender<PartitionTarget<Envelope>>,

--- a/crates/network/src/routing/shuffle.rs
+++ b/crates/network/src/routing/shuffle.rs
@@ -8,9 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{FindPartition, PartitionTableError};
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::message::PartitionTarget;
+use restate_types::partition_table::{FindPartition, PartitionTableError};
 use restate_wal_protocol::Envelope;
 use std::fmt::Debug;
 use tokio::sync::mpsc;

--- a/crates/network/src/routing/tests.rs
+++ b/crates/network/src/routing/tests.rs
@@ -19,11 +19,11 @@ use restate_types::identifiers::PartitionId;
 use restate_types::identifiers::{PartitionKey, PeerId};
 use restate_types::invocation::ServiceInvocation;
 use restate_types::message::PartitionTarget;
+use restate_types::partition_table::{FindPartition, PartitionTableError};
 use restate_wal_protocol::{AckMode, Command, Destination, Envelope, Header, Source};
 
 use crate::{
-    FindPartition, Network, NetworkHandle, PartitionTableError, ShuffleOrIngressTarget,
-    TargetShuffle, TargetShuffleOrIngress,
+    Network, NetworkHandle, ShuffleOrIngressTarget, TargetShuffle, TargetShuffleOrIngress,
 };
 
 #[derive(Debug, Default, Clone)]

--- a/crates/network/src/utils.rs
+++ b/crates/network/src/utils.rs
@@ -32,6 +32,8 @@ pub fn create_grpc_channel_from_network_address(
             // todo: Make the channel settings configurable
             Channel::builder(uri)
                 .connect_timeout(Duration::from_secs(5))
+                // todo: configure the channel from configuration file
+                .http2_adaptive_window(true)
                 .connect_lazy()
         }
     };

--- a/crates/network/src/v2/connection.rs
+++ b/crates/network/src/v2/connection.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+use std::sync::Weak;
+
+use tokio::sync::mpsc;
+use tracing::instrument;
+
+use restate_core::metadata;
+use restate_core::network::NetworkSendError;
+use restate_node_protocol::codec::serialize_message;
+use restate_node_protocol::codec::Targeted;
+use restate_node_protocol::codec::WireSerde;
+use restate_node_protocol::common::ProtocolVersion;
+use restate_node_protocol::node::message;
+use restate_node_protocol::node::Header;
+use restate_node_protocol::node::Message;
+use restate_types::GenerationalNodeId;
+
+/// A single streaming connection with a channel to the peer. A connection can be
+/// opened by either ends of the connection and has no direction. Any connection
+/// can be used to send or receive from a peer.
+///
+/// The primary owned of a connection is the running reactor, all other components
+/// should hold a Weak<Connection> if caching access to a certain connection is
+/// needed.
+pub(crate) struct Connection {
+    /// Connection identifier, randomly generated on this end of the connection.
+    pub(crate) cid: u64,
+    pub(crate) peer: GenerationalNodeId,
+    pub(crate) protocol_version: ProtocolVersion,
+    pub(crate) sender: mpsc::Sender<Message>,
+    pub(crate) created: std::time::Instant,
+}
+
+impl Connection {
+    pub fn new(
+        peer: GenerationalNodeId,
+        protocol_version: ProtocolVersion,
+        sender: mpsc::Sender<Message>,
+    ) -> Self {
+        Self {
+            cid: rand::random(),
+            peer,
+            protocol_version,
+            sender,
+            created: std::time::Instant::now(),
+        }
+    }
+
+    /// The current negotiated protocol version of the connection
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    /// Best-effort delivery of signals on the connection.
+    pub fn send_control_frame(&self, control: message::ConnectionControl) {
+        let msg = Message {
+            header: None,
+            body: Some(control.into()),
+        };
+        let _ = self.sender.try_send(msg);
+    }
+
+    /// A handle that sends messages through that connection. This hides the
+    /// wire protocol from the user and guarantees order of messages.
+    pub fn sender(self: &Arc<Self>) -> ConnectionSender {
+        ConnectionSender {
+            peer: self.peer,
+            connection: Arc::downgrade(self),
+            protocol_version: self.protocol_version,
+        }
+    }
+}
+
+impl PartialEq for Connection {
+    fn eq(&self, other: &Self) -> bool {
+        self.cid == other.cid && self.peer == other.peer
+    }
+}
+
+/// A handle to send messages through a connection. It's safe and cheap to hold
+/// and clone objects of this even if the connection has been dropped.
+#[derive(Clone)]
+pub struct ConnectionSender {
+    peer: GenerationalNodeId,
+    connection: Weak<Connection>,
+    protocol_version: ProtocolVersion,
+}
+
+impl ConnectionSender {
+    /// Send a message on this connection. This returns Ok(()) when the message is:
+    /// - Successfully serialized to the wire format based on the negotiated protocol
+    /// - Serialized message was enqueued on the send buffer of the socket
+    ///
+    /// That means that this is not a guarantee that the message has been sent
+    /// over the network or that the peer has received it.
+    ///
+    /// If this is needed, the caller must design the wire protocol with a
+    /// request/response state machine and perform retries on other nodes/connections if needed.
+    ///
+    /// This roughly maps to the semantics of a POSIX write/send socket operation.
+    ///
+    /// This doesn't auto-retry connection resets or send errors, this is up to the user
+    /// for retrying externally.
+    #[instrument(skip_all, fields(peer_node_id = %self.peer, target_service = ?message.target(), msg = ?message.kind()))]
+    pub async fn send<M>(&self, message: M) -> Result<(), NetworkSendError>
+    where
+        M: WireSerde + Targeted,
+    {
+        let header = Header::new(metadata().nodes_config_version());
+        let body = serialize_message(message, self.protocol_version)?;
+        self.connection
+            .upgrade()
+            .ok_or(NetworkSendError::ConnectionClosed)?
+            .sender
+            .send(Message::new(header, body))
+            .await
+            .map_err(|_| NetworkSendError::ConnectionClosed)
+    }
+}
+
+static_assertions::assert_impl_all!(ConnectionSender: Send, Sync);

--- a/crates/network/src/v2/connection_manager.rs
+++ b/crates/network/src/v2/connection_manager.rs
@@ -1,0 +1,782 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{hash_map, HashMap};
+use std::sync::{Arc, Mutex, Weak};
+
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt};
+use rand::seq::SliceRandom;
+use restate_core::network::{Handler, MessageRouter};
+use restate_node_protocol::codec::deserialize_message;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::Channel;
+use tracing::{debug, info, warn, Instrument, Span};
+
+use restate_core::metadata;
+use restate_core::{cancellation_watcher, current_task_id, task_center, TaskId, TaskKind};
+use restate_node_protocol::node::message::{self, ConnectionControl};
+use restate_node_protocol::node::{Header, Hello, Message, Welcome};
+use restate_node_services::node_svc::node_svc_client::NodeSvcClient;
+use restate_types::nodes_config::AdvertisedAddress;
+use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
+
+use super::connection::{Connection, ConnectionSender};
+use super::handshake::{negotiate_protocol_version, wait_for_hello, wait_for_welcome};
+use crate::error::{NetworkError, ProtocolError};
+use crate::utils::create_grpc_channel_from_network_address;
+
+// todo: make this configurable
+const SEND_QUEUE_SIZE: usize = 1;
+static_assertions::const_assert!(SEND_QUEUE_SIZE >= 1);
+
+#[derive(Default)]
+struct ConnectionManagerInner {
+    router: MessageRouter,
+    connections: HashMap<TaskId, Weak<Connection>>,
+    connection_by_gen_id: HashMap<GenerationalNodeId, Vec<Weak<Connection>>>,
+    /// This tracks the max generation we observed from connection attempts regardless of our nodes
+    /// configuration. We cannot accept connections from nodes older than ones we have observed
+    /// already.
+    observed_generations: HashMap<PlainNodeId, u32>,
+    channel_cache: HashMap<AdvertisedAddress, Channel>,
+}
+
+impl ConnectionManagerInner {
+    fn drop_connection(&mut self, task_id: TaskId) {
+        self.connections.remove(&task_id);
+    }
+
+    fn cleanup_stale_connections(&mut self, peer_node_id: &GenerationalNodeId) {
+        if let Some(connections) = self.connection_by_gen_id.get_mut(peer_node_id) {
+            connections.retain(|c| c.upgrade().is_some());
+        }
+    }
+
+    fn get_random_connection(&self, peer_node_id: &GenerationalNodeId) -> Option<Arc<Connection>> {
+        self.connection_by_gen_id
+            .get(peer_node_id)
+            .and_then(|connections| connections.choose(&mut rand::thread_rng())?.upgrade())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ConnectionManager {
+    inner: Arc<Mutex<ConnectionManagerInner>>,
+}
+
+impl ConnectionManager {
+    /// Updates the message router. Note that this only impacts new connections.
+    /// In general, this should be called once on application start after
+    /// initializing all message handlers.
+    pub fn set_message_router(&self, router: MessageRouter) {
+        self.inner.lock().unwrap().router = router;
+    }
+
+    /// Accept a new incoming connection stream and register a network reactor task for it.
+    pub async fn accept_incoming_connection<S>(
+        &self,
+        mut incoming: S,
+    ) -> Result<BoxStream<'static, Result<Message, tonic::Status>>, NetworkError>
+    where
+        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
+    {
+        // Perform the handshake inline before creating the reactor. This allows
+        // us to naturally push-back on stream creation by piggybacking on the
+        // concurrency limit of the server + the handshake timeout.
+        //
+        // How do we handshake a new connection?
+        // ---------------------------------
+        // Client -> Server: Hello
+        // Server -> Client: Ok(Stream)
+        // Server => Client: Welcome
+        // Handshake completed. Hello/Welcome messages are not allowed after this point.
+        //
+        // A client must send the Hello message within a preconfigured time-window as the very
+        // first message in the stream. The client **must** send the Hello message _before_ waiting
+        // for the response stream to be created. This allows the server to only create the
+        // control stream if the client can successfully negotiate with the server. The server can
+        // decide to abort the stream if it's not interested in connections coming from this node
+        // without allocating any resources.
+        //
+        // Timeouts are used in both ways (expectation to receive Hello/Welcome within a time
+        // window) to avoid dangling resources by misbehaving peers or under sever load conditions.
+        // The client can retry with an exponential backoff on handshake timeout.
+        let metadata = metadata();
+
+        info!("Accepting incoming connection");
+        let (header, hello) = wait_for_hello(&mut incoming).await?;
+        // NodeId **must** be generational at this layer
+        let peer_node_id = hello
+            .my_node_id
+            .clone()
+            .ok_or(ProtocolError::HandshakeFailed(
+                "NodeId is not set in the Hello message",
+            ))?;
+
+        if peer_node_id.generation() == 0 {
+            return Err(
+                ProtocolError::HandshakeFailed("NodeId has invalid generation number").into(),
+            );
+        }
+
+        let peer_node_id = NodeId::from(peer_node_id)
+            .as_generational()
+            .expect("peer node is generational");
+
+        // Sanity check. Nodes must not connect to themselves from other generations.
+        let my_node_id = metadata.my_node_id();
+        if my_node_id.as_plain() == peer_node_id.as_plain() && peer_node_id != my_node_id {
+            // My node ID but different generations!
+            return Err(ProtocolError::HandshakeFailed(
+                "cannot accept a connection to the same NodeID from a different generation",
+            )
+            .into());
+        }
+
+        // Are we both from the same cluster?
+        if hello.cluster_name != metadata.nodes_config().cluster_name() {
+            return Err(ProtocolError::HandshakeFailed("cluster name mismatch").into());
+        }
+
+        let selected_protocol_version = negotiate_protocol_version(&hello)?;
+        debug!(
+            "Negotiated protocol version {:?} with client",
+            selected_protocol_version
+        );
+
+        // If nodeId is unrecognized and peer is at higher nodes configuration version,
+        // TODO: issue a sync to the higher version
+        let peer_is_in_the_future = header
+            .my_nodes_config_version
+            .as_ref()
+            .is_some_and(|v| v.value > metadata.nodes_config_version().into());
+
+        if let Err(e) = metadata.nodes_config().find_node_by_id(peer_node_id) {
+            if peer_is_in_the_future {
+                info!(
+                    "Rejecting a connection from an unrecognized node v{}, the peer is at a higher \
+                    nodes configuration version {:?}, mine is {}",
+                    peer_node_id,
+                    header.my_nodes_config_version,
+                    metadata.nodes_config_version()
+                );
+                // TODO: notify metadata about higher version.
+                // let _ = self
+                //     .metadata
+                //     .notify_observed_version(
+                //         MetadataKind::NodesConfiguration,
+                //         header.my_nodes_config_version.unwrap().into(),
+                //     )
+                //     .await?;
+            }
+            return Err(NetworkError::UnknownNode(e));
+        }
+
+        let (tx, rx) = mpsc::channel(SEND_QUEUE_SIZE);
+        // Enqueue the welcome message
+        let welcome = Welcome::new(metadata.my_node_id(), selected_protocol_version);
+
+        let node_config_version = metadata.nodes_config_version();
+        let welcome = Message::new(Header::new(node_config_version), welcome);
+
+        tx.try_send(welcome)
+            .expect("channel accept Welcome message");
+
+        let connection = Connection::new(peer_node_id, selected_protocol_version, tx);
+        // Register the connection.
+        let _ = self.start_connection_reactor(connection, incoming)?;
+        // For uniformity with outbound connections, we map all responses to Ok, we never rely on
+        // sending tonic::Status errors explicitly. We use ConnectionControl frames to communicate
+        // errors and/or drop the stream when necessary.
+        let transformed = ReceiverStream::new(rx).map(Ok);
+
+        Ok(Box::pin(transformed))
+    }
+
+    /// Always attempts to create a new connection with peer
+    pub async fn enforced_new_node_sender(
+        &self,
+        node_id: GenerationalNodeId,
+    ) -> Result<ConnectionSender, NetworkError> {
+        let connection = self.connect(node_id).await?;
+        Ok(connection.sender())
+    }
+
+    /// Gets an existing connection or creates a new one if no active connection exists. If
+    /// multiple connections already exist, it returns a random one.
+    pub async fn get_node_sender(
+        &self,
+        node_id: GenerationalNodeId,
+    ) -> Result<ConnectionSender, NetworkError> {
+        // find a connection by node_id
+        let maybe_connection: Option<Arc<Connection>> = {
+            let guard = self.inner.lock().unwrap();
+            guard.get_random_connection(&node_id)
+            // lock is dropped.
+        };
+
+        if let Some(connection) = maybe_connection {
+            return Ok(connection.sender());
+        }
+        // We have no connection, or the connection we picked is stale. We attempt to create a
+        // new connection anyway.
+        let connection = self.connect(node_id).await?;
+        Ok(connection.sender())
+    }
+
+    async fn connect(&self, node_id: GenerationalNodeId) -> Result<Arc<Connection>, NetworkError> {
+        let address = metadata()
+            .nodes_config()
+            .find_node_by_id(node_id)?
+            .address
+            .clone();
+
+        info!("Attempting to connect to node {} at {}", node_id, address);
+        // Do we have a channel in cache for this address?
+        let channel = {
+            let mut guard = self.inner.lock().unwrap();
+            if let hash_map::Entry::Vacant(entry) = guard.channel_cache.entry(address.clone()) {
+                let channel = create_grpc_channel_from_network_address(address)
+                    .map_err(|e| NetworkError::BadNodeAddress(node_id.into(), e))?;
+                entry.insert(channel.clone());
+                channel
+            } else {
+                guard.channel_cache.get(&address).unwrap().clone()
+            }
+        };
+
+        self.connect_with_channel(node_id, channel).await
+    }
+
+    // Left here for future use. This allows the node to connect to itself and bypass the
+    // networking stack.
+    #[cfg(test)]
+    fn _connect_loopback(
+        &self,
+        node_id: GenerationalNodeId,
+    ) -> Result<Arc<Connection>, NetworkError> {
+        let (tx, rx) = mpsc::channel(SEND_QUEUE_SIZE);
+        let connection = Connection::new(
+            node_id,
+            restate_node_protocol::common::CURRENT_PROTOCOL_VERSION,
+            tx,
+        );
+
+        let transformed = ReceiverStream::new(rx).map(Ok);
+        let incoming = Box::pin(transformed);
+        self.start_connection_reactor(connection, incoming)
+    }
+
+    async fn connect_with_channel(
+        &self,
+        node_id: GenerationalNodeId,
+        channel: Channel,
+    ) -> Result<Arc<Connection>, NetworkError> {
+        let metadata = metadata();
+
+        let mut client = NodeSvcClient::new(channel);
+        let nodes_config = metadata.nodes_config();
+        let cluster_name = nodes_config.cluster_name();
+
+        let (tx, rx) = mpsc::channel(SEND_QUEUE_SIZE);
+        let hello = Hello::new(metadata.my_node_id(), cluster_name.to_owned());
+
+        // perform handshake.
+        let hello = Message::new(Header::new(nodes_config.version()), hello);
+
+        // Prime the channel with the hello message before connecting.
+        tx.send(hello).await.expect("Channel accept hello message");
+
+        // Establish the connection
+        let incoming = client
+            .create_connection(ReceiverStream::new(rx))
+            .await?
+            .into_inner();
+
+        let mut transformed = incoming.map(|x| x.map_err(ProtocolError::from));
+        // finish the handshake
+        let (_header, welcome) = wait_for_welcome(&mut transformed).await?;
+        let protocol_version = welcome.protocol_version();
+
+        if !protocol_version.is_supported() {
+            return Err(ProtocolError::UnsupportedVersion(protocol_version.into()).into());
+        }
+
+        // sanity checks
+        let peer_node_id: NodeId = welcome
+            .my_node_id
+            .ok_or(ProtocolError::HandshakeFailed(
+                "Peer must set my_node_id in Welcome message",
+            ))?
+            .into();
+
+        // we expect the node to identify itself as the same NodeId
+        // we think we are connecting to
+        if peer_node_id != node_id {
+            // Node claims that it's someone else!
+            return Err(ProtocolError::HandshakeFailed(
+                "Node returned an unexpected NodeId in Welcome message.",
+            )
+            .into());
+        }
+
+        let connection = Connection::new(
+            peer_node_id
+                .as_generational()
+                .expect("must be generational id"),
+            protocol_version,
+            tx,
+        );
+
+        self.start_connection_reactor(connection, transformed)
+    }
+
+    fn start_connection_reactor<S>(
+        &self,
+        connection: Connection,
+        incoming: S,
+    ) -> Result<Arc<Connection>, NetworkError>
+    where
+        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
+    {
+        // Lock is held, don't perform expensive or async operations here.
+
+        // If we have a connection with an older generation, we request to drop it.
+        // However, more than one connection with the same generation is allowed.
+        let mut _cleanup = false;
+        let mut guard = self.inner.lock().unwrap();
+        let known_generation = guard
+            .observed_generations
+            .get(&connection.peer.as_plain())
+            .copied()
+            .unwrap_or(connection.peer.generation());
+
+        if known_generation > connection.peer.generation() {
+            // This peer is _older_ than the one we have seen in the past, we cannot accept
+            // this connection. We terminate the stream immediately.
+            return Err(NetworkError::OldPeerGeneration(format!(
+                "newer generation '{}' has been observed",
+                NodeId::new_generational(connection.peer.id(), known_generation)
+            )));
+        }
+        if known_generation < connection.peer.generation() {
+            // We have observed newer generation of the same node.
+            // TODO: Terminate old node's connection by cancelling its reactor task,
+            // and continue with this connection.
+            _cleanup = true;
+        }
+        // update observed generation
+        guard
+            .observed_generations
+            .insert(connection.peer.as_plain(), connection.peer.generation());
+
+        let connection = Arc::new(connection);
+        let peer_node_id = connection.peer;
+        let connection_weak = Arc::downgrade(&connection);
+        let span = tracing::error_span!(parent: None, "network-reactor",
+            task_id = tracing::field::Empty,
+            peer_node_id = %peer_node_id,
+            protocol_version = ?connection.protocol_version() as i32,
+        );
+        let router = guard.router.clone();
+
+        let task_id = task_center().spawn_child(
+            TaskKind::ConnectionReactor,
+            "network-connection-reactor",
+            None,
+            run_reactor(self.inner.clone(), connection.clone(), router, incoming).instrument(span),
+        )?;
+        info!("Incoming connection accepted from node {}", peer_node_id);
+        // Reactor has already started by now.
+
+        guard.connections.insert(task_id, connection_weak.clone());
+        // clean up old connections
+        guard.cleanup_stale_connections(&peer_node_id);
+        // Add this connection.
+        guard
+            .connection_by_gen_id
+            .entry(peer_node_id)
+            .or_default()
+            .push(connection_weak);
+        Ok(connection)
+    }
+}
+
+async fn run_reactor<S>(
+    connection_manager: Arc<Mutex<ConnectionManagerInner>>,
+    connection: Arc<Connection>,
+    router: MessageRouter,
+    mut incoming: S,
+) -> anyhow::Result<()>
+where
+    S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send,
+{
+    Span::current().record(
+        "task_id",
+        tracing::field::display(current_task_id().unwrap()),
+    );
+    // Receive loop
+    loop {
+        // read a message from the stream
+        let msg = tokio::select! {
+            biased;
+            _ = cancellation_watcher() => {
+                connection.send_control_frame(ConnectionControl::shutdown());
+                break;
+            },
+            msg = incoming.next() => {
+                match msg {
+                    Some(Ok(msg)) => { msg }
+                    Some(Err(status)) => {
+                        // stream has terminated.
+                        info!("Error received: {status}, terminating stream");
+                        break;
+                    }
+                    None => {
+                        // stream has terminated cleanly.
+                        break;
+                    }
+                }
+            }
+        };
+
+        // header is optional on non-hello messages.
+        if let Some(_header) = msg.header {
+            // todo: if header contains newer config or metadata versions, notify metadata().
+        };
+
+        // body are not allowed to be empty.
+        let Some(body) = msg.body else {
+            connection
+                .send_control_frame(ConnectionControl::codec_error("Body is missing on message"));
+            break;
+        };
+
+        // Welcome and hello are not allowed after handshake
+        if body.is_welcome() || body.is_hello() {
+            connection.send_control_frame(ConnectionControl::codec_error(
+                "Hello/Welcome are not allowed after handshake",
+            ));
+            break;
+        };
+
+        // if it's a control signal, handle it, otherwise, route with message router.
+        if let message::Body::ConnectionControl(ctrl_msg) = &body {
+            // do something
+            info!(
+                "Terminating connection based on signal from peer: {:?} {}",
+                ctrl_msg.signal(),
+                ctrl_msg.message
+            );
+            break;
+        }
+
+        match deserialize_message(body, connection.protocol_version) {
+            Ok(msg) => {
+                if let Err(e) = router
+                    .call(
+                        connection.peer,
+                        connection.cid,
+                        connection.protocol_version,
+                        msg,
+                    )
+                    .await
+                {
+                    warn!("Error processing message: {:?}", e);
+                }
+            }
+            Err(status) => {
+                // terminate the stream
+                info!("Error processing message, reporting error to peer: {status}");
+                connection.send_control_frame(ConnectionControl::codec_error(status.to_string()));
+                break;
+            }
+        }
+    }
+
+    // remove from active set
+    on_connection_draining(&connection, &connection_manager);
+    let connection_id = connection.cid;
+    let protocol_version = connection.protocol_version;
+    let peer_node_id = connection.peer;
+    let connection_created_at = connection.created;
+    // dropping the connection since it's the owner of sender stream.
+    drop(connection);
+
+    let drain_start = std::time::Instant::now();
+    info!("Draining connection");
+    let mut drain_counter = 0;
+    // Draining of incoming queue
+    while let Some(Ok(msg)) = incoming.next().await {
+        if let Some(body) = msg.body {
+            // we ignore non-deserializable messages (serde errors, or control signals in drain)
+            if let Ok(msg) = deserialize_message(body, protocol_version) {
+                drain_counter += 1;
+                if let Err(e) = router
+                    .call(peer_node_id, connection_id, protocol_version, msg)
+                    .await
+                {
+                    debug!(
+                        "Error processing message while draining connection: {:?}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    // We should also terminate response stream. This happens automatically when
+    // the sender is dropped
+    on_connection_terminated(&connection_manager);
+    info!(
+        "Connection terminated, drained {} messages in {:?}, total connection age is {:?}",
+        drain_counter,
+        drain_start.elapsed(),
+        connection_created_at.elapsed()
+    );
+    Ok(())
+}
+
+fn on_connection_draining(connection: &Connection, inner_manager: &Mutex<ConnectionManagerInner>) {
+    let mut guard = inner_manager.lock().unwrap();
+    if let Some(connections) = guard.connection_by_gen_id.get_mut(&connection.peer) {
+        // Remove this connection from connections map to reduce the chance
+        // of picking it up as connection.
+        connections.retain(|c| {
+            c.upgrade()
+                .map(|c| c.as_ref() != connection)
+                .unwrap_or_default()
+        })
+    }
+}
+
+fn on_connection_terminated(inner_manager: &Mutex<ConnectionManagerInner>) {
+    let task_id = current_task_id().expect("TaskId is set");
+    let mut guard = inner_manager.lock().unwrap();
+    guard.drop_connection(task_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v2::handshake::HANDSHAKE_TIMEOUT;
+
+    use super::*;
+
+    use googletest::prelude::*;
+
+    use restate_core::TestCoreEnv;
+    use restate_node_protocol::node::message;
+    use restate_node_protocol::{
+        common::ProtocolVersion, CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION,
+    };
+    use restate_test_util::assert_eq;
+    use restate_types::nodes_config::NodesConfigError;
+
+    // Test handshake with a client
+    #[tokio::test]
+    async fn test_hello_welcome_handshake() -> Result<()> {
+        let test_setup = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
+        test_setup
+            .tc
+            .run_in_scope("test", None, async {
+                let metadata = restate_core::metadata();
+                let (tx, rx) = mpsc::channel(1);
+                let connections = ConnectionManager::default();
+
+                let hello = Hello::new(
+                    metadata.my_node_id(),
+                    metadata.nodes_config().cluster_name().to_owned(),
+                );
+                let hello = Message::new(Header::new(metadata.nodes_config_version()), hello);
+                tx.send(Ok(hello))
+                    .await
+                    .expect("Channel accept hello message");
+
+                let incoming = ReceiverStream::new(rx);
+                let mut output_stream = connections
+                    .accept_incoming_connection(incoming)
+                    .await
+                    .expect("handshake");
+                let msg = output_stream
+                    .next()
+                    .await
+                    .expect("welcome message")
+                    .expect("ok");
+                let welcome = match msg.body {
+                    Some(message::Body::Welcome(welcome)) => welcome,
+                    _ => panic!("unexpected message"),
+                };
+                assert_eq!(welcome.my_node_id, Some(metadata.my_node_id().into()));
+                Ok(())
+            })
+            .await
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_hello_welcome_timeout() -> Result<()> {
+        let test_setup = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
+        test_setup
+            .tc
+            .run_in_scope("test", None, async {
+                let (_tx, rx) = mpsc::channel(1);
+                let connections = ConnectionManager::default();
+
+                let start = tokio::time::Instant::now();
+                let incoming = ReceiverStream::new(rx);
+                let resp = connections.accept_incoming_connection(incoming).await;
+                assert!(resp.is_err());
+                assert!(matches!(
+                    resp,
+                    Err(NetworkError::ProtocolError(
+                        ProtocolError::HandshakeTimeout(_)
+                    ))
+                ));
+                assert!(start.elapsed() >= HANDSHAKE_TIMEOUT);
+                Ok(())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_bad_handshake() -> Result<()> {
+        let test_setup = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
+        test_setup
+            .tc
+            .run_in_scope("test", None, async {
+                let metadata = restate_core::metadata();
+
+                let (tx, rx) = mpsc::channel(1);
+                let my_node_id = metadata.my_node_id();
+
+                // unsupported protocol version
+                let hello = Hello {
+                    min_protocol_version: ProtocolVersion::Unknown.into(),
+                    max_protocol_version: ProtocolVersion::Unknown.into(),
+                    my_node_id: Some(my_node_id.into()),
+                    cluster_name: metadata.nodes_config().cluster_name().to_owned(),
+                };
+                let hello = Message::new(Header::new(metadata.nodes_config_version()), hello);
+                tx.send(Ok(hello))
+                    .await
+                    .expect("Channel accept hello message");
+
+                let connections = ConnectionManager::default();
+                let incoming = ReceiverStream::new(rx);
+                let resp = connections.accept_incoming_connection(incoming).await;
+                assert!(resp.is_err());
+                assert!(matches!(
+                    resp,
+                    Err(NetworkError::ProtocolError(
+                        ProtocolError::UnsupportedVersion(proto_version)
+                    )) if proto_version == ProtocolVersion::Unknown as i32
+                ));
+
+                // cluster name mismatch
+                let (tx, rx) = mpsc::channel(1);
+                let my_node_id = metadata.my_node_id();
+                let hello = Hello {
+                    min_protocol_version: MIN_SUPPORTED_PROTOCOL_VERSION.into(),
+                    max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
+                    my_node_id: Some(my_node_id.into()),
+                    cluster_name: "Random-cluster".to_owned(),
+                };
+                let hello = Message::new(Header::new(metadata.nodes_config_version()), hello);
+                tx.send(Ok(hello)).await?;
+
+                let connections = ConnectionManager::default();
+                let incoming = ReceiverStream::new(rx);
+                let err = connections
+                    .accept_incoming_connection(incoming)
+                    .await
+                    .err()
+                    .unwrap();
+                assert!(matches!(
+                    err,
+                    NetworkError::ProtocolError(ProtocolError::HandshakeFailed(
+                        "cluster name mismatch"
+                    ))
+                ));
+                Ok(())
+            })
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_node_generation() -> Result<()> {
+        let test_setup = TestCoreEnv::create_with_mock_nodes_config(1, 2).await;
+        test_setup
+            .tc
+            .run_in_scope("test", None, async {
+                let metadata = restate_core::metadata();
+
+                let (tx, rx) = mpsc::channel(1);
+                let mut my_node_id = metadata.my_node_id();
+                assert_eq!(2, my_node_id.generation());
+                my_node_id.bump_generation();
+
+                // newer generation
+                let hello = Hello::new(
+                    my_node_id,
+                    metadata.nodes_config().cluster_name().to_owned(),
+                );
+                let hello = Message::new(Header::new(metadata.nodes_config_version()), hello);
+                tx.send(Ok(hello))
+                    .await
+                    .expect("Channel accept hello message");
+
+                let connections = ConnectionManager::default();
+
+                let incoming = ReceiverStream::new(rx);
+                let err = connections
+                    .accept_incoming_connection(incoming)
+                    .await
+                    .err()
+                    .unwrap();
+                println!("{:?}", err);
+
+                assert!(matches!(
+                    err,
+                    NetworkError::ProtocolError(ProtocolError::HandshakeFailed(
+                        "cannot accept a connection to the same NodeID from a different generation",
+                    ))
+                ));
+
+                // Unrecognized node Id
+                let (tx, rx) = mpsc::channel(1);
+                let my_node_id = GenerationalNodeId::new(55, 2);
+
+                let hello = Hello::new(
+                    my_node_id,
+                    metadata.nodes_config().cluster_name().to_owned(),
+                );
+                let hello = Message::new(Header::new(metadata.nodes_config_version()), hello);
+                tx.send(Ok(hello))
+                    .await
+                    .expect("Channel accept hello message");
+
+                let connections = ConnectionManager::default();
+
+                let incoming = ReceiverStream::new(rx);
+                let err = connections
+                    .accept_incoming_connection(incoming)
+                    .await
+                    .err()
+                    .unwrap();
+                assert!(matches!(
+                    err,
+                    NetworkError::UnknownNode(NodesConfigError::UnknownNodeId(_))
+                ));
+                Ok(())
+            })
+            .await
+    }
+}

--- a/crates/network/src/v2/handshake.rs
+++ b/crates/network/src/v2/handshake.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use futures::Stream;
+use restate_node_protocol::common::{ProtocolVersion, CURRENT_PROTOCOL_VERSION};
+use restate_node_protocol::node::{message, Header, Hello, Message, Welcome};
+use tokio_stream::StreamExt;
+
+use crate::error::ProtocolError;
+
+//todo: make this configurable
+pub(crate) const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub async fn wait_for_hello<S>(incoming: &mut S) -> Result<(Header, Hello), ProtocolError>
+where
+    S: Stream<Item = Result<Message, ProtocolError>> + Unpin,
+{
+    let maybe_hello = tokio::time::timeout(HANDSHAKE_TIMEOUT, incoming.next())
+        .await
+        .map_err(|_| {
+            ProtocolError::HandshakeTimeout("Hello message wasn't received within deadline")
+        })?;
+
+    let Some(maybe_hello) = maybe_hello else {
+        return Err(ProtocolError::PeerDropped);
+    };
+
+    let maybe_hello = maybe_hello.map_err(|_| ProtocolError::PeerDropped)?;
+
+    let Some(header) = maybe_hello.header else {
+        return Err(ProtocolError::HandshakeFailed(
+            "Header should always be set",
+        ));
+    };
+
+    let Some(maybe_hello) = maybe_hello.body else {
+        return Err(ProtocolError::HandshakeFailed(
+            "Hello is expected on handshake",
+        ));
+    };
+
+    // only hello is allowed
+    let message::Body::Hello(hello) = maybe_hello else {
+        return Err(ProtocolError::HandshakeFailed(
+            "Only hello is allowed in handshake!",
+        ));
+    };
+    Ok((header, hello))
+}
+
+pub fn negotiate_protocol_version(hello: &Hello) -> Result<ProtocolVersion, ProtocolError> {
+    let selected_proto_version =
+        std::cmp::min(CURRENT_PROTOCOL_VERSION, hello.max_protocol_version());
+    if !selected_proto_version.is_supported() {
+        // We cannot support peer's protocol version
+        return Err(ProtocolError::UnsupportedVersion(
+            hello.max_protocol_version,
+        ));
+    }
+
+    // Invariant safety net.
+    // protocol version must be a value between the min/max version supported by the client.
+    // The server has minimum and maximum as well.
+    if selected_proto_version < hello.min_protocol_version()
+        || selected_proto_version > hello.max_protocol_version()
+    {
+        // The client cannot support our protocol version
+        return Err(ProtocolError::UnsupportedVersion(
+            hello.max_protocol_version,
+        ));
+    }
+    Ok(selected_proto_version)
+}
+
+pub async fn wait_for_welcome<S>(
+    response_stream: &mut S,
+) -> Result<(Header, Welcome), ProtocolError>
+where
+    S: Stream<Item = Result<Message, ProtocolError>> + Unpin,
+{
+    // first thing we expect is Welcome.
+    let maybe_welcome = tokio::time::timeout(HANDSHAKE_TIMEOUT, response_stream.next())
+        .await
+        .map_err(|_| ProtocolError::HandshakeTimeout("No Welcome received within deadline"))?;
+
+    let Some(maybe_welcome) = maybe_welcome else {
+        return Err(ProtocolError::HandshakeFailed("No Welcome received"));
+    };
+
+    let maybe_welcome = maybe_welcome.map_err(|_| ProtocolError::PeerDropped)?;
+
+    let Some(header) = maybe_welcome.header else {
+        return Err(ProtocolError::HandshakeFailed(
+            "Header should always be set",
+        ));
+    };
+
+    let Some(maybe_welcome) = maybe_welcome.body else {
+        return Err(ProtocolError::HandshakeFailed(
+            "Welcome is expected on handshake",
+        ));
+    };
+
+    // only welcome is allowed
+    let message::Body::Welcome(welcome) = maybe_welcome else {
+        return Err(ProtocolError::HandshakeFailed(
+            "Only Welcome is allowed in handshake!",
+        ));
+    };
+
+    Ok((header, welcome))
+}

--- a/crates/network/src/v2/mod.rs
+++ b/crates/network/src/v2/mod.rs
@@ -8,7 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod error;
+mod connection;
+mod connection_manager;
+mod handshake;
 mod networking;
 
+pub mod error;
+
+pub use connection::ConnectionSender;
+pub use connection_manager::ConnectionManager;
 pub use networking::Networking;

--- a/crates/network/src/v2/networking.rs
+++ b/crates/network/src/v2/networking.rs
@@ -8,23 +8,142 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
+use rand::Rng;
+use tracing::{info, instrument, trace};
+
+use restate_core::metadata;
 use restate_core::network::{NetworkSendError, NetworkSender};
 use restate_node_protocol::codec::{Targeted, WireSerde};
 use restate_types::NodeId;
 
-/// Access to node-to-node networking infrastructure;
-#[derive(Default, Clone)]
-pub struct Networking {}
+use crate::error::NetworkError;
+use crate::{ConnectionManager, ConnectionSender};
 
-impl Networking {}
+const DEFAULT_MAX_CONNECT_ATTEMPTS: u32 = 10;
+// todo: make this configurable
+const SEND_RETRY_BASE_DURATION: Duration = Duration::from_millis(250);
+
+/// Access to node-to-node networking infrastructure;
+#[derive(Clone, Default)]
+pub struct Networking {
+    connections: ConnectionManager,
+}
+
+impl Networking {
+    pub fn connection_manager(&self) -> ConnectionManager {
+        self.connections.clone()
+    }
+
+    /// A connection sender is pinned to a single stream, thus guaranteeing ordered delivery of
+    /// messages.
+    pub async fn node_connection(&self, node: NodeId) -> Result<ConnectionSender, NetworkError> {
+        // find latest generation if this is not generational node id
+
+        let node = match node.as_generational() {
+            Some(node) => node,
+            None => {
+                metadata()
+                    .nodes_config()
+                    .find_node_by_id(node)?
+                    .current_generation
+            }
+        };
+
+        self.connections.get_node_sender(node).await
+    }
+}
 
 impl NetworkSender for Networking {
-    async fn send<M>(&self, _to: NodeId, _message: &M) -> Result<(), NetworkSendError>
+    #[instrument(level = "debug", skip(self, message), fields(message = ?message.target()))]
+    async fn send<M>(&self, to: NodeId, message: &M) -> Result<(), NetworkSendError>
     where
         M: WireSerde + Targeted + Send + Sync,
     {
-        Ok(())
+        let target_is_generational = to.is_generational();
+        // we try to reconnect to the node for N times.
+        let mut attempts = 0;
+        loop {
+            // find latest generation if this is not generational node id. We do this in the loop
+            // to ensure we get the latest if it has been updated since last attempt.
+            let to = match to.as_generational() {
+                Some(to) => to,
+                None => match metadata().nodes_config().find_node_by_id(to) {
+                    Ok(node) => node.current_generation,
+                    Err(e) => return Err(NetworkSendError::UnknownNode(e)),
+                },
+            };
+
+            attempts += 1;
+            if attempts > DEFAULT_MAX_CONNECT_ATTEMPTS {
+                return Err(NetworkSendError::Unavailable(format!(
+                    "failed to connect to node {} after {} attempts",
+                    to, DEFAULT_MAX_CONNECT_ATTEMPTS
+                )));
+            }
+            if attempts > 1 {
+                sleep_with_jitter(SEND_RETRY_BASE_DURATION).await;
+            }
+
+            let sender = match self.connections.get_node_sender(to).await {
+                Ok(sender) => sender,
+                // retryable errors
+                Err(
+                    e @ NetworkError::Timeout(_)
+                    | e @ NetworkError::ConnectError(_)
+                    | e @ NetworkError::ConnectionClosed,
+                ) => {
+                    info!(
+                        "Connection to node {} failed with {}, next retry is attempt {}/{}",
+                        to,
+                        e,
+                        attempts + 1,
+                        DEFAULT_MAX_CONNECT_ATTEMPTS
+                    );
+                    continue;
+                }
+                // terminal errors
+                Err(NetworkError::OldPeerGeneration(e)) => {
+                    if target_is_generational {
+                        // Caller asked for this specific node generation and we know it's old.
+                        return Err(NetworkSendError::OldPeerGeneration(e));
+                    }
+                    info!(
+                        "Connection to node {} failed with {}, next retry is attempt {}/{}",
+                        to,
+                        e,
+                        attempts + 1,
+                        DEFAULT_MAX_CONNECT_ATTEMPTS
+                    );
+                    continue;
+                }
+                Err(e) => return Err(NetworkSendError::Unavailable(e.to_string())),
+            };
+
+            // can only fail due to codec errors or if connection is closed. Retry only if
+            // connection closed.
+            match sender.send(message).await {
+                Ok(_) => return Ok(()),
+                Err(NetworkSendError::ConnectionClosed) => {
+                    info!(
+                        "Sending message to node {} failed due to connection reset, next retry is attempt {}/{}",
+                        to, attempts + 1, DEFAULT_MAX_CONNECT_ATTEMPTS
+                    );
+                    continue;
+                }
+                Err(e) => return Err(NetworkSendError::Unavailable(e.to_string())),
+            }
+        }
     }
+}
+
+async fn sleep_with_jitter(duration: Duration) {
+    let max_jitter = duration.as_millis() * 2;
+    let jitter = rand::thread_rng().gen_range(1..max_jitter);
+    let retry_after = Duration::from_millis((duration.as_millis() + jitter) as u64);
+    trace!("sleeping for {:?}", retry_after);
+    tokio::time::sleep(retry_after).await;
 }
 
 static_assertions::assert_impl_all!(Networking: Send, Sync);

--- a/crates/node-protocol/src/metadata.rs
+++ b/crates/node-protocol/src/metadata.rs
@@ -11,6 +11,7 @@
 use bytes::Bytes;
 use enum_map::Enum;
 use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partition_table::FixedPartitionTable;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
@@ -77,6 +78,7 @@ pub enum MetadataKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MetadataContainer {
     NodesConfiguration(NodesConfiguration),
+    PartitionTable(FixedPartitionTable),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,6 +96,7 @@ impl MetadataContainer {
     pub fn kind(&self) -> MetadataKind {
         match self {
             MetadataContainer::NodesConfiguration(_) => MetadataKind::NodesConfiguration,
+            MetadataContainer::PartitionTable(_) => MetadataKind::PartitionTable,
         }
     }
 }
@@ -101,5 +104,11 @@ impl MetadataContainer {
 impl From<NodesConfiguration> for MetadataContainer {
     fn from(value: NodesConfiguration) -> Self {
         MetadataContainer::NodesConfiguration(value)
+    }
+}
+
+impl From<FixedPartitionTable> for MetadataContainer {
+    fn from(value: FixedPartitionTable) -> Self {
+        MetadataContainer::PartitionTable(value)
     }
 }

--- a/crates/node-services/proto/node_svc.proto
+++ b/crates/node-services/proto/node_svc.proto
@@ -31,6 +31,9 @@ service NodeSvc {
 
   // Updates the schema information on the worker node
   rpc UpdateSchemas(UpdateSchemaRequest) returns (google.protobuf.Empty);
+
+  // Create a bidirectional node-to-node stream
+  rpc CreateConnection(stream dev.restate.node.Message) returns (stream dev.restate.node.Message);
 }
 
 enum NodeStatus {

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -64,6 +64,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -105,6 +105,7 @@ impl Node {
         let bifrost = options.bifrost.build(options.worker.partitions);
 
         let server = options.server.build(
+            networking.connection_manager(),
             worker_role.as_ref().map(|worker| {
                 WorkerDependencies::new(
                     worker.rocksdb_storage().clone(),
@@ -121,6 +122,13 @@ impl Node {
                 )
             }),
         );
+
+        // Ensures that message router is updated after all services have registered themselves in
+        // the builder.
+        let message_router = sr_builder.build();
+        networking
+            .connection_manager()
+            .set_message_router(message_router);
 
         Ok(Node {
             options: opts,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -29,6 +29,7 @@ use tracing::{error, info};
 use restate_core::{spawn_metadata_manager, MetadataManager};
 use restate_core::{task_center, TaskKind};
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
+use restate_types::partition_table::FixedPartitionTable;
 use restate_types::{GenerationalNodeId, Version};
 
 use crate::network_server::{AdminDependencies, NetworkServer, WorkerDependencies};
@@ -184,6 +185,14 @@ impl Node {
             // Not supported at the moment
             bail!("Only cluster bootstrap mode is supported at the moment");
         }
+
+        // Update the partition table. Currently, only setting a single version is supported
+        metadata_writer
+            .update(FixedPartitionTable::new(
+                Version::MIN,
+                self.options.worker.partitions,
+            ))
+            .await?;
 
         let nodes_config = metadata.nodes_config();
         // Find my node in nodes configuration.

--- a/crates/node/src/network_server/options.rs
+++ b/crates/node/src/network_server/options.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 
 use serde_with::serde_as;
 
+use restate_network::ConnectionManager;
 use restate_types::nodes_config::AdvertisedAddress;
 
 use crate::network_server::service::{AdminDependencies, NetworkServer, WorkerDependencies};
@@ -58,9 +59,10 @@ impl Default for Options {
 impl Options {
     pub fn build(
         self,
+        connection_manager: ConnectionManager,
         node_deps: Option<WorkerDependencies>,
         admin_deps: Option<AdminDependencies>,
     ) -> NetworkServer {
-        NetworkServer::new(self, node_deps, admin_deps)
+        NetworkServer::new(self, connection_manager, node_deps, admin_deps)
     }
 }

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -18,6 +18,7 @@ use tracing::info;
 use restate_cluster_controller::ClusterControllerHandle;
 use restate_core::{cancellation_watcher, task_center};
 use restate_meta::FileMetaReader;
+use restate_network::ConnectionManager;
 use restate_node_protocol::{common, node};
 use restate_node_services::cluster_ctrl;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_server::ClusterCtrlSvcServer;
@@ -54,6 +55,7 @@ pub enum Error {
 
 pub struct NetworkServer {
     opts: Options,
+    connection_manager: ConnectionManager,
     worker_deps: Option<WorkerDependencies>,
     admin_deps: Option<AdminDependencies>,
 }
@@ -61,11 +63,13 @@ pub struct NetworkServer {
 impl NetworkServer {
     pub fn new(
         opts: Options,
+        connection_manager: ConnectionManager,
         worker_deps: Option<WorkerDependencies>,
         admin_deps: Option<AdminDependencies>,
     ) -> Self {
         Self {
             opts,
+            connection_manager,
             worker_deps,
             admin_deps,
         }
@@ -117,6 +121,7 @@ impl NetworkServer {
             .add_service(NodeSvcServer::new(NodeSvcHandler::new(
                 task_center(),
                 self.worker_deps,
+                self.connection_manager,
             )))
             .add_optional_service(cluster_controller_service)
             .add_service(reflection_service_builder.build()?);

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -54,4 +54,6 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
+test-log = { workspace = true }
+
 rand = { workspace = true }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod journal;
 pub mod logs;
 pub mod message;
 pub mod nodes_config;
+pub mod partition_table;
 pub mod retries;
 pub mod state_mut;
 pub mod subscription;

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -15,7 +15,17 @@
 /// type. For instance, if any side of the comparison is a generational node id, the other side
 /// must be also generational and the generations must match. If you are only interested in
 /// checking the id part, then compare using `x.id() == y.id()` instead of `x == y`.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, derive_more::From, derive_more::Display)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Hash,
+    derive_more::From,
+    derive_more::Display,
+    strum_macros::EnumIs,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NodeId {
     Plain(PlainNodeId),

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -17,8 +17,8 @@ use std::str::FromStr;
 use enumset::{EnumSet, EnumSetType};
 use http::Uri;
 
-use crate::Version;
 use crate::{GenerationalNodeId, NodeId, PlainNodeId};
+use crate::{Version, Versioned};
 
 #[derive(Debug, thiserror::Error)]
 pub enum NodesConfigError {
@@ -196,6 +196,16 @@ impl NodesConfiguration {
             MaybeNode::Node(node) if node.roles.contains(Role::Admin) => Some(node),
             _ => None,
         })
+    }
+}
+
+impl Versioned for NodesConfiguration {
+    fn version(&self) -> Version {
+        self.version()
+    }
+
+    fn increment_version(&mut self) {
+        self.increment_version();
     }
 }
 

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -29,10 +29,23 @@ pub struct Version(u32);
 impl Version {
     pub const INVALID: Version = Version(0);
     pub const MIN: Version = Version(1);
+
+    pub fn next(self) -> Self {
+        Version(self.0 + 1)
+    }
 }
 
 impl Default for Version {
     fn default() -> Self {
         Self::MIN
     }
+}
+
+/// A trait for all metadata types that have a version.
+pub trait Versioned {
+    /// Returns the version of the versioned value
+    fn version(&self) -> Version;
+
+    /// Increments the version of the versioned value
+    fn increment_version(&mut self);
 }

--- a/crates/worker/src/network_integration.rs
+++ b/crates/worker/src/network_integration.rs
@@ -13,7 +13,8 @@
 
 use crate::partition;
 use crate::partition::shuffle;
-use crate::partitioning_scheme::FixedConsecutivePartitions;
+use restate_types::partition_table::FixedPartitionTable;
+use std::sync::Arc;
 
 pub(super) type Network = restate_network::Network<
     shuffle::ShuffleInput,
@@ -21,7 +22,7 @@ pub(super) type Network = restate_network::Network<
     partition::types::AckResponse,
     partition::types::ShuffleAckResponse,
     partition::types::IngressAckResponse,
-    FixedConsecutivePartitions,
+    Arc<FixedPartitionTable>,
 >;
 
 mod partition_integration {


### PR DESCRIPTION
Add PartitionTable metadata

This commit adds the PartitionTable metadata to the MetadataManager.
Currently, the implementation is using the FixedPartitionTable which
only supports a fixed set of equally sized partitions.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1256).
* __->__ #1256
* #1245