### PR TITLE
Remove unnecessary SchemaView indirection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5595,6 +5595,7 @@ version = "0.9.0"
 dependencies = [
  "arc-swap",
  "bytes",
+ "derive_more",
  "http 0.2.12",
  "restate-schema-api",
  "restate-test-util",

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -121,12 +121,7 @@ impl<V> SchemaRegistry<V> {
         };
 
         let (id, components) = if !apply_mode.should_apply() {
-            let mut updater = SchemaUpdater::from(
-                metadata()
-                    .schema_information()
-                    .map(|schema_information| schema_information.deref().clone())
-                    .unwrap_or_default(),
-            );
+            let mut updater = SchemaUpdater::from(metadata().schema_information().deref().clone());
 
             // suppress logging output in case of a dry run
             let id = tracing::subscriber::with_default(NoSubscriber::new(), || {
@@ -278,16 +273,13 @@ impl<V> SchemaRegistry<V> {
     pub fn list_components(&self) -> Vec<ComponentMetadata> {
         metadata()
             .schema_information()
-            .map(|schema_information| schema_information.list_components())
-            .unwrap_or_default()
+            .list_components()
     }
 
     pub fn get_component(&self, component_name: impl AsRef<str>) -> Option<ComponentMetadata> {
         metadata()
             .schema_information()
-            .and_then(|schema_information| {
-                schema_information.resolve_latest_component(&component_name)
-            })
+            .resolve_latest_component(&component_name)
     }
 
     pub fn get_deployment(
@@ -296,16 +288,13 @@ impl<V> SchemaRegistry<V> {
     ) -> Option<(Deployment, Vec<ComponentMetadata>)> {
         metadata()
             .schema_information()
-            .and_then(|schema_information| {
-                schema_information.get_deployment_and_components(&deployment_id)
-            })
+            .get_deployment_and_components(&deployment_id)
     }
 
     pub fn list_deployments(&self) -> Vec<(Deployment, Vec<(String, ComponentRevision)>)> {
         metadata()
             .schema_information()
-            .map(|schema_information| schema_information.get_deployments())
-            .unwrap_or_default()
+            .get_deployments()
     }
 
     pub fn list_component_handlers(
@@ -314,11 +303,8 @@ impl<V> SchemaRegistry<V> {
     ) -> Option<Vec<HandlerMetadata>> {
         metadata()
             .schema_information()
-            .and_then(|schema_information| {
-                schema_information
-                    .resolve_latest_component(&component_name)
-                    .map(|m| m.handlers)
-            })
+            .resolve_latest_component(&component_name)
+            .map(|m| m.handlers)
     }
 
     pub fn get_component_handler(
@@ -328,28 +314,24 @@ impl<V> SchemaRegistry<V> {
     ) -> Option<HandlerMetadata> {
         metadata()
             .schema_information()
-            .and_then(|schema_information| {
-                schema_information
-                    .resolve_latest_component(&component_name)
-                    .and_then(|m| {
-                        m.handlers
-                            .into_iter()
-                            .find(|handler| handler.name == handler_name.as_ref())
-                    })
+            .resolve_latest_component(&component_name)
+            .and_then(|m| {
+                m.handlers
+                    .into_iter()
+                    .find(|handler| handler.name == handler_name.as_ref())
             })
     }
 
     pub fn get_subscription(&self, subscription_id: SubscriptionId) -> Option<Subscription> {
         metadata()
             .schema_information()
-            .and_then(|schema_information| schema_information.get_subscription(subscription_id))
+            .get_subscription(subscription_id)
     }
 
     pub fn list_subscriptions(&self, filters: &[ListSubscriptionFilter]) -> Vec<Subscription> {
         metadata()
             .schema_information()
-            .map(|schema_information| schema_information.list_subscriptions(filters))
-            .unwrap_or_default()
+            .list_subscriptions(filters)
     }
 }
 

--- a/crates/admin/src/schema_registry/updater.rs
+++ b/crates/admin/src/schema_registry/updater.rs
@@ -15,7 +15,7 @@ use crate::schema_registry::{ComponentName, ModifyComponentChange};
 use http::{HeaderValue, Uri};
 use restate_schema::component::{ComponentLocation, ComponentSchemas, HandlerSchemas};
 use restate_schema::deployment::DeploymentSchemas;
-use restate_schema::SchemaInformation;
+use restate_schema::Schema;
 use restate_schema_api::component::{ComponentType, HandlerType};
 use restate_schema_api::deployment::DeploymentMetadata;
 use restate_schema_api::invocation_target::{
@@ -32,17 +32,17 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use tracing::{info, warn};
 
-/// Responsible for updating the provided [`SchemaInformation`] with new
+/// Responsible for updating the provided [`Schema`] with new
 /// schema information. It makes sure that the version of schema information
 /// is incremented on changes.
 #[derive(Debug, Default)]
 pub struct SchemaUpdater {
-    schema_information: SchemaInformation,
+    schema_information: Schema,
     modified: bool,
 }
 
-impl From<SchemaInformation> for SchemaUpdater {
-    fn from(schema_information: SchemaInformation) -> Self {
+impl From<Schema> for SchemaUpdater {
+    fn from(schema_information: Schema) -> Self {
         Self {
             schema_information,
             modified: false,
@@ -51,7 +51,7 @@ impl From<SchemaInformation> for SchemaUpdater {
 }
 
 impl SchemaUpdater {
-    pub fn into_inner(mut self) -> SchemaInformation {
+    pub fn into_inner(mut self) -> Schema {
         if self.modified {
             self.schema_information.increment_version()
         }
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn register_new_deployment() {
-        let schema_information = SchemaInformation::default();
+        let schema_information = Schema::default();
         let initial_version = schema_information.version();
         let mut updater = SchemaUpdater::from(schema_information);
 

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -21,9 +21,7 @@ use enum_map::EnumMap;
 use tokio::sync::{oneshot, watch};
 
 pub use restate_node_protocol::metadata::MetadataKind;
-use restate_node_protocol::metadata::{
-    MetadataContainer, SchemaInformation, UpdatingSchemaInformation,
-};
+use restate_node_protocol::metadata::{MetadataContainer, Schema, UpdateableSchema};
 use restate_types::logs::metadata::Logs;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::partition_table::FixedPartitionTable;
@@ -117,16 +115,16 @@ impl Metadata {
         }
     }
 
-    pub fn schema_information(&self) -> Arc<SchemaInformation> {
-        self.inner.schema_information.load_full()
+    pub fn schema(&self) -> Arc<Schema> {
+        self.inner.schema.load_full()
     }
 
-    pub fn schema_information_version(&self) -> Version {
-        self.inner.schema_information.load().version()
+    pub fn schema_version(&self) -> Version {
+        self.inner.schema.load().version()
     }
 
-    pub fn schema_information_updating(&self) -> UpdatingSchemaInformation {
-        UpdatingSchemaInformation::from(Arc::clone(&self.inner.schema_information))
+    pub fn schema_updateable(&self) -> UpdateableSchema {
+        UpdateableSchema::from(Arc::clone(&self.inner.schema))
     }
 
     // Returns when the metadata kind is at the provided version (or newer)
@@ -166,7 +164,7 @@ struct MetadataInner {
     nodes_config: ArcSwapOption<NodesConfiguration>,
     partition_table: ArcSwapOption<FixedPartitionTable>,
     logs: ArcSwapOption<Logs>,
-    schema_information: Arc<ArcSwap<SchemaInformation>>,
+    schema: Arc<ArcSwap<Schema>>,
     write_watches: EnumMap<MetadataKind, VersionWatch>,
 }
 

--- a/crates/node-protocol/Cargo.toml
+++ b/crates/node-protocol/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 [dependencies]
 restate-types = { workspace = true }
 # merge schema creates with restate-types?
-restate-schema = { workspace =true }
+restate-schema = { workspace = true }
 
 bincode = { workspace = true }
 bytes = { workspace = true }

--- a/crates/node-protocol/src/metadata.rs
+++ b/crates/node-protocol/src/metadata.rs
@@ -10,7 +10,7 @@
 
 use bytes::Bytes;
 use enum_map::Enum;
-pub use restate_schema::SchemaInformation;
+pub use restate_schema::{SchemaInformation, UpdatingSchemaInformation};
 use restate_types::logs::metadata::Logs;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::partition_table::FixedPartitionTable;

--- a/crates/node-protocol/src/metadata.rs
+++ b/crates/node-protocol/src/metadata.rs
@@ -10,7 +10,7 @@
 
 use bytes::Bytes;
 use enum_map::Enum;
-pub use restate_schema::{SchemaInformation, UpdatingSchemaInformation};
+pub use restate_schema::{Schema, UpdateableSchema};
 use restate_types::logs::metadata::Logs;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::partition_table::FixedPartitionTable;
@@ -70,7 +70,7 @@ impl WireSerde for MetadataMessage {
 )]
 pub enum MetadataKind {
     NodesConfiguration,
-    Schemas,
+    Schema,
     PartitionTable,
     Logs,
 }
@@ -80,7 +80,7 @@ pub enum MetadataContainer {
     NodesConfiguration(NodesConfiguration),
     PartitionTable(FixedPartitionTable),
     Logs(Logs),
-    SchemaRegistry(SchemaInformation),
+    Schema(Schema),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -100,7 +100,7 @@ impl MetadataContainer {
             MetadataContainer::NodesConfiguration(_) => MetadataKind::NodesConfiguration,
             MetadataContainer::PartitionTable(_) => MetadataKind::PartitionTable,
             MetadataContainer::Logs(_) => MetadataKind::Logs,
-            MetadataContainer::SchemaRegistry(_) => MetadataKind::Schemas,
+            MetadataContainer::Schema(_) => MetadataKind::Schema,
         }
     }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -124,6 +124,7 @@ impl Node {
             MetadataManager::build(networking.clone(), metadata_store_client.clone());
         metadata_manager.register_in_message_router(&mut router_builder);
         let metadata = metadata_manager.metadata();
+        let updating_schema_information = metadata.schema_information_updating();
         let bifrost = BifrostService::new(metadata);
 
         let admin_role = if config.has_role(Role::Admin) {
@@ -143,6 +144,7 @@ impl Node {
                 networking.clone(),
                 bifrost.handle(),
                 metadata_store_client,
+                updating_schema_information,
             )?)
         } else {
             None

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -124,7 +124,7 @@ impl Node {
             MetadataManager::build(networking.clone(), metadata_store_client.clone());
         metadata_manager.register_in_message_router(&mut router_builder);
         let metadata = metadata_manager.metadata();
-        let updating_schema_information = metadata.schema_information_updating();
+        let updating_schema_information = metadata.schema_updateable();
         let bifrost = BifrostService::new(metadata);
 
         let admin_role = if config.has_role(Role::Admin) {
@@ -233,7 +233,7 @@ impl Node {
         metadata_writer.update(logs).await?;
 
         // fetch the latest schema information
-        metadata.sync(MetadataKind::Schemas).await?;
+        metadata.sync(MetadataKind::Schema).await?;
 
         let nodes_config = metadata.nodes_config();
 

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -24,7 +24,7 @@ use restate_metadata_store::MetadataStoreClient;
 use restate_node_protocol::metadata::MetadataKind;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_node_services::cluster_ctrl::AttachmentRequest;
-use restate_schema::UpdatingSchemaInformation;
+use restate_schema::UpdateableSchema;
 use restate_schema_api::subscription::SubscriptionResolver;
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_rocksdb::RocksDBStorage;
@@ -91,7 +91,7 @@ impl WorkerRole {
         networking: Networking,
         bifrost: Bifrost,
         metadata_store_client: MetadataStoreClient,
-        updating_schema_information: UpdatingSchemaInformation,
+        updating_schema_information: UpdateableSchema,
     ) -> Result<Self, WorkerRoleBuildError> {
         let worker = Worker::from_options(
             updateable_config,
@@ -170,7 +170,7 @@ impl WorkerRole {
         SC: SubscriptionController + Clone + Send + Sync,
     {
         let metadata = metadata();
-        let schema_view = metadata.schema_information_updating();
+        let schema_view = metadata.schema_updateable();
         let mut next_version = Version::MIN;
         let cancellation_watcher = cancellation_watcher();
         tokio::pin!(cancellation_watcher);
@@ -180,7 +180,7 @@ impl WorkerRole {
                 _ = &mut cancellation_watcher => {
                     break;
                 },
-                version = metadata.wait_for_version(MetadataKind::Schemas, next_version) => {
+                version = metadata.wait_for_version(MetadataKind::Schema, next_version) => {
                     next_version = version?.next();
 
                     // This might return subscriptions belonging to a higher schema version. As a

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -17,6 +17,7 @@ restate-test-util = { workspace = true, optional = true }
 
 arc-swap = { workspace = true }
 bytes = { workspace = true }
+derive_more = { workspace = true }
 http = { workspace = true }
 serde = { workspace = true }
 

--- a/crates/schema/src/component.rs
+++ b/crates/schema/src/component.rs
@@ -87,7 +87,7 @@ impl ComponentMetadataResolver for SchemaInformation {
     }
 }
 
-impl ComponentMetadataResolver for SchemaView {
+impl ComponentMetadataResolver for UpdatingSchemaInformation {
     fn resolve_latest_component(
         &self,
         component_name: impl AsRef<str>,

--- a/crates/schema/src/component.rs
+++ b/crates/schema/src/component.rs
@@ -57,7 +57,7 @@ pub struct ComponentLocation {
     pub public: bool,
 }
 
-impl ComponentMetadataResolver for SchemaInformation {
+impl ComponentMetadataResolver for Schema {
     fn resolve_latest_component(
         &self,
         component_name: impl AsRef<str>,
@@ -87,7 +87,7 @@ impl ComponentMetadataResolver for SchemaInformation {
     }
 }
 
-impl ComponentMetadataResolver for UpdatingSchemaInformation {
+impl ComponentMetadataResolver for UpdateableSchema {
     fn resolve_latest_component(
         &self,
         component_name: impl AsRef<str>,

--- a/crates/schema/src/deployment.rs
+++ b/crates/schema/src/deployment.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{SchemaInformation, UpdatingSchemaInformation};
+use super::{Schema, UpdateableSchema};
 use restate_schema_api::component::ComponentMetadata;
 use restate_schema_api::deployment::{Deployment, DeploymentMetadata, DeploymentResolver};
 use restate_types::identifiers::{ComponentRevision, DeploymentId};
@@ -22,7 +22,7 @@ pub struct DeploymentSchemas {
     pub components: Vec<ComponentMetadata>,
 }
 
-impl DeploymentResolver for SchemaInformation {
+impl DeploymentResolver for Schema {
     fn resolve_latest_deployment_for_component(
         &self,
         component_name: impl AsRef<str>,
@@ -80,7 +80,7 @@ impl DeploymentResolver for SchemaInformation {
     }
 }
 
-impl DeploymentResolver for UpdatingSchemaInformation {
+impl DeploymentResolver for UpdateableSchema {
     fn resolve_latest_deployment_for_component(
         &self,
         component_name: impl AsRef<str>,

--- a/crates/schema/src/deployment.rs
+++ b/crates/schema/src/deployment.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{SchemaInformation, SchemaView};
+use super::{SchemaInformation, UpdatingSchemaInformation};
 use restate_schema_api::component::ComponentMetadata;
 use restate_schema_api::deployment::{Deployment, DeploymentMetadata, DeploymentResolver};
 use restate_types::identifiers::{ComponentRevision, DeploymentId};
@@ -80,7 +80,7 @@ impl DeploymentResolver for SchemaInformation {
     }
 }
 
-impl DeploymentResolver for SchemaView {
+impl DeploymentResolver for UpdatingSchemaInformation {
     fn resolve_latest_deployment_for_component(
         &self,
         component_name: impl AsRef<str>,

--- a/crates/schema/src/invocation_target.rs
+++ b/crates/schema/src/invocation_target.rs
@@ -28,7 +28,7 @@ impl InvocationTargetResolver for SchemaInformation {
     }
 }
 
-impl InvocationTargetResolver for SchemaView {
+impl InvocationTargetResolver for UpdatingSchemaInformation {
     fn resolve_latest_invocation_target(
         &self,
         component_name: impl AsRef<str>,

--- a/crates/schema/src/invocation_target.rs
+++ b/crates/schema/src/invocation_target.rs
@@ -12,7 +12,7 @@ use super::*;
 
 use restate_schema_api::invocation_target::{InvocationTargetMetadata, InvocationTargetResolver};
 
-impl InvocationTargetResolver for SchemaInformation {
+impl InvocationTargetResolver for Schema {
     fn resolve_latest_invocation_target(
         &self,
         component_name: impl AsRef<str>,
@@ -28,7 +28,7 @@ impl InvocationTargetResolver for SchemaInformation {
     }
 }
 
-impl InvocationTargetResolver for UpdatingSchemaInformation {
+impl InvocationTargetResolver for UpdateableSchema {
     fn resolve_latest_invocation_target(
         &self,
         component_name: impl AsRef<str>,

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -25,19 +25,12 @@ use crate::component::ComponentSchemas;
 use crate::deployment::DeploymentSchemas;
 use restate_types::{Version, Versioned};
 
-/// Immutable view of the schema registry.
+/// Schema information which automatically loads the latest version when accessing it.
 ///
 /// Temporary bridge until users are migrated to directly using the metadata
-/// provided schema registry.
-#[derive(Debug, Default, Clone)]
-pub struct SchemaView(Arc<ArcSwap<SchemaInformation>>);
-
-impl SchemaView {
-    /// Update current view with new schema registry.
-    pub fn update(&self, schema_registry: Arc<SchemaInformation>) {
-        self.0.store(schema_registry);
-    }
-}
+/// provided schema information.
+#[derive(Debug, Default, Clone, derive_more::From)]
+pub struct UpdatingSchemaInformation(Arc<ArcSwap<SchemaInformation>>);
 
 /// The schema information
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -30,18 +30,18 @@ use restate_types::{Version, Versioned};
 /// Temporary bridge until users are migrated to directly using the metadata
 /// provided schema information.
 #[derive(Debug, Default, Clone, derive_more::From)]
-pub struct UpdatingSchemaInformation(Arc<ArcSwap<SchemaInformation>>);
+pub struct UpdateableSchema(Arc<ArcSwap<Schema>>);
 
 /// The schema information
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SchemaInformation {
+pub struct Schema {
     pub version: Version,
     pub components: HashMap<String, ComponentSchemas>,
     pub deployments: HashMap<DeploymentId, DeploymentSchemas>,
     pub subscriptions: HashMap<SubscriptionId, Subscription>,
 }
 
-impl Default for SchemaInformation {
+impl Default for Schema {
     fn default() -> Self {
         Self {
             version: Version::INVALID,
@@ -52,7 +52,7 @@ impl Default for SchemaInformation {
     }
 }
 
-impl SchemaInformation {
+impl Schema {
     pub fn increment_version(&mut self) {
         self.version = self.version.next();
     }
@@ -87,7 +87,7 @@ impl SchemaInformation {
     }
 }
 
-impl Versioned for SchemaInformation {
+impl Versioned for Schema {
     fn version(&self) -> Version {
         self.version
     }
@@ -101,7 +101,7 @@ mod test_util {
     use restate_schema_api::invocation_target::InvocationTargetResolver;
     use restate_test_util::{assert, assert_eq};
 
-    impl SchemaInformation {
+    impl Schema {
         #[track_caller]
         pub fn assert_component_handler(&self, component_name: &str, handler_name: &str) {
             assert!(self

--- a/crates/schema/src/subscriptions.rs
+++ b/crates/schema/src/subscriptions.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{SchemaInformation, SchemaView};
+use super::{SchemaInformation, UpdatingSchemaInformation};
 
 use restate_schema_api::subscription::{
     ListSubscriptionFilter, Subscription, SubscriptionResolver,
@@ -36,7 +36,7 @@ impl SubscriptionResolver for SchemaInformation {
     }
 }
 
-impl SubscriptionResolver for SchemaView {
+impl SubscriptionResolver for UpdatingSchemaInformation {
     fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription> {
         self.0.load().get_subscription(id)
     }

--- a/crates/schema/src/subscriptions.rs
+++ b/crates/schema/src/subscriptions.rs
@@ -8,14 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{SchemaInformation, UpdatingSchemaInformation};
+use super::{Schema, UpdateableSchema};
 
 use restate_schema_api::subscription::{
     ListSubscriptionFilter, Subscription, SubscriptionResolver,
 };
 use restate_types::identifiers::SubscriptionId;
 
-impl SubscriptionResolver for SchemaInformation {
+impl SubscriptionResolver for Schema {
     fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription> {
         self.subscriptions.get(&id).cloned()
     }
@@ -36,7 +36,7 @@ impl SubscriptionResolver for SchemaInformation {
     }
 }
 
-impl SubscriptionResolver for UpdatingSchemaInformation {
+impl SubscriptionResolver for UpdateableSchema {
     fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription> {
         self.0.load().get_subscription(id)
     }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -38,7 +38,7 @@ use restate_invoker_impl::{
 };
 use restate_metadata_store::MetadataStoreClient;
 use restate_network::Networking;
-use restate_schema::SchemaView;
+use restate_schema::UpdatingSchemaInformation;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_query_postgres::service::PostgresQueryService;
@@ -55,7 +55,7 @@ use restate_types::Version;
 type PartitionProcessor =
     partition::PartitionProcessor<ProtobufRawEntryCodec, InvokerChannelServiceHandle>;
 
-type ExternalClientIngress = HyperServerIngress<SchemaView, IngressDispatcher>;
+type ExternalClientIngress = HyperServerIngress<UpdatingSchemaInformation, IngressDispatcher>;
 
 #[derive(Debug, thiserror::Error, CodedError)]
 #[error("failed creating worker: {0}")]
@@ -104,8 +104,8 @@ pub struct Worker {
     invoker: InvokerService<
         InvokerStorageReader<RocksDBStorage>,
         InvokerStorageReader<RocksDBStorage>,
-        EntryEnricher<SchemaView, ProtobufRawEntryCodec>,
-        SchemaView,
+        EntryEnricher<UpdatingSchemaInformation, ProtobufRawEntryCodec>,
+        UpdatingSchemaInformation,
     >,
     external_client_ingress: ExternalClientIngress,
     ingress_kafka: IngressKafkaService,
@@ -120,7 +120,7 @@ impl Worker {
         networking: Networking,
         bifrost: Bifrost,
         router_builder: &mut MessageRouterBuilder,
-        schema_view: SchemaView,
+        schema_view: UpdatingSchemaInformation,
         metadata_store_client: MetadataStoreClient,
     ) -> Result<Worker, BuildError> {
         metric_definitions::describe_metrics();
@@ -139,7 +139,7 @@ impl Worker {
         networking: Networking,
         bifrost: Bifrost,
         router_builder: &mut MessageRouterBuilder,
-        schema_view: SchemaView,
+        schema_view: UpdatingSchemaInformation,
         metadata_store_client: MetadataStoreClient,
     ) -> Result<Self, BuildError> {
         let ingress_dispatcher = IngressDispatcher::new(bifrost);

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -38,7 +38,7 @@ use restate_invoker_impl::{
 };
 use restate_metadata_store::MetadataStoreClient;
 use restate_network::Networking;
-use restate_schema::UpdatingSchemaInformation;
+use restate_schema::UpdateableSchema;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_query_postgres::service::PostgresQueryService;
@@ -55,7 +55,7 @@ use restate_types::Version;
 type PartitionProcessor =
     partition::PartitionProcessor<ProtobufRawEntryCodec, InvokerChannelServiceHandle>;
 
-type ExternalClientIngress = HyperServerIngress<UpdatingSchemaInformation, IngressDispatcher>;
+type ExternalClientIngress = HyperServerIngress<UpdateableSchema, IngressDispatcher>;
 
 #[derive(Debug, thiserror::Error, CodedError)]
 #[error("failed creating worker: {0}")]
@@ -104,8 +104,8 @@ pub struct Worker {
     invoker: InvokerService<
         InvokerStorageReader<RocksDBStorage>,
         InvokerStorageReader<RocksDBStorage>,
-        EntryEnricher<UpdatingSchemaInformation, ProtobufRawEntryCodec>,
-        UpdatingSchemaInformation,
+        EntryEnricher<UpdateableSchema, ProtobufRawEntryCodec>,
+        UpdateableSchema,
     >,
     external_client_ingress: ExternalClientIngress,
     ingress_kafka: IngressKafkaService,
@@ -120,7 +120,7 @@ impl Worker {
         networking: Networking,
         bifrost: Bifrost,
         router_builder: &mut MessageRouterBuilder,
-        schema_view: UpdatingSchemaInformation,
+        schema_view: UpdateableSchema,
         metadata_store_client: MetadataStoreClient,
     ) -> Result<Worker, BuildError> {
         metric_definitions::describe_metrics();
@@ -139,7 +139,7 @@ impl Worker {
         networking: Networking,
         bifrost: Bifrost,
         router_builder: &mut MessageRouterBuilder,
-        schema_view: UpdatingSchemaInformation,
+        schema_view: UpdateableSchema,
         metadata_store_client: MetadataStoreClient,
     ) -> Result<Self, BuildError> {
         let ingress_dispatcher = IngressDispatcher::new(bifrost);


### PR DESCRIPTION
This commit removes the unnecessary SchemaView indirection that
was part of the WorkerRole. Instead, Metadata now directly offers
an UpdatingSchemaInformation object which an be passed down to
users.

This fixes https://github.com/restatedev/restate/issues/1367.

This PR is based on #1361.