### PR TITLE
Only insert NodesConfiguration, PartitionTable and Logs configuration if bootstrapping

### DIFF
--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -52,7 +52,7 @@ pub struct CommonOptions {
     /// have the same.
     cluster_name: String,
 
-    /// If true, then a new cluster is bootstrapped. This node *must* be has an admin
+    /// If true, then a new cluster is bootstrapped. This node *must* have an admin
     /// role and a new nodes configuration will be created that includes this node.
     pub allow_bootstrap: bool,
 


### PR DESCRIPTION
This commit restricts Nodes to only insert NodesConfiguration, PartitionTable and Logs configuration if in bootstrapping mode. Note that updating an existing NodesConfiguration is still possible if not bootstrapping.

This fixes #1371.