### PR TITLE
Refactor kafka config

### DIFF
--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -20,7 +20,7 @@ use restate_cluster_controller::ClusterControllerHandle;
 use restate_core::{task_center, TaskKind};
 use restate_meta::{FileMetaReader, FileMetaStorage, MetaService};
 use restate_node_services::node_svc::node_svc_client::NodeSvcClient;
-use restate_types::config::{KafkaIngressOptions, UpdateableConfiguration};
+use restate_types::config::{IngressOptions, UpdateableConfiguration};
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum AdminRoleBuildError {
@@ -37,7 +37,7 @@ pub struct AdminRole {
     updateable_config: UpdateableConfiguration,
     controller: restate_cluster_controller::Service,
     admin: AdminService,
-    meta: MetaService<FileMetaStorage, KafkaIngressOptions>,
+    meta: MetaService<FileMetaStorage, IngressOptions>,
 }
 
 impl AdminRole {
@@ -46,7 +46,7 @@ impl AdminRole {
         let meta = MetaService::from_options(
             &config.admin,
             &config.common.service_client,
-            config.ingress.kafka.clone(),
+            config.ingress.clone(),
         )?;
         let admin = AdminService::new(meta.schemas(), meta.meta_handle(), meta.schema_reader());
 

--- a/crates/schema-api/src/lib.rs
+++ b/crates/schema-api/src/lib.rs
@@ -481,7 +481,7 @@ pub mod subscription {
     use std::collections::HashMap;
     use std::fmt;
 
-    use restate_types::config::KafkaIngressOptions;
+    use restate_types::config::IngressOptions;
     use restate_types::identifiers::SubscriptionId;
     use tracing::warn;
 
@@ -639,13 +639,13 @@ pub mod subscription {
         reason: &'static str,
     }
 
-    impl SubscriptionValidator for KafkaIngressOptions {
+    impl SubscriptionValidator for IngressOptions {
         type Error = ValidationError;
 
         fn validate(&self, mut subscription: Subscription) -> Result<Subscription, Self::Error> {
             // Retrieve the cluster option and merge them with subscription metadata
             let Source::Kafka { cluster, .. } = subscription.source();
-            let cluster_options = &self.clusters.get(cluster).ok_or(ValidationError {
+            let cluster_options = &self.get_kafka_cluster(cluster).ok_or(ValidationError {
             name: "source",
             reason: "specified cluster in the source URI does not exist. Make sure it is defined in the KafkaOptions",
         })?.additional_options;

--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
-use super::KafkaIngressOptions;
+use super::KafkaClusterOptions;
 
 /// # Ingress options
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
@@ -34,7 +34,14 @@ pub struct IngressOptions {
     /// Max allowed value is 2305843009213693950
     pub concurrent_api_requests_limit: usize,
 
-    pub kafka: KafkaIngressOptions,
+    kafka_clusters: Vec<KafkaClusterOptions>,
+}
+
+impl IngressOptions {
+    pub fn get_kafka_cluster(&self, name: &str) -> Option<&KafkaClusterOptions> {
+        // a cluster is likely to have a very small number of kafka clusters configured.
+        self.kafka_clusters.iter().find(|c| c.name == name)
+    }
 }
 
 impl Default for IngressOptions {
@@ -43,7 +50,7 @@ impl Default for IngressOptions {
             bind_address: "0.0.0.0:8080".parse().unwrap(),
             // max is limited by Tower's LoadShedLayer.
             concurrent_api_requests_limit: Semaphore::MAX_PERMITS - 1,
-            kafka: Default::default(),
+            kafka_clusters: Default::default(),
         }
     }
 }

--- a/crates/types/src/config/kafka.rs
+++ b/crates/types/src/config/kafka.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct KafkaClusterOptions {
+    /// Cluster name (Used to identify subscriptions).
+    pub name: String,
     /// # Servers
     ///
     /// Initial list of brokers (host or host:port).
@@ -30,18 +32,4 @@ pub struct KafkaClusterOptions {
     /// https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
     #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
     pub additional_options: HashMap<String, String>,
-}
-
-/// # Subscription options
-#[derive(Debug, Default, Clone, Serialize, Deserialize, derive_builder::Builder)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schemars", schemars(rename = "SubscriptionOptions"))]
-#[serde(rename_all = "kebab-case")]
-#[builder(default)]
-pub struct KafkaIngressOptions {
-    /// # Kafka clusters
-    ///
-    /// Configuration parameters for the known kafka clusters
-    #[serde(flatten)]
-    pub clusters: HashMap<String, KafkaClusterOptions>,
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -157,7 +157,7 @@ impl Worker {
         let ingress_kafka = IngressKafkaService::new(ingress_dispatcher.clone());
         let subscription_controller_handle =
             subscription_integration::SubscriptionControllerHandle::new(
-                config.ingress.kafka.clone(),
+                config.ingress.clone(),
                 ingress_kafka.create_command_sender(),
             );
 
@@ -252,7 +252,7 @@ impl Worker {
             self.ingress_kafka.run(
                 self.updateable_config
                     .clone()
-                    .map_as_updateable_owned(|c| &c.ingress.kafka),
+                    .map_as_updateable_owned(|c| &c.ingress),
             ),
         )?;
 

--- a/crates/worker/src/subscription_integration.rs
+++ b/crates/worker/src/subscription_integration.rs
@@ -11,25 +11,25 @@
 use crate::{SubscriptionController, WorkerHandleError};
 use restate_ingress_kafka::SubscriptionCommandSender;
 use restate_schema_api::subscription::{Subscription, SubscriptionValidator};
-use restate_types::config::KafkaIngressOptions;
+use restate_types::config::IngressOptions;
 use restate_types::identifiers::SubscriptionId;
 use std::ops::Deref;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub struct SubscriptionControllerHandle(Arc<KafkaIngressOptions>, SubscriptionCommandSender);
+pub struct SubscriptionControllerHandle(Arc<IngressOptions>, SubscriptionCommandSender);
 
 impl SubscriptionControllerHandle {
     pub(crate) fn new(
-        kafka_options: KafkaIngressOptions,
+        ingress_options: IngressOptions,
         commands_tx: SubscriptionCommandSender,
     ) -> Self {
-        Self(Arc::new(kafka_options), commands_tx)
+        Self(Arc::new(ingress_options), commands_tx)
     }
 }
 
 impl SubscriptionValidator for SubscriptionControllerHandle {
-    type Error = <KafkaIngressOptions as SubscriptionValidator>::Error;
+    type Error = <IngressOptions as SubscriptionValidator>::Error;
 
     fn validate(&self, subscription: Subscription) -> Result<Subscription, Self::Error> {
         SubscriptionValidator::validate(self.0.deref(), subscription)


### PR DESCRIPTION
Refactor kafka config


Flattens kafka's configuration. The configuration now looks like this:
```
...
[[ingress.kafka_clusters]]
name = "cluster-1"
brokers = ["localhost:9092"]
...
any_additional_option = "value"

[[ingress.kafka_clusters]]
name = "cluster-2"
brokers = ["remote_host:9092"]


```
