### PR TITLE
InvocationStatus::Inboxed

### DIFF
--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -9,13 +9,15 @@
 // by the Apache License, Version 2.0.
 
 use crate::Result;
+use bytes::Bytes;
 use bytestring::ByteString;
 use futures_util::Stream;
 use restate_types::identifiers::{
     DeploymentId, EntryIndex, FullInvocationId, InvocationId, PartitionKey, ServiceId,
 };
 use restate_types::invocation::{
-    ResponseResult, ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
+    Header, InvocationInput, ResponseResult, ServiceInvocation, ServiceInvocationResponseSink,
+    ServiceInvocationSpanContext, Source,
 };
 use restate_types::time::MillisSinceEpoch;
 use std::collections::HashSet;
@@ -67,9 +69,10 @@ impl StatusTimestamps {
 /// Status of an invocation.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub enum InvocationStatus {
-    Invoked(InvocationMetadata),
+    Inboxed(InboxedInvocation),
+    Invoked(InFlightInvocationMetadata),
     Suspended {
-        metadata: InvocationMetadata,
+        metadata: InFlightInvocationMetadata,
         waiting_for_completed_entries: HashSet<EntryIndex>,
     },
     Completed(ResponseResult),
@@ -82,6 +85,7 @@ impl InvocationStatus {
     #[inline]
     pub fn service_id(&self) -> Option<ServiceId> {
         match self {
+            InvocationStatus::Inboxed(metadata) => Some(metadata.service_id.clone()),
             InvocationStatus::Invoked(metadata) => Some(metadata.service_id.clone()),
             InvocationStatus::Suspended { metadata, .. } => Some(metadata.service_id.clone()),
             _ => None,
@@ -116,7 +120,7 @@ impl InvocationStatus {
     }
 
     #[inline]
-    pub fn into_invocation_metadata(self) -> Option<InvocationMetadata> {
+    pub fn into_invocation_metadata(self) -> Option<InFlightInvocationMetadata> {
         match self {
             InvocationStatus::Invoked(metadata) => Some(metadata),
             InvocationStatus::Suspended { metadata, .. } => Some(metadata),
@@ -125,7 +129,7 @@ impl InvocationStatus {
     }
 
     #[inline]
-    pub fn get_invocation_metadata(&self) -> Option<&InvocationMetadata> {
+    pub fn get_invocation_metadata(&self) -> Option<&InFlightInvocationMetadata> {
         match self {
             InvocationStatus::Invoked(metadata) => Some(metadata),
             InvocationStatus::Suspended { metadata, .. } => Some(metadata),
@@ -134,7 +138,7 @@ impl InvocationStatus {
     }
 
     #[inline]
-    pub fn get_invocation_metadata_mut(&mut self) -> Option<&mut InvocationMetadata> {
+    pub fn get_invocation_metadata_mut(&mut self) -> Option<&mut InFlightInvocationMetadata> {
         match self {
             InvocationStatus::Invoked(metadata) => Some(metadata),
             InvocationStatus::Suspended { metadata, .. } => Some(metadata),
@@ -145,6 +149,7 @@ impl InvocationStatus {
     #[inline]
     pub fn get_timestamps(&self) -> Option<&StatusTimestamps> {
         match self {
+            InvocationStatus::Inboxed(metadata) => Some(&metadata.timestamps),
             InvocationStatus::Invoked(metadata) => Some(&metadata.timestamps),
             InvocationStatus::Suspended { metadata, .. } => Some(&metadata.timestamps),
             _ => None,
@@ -153,6 +158,7 @@ impl InvocationStatus {
 
     pub fn update_timestamps(&mut self) {
         match self {
+            InvocationStatus::Inboxed(metadata) => metadata.timestamps.update(),
             InvocationStatus::Invoked(metadata) => metadata.timestamps.update(),
             InvocationStatus::Suspended { metadata, .. } => metadata.timestamps.update(),
             _ => {}
@@ -180,8 +186,54 @@ impl JournalMetadata {
     }
 }
 
+/// This is similar to [ServiceInvocation], but allows many response sinks,
+/// plus holds some inbox metadata.
 #[derive(Debug, Clone, PartialEq)]
-pub struct InvocationMetadata {
+pub struct InboxedInvocation {
+    pub inbox_sequence_number: u64,
+    pub response_sinks: HashSet<ServiceInvocationResponseSink>,
+    pub timestamps: StatusTimestamps,
+
+    // --- From ServiceInvocation
+    // This field and handler_name will be part of a single id with https://github.com/restatedev/restate/issues/1329
+    pub service_id: ServiceId,
+    pub handler_name: ByteString,
+
+    // Could be split out of ServiceInvocation, e.g. InvocationContent or similar.
+    pub argument: Bytes,
+    pub source: Source,
+    pub span_context: ServiceInvocationSpanContext,
+    pub headers: Vec<Header>,
+    /// Time when the request should be executed
+    pub execution_time: Option<MillisSinceEpoch>,
+}
+
+impl InboxedInvocation {
+    pub fn from_service_invocation(
+        service_invocation: ServiceInvocation,
+        inbox_sequence_number: u64,
+    ) -> Self {
+        Self {
+            inbox_sequence_number,
+            response_sinks: service_invocation.response_sink.into_iter().collect(),
+            timestamps: StatusTimestamps::now(),
+            service_id: service_invocation.fid.service_id,
+            handler_name: service_invocation.method_name,
+            argument: service_invocation.argument,
+            source: service_invocation.source,
+            span_context: service_invocation.span_context,
+            headers: service_invocation.headers,
+            execution_time: service_invocation.execution_time,
+        }
+    }
+
+    pub fn append_response_sink(&mut self, new_sink: ServiceInvocationResponseSink) {
+        self.response_sinks.insert(new_sink);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InFlightInvocationMetadata {
     pub service_id: ServiceId,
     pub journal_metadata: JournalMetadata,
     pub deployment_id: Option<DeploymentId>,
@@ -194,31 +246,49 @@ pub struct InvocationMetadata {
     pub idempotency_key: Option<ByteString>,
 }
 
-impl InvocationMetadata {
-    #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::mutable_key_type)]
-    pub fn new(
-        service_id: ServiceId,
-        journal_metadata: JournalMetadata,
-        deployment_id: Option<DeploymentId>,
-        method: ByteString,
-        response_sinks: HashSet<ServiceInvocationResponseSink>,
-        timestamps: StatusTimestamps,
-        source: Source,
-        completion_retention_time: Duration,
-        idempotency_key: Option<ByteString>,
-    ) -> Self {
-        Self {
-            service_id,
-            journal_metadata,
-            deployment_id,
-            method,
-            response_sinks,
-            timestamps,
-            source,
-            completion_retention_time,
-            idempotency_key,
-        }
+impl InFlightInvocationMetadata {
+    pub fn from_service_invocation(
+        service_invocation: ServiceInvocation,
+    ) -> (Self, InvocationInput) {
+        (
+            Self {
+                service_id: service_invocation.fid.service_id,
+                journal_metadata: JournalMetadata::initialize(service_invocation.span_context),
+                deployment_id: None,
+                method: service_invocation.method_name,
+                response_sinks: service_invocation.response_sink.into_iter().collect(),
+                timestamps: StatusTimestamps::now(),
+                source: service_invocation.source,
+                completion_retention_time: Default::default(),
+                idempotency_key: None,
+            },
+            InvocationInput {
+                argument: service_invocation.argument,
+                headers: service_invocation.headers,
+            },
+        )
+    }
+
+    pub fn from_inboxed_invocation(
+        inboxed_invocation: InboxedInvocation,
+    ) -> (Self, InvocationInput) {
+        (
+            Self {
+                service_id: inboxed_invocation.service_id,
+                journal_metadata: JournalMetadata::initialize(inboxed_invocation.span_context),
+                deployment_id: None,
+                method: inboxed_invocation.handler_name,
+                response_sinks: inboxed_invocation.response_sinks,
+                timestamps: inboxed_invocation.timestamps,
+                source: inboxed_invocation.source,
+                completion_retention_time: Default::default(),
+                idempotency_key: None,
+            },
+            InvocationInput {
+                argument: inboxed_invocation.argument,
+                headers: inboxed_invocation.headers,
+            },
+        )
     }
 
     pub fn append_response_sink(&mut self, new_sink: ServiceInvocationResponseSink) {
@@ -255,9 +325,9 @@ pub trait InvocationStatusTable: ReadOnlyInvocationStatusTable {
 mod mocks {
     use super::*;
 
-    impl InvocationMetadata {
+    impl InFlightInvocationMetadata {
         pub fn mock() -> Self {
-            InvocationMetadata {
+            InFlightInvocationMetadata {
                 service_id: ServiceId::new("MyService", "MyKey"),
                 journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
                 deployment_id: None,

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -218,7 +218,7 @@ message StateMutation {
 
 message InboxEntry {
     oneof entry {
-        FullInvocationId invocation = 3;
+        FullInvocationId invocation_id = 3;
         StateMutation state_mutation = 4;
     }
 }

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -106,11 +106,28 @@ message InvocationStatus {
     message Free {
     }
 
+    message Inboxed {
+        uint64 inbox_sequence_number = 1;
+        repeated ServiceInvocationResponseSink response_sinks = 2;
+        uint64 creation_time = 3;
+        uint64 modification_time = 4;
+
+        ServiceId service_id = 5;
+        bytes handler = 6;
+
+        bytes argument = 7;
+        Source source = 8;
+        SpanContext span_context = 9;
+        repeated Header headers = 10;
+        uint64 execution_time = 11;
+    }
+
     oneof status {
         Invoked invoked = 1;
         Suspended suspended = 2;
         Free free = 3;
         Completed completed = 4;
+        Inboxed inboxed = 5;
     }
 }
 
@@ -200,12 +217,8 @@ message StateMutation {
 }
 
 message InboxEntry {
-    // Kept for backwards compatibility, should be removed once no more migrations are needed
-    ServiceInvocation service_invocation = 2;
-
-    // All new InboxEntries should have an entry starting from Restate >= 0.7.1
     oneof entry {
-        ServiceInvocation invocation = 3;
+        FullInvocationId invocation = 3;
         StateMutation state_mutation = 4;
     }
 }

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -665,7 +665,7 @@ pub mod storage {
                 fn try_from(value: InboxEntry) -> Result<Self, Self::Error> {
                     Ok(
                         match value.entry.ok_or(ConversionError::missing_field("entry"))? {
-                            inbox_entry::Entry::Invocation(fid) => {
+                            inbox_entry::Entry::InvocationId(fid) => {
                                 restate_storage_api::inbox_table::InboxEntry::Invocation(
                                     restate_types::identifiers::FullInvocationId::try_from(fid)?,
                                 )
@@ -686,7 +686,7 @@ pub mod storage {
                 fn from(inbox_entry: restate_storage_api::inbox_table::InboxEntry) -> Self {
                     let inbox_entry = match inbox_entry {
                         restate_storage_api::inbox_table::InboxEntry::Invocation(fid) => {
-                            inbox_entry::Entry::Invocation(FullInvocationId::from(fid))
+                            inbox_entry::Entry::InvocationId(FullInvocationId::from(fid))
                         }
                         restate_storage_api::inbox_table::InboxEntry::StateMutation(
                             state_mutation,

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -25,7 +25,7 @@ pub mod storage {
                 Awakeable, BackgroundCall, ClearAllState, ClearState, CompleteAwakeable, Custom,
                 GetState, GetStateKeys, Input, Invoke, Output, SetState, Sleep,
             };
-            use crate::storage::v1::invocation_status::{Free, Invoked, Suspended};
+            use crate::storage::v1::invocation_status::{Free, Inboxed, Invoked, Suspended};
             use crate::storage::v1::journal_entry::completion_result::{Empty, Failure, Success};
             use crate::storage::v1::journal_entry::{
                 completion_result, CompletionResult, Entry, Kind,
@@ -134,9 +134,18 @@ pub mod storage {
                         .status
                         .ok_or(ConversionError::missing_field("status"))?
                     {
+                        invocation_status::Status::Inboxed(inboxed) => {
+                            let invocation_metadata =
+                                restate_storage_api::invocation_status_table::InboxedInvocation::try_from(
+                                    inboxed,
+                                )?;
+                            restate_storage_api::invocation_status_table::InvocationStatus::Inboxed(
+                                invocation_metadata,
+                            )
+                        }
                         invocation_status::Status::Invoked(invoked) => {
                             let invocation_metadata =
-                                restate_storage_api::invocation_status_table::InvocationMetadata::try_from(
+                                restate_storage_api::invocation_status_table::InFlightInvocationMetadata::try_from(
                                     invoked,
                                 )?;
                             restate_storage_api::invocation_status_table::InvocationStatus::Invoked(
@@ -169,6 +178,9 @@ pub mod storage {
                     value: restate_storage_api::invocation_status_table::InvocationStatus,
                 ) -> Self {
                     let status = match value {
+                        restate_storage_api::invocation_status_table::InvocationStatus::Inboxed(
+                            inboxed_status,
+                        ) => invocation_status::Status::Inboxed(Inboxed::from(inboxed_status)),
                         restate_storage_api::invocation_status_table::InvocationStatus::Invoked(
                             invoked_status,
                         ) => invocation_status::Status::Invoked(Invoked::from(invoked_status)),
@@ -197,7 +209,7 @@ pub mod storage {
                 }
             }
 
-            impl TryFrom<Invoked> for restate_storage_api::invocation_status_table::InvocationMetadata {
+            impl TryFrom<Invoked> for restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                 type Error = ConversionError;
 
                 fn try_from(value: Invoked) -> Result<Self, Self::Error> {
@@ -259,29 +271,30 @@ pub mod storage {
                     };
 
                     Ok(
-                        restate_storage_api::invocation_status_table::InvocationMetadata::new(
+                        restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                             service_id,
                             journal_metadata,
                             deployment_id,
-                            method_name,
+                            method: method_name,
                             response_sinks,
-                            restate_storage_api::invocation_status_table::StatusTimestamps::new(
-                                MillisSinceEpoch::new(value.creation_time),
-                                MillisSinceEpoch::new(value.modification_time),
-                            ),
+                            timestamps:
+                                restate_storage_api::invocation_status_table::StatusTimestamps::new(
+                                    MillisSinceEpoch::new(value.creation_time),
+                                    MillisSinceEpoch::new(value.modification_time),
+                                ),
                             source,
                             completion_retention_time,
                             idempotency_key,
-                        ),
+                        },
                     )
                 }
             }
 
-            impl From<restate_storage_api::invocation_status_table::InvocationMetadata> for Invoked {
+            impl From<restate_storage_api::invocation_status_table::InFlightInvocationMetadata> for Invoked {
                 fn from(
-                    value: restate_storage_api::invocation_status_table::InvocationMetadata,
+                    value: restate_storage_api::invocation_status_table::InFlightInvocationMetadata,
                 ) -> Self {
-                    let restate_storage_api::invocation_status_table::InvocationMetadata {
+                    let restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                         service_id,
                         deployment_id,
                         method,
@@ -325,7 +338,7 @@ pub mod storage {
 
             impl TryFrom<Suspended>
                 for (
-                    restate_storage_api::invocation_status_table::InvocationMetadata,
+                    restate_storage_api::invocation_status_table::InFlightInvocationMetadata,
                     HashSet<restate_types::identifiers::EntryIndex>,
                 )
             {
@@ -391,20 +404,22 @@ pub mod storage {
                     };
 
                     Ok((
-                        restate_storage_api::invocation_status_table::InvocationMetadata::new(
+                        restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                             service_id,
                             journal_metadata,
-                            deployment_id.map(|d| d.parse().expect("valid deployment id")),
-                            method_name,
+                            deployment_id: deployment_id
+                                .map(|d| d.parse().expect("valid deployment id")),
+                            method: method_name,
                             response_sinks,
-                            restate_storage_api::invocation_status_table::StatusTimestamps::new(
-                                MillisSinceEpoch::new(value.creation_time),
-                                MillisSinceEpoch::new(value.modification_time),
-                            ),
-                            caller,
+                            timestamps:
+                                restate_storage_api::invocation_status_table::StatusTimestamps::new(
+                                    MillisSinceEpoch::new(value.creation_time),
+                                    MillisSinceEpoch::new(value.modification_time),
+                                ),
+                            source: caller,
                             completion_retention_time,
                             idempotency_key,
-                        ),
+                        },
                         waiting_for_completed_entries,
                     ))
                 }
@@ -412,13 +427,13 @@ pub mod storage {
 
             impl
                 From<(
-                    restate_storage_api::invocation_status_table::InvocationMetadata,
+                    restate_storage_api::invocation_status_table::InFlightInvocationMetadata,
                     HashSet<restate_types::identifiers::EntryIndex>,
                 )> for Suspended
             {
                 fn from(
                     (metadata, waiting_for_completed_entries): (
-                        restate_storage_api::invocation_status_table::InvocationMetadata,
+                        restate_storage_api::invocation_status_table::InFlightInvocationMetadata,
                         HashSet<restate_types::identifiers::EntryIndex>,
                     ),
                 ) -> Self {
@@ -460,6 +475,115 @@ pub mod storage {
                                 invocation_status::suspended::IdempotencyKey::IdempotencyKeyNone(())
                             }
                         }),
+                    }
+                }
+            }
+
+            impl TryFrom<Inboxed> for restate_storage_api::invocation_status_table::InboxedInvocation {
+                type Error = ConversionError;
+
+                fn try_from(value: Inboxed) -> Result<Self, Self::Error> {
+                    let service_id = value
+                        .service_id
+                        .ok_or(ConversionError::missing_field("service_id"))?
+                        .try_into()?;
+
+                    let handler_name = value.handler.try_into().map_err(|e| {
+                        ConversionError::InvalidData(anyhow!(
+                            "Cannot decode method_name string {e}"
+                        ))
+                    })?;
+                    let response_sinks = value
+                        .response_sinks
+                        .into_iter()
+                        .map(|s| {
+                            Ok::<_, ConversionError>(Option::<
+                                restate_types::invocation::ServiceInvocationResponseSink,
+                            >::try_from(s)
+                                .transpose()
+                                .ok_or(ConversionError::missing_field("response_sink"))??)
+                        })
+                        .collect::<Result<HashSet<_>, _>>()?;
+
+                    let source = restate_types::invocation::Source::try_from(
+                        value
+                            .source
+                            .ok_or(ConversionError::missing_field("source"))?,
+                    )?;
+
+                    let span_context =
+                        restate_types::invocation::ServiceInvocationSpanContext::try_from(
+                            value
+                                .span_context
+                                .ok_or(ConversionError::missing_field("span_context"))?,
+                        )?;
+                    let headers = value
+                        .headers
+                        .into_iter()
+                        .map(|h| restate_types::invocation::Header::try_from(h))
+                        .collect::<Result<Vec<_>, ConversionError>>()?;
+
+                    let execution_time = if value.execution_time == 0 {
+                        None
+                    } else {
+                        Some(MillisSinceEpoch::new(value.execution_time))
+                    };
+
+                    Ok(
+                        restate_storage_api::invocation_status_table::InboxedInvocation {
+                            inbox_sequence_number: value.inbox_sequence_number,
+                            response_sinks,
+                            timestamps:
+                                restate_storage_api::invocation_status_table::StatusTimestamps::new(
+                                    MillisSinceEpoch::new(value.creation_time),
+                                    MillisSinceEpoch::new(value.modification_time),
+                                ),
+                            service_id,
+                            handler_name,
+                            source,
+                            span_context,
+                            headers,
+                            argument: value.argument,
+                            execution_time,
+                        },
+                    )
+                }
+            }
+
+            impl From<restate_storage_api::invocation_status_table::InboxedInvocation> for Inboxed {
+                fn from(
+                    value: restate_storage_api::invocation_status_table::InboxedInvocation,
+                ) -> Self {
+                    let restate_storage_api::invocation_status_table::InboxedInvocation {
+                        inbox_sequence_number,
+                        service_id,
+                        response_sinks,
+                        timestamps,
+                        handler_name,
+                        argument,
+                        source,
+                        span_context,
+                        headers,
+                        execution_time,
+                    } = value;
+
+                    let headers = headers.into_iter().map(Into::into).collect();
+
+                    Inboxed {
+                        inbox_sequence_number,
+                        service_id: Some(service_id.into()),
+                        handler: handler_name.into_bytes(),
+                        response_sinks: response_sinks
+                            .into_iter()
+                            .map(|s| ServiceInvocationResponseSink::from(Some(s)))
+                            .collect(),
+                        creation_time: timestamps.creation_time().as_u64(),
+                        modification_time: timestamps.modification_time().as_u64(),
+                        source: Some(Source::from(source)),
+                        span_context: Some(SpanContext::from(span_context)),
+                        headers,
+                        argument,
+                        execution_time: execution_time.map(|m| m.as_u64()).unwrap_or_default(),
                     }
                 }
             }
@@ -539,21 +663,11 @@ pub mod storage {
                 type Error = ConversionError;
 
                 fn try_from(value: InboxEntry) -> Result<Self, Self::Error> {
-                    // Backwards compatibility to support Restate <= 0.7
-                    let inbox_entry = if let Some(service_invocation) = value.service_invocation {
-                        restate_storage_api::inbox_table::InboxEntry::Invocation(
-                            restate_types::invocation::ServiceInvocation::try_from(
-                                service_invocation,
-                            )?,
-                        )
-                    } else {
-                        // All InboxEntries starting with Restate >= 0.7.1 should have the entry field set
+                    Ok(
                         match value.entry.ok_or(ConversionError::missing_field("entry"))? {
-                            inbox_entry::Entry::Invocation(service_invocation) => {
+                            inbox_entry::Entry::Invocation(fid) => {
                                 restate_storage_api::inbox_table::InboxEntry::Invocation(
-                                    restate_types::invocation::ServiceInvocation::try_from(
-                                        service_invocation,
-                                    )?,
+                                    restate_types::identifiers::FullInvocationId::try_from(fid)?,
                                 )
                             }
                             inbox_entry::Entry::StateMutation(state_mutation) => {
@@ -563,29 +677,23 @@ pub mod storage {
                                     )?,
                                 )
                             }
-                        }
-                    };
-
-                    Ok(inbox_entry)
+                        },
+                    )
                 }
             }
 
             impl From<restate_storage_api::inbox_table::InboxEntry> for InboxEntry {
                 fn from(inbox_entry: restate_storage_api::inbox_table::InboxEntry) -> Self {
                     let inbox_entry = match inbox_entry {
-                        restate_storage_api::inbox_table::InboxEntry::Invocation(
-                            service_invocation,
-                        ) => inbox_entry::Entry::Invocation(ServiceInvocation::from(
-                            service_invocation,
-                        )),
+                        restate_storage_api::inbox_table::InboxEntry::Invocation(fid) => {
+                            inbox_entry::Entry::Invocation(FullInvocationId::from(fid))
+                        }
                         restate_storage_api::inbox_table::InboxEntry::StateMutation(
                             state_mutation,
                         ) => inbox_entry::Entry::StateMutation(StateMutation::from(state_mutation)),
                     };
 
                     InboxEntry {
-                        // Backwards compatibility to support Restate <= 0.7
-                        service_invocation: None,
                         entry: Some(inbox_entry),
                     }
                 }

--- a/crates/storage-query-datafusion/src/inbox/schema.rs
+++ b/crates/storage-query-datafusion/src/inbox/schema.rs
@@ -18,18 +18,11 @@ define_table!(inbox(
     partition_key: DataType::UInt64,
 
     component: DataType::LargeUtf8,
-    handler: DataType::LargeUtf8,
-
     component_key: DataType::LargeUtf8,
 
     id: DataType::LargeUtf8,
 
     sequence_number: DataType::UInt64,
-
-    invoked_by: DataType::LargeUtf8,
-    invoked_by_component: DataType::LargeUtf8,
-    invoked_by_id: DataType::LargeUtf8,
-    trace_id: DataType::LargeUtf8,
 
     created_at: DataType::Date64,
 ));

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -11,7 +11,7 @@
 use crate::invocation_status::schema::{InvocationStatusBuilder, InvocationStatusRowBuilder};
 use crate::table_util::format_using;
 use restate_storage_api::invocation_status_table::{
-    InvocationMetadata, InvocationStatus, JournalMetadata, StatusTimestamps,
+    InFlightInvocationMetadata, InvocationStatus, JournalMetadata, StatusTimestamps,
 };
 use restate_storage_rocksdb::invocation_status_table::OwnedInvocationStatusRow;
 use restate_types::identifiers::InvocationId;
@@ -51,6 +51,10 @@ pub(crate) fn append_invocation_status_row(
 
     // Additional invocation metadata
     let metadata = match status_row.invocation_status {
+        InvocationStatus::Inboxed(_) => {
+            row.status("inboxed");
+            None
+        }
         InvocationStatus::Invoked(metadata) => {
             row.status("invoked");
             Some(metadata)
@@ -77,7 +81,7 @@ pub(crate) fn append_invocation_status_row(
 fn fill_invocation_metadata(
     row: &mut InvocationStatusRowBuilder,
     output: &mut String,
-    meta: InvocationMetadata,
+    meta: InFlightInvocationMetadata,
 ) {
     // journal_metadata and stats are filled by other functions
     row.handler(meta.method);

--- a/crates/storage-rocksdb/tests/inbox_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/inbox_table_test/mod.rs
@@ -8,19 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{assert_stream_eq, mock_service_invocation, mock_state_mutation};
+use crate::{assert_stream_eq, mock_full_invocation_id, mock_state_mutation};
 use once_cell::sync::Lazy;
 use restate_storage_api::inbox_table::{InboxEntry, InboxTable, SequenceNumberInboxEntry};
 use restate_storage_api::Transaction;
 use restate_storage_rocksdb::RocksDBStorage;
-use restate_test_util::let_assert;
-use restate_types::identifiers::{InvocationId, ServiceId};
+use restate_types::identifiers::ServiceId;
 
 static INBOX_ENTRIES: Lazy<Vec<SequenceNumberInboxEntry>> = Lazy::new(|| {
     vec![
         SequenceNumberInboxEntry::new(
             7,
-            InboxEntry::Invocation(mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
+            InboxEntry::Invocation(mock_full_invocation_id(ServiceId::new("svc-1", "key-1"))),
         ),
         SequenceNumberInboxEntry::new(
             8,
@@ -28,11 +27,11 @@ static INBOX_ENTRIES: Lazy<Vec<SequenceNumberInboxEntry>> = Lazy::new(|| {
         ),
         SequenceNumberInboxEntry::new(
             9,
-            InboxEntry::Invocation(mock_service_invocation(ServiceId::new("svc-2", "key-1"))),
+            InboxEntry::Invocation(mock_full_invocation_id(ServiceId::new("svc-2", "key-1"))),
         ),
         SequenceNumberInboxEntry::new(
             10,
-            InboxEntry::Invocation(mock_service_invocation(ServiceId::new("svc-1", "key-1"))),
+            InboxEntry::Invocation(mock_full_invocation_id(ServiceId::new("svc-1", "key-1"))),
         ),
     ]
 });
@@ -75,94 +74,16 @@ async fn peek_after_delete<T: InboxTable>(table: &mut T) {
     assert_eq!(result.unwrap(), Some(INBOX_ENTRIES[1].clone()));
 }
 
-async fn get_invocations<T: InboxTable>(table: &mut T) {
-    for expected_inbox_entry in INBOX_ENTRIES.iter() {
-        if let InboxEntry::Invocation(expected_invocation) = &expected_inbox_entry.inbox_entry {
-            let actual_inbox_entry = table
-                .get_invocation(expected_invocation.fid.clone())
-                .await
-                .unwrap()
-                .unwrap();
-
-            assert_eq!(
-                actual_inbox_entry.inbox_sequence_number,
-                expected_inbox_entry.inbox_sequence_number
-            );
-            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
-
-            let actual_inbox_entry = table
-                .get_invocation(InvocationId::from(&expected_invocation.fid))
-                .await
-                .unwrap()
-                .unwrap();
-
-            assert_eq!(
-                actual_inbox_entry.inbox_sequence_number,
-                expected_inbox_entry.inbox_sequence_number
-            );
-            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
-        }
-    }
-
-    let not_existing_entry = table
-        .get_invocation(InvocationId::mock_random())
-        .await
-        .unwrap();
-
-    assert!(not_existing_entry.is_none());
-}
-
-async fn get_invocations_after_delete<T: InboxTable>(table: &mut T) {
-    let mut inbox_entries_iterator = INBOX_ENTRIES.iter();
-
-    let inbox_entry = inbox_entries_iterator.next().unwrap();
-
-    let_assert!(InboxEntry::Invocation(invocation) = &inbox_entry.inbox_entry);
-
-    let not_existing_entry = table.get_invocation(invocation.fid.clone()).await.unwrap();
-    assert!(not_existing_entry.is_none());
-
-    for expected_inbox_entry in inbox_entries_iterator {
-        if let InboxEntry::Invocation(expected_invocation) = &expected_inbox_entry.inbox_entry {
-            let actual_inbox_entry = table
-                .get_invocation(expected_invocation.fid.clone())
-                .await
-                .unwrap()
-                .unwrap();
-
-            assert_eq!(
-                actual_inbox_entry.inbox_sequence_number,
-                expected_inbox_entry.inbox_sequence_number
-            );
-            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
-
-            let actual_inbox_entry = table
-                .get_invocation(InvocationId::from(&expected_invocation.fid))
-                .await
-                .unwrap()
-                .unwrap();
-
-            assert_eq!(
-                actual_inbox_entry.inbox_sequence_number,
-                expected_inbox_entry.inbox_sequence_number
-            );
-            assert_eq!(actual_inbox_entry.invocation, *expected_invocation);
-        }
-    }
-}
-
 pub(crate) async fn run_tests(mut rocksdb: RocksDBStorage) {
     let mut txn = rocksdb.transaction();
     populate_data(&mut txn).await;
 
     find_the_next_message_in_an_inbox(&mut txn).await;
     get_svc_inbox(&mut txn).await;
-    get_invocations(&mut txn).await;
     delete_entry(&mut txn).await;
 
     txn.commit().await.expect("should not fail");
 
     let mut txn = rocksdb.transaction();
     peek_after_delete(&mut txn).await;
-    get_invocations_after_delete(&mut txn).await;
 }

--- a/crates/storage-rocksdb/tests/integration_test.rs
+++ b/crates/storage-rocksdb/tests/integration_test.rs
@@ -68,6 +68,10 @@ async fn test_read_write() {
     close.await;
 }
 
+pub(crate) fn mock_full_invocation_id(service_id: ServiceId) -> FullInvocationId {
+    FullInvocationId::generate(service_id)
+}
+
 pub(crate) fn mock_service_invocation(service_id: ServiceId) -> ServiceInvocation {
     ServiceInvocation::new(
         FullInvocationId::generate(service_id),

--- a/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
@@ -11,7 +11,8 @@
 use crate::assert_stream_eq;
 use once_cell::sync::Lazy;
 use restate_storage_api::invocation_status_table::{
-    InvocationMetadata, InvocationStatus, InvocationStatusTable, JournalMetadata, StatusTimestamps,
+    InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable, JournalMetadata,
+    StatusTimestamps,
 };
 use restate_storage_rocksdb::RocksDBStorage;
 use restate_types::identifiers::{
@@ -47,32 +48,32 @@ static INVOCATION_ID_3: Lazy<InvocationId> = Lazy::new(|| {
 });
 
 fn invoked_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
-    InvocationStatus::Invoked(InvocationMetadata::new(
-        service_id.into(),
-        JournalMetadata::new(0, ServiceInvocationSpanContext::empty()),
-        None,
-        "service".into(),
-        HashSet::new(),
-        StatusTimestamps::new(MillisSinceEpoch::new(0), MillisSinceEpoch::new(0)),
-        Source::Ingress,
-        Duration::ZERO,
-        None,
-    ))
+    InvocationStatus::Invoked(InFlightInvocationMetadata {
+        service_id: service_id.into(),
+        journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
+        deployment_id: None,
+        method: "service".into(),
+        response_sinks: HashSet::new(),
+        timestamps: StatusTimestamps::new(MillisSinceEpoch::new(0), MillisSinceEpoch::new(0)),
+        source: Source::Ingress,
+        completion_retention_time: Duration::ZERO,
+        idempotency_key: None,
+    })
 }
 
 fn suspended_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
     InvocationStatus::Suspended {
-        metadata: InvocationMetadata::new(
-            service_id.into(),
-            JournalMetadata::new(0, ServiceInvocationSpanContext::empty()),
-            None,
-            "service".into(),
-            HashSet::new(),
-            StatusTimestamps::new(MillisSinceEpoch::new(0), MillisSinceEpoch::new(0)),
-            Source::Ingress,
-            Duration::ZERO,
-            None,
-        ),
+        metadata: InFlightInvocationMetadata {
+            service_id: service_id.into(),
+            journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
+            deployment_id: None,
+            method: "service".into(),
+            response_sinks: HashSet::new(),
+            timestamps: StatusTimestamps::new(MillisSinceEpoch::new(0), MillisSinceEpoch::new(0)),
+            source: Source::Ingress,
+            completion_retention_time: Duration::ZERO,
+            idempotency_key: None,
+        },
         waiting_for_completed_entries: HashSet::default(),
     }
 }

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -77,6 +77,12 @@ impl ServiceInvocation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InvocationInput {
+    pub argument: Bytes,
+    pub headers: Vec<Header>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MaybeFullInvocationId {
     Partial(InvocationId),
     Full(FullInvocationId),

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -489,7 +489,7 @@ where
                 effects,
             ),
             _ => {
-                trace!("Received kill command for unknown invocation with id '{maybe_fid}'.");
+                trace!("Received cancel command for unknown invocation with id '{maybe_fid}'.");
                 // We still try to send the abort signal to the invoker,
                 // as it might be the case that previously the user sent an abort signal
                 // but some message was still between the invoker/PP queues.

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -13,19 +13,18 @@ use super::{Effects, Error};
 use crate::partition::services::non_deterministic;
 use crate::partition::state_machine::actions::Action;
 use crate::partition::state_machine::effects::Effect;
+use assert2::let_assert;
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use restate_invoker_api::InvokeInputJournal;
 use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
-use restate_storage_api::invocation_status_table::{
-    InvocationMetadata, InvocationStatus, JournalMetadata, StatusTimestamps,
-};
+use restate_storage_api::invocation_status_table::{InFlightInvocationMetadata, InvocationStatus};
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::service_status_table::VirtualObjectStatus;
 use restate_storage_api::timer_table::{Timer, TimerKey};
 use restate_storage_api::Result as StorageResult;
 use restate_types::identifiers::{EntryIndex, FullInvocationId, InvocationId, ServiceId};
-use restate_types::invocation::ServiceInvocation;
+use restate_types::invocation::InvocationInput;
 use restate_types::journal::enriched::{EnrichedEntryHeader, EnrichedRawEntry};
 use restate_types::journal::raw::{PlainRawEntry, RawEntryCodec};
 use restate_types::journal::{Completion, CompletionResult, EntryType};
@@ -33,7 +32,6 @@ use restate_types::message::MessageIndex;
 use restate_types::state_mut::{ExternalStateMutation, StateMutationVersion};
 use std::future::Future;
 use std::marker::PhantomData;
-use std::time::Duration;
 use tracing::{debug, warn};
 
 pub type ActionCollector = Vec<Action>;
@@ -170,7 +168,9 @@ pub(crate) struct EffectInterpreter<Codec> {
 }
 
 impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
-    pub(crate) async fn interpret_effects<S: StateStorage>(
+    pub(crate) async fn interpret_effects<
+        S: StateStorage + restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable,
+    >(
         effects: &mut Effects,
         state_storage: &mut S,
         action_collector: &mut ActionCollector,
@@ -182,14 +182,26 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
         Ok(())
     }
 
-    async fn interpret_effect<S: StateStorage>(
+    async fn interpret_effect<
+        S: StateStorage + restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable,
+    >(
         effect: Effect,
         state_storage: &mut S,
         collector: &mut ActionCollector,
     ) -> Result<(), Error> {
         match effect {
             Effect::InvokeService(service_invocation) => {
-                Self::invoke_service(state_storage, collector, service_invocation).await?;
+                let invocation_id = InvocationId::from(&service_invocation.fid);
+                let (in_flight_invocation_meta, invocation_input) =
+                    InFlightInvocationMetadata::from_service_invocation(service_invocation);
+                Self::invoke_service(
+                    state_storage,
+                    collector,
+                    invocation_id,
+                    in_flight_invocation_meta,
+                    invocation_input,
+                )
+                .await?;
             }
             Effect::ResumeService {
                 invocation_id,
@@ -220,6 +232,16 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                             waiting_for_completed_entries,
                         },
                     )
+                    .await?;
+            }
+            Effect::StoreInboxedInvocation(invocation_id, inboxed) => {
+                state_storage
+                    .store_invocation_status(&invocation_id, InvocationStatus::Inboxed(inboxed))
+                    .await?;
+            }
+            Effect::FreeInvocation(invocation_id) => {
+                state_storage
+                    .store_invocation_status(&invocation_id, InvocationStatus::Free)
                     .await?;
             }
             Effect::EnqueueIntoInbox {
@@ -360,7 +382,7 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
             Effect::TraceInvocationResult { .. } | Effect::TraceBackgroundInvoke { .. } => {
                 // these effects are only needed for span creation
             }
-            Effect::AbortInvocation(full_invocation_id) => {
+            Effect::SendAbortInvocationToInvoker(full_invocation_id) => {
                 collector.push(Action::AbortInvocation(full_invocation_id))
             }
             Effect::SendStoredEntryAckToInvoker(full_invocation_id, entry_index) => {
@@ -386,13 +408,31 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
         service_id: &ServiceId,
     ) -> Result<(), Error>
     where
-        S: StateStorage,
+        S: StateStorage
+            + restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable,
     {
-        // pop until we find the first invocation that we can invoke
+        // Pop until we find the first inbox entry.
+        // Note: the inbox seq numbers can have gaps.
         while let Some(inbox_entry) = state_storage.pop_inbox(service_id).await? {
             match inbox_entry.inbox_entry {
-                InboxEntry::Invocation(service_invocation) => {
-                    Self::invoke_service(state_storage, collector, service_invocation).await?;
+                InboxEntry::Invocation(fid) => {
+                    let invocation_id = InvocationId::from(fid);
+
+                    let inboxed_status =
+                        state_storage.get_invocation_status(&invocation_id).await?;
+
+                    let_assert!(InvocationStatus::Inboxed(inboxed_invocation) = inboxed_status);
+
+                    let (in_flight_invocation_meta, invocation_input) =
+                        InFlightInvocationMetadata::from_inboxed_invocation(inboxed_invocation);
+                    Self::invoke_service(
+                        state_storage,
+                        collector,
+                        invocation_id,
+                        in_flight_invocation_meta,
+                        invocation_input,
+                    )
+                    .await?;
                     return Ok(());
                 }
                 InboxEntry::StateMutation(state_mutation) => {
@@ -452,81 +492,83 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
     async fn invoke_service<S: StateStorage>(
         state_storage: &mut S,
         collector: &mut ActionCollector,
-        service_invocation: ServiceInvocation,
+        invocation_id: InvocationId,
+        mut in_flight_invocation_metadata: InFlightInvocationMetadata,
+        invocation_input: InvocationInput,
     ) -> Result<(), Error> {
-        let journal_metadata = JournalMetadata::new(
-            1, // initial length is 1, because we store the poll input stream entry
-            service_invocation.span_context.clone(),
+        let full_invocation_id = FullInvocationId::combine(
+            in_flight_invocation_metadata.service_id.clone(),
+            invocation_id.clone(),
         );
 
-        let invocation_id = InvocationId::from(&service_invocation.fid);
+        // In our current data model, ServiceInvocation has always an input, so initial length is 1
+        in_flight_invocation_metadata.journal_metadata.length = 1;
+
         state_storage
             .store_service_status(
-                &service_invocation.fid.service_id,
+                &in_flight_invocation_metadata.service_id,
                 VirtualObjectStatus::Locked(invocation_id.clone()),
             )
             .await?;
         state_storage
             .store_invocation_status(
                 &invocation_id,
-                InvocationStatus::Invoked(InvocationMetadata::new(
-                    service_invocation.fid.service_id.clone(),
-                    journal_metadata.clone(),
-                    None,
-                    service_invocation.method_name.clone(),
-                    service_invocation.response_sink.iter().cloned().collect(),
-                    StatusTimestamps::now(),
-                    service_invocation.source,
-                    Duration::ZERO,
-                    None,
-                )),
+                InvocationStatus::Invoked(in_flight_invocation_metadata.clone()),
             )
             .await?;
 
         let input_entry = if non_deterministic::ServiceInvoker::is_supported(
-            &service_invocation.fid.service_id.service_name,
+            &full_invocation_id.service_id.service_name,
         ) {
+            debug_assert!(
+                in_flight_invocation_metadata.response_sinks.len() <= 1,
+                "At most one response sink is supported for built-in services"
+            );
+
             collector.push(Action::InvokeBuiltInService {
-                full_invocation_id: service_invocation.fid.clone(),
-                span_context: service_invocation.span_context,
-                response_sink: service_invocation.response_sink,
-                method: service_invocation.method_name,
-                argument: service_invocation.argument.clone(),
+                full_invocation_id,
+                span_context: in_flight_invocation_metadata.journal_metadata.span_context,
+                response_sink: in_flight_invocation_metadata
+                    .response_sinks
+                    .into_iter()
+                    .next(),
+                method: in_flight_invocation_metadata.method,
+                argument: invocation_input.argument.clone(),
             });
 
             // TODO clean up custom entry hack by allowing to store bytes directly?
             EnrichedRawEntry::new(
                 EnrichedEntryHeader::Custom { code: 0 },
-                service_invocation.argument,
+                invocation_input.argument,
             )
         } else {
-            let poll_input_stream_entry = Codec::serialize_as_input_entry(
-                service_invocation.headers,
-                service_invocation.argument.clone(),
+            let input_entry = Codec::serialize_as_input_entry(
+                invocation_input.headers,
+                invocation_input.argument,
             );
-            let (header, serialized_entry) = poll_input_stream_entry.into_inner();
+            let (entry_header, serialized_entry) = input_entry.into_inner();
 
             collector.push(Action::Invoke {
-                full_invocation_id: service_invocation.fid.clone(),
+                full_invocation_id,
                 invoke_input_journal: InvokeInputJournal::CachedJournal(
                     restate_invoker_api::JournalMetadata::new(
-                        journal_metadata.length,
-                        journal_metadata.span_context,
-                        service_invocation.method_name.clone(),
+                        in_flight_invocation_metadata.journal_metadata.length,
+                        in_flight_invocation_metadata.journal_metadata.span_context,
+                        in_flight_invocation_metadata.method.clone(),
                         None,
                     ),
                     vec![PlainRawEntry::new(
-                        header.clone().erase_enrichment(),
+                        entry_header.clone().erase_enrichment(),
                         serialized_entry.clone(),
                     )],
                 ),
             });
 
-            EnrichedRawEntry::new(header, serialized_entry)
+            EnrichedRawEntry::new(entry_header, serialized_entry)
         };
 
         state_storage
-            .store_journal_entry(&InvocationId::from(&service_invocation.fid), 0, input_entry)
+            .store_journal_entry(&invocation_id, 0, input_entry)
             .await?;
 
         Ok(())

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -421,7 +421,11 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                     let inboxed_status =
                         state_storage.get_invocation_status(&invocation_id).await?;
 
-                    let_assert!(InvocationStatus::Inboxed(inboxed_invocation) = inboxed_status);
+                    let_assert!(
+                        InvocationStatus::Inboxed(inboxed_invocation) = inboxed_status,
+                        "InvocationStatus must contain an Inboxed invocation for the id {}",
+                        invocation_id
+                    );
 
                     let (in_flight_invocation_meta, invocation_input) =
                         InFlightInvocationMetadata::from_inboxed_invocation(inboxed_invocation);

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -15,9 +15,7 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use metrics::counter;
 use restate_storage_api::deduplication_table::ReadOnlyDeduplicationTable;
 use restate_storage_api::fsm_table::ReadOnlyFsmTable;
-use restate_storage_api::inbox_table::{
-    InboxEntry, SequenceNumberInboxEntry, SequenceNumberInvocation,
-};
+use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadOnlyInvocationStatusTable,
 };
@@ -36,7 +34,6 @@ use restate_types::identifiers::{
     EntryIndex, FullInvocationId, InvocationId, PartitionId, PartitionKey, ServiceId,
     WithPartitionKey,
 };
-use restate_types::invocation::MaybeFullInvocationId;
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::CompletionResult;
 use restate_types::logs::Lsn;
@@ -294,15 +291,6 @@ where
     ) -> StorageResult<InvocationStatus> {
         self.assert_partition_key(invocation_id);
         self.inner.get_invocation_status(invocation_id).await
-    }
-
-    fn get_inboxed_invocation(
-        &mut self,
-        maybe_fid: impl Into<MaybeFullInvocationId>,
-    ) -> impl Future<Output = StorageResult<Option<SequenceNumberInvocation>>> + Send {
-        let maybe_fid = maybe_fid.into();
-        self.assert_partition_key(&maybe_fid);
-        self.inner.get_invocation(maybe_fid)
     }
 
     // Returns true if the entry is a completable journal entry and is completed,
@@ -607,6 +595,25 @@ where
         journal_length: EntryIndex,
     ) -> impl Stream<Item = StorageResult<(EntryIndex, JournalEntry)>> + Send {
         self.inner.get_journal(invocation_id, journal_length)
+    }
+}
+
+impl<TransactionType> ReadOnlyInvocationStatusTable for Transaction<TransactionType>
+where
+    TransactionType: restate_storage_api::Transaction + Send,
+{
+    fn get_invocation_status(
+        &mut self,
+        invocation_id: &InvocationId,
+    ) -> impl Future<Output = StorageResult<InvocationStatus>> + Send {
+        self.inner.get_invocation_status(invocation_id)
+    }
+
+    fn invoked_invocations(
+        &mut self,
+        partition_key_range: RangeInclusive<PartitionKey>,
+    ) -> impl Stream<Item = StorageResult<FullInvocationId>> + Send {
+        self.inner.invoked_invocations(partition_key_range)
     }
 }
 


### PR DESCRIPTION
Store the metadata about the inboxed invocation in the invocation status table.

This simplifies a bunch of problems, such as terminating inboxed invocations and the upcoming issue of inboxed idempoten invocations (described in  https://github.com/restatedev/restate/pull/1326)