### PR TITLE
Fetch or insert fixed partition table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5253,8 +5253,11 @@ dependencies = [
  "bincode",
  "bytes",
  "bytestring",
+ "codederror",
+ "derive_builder",
  "futures",
  "googletest",
+ "humantime",
  "hyper 0.14.28",
  "prost 0.12.3",
  "prost-types",
@@ -5263,13 +5266,13 @@ dependencies = [
  "restate-node-protocol",
  "restate-types",
  "rocksdb",
+ "schemars",
  "serde",
  "static_assertions",
  "tempfile",
  "test-log",
  "thiserror",
  "tokio",
- "tokio-retry",
  "tonic 0.10.2",
  "tonic-build",
  "tonic-health",
@@ -5350,6 +5353,7 @@ dependencies = [
  "restate-errors",
  "restate-grpc-util",
  "restate-meta",
+ "restate-metadata-store",
  "restate-network",
  "restate-node-protocol",
  "restate-node-services",
@@ -6923,17 +6927,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,8 @@ test-log = { version = "0.2.11", default-features = false, features = ["trace"] 
 tikv-jemallocator = { git = "https://github.com/restatedev/jemallocator", rev = "7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0", default-features = false }
 thiserror = "1.0"
 tokio = { version = "1.29", default-features = false, features = ["rt-multi-thread", "signal", "macros", ] }
-tokio-util = { version = "0.7.10" }
 tokio-stream = "0.1.14"
+tokio-util = { version = "0.7.10" }
 tonic = { version = "0.10.2", default-features = false }
 tonic-reflection = { version = "0.10.2" }
 tonic-health = "0.10.2"

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -35,7 +35,7 @@ pub fn discover_deployment(current_thread_rt: &Runtime, address: Uri) {
     let discovery_payload = serde_json::json!({"uri": address.to_string()}).to_string();
     let discovery_result = current_thread_rt.block_on(async {
         RetryPolicy::fixed_delay(Duration::from_millis(200), 50)
-            .retry_operation(|| {
+            .retry(|| {
                 hyper::Client::new()
                     .request(
                         hyper::Request::post("http://localhost:9070/deployments")

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -73,6 +73,7 @@ pub enum TaskKind {
     #[strum(props(OnError = "log"))]
     ConnectionReactor,
     Shuffle,
+    MetadataStore,
     // -- Bifrost Tasks
     /// A background task that the system needs for its operation. The task requires a system
     /// shutdown on errors and the system will wait for its graceful cancellation on shutdown.

--- a/crates/grpc-util/src/lib.rs
+++ b/crates/grpc-util/src/lib.rs
@@ -24,7 +24,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;
-use tracing::info;
+use tracing::{debug, info};
 
 pub fn create_grpc_channel_from_advertised_address(
     address: AdvertisedAddress,
@@ -103,6 +103,8 @@ where
             run_tcp_server(socket_addr, service, shutdown_signal, server_name).await?
         }
     }
+
+    debug!("Stopped server '{}'", server_name);
 
     Ok(())
 }

--- a/crates/metadata-store/Cargo.toml
+++ b/crates/metadata-store/Cargo.toml
@@ -8,8 +8,10 @@ license.workspace = true
 publish = false
 
 [features]
+options_schema = ["dep:schemars"]
 
 [dependencies]
+codederror = { workspace = true }
 restate-core = { workspace = true }
 restate-grpc-util = { workspace = true }
 restate-node-protocol = { workspace = true }
@@ -20,11 +22,14 @@ async-trait = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+derive_builder = { workspace = true }
 futures = { workspace = true }
+humantime = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rocksdb = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
@@ -44,7 +49,6 @@ anyhow = { workspace = true }
 googletest = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }
-tokio-retry = "0.3.0"
 tracing-subscriber = { workspace = true }
 
 [build-dependencies]

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -12,5 +12,20 @@ mod grpc;
 mod store;
 
 mod service;
+
+pub use options::Options;
+use restate_types::net::AdvertisedAddress;
+pub use service::LocalMetadataStoreService;
+pub use store::BuildError;
+
+use crate::local::grpc::client::LocalMetadataStoreClient;
+use crate::MetadataStoreClient;
+
+/// Creates a [`MetadataStoreClient`] for the [`LocalMetadataStoreService`].
+pub fn create_client(advertised_address: AdvertisedAddress) -> MetadataStoreClient {
+    MetadataStoreClient::new(LocalMetadataStoreClient::new(advertised_address))
+}
+
+mod options;
 #[cfg(test)]
 mod tests;

--- a/crates/metadata-store/src/local/options.rs
+++ b/crates/metadata-store/src/local/options.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::local::store::{BuildError, LocalMetadataStore};
+use crate::local::LocalMetadataStoreService;
+use restate_types::net::BindAddress;
+use restate_types::DEFAULT_STORAGE_DIRECTORY;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "options_schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "options_schema",
+    schemars(rename = "LocalMetadataStoreOptions", default)
+)]
+#[builder(default)]
+pub struct Options {
+    /// Address to which the metadata store will bind to.
+    #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
+    bind_address: BindAddress,
+    /// Storage path under which the metadata store will store its data.
+    path: PathBuf,
+    /// Number of in-flight metadata store requests.
+    request_queue_length: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            bind_address: "0.0.0.0:5123".parse().expect("valid bind address"),
+            path: Path::new(DEFAULT_STORAGE_DIRECTORY).join("local_metadata_store"),
+            request_queue_length: 32,
+        }
+    }
+}
+
+impl Options {
+    pub fn build(self) -> Result<LocalMetadataStoreService, BuildError> {
+        let store = LocalMetadataStore::new(self.path, self.request_queue_length)?;
+        Ok(LocalMetadataStoreService::new(store, self.bind_address))
+    }
+
+    pub fn storage_path(&self) -> &Path {
+        self.path.as_path()
+    }
+}

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -14,7 +14,8 @@ options_schema = [
     "restate-admin/options_schema",
     "restate-meta/options_schema",
     "restate-worker/options_schema",
-    "restate-cluster-controller/options_schema"]
+    "restate-cluster-controller/options_schema",
+    "restate-metadata-store/options_schema"]
 
 [dependencies]
 restate-admin = { workspace = true }
@@ -24,6 +25,7 @@ restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-grpc-util = { workspace = true }
 restate-meta = { workspace = true }
+restate-metadata-store = { workspace = true }
 restate-network = { workspace = true }
 restate-node-protocol = { workspace = true }
 restate-node-services = { workspace = true, features = ["servers"] }

--- a/crates/node/src/options.rs
+++ b/crates/node/src/options.rs
@@ -38,6 +38,10 @@ pub struct Options {
     pub bifrost: restate_bifrost::Options,
     pub cluster_controller: restate_cluster_controller::Options,
 
+    #[cfg_attr(feature = "options_schema", schemars(with = "String"))]
+    pub metadata_store_client: AdvertisedAddress,
+    pub metadata_store: restate_metadata_store::local::Options,
+
     /// Defines the roles which this Restate node should run
     #[cfg_attr(feature = "options_schema", schemars(with = "Vec<String>"))]
     pub roles: EnumSet<Role>,
@@ -69,8 +73,12 @@ impl Default for Options {
             admin: Default::default(),
             bifrost: Default::default(),
             cluster_controller: Default::default(),
-            roles: Role::Worker | Role::Admin,
+            roles: Role::Worker | Role::Admin | Role::MetadataStore,
             admin_address: None,
+            metadata_store: Default::default(),
+            metadata_store_client: "http://127.0.0.1:5123"
+                .parse()
+                .expect("valid metadata store address"),
         }
     }
 }

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -177,7 +177,7 @@ impl WorkerRole {
         let cc_client = ClusterCtrlSvcClient::new(channel);
 
         let _response = RetryPolicy::exponential(Duration::from_millis(50), 2.0, 10, None)
-            .retry_operation(|| async {
+            .retry(|| async {
                 cc_client
                     .clone()
                     .attach_node(AttachmentRequest {
@@ -249,7 +249,7 @@ impl WorkerRole {
         cluster_ctrl_client: &ClusterCtrlSvcClient<Channel>,
     ) -> Result<Vec<SchemasUpdateCommand>, SchemaError> {
         let response = RetryPolicy::exponential(Duration::from_millis(50), 2.0, 10, None)
-            .retry_operation(|| {
+            .retry(|| {
                 let mut cluster_ctrl_client = cluster_ctrl_client.clone();
                 async move {
                     cluster_ctrl_client

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -53,6 +53,6 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
-test-log = { workspace = true }
-
 rand = { workspace = true }
+test-log = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod invocation;
 pub mod journal;
 pub mod logs;
 pub mod message;
+pub mod metadata_store;
 pub mod net;
 pub mod nodes_config;
 pub mod partition_table;

--- a/crates/types/src/metadata_store.rs
+++ b/crates/types/src/metadata_store.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod keys {
+    //! Keys of values stored in the metadata store
+
+    use bytestring::ByteString;
+
+    pub static NODES_CONFIG_KEY: ByteString = ByteString::from_static("nodes_config");
+    pub static BIFROST_CONFIG_KEY: ByteString = ByteString::from_static("bifrost_config");
+    pub static PARTITION_TABLE_KEY: ByteString = ByteString::from_static("partition_table");
+    pub static EPOCH_TABLE_KEY: ByteString = ByteString::from_static("epoch_table");
+}

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -39,6 +39,7 @@ pub struct GenerationalNodeId(PlainNodeId, u32);
 
 #[derive(
     Debug,
+    Default,
     PartialEq,
     Eq,
     Ord,
@@ -130,6 +131,11 @@ impl PartialEq<PlainNodeId> for NodeId {
 impl PlainNodeId {
     pub fn with_generation(self, generation: u32) -> GenerationalNodeId {
         GenerationalNodeId(self, generation)
+    }
+
+    pub fn next(mut self) -> Self {
+        self.0 += 1;
+        self
     }
 }
 

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -38,6 +38,7 @@ pub enum NodesConfigError {
 pub enum Role {
     Worker,
     Admin,
+    MetadataStore,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -167,6 +168,11 @@ impl NodesConfiguration {
             MaybeNode::Node(node) if node.roles.contains(Role::Admin) => Some(node),
             _ => None,
         })
+    }
+
+    /// Returns the maximum known plain node id.
+    pub fn max_plain_node_id(&self) -> Option<PlainNodeId> {
+        self.nodes.keys().max().cloned()
     }
 }
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -115,7 +115,7 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
     )?;
 
     let res = RetryPolicy::fixed_delay(Duration::from_millis(100), 20)
-        .retry_operation(|| async {
+        .retry(|| async {
             reqwest::Client::builder()
                 .build()?
                 .get(openapi_address.clone())


### PR DESCRIPTION
This commit tries to fetch the FixedPartitionTable from the metadata
store. If it is not present, then it will try to store an instance
of it.

This fixes https://github.com/restatedev/restate/issues/1308.

This PR is based on #1307.