### PR TITLE
Send output on `InvokerEffectKind::End`

### DIFF
--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -597,7 +597,16 @@ mod tests {
                 },
             }))
             .await;
+        // No ingress response is expected at this point because the invocation did not end yet
+        assert_that!(actions, not(contains(pat!(Action::IngressResponse(_)))));
 
+        // Send the End Effect
+        let actions = state_machine
+            .apply(Command::InvokerEffect(InvokerEffect {
+                full_invocation_id: fid.clone(),
+                kind: InvokerEffectKind::End,
+            }))
+            .await;
         // At this point we expect the completion to be forwarded to the invoker
         assert_that!(
             actions,

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -274,6 +274,8 @@ where
     }
 }
 
+// Avoid adding methods here, but rather use directly the storage_api traits!!!
+// See https://github.com/restatedev/restate/issues/276
 impl<TransactionType> super::state_machine::StateReader for Transaction<TransactionType>
 where
     TransactionType: restate_storage_api::Transaction + Send,
@@ -356,6 +358,8 @@ where
     }
 }
 
+// Avoid adding methods here, but rather use directly the storage_api traits!!!
+// See https://github.com/restatedev/restate/issues/276
 impl<TransactionType> super::state_machine::StateStorage for Transaction<TransactionType>
 where
     TransactionType: restate_storage_api::Transaction + Send,
@@ -581,6 +585,28 @@ where
     async fn delete_timer(&mut self, timer_key: &TimerKey) -> StorageResult<()> {
         self.inner.delete_timer(self.partition_id, timer_key).await;
         Ok(())
+    }
+}
+
+// Workaround until https://github.com/restatedev/restate/issues/276 is sorted out
+impl<TransactionType> ReadOnlyJournalTable for Transaction<TransactionType>
+where
+    TransactionType: restate_storage_api::Transaction + Send,
+{
+    fn get_journal_entry(
+        &mut self,
+        invocation_id: &InvocationId,
+        journal_index: u32,
+    ) -> impl Future<Output = StorageResult<Option<JournalEntry>>> + Send {
+        self.inner.get_journal_entry(invocation_id, journal_index)
+    }
+
+    fn get_journal(
+        &mut self,
+        invocation_id: &InvocationId,
+        journal_length: EntryIndex,
+    ) -> impl Stream<Item = StorageResult<(EntryIndex, JournalEntry)>> + Send {
+        self.inner.get_journal(invocation_id, journal_length)
     }
 }
 


### PR DESCRIPTION
And not anymore when receiving the `Output` entry. We need this for #1324 to avoid an interleaving issue between new invocations and output/end invoker effects.