### PR TITLE
Add single node MetadataStore implementation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5004,6 +5004,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-grpc-util"
+version = "0.9.0"
+dependencies = [
+ "http 0.2.12",
+ "restate-types",
+ "tokio",
+ "tonic 0.10.2",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "restate-ingress-dispatcher"
 version = "0.9.0"
 dependencies = [
@@ -5247,6 +5259,7 @@ dependencies = [
  "rand",
  "restate-core",
  "restate-errors",
+ "restate-grpc-util",
  "restate-node-protocol",
  "restate-node-services",
  "restate-test-util",
@@ -5294,6 +5307,7 @@ dependencies = [
  "restate-cluster-controller",
  "restate-core",
  "restate-errors",
+ "restate-grpc-util",
  "restate-meta",
  "restate-network",
  "restate-node-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5008,8 +5008,11 @@ name = "restate-grpc-util"
 version = "0.9.0"
 dependencies = [
  "http 0.2.12",
+ "hyper 0.14.28",
  "restate-types",
+ "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic 0.10.2",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,13 +5233,36 @@ dependencies = [
 name = "restate-metadata-store"
 version = "0.9.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "bytes",
+ "bytestring",
+ "futures",
+ "googletest",
+ "hyper 0.14.28",
+ "prost 0.12.3",
+ "prost-types",
+ "restate-core",
+ "restate-grpc-util",
+ "restate-node-protocol",
  "restate-types",
+ "rocksdb",
  "serde",
  "static_assertions",
+ "tempfile",
+ "test-log",
  "thiserror",
+ "tokio",
+ "tokio-retry",
+ "tonic 0.10.2",
+ "tonic-build",
+ "tonic-health",
+ "tonic-reflection",
+ "tower",
+ "tower-http 0.4.4",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5350,6 +5373,7 @@ version = "0.9.0"
 dependencies = [
  "bincode",
  "bytes",
+ "bytestring",
  "derive_more",
  "enum-map",
  "prost 0.12.3",
@@ -6881,6 +6905,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6998,6 +7033,19 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 2.0.53",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
+dependencies = [
+ "async-stream",
+ "prost 0.12.3",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.10.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ restate-core = { path = "crates/core" }
 restate-errors = { path = "crates/errors" }
 restate-fs-util = { path = "crates/fs-util" }
 restate-futures-util = { path = "crates/futures-util" }
+restate-grpc-util = { path = "crates/grpc-util" }
 restate-ingress-dispatcher = { path = "crates/ingress-dispatcher" }
 restate-ingress-http = { path = "crates/ingress-http" }
 restate-ingress-kafka = { path = "crates/ingress-kafka" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ tokio-util = { version = "0.7.10" }
 tokio-stream = "0.1.14"
 tonic = { version = "0.10.2", default-features = false }
 tonic-reflection = { version = "0.10.2" }
+tonic-health = "0.10.2"
 tonic-build = "0.11.0"
 tower = "0.4"
 tower-http = { version = "0.4", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 restate-test-util = { workspace = true }
+restate-types = { workspace = true, features = ["test-util"] }
 
 googletest = { workspace = true }
 rand = { workspace = true }

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -291,7 +291,8 @@ mod tests {
 
     use googletest::prelude::*;
     use restate_test_util::assert_eq;
-    use restate_types::nodes_config::{AdvertisedAddress, NodeConfig, Role};
+    use restate_types::net::AdvertisedAddress;
+    use restate_types::nodes_config::{NodeConfig, Role};
     use restate_types::{GenerationalNodeId, Version};
 
     use crate::metadata::spawn_metadata_manager;

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -17,7 +17,8 @@ use restate_node_protocol::codec::{deserialize_message, serialize_message, Targe
 use restate_node_protocol::metadata::MetadataKind;
 use restate_node_protocol::node::{Header, Message};
 use restate_node_protocol::CURRENT_PROTOCOL_VERSION;
-use restate_types::nodes_config::{AdvertisedAddress, NodeConfig, NodesConfiguration, Role};
+use restate_types::net::AdvertisedAddress;
+use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
 use restate_types::{GenerationalNodeId, NodeId, Version};
 use tracing::info;
 

--- a/crates/grpc-util/Cargo.toml
+++ b/crates/grpc-util/Cargo.toml
@@ -11,7 +11,10 @@ publish = false
 restate-types = { workspace = true }
 
 http = { workspace = true }
+hyper = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/crates/grpc-util/Cargo.toml
+++ b/crates/grpc-util/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "restate-grpc-util"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+restate-types = { workspace = true }
+
+http = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tower = { workspace = true }
+tracing = { workspace = true }

--- a/crates/grpc-util/src/lib.rs
+++ b/crates/grpc-util/src/lib.rs
@@ -8,13 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use http::Uri;
-use restate_types::net::AdvertisedAddress;
-use tokio::net::UnixStream;
+use hyper::body::HttpBody;
+use hyper::server::accept::Accept;
+use hyper::server::conn::AddrIncoming;
+use restate_types::net::{AdvertisedAddress, BindAddress};
+use tokio::io;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::{UnixListener, UnixStream};
+use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;
+use tracing::info;
 
 pub fn create_grpc_channel_from_advertised_address(
     address: AdvertisedAddress,
@@ -38,4 +47,120 @@ pub fn create_grpc_channel_from_advertised_address(
         }
     };
     Ok(channel)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed binding to address '{address}': {source}")]
+    TcpBinding {
+        address: SocketAddr,
+        #[source]
+        source: hyper::Error,
+    },
+    #[error("failed opening uds '{uds_path}': {source}")]
+    UdsBinding {
+        uds_path: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed running grpc server: {0}")]
+    Running(#[from] hyper::Error),
+}
+
+pub async fn run_hyper_server<S, B, F>(
+    bind_address: BindAddress,
+    service: S,
+    shutdown_signal: F,
+    server_name: &str,
+) -> Result<(), Error>
+where
+    S: hyper::service::Service<http::Request<hyper::Body>, Response = hyper::Response<B>>
+        + Send
+        + Clone
+        + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    F: Future<Output = ()>,
+{
+    match bind_address {
+        BindAddress::Uds(uds_path) => {
+            let unix_listener = UnixListener::bind(&uds_path).map_err(|err| Error::UdsBinding {
+                uds_path: uds_path.clone(),
+                source: err,
+            })?;
+            let acceptor =
+                hyper::server::accept::from_stream(UnixListenerStream::new(unix_listener));
+
+            info!(uds.path = %uds_path.display(), "Server '{}' listening", server_name);
+
+            run_server(acceptor, service, shutdown_signal).await?
+        }
+        BindAddress::Socket(socket_addr) => {
+            run_tcp_server(socket_addr, service, shutdown_signal, server_name).await?
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_tcp_server<S, B, F>(
+    socket_addr: SocketAddr,
+    service: S,
+    shutdown_signal: F,
+    server_name: &str,
+) -> Result<(), Error>
+where
+    S: hyper::service::Service<http::Request<hyper::Body>, Response = hyper::Response<B>>
+        + Send
+        + Clone
+        + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    F: Future<Output = ()>,
+{
+    let acceptor = AddrIncoming::bind(&socket_addr).map_err(|err| Error::TcpBinding {
+        address: socket_addr,
+        source: err,
+    })?;
+
+    info!(
+        net.host.addr = %acceptor.local_addr().ip(),
+        net.host.port = %acceptor.local_addr().port(),
+        "Server '{}' listening", server_name
+    );
+
+    run_server(acceptor, service, shutdown_signal).await
+}
+
+async fn run_server<S, B, Conn, Err, F>(
+    acceptor: impl Accept<Conn = Conn, Error = Err>,
+    service: S,
+    shutdown_signal: F,
+) -> Result<(), Error>
+where
+    S: hyper::service::Service<http::Request<hyper::Body>, Response = hyper::Response<B>>
+        + Send
+        + Clone
+        + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    Conn: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    Err: Into<Box<dyn std::error::Error + Send + Sync>>,
+    F: Future<Output = ()>,
+{
+    let server = hyper::Server::builder(acceptor).serve(tower::make::Shared::new(service));
+
+    server
+        .with_graceful_shutdown(shutdown_signal)
+        .await
+        .map_err(Error::Running)
 }

--- a/crates/grpc-util/src/lib.rs
+++ b/crates/grpc-util/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
 // All rights reserved.
 //
 // Use of this software is governed by the Business Source License
@@ -16,7 +16,7 @@ use tokio::net::UnixStream;
 use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;
 
-pub fn create_grpc_channel_from_network_address(
+pub fn create_grpc_channel_from_advertised_address(
     address: AdvertisedAddress,
 ) -> Result<Channel, http::Error> {
     let channel = match address {

--- a/crates/grpc-util/src/lib.rs
+++ b/crates/grpc-util/src/lib.rs
@@ -10,6 +10,7 @@
 
 use std::future::Future;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use http::Uri;
@@ -59,7 +60,7 @@ pub enum Error {
     },
     #[error("failed opening uds '{uds_path}': {source}")]
     UdsBinding {
-        uds_path: String,
+        uds_path: PathBuf,
         #[source]
         source: io::Error,
     },

--- a/crates/ingress-dispatcher/Cargo.toml
+++ b/crates/ingress-dispatcher/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { workspace = true }
 restate-bifrost = { workspace = true, features = ["memory_loglet"] }
 restate-core = { workspace = true, features = ["test-util"] }
 restate-test-util = { workspace = true, features = ["prost"] }
-restate-types = { workspace = true, features = ["mocks"] }
+restate-types = { workspace = true, features = ["test-util"] }
 
 googletest = { workspace = true }
 test-log = { workspace = true }

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -62,7 +62,7 @@ pin-project-lite = "0.2.13"
 restate-core = { workspace = true, features = ["test-util"] }
 restate-ingress-dispatcher = { workspace = true, features = ["mocks"] }
 restate-test-util = { workspace = true }
-restate-types = { workspace = true, features = ["mocks"] }
+restate-types = { workspace = true, features = ["test-util"] }
 restate-schema-api = { workspace = true, features = ["mocks"]}
 
 hyper = { version = "1.0", features = ["full"] }

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -41,7 +41,7 @@ restate-ingress-dispatcher = { workspace = true, features = ["mocks"] }
 restate-schema-api = { workspace = true, features = ["mocks"] }
 restate-schema-impl = { workspace = true }
 restate-test-util = { workspace = true }
-restate-types = { workspace = true, features = ["mocks"] }
+restate-types = { workspace = true, features = ["test-util"] }
 
 base64 = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/metadata-store/Cargo.toml
+++ b/crates/metadata-store/Cargo.toml
@@ -10,13 +10,42 @@ publish = false
 [features]
 
 [dependencies]
-restate-types = { workspace = true }
+restate-core = { workspace = true }
+restate-grpc-util = { workspace = true }
+restate-node-protocol = { workspace = true }
+restate-types = { workspace = true, features = ["serde"] }
 
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
+bytestring = { workspace = true }
+futures = { workspace = true }
+hyper = { workspace = true, features = ["full"] }
+prost = { workspace = true }
+prost-types = { workspace = true }
+rocksdb = { workspace = true }
 serde = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true, features = ["transport", "codegen", "prost"] }
+tonic-reflection = { workspace = true }
+tonic-health = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["trace"] }
+tracing = { workspace = true }
+
 
 [dev-dependencies]
+restate-core = { workspace = true, features = ["test-util"] }
+
+anyhow = { workspace = true }
+googletest = { workspace = true }
+tempfile = { workspace = true }
+test-log = { workspace = true }
+tokio-retry = "0.3.0"
+tracing-subscriber = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }

--- a/crates/metadata-store/build.rs
+++ b/crates/metadata-store/build.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    tonic_build::configure()
+        .bytes(["."])
+        .file_descriptor_set_path(out_dir.join("metadata_store_svc.bin"))
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&["./proto/metadata_store_svc.proto"], &["proto"])?;
+
+    Ok(())
+}

--- a/crates/metadata-store/proto/metadata_store_svc.proto
+++ b/crates/metadata-store/proto/metadata_store_svc.proto
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package dev.restate.metadata_store_svc;
+
+// Grpc service definition for a MetadataStore implementation.
+service MetadataStoreSvc {
+  // Get a versioned kv-pair
+  rpc Get(GetRequest) returns (GetResponse);
+
+  // Get the current version for a kv-pair
+  rpc GetVersion(GetRequest) returns (GetVersionResponse);
+
+  // Puts the given kv-pair into the metadata store
+  rpc Put(PutRequest) returns (google.protobuf.Empty);
+
+  // Deletes the given kv-pair
+  rpc Delete(DeleteRequest) returns (google.protobuf.Empty);
+}
+
+message GetRequest {
+  string key = 1;
+}
+
+message PutRequest {
+  string key = 1;
+  VersionedValue value = 2;
+  Precondition precondition = 3;
+}
+
+message DeleteRequest {
+  string key = 1;
+  Precondition precondition = 2;
+}
+
+message VersionedValue {
+  Version version = 1;
+  bytes bytes = 2;
+}
+
+message GetResponse {
+  optional VersionedValue value = 1;
+}
+
+message Version {
+  uint32 value = 1;
+}
+
+message GetVersionResponse {
+  optional Version version = 1;
+}
+
+enum PreconditionKind {
+  PreconditionKind_UNKNOWN = 0;
+  NONE = 1;
+  DOES_NOT_EXIST = 2;
+  MATCHES_VERSION = 3;
+}
+
+message Precondition {
+  PreconditionKind kind = 1;
+  // needs to be set in case of PreconditionKind::MATCHES_VERSION
+  optional Version version = 2;
+}
+
+

--- a/crates/metadata-store/src/grpc_svc.rs
+++ b/crates/metadata-store/src/grpc_svc.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+tonic::include_proto!("dev.restate.metadata_store_svc");
+
+pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("metadata_store_svc");

--- a/crates/metadata-store/src/local/grpc/client.rs
+++ b/crates/metadata-store/src/local/grpc/client.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::grpc_svc::metadata_store_svc_client::MetadataStoreSvcClient;
+use crate::grpc_svc::{DeleteRequest, GetRequest, PutRequest};
+use crate::local::grpc::pb_conversions::ConversionError;
+use crate::{MetadataStore, Precondition, ReadError, VersionedValue, WriteError};
+use async_trait::async_trait;
+use bytestring::ByteString;
+use restate_grpc_util::create_grpc_channel_from_advertised_address;
+use restate_types::net::AdvertisedAddress;
+use restate_types::Version;
+use tonic::transport::Channel;
+use tonic::{Code, Status};
+
+/// Client end to interact with the [`LocalMetadataStore`].
+#[derive(Debug, Clone)]
+pub struct LocalMetadataStoreClient {
+    svc_client: MetadataStoreSvcClient<Channel>,
+}
+impl LocalMetadataStoreClient {
+    pub fn new(metadata_store_address: AdvertisedAddress) -> Self {
+        let channel = create_grpc_channel_from_advertised_address(metadata_store_address)
+            .expect("should not fail");
+
+        Self {
+            svc_client: MetadataStoreSvcClient::new(channel),
+        }
+    }
+}
+
+#[async_trait]
+impl MetadataStore for LocalMetadataStoreClient {
+    async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+        let response = self
+            .svc_client
+            .clone()
+            .get(GetRequest { key: key.into() })
+            .await?;
+
+        response
+            .into_inner()
+            .try_into()
+            .map_err(|err: ConversionError| ReadError::Internal(err.to_string()))
+    }
+
+    async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+        let response = self
+            .svc_client
+            .clone()
+            .get_version(GetRequest { key: key.into() })
+            .await?;
+
+        Ok(response.into_inner().into())
+    }
+
+    async fn put(
+        &self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        self.svc_client
+            .clone()
+            .put(PutRequest {
+                key: key.into(),
+                value: Some(value.into()),
+                precondition: Some(precondition.into()),
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
+        self.svc_client
+            .clone()
+            .delete(DeleteRequest {
+                key: key.into(),
+                precondition: Some(precondition.into()),
+            })
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl From<Status> for ReadError {
+    fn from(status: Status) -> Self {
+        match &status.code() {
+            Code::Unavailable => ReadError::Network(status.into()),
+            _ => ReadError::Internal(status.to_string()),
+        }
+    }
+}
+
+impl From<Status> for WriteError {
+    fn from(status: Status) -> Self {
+        match &status.code() {
+            Code::Unavailable => WriteError::Network(status.into()),
+            Code::FailedPrecondition => {
+                WriteError::FailedPrecondition(status.message().to_string())
+            }
+            _ => WriteError::Internal(status.to_string()),
+        }
+    }
+}

--- a/crates/metadata-store/src/local/grpc/handler.rs
+++ b/crates/metadata-store/src/local/grpc/handler.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvc;
+use crate::grpc_svc::{DeleteRequest, GetRequest, GetResponse, GetVersionResponse, PutRequest};
+use crate::local::grpc::pb_conversions::ConversionError;
+use crate::local::store::{Error, MetadataStoreRequest, RequestSender};
+use async_trait::async_trait;
+use tokio::sync::oneshot;
+use tonic::{Request, Response, Status};
+
+/// Grpc svc handler for the [`LocalMetadataStore`].
+#[derive(Debug)]
+pub struct LocalMetadataStoreHandler {
+    request_tx: RequestSender,
+}
+
+impl LocalMetadataStoreHandler {
+    pub fn new(request_tx: RequestSender) -> Self {
+        Self { request_tx }
+    }
+}
+
+#[async_trait]
+impl MetadataStoreSvc for LocalMetadataStoreHandler {
+    async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
+        let (result_tx, result_rx) = oneshot::channel();
+
+        let request = request.into_inner();
+        self.request_tx
+            .send(MetadataStoreRequest::Get {
+                key: request.key.into(),
+                result_tx,
+            })
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))?;
+
+        let result = result_rx
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))??;
+
+        Ok(Response::new(GetResponse {
+            value: result.map(Into::into),
+        }))
+    }
+
+    async fn get_version(
+        &self,
+        request: Request<GetRequest>,
+    ) -> Result<Response<GetVersionResponse>, Status> {
+        let (result_tx, result_rx) = oneshot::channel();
+
+        let request = request.into_inner();
+        self.request_tx
+            .send(MetadataStoreRequest::GetVersion {
+                key: request.key.into(),
+                result_tx,
+            })
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))?;
+
+        let result = result_rx
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))??;
+
+        Ok(Response::new(GetVersionResponse {
+            version: result.map(Into::into),
+        }))
+    }
+
+    async fn put(&self, request: Request<PutRequest>) -> Result<Response<()>, Status> {
+        let (result_tx, result_rx) = oneshot::channel();
+
+        let request = request.into_inner();
+        self.request_tx
+            .send(MetadataStoreRequest::Put {
+                key: request.key.into(),
+                value: request
+                    .value
+                    .ok_or_else(|| Status::invalid_argument("missing value field"))?
+                    .try_into()
+                    .map_err(|err: ConversionError| Status::invalid_argument(err.to_string()))?,
+                precondition: request
+                    .precondition
+                    .ok_or_else(|| Status::invalid_argument("missing precondition field"))?
+                    .try_into()
+                    .map_err(|err: ConversionError| Status::invalid_argument(err.to_string()))?,
+                result_tx,
+            })
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))?;
+
+        result_rx
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))??;
+
+        Ok(Response::new(()))
+    }
+
+    async fn delete(&self, request: Request<DeleteRequest>) -> Result<Response<()>, Status> {
+        let (result_tx, result_rx) = oneshot::channel();
+
+        let request = request.into_inner();
+        self.request_tx
+            .send(MetadataStoreRequest::Delete {
+                key: request.key.into(),
+                precondition: request
+                    .precondition
+                    .ok_or_else(|| Status::invalid_argument("missing precondition field"))?
+                    .try_into()
+                    .map_err(|err: ConversionError| Status::invalid_argument(err.to_string()))?,
+                result_tx,
+            })
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))?;
+
+        result_rx
+            .await
+            .map_err(|_| Status::unavailable("metadata store is shut down"))??;
+
+        Ok(Response::new(()))
+    }
+}
+
+impl From<Error> for Status {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::FailedPrecondition(msg) => Status::failed_precondition(msg),
+            err => Status::internal(err.to_string()),
+        }
+    }
+}

--- a/crates/metadata-store/src/local/grpc/mod.rs
+++ b/crates/metadata-store/src/local/grpc/mod.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod client;
+pub mod handler;
+
+pub mod pb_conversions {
+    use crate::grpc_svc::{GetResponse, GetVersionResponse, PreconditionKind};
+    use crate::{grpc_svc, Precondition, VersionedValue};
+    use restate_types::Version;
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum ConversionError {
+        #[error("missing field '{0}'")]
+        MissingField(&'static str),
+        #[error("invalid data '{0}'")]
+        InvalidData(&'static str),
+    }
+
+    impl ConversionError {
+        pub fn missing_field(field: &'static str) -> Self {
+            ConversionError::MissingField(field)
+        }
+
+        pub fn invalid_data(field: &'static str) -> Self {
+            ConversionError::InvalidData(field)
+        }
+    }
+
+    impl TryFrom<GetResponse> for Option<VersionedValue> {
+        type Error = ConversionError;
+
+        fn try_from(value: GetResponse) -> Result<Self, Self::Error> {
+            if let Some(versioned_value) = value.value {
+                Ok(Some(VersionedValue::try_from(versioned_value)?))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    impl TryFrom<grpc_svc::VersionedValue> for VersionedValue {
+        type Error = ConversionError;
+
+        fn try_from(value: grpc_svc::VersionedValue) -> Result<Self, Self::Error> {
+            let version = value
+                .version
+                .ok_or_else(|| ConversionError::missing_field("version"))?;
+            Ok(VersionedValue::new(version.into(), value.bytes))
+        }
+    }
+
+    impl From<GetVersionResponse> for Option<Version> {
+        fn from(value: GetVersionResponse) -> Self {
+            value.version.map(Into::into)
+        }
+    }
+
+    impl From<VersionedValue> for grpc_svc::VersionedValue {
+        fn from(value: VersionedValue) -> Self {
+            grpc_svc::VersionedValue {
+                version: Some(value.version.into()),
+                bytes: value.value,
+            }
+        }
+    }
+
+    impl From<grpc_svc::Version> for Version {
+        fn from(value: grpc_svc::Version) -> Self {
+            Version::from(value.value)
+        }
+    }
+
+    impl From<Version> for grpc_svc::Version {
+        fn from(value: Version) -> Self {
+            grpc_svc::Version {
+                value: value.into(),
+            }
+        }
+    }
+
+    impl From<Precondition> for grpc_svc::Precondition {
+        fn from(value: Precondition) -> Self {
+            match value {
+                Precondition::None => grpc_svc::Precondition {
+                    kind: PreconditionKind::None.into(),
+                    version: None,
+                },
+                Precondition::DoesNotExist => grpc_svc::Precondition {
+                    kind: PreconditionKind::DoesNotExist.into(),
+                    version: None,
+                },
+                Precondition::MatchesVersion(version) => grpc_svc::Precondition {
+                    kind: PreconditionKind::MatchesVersion.into(),
+                    version: Some(version.into()),
+                },
+            }
+        }
+    }
+
+    impl TryFrom<grpc_svc::Precondition> for Precondition {
+        type Error = ConversionError;
+
+        fn try_from(value: grpc_svc::Precondition) -> Result<Self, Self::Error> {
+            match value.kind() {
+                PreconditionKind::Unknown => {
+                    Err(ConversionError::invalid_data("unknown precondition kind"))
+                }
+                PreconditionKind::None => Ok(Precondition::None),
+                PreconditionKind::DoesNotExist => Ok(Precondition::DoesNotExist),
+                PreconditionKind::MatchesVersion => Ok(Precondition::MatchesVersion(
+                    value
+                        .version
+                        .ok_or_else(|| ConversionError::missing_field("version"))?
+                        .into(),
+                )),
+            }
+        }
+    }
+}

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod grpc;
+mod store;
+
+mod service;
+#[cfg(test)]
+mod tests;

--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::grpc_svc;
+use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvcServer;
+use crate::local::grpc::handler::LocalMetadataStoreHandler;
+use crate::local::store::LocalMetadataStore;
+use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
+use restate_types::net::BindAddress;
+use tonic::server::NamedService;
+
+pub struct LocalMetadataStoreService {
+    metadata_store: LocalMetadataStore,
+    bind_address: BindAddress,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed running grpc server: {0}")]
+    GrpcServer(#[from] restate_grpc_util::Error),
+    #[error("error while running server server grpc reflection service: {0}")]
+    GrpcReflection(#[from] tonic_reflection::server::Error),
+    #[error("system is shutting down")]
+    Shutdown(#[from] ShutdownError),
+}
+
+impl LocalMetadataStoreService {
+    pub fn new(metadata_store: LocalMetadataStore, bind_address: BindAddress) -> Self {
+        Self {
+            metadata_store,
+            bind_address,
+        }
+    }
+
+    pub fn grpc_service_name(&self) -> &str {
+        MetadataStoreSvcServer::<LocalMetadataStoreHandler>::NAME
+    }
+
+    pub async fn run(self) -> Result<(), Error> {
+        // Trace layer
+        let span_factory = tower_http::trace::DefaultMakeSpan::new()
+            .include_headers(true)
+            .level(tracing::Level::ERROR);
+
+        let reflection_service_builder = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(grpc_svc::FILE_DESCRIPTOR_SET);
+
+        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+        health_reporter
+            .set_serving::<MetadataStoreSvcServer<LocalMetadataStoreHandler>>()
+            .await;
+
+        let server_builder = tonic::transport::Server::builder()
+            .layer(tower_http::trace::TraceLayer::new_for_grpc().make_span_with(span_factory))
+            .add_service(health_service)
+            .add_service(MetadataStoreSvcServer::new(LocalMetadataStoreHandler::new(
+                self.metadata_store.request_sender(),
+            )))
+            .add_service(reflection_service_builder.build()?);
+
+        let service = server_builder.into_service();
+
+        task_center().spawn_child(
+            TaskKind::RpcServer,
+            "metadata-store-grpc",
+            None,
+            async move {
+                restate_grpc_util::run_hyper_server(
+                    self.bind_address,
+                    service,
+                    cancellation_watcher(),
+                    "metadata-store-grpc",
+                )
+                .await?;
+                Ok(())
+            },
+        )?;
+
+        self.metadata_store.run().await;
+
+        Ok(())
+    }
+}

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -1,0 +1,320 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::{Precondition, VersionedValue};
+use bytes::Bytes;
+use bytestring::ByteString;
+use restate_core::cancellation_watcher;
+use restate_types::errors::GenericError;
+use restate_types::Version;
+use rocksdb::{ColumnFamily, Options, WriteOptions, DB};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::path::Path;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, trace};
+
+pub type RequestSender = mpsc::Sender<MetadataStoreRequest>;
+pub type RequestReceiver = mpsc::Receiver<MetadataStoreRequest>;
+
+type Result<T> = std::result::Result<T, Error>;
+
+const KV_PAIRS: &str = "kv_pairs";
+
+#[derive(Debug)]
+pub enum MetadataStoreRequest {
+    Get {
+        key: ByteString,
+        result_tx: oneshot::Sender<Result<Option<VersionedValue>>>,
+    },
+    GetVersion {
+        key: ByteString,
+        result_tx: oneshot::Sender<Result<Option<Version>>>,
+    },
+    Put {
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+        result_tx: oneshot::Sender<Result<()>>,
+    },
+    Delete {
+        key: ByteString,
+        precondition: Precondition,
+        result_tx: oneshot::Sender<Result<()>>,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("storage error: {0}")]
+    Storage(#[from] rocksdb::Error),
+    #[error("failed precondition: {0}")]
+    FailedPrecondition(String),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("codec error: {0}")]
+    Codec(GenericError),
+}
+
+impl Error {
+    fn kv_pair_exists() -> Self {
+        Error::FailedPrecondition("key-value pair already exists".to_owned())
+    }
+
+    fn version_mismatch(expected: Version, actual: Option<Version>) -> Self {
+        Error::FailedPrecondition(format!(
+            "Expected version '{}' but found version '{:?}'",
+            expected, actual
+        ))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    #[error("failed opening rocksdb: {0}")]
+    RocksDB(#[from] rocksdb::Error),
+}
+
+/// Single node metadata store which stores the key value pairs in RocksDB.
+///
+/// In order to avoid issues arising from concurrency, we run the metadata
+/// store in a single thread.
+pub struct LocalMetadataStore {
+    db: DB,
+    write_opts: WriteOptions,
+    request_rx: RequestReceiver,
+
+    // for creating other senders
+    request_tx: RequestSender,
+}
+
+impl LocalMetadataStore {
+    pub fn new(
+        path: impl AsRef<Path>,
+        channel_size: usize,
+    ) -> std::result::Result<Self, BuildError> {
+        let (request_tx, request_rx) = mpsc::channel(channel_size);
+
+        let cfs = vec![rocksdb::ColumnFamilyDescriptor::new(
+            KV_PAIRS,
+            Self::cf_options(),
+        )];
+
+        let db = DB::open_cf_descriptors(&Self::db_options(), path, cfs)?;
+
+        Ok(Self {
+            db,
+            write_opts: Self::default_write_options(),
+            request_rx,
+            request_tx,
+        })
+    }
+
+    fn db_options() -> Options {
+        // todo optimize db settings
+        let mut options = Options::default();
+
+        // create missing db/cfs if not present
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+
+        options
+    }
+
+    fn cf_options() -> Options {
+        // todo optimize cf settings
+        Options::default()
+    }
+
+    fn default_write_options() -> WriteOptions {
+        let mut write_opts = WriteOptions::default();
+
+        // make sure that we write to wal and sync to disc
+        write_opts.disable_wal(false);
+        write_opts.set_sync(true);
+
+        write_opts
+    }
+
+    pub fn request_sender(&self) -> RequestSender {
+        self.request_tx.clone()
+    }
+
+    pub async fn run(mut self) {
+        debug!("Running LocalMetadataStore");
+
+        loop {
+            tokio::select! {
+                request = self.request_rx.recv() => {
+                    let request = request.expect("receiver should not be closed since we own one clone.");
+                    self.handle_request(request).await;
+                }
+                _ = cancellation_watcher() => {
+                    break;
+                },
+            }
+        }
+
+        debug!("Stopped LocalMetadataStore");
+    }
+
+    fn kv_cf_handle(&self) -> &ColumnFamily {
+        self.db
+            .cf_handle(KV_PAIRS)
+            .expect("KV_PAIRS column family exists")
+    }
+
+    async fn handle_request(&self, request: MetadataStoreRequest) {
+        trace!("Handle request '{:?}'", request);
+
+        match request {
+            MetadataStoreRequest::Get { key, result_tx } => {
+                let result = self.get(&key);
+                Self::log_error(&result, "Get");
+                let _ = result_tx.send(result);
+            }
+            MetadataStoreRequest::GetVersion { key, result_tx } => {
+                let result = self.get_version(&key);
+                Self::log_error(&result, "GetVersion");
+                let _ = result_tx.send(result);
+            }
+            MetadataStoreRequest::Put {
+                key,
+                value,
+                precondition,
+                result_tx,
+            } => {
+                let result = self.put(&key, &value, precondition);
+                Self::log_error(&result, "Put");
+                let _ = result_tx.send(result);
+            }
+            MetadataStoreRequest::Delete {
+                key,
+                precondition,
+                result_tx,
+            } => {
+                let result = self.delete(&key, precondition);
+                Self::log_error(&result, "Delete");
+                let _ = result_tx.send(result);
+            }
+        };
+    }
+
+    fn get(&self, key: &ByteString) -> Result<Option<VersionedValue>> {
+        let cf_handle = self.kv_cf_handle();
+        let slice = self.db.get_pinned_cf(cf_handle, key)?;
+
+        if let Some(bytes) = slice {
+            Ok(Some(Self::decode(bytes)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_version(&self, key: &ByteString) -> Result<Option<Version>> {
+        let cf_handle = self.kv_cf_handle();
+        let slice = self.db.get_pinned_cf(cf_handle, key)?;
+
+        if let Some(bytes) = slice {
+            // todo only deserialize the version part
+            let versioned_value = Self::decode::<VersionedValue>(bytes)?;
+            Ok(Some(versioned_value.version))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn put(
+        &self,
+        key: &ByteString,
+        value: &VersionedValue,
+        precondition: Precondition,
+    ) -> Result<()> {
+        match precondition {
+            Precondition::None => Ok(self.write_versioned_kv_pair(key, value)?),
+            Precondition::DoesNotExist => {
+                let current_version = self.get_version(key)?;
+                if current_version.is_none() {
+                    Ok(self.write_versioned_kv_pair(key, value)?)
+                } else {
+                    Err(Error::kv_pair_exists())
+                }
+            }
+            Precondition::MatchesVersion(version) => {
+                let current_version = self.get_version(key)?;
+                if current_version == Some(version) {
+                    Ok(self.write_versioned_kv_pair(key, value)?)
+                } else {
+                    Err(Error::version_mismatch(version, current_version))
+                }
+            }
+        }
+    }
+
+    fn write_versioned_kv_pair(&self, key: &ByteString, value: &VersionedValue) -> Result<()> {
+        let cf_handle = self.kv_cf_handle();
+        let versioned_value = Self::encode(value)?;
+        self.db
+            .put_cf_opt(cf_handle, key, versioned_value, &self.write_opts)?;
+        Ok(())
+    }
+
+    fn delete(&self, key: &ByteString, precondition: Precondition) -> Result<()> {
+        match precondition {
+            Precondition::None => self.delete_kv_pair(key),
+            // this condition does not really make sense for the delete operation
+            Precondition::DoesNotExist => {
+                let current_version = self.get_version(key)?;
+
+                if current_version.is_none() {
+                    // nothing to do
+                    Ok(())
+                } else {
+                    Err(Error::kv_pair_exists())
+                }
+            }
+            Precondition::MatchesVersion(version) => {
+                let current_version = self.get_version(key)?;
+
+                if current_version == Some(version) {
+                    self.delete_kv_pair(key)
+                } else {
+                    Err(Error::version_mismatch(version, current_version))
+                }
+            }
+        }
+    }
+
+    fn delete_kv_pair(&self, key: &ByteString) -> Result<()> {
+        self.db
+            .delete_cf_opt(self.kv_cf_handle(), key, &self.write_opts)
+            .map_err(Into::into)
+    }
+
+    fn encode<T: Serialize>(value: T) -> Result<Bytes> {
+        // todo: Add version information
+        bincode::serde::encode_to_vec(value, bincode::config::standard())
+            .map(Into::into)
+            .map_err(|err| Error::Codec(err.into()))
+    }
+
+    fn decode<T: DeserializeOwned>(bytes: impl AsRef<[u8]>) -> Result<T> {
+        // todo: Add version information
+        bincode::serde::decode_from_slice(bytes.as_ref(), bincode::config::standard())
+            .map(|(value, _)| value)
+            .map_err(|err| Error::Codec(err.into()))
+    }
+
+    fn log_error<T>(result: &Result<T>, request: &str) {
+        if let Err(err) = &result {
+            debug!("failed to process request '{}': '{}'", request, err)
+        }
+    }
+}

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -1,0 +1,313 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::local::grpc::client::LocalMetadataStoreClient;
+use crate::local::service::LocalMetadataStoreService;
+use crate::local::store::LocalMetadataStore;
+use crate::{MetadataStoreClient, Precondition, WriteError};
+use bytestring::ByteString;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use restate_core::{MockNetworkSender, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
+use restate_grpc_util::create_grpc_channel_from_advertised_address;
+use restate_types::net::{AdvertisedAddress, BindAddress};
+use restate_types::{Version, Versioned};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use test_log::test;
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+#[derive(Debug, Clone, PartialOrd, PartialEq, Serialize, Deserialize, Default)]
+struct Value {
+    version: Version,
+    value: String,
+}
+
+impl Value {
+    fn next_version(mut self) -> Self {
+        self.version = self.version.next();
+        self
+    }
+}
+
+impl Versioned for Value {
+    fn version(&self) -> Version {
+        self.version
+    }
+}
+
+/// Tests basic operations of the metadata store.
+#[test(tokio::test)]
+async fn basic_metadata_store_operations() -> anyhow::Result<()> {
+    let (client, env) = create_test_environment().await?;
+
+    env.tc
+        .run_in_scope("test", None, async move {
+            let key: ByteString = "key".into();
+            let value = Value {
+                version: Version::MIN,
+                value: "test_value".to_owned(),
+            };
+
+            let next_value = Value {
+                version: Version::from(2),
+                value: "next_value".to_owned(),
+            };
+
+            let other_value = Value {
+                version: Version::MIN,
+                value: "other_value".to_owned(),
+            };
+
+            // first get should be empty
+            assert!(client.get::<Value>(key.clone()).await?.is_none());
+
+            // put initial value
+            client.put(key.clone(), &value, Precondition::None).await?;
+
+            assert_eq!(
+                client.get_version(key.clone()).await?,
+                Some(value.version())
+            );
+            assert_eq!(client.get(key.clone()).await?, Some(value));
+
+            // fail to overwrite existing value
+            assert!(matches!(
+                client
+                    .put(key.clone(), &other_value, Precondition::DoesNotExist)
+                    .await,
+                Err(WriteError::FailedPrecondition(_))
+            ));
+
+            // fail to overwrite existing value with wrong version
+            assert!(matches!(
+                client
+                    .put(
+                        key.clone(),
+                        &other_value,
+                        Precondition::MatchesVersion(Version::INVALID)
+                    )
+                    .await,
+                Err(WriteError::FailedPrecondition(_))
+            ));
+
+            // overwrite with matching version precondition
+            client
+                .put(
+                    key.clone(),
+                    &next_value,
+                    Precondition::MatchesVersion(Version::MIN),
+                )
+                .await?;
+            assert_eq!(client.get(key.clone()).await?, Some(next_value));
+
+            // try to delete value with wrong version should fail
+            assert!(matches!(
+                client
+                    .delete(key.clone(), Precondition::MatchesVersion(Version::MIN))
+                    .await,
+                Err(WriteError::FailedPrecondition(_))
+            ));
+
+            // delete should succeed with the right precondition
+            client
+                .delete(key.clone(), Precondition::MatchesVersion(Version::from(2)))
+                .await?;
+            assert!(client.get::<Value>(key.clone()).await?.is_none());
+
+            // unconditional delete
+            client
+                .put(key.clone(), &other_value, Precondition::None)
+                .await?;
+            client.delete(key.clone(), Precondition::None).await?;
+            assert!(client.get::<Value>(key.clone()).await?.is_none());
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .await?;
+
+    env.tc.shutdown_node("shutdown", 0).await;
+
+    Ok(())
+}
+
+/// Tests multiple concurrent operations issued by the same client
+#[test(tokio::test)]
+async fn concurrent_operations() -> anyhow::Result<()> {
+    let (client, env) = create_test_environment().await?;
+
+    env.tc
+        .run_in_scope("test", None, async move {
+            let mut concurrent_operations = FuturesUnordered::default();
+
+            for key in 1u32..=10 {
+                for _instance in 0..key {
+                    let client = client.clone();
+                    let key = ByteString::from(key.to_string());
+                    concurrent_operations.push(async move {
+                        loop {
+                            let value = client.get::<Value>(key.clone()).await?;
+
+                            let result = if let Some(value) = value {
+                                let previous_version = value.version();
+                                client
+                                    .put(
+                                        key.clone(),
+                                        value.next_version(),
+                                        Precondition::MatchesVersion(previous_version),
+                                    )
+                                    .await
+                            } else {
+                                client
+                                    .put(key.clone(), Value::default(), Precondition::DoesNotExist)
+                                    .await
+                            };
+
+                            match result {
+                                Ok(()) => return Ok::<(), anyhow::Error>(()),
+                                Err(WriteError::FailedPrecondition(_)) => continue,
+                                Err(err) => return Err(err.into()),
+                            }
+                        }
+                    });
+                }
+            }
+
+            while let Some(result) = concurrent_operations.next().await {
+                result?;
+            }
+
+            // sanity check
+            for key in 1u32..=10 {
+                let metadata_key = ByteString::from(key.to_string());
+                let value = client
+                    .get::<Value>(metadata_key)
+                    .await?
+                    .map(|v| v.version());
+
+                assert_eq!(value, Some(Version::from(key)));
+            }
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .await?;
+
+    env.tc.shutdown_node("shutdown", 0).await;
+    Ok(())
+}
+
+/// Tests that the metadata store stores values durably so that they can be read after a restart.
+#[test(tokio::test)]
+async fn durable_storage() -> anyhow::Result<()> {
+    let rocksdb_path = tempfile::tempdir()?.into_path();
+
+    let (client, env) = create_test_environment_with_path(rocksdb_path.clone()).await?;
+
+    // write data
+    env.tc
+        .run_in_scope("write-data", None, async move {
+            for key in 1u32..=10 {
+                let value = key.to_string();
+                let metadata_key = ByteString::from(value.clone());
+                client
+                    .put(
+                        metadata_key,
+                        Value {
+                            version: Version::from(key),
+                            value,
+                        },
+                        Precondition::DoesNotExist,
+                    )
+                    .await?;
+            }
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .await?;
+
+    env.tc.shutdown_node("shutdown", 0).await;
+
+    let (client, env) = create_test_environment_with_path(rocksdb_path).await?;
+
+    // validate data
+    env.tc
+        .run_in_scope("validate-data", None, async move {
+            for key in 1u32..=10 {
+                let value = key.to_string();
+                let metadata_key = ByteString::from(value.clone());
+
+                assert_eq!(
+                    client.get(metadata_key).await?,
+                    Some(Value {
+                        version: Version::from(key),
+                        value
+                    })
+                );
+            }
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .await?;
+
+    env.tc.shutdown_node("shutdown", 0).await;
+    Ok(())
+}
+
+async fn create_test_environment(
+) -> anyhow::Result<(MetadataStoreClient, TestCoreEnv<MockNetworkSender>)> {
+    create_test_environment_with_path(tempfile::tempdir()?.into_path()).await
+}
+
+/// Creates a test environment with the [`RocksDBMetadataStore`] and a [`MetadataStoreClient`]
+/// connected to it.
+async fn create_test_environment_with_path(
+    rocksdb_path: impl AsRef<Path>,
+) -> anyhow::Result<(MetadataStoreClient, TestCoreEnv<MockNetworkSender>)> {
+    let uds_path = tempfile::tempdir()?.into_path().join("grpc-server");
+    let bind_address = BindAddress::Uds(uds_path.clone());
+    let advertised_address = AdvertisedAddress::Uds(uds_path);
+    let store = LocalMetadataStore::new(rocksdb_path, 32)?;
+    let service = LocalMetadataStoreService::new(store, bind_address);
+    let grpc_service_name = service.grpc_service_name().to_owned();
+
+    let rocksdb_client = LocalMetadataStoreClient::new(advertised_address.clone());
+
+    let client = MetadataStoreClient::new(rocksdb_client);
+
+    let env = TestCoreEnvBuilder::new_with_mock_network().build().await;
+
+    env.tc.spawn(
+        TaskKind::SystemService,
+        "metadata-store",
+        None,
+        async move {
+            service.run().await?;
+            Ok(())
+        },
+    )?;
+
+    // await start-up of metadata store
+    let health_client = HealthClient::new(create_grpc_channel_from_advertised_address(
+        advertised_address,
+    )?);
+    let retry_strategy = tokio_retry::strategy::ExponentialBackoff::from_millis(10).factor(2);
+    tokio_retry::Retry::spawn(retry_strategy, || async {
+        health_client
+            .clone()
+            .check(HealthCheckRequest {
+                service: grpc_service_name.clone(),
+            })
+            .await
+    })
+    .await?;
+
+    Ok((client, env))
+}

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
+restate-grpc-util = { workspace = true }
 restate-node-protocol = { workspace = true }
 restate-node-services = { workspace = true, features = ["clients"] }
 restate-types = { workspace = true }

--- a/crates/network/src/connection_manager.rs
+++ b/crates/network/src/connection_manager.rs
@@ -24,6 +24,7 @@ use tracing::{debug, info, warn, Instrument, Span};
 
 use restate_core::metadata;
 use restate_core::{cancellation_watcher, current_task_id, task_center, TaskId, TaskKind};
+use restate_grpc_util::create_grpc_channel_from_advertised_address;
 use restate_node_protocol::node::message::{self, ConnectionControl};
 use restate_node_protocol::node::{Header, Hello, Message, Welcome};
 use restate_node_services::node_svc::node_svc_client::NodeSvcClient;
@@ -37,7 +38,6 @@ use crate::metric_definitions::{
     self, CONNECTION_DROPPED, INCOMING_CONNECTION, MESSAGE_PROCESSING_DURATION, MESSAGE_RECEIVED,
     ONGOING_DRAIN, OUTGOING_CONNECTION,
 };
-use crate::utils::create_grpc_channel_from_network_address;
 
 // todo: make this configurable
 const SEND_QUEUE_SIZE: usize = 1;
@@ -263,7 +263,7 @@ impl ConnectionManager {
         let channel = {
             let mut guard = self.inner.lock().unwrap();
             if let hash_map::Entry::Vacant(entry) = guard.channel_cache.entry(address.clone()) {
-                let channel = create_grpc_channel_from_network_address(address)
+                let channel = create_grpc_channel_from_advertised_address(address)
                     .map_err(|e| NetworkError::BadNodeAddress(node_id.into(), e))?;
                 entry.insert(channel.clone());
                 channel

--- a/crates/network/src/connection_manager.rs
+++ b/crates/network/src/connection_manager.rs
@@ -27,7 +27,7 @@ use restate_core::{cancellation_watcher, current_task_id, task_center, TaskId, T
 use restate_node_protocol::node::message::{self, ConnectionControl};
 use restate_node_protocol::node::{Header, Hello, Message, Welcome};
 use restate_node_services::node_svc::node_svc_client::NodeSvcClient;
-use restate_types::nodes_config::AdvertisedAddress;
+use restate_types::net::AdvertisedAddress;
 use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
 
 use super::connection::{Connection, ConnectionSender};

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -10,12 +10,10 @@
 
 mod connection;
 mod connection_manager;
+pub mod error;
 mod handshake;
 pub(crate) mod metric_definitions;
 mod networking;
-pub mod utils;
-
-pub mod error;
 
 pub use connection::ConnectionSender;
 pub use connection_manager::ConnectionManager;

--- a/crates/network/src/utils.rs
+++ b/crates/network/src/utils.rs
@@ -11,7 +11,7 @@
 use std::time::Duration;
 
 use http::Uri;
-use restate_types::nodes_config::AdvertisedAddress;
+use restate_types::net::AdvertisedAddress;
 use tokio::net::UnixStream;
 use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;

--- a/crates/node-protocol/Cargo.toml
+++ b/crates/node-protocol/Cargo.toml
@@ -15,6 +15,7 @@ restate-types = { workspace = true, features = ["serde"] }
 
 bincode = { workspace = true }
 bytes = { workspace = true }
+bytestring = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true }
 prost = { workspace = true }

--- a/crates/node-protocol/proto/common.proto
+++ b/crates/node-protocol/proto/common.proto
@@ -31,5 +31,7 @@ enum TargetName {
   TargetName_UNKNOWN = 0;
   METADATA_MANAGER = 1;
   INGRESS = 2;
+  LOCAL_METADATA_STORE = 3;
+  LOCAL_METADATA_STORE_CLIENT = 4;
 }
 

--- a/crates/node-protocol/src/metadata.rs
+++ b/crates/node-protocol/src/metadata.rs
@@ -15,7 +15,7 @@ use restate_types::partition_table::FixedPartitionTable;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
-use crate::codec::{Targeted, WireSerde};
+use crate::codec::{decode_default, encode_default, Targeted, WireSerde};
 use crate::common::ProtocolVersion;
 use crate::common::TargetName;
 use crate::CodecError;
@@ -43,14 +43,12 @@ impl Targeted for MetadataMessage {
 }
 
 impl WireSerde for MetadataMessage {
-    fn encode(&self, _protocol_version: ProtocolVersion) -> Result<Bytes, CodecError> {
-        // serialize message to bytes
-        Ok(bincode::serde::encode_to_vec(self, bincode::config::standard())?.into())
+    fn encode(&self, protocol_version: ProtocolVersion) -> Result<Bytes, CodecError> {
+        encode_default(self, protocol_version)
     }
 
-    fn decode(payload: Bytes, _protocol_version: ProtocolVersion) -> Result<Self, CodecError> {
-        let (output, _) = bincode::serde::decode_from_slice(&payload, bincode::config::standard())?;
-        Ok(output)
+    fn decode(payload: Bytes, protocol_version: ProtocolVersion) -> Result<Self, CodecError> {
+        decode_default(payload, protocol_version)
     }
 }
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -22,6 +22,7 @@ restate-bifrost = { workspace = true }
 restate-cluster-controller = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
+restate-grpc-util = { workspace = true }
 restate-meta = { workspace = true }
 restate-network = { workspace = true }
 restate-node-protocol = { workspace = true }

--- a/crates/node/src/network_server/options.rs
+++ b/crates/node/src/network_server/options.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use serde_with::serde_as;
 
 use restate_network::ConnectionManager;
-use restate_types::nodes_config::AdvertisedAddress;
+use restate_types::net::AdvertisedAddress;
 
 use crate::network_server::service::{AdminDependencies, NetworkServer, WorkerDependencies};
 

--- a/crates/node/src/network_server/options.rs
+++ b/crates/node/src/network_server/options.rs
@@ -8,13 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use serde_with::serde_as;
 
 use restate_network::ConnectionManager;
-use restate_types::net::AdvertisedAddress;
+use restate_types::net::{AdvertisedAddress, BindAddress};
 
 use crate::network_server::service::{AdminDependencies, NetworkServer, WorkerDependencies};
 
@@ -26,7 +25,8 @@ use crate::network_server::service::{AdminDependencies, NetworkServer, WorkerDep
 #[cfg_attr(feature = "options_schema", schemars(default))]
 pub struct Options {
     /// Address to bind for the Node server.
-    pub bind_address: SocketAddr,
+    #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
+    pub bind_address: BindAddress,
 
     /// Address that other nodes will use to connect to this node. Defaults to use bind_address if
     /// unset.

--- a/crates/node/src/options.rs
+++ b/crates/node/src/options.rs
@@ -10,7 +10,8 @@
 
 use crate::network_server;
 use enumset::EnumSet;
-use restate_types::nodes_config::{AdvertisedAddress, Role};
+use restate_types::net::AdvertisedAddress;
+use restate_types::nodes_config::Role;
 use restate_types::PlainNodeId;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -20,7 +20,7 @@ use tracing::trace;
 use restate_bifrost::Bifrost;
 use restate_core::TaskKind;
 use restate_core::{metadata, task_center};
-use restate_network::utils::create_grpc_channel_from_network_address;
+use restate_grpc_util::create_grpc_channel_from_advertised_address;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_node_services::cluster_ctrl::AttachmentRequest;
 use restate_node_services::cluster_ctrl::FetchSchemasRequest;
@@ -140,7 +140,7 @@ impl WorkerRole {
             .address
             .clone();
 
-        let channel = create_grpc_channel_from_network_address(admin_address.clone())
+        let channel = create_grpc_channel_from_advertised_address(admin_address.clone())
             .expect("valid admin address");
         let mut cluster_ctrl_client = ClusterCtrlSvcClient::new(channel);
 
@@ -171,7 +171,7 @@ impl WorkerRole {
     async fn attach_node(admin_address: AdvertisedAddress) -> Result<(), WorkerRoleError> {
         info!("Worker attaching to admin at '{admin_address}'");
 
-        let channel = create_grpc_channel_from_network_address(admin_address.clone())
+        let channel = create_grpc_channel_from_advertised_address(admin_address.clone())
             .map_err(WorkerRoleError::InvalidClusterControllerAddress)?;
 
         let cc_client = ClusterCtrlSvcClient::new(channel);

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -28,7 +28,7 @@ use restate_schema_api::subscription::SubscriptionResolver;
 use restate_schema_impl::{Schemas, SchemasUpdateCommand};
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_rocksdb::RocksDBStorage;
-use restate_types::nodes_config::AdvertisedAddress;
+use restate_types::net::AdvertisedAddress;
 use restate_types::retries::RetryPolicy;
 use restate_worker::{SubscriptionControllerHandle, Worker};
 use restate_worker_api::SubscriptionController;

--- a/crates/queue/Cargo.toml
+++ b/crates/queue/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 
 [dev-dependencies]
-restate-types = { workspace = true, features = ["serde", "mocks"] }
+restate-types = { workspace = true, features = ["serde", "test-util"] }
 
 criterion = { workspace = true, features = ["async_tokio"] }
 tempfile = { workspace = true }

--- a/crates/storage-query-postgres/src/service.rs
+++ b/crates/storage-query-postgres/src/service.rs
@@ -13,13 +13,12 @@ use codederror::CodedError;
 use restate_core::cancellation_watcher;
 use restate_storage_query_datafusion::context::QueryContext;
 
+use restate_types::errors::GenericError;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use tokio::select;
 use tracing::warn;
-
-pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum Error {

--- a/crates/storage-rocksdb/Cargo.toml
+++ b/crates/storage-rocksdb/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4.20"
 
 [dev-dependencies]
 restate-test-util = { workspace = true }
-restate-types = { workspace = true, features = ["mocks"] }
+restate-types = { workspace = true, features = ["test-util"] }
 
 criterion = { workspace = true, features = ["async_tokio"] }
 googletest = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [features]
 default = []
 
-mocks = []
+test-util = []
 serde = ["dep:serde", "dep:serde_with", "enumset/serde"]
 serde_schema = ["serde", "dep:schemars"]
 

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -13,6 +13,10 @@ use std::borrow::Cow;
 use std::convert::Into;
 use std::fmt;
 
+/// Error type which abstracts away the actual [`std::error::Error`] type. Use this type
+/// if you don't know the actual error type or if it is not important.
+pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -659,7 +659,7 @@ impl FromStr for LambdaARN {
     }
 }
 
-#[cfg(any(test, feature = "mocks"))]
+#[cfg(any(test, feature = "test-util"))]
 mod mocks {
     use super::*;
 

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -548,7 +548,7 @@ impl From<TraceId> for TraceIdDef {
     }
 }
 
-#[cfg(any(test, feature = "mocks"))]
+#[cfg(any(test, feature = "test-util"))]
 mod mocks {
     use super::*;
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod invocation;
 pub mod journal;
 pub mod logs;
 pub mod message;
+pub mod net;
 pub mod nodes_config;
 pub mod partition_table;
 pub mod retries;

--- a/crates/types/src/net.rs
+++ b/crates/types/src/net.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::Uri;
+use std::net::{AddrParseError, SocketAddr};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, derive_more::Display)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+pub enum AdvertisedAddress {
+    /// Unix domain socket
+    #[display(fmt = "unix:{}", _0)]
+    Uds(String),
+    /// Hostname or host:port pair, or any unrecognizable string.
+    #[display(fmt = "{}", _0)]
+    Http(Uri),
+}
+
+impl FromStr for AdvertisedAddress {
+    type Err = http::uri::InvalidUri;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(stripped_address) = s.strip_prefix("unix:") {
+            Ok(AdvertisedAddress::Uds(stripped_address.to_owned()))
+        } else {
+            // try to parse as a URI
+            Ok(AdvertisedAddress::Http(s.parse()?))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, derive_more::Display)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+pub enum BindAddress {
+    /// Unix domain socket
+    #[display(fmt = "unix:{}", _0)]
+    Uds(String),
+    /// Socket addr.
+    #[display(fmt = "{}", _0)]
+    Socket(SocketAddr),
+}
+
+impl FromStr for BindAddress {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(stripped_address) = s.strip_prefix("unix:") {
+            Ok(BindAddress::Uds(stripped_address.to_owned()))
+        } else {
+            // try to parse as a URI
+            Ok(BindAddress::Socket(s.parse()?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::net::AdvertisedAddress;
+    use http::Uri;
+
+    // test parsing [`AdvertisedAddress`]
+    #[test]
+    fn test_parse_network_address() -> anyhow::Result<()> {
+        let tcp: AdvertisedAddress = "127.0.0.1:5123".parse()?;
+        restate_test_util::assert_eq!(tcp, AdvertisedAddress::Http("127.0.0.1:5123".parse()?));
+
+        let tcp: AdvertisedAddress = "unix:/tmp/unix.socket".parse()?;
+        restate_test_util::assert_eq!(tcp, AdvertisedAddress::Uds("/tmp/unix.socket".to_owned()));
+
+        let tcp: AdvertisedAddress = "localhost:5123".parse()?;
+        restate_test_util::assert_eq!(tcp, AdvertisedAddress::Http("localhost:5123".parse()?));
+
+        let tcp: AdvertisedAddress = "https://localhost:5123".parse()?;
+        restate_test_util::assert_eq!(
+            tcp,
+            AdvertisedAddress::Http(Uri::from_static("https://localhost:5123"))
+        );
+
+        Ok(())
+    }
+}

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -99,7 +99,7 @@ impl NodesConfiguration {
         self.version += Version::from(1);
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn set_version(&mut self, version: Version) {
         self.version = version;
     }
@@ -173,10 +173,6 @@ impl NodesConfiguration {
 impl Versioned for NodesConfiguration {
     fn version(&self) -> Version {
         self.version()
-    }
-
-    fn increment_version(&mut self) {
-        self.increment_version();
     }
 }
 

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -49,6 +49,11 @@ impl FixedPartitionTable {
         self.version = self.version.next();
     }
 
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_version(&mut self, version: Version) {
+        self.version = version;
+    }
+
     pub fn partitioner(&self) -> Partitioner {
         Partitioner::new(self.num_partitions)
     }
@@ -96,10 +101,6 @@ impl FixedPartitionTable {
 impl Versioned for FixedPartitionTable {
     fn version(&self) -> Version {
         self.version()
-    }
-
-    fn increment_version(&mut self) {
-        self.increment_version();
     }
 }
 

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -45,7 +45,4 @@ impl Default for Version {
 pub trait Versioned {
     /// Returns the version of the versioned value
     fn version(&self) -> Version;
-
-    /// Increments the version of the versioned value
-    fn increment_version(&mut self);
 }

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -46,3 +46,21 @@ pub trait Versioned {
     /// Returns the version of the versioned value
     fn version(&self) -> Version;
 }
+
+impl<T: Versioned> Versioned for &T {
+    fn version(&self) -> Version {
+        (**self).version()
+    }
+}
+
+impl<T: Versioned> Versioned for &mut T {
+    fn version(&self) -> Version {
+        (**self).version()
+    }
+}
+
+impl<T: Versioned> Versioned for Box<T> {
+    fn version(&self) -> Version {
+        (**self).version()
+    }
+}

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -77,7 +77,7 @@ restate-schema-api = { workspace = true, features = ["mocks"] }
 restate-service-protocol = { workspace = true, features = ["mocks"] }
 restate-storage-api = { workspace = true, features = ["mocks"] }
 restate-test-util = { workspace = true, features = ["prost"] }
-restate-types = { workspace = true, features = ["mocks"] }
+restate-types = { workspace = true, features = ["test-util"] }
 
 googletest = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
The implementation is based on a single node which uses Restate's
networking and stores the kv pairs durably in a RocksDB instance.

This fixes https://github.com/restatedev/restate/issues/1284.

This PR is based on #1288.