### PR TITLE
Quick patch latency issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4469,9 +4469,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978385d59daf9269189d052ca8a84c1acfd0715c0599a5d5188d4acc078ca46a"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4993,6 +4993,7 @@ dependencies = [
  "rand",
  "restate-core",
  "restate-node",
+ "restate-rocksdb",
  "restate-server",
  "restate-types",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,6 +5017,7 @@ dependencies = [
  "enum-map",
  "googletest",
  "humantime",
+ "metrics",
  "once_cell",
  "restate-core",
  "restate-metadata-store",

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -12,8 +12,9 @@ default = []
 frame-pointer = ["pprof/frame-pointer"]
 
 [dependencies]
-restate-core = { workspace = true }
+restate-core = { workspace = true, features = ["test-util"] }
 restate-node = { workspace = true }
+restate-rocksdb = { workspace = true }
 restate-server = { workspace = true }
 restate-types = { workspace = true, features = ["clap"] }
 
@@ -23,7 +24,7 @@ drain = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hyper = { workspace = true, features = ["client"] }
-pprof = { version = "0.12", features = ["criterion", "flamegraph"] }
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/benchmarks/benches/throughput_parallel.rs
+++ b/crates/benchmarks/benches/throughput_parallel.rs
@@ -19,6 +19,7 @@ use hyper::{Body, Uri};
 use pprof::criterion::{Output, PProfProfiler};
 use rand::distributions::{Alphanumeric, DistString};
 use restate_benchmarks::{parse_benchmark_settings, BenchmarkSettings};
+use restate_rocksdb::RocksDbManager;
 use tokio::runtime::Builder;
 
 fn throughput_benchmark(criterion: &mut Criterion) {
@@ -53,7 +54,9 @@ fn throughput_benchmark(criterion: &mut Criterion) {
             })
         });
 
+    group.finish();
     current_thread_rt.block_on(tc.shutdown_node("completed", 0));
+    current_thread_rt.block_on(RocksDbManager::get().shutdown());
 }
 
 async fn send_parallel_counter_requests(

--- a/crates/benchmarks/benches/throughput_sequential.rs
+++ b/crates/benchmarks/benches/throughput_sequential.rs
@@ -15,6 +15,7 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use hyper::client::HttpConnector;
 use hyper::{Body, Uri};
 use pprof::criterion::{Output, PProfProfiler};
+use restate_rocksdb::RocksDbManager;
 use tokio::runtime::Builder;
 
 fn throughput_benchmark(criterion: &mut Criterion) {
@@ -42,8 +43,9 @@ fn throughput_benchmark(criterion: &mut Criterion) {
                 .to_async(&current_thread_rt)
                 .iter(|| send_sequential_counter_requests(&client, num_requests))
         });
-
+    group.finish();
     current_thread_rt.block_on(tc.shutdown_node("completed", 0));
+    current_thread_rt.block_on(RocksDbManager::get().shutdown());
 }
 
 async fn send_sequential_counter_requests(

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -28,6 +28,7 @@ derive_more = { workspace = true }
 drain = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }
 humantime = { workspace = true }
+metrics = { workspace = true }
 once_cell = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/bifrost/src/loglets/local_loglet/metric_definitions.rs
+++ b/crates/bifrost/src/loglets/local_loglet/metric_definitions.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Optional to have but adds description/help message to the metrics emitted to
+/// the metrics' sink.
+use metrics::{describe_counter, describe_histogram, Unit};
+
+pub(crate) const BIFROST_LOCAL_APPEND: &str = "restate.bifrost.localloglet.appends.total";
+
+pub(crate) const BIFROST_LOCAL_APPEND_DURATION: &str =
+    "restate.bifrost.localloglet.append_duration.seconds";
+
+pub(crate) fn describe_metrics() {
+    describe_counter!(
+        BIFROST_LOCAL_APPEND,
+        Unit::Count,
+        "Number of append requests to bifrost's local loglet"
+    );
+    describe_histogram!(
+        BIFROST_LOCAL_APPEND_DURATION,
+        Unit::Seconds,
+        "Total latency of bifrost's local loglet appends"
+    );
+}

--- a/crates/bifrost/src/loglets/local_loglet/provider.rs
+++ b/crates/bifrost/src/loglets/local_loglet/provider.rs
@@ -22,7 +22,7 @@ use tracing::debug;
 
 use super::log_store::RocksDbLogStore;
 use super::log_store_writer::RocksDbLogWriterHandle;
-use super::LocalLoglet;
+use super::{metric_definitions, LocalLoglet};
 use crate::loglet::{Loglet, LogletOffset, LogletProvider};
 use crate::Error;
 use crate::ProviderError;
@@ -42,6 +42,7 @@ impl LocalLogletProvider {
         let log_store = RocksDbLogStore::new(data_dir, updateable_rocksdb_options)
             .context("RocksDb LogStore")?;
 
+        metric_definitions::describe_metrics();
         Ok(Arc::new(Self {
             log_store,
             active_loglets: Default::default(),

--- a/crates/storage-rocksdb/benches/basic_benchmark.rs
+++ b/crates/storage-rocksdb/benches/basic_benchmark.rs
@@ -69,9 +69,9 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
             .iter(|| writing_to_rocksdb(worker_options.clone()));
     });
 
-    rt.block_on(RocksDbManager::get().shutdown());
     group.finish();
     rt.block_on(tc.shutdown_node("completed", 0));
+    rt.block_on(RocksDbManager::get().shutdown());
 }
 
 criterion_group!(benches, basic_writing_reading_benchmark);

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::path::PathBuf;
-use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -56,15 +55,15 @@ pub struct LocalLogletOptions {
     /// write batch on every command.
     ///
     /// Supports hot-reloading.
-    pub writer_commit_batch_size_threshold: usize,
+    pub writer_batch_commit_count: usize,
     /// Trigger a commit when the time since the last commit exceeds this threshold.
     ///
     /// Supports hot-reloading.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-    pub writer_commit_time_interval: humantime::Duration,
-    /// The maximum number of write commands that can be queued.
-    pub writer_queue_len: usize,
+    pub writer_batch_commit_duration: Option<humantime::Duration>,
+    /// The maximum number of write commands that can be queued. Use 0 for no batching
+    pub writer_queue_length: usize,
 
     #[cfg(any(test, feature = "test-util"))]
     #[serde(skip, default = "super::default_arc_tmp")]
@@ -91,9 +90,9 @@ impl Default for LocalLogletOptions {
             .unwrap();
         Self {
             rocksdb,
-            writer_commit_batch_size_threshold: 200,
-            writer_commit_time_interval: Duration::from_millis(13).into(),
-            writer_queue_len: 200,
+            writer_batch_commit_count: 0,
+            writer_batch_commit_duration: None,
+            writer_queue_length: 200,
             #[cfg(any(test, feature = "test-util"))]
             data_dir: super::default_arc_tmp(),
         }


### PR DESCRIPTION
Quick patch latency issues

According to my test, this takes a simple wrk load test result from ~10rps to ~700qps

before:
```
~/w/r/sdk-java ❯❯❯ wrk -t 15 -c 25 http://localhost:8080/Counter/my-counter/get

Running 10s test @ http://localhost:8080/Counter/my-counter/get
  15 threads and 25 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.20s   230.15ms   1.34s    90.68%
    Req/Sec     0.14      0.56     4.00     91.53%
  118 requests in 10.09s, 26.16KB read
Requests/sec:     11.69
Transfer/sec:      2.59KB
```

after:
```
~/w/r/sdk-java ❯❯❯ wrk -t 15 -c 25 http://localhost:8080/Counter/my-counter/get

Running 10s test @ http://localhost:8080/Counter/my-counter/get
  15 threads and 25 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    18.01ms    2.98ms  52.11ms   62.40%
    Req/Sec    55.54      9.63    80.00     68.93%
  8370 requests in 10.07s, 1.81MB read
Requests/sec:    831.27
Transfer/sec:    184.27KB
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1396).
* __->__ #1396
* #1395