### PR TITLE
Remove duplicate AWS_EXTERNAL_ID

### DIFF
--- a/server/src/config_loader.rs
+++ b/server/src/config_loader.rs
@@ -77,11 +77,6 @@ impl ConfigLoader {
                     .only(&["AWS_EXTERNAL_ID"])
                     .map(|_| "aws_assume_role_external_id".into()),
             )
-            .merge(
-                Env::raw()
-                    .only(&["AWS_EXTERNAL_ID"])
-                    .map(|_| "aws_assume_role_external_id".into()),
-            )
     }
 
     pub fn start(self) {


### PR DESCRIPTION
If there is only one service client, we only need to set this once