### PR TITLE
[1/n] Use snake_case for all configuration enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "pear",
  "serde",
  "serde_yaml",
+ "toml",
  "uncased",
  "version_check",
 ]
@@ -4374,7 +4375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -6241,6 +6242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_tokenstream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6965,10 +6975,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.9",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -6978,7 +7003,20 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -7795,6 +7833,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -34,6 +34,7 @@ use crate::{Error, LogRecord, LsnExt, Options};
     strum_macros::EnumIter,
     strum_macros::Display,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum ProviderKind {
     #[cfg(any(test, feature = "local_loglet"))]
     /// A local rocksdb-backed loglet.

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -32,9 +32,10 @@ pub enum NodesConfigError {
 }
 
 // PartialEq+Eq+Clone+Copy are implemented by EnumSetType
-#[derive(Debug, Hash, EnumSetType, derive_more::Display)]
+#[derive(Debug, Hash, EnumSetType, strum_macros::Display)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", enumset(serialize_repr = "list"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum Role {
     Worker,
     Admin,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,7 +40,7 @@ codederror = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
 enumset = { workspace = true }
-figment = { version = "0.10.8", features = ["env", "yaml"] }
+figment = { version = "0.10.8", features = ["env", "yaml", "toml"] }
 futures-util = { workspace = true }
 humantime = { workspace = true }
 pin-project = { workspace = true }


### PR DESCRIPTION
[1/n] Use snake_case for all configuration enums

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1321).
* #1328
* #1325
* #1322
* __->__ #1321