### PR TITLE
Remove FullInvocationId as dependency to send invocation responses

### DIFF
--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::identifiers::FullInvocationId;
+use crate::identifiers::InvocationId;
 use crate::invocation::ResponseResult;
 use crate::GenerationalNodeId;
 
@@ -16,6 +16,6 @@ use crate::GenerationalNodeId;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IngressResponse {
     pub target_node: GenerationalNodeId,
-    pub full_invocation_id: FullInvocationId,
+    pub invocation_id: InvocationId,
     pub response: ResponseResult,
 }

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -198,7 +198,6 @@ pub enum ServiceInvocationResponseSink {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Source {
     Ingress,
-    // TODO This can be changed to simply InvocationId
     Service(FullInvocationId),
     /// Internal calls for the non-deterministic built-in services
     Internal,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -448,7 +448,7 @@ where
                     .await;
             }
             Action::IngressResponse(ingress_response) => {
-                let invocation_id: InvocationId = ingress_response.full_invocation_id.into();
+                let invocation_id: InvocationId = ingress_response.invocation_id;
                 // NOTE: We dispatch the response in a non-blocking task-center task to avoid
                 // blocking partition processor. This comes with the risk of overwhelming the
                 // runtime. This should be a temporary solution until we have a better way to

--- a/crates/worker/src/partition/services/deterministic/mod.rs
+++ b/crates/worker/src/partition/services/deterministic/mod.rs
@@ -15,7 +15,7 @@ use restate_pb::restate::internal::AwakeablesInvoker;
 use restate_pb::restate::internal::ProxyInvoker;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_types::errors::InvocationError;
-use restate_types::identifiers::FullInvocationId;
+use restate_types::identifiers::{FullInvocationId, InvocationId};
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
 use std::ops::Deref;
@@ -59,7 +59,11 @@ impl<'a> ServiceInvoker<'a> {
         let res = this._invoke(method, argument).await;
 
         if let Some(response_sink) = response_sink {
-            match create_response_message(fid, response_sink.clone(), res.into()) {
+            match create_response_message(
+                &InvocationId::from(fid),
+                response_sink.clone(),
+                res.into(),
+            ) {
                 ResponseMessage::Outbox(outbox) => this.outbox_message(outbox),
                 ResponseMessage::Ingress(ingress) => this.ingress_response(ingress),
             }

--- a/crates/worker/src/partition/services/non_deterministic/idempotent_invoker.rs
+++ b/crates/worker/src/partition/services/non_deterministic/idempotent_invoker.rs
@@ -14,7 +14,7 @@ use crate::partition::types::create_response_message;
 use prost::Message;
 use restate_pb::builtin_service::ResponseSerializer;
 use restate_pb::restate::internal::*;
-use restate_types::identifiers::InvocationUuid;
+use restate_types::identifiers::{InvocationId, InvocationUuid};
 use restate_types::invocation::{ServiceInvocation, SpanRelation};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime};
@@ -188,7 +188,7 @@ impl<'a, State: StateReader + Send + Sync> IdempotentInvokerBuiltInService
             .into_iter()
         {
             self.send_response(create_response_message(
-                &callee_fid,
+                &InvocationId::from(&callee_fid),
                 sink,
                 ResponseResult::Success(encoded_response.clone()),
             ))
@@ -335,7 +335,7 @@ mod tests {
             all!(
                 contains(pat!(BuiltinServiceEffect::IngressResponse(pat!(
                     IngressResponse {
-                        full_invocation_id: eq(expected_fid.clone()),
+                        invocation_id: eq(InvocationId::from(&expected_fid)),
                         response: pat!(ResponseResult::Success(protobuf_decoded(pat!(
                             IdempotentInvokeResponse {
                                 response: some(pat!(
@@ -384,7 +384,7 @@ mod tests {
             all!(
                 contains(pat!(BuiltinServiceEffect::IngressResponse(pat!(
                     IngressResponse {
-                        full_invocation_id: eq(expected_fid),
+                        invocation_id: eq(InvocationId::from(expected_fid)),
                         response: pat!(ResponseResult::Success(protobuf_decoded(pat!(
                             IdempotentInvokeResponse {
                                 response: some(pat!(

--- a/crates/worker/src/partition/services/non_deterministic/mod.rs
+++ b/crates/worker/src/partition/services/non_deterministic/mod.rs
@@ -18,7 +18,7 @@ use restate_pb::restate::internal::IdempotentInvokerInvoker;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_rocksdb::RocksDBStorage;
 use restate_types::errors::InvocationError;
-use restate_types::identifiers::FullInvocationId;
+use restate_types::identifiers::{FullInvocationId, InvocationId};
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{
     ResponseResult, ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
@@ -229,7 +229,7 @@ impl<S: StateReader> InvocationContext<'_, S> {
     fn reply_to_caller(&mut self, res: ResponseResult) {
         if let Some(response_sink) = self.response_sink {
             self.send_response(create_response_message(
-                self.full_invocation_id,
+                &InvocationId::from(self.full_invocation_id),
                 response_sink.clone(),
                 res,
             ));

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -920,7 +920,7 @@ where
             // TODO: We probably only need to send the response if we haven't send a response before
             self.send_response(
                 create_response_message(
-                    full_invocation_id,
+                    &InvocationId::from(full_invocation_id),
                     response_sink,
                     ResponseResult::from(error),
                 ),
@@ -955,7 +955,7 @@ where
 
                     self.send_response(
                         create_response_message(
-                            &full_invocation_id,
+                            &InvocationId::from(&full_invocation_id),
                             response_sink.clone(),
                             result.into(),
                         ),

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -280,19 +280,19 @@ impl Effect {
             ),
             Effect::IngressResponse(IngressResponse {
                 response: ResponseResult::Success(_),
-                full_invocation_id,
+                invocation_id,
                 ..
             }) => debug_if_leader!(
                 is_leader,
-                restate.invocation.id = %full_invocation_id,
+                restate.invocation.id = %invocation_id,
                 "Effect: Send response to ingress: Success"),
             Effect::IngressResponse(IngressResponse {
                 response: ResponseResult::Failure(error_code, error_msg),
-                full_invocation_id,
+                invocation_id,
                 ..
             }) => debug_if_leader!(
                 is_leader,
-                restate.invocation.id = %full_invocation_id,
+                restate.invocation.id = %invocation_id,
                 "Effect: Send response to ingress: Failure(code: {}, msg: {})",
                 error_code,
                 error_msg,

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -10,7 +10,6 @@
 
 use prost::Message;
 use restate_storage_api::outbox_table::OutboxMessage;
-use restate_types::identifiers::FullInvocationId;
 use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{
@@ -56,7 +55,7 @@ impl OutboxMessageExt for OutboxMessage {
 }
 
 pub fn create_response_message(
-    callee: &FullInvocationId,
+    callee: &InvocationId,
     response_sink: ServiceInvocationResponseSink,
     result: ResponseResult,
 ) -> ResponseMessage {
@@ -72,7 +71,7 @@ pub fn create_response_message(
         ServiceInvocationResponseSink::Ingress(ingress_dispatcher_id) => {
             ResponseMessage::Ingress(IngressResponse {
                 target_node: ingress_dispatcher_id,
-                full_invocation_id: callee.clone(),
+                invocation_id: callee.clone(),
                 response: result,
             })
         }
@@ -90,7 +89,7 @@ pub fn create_response_message(
                     caller_context,
                 }
                 .encode_to_vec(),
-                Source::Service(callee.clone()),
+                Source::Internal,
                 None,
                 SpanRelation::None,
                 vec![],


### PR DESCRIPTION
See `create_response_message` signature. This removes the need to store additional data when implementing #1324