### PR TITLE
TestEnv support for mock networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4948,6 +4948,7 @@ dependencies = [
  "enum-map",
  "futures",
  "googletest",
+ "rand",
  "restate-node-protocol",
  "restate-test-util",
  "restate-types",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [features]
-test-util = []
+test-util = ["dep:rand"]
 
 [dependencies]
 restate-types = { workspace = true }
@@ -20,6 +20,7 @@ async-trait = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true }
 futures = { workspace = true }
+rand = { workspace = true, optional = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
@@ -34,8 +35,9 @@ tracing = { workspace = true }
 restate-test-util = { workspace = true }
 
 googletest = { workspace = true }
+rand = { workspace = true }
 test-log = { workspace = true }
-tracing-test = { workspace = true }
-tracing-subscriber = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+tracing-subscriber = { workspace = true }
+tracing-test = { workspace = true }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,4 +21,4 @@ pub use task_center_types::*;
 mod test_env;
 
 #[cfg(any(test, feature = "test-util"))]
-pub use test_env::{create_mock_nodes_config, TestCoreEnv};
+pub use test_env::{create_mock_nodes_config, TestCoreEnv, TestCoreEnvBuilder};

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -323,7 +323,7 @@ mod tests {
         T: Into<MetadataContainer> + Versioned + Clone,
         F: Fn(&Metadata) -> Version,
     {
-        let network_sender = MockNetworkSender;
+        let network_sender = MockNetworkSender::default();
         let tc = TaskCenterFactory::create(tokio::runtime::Handle::current());
         let metadata_manager = MetadataManager::build(network_sender);
         let metadata_writer = metadata_manager.writer();
@@ -397,7 +397,7 @@ mod tests {
         T: Into<MetadataContainer> + Versioned + Clone,
         F: Fn(&Metadata) -> Version,
     {
-        let network_sender = MockNetworkSender;
+        let network_sender = MockNetworkSender::default();
         let tc = TaskCenterFactory::create(tokio::runtime::Handle::current());
         let metadata_manager = MetadataManager::build(network_sender);
         let metadata_writer = metadata_manager.writer();


### PR DESCRIPTION
TestEnv support for mock networking

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1264).
* #1274
* #1269
* #1268
* __->__ #1264