### PR TITLE
Support `HandlerType::Shared`

### DIFF
--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -126,6 +126,20 @@ impl InvocationTarget {
             }
         }
     }
+
+    pub fn service_ty(&self) -> ComponentType {
+        match self {
+            InvocationTarget::Service { .. } => ComponentType::Service,
+            InvocationTarget::VirtualObject { .. } => ComponentType::VirtualObject,
+        }
+    }
+
+    pub fn handler_ty(&self) -> Option<HandlerType> {
+        match self {
+            InvocationTarget::Service { .. } => None,
+            InvocationTarget::VirtualObject { handler_ty, .. } => Some(*handler_ty),
+        }
+    }
 }
 
 impl fmt::Display for InvocationTarget {


### PR DESCRIPTION
Fix #1092

This implements the Shared handlers semantics, that is skip the inbox and directly handle invocations.