### PR TITLE
Fix Response error code data model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5740,7 +5740,6 @@ dependencies = [
  "test-log",
  "thiserror",
  "tokio",
- "tonic 0.10.2",
  "tracing",
  "tracing-opentelemetry",
  "ulid",

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -12,7 +12,7 @@ use super::APPLICATION_JSON;
 
 use bytes::Bytes;
 use http::{header, Response, StatusCode};
-use restate_types::errors::{InvocationError, UserErrorCode};
+use restate_types::errors::InvocationError;
 use serde::Serialize;
 use std::string;
 
@@ -82,7 +82,7 @@ impl HandlerError {
             HandlerError::BadAwakeablesPath => StatusCode::BAD_REQUEST,
             HandlerError::NotImplemented => StatusCode::NOT_IMPLEMENTED,
             HandlerError::Invocation(e) => {
-                invocation_status_code_to_http_status_code(e.code().into())
+                StatusCode::from_u16(e.code().into()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
             HandlerError::BadHeader(_, _) => StatusCode::BAD_REQUEST,
         };
@@ -107,26 +107,5 @@ impl HandlerError {
 
     pub(crate) fn into_response<B: http_body::Body + Default + From<Bytes>>(self) -> Response<B> {
         self.fill_builder(http::response::Builder::new())
-    }
-}
-
-fn invocation_status_code_to_http_status_code(code: UserErrorCode) -> StatusCode {
-    match code {
-        UserErrorCode::Cancelled => StatusCode::REQUEST_TIMEOUT,
-        UserErrorCode::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
-        UserErrorCode::InvalidArgument => StatusCode::BAD_REQUEST,
-        UserErrorCode::DeadlineExceeded => StatusCode::REQUEST_TIMEOUT,
-        UserErrorCode::NotFound => StatusCode::NOT_FOUND,
-        UserErrorCode::AlreadyExists => StatusCode::CONFLICT,
-        UserErrorCode::PermissionDenied => StatusCode::FORBIDDEN,
-        UserErrorCode::Unauthenticated => StatusCode::UNAUTHORIZED,
-        UserErrorCode::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
-        UserErrorCode::FailedPrecondition => StatusCode::PRECONDITION_FAILED,
-        UserErrorCode::Aborted => StatusCode::CONFLICT,
-        UserErrorCode::OutOfRange => StatusCode::BAD_REQUEST,
-        UserErrorCode::Unimplemented => StatusCode::NOT_IMPLEMENTED,
-        UserErrorCode::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-        UserErrorCode::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-        UserErrorCode::DataLoss => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/crates/pb/build.rs
+++ b/crates/pb/build.rs
@@ -120,7 +120,7 @@ mod built_in_service_gen {
                         r#""{}" => {{
                             use prost::Message;
 
-                            let mut input_t = {}::decode(&mut input).map_err(|e| restate_types::errors::InvocationError::new(restate_types::errors::UserErrorCode::InvalidArgument, e.to_string()))?;
+                            let mut input_t = {}::decode(&mut input).map_err(|e| restate_types::errors::InvocationError::new(restate_types::errors::codes::BAD_REQUEST, e.to_string()))?;
                             let output_t = T::{}(&mut self.0, input_t).await?;
                             Ok(output_t.encode_to_vec().into())
                         }},"#,
@@ -142,7 +142,7 @@ mod built_in_service_gen {
                     async move {{
                         match method {{
                             {impl_built_in_service_match_arms}
-                            _ => Err(restate_types::errors::InvocationError::service_method_not_found("{service_name}", method))
+                            _ => Err(restate_types::errors::InvocationError::component_handler_not_found("{service_name}", method))
                         }}
                     }}
                 }}
@@ -240,7 +240,7 @@ mod manual_response_built_in_service_gen {
                         r#""{}" => {{
                             use prost::Message;
 
-                            let mut input_t = <{}>::decode(&mut input).map_err(|e| restate_types::errors::InvocationError::new(restate_types::errors::UserErrorCode::InvalidArgument, e.to_string()))?;
+                            let mut input_t = <{}>::decode(&mut input).map_err(|e| restate_types::errors::InvocationError::new(restate_types::errors::codes::BAD_REQUEST, e.to_string()))?;
                             T::{}(&mut self.0, input_t, crate::builtin_service::ResponseSerializer::default()).await?;
                             Ok(())
                         }},"#,
@@ -263,7 +263,7 @@ mod manual_response_built_in_service_gen {
                     async move {{
                         match method {{
                             {impl_built_in_service_match_arms}
-                            _ => Err(restate_types::errors::InvocationError::service_method_not_found("{service_name}", method))
+                            _ => Err(restate_types::errors::InvocationError::component_handler_not_found("{service_name}", method))
                         }}
                     }}
                 }}

--- a/crates/pb/src/lib.rs
+++ b/crates/pb/src/lib.rs
@@ -86,7 +86,7 @@ pub mod builtin_service {
         }
 
         pub fn serialize_failure(&self, err: InvocationError) -> ResponseResult {
-            ResponseResult::Failure(err.code().into(), err.message().into())
+            ResponseResult::Failure(err.code(), err.message().into())
         }
     }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -13,7 +13,6 @@ default = []
 mocks = []
 serde = ["dep:serde", "dep:serde_with", "enumset/serde"]
 serde_schema = ["serde", "dep:schemars"]
-tonic_conversions = ["dep:tonic"]
 
 [dependencies]
 restate-base64-util = { workspace = true }
@@ -39,7 +38,6 @@ strum_macros = { workspace = true }
 sync_wrapper = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["time", "sync"]}
-tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 ulid = { workspace = true }

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -12,219 +12,68 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::convert::Into;
 use std::fmt;
-use std::fmt::Display;
 
-/// This error code set matches the [gRPC error code set](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc),
-/// representing all the error codes visible to the user code. Note, it does not include the Ok
-/// variant because only error cases are contained.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[repr(u16)]
-pub enum UserErrorCode {
-    /// The operation was cancelled.
-    Cancelled = 1,
-
-    /// Unknown error.
-    Unknown = 2,
-
-    /// Client specified an invalid argument.
-    InvalidArgument = 3,
-
-    /// Deadline expired before operation could complete.
-    DeadlineExceeded = 4,
-
-    /// Some requested entity was not found.
-    NotFound = 5,
-
-    /// Some entity that we attempted to create already exists.
-    AlreadyExists = 6,
-
-    /// The caller does not have permission to execute the specified operation.
-    PermissionDenied = 7,
-
-    /// Some resource has been exhausted.
-    ResourceExhausted = 8,
-
-    /// The system is not in a state required for the operation's execution.
-    FailedPrecondition = 9,
-
-    /// The operation was aborted, for example due to killing an invocation forcefully.
-    Aborted = 10,
-
-    /// Operation was attempted past the valid range.
-    OutOfRange = 11,
-
-    /// Operation is not implemented or not supported.
-    Unimplemented = 12,
-
-    /// Internal error.
-    Internal = 13,
-
-    /// The service is currently unavailable.
-    Unavailable = 14,
-
-    /// Unrecoverable data loss or corruption.
-    DataLoss = 15,
-
-    /// The request does not have valid authentication credentials.
-    Unauthenticated = 16,
-}
-
-impl Display for UserErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl From<u32> for UserErrorCode {
-    fn from(value: u32) -> Self {
-        use UserErrorCode::*;
-
-        match value {
-            1 => Cancelled,
-            2 => Unknown,
-            3 => InvalidArgument,
-            4 => DeadlineExceeded,
-            5 => NotFound,
-            6 => AlreadyExists,
-            7 => PermissionDenied,
-            8 => ResourceExhausted,
-            9 => FailedPrecondition,
-            10 => Aborted,
-            11 => OutOfRange,
-            12 => Unimplemented,
-            13 => Internal,
-            14 => Unavailable,
-            15 => DataLoss,
-            16 => Unauthenticated,
-            _ => Unknown,
-        }
-    }
-}
-
-impl From<UserErrorCode> for u32 {
-    fn from(value: UserErrorCode) -> Self {
-        value as u32
-    }
-}
-
-/// Error parsing/decoding a resource ID.
-#[derive(Debug, thiserror::Error, Clone, Eq, PartialEq)]
-pub enum IdDecodeError {
-    #[error("bad length")]
-    Length,
-    #[error("base62 decode error")]
-    Codec,
-    #[error("bad format")]
-    Format,
-    #[error("unrecognized codec version")]
-    Version,
-    #[error("id doesn't match the expected type")]
-    TypeMismatch,
-    #[error("unrecognized resource type: {0}")]
-    UnrecognizedType(String),
-}
-
-/// Error codes used by Restate to carry Restate specific error codes.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[repr(u16)]
-pub enum RestateErrorCode {
-    // The invocation cannot be replayed due to the mismatch between the journal and the actual code.
-    JournalMismatch = 32,
-
-    // Violation of the protocol state machine.
-    ProtocolViolation = 33,
-
-    // The invocation was killed by Restate
-    Killed = 64,
-}
-
-impl Display for RestateErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl From<RestateErrorCode> for u32 {
-    fn from(value: RestateErrorCode) -> Self {
-        value as u32
-    }
-}
-
-/// Error codes representing the possible error variants that can arise during an invocation.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum InvocationErrorCode {
-    User(UserErrorCode),
-    Restate(RestateErrorCode),
-    Unknown(u32),
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct InvocationErrorCode(u16);
+
+impl InvocationErrorCode {
+    pub const fn new(code: u16) -> Self {
+        InvocationErrorCode(code)
+    }
 }
 
 impl fmt::Debug for InvocationErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            InvocationErrorCode::User(c) => fmt::Debug::fmt(c, f),
-            InvocationErrorCode::Restate(c) => fmt::Debug::fmt(c, f),
-            InvocationErrorCode::Unknown(c) => write!(f, "{}", c),
-        }
+        write!(f, "{}", self.0)
     }
 }
 
-impl Display for InvocationErrorCode {
+impl fmt::Display for InvocationErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
+    }
+}
+
+impl From<u16> for InvocationErrorCode {
+    fn from(value: u16) -> Self {
+        InvocationErrorCode(value)
     }
 }
 
 impl From<u32> for InvocationErrorCode {
     fn from(value: u32) -> Self {
-        use InvocationErrorCode::*;
-        use RestateErrorCode::*;
+        value
+            .try_into()
+            .map(InvocationErrorCode)
+            .unwrap_or(codes::INTERNAL)
+    }
+}
 
-        if value <= 16 {
-            return User(value.into());
-        }
-        match value {
-            32 => Restate(JournalMismatch),
-            33 => Restate(ProtocolViolation),
-            64 => Restate(Killed),
-
-            c => Unknown(c),
-        }
+impl From<InvocationErrorCode> for u16 {
+    fn from(value: InvocationErrorCode) -> Self {
+        value.0
     }
 }
 
 impl From<InvocationErrorCode> for u32 {
     fn from(value: InvocationErrorCode) -> Self {
-        match value {
-            InvocationErrorCode::User(c) => c as u32,
-            InvocationErrorCode::Restate(c) => c as u32,
-            InvocationErrorCode::Unknown(c) => c,
-        }
+        value.0 as u32
     }
 }
 
-impl From<InvocationErrorCode> for UserErrorCode {
-    fn from(value: InvocationErrorCode) -> Self {
-        match value {
-            InvocationErrorCode::User(u) => u,
-            InvocationErrorCode::Restate(RestateErrorCode::Killed) => UserErrorCode::Aborted,
-            _ => UserErrorCode::Unknown,
-        }
-    }
-}
+pub mod codes {
+    use super::InvocationErrorCode;
 
-impl From<UserErrorCode> for InvocationErrorCode {
-    fn from(value: UserErrorCode) -> Self {
-        InvocationErrorCode::User(value)
-    }
-}
-
-impl From<RestateErrorCode> for InvocationErrorCode {
-    fn from(value: RestateErrorCode) -> Self {
-        InvocationErrorCode::Restate(value)
-    }
+    pub const BAD_REQUEST: InvocationErrorCode = InvocationErrorCode(400);
+    pub const NOT_FOUND: InvocationErrorCode = InvocationErrorCode(404);
+    pub const INTERNAL: InvocationErrorCode = InvocationErrorCode(500);
+    pub const UNKNOWN: InvocationErrorCode = INTERNAL;
+    pub const ABORTED: InvocationErrorCode = InvocationErrorCode(409);
+    pub const KILLED: InvocationErrorCode = ABORTED;
+    pub const JOURNAL_MISMATCH: InvocationErrorCode = InvocationErrorCode(570);
+    pub const PROTOCOL_VIOLATION: InvocationErrorCode = InvocationErrorCode(571);
 }
 
 /// This struct represents errors arisen when processing a service invocation.
@@ -237,7 +86,7 @@ pub struct InvocationError {
 }
 
 pub const UNKNOWN_INVOCATION_ERROR: InvocationError =
-    InvocationError::new_static(InvocationErrorCode::User(UserErrorCode::Unknown), "unknown");
+    InvocationError::new_static(codes::UNKNOWN, "unknown");
 
 impl Default for InvocationError {
     fn default() -> Self {
@@ -245,7 +94,7 @@ impl Default for InvocationError {
     }
 }
 
-impl Display for InvocationError {
+impl fmt::Display for InvocationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{:?}] {}", self.code(), self.message())?;
         if self.description.is_some() {
@@ -266,7 +115,7 @@ impl InvocationError {
         }
     }
 
-    pub fn new(code: impl Into<InvocationErrorCode>, message: impl Display) -> Self {
+    pub fn new(code: impl Into<InvocationErrorCode>, message: impl fmt::Display) -> Self {
         Self {
             code: code.into(),
             message: Cow::Owned(message.to_string()),
@@ -274,26 +123,29 @@ impl InvocationError {
         }
     }
 
-    pub fn internal(message: impl Display) -> Self {
+    pub fn internal(message: impl fmt::Display) -> Self {
         Self {
-            code: UserErrorCode::Internal.into(),
+            code: codes::INTERNAL,
             message: Cow::Owned(message.to_string()),
             description: None,
         }
     }
 
-    pub fn service_not_found(service: impl Display) -> Self {
+    pub fn component_not_found(component: impl fmt::Display) -> Self {
         Self {
-            code: UserErrorCode::NotFound.into(),
-            message: Cow::Owned(format!("Service '{}' not found. Check whether the deployment containing the service is registered.", service)),
+            code: codes::NOT_FOUND,
+            message: Cow::Owned(format!("Component '{}' not found. Check whether the deployment containing the component is registered.", component)),
             description: None,
         }
     }
 
-    pub fn service_method_not_found(service: impl Display, method: impl Display) -> Self {
+    pub fn component_handler_not_found(
+        component: impl fmt::Display,
+        handler: impl fmt::Display,
+    ) -> Self {
         Self {
-            code: UserErrorCode::NotFound.into(),
-            message: Cow::Owned(format!("Service method '{}/{}' not found. Check whether you've registered the correct version of your service.", service, method)),
+            code: codes::NOT_FOUND,
+            message: Cow::Owned(format!("Component handler '{}/{}' not found. Check whether you've registered the correct version of your component.", component, handler)),
             description: None,
         }
     }
@@ -303,7 +155,7 @@ impl InvocationError {
         self
     }
 
-    pub fn with_message(mut self, message: impl Display) -> InvocationError {
+    pub fn with_message(mut self, message: impl fmt::Display) -> InvocationError {
         self.message = Cow::Owned(message.to_string());
         self
     }
@@ -313,7 +165,7 @@ impl InvocationError {
         self
     }
 
-    pub fn with_description(mut self, description: impl Display) -> InvocationError {
+    pub fn with_description(mut self, description: impl fmt::Display) -> InvocationError {
         self.description = Some(Cow::Owned(description.to_string()));
         self
     }
@@ -339,58 +191,29 @@ impl From<anyhow::Error> for InvocationError {
 
 // -- Some known errors
 
-pub const KILLED_INVOCATION_ERROR: InvocationError = InvocationError::new_static(
-    InvocationErrorCode::Restate(RestateErrorCode::Killed),
-    "killed",
-);
+pub const KILLED_INVOCATION_ERROR: InvocationError =
+    InvocationError::new_static(codes::KILLED, "killed");
 
 // TODO: Once we want to distinguish server side cancellations from user code returning the
 //  UserErrorCode::Cancelled, we need to add a new RestateErrorCode.
-pub const CANCELED_INVOCATION_ERROR: InvocationError = InvocationError::new_static(
-    InvocationErrorCode::User(UserErrorCode::Cancelled),
-    "canceled",
-);
+pub const CANCELED_INVOCATION_ERROR: InvocationError =
+    InvocationError::new_static(codes::ABORTED, "canceled");
 
-#[cfg(feature = "tonic_conversions")]
-mod tonic_conversions_impl {
-    use super::{InvocationError, InvocationErrorCode};
-    use crate::errors::UserErrorCode;
-    use tonic::{Code, Status};
-
-    impl From<UserErrorCode> for Code {
-        fn from(value: UserErrorCode) -> Self {
-            match value {
-                UserErrorCode::Cancelled => Code::Cancelled,
-                UserErrorCode::Unknown => Code::Unknown,
-                UserErrorCode::InvalidArgument => Code::InvalidArgument,
-                UserErrorCode::DeadlineExceeded => Code::DeadlineExceeded,
-                UserErrorCode::NotFound => Code::NotFound,
-                UserErrorCode::AlreadyExists => Code::AlreadyExists,
-                UserErrorCode::PermissionDenied => Code::PermissionDenied,
-                UserErrorCode::ResourceExhausted => Code::ResourceExhausted,
-                UserErrorCode::FailedPrecondition => Code::FailedPrecondition,
-                UserErrorCode::Aborted => Code::Aborted,
-                UserErrorCode::OutOfRange => Code::OutOfRange,
-                UserErrorCode::Unimplemented => Code::Unimplemented,
-                UserErrorCode::Internal => Code::Internal,
-                UserErrorCode::Unavailable => Code::Unavailable,
-                UserErrorCode::DataLoss => Code::DataLoss,
-                UserErrorCode::Unauthenticated => Code::Unauthenticated,
-            }
-        }
-    }
-
-    impl From<InvocationErrorCode> for Code {
-        fn from(value: InvocationErrorCode) -> Self {
-            UserErrorCode::from(value).into()
-        }
-    }
-
-    impl From<InvocationError> for Status {
-        fn from(value: InvocationError) -> Self {
-            Status::new(value.code().into(), value.message)
-        }
-    }
+/// Error parsing/decoding a resource ID.
+#[derive(Debug, thiserror::Error, Clone, Eq, PartialEq)]
+pub enum IdDecodeError {
+    #[error("bad length")]
+    Length,
+    #[error("base62 decode error")]
+    Codec,
+    #[error("bad format")]
+    Format,
+    #[error("unrecognized codec version")]
+    Version,
+    #[error("id doesn't match the expected type")]
+    TypeMismatch,
+    #[error("unrecognized resource type: {0}")]
+    UnrecognizedType(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -10,7 +10,7 @@
 
 //! This module contains all the core types representing a service invocation.
 
-use crate::errors::{InvocationError, UserErrorCode};
+use crate::errors::{InvocationError, InvocationErrorCode};
 use crate::identifiers::{
     EntryIndex, FullInvocationId, InvocationId, PartitionKey, WithPartitionKey,
 };
@@ -132,7 +132,7 @@ pub struct InvocationResponse {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResponseResult {
     Success(Bytes),
-    Failure(UserErrorCode, ByteString),
+    Failure(InvocationErrorCode, ByteString),
 }
 
 impl From<Result<Bytes, InvocationError>> for ResponseResult {
@@ -157,13 +157,13 @@ impl From<ResponseResult> for Result<Bytes, InvocationError> {
 
 impl From<InvocationError> for ResponseResult {
     fn from(e: InvocationError) -> Self {
-        ResponseResult::Failure(e.code().into(), e.message().into())
+        ResponseResult::Failure(e.code(), e.message().into())
     }
 }
 
 impl From<&InvocationError> for ResponseResult {
     fn from(e: &InvocationError) -> Self {
-        ResponseResult::Failure(e.code().into(), e.message().into())
+        ResponseResult::Failure(e.code(), e.message().into())
     }
 }
 

--- a/crates/types/src/journal/entries.rs
+++ b/crates/types/src/journal/entries.rs
@@ -12,7 +12,7 @@
 
 use super::*;
 
-use crate::errors::{InvocationError, UserErrorCode};
+use crate::errors::{InvocationError, InvocationErrorCode};
 use crate::identifiers::EntryIndex;
 use crate::time::MillisSinceEpoch;
 use std::fmt;
@@ -121,7 +121,7 @@ impl Completion {
 pub enum CompletionResult {
     Empty,
     Success(Bytes),
-    Failure(UserErrorCode, ByteString),
+    Failure(InvocationErrorCode, ByteString),
 }
 
 impl From<ResponseResult> for CompletionResult {
@@ -137,7 +137,7 @@ impl From<ResponseResult> for CompletionResult {
 
 impl From<&InvocationError> for CompletionResult {
     fn from(value: &InvocationError) -> Self {
-        CompletionResult::Failure(UserErrorCode::from(value.code()), value.message().into())
+        CompletionResult::Failure(value.code(), value.message().into())
     }
 }
 
@@ -167,7 +167,7 @@ impl fmt::Display for EntryType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EntryResult {
     Success(Bytes),
-    Failure(UserErrorCode, ByteString),
+    Failure(InvocationErrorCode, ByteString),
 }
 
 impl From<EntryResult> for ResponseResult {
@@ -209,7 +209,7 @@ pub struct OutputEntry {
 pub enum GetStateResult {
     Empty,
     Result(Bytes),
-    Failure(UserErrorCode, ByteString),
+    Failure(InvocationErrorCode, ByteString),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -238,7 +238,7 @@ pub struct ClearStateEntry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GetStateKeysResult {
     Result(Vec<Bytes>),
-    Failure(UserErrorCode, ByteString),
+    Failure(InvocationErrorCode, ByteString),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -255,7 +255,7 @@ impl CompletableEntry for GetStateKeysEntry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SleepResult {
     Fired,
-    Failure(UserErrorCode, ByteString),
+    Failure(InvocationErrorCode, ByteString),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/worker/src/invoker_integration.rs
+++ b/crates/worker/src/invoker_integration.rs
@@ -12,7 +12,7 @@ use assert2::let_assert;
 use bytes::Bytes;
 use restate_schema_api::component::ComponentType;
 use restate_service_protocol::awakeable_id::AwakeableIdentifier;
-use restate_types::errors::{InvocationError, UserErrorCode};
+use restate_types::errors::{codes, InvocationError};
 use restate_types::identifiers::{FullInvocationId, InvocationUuid, ServiceId};
 use restate_types::invocation::{ServiceInvocationSpanContext, SpanRelation};
 use restate_types::journal::enriched::{
@@ -67,7 +67,7 @@ where
                 }
             },
             None => {
-                return Err(InvocationError::service_method_not_found(
+                return Err(InvocationError::component_handler_not_found(
                     &request.service_name,
                     &request.method_name,
                 ))
@@ -170,7 +170,7 @@ where
                 let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&id)
                     .map_err(|e| {
                         InvocationError::new(
-                            UserErrorCode::InvalidArgument,
+                            codes::BAD_REQUEST,
                             format!("Invalid awakeable identifier: {}", e),
                         )
                     })?

--- a/crates/worker/src/partition/services/deterministic/awakeables.rs
+++ b/crates/worker/src/partition/services/deterministic/awakeables.rs
@@ -15,12 +15,13 @@ use crate::partition::services::deterministic::*;
 use restate_pb::restate::internal::AwakeablesBuiltInService;
 use restate_pb::restate::internal::*;
 use restate_service_protocol::awakeable_id::AwakeableIdentifier;
+use restate_types::errors::codes;
 use restate_types::invocation::ResponseResult;
 
 impl AwakeablesBuiltInService for &mut ServiceInvoker<'_> {
     async fn resolve(&mut self, req: ResolveAwakeableRequest) -> Result<(), InvocationError> {
         let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&req.id)
-            .map_err(|e| InvocationError::new(UserErrorCode::InvalidArgument, e.to_string()))?
+            .map_err(|e| InvocationError::new(codes::BAD_REQUEST, e.to_string()))?
             .into_inner();
 
         self.outbox_message(OutboxMessage::from_awakeable_completion(
@@ -33,16 +34,13 @@ impl AwakeablesBuiltInService for &mut ServiceInvoker<'_> {
 
     async fn reject(&mut self, req: RejectAwakeableRequest) -> Result<(), InvocationError> {
         let (invocation_id, entry_index) = AwakeableIdentifier::from_str(&req.id)
-            .map_err(|e| InvocationError::new(UserErrorCode::InvalidArgument, e.to_string()))?
+            .map_err(|e| InvocationError::new(codes::BAD_REQUEST, e.to_string()))?
             .into_inner();
 
         self.outbox_message(OutboxMessage::from_awakeable_completion(
             invocation_id,
             entry_index,
-            ResponseResult::from(Err(InvocationError::new(
-                UserErrorCode::Unknown,
-                req.reason,
-            ))),
+            ResponseResult::from(Err(InvocationError::new(codes::UNKNOWN, req.reason))),
         ));
 
         Ok(())

--- a/crates/worker/src/partition/services/deterministic/mod.rs
+++ b/crates/worker/src/partition/services/deterministic/mod.rs
@@ -14,7 +14,7 @@ use restate_pb::builtin_service::BuiltInService;
 use restate_pb::restate::internal::AwakeablesInvoker;
 use restate_pb::restate::internal::ProxyInvoker;
 use restate_storage_api::outbox_table::OutboxMessage;
-use restate_types::errors::{InvocationError, UserErrorCode};
+use restate_types::errors::InvocationError;
 use restate_types::identifiers::FullInvocationId;
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
@@ -89,7 +89,7 @@ impl ServiceInvoker<'_> {
             restate_pb::PROXY_SERVICE_NAME => {
                 ProxyInvoker(self).invoke_builtin(method, argument).await
             }
-            _ => Err(InvocationError::service_not_found(
+            _ => Err(InvocationError::component_not_found(
                 &self.fid.service_id.service_name,
             )),
         }

--- a/crates/worker/src/partition/services/non_deterministic/mod.rs
+++ b/crates/worker/src/partition/services/non_deterministic/mod.rs
@@ -88,7 +88,7 @@ impl ServiceInvoker {
                     .invoke_builtin(method, argument)
                     .await
             }
-            _ => Err(InvocationError::service_not_found(
+            _ => Err(InvocationError::component_not_found(
                 &full_invocation_id.service_id.service_name,
             )),
         };

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -14,7 +14,7 @@ use restate_storage_api::invocation_status_table::JournalMetadata;
 use restate_storage_api::{Result as StorageResult, StorageError};
 use restate_test_util::matchers::*;
 use restate_test_util::{assert_eq, let_assert};
-use restate_types::errors::UserErrorCode;
+use restate_types::errors::codes;
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::journal::EntryResult;
 use restate_types::journal::{CompleteAwakeableEntry, Entry};
@@ -311,7 +311,7 @@ async fn awakeable_with_failure() {
             id: AwakeableIdentifier::new(sid_callee.clone().into(), 1)
                 .to_string()
                 .into(),
-            result: EntryResult::Failure(UserErrorCode::FailedPrecondition, "Some failure".into()),
+            result: EntryResult::Failure(codes::BAD_REQUEST, "Some failure".into()),
         },
     ));
     let cmd = Command::InvokerEffect(InvokerEffect {
@@ -341,7 +341,7 @@ async fn awakeable_with_failure() {
         OutboxMessage::ServiceResponse(InvocationResponse {
             id,
             entry_index,
-            result: ResponseResult::Failure(UserErrorCode::FailedPrecondition, failure_reason),
+            result: ResponseResult::Failure(codes::BAD_REQUEST, failure_reason),
         }) = message
     );
     assert_eq!(
@@ -438,7 +438,7 @@ async fn kill_inboxed_invocation() -> Result<(), Error> {
                             id: eq(MaybeFullInvocationId::from(caller_fid)),
                             entry_index: eq(0),
                             result: pat!(ResponseResult::Failure(
-                                eq(UserErrorCode::Aborted),
+                                eq(codes::ABORTED),
                                 eq(ByteString::from_static("killed"))
                             ))
                         }
@@ -695,7 +695,7 @@ fn canceled_completion_matcher(entry_index: EntryIndex) -> impl Matcher<ActualT 
     pat!(Completion {
         entry_index: eq(entry_index),
         result: pat!(CompletionResult::Failure(
-            eq(UserErrorCode::Cancelled),
+            eq(codes::ABORTED),
             eq(ByteString::from_static("canceled"))
         ))
     })

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -93,7 +93,7 @@ mod tests {
     use restate_storage_api::Transaction;
     use restate_storage_rocksdb::RocksDBStorage;
     use restate_test_util::matchers::*;
-    use restate_types::errors::UserErrorCode;
+    use restate_types::errors::codes;
     use restate_types::identifiers::{
         FullInvocationId, InvocationId, PartitionId, PartitionKey, ServiceId,
     };
@@ -357,7 +357,7 @@ mod tests {
                         id: eq(MaybeFullInvocationId::Full(caller_fid)),
                         entry_index: eq(0),
                         result: pat!(ResponseResult::Failure(
-                            eq(UserErrorCode::Aborted),
+                            eq(codes::ABORTED),
                             eq(ByteString::from_static("killed"))
                         ))
                     }


### PR DESCRIPTION
Previously the response error codes were related to gRPC status codes. From now on, we allow any HTTP status code as output. Fix #1231