### PR TITLE
Support adding delay to send requests through the ingress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,6 +3117,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,8 +5255,10 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
+ "humantime",
  "hyper 1.2.0",
  "hyper-util",
+ "iso8601",
  "metrics",
  "opentelemetry",
  "pin-project-lite",
@@ -5272,6 +5283,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
+ "url",
  "urlencoding",
 ]
 

--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -85,6 +85,7 @@ impl DispatchIngressRequest for IngressDispatcher {
             request_mode,
             idempotency,
             headers,
+            execution_time,
         } = ingress_request;
 
         let invocation_id: InvocationId = fid.clone().into();
@@ -102,7 +103,7 @@ impl DispatchIngressRequest for IngressDispatcher {
             response_sink,
             span_context,
             headers,
-            execution_time: None,
+            execution_time,
             idempotency,
         };
 

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -38,6 +38,7 @@ restate-futures-util = { workspace = true }
 hyper = { version = "1", features = ["server"] }
 tokio = { workspace = true }
 http = "1.0"
+url = "2.5.0"
 http-body = "1.0"
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["http1", "http2", "server", "tokio"] }
@@ -62,6 +63,8 @@ schemars = { workspace = true, optional = true }
 thiserror = { workspace = true }
 urlencoding = "2.1"
 pin-project-lite = "0.2.13"
+iso8601 = "0.6.1"
+humantime = { workspace = true }
 
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }

--- a/crates/ingress-http/src/handler/component_handler.rs
+++ b/crates/ingress-http/src/handler/component_handler.rs
@@ -24,17 +24,24 @@ use restate_schema_api::invocation_target::{InvocationTargetMetadata, Invocation
 use restate_types::identifiers::{FullInvocationId, InvocationId, ServiceId};
 use restate_types::invocation::{Header, Idempotency, ResponseResult, SpanRelation};
 use serde::Serialize;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tracing::{info, trace, warn, Instrument};
 
 pub(crate) const IDEMPOTENCY_KEY: HeaderName = HeaderName::from_static("idempotency-key");
 const IDEMPOTENCY_EXPIRES: HeaderName = HeaderName::from_static("idempotency-expires");
+const DELAY_QUERY_PARAM: &str = "delay";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(serde::Deserialize))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SendResponse {
     invocation_id: InvocationId,
+    #[serde(
+        with = "serde_with::As::<Option<serde_with::DisplayFromStr>>",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    execution_time: Option<humantime::Timestamp>,
 }
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
@@ -128,9 +135,15 @@ where
             // Get headers
             let headers = parse_headers(parts.headers)?;
 
+            // Parse delay query parameter
+            let delay = parse_delay(parts.uri.query())?;
+
             let span_relation = SpanRelation::Parent(ingress_span_context);
             match invoke_ty {
                 InvokeType::Call => {
+                    if delay.is_some() {
+                        return Err(HandlerError::UnsupportedDelay);
+                    }
                     Self::handle_component_call(
                         fid,
                         cloned_handler_name,
@@ -151,6 +164,7 @@ where
                         body,
                         span_relation,
                         headers,
+                        delay,
                         self.dispatcher,
                     )
                     .await
@@ -253,6 +267,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_component_send(
         fid: FullInvocationId,
         handler: String,
@@ -260,9 +275,13 @@ where
         body: Bytes,
         span_relation: SpanRelation,
         headers: Vec<Header>,
+        delay: Option<Duration>,
         dispatcher: Dispatcher,
     ) -> Result<Response<Full<Bytes>>, HandlerError> {
         let invocation_id = InvocationId::from(&fid);
+
+        // Establish execution_time
+        let execution_time = delay.map(|d| SystemTime::now() + d);
 
         // Send the service invocation
         let invocation = IngressDispatcherRequest::background_invocation(
@@ -273,6 +292,7 @@ where
             None,
             idempotency,
             headers,
+            execution_time,
         );
         if let Err(e) = dispatcher.dispatch_ingress_request(invocation).await {
             warn!(
@@ -288,9 +308,12 @@ where
             .status(StatusCode::ACCEPTED)
             .header(header::CONTENT_TYPE, APPLICATION_JSON)
             .body(Full::new(
-                serde_json::to_vec(&SendResponse { invocation_id })
-                    .unwrap()
-                    .into(),
+                serde_json::to_vec(&SendResponse {
+                    invocation_id,
+                    execution_time: execution_time.map(Into::into),
+                })
+                .unwrap()
+                .into(),
             ))
             .unwrap())
     }
@@ -314,6 +337,24 @@ fn parse_headers(headers: HeaderMap) -> Result<Vec<Header>, HandlerError> {
             Ok(Header::new(k.as_str(), value))
         })
         .collect()
+}
+
+fn parse_delay(query: Option<&str>) -> Result<Option<Duration>, HandlerError> {
+    if query.is_none() {
+        return Ok(None);
+    }
+
+    for (k, v) in url::form_urlencoded::parse(query.unwrap().as_bytes()) {
+        if k.eq_ignore_ascii_case(DELAY_QUERY_PARAM) {
+            return Ok(Some(
+                iso8601::duration(v.as_ref())
+                    .map_err(HandlerError::BadDelayDuration)?
+                    .into(),
+            ));
+        }
+    }
+
+    Ok(None)
 }
 
 fn parse_idempotency(

--- a/crates/ingress-http/src/handler/component_handler.rs
+++ b/crates/ingress-http/src/handler/component_handler.rs
@@ -30,6 +30,7 @@ use tracing::{info, trace, warn, Instrument};
 pub(crate) const IDEMPOTENCY_KEY: HeaderName = HeaderName::from_static("idempotency-key");
 const IDEMPOTENCY_EXPIRES: HeaderName = HeaderName::from_static("idempotency-expires");
 const DELAY_QUERY_PARAM: &str = "delay";
+const DELAYSEC_QUERY_PARAM: &str = "delaysec";
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(serde::Deserialize))]
@@ -351,6 +352,11 @@ fn parse_delay(query: Option<&str>) -> Result<Option<Duration>, HandlerError> {
                     .map_err(HandlerError::BadDelayDuration)?
                     .into(),
             ));
+        }
+        if k.eq_ignore_ascii_case(DELAYSEC_QUERY_PARAM) {
+            return Ok(Some(Duration::from_secs(
+                k.parse().map_err(HandlerError::BadDelaySecDuration)?,
+            )));
         }
     }
 

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -35,6 +35,8 @@ pub(crate) enum HandlerError {
     BadHeader(header::HeaderName, #[source] header::ToStrError),
     #[error("bad delay query parameter, must be a ISO8601 duration: {0}")]
     BadDelayDuration(String),
+    #[error("bad delaySec query parameter, must be a number: {0:?}")]
+    BadDelaySecDuration(std::num::ParseIntError),
     #[error("bad path, cannot decode key: {0:?}")]
     UrlDecodingError(string::FromUtf8Error),
     #[error("the invoked component is not public")]
@@ -80,6 +82,7 @@ impl HandlerError {
             | HandlerError::PrivateComponent
             | HandlerError::UrlDecodingError(_)
             | HandlerError::BadDelayDuration(_)
+            | HandlerError::BadDelaySecDuration(_)
             | HandlerError::BadAwakeablesPath
             | HandlerError::UnsupportedDelay
             | HandlerError::BadHeader(_, _)

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -33,6 +33,8 @@ pub(crate) enum HandlerError {
     NotImplemented,
     #[error("bad header {0}: {1:?}")]
     BadHeader(header::HeaderName, #[source] header::ToStrError),
+    #[error("bad delay query parameter, must be a ISO8601 duration: {0}")]
+    BadDelayDuration(String),
     #[error("bad path, cannot decode key: {0:?}")]
     UrlDecodingError(string::FromUtf8Error),
     #[error("the invoked component is not public")]
@@ -47,6 +49,10 @@ pub(crate) enum HandlerError {
     Invocation(InvocationError),
     #[error("input validation error: {0}")]
     InputValidation(#[from] InputValidationError),
+    #[error(
+        "cannot use the delay query parameter with calls. The delay is supported only with sends"
+    )]
+    UnsupportedDelay,
 }
 
 #[derive(Debug, Serialize)]
@@ -70,19 +76,21 @@ impl HandlerError {
     ) -> Response<B> {
         let status_code = match &self {
             HandlerError::NotFound => StatusCode::NOT_FOUND,
-            HandlerError::BadComponentPath => StatusCode::BAD_REQUEST,
-            HandlerError::PrivateComponent => StatusCode::BAD_REQUEST,
+            HandlerError::BadComponentPath
+            | HandlerError::PrivateComponent
+            | HandlerError::UrlDecodingError(_)
+            | HandlerError::BadDelayDuration(_)
+            | HandlerError::BadAwakeablesPath
+            | HandlerError::UnsupportedDelay
+            | HandlerError::BadHeader(_, _)
+            | HandlerError::InputValidation(_) => StatusCode::BAD_REQUEST,
             HandlerError::Body(_) => StatusCode::INTERNAL_SERVER_ERROR,
             HandlerError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
             HandlerError::MethodNotAllowed => StatusCode::METHOD_NOT_ALLOWED,
-            HandlerError::UrlDecodingError(_) => StatusCode::BAD_REQUEST,
-            HandlerError::BadAwakeablesPath => StatusCode::BAD_REQUEST,
             HandlerError::NotImplemented => StatusCode::NOT_IMPLEMENTED,
             HandlerError::Invocation(e) => {
                 StatusCode::from_u16(e.code().into()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
-            HandlerError::BadHeader(_, _) => StatusCode::BAD_REQUEST,
-            HandlerError::InputValidation(_) => StatusCode::BAD_REQUEST,
         };
 
         let error_response = match self {


### PR DESCRIPTION
Fix #1235

You can pass a duration as query parameter either as:

`delay={ISO8601 string}` or `delaySec={number}`.

E.g: `delay=PT1H30M` or `delaySec=120`.