### PR TITLE
Add request identity v1 to lambda calls

### DIFF
--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -10,9 +10,8 @@
 
 use super::proxy::ProxyConnector;
 
-use crate::request_identity::SignRequest;
 use crate::utils::ErrorExt;
-use arc_swap::ArcSwapOption;
+
 use futures::future::Either;
 use futures::FutureExt;
 use hyper::client::HttpConnector;
@@ -24,49 +23,27 @@ use restate_types::config::HttpOptions;
 use std::fmt::Debug;
 use std::future;
 use std::future::Future;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 type Connector = ProxyConnector<HttpsConnector<HttpConnector>>;
 
 #[derive(Clone, Debug)]
 pub struct HttpClient {
     client: hyper::Client<Connector, Body>,
-    // this can be changed to re-read periodically if necessary
-    request_identity_key: Arc<ArcSwapOption<crate::request_identity::v1::SigningKey>>,
 }
 
 impl HttpClient {
-    pub fn new(
-        client: hyper::Client<Connector, Body>,
-        request_identity_private_key_pem_file: Option<PathBuf>,
-    ) -> Result<Self, HttpClientError> {
-        let request_identity_key = if let Some(request_identity_private_key_pem_file) =
-            request_identity_private_key_pem_file
-        {
-            Arc::new(ArcSwapOption::from_pointee(
-                crate::request_identity::v1::SigningKey::from_pem_file(
-                    request_identity_private_key_pem_file,
-                )?,
-            ))
-        } else {
-            Arc::new(ArcSwapOption::empty())
-        };
-
-        Ok(Self {
-            client,
-            request_identity_key,
-        })
+    pub fn new(client: hyper::Client<Connector, Body>) -> Self {
+        Self { client }
     }
 
-    pub fn from_options(options: &HttpOptions) -> Result<HttpClient, BuildError> {
+    pub fn from_options(options: &HttpOptions) -> HttpClient {
         let mut builder = hyper::Client::builder();
         builder
             .http2_only(true)
             .http2_keep_alive_timeout(options.http_keep_alive_options.timeout.into())
             .http2_keep_alive_interval(Some(options.http_keep_alive_options.interval.into()));
 
-        Ok(HttpClient::new(
+        HttpClient::new(
             builder.build::<_, hyper::Body>(ProxyConnector::new(
                 options.http_proxy.clone(),
                 hyper_rustls::HttpsConnectorBuilder::new()
@@ -75,8 +52,7 @@ impl HttpClient {
                     .enable_http2()
                     .build(),
             )),
-            options.request_identity_private_key_pem_file.clone(),
-        )?)
+        )
     }
 
     fn build_request(
@@ -132,24 +108,7 @@ impl HttpClient {
     ) -> impl Future<Output = Result<Response<Body>, HttpError>> + Send + 'static {
         let method = Method::POST;
 
-        let request_identity_key = self.request_identity_key.load();
-
-        let signer = if let Some(request_identity_key) = request_identity_key.as_deref() {
-            match crate::request_identity::v1::Signer::new(path.path().into(), request_identity_key)
-            {
-                Ok(signing_parameters_v1) => Some(signing_parameters_v1),
-                Err(err) => return future::ready(Err(err)).right_future(),
-            }
-        } else {
-            None // will use null signing scheme
-        };
-
         let request = match Self::build_request(uri, version, body, method, path, headers) {
-            Ok(request) => request,
-            Err(err) => return future::ready(Err(err.into())).right_future(),
-        };
-
-        let request = match signer.sign_request(request) {
             Ok(request) => request,
             Err(err) => return future::ready(Err(err.into())).right_future(),
         };
@@ -161,37 +120,11 @@ impl HttpClient {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum BuildError {
-    #[error(transparent)]
-    HttpClient(#[from] HttpClientError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum HttpClientError {
-    #[error("Failed to read request signing private key: {0}")]
-    SigningPrivateKeyReadError(#[from] SigningPrivateKeyReadError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum SigningPrivateKeyReadError {
-    #[error("Only one private key in PEM format is expected, found {0}")]
-    OneKeyExpected(usize),
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error(transparent)]
-    Pem(#[from] pem::PemError),
-    #[error("Key was rejected by ring: {0}")]
-    KeyRejected(ring::error::KeyRejected),
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum HttpError {
     #[error(transparent)]
     Hyper(#[from] hyper::Error),
     #[error(transparent)]
     Http(#[from] hyper::http::Error),
-    #[error(transparent)]
-    IdentityV1(#[from] <super::request_identity::v1::Signer<'static> as SignRequest>::Error),
 }
 
 impl HttpError {
@@ -201,7 +134,6 @@ impl HttpError {
         match self {
             HttpError::Hyper(err) => err.is_retryable(),
             HttpError::Http(err) => err.is_retryable(),
-            HttpError::IdentityV1(_) => false, // this really should never happen
         }
     }
 }

--- a/crates/service-client/src/request_identity/mod.rs
+++ b/crates/service-client/src/request_identity/mod.rs
@@ -1,6 +1,6 @@
 use hyper::header::HeaderName;
 
-use hyper::{Body, Request};
+use hyper::HeaderMap;
 
 pub(crate) mod v1;
 
@@ -8,15 +8,15 @@ const SCHEME_HEADER: HeaderName = HeaderName::from_static("x-restate-signature-s
 
 pub trait SignRequest {
     type Error;
-    fn sign_request(self, request: Request<Body>) -> Result<Request<Body>, Self::Error>;
+    fn insert_identity(self, headers: HeaderMap) -> Result<HeaderMap, Self::Error>;
 }
 
 impl<T: SignRequest> SignRequest for Option<T> {
     type Error = T::Error;
-    fn sign_request(self, request: Request<Body>) -> Result<Request<Body>, Self::Error> {
+    fn insert_identity(self, headers: HeaderMap) -> Result<HeaderMap, Self::Error> {
         match self {
-            Some(signer) => signer.sign_request(request),
-            None => Ok(request),
+            Some(signer) => signer.insert_identity(headers),
+            None => Ok(headers),
         }
     }
 }

--- a/crates/service-client/src/request_identity/v1.rs
+++ b/crates/service-client/src/request_identity/v1.rs
@@ -1,16 +1,15 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
 use hyper::header::{HeaderName, HeaderValue};
-use hyper::{Body, Request};
+use hyper::HeaderMap;
 
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde::{Deserialize, Serialize};
 use tracing::info;
-
-use crate::http::{HttpError, SigningPrivateKeyReadError};
 
 pub(crate) struct SigningKey {
     header: jsonwebtoken::Header,
@@ -58,14 +57,26 @@ impl SigningKey {
     }
 }
 
-pub struct Signer<'key> {
-    claims: Claims,
+#[derive(Debug, thiserror::Error)]
+pub enum SigningPrivateKeyReadError {
+    #[error("Only one private key in PEM format is expected, found {0}")]
+    OneKeyExpected(usize),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Pem(#[from] pem::PemError),
+    #[error("Key was rejected by ring: {0}")]
+    KeyRejected(ring::error::KeyRejected),
+}
+
+pub struct Signer<'key, 'aud> {
+    claims: Claims<'aud>,
     signing_key: &'key SigningKey,
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct Claims {
-    aud: String,
+pub(crate) struct Claims<'aud> {
+    aud: Cow<'aud, str>,
     exp: u64,
     iat: u64,
     nbf: u64,
@@ -76,37 +87,37 @@ const JWT_HEADER: HeaderName = HeaderName::from_static("x-restate-jwt-v1");
 /// The time to add and subtract from the current time to determine expiry and not-before times
 const LEEWAY_SECONDS: u64 = 60;
 
-impl<'key> Signer<'key> {
+impl<'key, 'aud> Signer<'key, 'aud> {
     const SCHEME: HeaderValue = HeaderValue::from_static("v1");
 
-    pub(crate) fn new(path: String, signing_key: &'key SigningKey) -> Result<Self, HttpError> {
+    pub(crate) fn new(path: &'aud str, signing_key: &'key SigningKey) -> Self {
         let unix_seconds = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("duration since Unix epoch should be well-defined")
             .as_secs();
 
-        Ok(Self {
+        Self {
             claims: Claims {
-                aud: path,
+                aud: Cow::Borrowed(path),
                 nbf: unix_seconds.saturating_sub(LEEWAY_SECONDS),
                 iat: unix_seconds,
                 exp: unix_seconds.saturating_add(LEEWAY_SECONDS),
             },
             signing_key,
-        })
+        }
     }
 }
 
-impl<'key> super::SignRequest for Signer<'key> {
+impl<'key, 'aud> super::SignRequest for Signer<'key, 'aud> {
     type Error = jsonwebtoken::errors::Error;
-    fn sign_request(self, mut request: Request<Body>) -> Result<Request<Body>, Self::Error> {
+    fn insert_identity(self, mut headers: HeaderMap) -> Result<HeaderMap, Self::Error> {
         let jwt = jsonwebtoken::encode(
             &self.signing_key.header,
             &self.claims,
             &self.signing_key.key,
         )?;
 
-        request.headers_mut().extend([
+        headers.extend([
             (super::SCHEME_HEADER, Self::SCHEME),
             (
                 JWT_HEADER,
@@ -115,13 +126,14 @@ impl<'key> super::SignRequest for Signer<'key> {
             ),
         ]);
 
-        Ok(request)
+        Ok(headers)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::request_identity::SignRequest;
 
     use std::collections::HashSet;
@@ -153,22 +165,18 @@ MCowBQYDK2VwAyEAj5BTvH+WJo0QGHm2hdLOuk6P7szKgTQxmpnnmZe/DcU=
         pemfile.write_all(PRIVATE_KEY).unwrap();
 
         let key = SigningKey::from_pem_file(pemfile.path().to_path_buf()).unwrap();
-        let signer = Signer::new("/invoke/foo".into(), &key).unwrap();
+        let signer = Signer::new("/invoke/foo", &key);
 
-        let request = Request::new(Body::empty());
-
-        let request = signer.sign_request(request).unwrap();
+        let headers = signer.insert_identity(HeaderMap::new()).unwrap();
 
         assert_eq!(
-            request
-                .headers()
+            headers
                 .get("x-restate-signature-scheme")
                 .expect("signature scheme header must be present"),
             &Signer::SCHEME
         );
 
-        let jwt = request
-            .headers()
+        let jwt = headers
             .get("x-restate-jwt-v1")
             .expect("jwt must be present");
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -222,11 +222,23 @@ impl Default for CommonOptions {
 )]
 #[builder(default)]
 #[derive(Default)]
+#[serde(rename_all = "kebab-case")]
 pub struct ServiceClientOptions {
     #[serde(flatten)]
     pub http: HttpOptions,
     #[serde(flatten)]
     pub lambda: AwsOptions,
+
+    /// # Request identity private key PEM file
+    ///
+    /// A path to a file, such as "/var/secrets/key.pem", which contains exactly one ed25519 private
+    /// key in PEM format. Such a file can be generated with `openssl genpkey -algorithm ed25519`.
+    /// If provided, this key will be used to attach JWTs to requests from this client which
+    /// SDKs may optionally verify, proving that the caller is a particular Restate instance.
+    ///
+    /// This file is currently only read on client creation, but this may change in future.
+    /// Parsed public keys will be logged at INFO level in the same format that SDKs expect.
+    pub request_identity_private_key_pem_file: Option<PathBuf>,
 }
 
 /// # Log format

--- a/crates/types/src/config/http.rs
+++ b/crates/types/src/config/http.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt;
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -38,16 +37,6 @@ pub struct HttpOptions {
     /// Can be overridden by the `HTTP_PROXY` environment variable.
     #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     pub http_proxy: Option<ProxyUri>,
-    /// # Request identity private key PEM file
-    ///
-    /// A path to a file, such as "/var/secrets/key.pem", which contains exactly one ed25519 private
-    /// key in PEM format. Such a file can be generated with `openssl genpkey -algorithm ed25519`.
-    /// If provided, this key will be used to attach JWTs to HTTP requests from this client which
-    /// SDKs may optionally verify, proving that the caller is a particular Restate instance.
-    ///
-    /// This file is currently only read on client creation, but this may change in future.
-    /// Parsed public keys will be logged at INFO level in the same format that SDKs expect.
-    pub request_identity_private_key_pem_file: Option<PathBuf>,
 }
 
 /// # HTTP/2 Keep alive options


### PR DESCRIPTION
There is no particularly good reason not to just add these JWTs to all types of requests. Yes, in Lambda there is less of a 'public internet exposed' threat model, but still it could be useful defense in depth

Moreover, sdk usability is better if the JWT is sent irrelevant of the channel. For example, switching between GCF (which is over public HTTPs, but still uses the lambdaesque SDK apis) and Lambda should not require you to remove the public key.

Pr just lifts some logic out of http.rs into lib.rs