### PR TITLE
Implement business logic of idempotent invocations

### DIFF
--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -137,6 +137,7 @@ impl DispatchIngressRequest for IngressDispatcher {
                         span_context,
                         headers,
                         execution_time: None,
+                        idempotency: None,
                     },
                     MapResponseAction::IdempotentInvokerResponse,
                 )
@@ -151,6 +152,7 @@ impl DispatchIngressRequest for IngressDispatcher {
                         span_context,
                         headers,
                         execution_time: None,
+                        idempotency: None,
                     },
                     MapResponseAction::None,
                 )

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -101,6 +101,12 @@ message InvocationStatus {
 
     message Completed {
         ResponseResult result = 1;
+        ServiceId service_id = 2;
+        bytes handler_name = 3;
+        oneof idempotency_key {
+            google.protobuf.Empty idempotency_key_none = 12;
+            string idempotency_key_value = 13;
+        }
     }
 
     message Free {
@@ -120,6 +126,7 @@ message InvocationStatus {
         SpanContext span_context = 9;
         repeated Header headers = 10;
         uint64 execution_time = 11;
+        IdempotentRequestMetadata idempotency = 12;
     }
 
     oneof status {
@@ -208,6 +215,7 @@ message ServiceInvocation {
     Source source = 6;
     repeated Header headers = 7;
     uint64 execution_time = 8;
+    IdempotentRequestMetadata idempotency = 9;
 }
 
 message StateMutation {
@@ -414,9 +422,14 @@ message Timer {
         bytes service_key = 2;
     }
 
+    message CleanInvocationStatus {
+        bytes invocation_id = 1;
+    }
+
     oneof value {
         CompleteSleepEntry complete_sleep_entry = 100;
         ServiceInvocation invoke = 101;
+        CleanInvocationStatus clean_invocation_status = 102;
     }
 }
 
@@ -452,4 +465,9 @@ message DedupSequenceNumber {
 
 message IdempotencyMetadata {
     bytes invocation_id = 1;
+}
+
+message IdempotentRequestMetadata {
+    string key = 1;
+    Duration retention = 2;
 }

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -25,7 +25,9 @@ pub mod storage {
                 Awakeable, BackgroundCall, ClearAllState, ClearState, CompleteAwakeable, Custom,
                 GetState, GetStateKeys, Input, Invoke, Output, SetState, Sleep,
             };
-            use crate::storage::v1::invocation_status::{Free, Inboxed, Invoked, Suspended};
+            use crate::storage::v1::invocation_status::{
+                Completed, Free, Inboxed, Invoked, Suspended,
+            };
             use crate::storage::v1::journal_entry::completion_result::{Empty, Failure, Success};
             use crate::storage::v1::journal_entry::{
                 completion_result, CompletionResult, Entry, Kind,
@@ -42,17 +44,18 @@ pub mod storage {
                 invocation_status, maybe_full_invocation_id, outbox_message, response_result,
                 service_status, source, span_relation, timer, BackgroundCallResolutionResult,
                 DedupSequenceNumber, Duration, EnrichedEntryHeader, EpochSequenceNumber,
-                FullInvocationId, Header, IdempotencyMetadata, InboxEntry,
-                InvocationResolutionResult, InvocationStatus, JournalEntry, JournalMeta, KvPair,
-                MaybeFullInvocationId, OutboxMessage, ResponseResult, ServiceId, ServiceInvocation,
-                ServiceInvocationResponseSink, ServiceStatus, Source, SpanContext, SpanRelation,
-                StateMutation, Timer,
+                FullInvocationId, Header, IdempotencyMetadata, IdempotentRequestMetadata,
+                InboxEntry, InvocationResolutionResult, InvocationStatus, JournalEntry,
+                JournalMeta, KvPair, MaybeFullInvocationId, OutboxMessage, ResponseResult,
+                ServiceId, ServiceInvocation, ServiceInvocationResponseSink, ServiceStatus, Source,
+                SpanContext, SpanRelation, StateMutation, Timer,
             };
             use anyhow::anyhow;
             use bytes::{Buf, Bytes};
             use bytestring::ByteString;
             use opentelemetry_api::trace::TraceState;
             use restate_storage_api::StorageError;
+            use restate_types::errors::IdDecodeError;
             use restate_types::identifiers::InvocationUuid;
             use restate_types::invocation::{InvocationTermination, TerminationFlavor};
             use restate_types::journal::enriched::AwakeableEnrichmentResult;
@@ -77,6 +80,12 @@ pub mod storage {
 
                 pub fn missing_field(field: &'static str) -> Self {
                     ConversionError::MissingField(field)
+                }
+            }
+
+            impl From<IdDecodeError> for ConversionError {
+                fn from(value: IdDecodeError) -> Self {
+                    ConversionError::invalid_data(value)
                 }
             }
 
@@ -161,7 +170,7 @@ pub mod storage {
                         }
                         invocation_status::Status::Completed(completed) => {
                             restate_storage_api::invocation_status_table::InvocationStatus::Completed(
-                                completed.result.ok_or(ConversionError::missing_field("result"))?.try_into()?
+                                completed.try_into()?
                             )
                         }
                         invocation_status::Status::Free(_) => {
@@ -191,12 +200,8 @@ pub mod storage {
                             metadata,
                             waiting_for_completed_entries,
                         ))),
-                        restate_storage_api::invocation_status_table::InvocationStatus::Completed(
-                        result
-                        ) => invocation_status::Status::Completed(
-                            invocation_status::Completed {
-                                result: Some(ResponseResult::from(result)),
-                            }
+                        restate_storage_api::invocation_status_table::InvocationStatus::Completed(completed) => invocation_status::Status::Completed(
+                            Completed::from(completed)
                             ),
                         restate_storage_api::invocation_status_table::InvocationStatus::Free => {
                             invocation_status::Status::Free(Free {})
@@ -529,6 +534,11 @@ pub mod storage {
                         Some(MillisSinceEpoch::new(value.execution_time))
                     };
 
+                    let idempotency = value
+                        .idempotency
+                        .map(restate_types::invocation::Idempotency::try_from)
+                        .transpose()?;
+
                     Ok(
                         restate_storage_api::invocation_status_table::InboxedInvocation {
                             inbox_sequence_number: value.inbox_sequence_number,
@@ -545,6 +555,7 @@ pub mod storage {
                             headers,
                             argument: value.argument,
                             execution_time,
+                            idempotency,
                         },
                     )
                 }
@@ -565,6 +576,7 @@ pub mod storage {
                         span_context,
                         headers,
                         execution_time,
+                        idempotency,
                     } = value;
 
                     let headers = headers.into_iter().map(Into::into).collect();
@@ -584,6 +596,73 @@ pub mod storage {
                         headers,
                         argument,
                         execution_time: execution_time.map(|m| m.as_u64()).unwrap_or_default(),
+                        idempotency: idempotency.map(Into::into),
+                    }
+                }
+            }
+
+            impl TryFrom<Completed> for restate_storage_api::invocation_status_table::CompletedInvocation {
+                type Error = ConversionError;
+
+                fn try_from(value: Completed) -> Result<Self, Self::Error> {
+                    let handler_name = value.handler_name.try_into().map_err(|e| {
+                        ConversionError::InvalidData(anyhow!(
+                            "Cannot decode method_name string {e}"
+                        ))
+                    })?;
+
+                    let idempotency_key = match value
+                        .idempotency_key
+                        .ok_or(ConversionError::missing_field("idempotency_key"))?
+                    {
+                        invocation_status::completed::IdempotencyKey::IdempotencyKeyValue(key) => {
+                            Some(ByteString::from(key))
+                        }
+                        invocation_status::completed::IdempotencyKey::IdempotencyKeyNone(_) => None,
+                    };
+
+                    Ok(
+                        restate_storage_api::invocation_status_table::CompletedInvocation {
+                            service_id: value
+                                .service_id
+                                .ok_or(ConversionError::missing_field("service_id"))?
+                                .try_into()?,
+                            handler: handler_name,
+                            response_result: value
+                                .result
+                                .ok_or(ConversionError::missing_field("result"))?
+                                .try_into()?,
+                            idempotency_key,
+                        },
+                    )
+                }
+            }
+
+            impl From<restate_storage_api::invocation_status_table::CompletedInvocation> for Completed {
+                fn from(
+                    value: restate_storage_api::invocation_status_table::CompletedInvocation,
+                ) -> Self {
+                    let restate_storage_api::invocation_status_table::CompletedInvocation {
+                        service_id,
+                        handler,
+                        idempotency_key,
+                        response_result,
+                    } = value;
+
+                    Completed {
+                        result: Some(ResponseResult::from(response_result)),
+                        service_id: Some(service_id.into()),
+                        handler_name: handler.into_bytes(),
+                        idempotency_key: Some(match idempotency_key {
+                            Some(key) => {
+                                invocation_status::completed::IdempotencyKey::IdempotencyKeyValue(
+                                    key.to_string(),
+                                )
+                            }
+                            _ => {
+                                invocation_status::completed::IdempotencyKey::IdempotencyKeyNone(())
+                            }
+                        }),
                     }
                 }
             }
@@ -712,6 +791,7 @@ pub mod storage {
                         source,
                         headers,
                         execution_time,
+                        idempotency,
                     } = value;
 
                     let id = restate_types::identifiers::FullInvocationId::try_from(
@@ -747,6 +827,10 @@ pub mod storage {
                         Some(MillisSinceEpoch::new(execution_time))
                     };
 
+                    let idempotency = idempotency
+                        .map(restate_types::invocation::Idempotency::try_from)
+                        .transpose()?;
+
                     Ok(restate_types::invocation::ServiceInvocation {
                         fid: id,
                         method_name,
@@ -756,6 +840,7 @@ pub mod storage {
                         span_context,
                         headers,
                         execution_time,
+                        idempotency,
                     })
                 }
             }
@@ -781,6 +866,32 @@ pub mod storage {
                             .execution_time
                             .map(|m| m.as_u64())
                             .unwrap_or_default(),
+                        idempotency: value.idempotency.map(Into::into),
+                    }
+                }
+            }
+
+            impl TryFrom<IdempotentRequestMetadata> for restate_types::invocation::Idempotency {
+                type Error = ConversionError;
+
+                fn try_from(value: IdempotentRequestMetadata) -> Result<Self, Self::Error> {
+                    let retention: std::time::Duration = value
+                        .retention
+                        .ok_or(ConversionError::missing_field("retention"))?
+                        .try_into()?;
+
+                    Ok(Self {
+                        key: ByteString::from(value.key),
+                        retention,
+                    })
+                }
+            }
+
+            impl From<restate_types::invocation::Idempotency> for IdempotentRequestMetadata {
+                fn from(value: restate_types::invocation::Idempotency) -> Self {
+                    Self {
+                        key: value.key.to_string(),
+                        retention: Some(value.retention.into()),
                     }
                 }
             }
@@ -1776,6 +1887,13 @@ pub mod storage {
                                     restate_types::invocation::ServiceInvocation::try_from(si)?,
                                 )
                             }
+                            timer::Value::CleanInvocationStatus(clean_invocation_status) => {
+                                restate_storage_api::timer_table::Timer::CleanInvocationStatus(
+                                    restate_types::identifiers::InvocationId::from_slice(
+                                        &clean_invocation_status.invocation_id,
+                                    )?,
+                                )
+                            }
                         },
                     )
                 }
@@ -1783,20 +1901,28 @@ pub mod storage {
 
             impl From<restate_storage_api::timer_table::Timer> for Timer {
                 fn from(value: restate_storage_api::timer_table::Timer) -> Self {
-                    match value {
-                        restate_storage_api::timer_table::Timer::CompleteSleepEntry(service_id) => {
-                            Timer {
-                                value: Some(timer::Value::CompleteSleepEntry(
-                                    timer::CompleteSleepEntry {
-                                        service_name: service_id.service_name.into_bytes(),
-                                        service_key: service_id.key,
-                                    },
-                                )),
+                    Timer {
+                        value: Some(match value {
+                            restate_storage_api::timer_table::Timer::CompleteSleepEntry(
+                                service_id,
+                            ) => timer::Value::CompleteSleepEntry(timer::CompleteSleepEntry {
+                                service_name: service_id.service_name.into_bytes(),
+                                service_key: service_id.key,
+                            }),
+
+                            restate_storage_api::timer_table::Timer::Invoke(si) => {
+                                timer::Value::Invoke(ServiceInvocation::from(si))
                             }
-                        }
-                        restate_storage_api::timer_table::Timer::Invoke(si) => Timer {
-                            value: Some(timer::Value::Invoke(ServiceInvocation::from(si))),
-                        },
+                            restate_storage_api::timer_table::Timer::CleanInvocationStatus(
+                                invocation_id,
+                            ) => {
+                                timer::Value::CleanInvocationStatus(timer::CleanInvocationStatus {
+                                    invocation_id: Bytes::copy_from_slice(
+                                        &invocation_id.to_bytes(),
+                                    ),
+                                })
+                            }
+                        }),
                     }
                 }
             }

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -67,7 +67,7 @@ pub(crate) fn append_invocation_status_row(
             row.status("free");
             None
         }
-        InvocationStatus::Completed(_) => {
+        InvocationStatus::Completed { .. } => {
             row.status("completed");
             None
         }

--- a/crates/storage-rocksdb/tests/integration_test.rs
+++ b/crates/storage-rocksdb/tests/integration_test.rs
@@ -82,6 +82,7 @@ pub(crate) fn mock_service_invocation(service_id: ServiceId) -> ServiceInvocatio
         SpanRelation::None,
         vec![],
         None,
+        None,
     )
 }
 
@@ -102,6 +103,7 @@ pub(crate) fn mock_random_service_invocation() -> ServiceInvocation {
         None,
         SpanRelation::None,
         vec![],
+        None,
         None,
     )
 }

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -75,6 +75,7 @@ pub mod codes {
     pub const UNKNOWN: InvocationErrorCode = INTERNAL;
     pub const ABORTED: InvocationErrorCode = InvocationErrorCode(409);
     pub const KILLED: InvocationErrorCode = ABORTED;
+    pub const GONE: InvocationErrorCode = InvocationErrorCode(410);
     pub const JOURNAL_MISMATCH: InvocationErrorCode = InvocationErrorCode(570);
     pub const PROTOCOL_VIOLATION: InvocationErrorCode = InvocationErrorCode(571);
 }
@@ -200,6 +201,8 @@ pub const KILLED_INVOCATION_ERROR: InvocationError =
 //  UserErrorCode::Cancelled, we need to add a new RestateErrorCode.
 pub const CANCELED_INVOCATION_ERROR: InvocationError =
     InvocationError::new_static(codes::ABORTED, "canceled");
+
+pub const GONE_INVOCATION_ERROR: InvocationError = InvocationError::new_static(codes::GONE, "gone");
 
 /// Error parsing/decoding a resource ID.
 #[derive(Debug, thiserror::Error, Clone, Eq, PartialEq)]

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -22,6 +22,7 @@ use opentelemetry_api::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags,
 use opentelemetry_api::Context;
 use std::fmt;
 use std::str::FromStr;
+use std::time::Duration;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -42,6 +43,13 @@ pub struct ServiceInvocation {
     pub headers: Vec<Header>,
     /// Time when the request should be executed
     pub execution_time: Option<MillisSinceEpoch>,
+    pub idempotency: Option<Idempotency>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Idempotency {
+    pub key: ByteString,
+    pub retention: Duration,
 }
 
 impl ServiceInvocation {
@@ -61,6 +69,7 @@ impl ServiceInvocation {
         related_span: SpanRelation,
         headers: Vec<Header>,
         execution_time: Option<MillisSinceEpoch>,
+        idempotency: Option<Idempotency>,
     ) -> Self {
         let span_context = ServiceInvocationSpanContext::start(&fid, related_span);
         Self {
@@ -72,7 +81,14 @@ impl ServiceInvocation {
             span_context,
             headers,
             execution_time,
+            idempotency,
         }
+    }
+}
+
+impl WithPartitionKey for ServiceInvocation {
+    fn partition_key(&self) -> PartitionKey {
+        self.fid.partition_key()
     }
 }
 
@@ -562,6 +578,7 @@ mod mocks {
                 span_context: Default::default(),
                 headers: vec![],
                 execution_time: None,
+                idempotency: None,
             }
         }
     }

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -130,6 +130,8 @@ pub enum Command {
     InvokerEffect(restate_invoker_api::Effect),
     /// Timer has fired
     Timer(TimerValue),
+    /// Schedule timer
+    ScheduleTimer(TimerValue),
     /// Another partition processor is reporting a response of an invocation we requested.
     InvocationResponse(InvocationResponse),
     /// A built-in invoker reporting effects from an invocation.

--- a/crates/wal-protocol/src/timer.rs
+++ b/crates/wal-protocol/src/timer.rs
@@ -79,10 +79,7 @@ impl TimerValue {
     }
 
     pub fn invocation_id(&self) -> InvocationId {
-        InvocationId::new(
-            self.value.service_id().partition_key(),
-            self.timer_key.0.invocation_uuid,
-        )
+        InvocationId::new(self.value.partition_key(), self.timer_key.0.invocation_uuid)
     }
 
     pub fn wake_up_time(&self) -> MillisSinceEpoch {

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -101,6 +101,8 @@ impl ActionEffectHandler {
                 }
             }
             ActionEffect::ScheduleCleanupTimer(invocation_id, duration) => {
+                // We need this self proposal because we need to agree between leaders and followers on the wakeup time.
+                //  We can get rid of this once we'll have a synchronized clock between leaders/followers.
                 let header = self.create_header(invocation_id.partition_key());
                 append_envelope_to_bifrost(
                     &mut self.bifrost,

--- a/crates/worker/src/partition/services/deterministic/proxy.rs
+++ b/crates/worker/src/partition/services/deterministic/proxy.rs
@@ -36,6 +36,7 @@ impl ProxyBuiltInService for &mut ServiceInvoker<'_> {
             self.span_context.as_parent(),
             vec![],
             None,
+            None,
         )));
 
         Ok(())

--- a/crates/worker/src/partition/services/non_deterministic/idempotent_invoker.rs
+++ b/crates/worker/src/partition/services/non_deterministic/idempotent_invoker.rs
@@ -116,6 +116,7 @@ impl<'a, State: StateReader + Send + Sync> IdempotentInvokerBuiltInService
             self.span_context.as_parent(),
             vec![], // TODO we need to fix the data structure passed as input of this invoke method to be as close as possible to the original ServiceInvocation.
             None,
+            None,
         )));
 
         Ok(())
@@ -177,6 +178,7 @@ impl<'a, State: StateReader + Send + Sync> IdempotentInvokerBuiltInService
             SpanRelation::None,
             vec![],
             Some(idempotency_expiration_time.into()),
+            None,
         )));
 
         // Send response to registered sinks

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -13,12 +13,13 @@ use bytestring::ByteString;
 use restate_invoker_api::InvokeInputJournal;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::timer_table::TimerKey;
-use restate_types::identifiers::{EntryIndex, FullInvocationId};
+use restate_types::identifiers::{EntryIndex, FullInvocationId, InvocationId};
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
 use restate_types::journal::Completion;
 use restate_types::message::MessageIndex;
 use restate_wal_protocol::timer::TimerValue;
+use std::time::Duration;
 
 #[derive(Debug)]
 pub enum Action {
@@ -53,4 +54,8 @@ pub enum Action {
     },
     AbortInvocation(FullInvocationId),
     IngressResponse(IngressResponse),
+    ScheduleInvocationStatusCleanup {
+        invocation_id: InvocationId,
+        retention: Duration,
+    },
 }

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -21,9 +21,10 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use futures::{Stream, StreamExt};
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
+use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
 use restate_storage_api::inbox_table::InboxEntry;
 use restate_storage_api::invocation_status_table::{
-    InFlightInvocationMetadata, InboxedInvocation, InvocationStatus,
+    CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation, InvocationStatus,
 };
 use restate_storage_api::journal_table::{JournalEntry, ReadOnlyJournalTable};
 use restate_storage_api::outbox_table::OutboxMessage;
@@ -31,11 +32,12 @@ use restate_storage_api::service_status_table::VirtualObjectStatus;
 use restate_storage_api::timer_table::{Timer, TimerKey};
 use restate_storage_api::Result as StorageResult;
 use restate_types::errors::{
-    InvocationError, InvocationErrorCode, CANCELED_INVOCATION_ERROR, KILLED_INVOCATION_ERROR,
+    InvocationError, InvocationErrorCode, CANCELED_INVOCATION_ERROR, GONE_INVOCATION_ERROR,
+    KILLED_INVOCATION_ERROR,
 };
 use restate_types::identifiers::{
-    EntryIndex, FullInvocationId, InvocationId, InvocationUuid, PartitionKey, ServiceId,
-    WithPartitionKey,
+    EntryIndex, FullInvocationId, IdempotencyId, InvocationId, InvocationUuid, PartitionKey,
+    ServiceId, WithPartitionKey,
 };
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{
@@ -147,7 +149,9 @@ where
     ///
     /// We use the returned service invocation id and span relation to log the effects (see [`Effects#log`]).
     #[instrument(level = "trace", skip_all, fields(command = ?command), err)]
-    pub(crate) async fn on_apply<State: StateReader + ReadOnlyJournalTable>(
+    pub(crate) async fn on_apply<
+        State: StateReader + ReadOnlyJournalTable + ReadOnlyIdempotencyTable,
+    >(
         &mut self,
         command: Command,
         effects: &mut Effects,
@@ -195,20 +199,55 @@ where
                 // no-op :-)
                 Ok((None, SpanRelation::None))
             }
+            Command::ScheduleTimer(timer) => {
+                effects.register_timer(timer, Default::default());
+                Ok((None, SpanRelation::None))
+            }
         }
     }
 
-    async fn handle_invoke<State: StateReader>(
+    async fn handle_invoke<State: StateReader + ReadOnlyIdempotencyTable>(
         &mut self,
         effects: &mut Effects,
         state: &mut State,
         service_invocation: ServiceInvocation,
     ) -> Result<(Option<FullInvocationId>, SpanRelation), Error> {
         debug_assert!(
-            self.partition_key_range.contains(&service_invocation.fid.partition_key()),
+            self.partition_key_range.contains(&service_invocation.partition_key()),
                 "Service invocation with partition key '{}' has been delivered to a partition processor with key range '{:?}'. This indicates a bug.",
-                service_invocation.fid.partition_key(),
+                service_invocation.partition_key(),
                 self.partition_key_range);
+
+        // If an idempotency key is set, handle idempotency
+        if let Some(idempotency) = &service_invocation.idempotency {
+            let idempotency_id = IdempotencyId::new(
+                service_invocation.fid.service_id.service_name.clone(),
+                // The service_id.key will always be the idempotency key now,
+                // until we get rid of that field for regular services with https://github.com/restatedev/restate/issues/1329
+                Some(service_invocation.fid.service_id.key.clone()),
+                service_invocation.method_name.clone(),
+                idempotency.key.clone(),
+            );
+            if self
+                .try_resolve_idempotent_request(
+                    effects,
+                    state,
+                    &idempotency_id,
+                    &InvocationId::from(&service_invocation.fid),
+                    service_invocation.response_sink.as_ref(),
+                )
+                .await?
+            {
+                // Invocation was either resolved, or the sink was enqueued. Nothing else to do here.
+                return Ok((
+                    Some(service_invocation.fid),
+                    service_invocation.span_context.as_parent(),
+                ));
+            }
+            // Idempotent invocation needs to be processed for the first time, let's roll!
+            effects
+                .store_idempotency_id(idempotency_id, InvocationId::from(&service_invocation.fid));
+        }
 
         // If an execution_time is set, we schedule the invocation to be processed later
         if let Some(execution_time) = service_invocation.execution_time {
@@ -261,6 +300,67 @@ where
         effects.enqueue_into_inbox(self.inbox_seq_number, inbox_entry);
         self.inbox_seq_number += 1;
         inbox_seq_number
+    }
+
+    /// If true is returned, the request has been resolved and no further processing is needed
+    async fn try_resolve_idempotent_request<State: StateReader + ReadOnlyIdempotencyTable>(
+        &mut self,
+        effects: &mut Effects,
+        state: &mut State,
+        idempotency_id: &IdempotencyId,
+        caller_id: &InvocationId,
+        response_sink: Option<&ServiceInvocationResponseSink>,
+    ) -> Result<bool, Error> {
+        if let Some(idempotency_meta) = state.get_idempotency_metadata(idempotency_id).await? {
+            let original_invocation_id = idempotency_meta.invocation_id;
+            match state.get_invocation_status(&original_invocation_id).await? {
+                executing_invocation_status @ InvocationStatus::Invoked(_)
+                | executing_invocation_status @ InvocationStatus::Suspended { .. } => {
+                    if let Some(response_sink) = response_sink {
+                        if !executing_invocation_status
+                            .get_invocation_metadata()
+                            .expect("InvocationMetadata must be present")
+                            .response_sinks
+                            .contains(response_sink)
+                        {
+                            effects.append_response_sink(
+                                original_invocation_id,
+                                executing_invocation_status,
+                                response_sink.clone(),
+                            )
+                        }
+                    }
+                }
+                InvocationStatus::Inboxed(inboxed) => {
+                    if let Some(response_sink) = response_sink {
+                        if !inboxed.response_sinks.contains(response_sink) {
+                            effects.append_response_sink(
+                                original_invocation_id,
+                                InvocationStatus::Inboxed(inboxed),
+                                response_sink.clone(),
+                            )
+                        }
+                    }
+                }
+                InvocationStatus::Completed(completed) => {
+                    self.send_response_to_sinks(
+                        effects,
+                        caller_id,
+                        response_sink.cloned(),
+                        completed.response_result,
+                    );
+                }
+                InvocationStatus::Free => self.send_response_to_sinks(
+                    effects,
+                    caller_id,
+                    response_sink.cloned(),
+                    GONE_INVOCATION_ERROR,
+                ),
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     async fn handle_external_state_mutation<State: StateReader>(
@@ -361,7 +461,7 @@ where
             BuiltinServiceEffect::End(Some(e)) => {
                 self.fail_invocation(
                     effects,
-                    full_invocation_id.clone(),
+                    InvocationId::from(full_invocation_id),
                     invocation_metadata.clone(),
                     e,
                 )
@@ -563,7 +663,7 @@ where
 
         self.fail_invocation(
             effects,
-            full_invocation_id.clone(),
+            InvocationId::from(&full_invocation_id),
             metadata,
             KILLED_INVOCATION_ERROR,
         )
@@ -726,7 +826,7 @@ where
         }
     }
 
-    async fn on_timer<State: StateReader>(
+    async fn on_timer<State: StateReader + ReadOnlyIdempotencyTable>(
         &mut self,
         timer_value: TimerValue,
         state: &mut State,
@@ -761,6 +861,39 @@ where
                 // ServiceInvocations scheduled with a timer are always owned by the same partition processor
                 // where the invocation should be executed
                 self.handle_invoke(effects, state, service_invocation).await
+            }
+            Timer::CleanInvocationStatus(invocation_id) => {
+                match state.get_invocation_status(&invocation_id).await? {
+                    InvocationStatus::Completed(CompletedInvocation {
+                        service_id,
+                        handler,
+                        idempotency_key: Some(idempotency_key),
+                        ..
+                    }) => {
+                        effects.free_invocation(invocation_id);
+                        // Also cleanup the associated idempotency key
+                        effects.delete_idempotency_id(IdempotencyId::new(
+                            service_id.service_name,
+                            // The service_id.key will always be the idempotency key now,
+                            // until we get rid of that field for regular services with https://github.com/restatedev/restate/issues/1329
+                            Some(service_id.key),
+                            handler,
+                            idempotency_key,
+                        ));
+                    }
+                    InvocationStatus::Completed(_) => {
+                        // Just free the invocation
+                        effects.free_invocation(invocation_id);
+                    }
+                    InvocationStatus::Free => {
+                        // Nothing to do
+                    }
+                    _ => {
+                        panic!("Unexpected state. Trying to cleanup an invocation that did not complete yet.")
+                    }
+                };
+
+                Ok((None, SpanRelation::None))
             }
         }
     }
@@ -855,12 +988,22 @@ where
                 }
             }
             InvokerEffectKind::End => {
-                self.end_invocation(state, effects, full_invocation_id, invocation_metadata)
-                    .await?;
+                self.end_invocation(
+                    state,
+                    effects,
+                    InvocationId::from(&full_invocation_id),
+                    invocation_metadata,
+                )
+                .await?;
             }
             InvokerEffectKind::Failed(e) => {
-                self.fail_invocation(effects, full_invocation_id, invocation_metadata, e)
-                    .await?;
+                self.fail_invocation(
+                    effects,
+                    InvocationId::from(&full_invocation_id),
+                    invocation_metadata,
+                    e,
+                )
+                .await?;
             }
         }
 
@@ -871,69 +1014,81 @@ where
         &mut self,
         state: &mut State,
         effects: &mut Effects,
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         invocation_metadata: InFlightInvocationMetadata,
     ) -> Result<(), Error> {
-        // Send response back, if anyone is interested
-        if !invocation_metadata.response_sinks.is_empty() {
-            let invocation_id = InvocationId::from(&full_invocation_id);
-
-            // Find last output entry
-            let mut output_entry = None;
-            for i in (0..invocation_metadata.journal_metadata.length).rev() {
-                if let JournalEntry::Entry(e) = state
-                    .get_journal_entry(&invocation_id, i)
-                    .await?
-                    .unwrap_or_else(|| panic!("There should be a journal entry at index {}", i))
-                {
-                    if e.ty() == EntryType::Output {
-                        output_entry = Some(e);
-                        break;
-                    }
-                }
-            }
-
-            if let Some(output_entry) = output_entry {
-                let_assert!(
-                    Entry::Output(OutputEntry { result }) =
-                        output_entry.deserialize_entry_ref::<Codec>()?
-                );
-                self.send_response_to_sinks(
-                    effects,
-                    &InvocationId::from(&full_invocation_id),
-                    invocation_metadata.response_sinks.clone(),
-                    result,
-                );
-            } else {
-                // We don't panic on this, although it indicates a bug at the moment.
-                warn!("Invocation completed without an output entry. This is not supported yet.");
-                return Ok(());
-            }
-        }
+        let service_id = invocation_metadata.service_id.clone();
+        let journal_length = invocation_metadata.journal_metadata.length;
+        let completion_retention_time = invocation_metadata.completion_retention_time;
 
         self.notify_invocation_result(
-            &full_invocation_id,
-            invocation_metadata.method,
-            invocation_metadata.journal_metadata.span_context,
+            &FullInvocationId::combine(
+                invocation_metadata.service_id.clone(),
+                invocation_id.clone(),
+            ),
+            invocation_metadata.method.clone(),
+            invocation_metadata.journal_metadata.span_context.clone(),
             invocation_metadata.timestamps.creation_time(),
             Ok(()),
             effects,
         );
 
-        self.end_invocation_lifecycle(
-            full_invocation_id,
-            invocation_metadata.journal_metadata.length,
-            effects,
-        )
-        .await
+        // If there are any response sinks, or we need to store back the completed status,
+        //  we need to find the latest output entry
+        if !invocation_metadata.response_sinks.is_empty() || !completion_retention_time.is_zero() {
+            let result = if let Some(output_entry) = self
+                .read_last_output_entry(state, &invocation_id, journal_length)
+                .await?
+            {
+                ResponseResult::from(output_entry.result)
+            } else {
+                // We don't panic on this, although it indicates a bug at the moment.
+                warn!("Invocation completed without an output entry. This is not supported yet.");
+                return Ok(());
+            };
+
+            // Send responses out
+            self.send_response_to_sinks(
+                effects,
+                &invocation_id,
+                invocation_metadata.response_sinks.clone(),
+                result.clone(),
+            );
+
+            // Store the completed status, if needed
+            if !completion_retention_time.is_zero() {
+                let (completed_invocation, completion_retention_time) =
+                    CompletedInvocation::from_in_flight_invocation_metadata(
+                        invocation_metadata,
+                        result,
+                    );
+                effects.store_completed_invocation(
+                    invocation_id.clone(),
+                    completion_retention_time,
+                    completed_invocation,
+                );
+            }
+        }
+
+        // If no retention, immediately cleanup the invocation status
+        if completion_retention_time.is_zero() {
+            effects.free_invocation(invocation_id.clone());
+        }
+        effects.drop_journal(invocation_id, journal_length);
+        effects.pop_inbox(service_id);
+
+        Ok(())
     }
 
+    // This needs a different method because for built-in invocations we send back the output as soon as we have it.
     async fn end_built_in_invocation(
         &mut self,
         effects: &mut Effects,
         full_invocation_id: FullInvocationId,
         invocation_metadata: InFlightInvocationMetadata,
     ) -> Result<(), Error> {
+        let invocation_id = InvocationId::from(&full_invocation_id);
+
         self.notify_invocation_result(
             &full_invocation_id,
             invocation_metadata.method,
@@ -943,43 +1098,65 @@ where
             effects,
         );
 
-        self.end_invocation_lifecycle(
-            full_invocation_id,
-            invocation_metadata.journal_metadata.length,
-            effects,
-        )
-        .await
+        effects.free_invocation(invocation_id.clone());
+        effects.drop_journal(invocation_id, invocation_metadata.journal_metadata.length);
+        effects.pop_inbox(full_invocation_id.service_id);
+
+        Ok(())
     }
 
     async fn fail_invocation(
         &mut self,
         effects: &mut Effects,
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         invocation_metadata: InFlightInvocationMetadata,
         error: InvocationError,
     ) -> Result<(), Error> {
-        self.send_response_to_sinks(
-            effects,
-            &InvocationId::from(&full_invocation_id),
-            invocation_metadata.response_sinks,
-            &error,
-        );
+        let service_id = invocation_metadata.service_id.clone();
+        let journal_length = invocation_metadata.journal_metadata.length;
 
         self.notify_invocation_result(
-            &full_invocation_id,
-            invocation_metadata.method,
-            invocation_metadata.journal_metadata.span_context,
+            &FullInvocationId::combine(
+                invocation_metadata.service_id.clone(),
+                invocation_id.clone(),
+            ),
+            invocation_metadata.method.clone(),
+            invocation_metadata.journal_metadata.span_context.clone(),
             invocation_metadata.timestamps.creation_time(),
             Err((error.code(), error.to_string())),
             effects,
         );
 
-        self.end_invocation_lifecycle(
-            full_invocation_id,
-            invocation_metadata.journal_metadata.length,
+        let response_result = ResponseResult::from(error);
+
+        // Send responses out
+        self.send_response_to_sinks(
             effects,
-        )
-        .await
+            &invocation_id,
+            invocation_metadata.response_sinks.clone(),
+            response_result.clone(),
+        );
+
+        // Store the completed status or free it
+        if !invocation_metadata.completion_retention_time.is_zero() {
+            let (completed_invocation, completion_retention_time) =
+                CompletedInvocation::from_in_flight_invocation_metadata(
+                    invocation_metadata,
+                    response_result,
+                );
+            effects.store_completed_invocation(
+                invocation_id.clone(),
+                completion_retention_time,
+                completed_invocation,
+            );
+        } else {
+            effects.free_invocation(invocation_id.clone());
+        }
+
+        effects.drop_journal(invocation_id, journal_length);
+        effects.pop_inbox(service_id);
+
+        Ok(())
     }
 
     fn send_response_to_sinks(
@@ -1340,6 +1517,35 @@ where
         })
     }
 
+    async fn read_last_output_entry<State: ReadOnlyJournalTable>(
+        &mut self,
+        state: &mut State,
+        invocation_id: &InvocationId,
+        journal_length: EntryIndex,
+    ) -> Result<Option<OutputEntry>, Error> {
+        // Find last output entry
+        let mut output_entry = None;
+        for i in (0..journal_length).rev() {
+            if let JournalEntry::Entry(e) = state
+                .get_journal_entry(invocation_id, i)
+                .await?
+                .unwrap_or_else(|| panic!("There should be a journal entry at index {}", i))
+            {
+                if e.ty() == EntryType::Output {
+                    output_entry = Some(e);
+                    break;
+                }
+            }
+        }
+
+        output_entry
+            .map(|enriched_entry| {
+                let_assert!(Entry::Output(e) = enriched_entry.deserialize_entry_ref::<Codec>()?);
+                Ok(e)
+            })
+            .transpose()
+    }
+
     async fn handle_deterministic_built_in_service_invocation(
         &mut self,
         invocation: ServiceInvocation,
@@ -1382,17 +1588,6 @@ where
             creation_time,
             result,
         );
-    }
-
-    async fn end_invocation_lifecycle(
-        &mut self,
-        full_invocation_id: FullInvocationId,
-        journal_length: EntryIndex,
-        effects: &mut Effects,
-    ) -> Result<(), Error> {
-        effects.drop_journal_and_pop_inbox(full_invocation_id, journal_length);
-
-        Ok(())
     }
 
     fn handle_outgoing_message(&mut self, message: OutboxMessage, effects: &mut Effects) {
@@ -1455,6 +1650,7 @@ where
             span_context,
             headers: vec![],
             execution_time,
+            idempotency: None,
         }
     }
 }

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -238,15 +238,11 @@ impl ReadOnlyJournalTable for StateReaderMock {
 }
 
 impl ReadOnlyIdempotencyTable for StateReaderMock {
-    fn get_idempotency_metadata(
+    async fn get_idempotency_metadata(
         &mut self,
         _idempotency_id: &IdempotencyId,
-    ) -> impl Future<Output = StorageResult<Option<IdempotencyMetadata>>> + Send {
+    ) -> StorageResult<Option<IdempotencyMetadata>> {
         unimplemented!();
-
-        // Code inference for impl Future won't work without this
-        #[allow(unreachable_code)]
-        futures::future::ok(None)
     }
 }
 

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -9,6 +9,7 @@ use restate_invoker_api::EffectKind;
 use restate_service_protocol::awakeable_id::AwakeableIdentifier;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_service_protocol::pb::protocol::SleepEntryMessage;
+use restate_storage_api::idempotency_table::IdempotencyMetadata;
 use restate_storage_api::inbox_table::SequenceNumberInboxEntry;
 use restate_storage_api::invocation_status_table::{JournalMetadata, StatusTimestamps};
 use restate_storage_api::{Result as StorageResult, StorageError};
@@ -236,6 +237,19 @@ impl ReadOnlyJournalTable for StateReaderMock {
     }
 }
 
+impl ReadOnlyIdempotencyTable for StateReaderMock {
+    fn get_idempotency_metadata(
+        &mut self,
+        _idempotency_id: &IdempotencyId,
+    ) -> impl Future<Output = StorageResult<Option<IdempotencyMetadata>>> + Send {
+        unimplemented!();
+
+        // Code inference for impl Future won't work without this
+        #[allow(unreachable_code)]
+        futures::future::ok(None)
+    }
+}
+
 #[test(tokio::test)]
 async fn awakeable_with_success() {
     let mut state_machine: CommandInterpreter<ProtobufRawEntryCodec> =
@@ -421,6 +435,7 @@ async fn kill_inboxed_invocation() -> Result<(), Error> {
             span_context: Default::default(),
             headers: vec![],
             execution_time: None,
+            idempotency: None,
         }),
     );
 
@@ -501,9 +516,11 @@ async fn kill_call_tree() -> Result<(), Error> {
         effects,
         all!(
             contains(pat!(Effect::SendAbortInvocationToInvoker(eq(fid.clone())))),
-            contains(pat!(Effect::DropJournalAndPopInbox {
-                full_invocation_id: eq(fid.clone()),
+            contains(pat!(Effect::FreeInvocation(eq(InvocationId::from(&fid))))),
+            contains(pat!(Effect::DropJournal {
+                invocation_id: eq(InvocationId::from(&fid)),
             })),
+            contains(pat!(Effect::PopInbox(eq(fid.service_id.clone())))),
             contains(terminate_invocation_outbox_message_matcher(
                 call_fid,
                 TerminationFlavor::Kill

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -12,18 +12,20 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use opentelemetry_api::trace::SpanId;
 use restate_storage_api::inbox_table::InboxEntry;
-use restate_storage_api::invocation_status_table::{InFlightInvocationMetadata, InboxedInvocation};
+use restate_storage_api::invocation_status_table::{
+    CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation,
+};
 use restate_storage_api::invocation_status_table::{InvocationStatus, JournalMetadata};
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::timer_table::{Timer, TimerKey};
 use restate_types::errors::InvocationErrorCode;
 use restate_types::identifiers::{
-    DeploymentId, EntryIndex, FullInvocationId, InvocationId, ServiceId,
+    DeploymentId, EntryIndex, FullInvocationId, IdempotencyId, InvocationId, ServiceId,
 };
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{
-    InvocationResponse, ResponseResult, ServiceInvocation, ServiceInvocationSpanContext,
-    SpanRelation,
+    InvocationResponse, ResponseResult, ServiceInvocation, ServiceInvocationResponseSink,
+    ServiceInvocationSpanContext, SpanRelation,
 };
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::{Completion, CompletionResult};
@@ -34,6 +36,7 @@ use restate_wal_protocol::timer::TimerKeyDisplay;
 use restate_wal_protocol::timer::TimerValue;
 use std::collections::HashSet;
 use std::fmt;
+use std::time::Duration;
 use std::vec::Drain;
 use tracing::{debug_span, event_enabled, span_enabled, trace, trace_span, Level};
 
@@ -50,6 +53,11 @@ pub(crate) enum Effect {
         metadata: InFlightInvocationMetadata,
         waiting_for_completed_entries: HashSet<EntryIndex>,
     },
+    StoreCompletedInvocation {
+        invocation_id: InvocationId,
+        retention: Duration,
+        completed_invocation: CompletedInvocation,
+    },
     StoreInboxedInvocation(InvocationId, InboxedInvocation),
     FreeInvocation(InvocationId),
 
@@ -58,15 +66,12 @@ pub(crate) enum Effect {
         seq_number: MessageIndex,
         inbox_entry: InboxEntry,
     },
+    PopInbox(ServiceId),
     EnqueueIntoOutbox {
         seq_number: MessageIndex,
         message: OutboxMessage,
     },
     TruncateOutbox(MessageIndex),
-    DropJournalAndPopInbox {
-        full_invocation_id: FullInvocationId,
-        journal_length: EntryIndex,
-    },
     DeleteInboxEntry {
         service_id: ServiceId,
         sequence_number: MessageIndex,
@@ -105,6 +110,14 @@ pub(crate) enum Effect {
         deployment_id: DeploymentId,
         metadata: InFlightInvocationMetadata,
     },
+    AppendResponseSink {
+        invocation_id: InvocationId,
+        // We pass around the invocation_status here to avoid an additional read.
+        // We could in theory get rid of this here (and in other places, such as StoreDeploymentId),
+        // by using a merge operator in rocksdb.
+        previous_invocation_status: InvocationStatus,
+        additional_response_sink: ServiceInvocationResponseSink,
+    },
     AppendJournalEntry {
         invocation_id: InvocationId,
         // We pass around the invocation_status here to avoid an additional read.
@@ -122,6 +135,10 @@ pub(crate) enum Effect {
         // TODO this can be invocation_id once the invoker uses only InvocationId
         full_invocation_id: FullInvocationId,
         completion: Completion,
+    },
+    DropJournal {
+        invocation_id: InvocationId,
+        journal_length: EntryIndex,
     },
 
     // Effects used only for tracing purposes
@@ -146,6 +163,11 @@ pub(crate) enum Effect {
     // State mutations
     MutateState(ExternalStateMutation),
 
+    // Idempotency
+    StoreIdempotencyId(IdempotencyId, InvocationId),
+    DeleteIdempotencyId(IdempotencyId),
+
+    // Send ingress response
     IngressResponse(IngressResponse),
 }
 
@@ -328,11 +350,11 @@ impl Effect {
             Effect::TruncateOutbox(seq_number) => {
                 trace!(restate.outbox.seq = seq_number, "Effect: Truncate outbox")
             }
-            Effect::DropJournalAndPopInbox { journal_length, .. } => {
+            Effect::DropJournal { journal_length, .. } => {
                 debug_if_leader!(
                     is_leader,
                     restate.journal.length = journal_length,
-                    "Effect: Drop journal and pop from inbox"
+                    "Effect: Drop journal"
                 );
             }
             Effect::SetState {
@@ -434,6 +456,15 @@ impl Effect {
                         restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
                         "Effect: Register background invoke timer"
+                    )
+                }
+                Timer::CleanInvocationStatus(invocation_id) => {
+                    debug_if_leader!(
+                        is_leader,
+                        restate.invocation.id = %invocation_id,
+                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
+                        restate.timer.wake_up_time = %timer_value.wake_up_time(),
+                        "Effect: Register cleanup invocation status timer"
                     )
                 }
             },
@@ -568,6 +599,47 @@ impl Effect {
                     &state_mutation.component_id
                 );
             }
+            Effect::StoreCompletedInvocation { invocation_id, .. } => {
+                debug_if_leader!(
+                    is_leader,
+                    restate.invocation.id = %invocation_id,
+                    "Effect: Store completed invocation"
+                );
+            }
+            Effect::PopInbox(service_id) => {
+                debug_if_leader!(
+                    is_leader,
+                    rpc.service = %service_id.service_name,
+                    "Effect: Pop inbox"
+                );
+            }
+            Effect::AppendResponseSink {
+                invocation_id,
+                additional_response_sink,
+                ..
+            } => {
+                debug_if_leader!(
+                    is_leader,
+                    restate.invocation.id = %invocation_id,
+                    "Effect: Store additional response sink {:?}",
+                    additional_response_sink
+                );
+            }
+            Effect::StoreIdempotencyId(idempotency_id, invocation_id) => {
+                debug_if_leader!(
+                    is_leader,
+                    restate.invocation.id = %invocation_id,
+                    "Effect: Store idempotency id {:?}",
+                    idempotency_id
+                );
+            }
+            Effect::DeleteIdempotencyId(idempotency_id) => {
+                debug_if_leader!(
+                    is_leader,
+                    "Effect: Delete idempotency id {:?}",
+                    idempotency_id
+                );
+            }
         }
     }
 }
@@ -638,6 +710,19 @@ impl Effects {
         ))
     }
 
+    pub(crate) fn store_completed_invocation(
+        &mut self,
+        invocation_id: InvocationId,
+        retention: Duration,
+        completed_invocation: CompletedInvocation,
+    ) {
+        self.effects.push(Effect::StoreCompletedInvocation {
+            invocation_id,
+            retention,
+            completed_invocation,
+        })
+    }
+
     pub(crate) fn free_invocation(&mut self, invocation_id: InvocationId) {
         self.effects.push(Effect::FreeInvocation(invocation_id))
     }
@@ -658,6 +743,10 @@ impl Effects {
             service_id,
             sequence_number,
         });
+    }
+
+    pub(crate) fn pop_inbox(&mut self, service_id: ServiceId) {
+        self.effects.push(Effect::PopInbox(service_id))
     }
 
     pub(crate) fn enqueue_into_outbox(&mut self, seq_number: MessageIndex, message: OutboxMessage) {
@@ -744,6 +833,19 @@ impl Effects {
         })
     }
 
+    pub(crate) fn append_response_sink(
+        &mut self,
+        invocation_id: InvocationId,
+        previous_invocation_status: InvocationStatus,
+        response_sink: ServiceInvocationResponseSink,
+    ) {
+        self.effects.push(Effect::AppendResponseSink {
+            invocation_id,
+            previous_invocation_status,
+            additional_response_sink: response_sink,
+        });
+    }
+
     pub(crate) fn append_journal_entry(
         &mut self,
         invocation_id: InvocationId,
@@ -782,15 +884,11 @@ impl Effects {
         });
     }
 
-    pub(crate) fn drop_journal_and_pop_inbox(
-        &mut self,
-        full_invocation_id: FullInvocationId,
-        journal_length: EntryIndex,
-    ) {
-        self.effects.push(Effect::DropJournalAndPopInbox {
-            full_invocation_id,
+    pub(crate) fn drop_journal(&mut self, invocation_id: InvocationId, journal_length: EntryIndex) {
+        self.effects.push(Effect::DropJournal {
+            invocation_id,
             journal_length,
-        });
+        })
     }
 
     pub(crate) fn trace_background_invoke(
@@ -828,6 +926,20 @@ impl Effects {
     pub(crate) fn abort_invocation(&mut self, full_invocation_id: FullInvocationId) {
         self.effects
             .push(Effect::SendAbortInvocationToInvoker(full_invocation_id));
+    }
+
+    pub(crate) fn store_idempotency_id(
+        &mut self,
+        idempotency_id: IdempotencyId,
+        invocation_id: InvocationId,
+    ) {
+        self.effects
+            .push(Effect::StoreIdempotencyId(idempotency_id, invocation_id));
+    }
+
+    pub(crate) fn delete_idempotency_id(&mut self, idempotency_id: IdempotencyId) {
+        self.effects
+            .push(Effect::DeleteIdempotencyId(idempotency_id));
     }
 
     pub(crate) fn send_stored_ack_to_invoker(

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -15,6 +15,7 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use metrics::counter;
 use restate_storage_api::deduplication_table::ReadOnlyDeduplicationTable;
 use restate_storage_api::fsm_table::ReadOnlyFsmTable;
+use restate_storage_api::idempotency_table::IdempotencyMetadata;
 use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadOnlyInvocationStatusTable,
@@ -31,8 +32,8 @@ use restate_storage_api::StorageError;
 use restate_timer::TimerReader;
 use restate_types::dedup::{DedupSequenceNumber, ProducerId};
 use restate_types::identifiers::{
-    EntryIndex, FullInvocationId, InvocationId, PartitionId, PartitionKey, ServiceId,
-    WithPartitionKey,
+    EntryIndex, FullInvocationId, IdempotencyId, InvocationId, PartitionId, PartitionKey,
+    ServiceId, WithPartitionKey,
 };
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::CompletionResult;
@@ -614,6 +615,43 @@ where
         partition_key_range: RangeInclusive<PartitionKey>,
     ) -> impl Stream<Item = StorageResult<FullInvocationId>> + Send {
         self.inner.invoked_invocations(partition_key_range)
+    }
+}
+
+// Workaround until https://github.com/restatedev/restate/issues/276 is sorted out
+impl<TransactionType> restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable
+    for Transaction<TransactionType>
+where
+    TransactionType: restate_storage_api::Transaction + Send,
+{
+    fn get_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+    ) -> impl Future<Output = StorageResult<Option<IdempotencyMetadata>>> + Send {
+        self.inner.get_idempotency_metadata(idempotency_id)
+    }
+}
+
+// Workaround until https://github.com/restatedev/restate/issues/276 is sorted out
+impl<TransactionType> restate_storage_api::idempotency_table::IdempotencyTable
+    for Transaction<TransactionType>
+where
+    TransactionType: restate_storage_api::Transaction + Send,
+{
+    fn put_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+        metadata: IdempotencyMetadata,
+    ) -> impl Future<Output = ()> + Send {
+        self.inner
+            .put_idempotency_metadata(idempotency_id, metadata)
+    }
+
+    fn delete_idempotency_metadata(
+        &mut self,
+        idempotency_id: &IdempotencyId,
+    ) -> impl Future<Output = ()> + Send {
+        self.inner.delete_idempotency_metadata(idempotency_id)
     }
 }
 

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -94,6 +94,7 @@ pub fn create_response_message(
                 SpanRelation::None,
                 vec![],
                 None,
+                None,
             )))
         }
     }


### PR DESCRIPTION
Part of #1324, based on #1334.

This PR implements the idempotent invocation business logic. This logic is triggered when the field `ServiceInvocation.idempotency` is set.

In a followup PR I'll finally wire-up this field with the ingress and schema registry (to override the default idempotency retention timer).