### PR TITLE
Patch google/protobuf/descriptor.proto and dev/restate/ext.proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5443,6 +5443,7 @@ dependencies = [
  "prost-types",
  "restate-base64-util",
  "restate-errors",
+ "restate-pb",
  "restate-schema-api",
  "restate-service-client",
  "restate-test-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -20,6 +20,8 @@ protocol = []
 [dependencies]
 restate-base64-util = { workspace = true, optional = true }
 restate-errors = { workspace = true, optional = true }
+# Temporary dependency which can be removed once we need no longer to patch file descriptors
+restate-pb = { workspace = true }
 restate-schema-api = { workspace = true, optional = true, features = ["deployment"] }
 restate-service-client =  { workspace = true, optional = true }
 restate-types = { workspace = true, optional = true }


### PR DESCRIPTION
The TS SDK seems to send incorrect file descriptors for google/protobuf/descriptor.proto and dev/restate/ext.proto. This commit patches these files on the server as a temporary solution until we remove the need for shipping Protobuf file descriptors.

This fixes #1262.