### PR TITLE
Invoker doesn't use FullInvocationId anymore

### DIFF
--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -1012,10 +1012,9 @@ pub async fn get_invocation_journal(
                     invoked_handler,
                     invoked_component_key,
                 }),
-                "Awakeable" => JournalEntryType::Awakeable(AwakeableIdentifier::new(
-                    my_invocation_id.clone(),
-                    index,
-                )),
+                "Awakeable" => {
+                    JournalEntryType::Awakeable(AwakeableIdentifier::new(my_invocation_id, index))
+                }
                 "GetState" => JournalEntryType::GetState,
                 "SetState" => JournalEntryType::SetState,
                 "ClearState" => JournalEntryType::ClearState,

--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -154,9 +154,7 @@ impl MessageHandler for IngressDispatcher {
                         IngressCorrelationId::IdempotencyId(idempotency_id.clone())
                     })
                     .unwrap_or_else(|| {
-                        IngressCorrelationId::InvocationId(
-                            invocation_response.invocation_id.clone(),
-                        )
+                        IngressCorrelationId::InvocationId(invocation_response.invocation_id)
                     });
                 if let Some((_, sender)) = self.state.waiting_responses.remove(&correlation_id) {
                     let dispatcher_response = IngressDispatcherResponse {

--- a/crates/invoker-api/src/effects.rs
+++ b/crates/invoker-api/src/effects.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use restate_types::errors::InvocationError;
-use restate_types::identifiers::FullInvocationId;
+use restate_types::identifiers::InvocationId;
 use restate_types::identifiers::{DeploymentId, EntryIndex};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use std::collections::HashSet;
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Effect {
-    pub full_invocation_id: FullInvocationId,
+    pub invocation_id: InvocationId,
     pub kind: EffectKind,
 }
 

--- a/crates/invoker-api/src/journal_reader.rs
+++ b/crates/invoker-api/src/journal_reader.rs
@@ -10,7 +10,7 @@
 
 use bytestring::ByteString;
 use futures::Stream;
-use restate_types::identifiers::{DeploymentId, FullInvocationId};
+use restate_types::identifiers::{DeploymentId, InvocationId};
 use restate_types::invocation::ServiceInvocationSpanContext;
 use restate_types::journal::raw::PlainRawEntry;
 use restate_types::journal::EntryIndex;
@@ -21,6 +21,7 @@ use std::future::Future;
 pub struct JournalMetadata {
     pub length: EntryIndex,
     pub span_context: ServiceInvocationSpanContext,
+    // TODO could be removed once we introduce InvocationTarget with https://github.com/restatedev/restate/issues/1329
     pub method: ByteString,
     pub deployment_id: Option<DeploymentId>,
 }
@@ -47,7 +48,7 @@ pub trait JournalReader {
 
     fn read_journal<'a>(
         &'a mut self,
-        fid: &'a FullInvocationId,
+        fid: &'a InvocationId,
     ) -> impl Future<Output = Result<(JournalMetadata, Self::JournalStream), Self::Error>> + Send;
 }
 
@@ -66,7 +67,7 @@ pub mod mocks {
 
         async fn read_journal<'a>(
             &'a mut self,
-            _sid: &'a FullInvocationId,
+            _sid: &'a InvocationId,
         ) -> Result<(JournalMetadata, Self::JournalStream), Self::Error> {
             Ok((
                 JournalMetadata::new(

--- a/crates/invoker-api/src/status_handle.rs
+++ b/crates/invoker-api/src/status_handle.rs
@@ -10,7 +10,7 @@
 
 use codederror::Code;
 use restate_types::errors::{InvocationError, InvocationErrorCode};
-use restate_types::identifiers::{DeploymentId, FullInvocationId, PartitionKey};
+use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
 use std::fmt;
 use std::future::Future;
@@ -44,21 +44,21 @@ impl Default for InvocationStatusReportInner {
 
 #[derive(Debug, Clone)]
 pub struct InvocationStatusReport(
-    FullInvocationId,
+    InvocationId,
     PartitionLeaderEpoch,
     InvocationStatusReportInner,
 );
 
 impl InvocationStatusReport {
     pub fn new(
-        fid: FullInvocationId,
+        invocation_id: InvocationId,
         partition: PartitionLeaderEpoch,
         report: InvocationStatusReportInner,
     ) -> Self {
-        Self(fid, partition, report)
+        Self(invocation_id, partition, report)
     }
 
-    pub fn full_invocation_id(&self) -> &FullInvocationId {
+    pub fn invocation_id(&self) -> &InvocationId {
         &self.0
     }
 

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -21,6 +21,7 @@ use tokio::task::AbortHandle;
 /// Component encapsulating the business logic of the invocation state machine
 #[derive(Debug)]
 pub(super) struct InvocationStateMachine {
+    pub(super) service_id: ServiceId,
     invocation_state: InvocationState,
     retry_iter: retries::RetryIter,
 }
@@ -127,8 +128,12 @@ impl fmt::Debug for InvocationState {
 }
 
 impl InvocationStateMachine {
-    pub(super) fn create(retry_policy: RetryPolicy) -> InvocationStateMachine {
+    pub(super) fn create(
+        service_id: ServiceId,
+        retry_policy: RetryPolicy,
+    ) -> InvocationStateMachine {
         Self {
+            service_id,
             invocation_state: InvocationState::New,
             retry_iter: retry_policy.into_iter(),
         }
@@ -330,8 +335,10 @@ mod tests {
 
     #[test]
     fn handle_error_when_waiting_for_retry() {
-        let mut invocation_state_machine =
-            InvocationStateMachine::create(RetryPolicy::fixed_delay(Duration::from_secs(1), 10));
+        let mut invocation_state_machine = InvocationStateMachine::create(
+            ServiceId::mock_random(),
+            RetryPolicy::fixed_delay(Duration::from_secs(1), 10),
+        );
 
         assert!(invocation_state_machine.handle_task_error().is_some());
         check!(let InvocationState::WaitingRetry { .. } = invocation_state_machine.invocation_state);
@@ -345,8 +352,10 @@ mod tests {
 
     #[test(tokio::test)]
     async fn handle_requires_ack() {
-        let mut invocation_state_machine =
-            InvocationStateMachine::create(RetryPolicy::fixed_delay(Duration::from_secs(1), 10));
+        let mut invocation_state_machine = InvocationStateMachine::create(
+            ServiceId::mock_random(),
+            RetryPolicy::fixed_delay(Duration::from_secs(1), 10),
+        );
 
         let abort_handle = tokio::spawn(async {}).abort_handle();
         let (tx, mut rx) = mpsc::unbounded_channel();

--- a/crates/invoker-impl/src/status_store.rs
+++ b/crates/invoker-impl/src/status_store.rs
@@ -16,7 +16,7 @@ use std::time::SystemTime;
 
 #[derive(Default, Debug)]
 pub(super) struct InvocationStatusStore(
-    HashMap<PartitionLeaderEpoch, HashMap<FullInvocationId, InvocationStatusReportInner>>,
+    HashMap<PartitionLeaderEpoch, HashMap<InvocationId, InvocationStatusReportInner>>,
 );
 
 impl InvocationStatusStore {
@@ -28,16 +28,29 @@ impl InvocationStatusStore {
             .get(&partition_leader_epoch)
             .into_iter()
             .flat_map(move |hash| {
-                hash.iter().map(move |(fid, report)| {
-                    InvocationStatusReport::new(fid.clone(), partition_leader_epoch, report.clone())
+                hash.iter().map(move |(invocation_id, report)| {
+                    InvocationStatusReport::new(
+                        *invocation_id,
+                        partition_leader_epoch,
+                        report.clone(),
+                    )
                 })
             })
     }
 
     // -- Methods used by the invoker to notify the status
 
-    pub(super) fn on_start(&mut self, partition: PartitionLeaderEpoch, fid: FullInvocationId) {
-        let report = self.0.entry(partition).or_default().entry(fid).or_default();
+    pub(super) fn on_start(
+        &mut self,
+        partition: PartitionLeaderEpoch,
+        invocation_id: InvocationId,
+    ) {
+        let report = self
+            .0
+            .entry(partition)
+            .or_default()
+            .entry(invocation_id)
+            .or_default();
         report.start_count += 1;
         report.last_start_at = SystemTime::now();
         report.next_retry_at = None;
@@ -47,19 +60,23 @@ impl InvocationStatusStore {
     pub(super) fn on_deployment_chosen(
         &mut self,
         partition: &PartitionLeaderEpoch,
-        fid: &FullInvocationId,
+        invocation_id: &InvocationId,
         deployment_id: DeploymentId,
     ) {
         if let Some(inner) = self.0.get_mut(partition) {
-            if let Some(report) = inner.get_mut(fid) {
+            if let Some(report) = inner.get_mut(invocation_id) {
                 report.last_attempt_deployment_id = Some(deployment_id);
             }
         }
     }
 
-    pub(super) fn on_end(&mut self, partition: &PartitionLeaderEpoch, fid: &FullInvocationId) {
+    pub(super) fn on_end(
+        &mut self,
+        partition: &PartitionLeaderEpoch,
+        invocation_id: &InvocationId,
+    ) {
         if let Some(inner) = self.0.get_mut(partition) {
-            inner.remove(fid);
+            inner.remove(invocation_id);
             if inner.is_empty() {
                 self.0.remove(partition);
             }
@@ -69,11 +86,16 @@ impl InvocationStatusStore {
     pub(super) fn on_failure(
         &mut self,
         partition: PartitionLeaderEpoch,
-        fid: FullInvocationId,
+        invocation_id: InvocationId,
         reason: InvocationErrorReport,
         next_retry_at: Option<SystemTime>,
     ) {
-        let report = self.0.entry(partition).or_default().entry(fid).or_default();
+        let report = self
+            .0
+            .entry(partition)
+            .or_default()
+            .entry(invocation_id)
+            .or_default();
         report.in_flight = false;
         report.next_retry_at = next_retry_at;
         report.last_retry_attempt_failure = Some(reason);
@@ -88,11 +110,11 @@ mod tests {
         pub fn resolve_invocation(
             &self,
             partition: PartitionLeaderEpoch,
-            fid: &FullInvocationId,
+            invocation_id: &InvocationId,
         ) -> Option<InvocationStatusReport> {
             self.0.get(&partition).and_then(|inner| {
-                inner.get(fid).map(|report| {
-                    InvocationStatusReport::new(fid.clone(), partition, report.clone())
+                inner.get(invocation_id).map(|report| {
+                    InvocationStatusReport::new(*invocation_id, partition, report.clone())
                 })
             })
         }

--- a/crates/service-protocol/src/awakeable_id.rs
+++ b/crates/service-protocol/src/awakeable_id.rs
@@ -108,7 +108,7 @@ mod tests {
         let expected_entry_index = 2_u32;
 
         let input_str = AwakeableIdentifier {
-            invocation_id: expected_invocation_id.clone(),
+            invocation_id: expected_invocation_id,
             entry_index: expected_entry_index,
         }
         .to_string();

--- a/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-proto/proto/dev/restate/storage/v1/domain.proto
@@ -151,7 +151,7 @@ message ServiceStatus {
 message ServiceInvocationResponseSink {
 
     message PartitionProcessor {
-        FullInvocationId caller = 1;
+        bytes caller = 1;
         uint32 entry_index = 2;
     }
 
@@ -383,7 +383,7 @@ message OutboxMessage {
     }
 
     message OutboxServiceInvocationResponse {
-        MaybeFullInvocationId maybe_fid = 1;
+        bytes invocation_id = 1;
         uint32 entry_index = 2;
         ResponseResult response_result = 3;
     }

--- a/crates/storage-query-datafusion/src/idempotency/tests.rs
+++ b/crates/storage-query-datafusion/src/idempotency/tests.rs
@@ -34,7 +34,7 @@ async fn get_idempotency_key() {
             "my-idempotency-key".into(),
         ),
         IdempotencyMetadata {
-            invocation_id: invocation_id_1.clone(),
+            invocation_id: invocation_id_1,
         },
     )
     .await;
@@ -47,7 +47,7 @@ async fn get_idempotency_key() {
             "my-idempotency-key".into(),
         ),
         IdempotencyMetadata {
-            invocation_id: invocation_id_2.clone(),
+            invocation_id: invocation_id_2,
         },
     )
     .await;

--- a/crates/storage-query-datafusion/src/invocation_state/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/row.rs
@@ -11,7 +11,7 @@
 use crate::invocation_state::schema::StateBuilder;
 use crate::table_util::format_using;
 use restate_invoker_api::InvocationStatusReport;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::WithPartitionKey;
 use restate_types::time::MillisSinceEpoch;
 
 #[inline]
@@ -22,15 +22,11 @@ pub(crate) fn append_state_row(
 ) {
     let mut row = builder.row();
 
-    let invocation_id = status_row.full_invocation_id();
+    let invocation_id = status_row.invocation_id();
 
-    row.partition_key(invocation_id.service_id.partition_key());
-    row.component(&invocation_id.service_id.service_name);
-    row.component_key(
-        std::str::from_utf8(&invocation_id.service_id.key).expect("The key must be a string!"),
-    );
+    row.partition_key(invocation_id.partition_key());
     if row.is_id_defined() {
-        row.id(format_using(output, &InvocationId::from(invocation_id)));
+        row.id(format_using(output, &invocation_id));
     }
     row.in_flight(status_row.in_flight());
     row.retry_count(status_row.retry_count() as u64);

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -16,8 +16,6 @@ use datafusion::arrow::datatypes::DataType;
 
 define_table!(state(
     partition_key: DataType::UInt64,
-    component: DataType::LargeUtf8,
-    component_key: DataType::LargeUtf8,
     id: DataType::LargeUtf8,
     in_flight: DataType::Boolean,
     retry_count: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -72,7 +72,7 @@ async fn for_each_state<'a, I>(
     let mut temp = String::new();
     let mut rows = rows.collect::<Vec<_>>();
     // need to be ordered by partition key for symmetric joins
-    rows.sort_unstable_by_key(|row| row.full_invocation_id().service_id.partition_key());
+    rows.sort_unstable_by_key(|row| row.invocation_id().partition_key());
     for row in rows {
         append_state_row(&mut builder, &mut temp, row);
         if builder.full() {

--- a/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
@@ -102,8 +102,8 @@ async fn verify_all_svc_with_status_invoked<T: InvocationStatusTable>(txn: &mut 
     let stream = txn.invoked_invocations(0..=u64::MAX);
 
     let expected = vec![
-        FullInvocationId::combine(SERVICE_ID_1.clone(), INVOCATION_ID_1.clone()),
-        FullInvocationId::combine(SERVICE_ID_2.clone(), INVOCATION_ID_2.clone()),
+        FullInvocationId::combine(SERVICE_ID_1.clone(), *INVOCATION_ID_1),
+        FullInvocationId::combine(SERVICE_ID_2.clone(), *INVOCATION_ID_2),
     ];
 
     assert_stream_eq(stream, expected).await;

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -328,6 +328,7 @@ impl WithPartitionKey for ServiceId {
     Hash,
     PartialEq,
     Clone,
+    Copy,
     Debug,
     PartialOrd,
     Ord,

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -146,8 +146,7 @@ impl fmt::Display for MaybeFullInvocationId {
 /// Representing a response for a caller
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InvocationResponse {
-    /// Depending on the source of the response, this can be either the full identifier, or the short one.
-    pub id: MaybeFullInvocationId,
+    pub id: InvocationId,
     pub entry_index: EntryIndex,
     pub result: ResponseResult,
 }
@@ -193,8 +192,7 @@ impl From<&InvocationError> for ResponseResult {
 pub enum ServiceInvocationResponseSink {
     /// The invocation has been created by a partition processor and is expecting a response.
     PartitionProcessor {
-        // TODO this can be changed to simply InvocationId
-        caller: FullInvocationId,
+        caller: InvocationId,
         entry_index: EntryIndex,
     },
     /// The result needs to be used as input argument of a new invocation

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -49,7 +49,7 @@ impl ActionEffectHandler {
     pub(super) async fn handle(&mut self, actuator_output: ActionEffect) -> anyhow::Result<()> {
         match actuator_output {
             ActionEffect::Invoker(invoker_output) => {
-                let header = self.create_header(invoker_output.full_invocation_id.partition_key());
+                let header = self.create_header(invoker_output.invocation_id.partition_key());
                 append_envelope_to_bifrost(
                     &mut self.bifrost,
                     Envelope::new(header, Command::InvokerEffect(invoker_output)),

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -45,14 +45,14 @@ pub enum Action {
         timer_key: TimerKey,
     },
     AckStoredEntry {
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         entry_index: EntryIndex,
     },
     ForwardCompletion {
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         completion: Completion,
     },
-    AbortInvocation(FullInvocationId),
+    AbortInvocation(InvocationId),
     IngressResponse(IngressResponse),
     ScheduleInvocationStatusCleanup {
         invocation_id: InvocationId,

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -386,11 +386,11 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                 Self::store_completion(state_storage, &invocation_id, entry_index, result).await?;
             }
             Effect::ForwardCompletion {
-                full_invocation_id,
+                invocation_id,
                 completion,
             } => {
                 collector.push(Action::ForwardCompletion {
-                    full_invocation_id,
+                    invocation_id,
                     completion,
                 });
             }
@@ -423,12 +423,12 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
             Effect::TraceInvocationResult { .. } | Effect::TraceBackgroundInvoke { .. } => {
                 // these effects are only needed for span creation
             }
-            Effect::SendAbortInvocationToInvoker(full_invocation_id) => {
-                collector.push(Action::AbortInvocation(full_invocation_id))
+            Effect::SendAbortInvocationToInvoker(invocation_id) => {
+                collector.push(Action::AbortInvocation(invocation_id))
             }
-            Effect::SendStoredEntryAckToInvoker(full_invocation_id, entry_index) => {
+            Effect::SendStoredEntryAckToInvoker(invocation_id, entry_index) => {
                 collector.push(Action::AckStoredEntry {
-                    full_invocation_id,
+                    invocation_id,
                     entry_index,
                 });
             }
@@ -543,7 +543,7 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
     ) -> Result<(), Error> {
         let full_invocation_id = FullInvocationId::combine(
             in_flight_invocation_metadata.service_id.clone(),
-            invocation_id.clone(),
+            invocation_id,
         );
 
         // In our current data model, ServiceInvocation has always an input, so initial length is 1
@@ -552,7 +552,7 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
         state_storage
             .store_service_status(
                 &in_flight_invocation_metadata.service_id,
-                VirtualObjectStatus::Locked(invocation_id.clone()),
+                VirtualObjectStatus::Locked(invocation_id),
             )
             .await?;
         state_storage

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -132,8 +132,7 @@ pub(crate) enum Effect {
         completion: Completion,
     },
     ForwardCompletion {
-        // TODO this can be invocation_id once the invoker uses only InvocationId
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         completion: Completion,
     },
     DropJournal {
@@ -157,8 +156,8 @@ pub(crate) enum Effect {
     },
 
     // Invoker commands
-    SendAbortInvocationToInvoker(FullInvocationId),
-    SendStoredEntryAckToInvoker(FullInvocationId, EntryIndex),
+    SendAbortInvocationToInvoker(InvocationId),
+    SendStoredEntryAckToInvoker(InvocationId, EntryIndex),
 
     // State mutations
     MutateState(ExternalStateMutation),
@@ -873,11 +872,11 @@ impl Effects {
 
     pub(crate) fn forward_completion(
         &mut self,
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         completion: Completion,
     ) {
         self.effects.push(Effect::ForwardCompletion {
-            full_invocation_id,
+            invocation_id,
             completion,
         });
     }
@@ -921,9 +920,9 @@ impl Effects {
         })
     }
 
-    pub(crate) fn abort_invocation(&mut self, full_invocation_id: FullInvocationId) {
+    pub(crate) fn abort_invocation(&mut self, invocation_id: InvocationId) {
         self.effects
-            .push(Effect::SendAbortInvocationToInvoker(full_invocation_id));
+            .push(Effect::SendAbortInvocationToInvoker(invocation_id));
     }
 
     pub(crate) fn store_idempotency_id(
@@ -942,11 +941,11 @@ impl Effects {
 
     pub(crate) fn send_stored_ack_to_invoker(
         &mut self,
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
         entry_index: EntryIndex,
     ) {
         self.effects.push(Effect::SendStoredEntryAckToInvoker(
-            full_invocation_id,
+            invocation_id,
             entry_index,
         ));
     }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -248,11 +248,12 @@ mod tests {
     async fn awakeable_completion_received_before_entry() -> TestResult {
         let mut state_machine = MockStateMachine::default();
         let fid = mock_start_invocation(&mut state_machine).await;
+        let invocation_id = InvocationId::from(&fid);
 
         // Send completion first
         let _ = state_machine
             .apply(Command::InvocationResponse(InvocationResponse {
-                id: MaybeFullInvocationId::Full(fid.clone()),
+                id: invocation_id,
                 entry_index: 1,
                 result: ResponseResult::Success(Bytes::default()),
             }))
@@ -274,7 +275,7 @@ mod tests {
 
         let actions = state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::JournalEntry {
                     entry_index: 1,
                     entry: ProtobufRawEntryCodec::serialize_enriched(Entry::awakeable(None)),
@@ -286,7 +287,7 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::ForwardCompletion {
-                full_invocation_id: eq(fid.clone()),
+                invocation_id: eq(invocation_id),
                 completion: eq(Completion::new(
                     1,
                     CompletionResult::Success(Bytes::default())
@@ -312,7 +313,7 @@ mod tests {
 
         let actions = state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::Suspended {
                     waiting_for_completed_entries: HashSet::from([1]),
                 },
@@ -336,6 +337,7 @@ mod tests {
         let fid = FullInvocationId::generate(ServiceId::new("svc", "key"));
         let inboxed_fid = FullInvocationId::generate(ServiceId::new("svc", "key"));
         let caller_fid = FullInvocationId::mock_random();
+        let caller_invocation_id = InvocationId::from(&caller_fid);
 
         let _ = state_machine
             .apply(Command::Invoke(ServiceInvocation {
@@ -348,7 +350,7 @@ mod tests {
             .apply(Command::Invoke(ServiceInvocation {
                 fid: inboxed_fid.clone(),
                 response_sink: Some(ServiceInvocationResponseSink::PartitionProcessor {
-                    caller: caller_fid.clone(),
+                    caller: caller_invocation_id,
                     entry_index: 0,
                 }),
                 ..ServiceInvocation::mock()
@@ -380,12 +382,12 @@ mod tests {
         assert!(let InvocationStatus::Free = current_invocation_status);
 
         fn outbox_message_matcher(
-            caller_fid: FullInvocationId,
+            caller_id: InvocationId,
         ) -> impl Matcher<ActualT = restate_storage_api::outbox_table::OutboxMessage> {
             pat!(
                 restate_storage_api::outbox_table::OutboxMessage::ServiceResponse(pat!(
                     restate_types::invocation::InvocationResponse {
-                        id: eq(MaybeFullInvocationId::Full(caller_fid)),
+                        id: eq(caller_id),
                         entry_index: eq(0),
                         result: eq(ResponseResult::Failure(KILLED_INVOCATION_ERROR))
                     }
@@ -396,7 +398,7 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::NewOutboxMessage {
-                message: outbox_message_matcher(caller_fid.clone())
+                message: outbox_message_matcher(caller_invocation_id)
             }))
         );
 
@@ -409,7 +411,7 @@ mod tests {
 
         assert_that!(
             outbox_message,
-            some((ge(0), outbox_message_matcher(caller_fid.clone())))
+            some((ge(0), outbox_message_matcher(caller_invocation_id)))
         );
 
         state_machine.shutdown().await
@@ -419,6 +421,7 @@ mod tests {
     async fn mutate_state() -> anyhow::Result<()> {
         let mut state_machine = MockStateMachine::default();
         let fid = mock_start_invocation(&mut state_machine).await;
+        let invocation_id = InvocationId::from(&fid);
 
         let first_state_mutation: HashMap<Bytes, Bytes> = [
             (Bytes::from_static(b"foobar"), Bytes::from_static(b"foobar")),
@@ -461,7 +464,7 @@ mod tests {
         // next invocation is found
         state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::End,
             }))
             .await;
@@ -493,10 +496,11 @@ mod tests {
 
         let fid =
             mock_start_invocation_with_service_id(&mut state_machine, service_id.clone()).await;
+        let invocation_id = InvocationId::from(&fid);
 
         state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::JournalEntry {
                     entry_index: 1,
                     entry: ProtobufRawEntryCodec::serialize_enriched(Entry::clear_all_state()),
@@ -518,6 +522,7 @@ mod tests {
     async fn get_state_keys() -> TestResult {
         let mut state_machine = MockStateMachine::default();
         let fid = mock_start_invocation(&mut state_machine).await;
+        let invocation_id = InvocationId::from(&fid);
 
         // Mock some state
         let mut txn = state_machine.rocksdb_storage.transaction();
@@ -529,7 +534,7 @@ mod tests {
 
         let actions = state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::JournalEntry {
                     entry_index: 1,
                     entry: ProtobufRawEntryCodec::serialize_enriched(Entry::get_state_keys(None)),
@@ -541,7 +546,7 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::ForwardCompletion {
-                full_invocation_id: eq(fid.clone()),
+                invocation_id: eq(invocation_id),
                 completion: eq(Completion::new(
                     1,
                     ProtobufRawEntryCodec::serialize_get_state_keys_completion(vec![
@@ -598,7 +603,7 @@ mod tests {
         let response_bytes = Bytes::from_static(b"123");
         let actions = state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::JournalEntry {
                     entry_index: 1,
                     entry: ProtobufRawEntryCodec::serialize_enriched(Entry::output(
@@ -613,7 +618,7 @@ mod tests {
         // Send the End Effect
         let actions = state_machine
             .apply(Command::InvokerEffect(InvokerEffect {
-                full_invocation_id: fid.clone(),
+                invocation_id,
                 kind: InvokerEffectKind::End,
             }))
             .await;
@@ -695,7 +700,7 @@ mod tests {
                     .unwrap()
                     .unwrap(),
                 pat!(IdempotencyMetadata {
-                    invocation_id: eq(invocation_id.clone()),
+                    invocation_id: eq(invocation_id),
                 })
             );
             txn.commit().await.unwrap();
@@ -705,7 +710,7 @@ mod tests {
             let actions = state_machine
                 .apply_multiple([
                     Command::InvokerEffect(InvokerEffect {
-                        full_invocation_id: fid.clone(),
+                        invocation_id,
                         kind: InvokerEffectKind::JournalEntry {
                             entry_index: 1,
                             entry: ProtobufRawEntryCodec::serialize_enriched(Entry::output(
@@ -714,7 +719,7 @@ mod tests {
                         },
                     }),
                     Command::InvokerEffect(InvokerEffect {
-                        full_invocation_id: fid.clone(),
+                        invocation_id,
                         kind: InvokerEffectKind::End,
                     }),
                 ])
@@ -730,7 +735,7 @@ mod tests {
                         response: eq(ResponseResult::Success(response_bytes.clone()))
                     })))),
                     contains(pat!(Action::ScheduleInvocationStatusCleanup {
-                        invocation_id: eq(invocation_id.clone())
+                        invocation_id: eq(invocation_id)
                     }))
                 )
             );
@@ -773,13 +778,8 @@ mod tests {
 
             // Prepare idempotency metadata and completed status
             let mut txn = state_machine.storage().transaction();
-            txn.put_idempotency_metadata(
-                &idempotency_id,
-                IdempotencyMetadata {
-                    invocation_id: invocation_id.clone(),
-                },
-            )
-            .await;
+            txn.put_idempotency_metadata(&idempotency_id, IdempotencyMetadata { invocation_id })
+                .await;
             txn.put_invocation_status(
                 &invocation_id,
                 InvocationStatus::Completed(CompletedInvocation {
@@ -845,13 +845,8 @@ mod tests {
 
             // Prepare idempotency metadata
             let mut txn = state_machine.rocksdb_storage.transaction();
-            txn.put_idempotency_metadata(
-                &idempotency_id,
-                IdempotencyMetadata {
-                    invocation_id: invocation_id.clone(),
-                },
-            )
-            .await;
+            txn.put_idempotency_metadata(&idempotency_id, IdempotencyMetadata { invocation_id })
+                .await;
             txn.commit().await.unwrap();
 
             // Send a request, should be completed immediately with result
@@ -891,6 +886,7 @@ mod tests {
         async fn latch_invocation_while_executing() {
             let mut state_machine = MockStateMachine::default();
             let original_request_fid = FullInvocationId::generate(ServiceId::new("MyObj", "MyKey"));
+            let original_invocation_id = InvocationId::from(&original_request_fid);
             let handler_name = ByteString::from_static("handler");
             let idempotency = Idempotency {
                 key: ByteString::from_static("my-idempotency-key"),
@@ -942,7 +938,7 @@ mod tests {
             let actions = state_machine
                 .apply_multiple([
                     Command::InvokerEffect(InvokerEffect {
-                        full_invocation_id: original_request_fid.clone(),
+                        invocation_id: original_invocation_id,
                         kind: InvokerEffectKind::JournalEntry {
                             entry_index: 1,
                             entry: ProtobufRawEntryCodec::serialize_enriched(Entry::output(
@@ -951,7 +947,7 @@ mod tests {
                         },
                     }),
                     Command::InvokerEffect(InvokerEffect {
-                        full_invocation_id: original_request_fid.clone(),
+                        invocation_id: original_invocation_id,
                         kind: InvokerEffectKind::End,
                     }),
                 ])
@@ -996,13 +992,8 @@ mod tests {
 
             // Prepare idempotency metadata and completed status
             let mut txn = state_machine.storage().transaction();
-            txn.put_idempotency_metadata(
-                &idempotency_id,
-                IdempotencyMetadata {
-                    invocation_id: invocation_id.clone(),
-                },
-            )
-            .await;
+            txn.put_idempotency_metadata(&idempotency_id, IdempotencyMetadata { invocation_id })
+                .await;
             txn.put_invocation_status(
                 &invocation_id,
                 InvocationStatus::Completed(CompletedInvocation {
@@ -1023,7 +1014,7 @@ mod tests {
                         invocation_uuid: invocation_id.invocation_uuid(),
                         journal_index: 0,
                     },
-                    Timer::CleanInvocationStatus(invocation_id.clone()),
+                    Timer::CleanInvocationStatus(invocation_id),
                 )))
                 .await;
             assert_that!(

--- a/crates/worker/src/partition/storage/invoker.rs
+++ b/crates/worker/src/partition/storage/invoker.rs
@@ -16,8 +16,8 @@ use restate_storage_api::invocation_status_table::{
 };
 use restate_storage_api::journal_table::{JournalEntry, ReadOnlyJournalTable};
 use restate_storage_api::state_table::ReadOnlyStateTable;
+use restate_types::identifiers::InvocationId;
 use restate_types::identifiers::ServiceId;
-use restate_types::identifiers::{FullInvocationId, InvocationId};
 use restate_types::journal::raw::PlainRawEntry;
 use std::vec::IntoIter;
 
@@ -47,12 +47,9 @@ where
 
     async fn read_journal<'a>(
         &'a mut self,
-        fid: &'a FullInvocationId,
+        invocation_id: &'a InvocationId,
     ) -> Result<(JournalMetadata, Self::JournalStream), Self::Error> {
-        let invocation_status = self
-            .0
-            .get_invocation_status(&InvocationId::from(fid))
-            .await?;
+        let invocation_status = self.0.get_invocation_status(invocation_id).await?;
 
         if let InvocationStatus::Invoked(invoked_status) = invocation_status {
             let journal_metadata = JournalMetadata::new(
@@ -63,7 +60,7 @@ where
             );
             let journal_stream = self
                 .0
-                .get_journal(&InvocationId::from(fid), journal_metadata.length)
+                .get_journal(invocation_id, journal_metadata.length)
                 .map(|entry| {
                     entry
                         .map_err(InvokerStorageReaderError::Storage)

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -13,8 +13,8 @@ use restate_storage_api::outbox_table::OutboxMessage;
 use restate_types::identifiers::{EntryIndex, IdempotencyId, InvocationId};
 use restate_types::ingress::IngressResponse;
 use restate_types::invocation::{
-    InvocationResponse, MaybeFullInvocationId, ResponseResult, ServiceInvocation,
-    ServiceInvocationResponseSink, Source, SpanRelation,
+    InvocationResponse, ResponseResult, ServiceInvocation, ServiceInvocationResponseSink, Source,
+    SpanRelation,
 };
 use restate_wal_protocol::Command;
 
@@ -41,7 +41,7 @@ impl OutboxMessageExt for OutboxMessage {
         OutboxMessage::ServiceResponse(InvocationResponse {
             entry_index,
             result,
-            id: MaybeFullInvocationId::Partial(invocation_id),
+            id: invocation_id,
         })
     }
 
@@ -65,14 +65,14 @@ pub fn create_response_message(
             entry_index,
             caller,
         } => ResponseMessage::Outbox(OutboxMessage::ServiceResponse(InvocationResponse {
-            id: MaybeFullInvocationId::Full(caller),
+            id: caller,
             entry_index,
             result,
         })),
         ServiceInvocationResponseSink::Ingress(ingress_dispatcher_id) => {
             ResponseMessage::Ingress(IngressResponse {
                 target_node: ingress_dispatcher_id,
-                invocation_id: callee.clone(),
+                invocation_id: *callee,
                 idempotency_id,
                 response: result,
             })


### PR DESCRIPTION
Fix #1297

* InvocationResponse now uses only invocation_id, not MaybeFullInvocationId anymore
* Changed the api of the invoker to use only InvocationId (except in start, where also ServiceId is used)
* InvocationId now implements Copy