### PR TITLE
Implement content-type validation on ingress and set the correct content-type on output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,15 +2592,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3055,6 +3055,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4694,11 +4705,11 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "regress"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
+checksum = "4f5f39ba4513916c1b2657b72af6ec671f091cd637992f58d0ede5cae4e5dea0"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "memchr",
 ]
 
@@ -5056,6 +5067,7 @@ dependencies = [
  "codederror",
  "derive_builder",
  "futures",
+ "http 0.2.12",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
@@ -5439,12 +5451,14 @@ dependencies = [
  "bytes",
  "bytestring",
  "http 0.2.12",
+ "itertools 0.11.0",
  "restate-base64-util",
  "restate-serde-util",
  "restate-types",
  "schemars",
  "serde",
  "serde_with",
+ "thiserror",
 ]
 
 [[package]]
@@ -5561,6 +5575,7 @@ dependencies = [
  "bytes-utils",
  "codederror",
  "hyper 0.14.28",
+ "jsonptr",
  "paste",
  "prettyplease",
  "prost 0.12.3",
@@ -7295,9 +7310,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typify"
-version = "0.0.15"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ed4d717aa95e598e2f9183376b060e95669ef8f444701ea6afb990fde1cf69"
+checksum = "5c61e9db210bbff218e6535c664b37ec47da449169b98e7866d0580d0db75529"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -7305,15 +7320,15 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.0.15"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89057244dfade7c58af9e62beccbcbeb7a7e7701697a33b06dbe0b7331fb79cf"
+checksum = "95e32f38493804f88e2dc7a5412eccd872ea5452b4db9b0a77de4df180f2a87e"
 dependencies = [
  "heck 0.4.1",
  "log",
  "proc-macro2",
  "quote",
- "regress 0.7.1",
+ "regress 0.8.0",
  "schemars",
  "serde_json",
  "syn 2.0.55",
@@ -7323,9 +7338,9 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.0.15"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddade397f5957d2cd7fb27f905a9a569db20e8e1e3ea589edce40be07b92825"
+checksum = "cc09508b72f63d521d68e42c7f172c7416d67986df44b3c7d1f7f9963948ed32"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/commands/deployments/describe.rs
+++ b/cli/src/commands/deployments/describe.rs
@@ -152,8 +152,8 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
 
             methods_table.add_row(vec![
                 Cell::new(&handler.name),
-                Cell::new(handler.input_description.as_deref().unwrap_or("any")),
-                Cell::new(handler.output_description.as_deref().unwrap_or("any")),
+                Cell::new(&handler.input_description),
+                Cell::new(&handler.output_description),
                 render_active_invocations(active_inv),
             ]);
         }

--- a/cli/src/ui/component_methods.rs
+++ b/cli/src/ui/component_methods.rs
@@ -25,8 +25,8 @@ pub fn create_component_handlers_table(
     for handler in handlers {
         table.add_row(vec![
             Cell::new(&handler.name),
-            Cell::new(handler.input_description.as_deref().unwrap_or("any")),
-            Cell::new(handler.output_description.as_deref().unwrap_or("any")),
+            Cell::new(&handler.input_description),
+            Cell::new(&handler.output_description),
         ]);
     }
     table
@@ -58,8 +58,8 @@ pub fn create_component_handlers_table_diff(
             row.push(Cell::new(&handler.name).fg(Color::Green));
         }
         row.extend_from_slice(&[
-            Cell::new(handler.input_description.as_deref().unwrap_or("any")),
-            Cell::new(handler.output_description.as_deref().unwrap_or("any")),
+            Cell::new(&handler.input_description),
+            Cell::new(&handler.output_description),
         ]);
         table.add_row(row);
     }
@@ -69,8 +69,8 @@ pub fn create_component_handlers_table_diff(
         let row = vec![
             Cell::new("--").fg(Color::Red),
             Cell::new(&handler.name).fg(Color::Red),
-            Cell::new(handler.input_description.as_deref().unwrap_or("any")),
-            Cell::new(handler.output_description.as_deref().unwrap_or("any")),
+            Cell::new(&handler.input_description),
+            Cell::new(&handler.output_description),
         ];
 
         table.add_row(row);

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -16,7 +16,7 @@ options_schema = ["dep:schemars"]
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-ingress-dispatcher = { workspace = true }
-restate-schema-api = { workspace = true, features = ["component"]}
+restate-schema-api = { workspace = true, features = ["component", "invocation_target"]}
 restate-types = { workspace = true }
 
 # To invoke the awakeables built-in service
@@ -42,6 +42,10 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["http1", "http2", "server", "tokio"] }
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.5.2", features = ["cors", "normalize-path"] }
+
+# We need this until we convert everything else to http 1.0/hyper 1.0
+# https://github.com/restatedev/restate/issues/96
+http-old = { package = "http", version = "0.2.12" }
 
 # Tracing
 opentelemetry = { workspace = true }

--- a/crates/ingress-http/src/handler/component_handler.rs
+++ b/crates/ingress-http/src/handler/component_handler.rs
@@ -19,7 +19,7 @@ use http::{header, HeaderMap, HeaderName, Method, Request, Response, StatusCode}
 use http_body_util::{BodyExt, Full};
 use metrics::{counter, histogram};
 use restate_ingress_dispatcher::{DispatchIngressRequest, IdempotencyMode, IngressRequest};
-use restate_schema_api::component::ComponentMetadataResolver;
+use restate_schema_api::invocation_target::{InvocationTargetMetadata, InvocationTargetResolver};
 use restate_types::identifiers::{FullInvocationId, InvocationId, ServiceId};
 use restate_types::invocation::{Header, SpanRelation};
 use serde::Serialize;
@@ -41,7 +41,7 @@ pub(crate) struct SendResponse {
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
 where
-    Schemas: ComponentMetadataResolver + Clone + Send + Sync + 'static,
+    Schemas: InvocationTargetResolver + Clone + Send + Sync + 'static,
     Dispatcher: DispatchIngressRequest + Clone + Send + Sync + 'static,
 {
     pub(crate) async fn handle_component_request<B: http_body::Body>(
@@ -61,16 +61,17 @@ where
             invoke_ty,
         } = component_request;
 
-        if let Some(basic_component_metadata) = self
+        let invocation_target_meta = if let Some(invocation_target) = self
             .schemas
-            .resolve_latest_component_handler(&component_name, &handler_name)
+            .resolve_latest_invocation_target(&component_name, &handler_name)
         {
-            if !basic_component_metadata.public {
+            if !invocation_target.public {
                 return Err(HandlerError::PrivateComponent);
             }
+            invocation_target
         } else {
             return Err(HandlerError::NotFound);
-        }
+        };
 
         // Craft FullInvocationId
         let fid = if let TargetType::VirtualObject { key } = target {
@@ -83,7 +84,7 @@ where
         let (ingress_span, ingress_span_context) = prepare_tracing_span(&fid, &handler_name, &req);
 
         let cloned_handler_name = handler_name.clone();
-        let handle_fut = async move {
+        let result = async move {
             info!("Processing ingress request");
 
             let (parts, body) = req.into_parts();
@@ -93,34 +94,44 @@ where
                 return Err(HandlerError::MethodNotAllowed);
             }
 
-            // TODO validate content-type
-            //  https://github.com/restatedev/restate/issues/1230
-
             // Check if Idempotency-Key is available
             let idempotency_mode = parse_idempotency_key_and_retention_period(&parts.headers)?;
 
-            // Get headers
-            let headers = parse_headers(parts.headers)?;
-
             // Collect body
-            let collected_request_bytes = body
+            let body = body
                 .collect()
                 .await
                 .map_err(|e| HandlerError::Body(e.into()))?
                 .to_bytes();
-            trace!(rpc.request = ?collected_request_bytes);
+            trace!(rpc.request = ?body);
+
+            // Validate content-type and body
+            invocation_target_meta.input_rules.validate(
+                parts
+                    .headers
+                    .get(header::CONTENT_TYPE)
+                    .map(|h| {
+                        h.to_str()
+                            .map_err(|e| HandlerError::BadHeader(header::CONTENT_TYPE, e))
+                    })
+                    .transpose()?,
+                &body,
+            )?;
+
+            // Get headers
+            let headers = parse_headers(parts.headers)?;
 
             let span_relation = SpanRelation::Parent(ingress_span_context);
-
             match invoke_ty {
                 InvokeType::Call => {
                     Self::handle_component_call(
                         fid,
                         cloned_handler_name,
                         idempotency_mode,
-                        collected_request_bytes,
+                        body,
                         span_relation,
                         headers,
+                        invocation_target_meta,
                         self.dispatcher,
                     )
                     .await
@@ -130,7 +141,7 @@ where
                         fid,
                         cloned_handler_name,
                         idempotency_mode,
-                        collected_request_bytes,
+                        body,
                         span_relation,
                         headers,
                         self.dispatcher,
@@ -139,45 +150,44 @@ where
                 }
             }
         }
-        .instrument(ingress_span);
+        .instrument(ingress_span)
+        .await;
 
-        async move {
-            let result = handle_fut.await;
-            // Note that we only record (mostly) successful requests here. We might want to
-            // change this in the _near_ future.
-            histogram!(
-                INGRESS_REQUEST_DURATION,
-                "rpc.service" => component_name.clone(),
-                "rpc.method" => handler_name.clone(),
-            )
-            .record(start_time.elapsed());
+        // Note that we only record (mostly) successful requests here. We might want to
+        // change this in the _near_ future.
+        histogram!(
+            INGRESS_REQUEST_DURATION,
+            "rpc.service" => component_name.clone(),
+            "rpc.method" => handler_name.clone(),
+        )
+        .record(start_time.elapsed());
 
-            counter!(
-                INGRESS_REQUESTS,
-                "status" => REQUEST_COMPLETED,
-                "rpc.service" => component_name,
-                "rpc.method" => handler_name,
-            )
-            .increment(1);
-            result
-        }
-        .await
+        counter!(
+            INGRESS_REQUESTS,
+            "status" => REQUEST_COMPLETED,
+            "rpc.service" => component_name,
+            "rpc.method" => handler_name,
+        )
+        .increment(1);
+        result
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_component_call(
         fid: FullInvocationId,
-        cloned_handler_name: String,
+        handler: String,
         idempotency_mode: IdempotencyMode,
-        collected_request_bytes: Bytes,
+        body: Bytes,
         span_relation: SpanRelation,
         headers: Vec<Header>,
+        invocation_target_metadata: InvocationTargetMetadata,
         dispatcher: Dispatcher,
     ) -> Result<Response<Full<Bytes>>, HandlerError> {
         let invocation_id: InvocationId = fid.clone().into();
         let (invocation, response_rx) = IngressRequest::invocation(
             fid,
-            cloned_handler_name,
-            collected_request_bytes,
+            handler,
+            body,
             span_relation,
             idempotency_mode,
             headers,
@@ -211,9 +221,19 @@ where
         match response.into() {
             Ok(response_payload) => {
                 trace!(rpc.response = ?response_payload, "Complete external HTTP request successfully");
-                // TODO this is a temporary solution until we have some format awareness.
-                //  https://github.com/restatedev/restate/issues/1230
-                response_builder = response_builder.header(header::CONTENT_TYPE, APPLICATION_JSON);
+
+                // Write out the content-type, if any
+                if let Some(ct) = invocation_target_metadata
+                    .output_rules
+                    .infer_content_type(response_payload.is_empty())
+                {
+                    response_builder = response_builder.header(
+                        header::CONTENT_TYPE,
+                        // TODO we need this to_str().unwrap() because these two HeaderValue come from two different http crates
+                        //  We can remove it once https://github.com/restatedev/restate/issues/96 is done
+                        ct.to_str().unwrap(),
+                    )
+                }
 
                 Ok(response_builder.body(Full::new(response_payload)).unwrap())
             }
@@ -226,9 +246,9 @@ where
 
     async fn handle_component_send(
         fid: FullInvocationId,
-        handler_name: String,
+        handler: String,
         idempotency_mode: IdempotencyMode,
-        collected_request_bytes: Bytes,
+        body: Bytes,
         span_relation: SpanRelation,
         headers: Vec<Header>,
         dispatcher: Dispatcher,
@@ -241,14 +261,8 @@ where
         let invocation_id = InvocationId::from(&fid);
 
         // Send the service invocation
-        let invocation = IngressRequest::background_invocation(
-            fid,
-            handler_name,
-            collected_request_bytes,
-            span_relation,
-            None,
-            headers,
-        );
+        let invocation =
+            IngressRequest::background_invocation(fid, handler, body, span_relation, None, headers);
         if let Err(e) = dispatcher.dispatch_ingress_request(invocation).await {
             warn!(
                 restate.invocation.id = %invocation_id,

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -12,6 +12,7 @@ use super::APPLICATION_JSON;
 
 use bytes::Bytes;
 use http::{header, Response, StatusCode};
+use restate_schema_api::invocation_target::InputValidationError;
 use restate_types::errors::InvocationError;
 use serde::Serialize;
 use std::string;
@@ -48,6 +49,8 @@ pub(crate) enum HandlerError {
     SendAndIdempotencyKey,
     #[error("invocation error: {0:?}")]
     Invocation(InvocationError),
+    #[error("input validation error: {0}")]
+    InputValidation(#[from] InputValidationError),
 }
 
 #[derive(Debug, Serialize)]
@@ -85,6 +88,7 @@ impl HandlerError {
                 StatusCode::from_u16(e.code().into()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
             HandlerError::BadHeader(_, _) => StatusCode::BAD_REQUEST,
+            HandlerError::InputValidation(_) => StatusCode::BAD_REQUEST,
         };
 
         let error_response = match self {

--- a/crates/ingress-http/src/handler/mod.rs
+++ b/crates/ingress-http/src/handler/mod.rs
@@ -19,6 +19,7 @@ use hyper::{Request, Response};
 use path_parsing::RequestType;
 use restate_ingress_dispatcher::DispatchIngressRequest;
 use restate_schema_api::component::ComponentMetadataResolver;
+use restate_schema_api::invocation_target::InvocationTargetResolver;
 use std::convert::Infallible;
 use std::task::{Context, Poll};
 
@@ -50,7 +51,7 @@ impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher> {
 
 impl<Schemas, Dispatcher, Body> tower::Service<Request<Body>> for Handler<Schemas, Dispatcher>
 where
-    Schemas: ComponentMetadataResolver + Clone + Send + Sync + 'static,
+    Schemas: ComponentMetadataResolver + InvocationTargetResolver + Clone + Send + Sync + 'static,
     Dispatcher: DispatchIngressRequest + Clone + Send + Sync + 'static,
     Body: http_body::Body + Send + 'static,
     <Body as http_body::Body>::Data: Send + 'static,

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -42,7 +42,14 @@ impl ConnectInfo {
 #[cfg(test)]
 mod mocks {
     use restate_schema_api::component::mocks::MockComponentMetadataResolver;
-    use restate_schema_api::component::ComponentMetadata;
+    use restate_schema_api::component::{
+        ComponentMetadata, ComponentMetadataResolver, ComponentType, HandlerMetadata, HandlerType,
+    };
+    use restate_schema_api::invocation_target::mocks::MockInvocationTargetResolver;
+    use restate_schema_api::invocation_target::{
+        InvocationTargetMetadata, InvocationTargetResolver,
+    };
+    use restate_types::identifiers::DeploymentId;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -55,24 +62,92 @@ mod mocks {
         pub greeting: String,
     }
 
-    pub(super) fn mock_component_resolver() -> MockComponentMetadataResolver {
-        let mut components = MockComponentMetadataResolver::default();
+    #[derive(Debug, Clone, Default)]
+    pub(crate) struct MockSchemas(
+        pub(crate) MockComponentMetadataResolver,
+        pub(crate) MockInvocationTargetResolver,
+    );
 
-        components.add(ComponentMetadata::mock_service(
+    impl MockSchemas {
+        pub fn add_component_and_target(
+            &mut self,
+            component_name: &str,
+            handler_name: &str,
+            invocation_target_metadata: InvocationTargetMetadata,
+        ) {
+            self.0.add(ComponentMetadata {
+                name: component_name.to_string(),
+                handlers: vec![HandlerMetadata {
+                    name: handler_name.to_string(),
+                    ty: invocation_target_metadata.handler_ty,
+                    input_description: "any".to_string(),
+                    output_description: "any".to_string(),
+                }],
+                ty: invocation_target_metadata.component_ty,
+                deployment_id: DeploymentId::default(),
+                revision: 0,
+                public: invocation_target_metadata.public,
+            });
+            self.1
+                .add(component_name, [(handler_name, invocation_target_metadata)]);
+        }
+
+        pub fn with_component_and_target(
+            mut self,
+            component_name: &str,
+            handler_name: &str,
+            invocation_target_metadata: InvocationTargetMetadata,
+        ) -> Self {
+            self.add_component_and_target(component_name, handler_name, invocation_target_metadata);
+            self
+        }
+    }
+
+    impl ComponentMetadataResolver for MockSchemas {
+        fn resolve_latest_component(
+            &self,
+            component_name: impl AsRef<str>,
+        ) -> Option<ComponentMetadata> {
+            self.0.resolve_latest_component(component_name)
+        }
+
+        fn resolve_latest_component_type(
+            &self,
+            component_name: impl AsRef<str>,
+        ) -> Option<ComponentType> {
+            self.0.resolve_latest_component_type(component_name)
+        }
+
+        fn list_components(&self) -> Vec<ComponentMetadata> {
+            self.0.list_components()
+        }
+    }
+
+    impl InvocationTargetResolver for MockSchemas {
+        fn resolve_latest_invocation_target(
+            &self,
+            component_name: impl AsRef<str>,
+            handler_name: impl AsRef<str>,
+        ) -> Option<InvocationTargetMetadata> {
+            self.1
+                .resolve_latest_invocation_target(component_name, handler_name)
+        }
+    }
+
+    pub(super) fn mock_schemas() -> MockSchemas {
+        let mut mock_schemas = MockSchemas::default();
+
+        mock_schemas.add_component_and_target(
             "greeter.Greeter",
-            ["greet"],
-        ));
-        components.add(ComponentMetadata::mock_virtual_object(
+            "greet",
+            InvocationTargetMetadata::mock(ComponentType::Service, HandlerType::Shared),
+        );
+        mock_schemas.add_component_and_target(
             "greeter.GreeterObject",
-            ["greet"],
-        ));
-        components.add({
-            let mut private_component_metadata =
-                ComponentMetadata::mock_service("greeter.GreeterPrivate", ["greet"]);
-            private_component_metadata.public = false;
-            private_component_metadata
-        });
+            "greet",
+            InvocationTargetMetadata::mock(ComponentType::VirtualObject, HandlerType::Exclusive),
+        );
 
-        components
+        mock_schemas
     }
 }

--- a/crates/ingress-http/src/options.rs
+++ b/crates/ingress-http/src/options.rs
@@ -12,6 +12,7 @@ use super::HyperServerIngress;
 
 use restate_ingress_dispatcher::IngressDispatcher;
 use restate_schema_api::component::ComponentMetadataResolver;
+use restate_schema_api::invocation_target::InvocationTargetResolver;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
@@ -49,7 +50,8 @@ impl Options {
         schemas: Schemas,
     ) -> HyperServerIngress<Schemas, IngressDispatcher>
     where
-        Schemas: ComponentMetadataResolver + Clone + Send + Sync + 'static,
+        Schemas:
+            ComponentMetadataResolver + InvocationTargetResolver + Clone + Send + Sync + 'static,
     {
         let Options {
             bind_address,

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -21,6 +21,7 @@ use hyper_util::server::conn::auto;
 use restate_core::{cancellation_watcher, task_center, TaskKind};
 use restate_ingress_dispatcher::DispatchIngressRequest;
 use restate_schema_api::component::ComponentMetadataResolver;
+use restate_schema_api::invocation_target::InvocationTargetResolver;
 use std::convert::Infallible;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -63,7 +64,7 @@ pub struct HyperServerIngress<Schemas, Dispatcher> {
 
 impl<Schemas, Dispatcher> HyperServerIngress<Schemas, Dispatcher>
 where
-    Schemas: ComponentMetadataResolver + Clone + Send + Sync + 'static,
+    Schemas: ComponentMetadataResolver + InvocationTargetResolver + Clone + Send + Sync + 'static,
     Dispatcher: DispatchIngressRequest + Clone + Send + Sync + 'static,
 {
     pub(crate) fn new(
@@ -301,7 +302,7 @@ mod tests {
         let (ingress, start_signal) = HyperServerIngress::new(
             "0.0.0.0:0".parse().unwrap(),
             Semaphore::MAX_PERMITS,
-            mock_component_resolver(),
+            mock_schemas(),
             MockDispatcher::new(ingress_request_tx),
         );
         node_env

--- a/crates/meta/src/storage.rs
+++ b/crates/meta/src/storage.rs
@@ -301,8 +301,9 @@ mod tests {
             fully_qualified_component_name: "greeter".parse().unwrap(),
             handlers: vec![schema::Handler {
                 name: "greet".parse().unwrap(),
-                input_schema: None,
-                output_schema: None,
+                handler_type: None,
+                input: None,
+                output: None,
             }],
         }
     }
@@ -313,8 +314,9 @@ mod tests {
             fully_qualified_component_name: "another-greeter".parse().unwrap(),
             handlers: vec![schema::Handler {
                 name: "another_greeter".parse().unwrap(),
-                input_schema: None,
-                output_schema: None,
+                handler_type: None,
+                input: None,
+                output: None,
             }],
         }
     }

--- a/crates/schema-api/Cargo.toml
+++ b/crates/schema-api/Cargo.toml
@@ -15,6 +15,7 @@ mocks = []
 serde = ["dep:serde", "dep:serde_with", "restate-types?/serde", "dep:restate-serde-util"]
 serde_schema = ["serde", "dep:schemars", "restate-types?/serde_schema", "restate-serde-util?/schema"]
 component = ["dep:bytes", "dep:restate-types"]
+invocation_target = ["component", "dep:bytes", "dep:restate-types", "dep:thiserror", "dep:http", "dep:restate-serde-util", "dep:bytestring", "dep:itertools"]
 subscription = ["dep:anyhow", "dep:restate-types"]
 
 [dependencies]
@@ -27,6 +28,8 @@ base64 = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 bytestring = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
+itertools = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }

--- a/crates/schema-api/src/invocation_target.rs
+++ b/crates/schema-api/src/invocation_target.rs
@@ -1,0 +1,596 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::component::{ComponentType, HandlerType};
+use bytes::Bytes;
+use bytestring::ByteString;
+use itertools::Itertools;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct InvocationTargetMetadata {
+    pub public: bool,
+    pub component_ty: ComponentType,
+    pub handler_ty: HandlerType,
+    pub input_rules: InputRules,
+    pub output_rules: OutputRules,
+}
+
+/// This API resolves invocation targets.
+pub trait InvocationTargetResolver {
+    /// Returns None if the component handler doesn't exist, Some(basic_component_metadata) otherwise.
+    fn resolve_latest_invocation_target(
+        &self,
+        component_name: impl AsRef<str>,
+        handler_name: impl AsRef<str>,
+    ) -> Option<InvocationTargetMetadata>;
+}
+
+// --- Input rules
+
+#[derive(Debug, thiserror::Error)]
+pub enum InputValidationError {
+    #[error("Expected body and content-type to be empty, but wasn't with content-type '{0:?}'")]
+    NonEmptyInput(Option<String>),
+    #[error("Empty content-type")]
+    EmptyContentType,
+    #[error("Empty body not allowed")]
+    EmptyValue,
+    #[error("Bad configuration of the input validation rules")]
+    BadConfiguration,
+    #[error("Content-type '{0}' does not match '{1}'")]
+    ContentTypeNotMatching(String, InputContentType),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct InputRules {
+    /// Input validation will try each of these rules. Validation passes if at least one rule matches.
+    pub input_validation_rules: Vec<InputValidationRule>,
+}
+
+impl InputRules {
+    pub fn validate(
+        &self,
+        content_type: Option<&str>,
+        buf: &Bytes,
+    ) -> Result<(), InputValidationError> {
+        let mut res = Err(InputValidationError::BadConfiguration);
+
+        for rule in &self.input_validation_rules {
+            res = rule.validate(content_type, buf);
+            if res.is_ok() {
+                return Ok(());
+            }
+        }
+
+        res
+    }
+}
+
+impl Default for InputRules {
+    fn default() -> Self {
+        Self {
+            input_validation_rules: vec![
+                InputValidationRule::NoBodyAndContentType,
+                InputValidationRule::ContentType {
+                    content_type: InputContentType::Any,
+                },
+            ],
+        }
+    }
+}
+
+impl fmt::Display for InputRules {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.input_validation_rules.len() {
+            0 => write!(f, "<invalid rules>"),
+            1 => write!(f, "{}", self.input_validation_rules[0]),
+            _ => write!(
+                f,
+                "one of {:?}",
+                self.input_validation_rules.iter().join(" or ")
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum InputValidationRule {
+    // Input and content-type must be empty
+    NoBodyAndContentType,
+
+    // Validates only the content-type, not the content
+    ContentType {
+        // Can use wildcards
+        content_type: InputContentType,
+    },
+
+    // Validates the input as json value
+    JsonValue {
+        // Can use wildcards
+        content_type: InputContentType,
+        // TODO add json schema.
+    },
+}
+
+impl fmt::Display for InputValidationRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InputValidationRule::NoBodyAndContentType => write!(f, "empty"),
+            InputValidationRule::ContentType { content_type } => {
+                write!(f, "value of content-type {}", content_type)
+            }
+            InputValidationRule::JsonValue { content_type } => {
+                write!(f, "JSON value with content-type {}", content_type)
+            }
+        }
+    }
+}
+
+impl InputValidationRule {
+    fn validate(
+        &self,
+        input_content_type: Option<&str>,
+        buf: &Bytes,
+    ) -> Result<(), InputValidationError> {
+        match self {
+            InputValidationRule::NoBodyAndContentType => {
+                if !(buf.is_empty() && input_content_type.is_none()) {
+                    return Err(InputValidationError::NonEmptyInput(
+                        input_content_type.map(str::to_owned),
+                    ));
+                }
+            }
+            InputValidationRule::ContentType { content_type } => {
+                if input_content_type.is_none() {
+                    return Err(InputValidationError::EmptyContentType);
+                }
+                content_type.validate(input_content_type.unwrap())?;
+            }
+            InputValidationRule::JsonValue { content_type } => {
+                if input_content_type.is_none() {
+                    return Err(InputValidationError::EmptyContentType);
+                }
+                content_type.validate(input_content_type.unwrap())?;
+
+                if buf.is_empty() {
+                    // In JSON empty values are not allowed
+                    return Err(InputValidationError::EmptyValue);
+                }
+
+                // TODO add additional json validation.
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Describes a content type in the same format of the [`Accept` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum InputContentType {
+    /// `*/*`
+    #[default]
+    Any,
+    /// `<MIME_type>/*`
+    MimeType(ByteString),
+    /// `<MIME_type>/<MIME_subtype>`
+    MimeTypeAndSubtype(ByteString, ByteString),
+}
+
+impl InputContentType {
+    fn validate(&self, input_content_type: &str) -> Result<(), InputValidationError> {
+        match self {
+            InputContentType::Any => Ok(()),
+            InputContentType::MimeType(ty) => {
+                let (first_part, _) = self.extract_content_type_parts(input_content_type)?;
+                if ty != first_part {
+                    return Err(InputValidationError::ContentTypeNotMatching(
+                        input_content_type.to_owned(),
+                        self.clone(),
+                    ));
+                }
+                Ok(())
+            }
+            InputContentType::MimeTypeAndSubtype(ty, sub_ty) => {
+                let (first_part, second_part) =
+                    self.extract_content_type_parts(input_content_type)?;
+                if ty != first_part {
+                    return Err(InputValidationError::ContentTypeNotMatching(
+                        input_content_type.to_owned(),
+                        self.clone(),
+                    ));
+                }
+                if sub_ty != second_part {
+                    return Err(InputValidationError::ContentTypeNotMatching(
+                        input_content_type.to_owned(),
+                        self.clone(),
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn extract_content_type_parts<'a>(
+        &'a self,
+        input_content_type: &'a str,
+    ) -> Result<(&str, &str), InputValidationError> {
+        return match input_content_type.trim().split_once('/') {
+            Some((first_part, second_part)) => Ok((first_part, second_part)),
+            None => Err(InputValidationError::ContentTypeNotMatching(
+                input_content_type.to_owned(),
+                self.clone(),
+            )),
+        };
+    }
+}
+
+impl fmt::Display for InputContentType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InputContentType::Any => write!(f, "*/*"),
+            InputContentType::MimeType(t) => write!(f, "{}/*", t),
+            InputContentType::MimeTypeAndSubtype(t, st) => write!(f, "{}/{}", t, st),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("can't parse the content-type '{str}': {reason}")]
+pub struct BadInputContentType {
+    str: String,
+    reason: &'static str,
+}
+
+impl FromStr for InputContentType {
+    type Err = BadInputContentType;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().split_once('/') {
+            None => Err(BadInputContentType {
+                str: s.to_owned(),
+                reason: "must contain one /",
+            }),
+            Some(("*", "*")) => Ok(InputContentType::Any),
+            Some(("*", _)) => Err(BadInputContentType {
+                str: s.to_owned(),
+                reason: "the wildcard format */subType is not supported",
+            }),
+            Some((t, "*")) => Ok(InputContentType::MimeType(t.into())),
+            Some((t, st)) => Ok(InputContentType::MimeTypeAndSubtype(t.into(), st.into())),
+        }
+    }
+}
+
+// --- Output rules
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OutputRules {
+    pub content_type_rule: OutputContentTypeRule,
+}
+
+impl OutputRules {
+    pub fn infer_content_type(&self, is_output_empty: bool) -> Option<http::HeaderValue> {
+        match &self.content_type_rule {
+            OutputContentTypeRule::None => None,
+            OutputContentTypeRule::Set {
+                content_type,
+                set_content_type_if_empty,
+                ..
+            } => {
+                if is_output_empty && !set_content_type_if_empty {
+                    None
+                } else {
+                    Some(content_type.clone())
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for OutputRules {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.content_type_rule)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum OutputContentTypeRule {
+    None,
+    Set {
+        #[cfg_attr(
+            feature = "serde",
+            serde(with = "serde_with::As::<restate_serde_util::HeaderValueSerde>")
+        )]
+        content_type: http::HeaderValue,
+        // If true, sets the content-type even if the output is empty.
+        // Otherwise, don't set the content-type.
+        set_content_type_if_empty: bool,
+        // If true, this should be a JSON Value.
+        has_json_schema: bool,
+    },
+}
+
+impl Default for OutputContentTypeRule {
+    fn default() -> Self {
+        Self::Set {
+            content_type: http::HeaderValue::from_static("application/json"),
+            set_content_type_if_empty: false,
+            has_json_schema: false,
+        }
+    }
+}
+
+impl fmt::Display for OutputContentTypeRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputContentTypeRule::None => write!(f, "Empty"),
+            OutputContentTypeRule::Set {
+                content_type,
+                has_json_schema,
+                set_content_type_if_empty,
+            } => {
+                if *set_content_type_if_empty {
+                    write!(f, "optional ")?;
+                }
+                if *has_json_schema {
+                    write!(f, "JSON ")?;
+                }
+                write!(f, "value with content-type {:?}", content_type)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "mocks")]
+#[allow(dead_code)]
+pub mod mocks {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    #[derive(Debug, Clone)]
+    pub struct MockComponent(HashMap<String, InvocationTargetMetadata>);
+
+    #[derive(Debug, Default, Clone)]
+    pub struct MockInvocationTargetResolver(HashMap<String, MockComponent>);
+
+    impl MockInvocationTargetResolver {
+        pub fn add(
+            &mut self,
+            component_name: &str,
+            handlers: impl IntoIterator<Item = (impl ToString, InvocationTargetMetadata)>,
+        ) {
+            self.0.insert(
+                component_name.to_owned(),
+                MockComponent(
+                    handlers
+                        .into_iter()
+                        .map(|(s, i)| (s.to_string(), i))
+                        .collect(),
+                ),
+            );
+        }
+    }
+
+    impl InvocationTargetResolver for MockInvocationTargetResolver {
+        fn resolve_latest_invocation_target(
+            &self,
+            component_name: impl AsRef<str>,
+            handler_name: impl AsRef<str>,
+        ) -> Option<InvocationTargetMetadata> {
+            self.0
+                .get(component_name.as_ref())
+                .and_then(|c| c.0.get(handler_name.as_ref()).cloned())
+        }
+    }
+
+    impl InvocationTargetMetadata {
+        pub fn mock(component_ty: ComponentType, handler_ty: HandlerType) -> Self {
+            Self {
+                public: true,
+                component_ty,
+                handler_ty,
+                input_rules: Default::default(),
+                output_rules: Default::default(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_input_valid {
+        ($rule:expr, $ct:expr, $body:expr) => {
+            let res = $rule.validate($ct, &$body);
+            assert!(
+                res.is_ok(),
+                "Rule {:?} with content-type {:?} and body {:?} should be valid, error: {:?}",
+                $rule,
+                $ct as Option<&'static str>,
+                $body,
+                res.unwrap_err()
+            )
+        };
+    }
+
+    macro_rules! assert_input_not_valid {
+        ($rule:expr, $ct:expr, $body:expr) => {
+            let res = $rule.validate($ct, &$body);
+            assert!(
+                res.is_err(),
+                "Rule {:?} with content-type {:?} and body {:?} should be invalid",
+                $rule,
+                $ct as Option<&'static str>,
+                $body
+            )
+        };
+    }
+
+    #[test]
+    fn validate_default() {
+        let input_rules = InputRules::default();
+
+        assert_input_valid!(input_rules, Some("application/json"), Bytes::new());
+        assert_input_valid!(input_rules, Some("text/plain"), Bytes::new());
+        assert_input_valid!(
+            input_rules,
+            Some("application/json"),
+            Bytes::from_static(b"{}")
+        );
+        assert_input_not_valid!(input_rules, None, Bytes::from_static(b"123"));
+    }
+
+    #[test]
+    fn validate_empty_only() {
+        let input_rules = InputRules {
+            input_validation_rules: vec![InputValidationRule::NoBodyAndContentType],
+        };
+
+        assert_input_valid!(input_rules, None, Bytes::new());
+        assert_input_not_valid!(input_rules, Some("application/json"), Bytes::new());
+        assert_input_not_valid!(input_rules, None, Bytes::from_static(b"{}"));
+    }
+
+    #[test]
+    fn validate_any_content_type() {
+        let input_rules = InputRules {
+            input_validation_rules: vec![InputValidationRule::ContentType {
+                content_type: InputContentType::Any,
+            }],
+        };
+
+        assert_input_valid!(
+            input_rules,
+            Some("application/restate+json"),
+            Bytes::from_static(b"{}")
+        );
+        assert_input_valid!(input_rules, Some("application/restate+json"), Bytes::new());
+        assert_input_not_valid!(input_rules, None, Bytes::from_static(b"{}"));
+        assert_input_not_valid!(input_rules, None, Bytes::new());
+    }
+
+    #[test]
+    fn validate_mime_content_type() {
+        let input_rules = InputRules {
+            input_validation_rules: vec![InputValidationRule::ContentType {
+                content_type: InputContentType::MimeType("application".into()),
+            }],
+        };
+
+        assert_input_valid!(input_rules, Some("application/restate+json"), Bytes::new());
+        assert_input_not_valid!(input_rules, Some("text/json"), Bytes::new());
+    }
+
+    #[test]
+    fn validate_mime_and_subtype_content_type() {
+        let input_rules = InputRules {
+            input_validation_rules: vec![InputValidationRule::ContentType {
+                content_type: InputContentType::MimeTypeAndSubtype(
+                    "application".into(),
+                    "json".into(),
+                ),
+            }],
+        };
+
+        assert_input_valid!(input_rules, Some("application/json"), Bytes::new());
+        assert_input_not_valid!(input_rules, Some("application/cbor"), Bytes::new());
+    }
+
+    #[test]
+    fn validate_either_empty_or_non_empty_json() {
+        let input_rules = InputRules {
+            input_validation_rules: vec![
+                InputValidationRule::NoBodyAndContentType,
+                InputValidationRule::JsonValue {
+                    content_type: InputContentType::Any,
+                },
+            ],
+        };
+
+        assert_input_valid!(input_rules, None, Bytes::new());
+        assert_input_valid!(
+            input_rules,
+            Some("application/restate+json"),
+            Bytes::from_static(b"{}")
+        );
+        assert_input_not_valid!(input_rules, Some("application/json"), Bytes::new());
+    }
+
+    #[test]
+    fn validate_json_only() {
+        let input_rules = InputRules {
+            input_validation_rules: vec![InputValidationRule::JsonValue {
+                content_type: InputContentType::MimeTypeAndSubtype(
+                    "application".into(),
+                    "restate+json".into(),
+                ),
+            }],
+        };
+
+        assert_input_valid!(
+            input_rules,
+            Some("application/restate+json"),
+            Bytes::from_static(b"{}")
+        );
+        assert_input_not_valid!(
+            input_rules,
+            Some("application/json"),
+            Bytes::from_static(b"{}")
+        );
+        assert_input_not_valid!(input_rules, None, Bytes::from_static(b"{}"));
+        assert_input_not_valid!(input_rules, Some("application/restate+json"), Bytes::new());
+    }
+
+    #[test]
+    fn infer_content_type_default() {
+        let input_rules = OutputRules::default();
+
+        assert_eq!(
+            input_rules.infer_content_type(false),
+            Some(http::HeaderValue::from_static("application/json"))
+        );
+        assert_eq!(input_rules.infer_content_type(true), None);
+    }
+
+    #[test]
+    fn infer_content_type_set_content_type_if_empty() {
+        let ct = http::HeaderValue::from_static("application/restate");
+        let input_rules = OutputRules {
+            content_type_rule: OutputContentTypeRule::Set {
+                content_type: ct.clone(),
+                set_content_type_if_empty: true,
+                has_json_schema: false,
+            },
+        };
+
+        assert_eq!(input_rules.infer_content_type(false), Some(ct.clone()));
+        assert_eq!(input_rules.infer_content_type(true), Some(ct));
+    }
+
+    #[test]
+    fn infer_content_type_empty() {
+        let input_rules = OutputRules {
+            content_type_rule: OutputContentTypeRule::None,
+        };
+
+        assert_eq!(input_rules.infer_content_type(false), None);
+        assert_eq!(input_rules.infer_content_type(true), None);
+    }
+}

--- a/crates/schema-impl/Cargo.toml
+++ b/crates/schema-impl/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 restate-errors = { workspace = true }
 restate-pb = { workspace = true }
-restate-schema-api = { workspace = true, features = ["component", "deployment", "subscription", "serde"] }
+restate-schema-api = { workspace = true, features = ["component", "deployment", "subscription", "invocation_target", "serde"] }
 restate-serde-util = { workspace = true }
 restate-types = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["discovery"] }

--- a/crates/schema-impl/src/component.rs
+++ b/crates/schema-impl/src/component.rs
@@ -10,26 +10,16 @@
 
 use super::*;
 
-use restate_schema_api::component::{BasicComponentMetadata, ComponentMetadataResolver};
+use restate_schema_api::component::ComponentMetadataResolver;
 
 impl ComponentMetadataResolver for Schemas {
-    fn resolve_latest_component_handler(
+    fn resolve_latest_component(
         &self,
         component_name: impl AsRef<str>,
-        handler_name: impl AsRef<str>,
-    ) -> Option<BasicComponentMetadata> {
-        self.use_component_schema(component_name.as_ref(), |component_schemas| {
-            if component_schemas
-                .handlers
-                .contains_key(handler_name.as_ref())
-            {
-                Some(BasicComponentMetadata {
-                    public: component_schemas.location.is_ingress_available(),
-                    ty: component_schemas.ty,
-                })
-            } else {
-                None
-            }
+    ) -> Option<ComponentMetadata> {
+        let name = component_name.as_ref();
+        self.use_component_schema(name, |component_schemas| {
+            component_schemas.as_component_metadata(name.to_owned())
         })
         .flatten()
     }
@@ -41,17 +31,6 @@ impl ComponentMetadataResolver for Schemas {
         self.use_component_schema(component_name.as_ref(), |component_schemas| {
             component_schemas.ty
         })
-    }
-
-    fn resolve_latest_component(
-        &self,
-        component_name: impl AsRef<str>,
-    ) -> Option<ComponentMetadata> {
-        let name = component_name.as_ref();
-        self.use_component_schema(name, |component_schemas| {
-            component_schemas.as_component_metadata(name.to_owned())
-        })
-        .flatten()
     }
 
     fn list_components(&self) -> Vec<ComponentMetadata> {

--- a/crates/schema-impl/src/invocation_target.rs
+++ b/crates/schema-impl/src/invocation_target.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+
+use restate_schema_api::invocation_target::{InvocationTargetMetadata, InvocationTargetResolver};
+
+impl InvocationTargetResolver for Schemas {
+    fn resolve_latest_invocation_target(
+        &self,
+        component_name: impl AsRef<str>,
+        handler_name: impl AsRef<str>,
+    ) -> Option<InvocationTargetMetadata> {
+        self.use_component_schema(component_name.as_ref(), |component_schemas| {
+            component_schemas
+                .handlers
+                .get(handler_name.as_ref())
+                .map(|handler_schemas| handler_schemas.target_meta.clone())
+        })
+        .flatten()
+    }
+}

--- a/crates/schema-impl/src/schemas_impl/component.rs
+++ b/crates/schema-impl/src/schemas_impl/component.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+use http::header::InvalidHeaderValue;
+use http::HeaderValue;
+use restate_schema_api::invocation_target::{
+    BadInputContentType, InputValidationRule, OutputContentTypeRule,
+};
+
 #[derive(Debug, thiserror::Error, codederror::CodedError)]
 pub enum ComponentError {
     #[error("cannot insert/modify component '{0}' as it contains a reserved name")]
@@ -11,6 +17,92 @@ pub enum ComponentError {
     #[error("the component '{0}' already exists but the new revision removed the handlers {1:?}")]
     #[code(restate_errors::META0006)]
     RemovedHandlers(String, Vec<String>),
+    #[error("the handler '{0}' input content-type is not valid: {1}")]
+    #[code(unknown)]
+    BadInputContentType(String, BadInputContentType),
+    #[error("the handler '{0}' output content-type is not valid: {1}")]
+    #[code(unknown)]
+    BadOutputContentType(String, InvalidHeaderValue),
+}
+
+impl DiscoveredHandlerMetadata {
+    pub(crate) fn from_schema(
+        component_type: ComponentType,
+        handler: schema::Handler,
+    ) -> Result<Self, ComponentError> {
+        let handler_type = match handler.handler_type {
+            None => HandlerType::default_for_component_type(component_type),
+            Some(schema::HandlerType::Exclusive) => HandlerType::Exclusive,
+            Some(schema::HandlerType::Shared) => HandlerType::Shared,
+        };
+
+        Ok(Self {
+            name: handler.name.to_string(),
+            ty: handler_type,
+            input: handler
+                .input
+                .map(|s| DiscoveredHandlerMetadata::input_rules_from_schema(&handler.name, s))
+                .transpose()?
+                .unwrap_or_default(),
+            output: handler
+                .output
+                .map(DiscoveredHandlerMetadata::output_rules_from_schema)
+                .transpose()?
+                .unwrap_or_default(),
+        })
+    }
+
+    fn input_rules_from_schema(
+        handler_name: &str,
+        schema: schema::InputPayload,
+    ) -> Result<InputRules, ComponentError> {
+        let required = schema.required.unwrap_or(false);
+
+        let mut input_validation_rules = vec![];
+
+        // Add rule for empty if input not required
+        if !required {
+            input_validation_rules.push(InputValidationRule::NoBodyAndContentType);
+        }
+
+        // Add content-type validation rule
+        let content_type = schema
+            .content_type
+            .map(|s| {
+                s.parse()
+                    .map_err(|e| ComponentError::BadInputContentType(handler_name.to_owned(), e))
+            })
+            .transpose()?
+            .unwrap_or_default();
+        if schema.json_schema.is_some() {
+            input_validation_rules.push(InputValidationRule::JsonValue { content_type });
+        } else {
+            input_validation_rules.push(InputValidationRule::ContentType { content_type });
+        }
+
+        Ok(InputRules {
+            input_validation_rules,
+        })
+    }
+
+    fn output_rules_from_schema(
+        schema: schema::OutputPayload,
+    ) -> Result<OutputRules, ComponentError> {
+        Ok(if let Some(ct) = schema.content_type {
+            OutputRules {
+                content_type_rule: OutputContentTypeRule::Set {
+                    content_type: HeaderValue::from_str(&ct)
+                        .map_err(|e| ComponentError::BadOutputContentType(ct, e))?,
+                    set_content_type_if_empty: schema.set_content_type_if_empty.unwrap_or(false),
+                    has_json_schema: schema.json_schema.is_some(),
+                },
+            }
+        } else {
+            OutputRules {
+                content_type_rule: OutputContentTypeRule::None,
+            }
+        })
+    }
 }
 
 impl SchemasInner {
@@ -56,7 +148,8 @@ impl SchemasInner {
 
                 component_schemas.revision = revision;
                 component_schemas.ty = ty;
-                component_schemas.handlers = ComponentSchemas::compute_handlers(handlers.clone());
+                component_schemas.handlers =
+                    ComponentSchemas::compute_handlers(ty, handlers.clone());
                 if let ComponentLocation::Deployment {
                     latest_deployment, ..
                 } = &mut component_schemas.location
@@ -66,7 +159,7 @@ impl SchemasInner {
             })
             .or_insert_with(|| ComponentSchemas {
                 revision,
-                handlers: ComponentSchemas::compute_handlers(handlers),
+                handlers: ComponentSchemas::compute_handlers(ty, handlers),
                 ty,
                 location: ComponentLocation::Deployment {
                     latest_deployment: deployment_id,
@@ -95,6 +188,9 @@ impl SchemasInner {
             } = &mut schemas.location
             {
                 *old_public_value = new_public_value;
+            }
+            for h in schemas.handlers.values_mut() {
+                h.target_meta.public = new_public_value;
             }
         }
     }

--- a/crates/schema-impl/src/schemas_impl/deployment.rs
+++ b/crates/schema-impl/src/schemas_impl/deployment.rs
@@ -160,20 +160,8 @@ impl SchemasInner {
                     handlers: component
                         .handlers
                         .into_iter()
-                        .map(|h| DiscoveredHandlerMetadata {
-                            name: h.name.to_string(),
-                            input_schema: h.input_schema.map(|v| {
-                                serde_json::to_vec(&v)
-                                    .expect("Serializing Values must never fail")
-                                    .into()
-                            }),
-                            output_schema: h.output_schema.map(|v| {
-                                serde_json::to_vec(&v)
-                                    .expect("Serializing Values must never fail")
-                                    .into()
-                            }),
-                        })
-                        .collect(),
+                        .map(|h| DiscoveredHandlerMetadata::from_schema(component_type, h))
+                        .collect::<Result<Vec<_>, _>>()?,
                 },
             ));
         }
@@ -245,8 +233,9 @@ mod tests {
             fully_qualified_component_name: GREETER_SERVICE_NAME.parse().unwrap(),
             handlers: vec![schema::Handler {
                 name: "greet".parse().unwrap(),
-                input_schema: None,
-                output_schema: None,
+                handler_type: None,
+                input: None,
+                output: None,
             }],
         }
     }
@@ -257,8 +246,9 @@ mod tests {
             fully_qualified_component_name: GREETER_SERVICE_NAME.parse().unwrap(),
             handlers: vec![schema::Handler {
                 name: "greet".parse().unwrap(),
-                input_schema: None,
-                output_schema: None,
+                handler_type: None,
+                input: None,
+                output: None,
             }],
         }
     }
@@ -269,8 +259,9 @@ mod tests {
             fully_qualified_component_name: ANOTHER_GREETER_SERVICE_NAME.parse().unwrap(),
             handlers: vec![schema::Handler {
                 name: "another_greeter".parse().unwrap(),
-                input_schema: None,
-                output_schema: None,
+                handler_type: None,
+                input: None,
+                output: None,
             }],
         }
     }
@@ -584,13 +575,15 @@ mod tests {
                 handlers: vec![
                     schema::Handler {
                         name: "greet".parse().unwrap(),
-                        input_schema: None,
-                        output_schema: None,
+                        handler_type: None,
+                        input: None,
+                        output: None,
                     },
                     schema::Handler {
                         name: "doSomething".parse().unwrap(),
-                        input_schema: None,
-                        output_schema: None,
+                        handler_type: None,
+                        input: None,
+                        output: None,
                     },
                 ],
             }
@@ -602,8 +595,9 @@ mod tests {
                 fully_qualified_component_name: GREETER_SERVICE_NAME.parse().unwrap(),
                 handlers: vec![schema::Handler {
                     name: "greet".parse().unwrap(),
-                    input_schema: None,
-                    output_schema: None,
+                    handler_type: None,
+                    input: None,
+                    output: None,
                 }],
             }
         }

--- a/crates/serde-util/src/header_value.rs
+++ b/crates/serde-util/src/header_value.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::HeaderValue;
+use serde::Deserialize;
+use serde_with::{DeserializeAs, SerializeAs};
+
+/// SerializeAs/DeserializeAs to implement ser/de trait for [HeaderValue]
+/// Use it with `#[serde(with = "serde_with::As::<HeaderValueSerde>")]`.
+pub struct HeaderValueSerde;
+
+impl SerializeAs<HeaderValue> for HeaderValueSerde {
+    fn serialize_as<S>(source: &HeaderValue, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(source.to_str().map_err(serde::ser::Error::custom)?)
+    }
+}
+
+impl<'de> DeserializeAs<'de, HeaderValue> for HeaderValueSerde {
+    fn deserialize_as<D>(deserializer: D) -> Result<HeaderValue, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = String::deserialize(deserializer)?;
+        HeaderValue::from_str(&buf).map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/serde-util/src/lib.rs
+++ b/crates/serde-util/src/lib.rs
@@ -13,7 +13,9 @@ mod header_map;
 mod proto;
 
 pub mod default;
+pub mod header_value;
 
 pub use header_map::SerdeableHeaderHashMap;
+pub use header_value::HeaderValueSerde;
 #[cfg(feature = "proto")]
 pub use proto::ProtobufEncoded;

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -53,4 +53,5 @@ prettyplease = "0.2"
 schemars = { workspace = true }
 serde_json = { workspace = true }
 syn = "2.0"
-typify = { version = "0.0.15" }
+typify = { version = "0.0.16" }
+jsonptr = "0.4.7"

--- a/crates/service-protocol/service-protocol/deployment_manifest_schema.json
+++ b/crates/service-protocol/service-protocol/deployment_manifest_schema.json
@@ -41,19 +41,95 @@
                   "type": "string",
                   "pattern": "^([a-zA-Z]|_[a-zA-Z0-9])[a-zA-Z0-9_]*$"
                 },
-                "inputSchema": {},
-                "outputSchema": {}
+                "handlerType": {
+                  "title": "HandlerType",
+                  "enum": ["EXCLUSIVE", "SHARED"],
+                  "description": "If unspecified, defaults to EXCLUSIVE for Virtual Object. This should be unset for Services."
+                },
+                "input": {
+                  "type": "object",
+                  "title": "InputPayload",
+                  "description": "Description of an input payload. This will be used by Restate to validate incoming requests.",
+                  "properties": {
+                    "required": {
+                      "type": "boolean",
+                      "description": "If true, a body MUST be sent with a content-type, even if the body length is zero."
+                    },
+                    "contentType": {
+                      "type": "string",
+                      "description": "Content type of the input. It can accept wildcards, in the same format as the 'Accept' header. When this field is unset, it implies emptiness, meaning no content-type/body is expected."
+                    },
+                    "jsonSchema": {}
+                  },
+                  "additionalProperties": false,
+                  "default": {
+                    "contentType": "*/*",
+                    "required": false
+                  },
+                  "examples": {
+                    "empty input": {},
+                    "non empty json input": {
+                      "required": true,
+                      "contentType": "application/json",
+                      "jsonSchema": true
+                    },
+                    "either empty or non empty json input": {
+                      "required": false,
+                      "contentType": "application/json",
+                      "jsonSchema": true
+                    },
+                    "bytes input": {
+                      "required": true,
+                      "contentType": "application/octet-stream"
+                    }
+                  }
+                },
+                "output": {
+                  "type": "object",
+                  "title": "OutputPayload",
+                  "description": "Description of an output payload.",
+                  "properties": {
+                    "contentType": {
+                      "type": "string",
+                      "description": "Content type set on output. This will be used by Restate to set the output content type at the ingress."
+                    },
+                    "setContentTypeIfEmpty": {
+                      "type": "boolean",
+                      "description": "If true, the specified content-type is set even if the output is empty."
+                    },
+                    "jsonSchema": {}
+                  },
+                  "additionalProperties": false,
+                  "default": {
+                    "contentType": "application/json",
+                    "setContentTypeIfEmpty": false
+                  },
+                  "examples": {
+                    "empty output": {
+                      "setContentTypeIfEmpty": false
+                    },
+                    "non-empty json output": {
+                      "contentType": "application/json",
+                      "setContentTypeIfEmpty": false,
+                      "jsonSchema": true
+                    },
+                    "protobuf output": {
+                      "contentType": "application/proto",
+                      "setContentTypeIfEmpty": true
+                    }
+                  }
+                }
               },
-              "required": [ "name" ],
+              "required": ["name"],
               "additionalProperties": false
             }
           }
         },
-        "required": [ "fullyQualifiedComponentName","componentType", "handlers" ],
+        "required": ["fullyQualifiedComponentName", "componentType", "handlers"],
         "additionalProperties": false
       }
     }
   },
-  "required": [ "minProtocolVersion", "maxProtocolVersion", "components" ],
+  "required": ["minProtocolVersion", "maxProtocolVersion", "components"],
   "additionalProperties": false
 }

--- a/crates/service-protocol/service-protocol/dev/restate/service/protocol.proto
+++ b/crates/service-protocol/service-protocol/dev/restate/service/protocol.proto
@@ -11,8 +11,6 @@ syntax = "proto3";
 
 package dev.restate.service.protocol;
 
-import "google/protobuf/empty.proto";
-
 option java_package = "dev.restate.generated.service.protocol";
 option go_package = "restate.dev/sdk-go/pb/service/protocol";
 
@@ -49,7 +47,7 @@ message CompletionMessage {
   uint32 entry_index = 1;
 
   oneof result {
-    google.protobuf.Empty empty = 13;
+    Empty empty = 13;
     bytes value = 14;
     Failure failure = 15;
   };
@@ -68,12 +66,10 @@ message SuspensionMessage {
 
 // Type: 0x0000 + 3
 message ErrorMessage {
-  // The code can be:
-  // * Any of the error codes defined by OutputStreamEntry.failure (see Failure message)
-  // * JOURNAL_MISMATCH = 32, that is when the SDK cannot replay a journal due to the mismatch between the journal and the actual code.
-  // * PROTOCOL_VIOLATION = 33, that is when the SDK receives an unexpected message or an expected message variant, given its state.
-  //
-  // If 16 < code < 32, or code > 33, the runtime will interpret it as code 2 (UNKNOWN).
+  // The code can be any HTTP status code, as described https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml.
+  // In addition, we define the following error codes that MAY be used by the SDK for better error reporting:
+  // * JOURNAL_MISMATCH = 570, that is when the SDK cannot replay a journal due to the mismatch between the journal and the actual code.
+  // * PROTOCOL_VIOLATION = 571, that is when the SDK receives an unexpected message or an expected message variant, given its state.
   uint32 code = 1;
   // Contains a concise error message, e.g. Throwable#getMessage() in Java.
   string message = 2;
@@ -132,7 +128,7 @@ message GetStateEntryMessage {
   bytes key = 1;
 
   oneof result {
-    google.protobuf.Empty empty = 13;
+    Empty empty = 13;
     bytes value = 14;
     Failure failure = 15;
   };
@@ -184,7 +180,7 @@ message SleepEntryMessage {
   uint64 wake_up_time = 1;
 
   oneof result {
-    google.protobuf.Empty empty = 13;
+    Empty empty = 13;
     Failure failure = 15;
   }
 }
@@ -259,10 +255,7 @@ message CompleteAwakeableEntryMessage {
 // This failure object carries user visible errors,
 // e.g. invocation failure return value or failure result of an InvokeEntryMessage.
 message Failure {
-  // The code should be any of the gRPC error codes,
-  // as defined here: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc
-  //
-  // If code > 16, the runtime will interpret it as code 2 (UNKNOWN).
+  // The code can be any HTTP status code, as described https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml.
   uint32 code = 1;
   // Contains a concise error message, e.g. Throwable#getMessage() in Java.
   string message = 2;
@@ -271,4 +264,7 @@ message Failure {
 message Header {
   string key = 1;
   string value = 2;
+}
+
+message Empty {
 }

--- a/crates/service-protocol/src/codec.rs
+++ b/crates/service-protocol/src/codec.rs
@@ -101,7 +101,9 @@ impl RawEntryCodec for ProtobufRawEntryCodec {
 
         // Prepare the result to serialize in protobuf
         let completion_result_message = match completion_result {
-            CompletionResult::Empty => protocol::completion_message::Result::Empty(()),
+            CompletionResult::Empty => {
+                protocol::completion_message::Result::Empty(protocol::Empty {})
+            }
             CompletionResult::Success(b) => protocol::completion_message::Result::Value(b),
             CompletionResult::Failure(code, message) => {
                 protocol::completion_message::Result::Failure(protocol::Failure {
@@ -185,7 +187,9 @@ mod mocks {
                     GetStateEntryMessage {
                         key: entry.key,
                         result: entry.value.map(|value| match value {
-                            GetStateResult::Empty => get_state_entry_message::Result::Empty(()),
+                            GetStateResult::Empty => {
+                                get_state_entry_message::Result::Empty(protocol::Empty {})
+                            }
                             GetStateResult::Result(v) => get_state_entry_message::Result::Value(v),
                             GetStateResult::Failure(code, reason) => {
                                 get_state_entry_message::Result::Failure(Failure {

--- a/crates/service-protocol/src/message/mod.rs
+++ b/crates/service-protocol/src/message/mod.rs
@@ -87,7 +87,9 @@ impl From<Completion> for ProtocolMessage {
             CompletionResult::Empty => {
                 ProtocolMessage::Completion(pb::protocol::CompletionMessage {
                     entry_index: completion.entry_index,
-                    result: Some(pb::protocol::completion_message::Result::Empty(())),
+                    result: Some(pb::protocol::completion_message::Result::Empty(
+                        pb::protocol::Empty {},
+                    )),
                 })
             }
             CompletionResult::Success(b) => {

--- a/crates/worker/src/invoker_integration.rs
+++ b/crates/worker/src/invoker_integration.rs
@@ -42,7 +42,7 @@ impl<Schemas, Codec> EntryEnricher<Schemas, Codec> {
 
 impl<Schemas, Codec> EntryEnricher<Schemas, Codec>
 where
-    Schemas: restate_schema_api::component::ComponentMetadataResolver,
+    Schemas: restate_schema_api::invocation_target::InvocationTargetResolver,
     Codec: RawEntryCodec,
 {
     fn resolve_service_invocation_target(
@@ -58,9 +58,9 @@ where
 
         let service_id = match self
             .schemas
-            .resolve_latest_component_handler(&request.service_name, &request.method_name)
+            .resolve_latest_invocation_target(&request.service_name, &request.method_name)
         {
-            Some(meta) => match meta.ty {
+            Some(meta) => match meta.component_ty {
                 ComponentType::Service => ServiceId::unkeyed(request.service_name.clone()),
                 ComponentType::VirtualObject => {
                     ServiceId::new(request.service_name.clone(), request.key.into_bytes())
@@ -97,7 +97,7 @@ where
 
 impl<Schemas, Codec> restate_invoker_api::EntryEnricher for EntryEnricher<Schemas, Codec>
 where
-    Schemas: restate_schema_api::component::ComponentMetadataResolver,
+    Schemas: restate_schema_api::invocation_target::InvocationTargetResolver,
     Codec: RawEntryCodec,
 {
     fn enrich_entry(


### PR DESCRIPTION
Fix #1230

This PR lays the foundations for:

* Allowing to have content-type validation on ingress
* Eventually add in future json schema validation as well
* Set the correct content-type in the ingress response
* Have more visibility over input/output metadata (more to follow once we start interpreting the json schema)