### PR TITLE
Add IdempotencyTable and modify InvocationStatus table

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
 # https://github.com/rust-lang/rust-clippy/issues/9801
-ignore-interior-mutability = ["bytes::Bytes", "http::header::HeaderName", "http::header::HeaderValue"]
+ignore-interior-mutability = ["bytes::Bytes", "bytestring::ByteString", "http::header::HeaderName", "http::header::HeaderValue"]

--- a/crates/storage-api/src/idempotency_table/mod.rs
+++ b/crates/storage-api/src/idempotency_table/mod.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::Result;
+
+use restate_types::identifiers::{IdempotencyId, InvocationId};
+use std::future::Future;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IdempotencyMetadata {
+    pub invocation_id: InvocationId,
+}
+
+pub trait ReadOnlyIdempotencyTable {
+    fn get_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+    ) -> impl Future<Output = Result<Option<IdempotencyMetadata>>> + Send;
+}
+
+pub trait IdempotencyTable: ReadOnlyIdempotencyTable {
+    fn put_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+        metadata: IdempotencyMetadata,
+    ) -> impl Future<Output = ()> + Send;
+
+    fn delete_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+    ) -> impl Future<Output = ()> + Send;
+}

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -266,6 +266,7 @@ mod mocks {
                 timestamps: StatusTimestamps::now(),
                 source: Source::Ingress,
                 completion_retention_time: Duration::ZERO,
+                idempotency_key: None,
             }
         }
     }

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -15,12 +15,13 @@ use restate_types::identifiers::{
     DeploymentId, EntryIndex, FullInvocationId, InvocationId, PartitionKey, ServiceId,
 };
 use restate_types::invocation::{
-    ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
+    ResponseResult, ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
 };
 use restate_types::time::MillisSinceEpoch;
 use std::collections::HashSet;
 use std::future::Future;
 use std::ops::RangeInclusive;
+use std::time::Duration;
 
 /// Holds timestamps of the [`InvocationStatus`].
 #[derive(Debug, Clone, PartialEq)]
@@ -71,6 +72,7 @@ pub enum InvocationStatus {
         metadata: InvocationMetadata,
         waiting_for_completed_entries: HashSet<EntryIndex>,
     },
+    Completed(ResponseResult),
     /// Service instance is currently not invoked
     #[default]
     Free,
@@ -91,7 +93,7 @@ impl InvocationStatus {
         match self {
             InvocationStatus::Invoked(metadata) => Some(metadata.journal_metadata),
             InvocationStatus::Suspended { metadata, .. } => Some(metadata.journal_metadata),
-            InvocationStatus::Free => None,
+            _ => None,
         }
     }
 
@@ -100,7 +102,7 @@ impl InvocationStatus {
         match self {
             InvocationStatus::Invoked(metadata) => Some(&metadata.journal_metadata),
             InvocationStatus::Suspended { metadata, .. } => Some(&metadata.journal_metadata),
-            InvocationStatus::Free => None,
+            _ => None,
         }
     }
 
@@ -109,7 +111,34 @@ impl InvocationStatus {
         match self {
             InvocationStatus::Invoked(metadata) => Some(&mut metadata.journal_metadata),
             InvocationStatus::Suspended { metadata, .. } => Some(&mut metadata.journal_metadata),
-            InvocationStatus::Free => None,
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn into_invocation_metadata(self) -> Option<InvocationMetadata> {
+        match self {
+            InvocationStatus::Invoked(metadata) => Some(metadata),
+            InvocationStatus::Suspended { metadata, .. } => Some(metadata),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn get_invocation_metadata(&self) -> Option<&InvocationMetadata> {
+        match self {
+            InvocationStatus::Invoked(metadata) => Some(metadata),
+            InvocationStatus::Suspended { metadata, .. } => Some(metadata),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn get_invocation_metadata_mut(&mut self) -> Option<&mut InvocationMetadata> {
+        match self {
+            InvocationStatus::Invoked(metadata) => Some(metadata),
+            InvocationStatus::Suspended { metadata, .. } => Some(metadata),
+            _ => None,
         }
     }
 
@@ -118,7 +147,7 @@ impl InvocationStatus {
         match self {
             InvocationStatus::Invoked(metadata) => Some(&metadata.timestamps),
             InvocationStatus::Suspended { metadata, .. } => Some(&metadata.timestamps),
-            InvocationStatus::Free => None,
+            _ => None,
         }
     }
 
@@ -126,7 +155,7 @@ impl InvocationStatus {
         match self {
             InvocationStatus::Invoked(metadata) => metadata.timestamps.update(),
             InvocationStatus::Suspended { metadata, .. } => metadata.timestamps.update(),
-            InvocationStatus::Free => {}
+            _ => {}
         }
     }
 }
@@ -157,31 +186,43 @@ pub struct InvocationMetadata {
     pub journal_metadata: JournalMetadata,
     pub deployment_id: Option<DeploymentId>,
     pub method: ByteString,
-    pub response_sink: Option<ServiceInvocationResponseSink>,
+    pub response_sinks: HashSet<ServiceInvocationResponseSink>,
     pub timestamps: StatusTimestamps,
     pub source: Source,
+    /// If zero, the invocation completion will not be retained.
+    pub completion_retention_time: Duration,
+    pub idempotency_key: Option<ByteString>,
 }
 
 impl InvocationMetadata {
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::mutable_key_type)]
     pub fn new(
         service_id: ServiceId,
         journal_metadata: JournalMetadata,
         deployment_id: Option<DeploymentId>,
         method: ByteString,
-        response_sink: Option<ServiceInvocationResponseSink>,
+        response_sinks: HashSet<ServiceInvocationResponseSink>,
         timestamps: StatusTimestamps,
         source: Source,
+        completion_retention_time: Duration,
+        idempotency_key: Option<ByteString>,
     ) -> Self {
         Self {
             service_id,
             journal_metadata,
             deployment_id,
             method,
-            response_sink,
+            response_sinks,
             timestamps,
             source,
+            completion_retention_time,
+            idempotency_key,
         }
+    }
+
+    pub fn append_response_sink(&mut self, new_sink: ServiceInvocationResponseSink) {
+        self.response_sinks.insert(new_sink);
     }
 }
 
@@ -221,9 +262,10 @@ mod mocks {
                 journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
                 deployment_id: None,
                 method: ByteString::from("mock"),
-                response_sink: None,
+                response_sinks: HashSet::new(),
                 timestamps: StatusTimestamps::now(),
                 source: Source::Ingress,
+                completion_retention_time: Duration::ZERO,
             }
         }
     }

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -27,6 +27,7 @@ pub type Result<T> = std::result::Result<T, StorageError>;
 
 pub mod deduplication_table;
 pub mod fsm_table;
+pub mod idempotency_table;
 pub mod inbox_table;
 pub mod invocation_status_table;
 pub mod journal_table;
@@ -53,6 +54,7 @@ pub trait Transaction:
     + journal_table::JournalTable
     + fsm_table::FsmTable
     + timer_table::TimerTable
+    + idempotency_table::IdempotencyTable
     + Send
 {
     fn commit(self) -> impl Future<Output = Result<()>> + Send;

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -36,6 +36,11 @@ message KvPair {
     bytes value = 2;
 }
 
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
 // ---------------------------------------------------------------------
 // Service Invocation
 // ---------------------------------------------------------------------
@@ -58,7 +63,7 @@ message InvocationStatus {
     message Invoked {
         ServiceId service_id = 1;
         JournalMeta journal_meta = 2;
-        ServiceInvocationResponseSink response_sink = 3;
+        repeated ServiceInvocationResponseSink response_sinks = 3;
         uint64 creation_time = 4;
         uint64 modification_time = 5;
         bytes method_name = 6;
@@ -67,12 +72,17 @@ message InvocationStatus {
             string value = 8;
         }
         Source source = 9;
+        Duration completion_retention_time = 10;
+        oneof idempotency_key {
+            google.protobuf.Empty idempotency_key_none = 11;
+            string idempotency_key_value = 12;
+        }
     }
 
     message Suspended {
         ServiceId service_id = 1;
         JournalMeta journal_meta = 2;
-        ServiceInvocationResponseSink response_sink = 3;
+        repeated ServiceInvocationResponseSink response_sinks = 3;
         uint64 creation_time = 4;
         uint64 modification_time = 5;
         repeated uint32 waiting_for_completed_entries = 6;
@@ -82,6 +92,15 @@ message InvocationStatus {
             string value = 9;
         }
         Source source = 10;
+        Duration completion_retention_time = 11;
+        oneof idempotency_key {
+            google.protobuf.Empty idempotency_key_none = 12;
+            string idempotency_key_value = 13;
+        }
+    }
+
+    message Completed {
+        ResponseResult result = 1;
     }
 
     message Free {
@@ -91,6 +110,7 @@ message InvocationStatus {
         Invoked invoked = 1;
         Suspended suspended = 2;
         Free free = 3;
+        Completed completed = 4;
     }
 }
 
@@ -411,4 +431,12 @@ message DedupSequenceNumber {
         // Variant which is used for guarding against messages from previous epochs/leaders
         EpochSequenceNumber epoch_sequence_number = 2;
     }
+}
+
+// ---------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------
+
+message IdempotencyMetadata {
+    bytes invocation_id = 1;
 }

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -63,6 +63,10 @@ pub(crate) fn append_invocation_status_row(
             row.status("free");
             None
         }
+        InvocationStatus::Completed(_) => {
+            row.status("completed");
+            None
+        }
     };
     if let Some(metadata) = metadata {
         fill_invocation_metadata(&mut row, output, metadata);

--- a/crates/storage-rocksdb/src/idempotency_table/mod.rs
+++ b/crates/storage-rocksdb/src/idempotency_table/mod.rs
@@ -33,7 +33,7 @@ define_table_key!(
     )
 );
 
-fn write_key(idempotency_id: &IdempotencyId) -> IdempotencyKey {
+fn create_key(idempotency_id: &IdempotencyId) -> IdempotencyKey {
     IdempotencyKey::default()
         .partition_key(idempotency_id.partition_key())
         .component_name(idempotency_id.component_name.clone())
@@ -52,7 +52,7 @@ fn get_idempotency_metadata<S: StorageAccess>(
     storage: &mut S,
     idempotency_id: &IdempotencyId,
 ) -> Result<Option<IdempotencyMetadata>> {
-    storage.get_blocking(write_key(idempotency_id), move |_, v| {
+    storage.get_blocking(create_key(idempotency_id), move |_, v| {
         if v.is_none() {
             return Ok(None);
         }
@@ -71,13 +71,13 @@ fn put_idempotency_metadata<S: StorageAccess>(
     metadata: IdempotencyMetadata,
 ) {
     storage.put_kv(
-        write_key(idempotency_id),
+        create_key(idempotency_id),
         ProtoValue(storage::v1::IdempotencyMetadata::from(metadata)),
     );
 }
 
 fn delete_idempotency_metadata<S: StorageAccess>(storage: &mut S, idempotency_id: &IdempotencyId) {
-    let key = write_key(idempotency_id);
+    let key = create_key(idempotency_id);
     storage.delete_key(&key);
 }
 

--- a/crates/storage-rocksdb/src/idempotency_table/mod.rs
+++ b/crates/storage-rocksdb/src/idempotency_table/mod.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::codec::ProtoValue;
+use crate::keys::define_table_key;
+use crate::{RocksDBStorage, TableKind};
+use crate::{RocksDBTransaction, StorageAccess};
+use bytes::Bytes;
+use bytestring::ByteString;
+use prost::Message;
+use restate_storage_api::idempotency_table::{
+    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
+};
+use restate_storage_api::{Result, StorageError};
+use restate_storage_proto::storage;
+use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
+
+define_table_key!(
+    TableKind::Idempotency,
+    IdempotencyKey(
+        partition_key: PartitionKey,
+        component_name: ByteString,
+        component_key: Bytes,
+        component_handler: ByteString,
+        idempotency_key: ByteString
+    )
+);
+
+fn write_key(idempotency_id: &IdempotencyId) -> IdempotencyKey {
+    IdempotencyKey::default()
+        .partition_key(idempotency_id.partition_key())
+        .component_name(idempotency_id.component_name.clone())
+        .component_key(
+            idempotency_id
+                .component_key
+                .as_ref()
+                .cloned()
+                .unwrap_or_default(),
+        )
+        .component_handler(idempotency_id.component_handler.clone())
+        .idempotency_key(idempotency_id.idempotency_key.clone())
+}
+
+fn get_idempotency_metadata<S: StorageAccess>(
+    storage: &mut S,
+    idempotency_id: &IdempotencyId,
+) -> Result<Option<IdempotencyMetadata>> {
+    storage.get_blocking(write_key(idempotency_id), move |_, v| {
+        if v.is_none() {
+            return Ok(None);
+        }
+        let proto = storage::v1::IdempotencyMetadata::decode(v.unwrap())
+            .map_err(|err| StorageError::Generic(err.into()))?;
+
+        Ok(Some(
+            IdempotencyMetadata::try_from(proto).map_err(StorageError::from)?,
+        ))
+    })
+}
+
+fn put_idempotency_metadata<S: StorageAccess>(
+    storage: &mut S,
+    idempotency_id: &IdempotencyId,
+    metadata: IdempotencyMetadata,
+) {
+    storage.put_kv(
+        write_key(idempotency_id),
+        ProtoValue(storage::v1::IdempotencyMetadata::from(metadata)),
+    );
+}
+
+fn delete_idempotency_metadata<S: StorageAccess>(storage: &mut S, idempotency_id: &IdempotencyId) {
+    let key = write_key(idempotency_id);
+    storage.delete_key(&key);
+}
+
+impl ReadOnlyIdempotencyTable for RocksDBStorage {
+    async fn get_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+    ) -> Result<Option<IdempotencyMetadata>> {
+        get_idempotency_metadata(self, idempotency_id)
+    }
+}
+
+impl<'a> ReadOnlyIdempotencyTable for RocksDBTransaction<'a> {
+    async fn get_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+    ) -> Result<Option<IdempotencyMetadata>> {
+        get_idempotency_metadata(self, idempotency_id)
+    }
+}
+
+impl<'a> IdempotencyTable for RocksDBTransaction<'a> {
+    async fn put_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+        metadata: IdempotencyMetadata,
+    ) {
+        put_idempotency_metadata(self, idempotency_id, metadata)
+    }
+
+    async fn delete_idempotency_metadata(&mut self, idempotency_id: &IdempotencyId) {
+        delete_idempotency_metadata(self, idempotency_id)
+    }
+}

--- a/crates/storage-rocksdb/tests/idempotency_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/idempotency_table_test/mod.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Unfortunately we need this because of https://github.com/rust-lang/rust-clippy/issues/9801
+#![allow(clippy::borrow_interior_mutable_const)]
+#![allow(clippy::declare_interior_mutable_const)]
+
+use crate::storage_test_environment;
+use restate_storage_api::idempotency_table::{
+    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
+};
+use restate_storage_api::Transaction;
+use restate_types::identifiers::{IdempotencyId, InvocationId, InvocationUuid};
+
+const FIXTURE_INVOCATION_1: InvocationUuid =
+    InvocationUuid::from_parts(1706027034946, 12345678900001);
+const FIXTURE_INVOCATION_2: InvocationUuid =
+    InvocationUuid::from_parts(1706027034946, 12345678900002);
+const FIXTURE_INVOCATION_3: InvocationUuid =
+    InvocationUuid::from_parts(1706027034946, 12345678900003);
+
+const IDEMPOTENCY_ID_1: IdempotencyId =
+    IdempotencyId::unkeyed(10, "my-component", "my-handler", "my-key");
+const IDEMPOTENCY_ID_2: IdempotencyId =
+    IdempotencyId::unkeyed(10, "my-component", "my-handler", "another-key");
+const IDEMPOTENCY_ID_3: IdempotencyId =
+    IdempotencyId::unkeyed(10, "my-component", "my-handler-2", "my-key");
+
+#[tokio::test]
+async fn test_idempotency_key() {
+    let (mut rocksdb, close) = storage_test_environment();
+
+    // Fill in some data
+    let mut txn = rocksdb.transaction();
+    txn.put_idempotency_metadata(
+        &IDEMPOTENCY_ID_1,
+        IdempotencyMetadata {
+            invocation_id: InvocationId::new(10, FIXTURE_INVOCATION_1),
+        },
+    )
+    .await;
+    txn.put_idempotency_metadata(
+        &IDEMPOTENCY_ID_2,
+        IdempotencyMetadata {
+            invocation_id: InvocationId::new(10, FIXTURE_INVOCATION_2),
+        },
+    )
+    .await;
+    txn.put_idempotency_metadata(
+        &IDEMPOTENCY_ID_3,
+        IdempotencyMetadata {
+            invocation_id: InvocationId::new(10, FIXTURE_INVOCATION_3),
+        },
+    )
+    .await;
+    txn.commit().await.unwrap();
+
+    // Query
+    let mut txn = rocksdb.transaction();
+    assert_eq!(
+        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_1)
+            .await
+            .unwrap(),
+        Some(IdempotencyMetadata {
+            invocation_id: InvocationId::new(10, FIXTURE_INVOCATION_1),
+        })
+    );
+    assert_eq!(
+        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_2)
+            .await
+            .unwrap(),
+        Some(IdempotencyMetadata {
+            invocation_id: InvocationId::new(10, FIXTURE_INVOCATION_2),
+        })
+    );
+    assert_eq!(
+        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_3)
+            .await
+            .unwrap(),
+        Some(IdempotencyMetadata {
+            invocation_id: InvocationId::new(10, FIXTURE_INVOCATION_3),
+        })
+    );
+    assert_eq!(
+        txn.get_idempotency_metadata(&IdempotencyId::unkeyed(
+            10,
+            "my-component",
+            "my-handler-3",
+            "my-key",
+        ))
+        .await
+        .unwrap(),
+        None
+    );
+    txn.commit().await.unwrap();
+
+    // Delete and query afterwards
+    let mut txn = rocksdb.transaction();
+    txn.delete_idempotency_metadata(&IDEMPOTENCY_ID_1).await;
+    txn.commit().await.unwrap();
+    let mut txn = rocksdb.transaction();
+    assert_eq!(
+        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_1)
+            .await
+            .unwrap(),
+        None
+    );
+    txn.commit().await.unwrap();
+
+    close.await;
+}

--- a/crates/storage-rocksdb/tests/idempotency_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/idempotency_table_test/mod.rs
@@ -63,9 +63,9 @@ async fn test_idempotency_key() {
     txn.commit().await.unwrap();
 
     // Query
-    let mut txn = rocksdb.transaction();
     assert_eq!(
-        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_1)
+        rocksdb
+            .get_idempotency_metadata(&IDEMPOTENCY_ID_1)
             .await
             .unwrap(),
         Some(IdempotencyMetadata {
@@ -73,7 +73,8 @@ async fn test_idempotency_key() {
         })
     );
     assert_eq!(
-        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_2)
+        rocksdb
+            .get_idempotency_metadata(&IDEMPOTENCY_ID_2)
             .await
             .unwrap(),
         Some(IdempotencyMetadata {
@@ -81,7 +82,8 @@ async fn test_idempotency_key() {
         })
     );
     assert_eq!(
-        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_3)
+        rocksdb
+            .get_idempotency_metadata(&IDEMPOTENCY_ID_3)
             .await
             .unwrap(),
         Some(IdempotencyMetadata {
@@ -89,30 +91,29 @@ async fn test_idempotency_key() {
         })
     );
     assert_eq!(
-        txn.get_idempotency_metadata(&IdempotencyId::unkeyed(
-            10,
-            "my-component",
-            "my-handler-3",
-            "my-key",
-        ))
-        .await
-        .unwrap(),
+        rocksdb
+            .get_idempotency_metadata(&IdempotencyId::unkeyed(
+                10,
+                "my-component",
+                "my-handler-3",
+                "my-key",
+            ))
+            .await
+            .unwrap(),
         None
     );
-    txn.commit().await.unwrap();
 
     // Delete and query afterwards
     let mut txn = rocksdb.transaction();
     txn.delete_idempotency_metadata(&IDEMPOTENCY_ID_1).await;
     txn.commit().await.unwrap();
-    let mut txn = rocksdb.transaction();
     assert_eq!(
-        txn.get_idempotency_metadata(&IDEMPOTENCY_ID_1)
+        rocksdb
+            .get_idempotency_metadata(&IDEMPOTENCY_ID_1)
             .await
             .unwrap(),
         None
     );
-    txn.commit().await.unwrap();
 
     close.await;
 }

--- a/crates/storage-rocksdb/tests/integration_test.rs
+++ b/crates/storage-rocksdb/tests/integration_test.rs
@@ -23,6 +23,7 @@ use std::pin::pin;
 use tempfile::tempdir;
 use tokio_stream::StreamExt;
 
+mod idempotency_table_test;
 mod inbox_table_test;
 mod invocation_status_table_test;
 mod journal_table_test;

--- a/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
@@ -20,6 +20,7 @@ use restate_types::identifiers::{
 use restate_types::invocation::{ServiceInvocationSpanContext, Source};
 use restate_types::time::MillisSinceEpoch;
 use std::collections::HashSet;
+use std::time::Duration;
 
 static SERVICE_ID_1: Lazy<ServiceId> = Lazy::new(|| ServiceId::new("abc", "1"));
 static INVOCATION_ID_1: Lazy<InvocationId> = Lazy::new(|| {
@@ -51,9 +52,11 @@ fn invoked_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
         JournalMetadata::new(0, ServiceInvocationSpanContext::empty()),
         None,
         "service".into(),
-        None,
+        HashSet::new(),
         StatusTimestamps::new(MillisSinceEpoch::new(0), MillisSinceEpoch::new(0)),
         Source::Ingress,
+        Duration::ZERO,
+        None,
     ))
 }
 
@@ -64,9 +67,11 @@ fn suspended_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
             JournalMetadata::new(0, ServiceInvocationSpanContext::empty()),
             None,
             "service".into(),
-            None,
+            HashSet::new(),
             StatusTimestamps::new(MillisSinceEpoch::new(0), MillisSinceEpoch::new(0)),
             Source::Ingress,
+            Duration::ZERO,
+            None,
         ),
         waiting_for_completed_entries: HashSet::default(),
     }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -536,10 +536,9 @@ impl IdempotencyId {
     ) -> Self {
         // The ownership model for idempotent invocations is the following:
         //
-        // * For components without key, the PP partition key is the hash(idempotency key).
-        //   This makes sure that for a given idempotency key and its scope, we always land in the same PP.
-        // * For components with key, the PP partition key is the hash(component key).
-        //   This to avoid additional hops between PPs, because hash(idempotency key) might be different from hash(component key).
+        // * For components without key, the partition key is the hash(idempotency key).
+        //   This makes sure that for a given idempotency key and its scope, we always land in the same partition.
+        // * For components with key, the partition key is the hash(component key), this due to the virtual object locking requirement.
         let partition_key = component_key
             .as_ref()
             .map(|k| partitioner::HashPartitioner::compute_partition_key(&k))

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -174,7 +174,7 @@ impl From<&InvocationError> for ResponseResult {
 }
 
 /// Definition of the sink where to send the result of a service invocation.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ServiceInvocationResponseSink {
     /// The invocation has been created by a partition processor and is expecting a response.

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -272,7 +272,9 @@ where
             let_assert!(InvocationStatus::Invoked(metadata) = status);
 
             let method = metadata.method;
-            let response_sink = metadata.response_sink;
+            // Built-in services support only one response_sink
+            debug_assert!(metadata.response_sinks.len() <= 1);
+            let response_sink = metadata.response_sinks.into_iter().next();
             let argument = input_entry.serialized_entry().clone();
             built_in_service_invoker
                 .invoke(

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -273,7 +273,10 @@ where
 
             let method = metadata.method;
             // Built-in services support only one response_sink
-            debug_assert!(metadata.response_sinks.len() <= 1);
+            debug_assert!(
+                metadata.response_sinks.len() <= 1,
+                "Built-in services support only one response_sink"
+            );
             let response_sink = metadata.response_sinks.into_iter().next();
             let argument = input_entry.serialized_entry().clone();
             built_in_service_invoker

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -521,7 +521,7 @@ where
         self.send_response_to_sinks(
             effects,
             &InvocationId::from(&fid),
-            service_invocation.response_sink.clone(),
+            service_invocation.response_sink,
             &error,
         );
 

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -518,7 +518,12 @@ where
         let span_context = service_invocation.span_context;
         let parent_span = span_context.as_parent();
 
-        self.try_send_failure_response(effects, &fid, service_invocation.response_sink, &error);
+        self.send_response_to_sinks(
+            effects,
+            &InvocationId::from(&fid),
+            service_invocation.response_sink.clone(),
+            &error,
+        );
 
         self.notify_invocation_result(
             &fid,
@@ -885,10 +890,10 @@ where
         invocation_metadata: InvocationMetadata,
         error: InvocationError,
     ) -> Result<(), Error> {
-        self.try_send_failure_response(
+        self.send_response_to_sinks(
             effects,
-            &full_invocation_id,
-            invocation_metadata.response_sink,
+            &InvocationId::from(&full_invocation_id),
+            invocation_metadata.response_sinks,
             &error,
         );
 
@@ -909,23 +914,21 @@ where
         .await
     }
 
-    fn try_send_failure_response(
+    fn send_response_to_sinks(
         &mut self,
         effects: &mut Effects,
-        full_invocation_id: &FullInvocationId,
-        response_sink: Option<ServiceInvocationResponseSink>,
-        error: &InvocationError,
+        invocation_id: &InvocationId,
+        response_sinks: impl IntoIterator<Item = ServiceInvocationResponseSink>,
+        res: impl Into<ResponseResult>,
     ) {
-        if let Some(response_sink) = response_sink {
-            // TODO: We probably only need to send the response if we haven't send a response before
-            self.send_response(
-                create_response_message(
-                    &InvocationId::from(full_invocation_id),
-                    response_sink,
-                    ResponseResult::from(error),
-                ),
-                effects,
-            );
+        let result = res.into();
+        for response_sink in response_sinks {
+            let response_message =
+                create_response_message(invocation_id, response_sink, result.clone());
+            match response_message {
+                ResponseMessage::Outbox(outbox) => self.outbox_message(outbox, effects),
+                ResponseMessage::Ingress(ingress) => self.ingress_response(ingress, effects),
+            }
         }
     }
 
@@ -947,19 +950,16 @@ where
             // nothing to do
             EnrichedEntryHeader::Input { .. } => {}
             EnrichedEntryHeader::Output { .. } => {
-                if let Some(ref response_sink) = invocation_metadata.response_sink {
+                if !invocation_metadata.response_sinks.is_empty() {
                     let_assert!(
                         Entry::Output(OutputEntry { result }) =
                             journal_entry.deserialize_entry_ref::<Codec>()?
                     );
-
-                    self.send_response(
-                        create_response_message(
-                            &InvocationId::from(&full_invocation_id),
-                            response_sink.clone(),
-                            result.into(),
-                        ),
+                    self.send_response_to_sinks(
                         effects,
+                        &InvocationId::from(&full_invocation_id),
+                        invocation_metadata.response_sinks.clone(),
+                        result,
                     );
                 }
             }
@@ -1355,11 +1355,9 @@ where
         self.outbox_seq_number += 1;
     }
 
-    fn send_response(&mut self, response: ResponseMessage, effects: &mut Effects) {
-        match response {
-            ResponseMessage::Outbox(outbox) => self.handle_outgoing_message(outbox, effects),
-            ResponseMessage::Ingress(ingress) => self.ingress_response(ingress, effects),
-        }
+    fn outbox_message(&mut self, message: OutboxMessage, effects: &mut Effects) {
+        effects.enqueue_into_outbox(self.outbox_seq_number, message);
+        self.outbox_seq_number += 1;
     }
 
     fn ingress_response(&mut self, ingress_response: IngressResponse, effects: &mut Effects) {

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -33,6 +33,7 @@ use restate_types::message::MessageIndex;
 use restate_types::state_mut::{ExternalStateMutation, StateMutationVersion};
 use std::future::Future;
 use std::marker::PhantomData;
+use std::time::Duration;
 use tracing::{debug, warn};
 
 pub type ActionCollector = Vec<Action>;
@@ -473,9 +474,11 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                     journal_metadata.clone(),
                     None,
                     service_invocation.method_name.clone(),
-                    service_invocation.response_sink.clone(),
+                    service_invocation.response_sink.iter().cloned().collect(),
                     StatusTimestamps::now(),
                     service_invocation.source,
+                    Duration::ZERO,
+                    None,
                 )),
             )
             .await?;

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -95,7 +95,7 @@ mod tests {
     use restate_service_protocol::codec::ProtobufRawEntryCodec;
     use restate_storage_api::inbox_table::InboxTable;
     use restate_storage_api::invocation_status_table::{
-        InvocationMetadata, InvocationStatus, ReadOnlyInvocationStatusTable,
+        InvocationMetadata, InvocationStatus, InvocationStatusTable, ReadOnlyInvocationStatusTable,
     };
     use restate_storage_api::journal_table::{JournalEntry, ReadOnlyJournalTable};
     use restate_storage_api::outbox_table::OutboxTable;
@@ -107,14 +107,16 @@ mod tests {
     use restate_types::identifiers::{
         FullInvocationId, InvocationId, PartitionId, PartitionKey, ServiceId,
     };
+    use restate_types::ingress::IngressResponse;
     use restate_types::invocation::{
         InvocationResponse, InvocationTermination, MaybeFullInvocationId, ResponseResult,
         ServiceInvocation, ServiceInvocationResponseSink, Source,
     };
     use restate_types::journal::enriched::EnrichedRawEntry;
-    use restate_types::journal::{Completion, CompletionResult};
+    use restate_types::journal::{Completion, CompletionResult, EntryResult};
     use restate_types::journal::{Entry, EntryType};
     use restate_types::state_mut::ExternalStateMutation;
+    use restate_types::GenerationalNodeId;
     use std::collections::{HashMap, HashSet};
     use tempfile::tempdir;
     use test_log::test;
@@ -536,6 +538,79 @@ mod tests {
                     ])
                 ))
             }))
+        );
+
+        state_machine.shutdown().await
+    }
+
+    #[test(tokio::test)]
+    async fn send_ingress_response_to_multiple_targets() -> TestResult {
+        let mut state_machine = MockStateMachine::default();
+        let fid = FullInvocationId::generate(ServiceId::new("MyObj", "MyKey"));
+        let invocation_id = InvocationId::from(&fid);
+
+        let actions = state_machine
+            .apply(Command::Invoke(ServiceInvocation {
+                fid: fid.clone(),
+                method_name: ByteString::from("MyHandler"),
+                argument: Default::default(),
+                source: Source::Ingress,
+                response_sink: Some(ServiceInvocationResponseSink::Ingress(
+                    GenerationalNodeId::new(1, 1),
+                )),
+                span_context: Default::default(),
+                headers: vec![],
+                execution_time: None,
+            }))
+            .await;
+        assert_that!(
+            actions,
+            contains(pat!(Action::Invoke {
+                full_invocation_id: eq(fid.clone()),
+                invoke_input_journal: pat!(InvokeInputJournal::CachedJournal(_, _))
+            }))
+        );
+
+        // Let's add another ingress
+        let mut txn = state_machine.rocksdb_storage.transaction();
+        let mut invocation_status = txn.get_invocation_status(&invocation_id).await.unwrap();
+        invocation_status
+            .get_invocation_metadata_mut()
+            .unwrap()
+            .append_response_sink(ServiceInvocationResponseSink::Ingress(
+                GenerationalNodeId::new(2, 2),
+            ));
+        txn.put_invocation_status(&invocation_id, invocation_status)
+            .await;
+        txn.commit().await.unwrap();
+
+        // Now let's send the output entry
+        let response_bytes = Bytes::from_static(b"123");
+        let actions = state_machine
+            .apply(Command::InvokerEffect(InvokerEffect {
+                full_invocation_id: fid.clone(),
+                kind: InvokerEffectKind::JournalEntry {
+                    entry_index: 1,
+                    entry: ProtobufRawEntryCodec::serialize_enriched(Entry::output(
+                        EntryResult::Success(response_bytes.clone()),
+                    )),
+                },
+            }))
+            .await;
+
+        // At this point we expect the completion to be forwarded to the invoker
+        assert_that!(
+            actions,
+            all!(
+                contains(pat!(Action::IngressResponse(pat!(IngressResponse {
+                    target_node: eq(GenerationalNodeId::new(1, 1)),
+                    response: eq(ResponseResult::Success(response_bytes.clone()))
+                })))),
+                contains(pat!(Action::IngressResponse(pat!(IngressResponse {
+                    target_node: eq(GenerationalNodeId::new(2, 2)),
+                    response: eq(ResponseResult::Success(response_bytes.clone()))
+                })))),
+            )
         );
 
         state_machine.shutdown().await


### PR DESCRIPTION
Based on https://github.com/restatedev/restate/pull/1331, This PR performs the required changes to the PP storage to implement the idempotency business logic. Part of #1324.

* `IdempotencyTable`:
  * Store the mapping `(PP key + component name + [virtual object key]? + handler name + Idempotency key) -> InvocationId`. The `InvocationMetadata` struct is meant to hold eventual additional metadata in future to validate subsequent invocations to the same idempotency key.
* `InvocationStatusTable`:
  * Now `InvocationMetadata` can store multiple response_sinks. This is required to be able to deliver back the response to multiple ingress nodes. The ingress dispatcher themself will handle routing between multiple handlers (next PRs).
  * Add `InvocationStatus::Completed` to retain result of the invocation once completed
  * Add `InvocationMetadata.completion_retention_time`, to configure the retention time of `InvocationStatus::Completed`
  * Add `InvocationMetadata.idempotency_key` to refer to the idempotency key of the invocation, if any

The updated implementation plan is available here https://github.com/restatedev/restate/issues/1324