### PR TITLE
More removal of old IDs

### DIFF
--- a/crates/invoker-api/src/handle.rs
+++ b/crates/invoker-api/src/handle.rs
@@ -13,7 +13,8 @@ use super::JournalMetadata;
 
 use restate_errors::NotRunningError;
 use restate_types::identifiers::PartitionKey;
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionLeaderEpoch, ServiceId};
+use restate_types::identifiers::{EntryIndex, InvocationId, PartitionLeaderEpoch};
+use restate_types::invocation::InvocationTarget;
 use restate_types::journal::raw::PlainRawEntry;
 use restate_types::journal::Completion;
 use std::future::Future;
@@ -34,8 +35,7 @@ pub trait ServiceHandle {
         &mut self,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        // TODO replace this with InvocationTarget with https://github.com/restatedev/restate/issues/1329
-        service_id: ServiceId,
+        invocation_target: InvocationTarget,
         journal: InvokeInputJournal,
     ) -> Self::Future;
 

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -12,9 +12,8 @@ use restate_errors::NotRunningError;
 use restate_invoker_api::{
     Effect, InvocationStatusReport, InvokeInputJournal, ServiceHandle, StatusHandle,
 };
-use restate_types::identifiers::{
-    EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch, ServiceId,
-};
+use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch};
+use restate_types::invocation::InvocationTarget;
 use restate_types::journal::Completion;
 use std::ops::RangeInclusive;
 use tokio::sync::mpsc;
@@ -25,7 +24,7 @@ use tokio::sync::mpsc;
 pub(crate) struct InvokeCommand {
     pub(super) partition: PartitionLeaderEpoch,
     pub(super) invocation_id: InvocationId,
-    pub(super) service_id: ServiceId,
+    pub(super) invocation_target: InvocationTarget,
     #[serde(skip)]
     pub(super) journal: InvokeInputJournal,
 }
@@ -77,7 +76,7 @@ impl ServiceHandle for ChannelServiceHandle {
         &mut self,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        service_id: ServiceId,
+        invocation_target: InvocationTarget,
         journal: InvokeInputJournal,
     ) -> Self::Future {
         futures::future::ready(
@@ -85,7 +84,7 @@ impl ServiceHandle for ChannelServiceHandle {
                 .send(InputCommand::Invoke(InvokeCommand {
                     partition,
                     invocation_id,
-                    service_id,
+                    invocation_target,
                     journal,
                 }))
                 .map_err(|_| NotRunningError),

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -21,7 +21,7 @@ use tokio::task::AbortHandle;
 /// Component encapsulating the business logic of the invocation state machine
 #[derive(Debug)]
 pub(super) struct InvocationStateMachine {
-    pub(super) service_id: ServiceId,
+    pub(super) invocation_target: InvocationTarget,
     invocation_state: InvocationState,
     retry_iter: retries::RetryIter,
 }
@@ -129,11 +129,11 @@ impl fmt::Debug for InvocationState {
 
 impl InvocationStateMachine {
     pub(super) fn create(
-        service_id: ServiceId,
+        invocation_target: InvocationTarget,
         retry_policy: RetryPolicy,
     ) -> InvocationStateMachine {
         Self {
-            service_id,
+            invocation_target,
             invocation_state: InvocationState::New,
             retry_iter: retry_policy.into_iter(),
         }
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn handle_error_when_waiting_for_retry() {
         let mut invocation_state_machine = InvocationStateMachine::create(
-            ServiceId::mock_random(),
+            InvocationTarget::mock_virtual_object(),
             RetryPolicy::fixed_delay(Duration::from_secs(1), 10),
         );
 
@@ -353,7 +353,7 @@ mod tests {
     #[test(tokio::test)]
     async fn handle_requires_ack() {
         let mut invocation_state_machine = InvocationStateMachine::create(
-            ServiceId::mock_random(),
+            InvocationTarget::mock_virtual_object(),
             RetryPolicy::fixed_delay(Duration::from_secs(1), 10),
         );
 

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -401,7 +401,7 @@ where
         let path: PathAndQuery = format!(
             "/invoke/{}/{}",
             self.invocation_target.service_name(),
-            &self.invocation_target.handler_name()
+            self.invocation_target.handler_name()
         )
         .try_into()
         .expect("must be able to build a valid invocation path");

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -35,9 +35,7 @@ use restate_timer_queue::TimerQueue;
 use restate_types::arc_util::Updateable;
 use restate_types::config::{InvokerOptions, ServiceClientOptions};
 use restate_types::errors::InvocationError;
-use restate_types::identifiers::{
-    DeploymentId, InvocationId, PartitionKey, ServiceId, WithPartitionKey,
-};
+use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey, WithPartitionKey};
 use restate_types::identifiers::{EntryIndex, PartitionLeaderEpoch};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::raw::PlainRawEntry;
@@ -60,6 +58,7 @@ pub use input_command::ChannelServiceHandle;
 pub use input_command::ChannelStatusReader;
 use restate_service_client::{AssumeRoleCacheMode, ServiceClient};
 use restate_service_protocol::RESTATE_SERVICE_PROTOCOL_VERSION;
+use restate_types::invocation::InvocationTarget;
 
 use crate::metric_definitions::{
     INVOKER_ENQUEUE, INVOKER_INVOCATION_TASK, TASK_OP_COMPLETED, TASK_OP_FAILED, TASK_OP_STARTED,
@@ -87,7 +86,7 @@ trait InvocationTaskRunner {
         options: &InvokerOptions,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        service_id: ServiceId,
+        invocation_target: InvocationTarget,
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
         invoker_rx: mpsc::UnboundedReceiver<Notification>,
         input_journal: InvokeInputJournal,
@@ -118,7 +117,7 @@ where
         opts: &InvokerOptions,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        service_id: ServiceId,
+        invocation_target: InvocationTarget,
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
         invoker_rx: mpsc::UnboundedReceiver<Notification>,
         input_journal: InvokeInputJournal,
@@ -129,7 +128,7 @@ where
                 self.client.clone(),
                 partition,
                 invocation_id,
-                service_id,
+                invocation_target,
                 RESTATE_SERVICE_PROTOCOL_VERSION,
                 opts.inactivity_timeout.into(),
                 opts.abort_timeout.into(),
@@ -374,7 +373,7 @@ where
             },
 
             Some(invoke_input_command) = segmented_input_queue.dequeue(), if !segmented_input_queue.is_empty() && self.quota.is_slot_available() => {
-                self.handle_invoke(options, invoke_input_command.partition, invoke_input_command.invocation_id, invoke_input_command.service_id, invoke_input_command.journal).await;
+                self.handle_invoke(options, invoke_input_command.partition, invoke_input_command.invocation_id, invoke_input_command.invocation_target, invoke_input_command.journal).await;
             },
 
             Some(invocation_task_msg) = self.invocation_tasks_rx.recv() => {
@@ -469,7 +468,7 @@ where
         level = "trace",
         skip_all,
         fields(
-            rpc.service = %service_id.service_name,
+            rpc.service = %invocation_target.service_name(),
             restate.invocation.id = %invocation_id,
             restate.invoker.partition_leader_epoch = ?partition,
         )
@@ -479,7 +478,7 @@ where
         options: &InvokerOptions,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        service_id: ServiceId,
+        invocation_target: InvocationTarget,
         journal: InvokeInputJournal,
     ) {
         debug_assert!(self
@@ -496,7 +495,7 @@ where
             partition,
             invocation_id,
             journal,
-            InvocationStateMachine::create(service_id, options.retry_policy.clone()),
+            InvocationStateMachine::create(invocation_target, options.retry_policy.clone()),
         )
         .await
     }
@@ -928,7 +927,7 @@ where
             options,
             partition,
             invocation_id,
-            ism.service_id.clone(),
+            ism.invocation_target.clone(),
             self.invocation_tasks_tx.clone(),
             completions_rx,
             journal,
@@ -1010,8 +1009,7 @@ mod tests {
     use restate_invoker_api::{entry_enricher, journal_reader, state_reader, ServiceHandle};
     use restate_schema_api::deployment::mocks::MockDeploymentMetadataRegistry;
     use restate_test_util::{check, let_assert};
-    use restate_types::identifiers::InvocationUuid;
-    use restate_types::identifiers::{FullInvocationId, LeaderEpoch};
+    use restate_types::identifiers::LeaderEpoch;
     use restate_types::journal::enriched::EnrichedEntryHeader;
     use restate_types::journal::raw::RawEntry;
     use restate_types::retries::RetryPolicy;
@@ -1072,7 +1070,7 @@ mod tests {
         F: Fn(
             PartitionLeaderEpoch,
             InvocationId,
-            ServiceId,
+            InvocationTarget,
             mpsc::UnboundedSender<InvocationTaskOutput>,
             mpsc::UnboundedReceiver<Notification>,
             InvokeInputJournal,
@@ -1084,7 +1082,7 @@ mod tests {
             _options: &InvokerOptions,
             partition: PartitionLeaderEpoch,
             invocation_id: InvocationId,
-            service_id: ServiceId,
+            invocation_target: InvocationTarget,
             invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
             invoker_rx: mpsc::UnboundedReceiver<Notification>,
             input_journal: InvokeInputJournal,
@@ -1093,7 +1091,7 @@ mod tests {
             task_pool.spawn((*self)(
                 partition,
                 invocation_id,
-                service_id,
+                invocation_target,
                 invoker_tx,
                 invoker_rx,
                 input_journal,
@@ -1141,7 +1139,8 @@ mod tests {
             .unwrap();
 
         let partition_leader_epoch = (0, LeaderEpoch::INITIAL);
-        let fid = FullInvocationId::new("TestService", Bytes::new(), InvocationUuid::new());
+        let invocation_target = InvocationTarget::mock_service();
+        let invocation_id = InvocationId::generate(&invocation_target, None::<String>);
 
         let (output_tx, mut output_rx) = mpsc::channel(1);
 
@@ -1152,8 +1151,8 @@ mod tests {
         handle
             .invoke(
                 partition_leader_epoch,
-                InvocationId::from(&fid),
-                fid.service_id,
+                invocation_id,
+                invocation_target,
                 InvokeInputJournal::NoCachedJournal,
             )
             .await
@@ -1197,7 +1196,7 @@ mod tests {
             .enqueue(InvokeCommand {
                 partition: MOCK_PARTITION,
                 invocation_id: invocation_id_1,
-                service_id: ServiceId::mock_random(),
+                invocation_target: InvocationTarget::mock_virtual_object(),
                 journal: InvokeInputJournal::NoCachedJournal,
             })
             .await;
@@ -1205,7 +1204,7 @@ mod tests {
             .enqueue(InvokeCommand {
                 partition: MOCK_PARTITION,
                 invocation_id: invocation_id_2,
-                service_id: ServiceId::mock_random(),
+                invocation_target: InvocationTarget::mock_virtual_object(),
                 journal: InvokeInputJournal::NoCachedJournal,
             })
             .await;
@@ -1305,7 +1304,7 @@ mod tests {
                 &invoker_options,
                 MOCK_PARTITION,
                 invocation_id,
-                ServiceId::mock_random(),
+                InvocationTarget::mock_virtual_object(),
                 InvokeInputJournal::NoCachedJournal,
             )
             .await;

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -469,7 +469,9 @@ where
         skip_all,
         fields(
             rpc.service = %invocation_target.service_name(),
+            rpc.method = %invocation_target.handler_name(),
             restate.invocation.id = %invocation_id,
+            restate.invocation.target = %invocation_target,
             restate.invoker.partition_leader_epoch = ?partition,
         )
     )]

--- a/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
@@ -8,7 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::assert_stream_eq;
+// Unfortunately we need this because of https://github.com/rust-lang/rust-clippy/issues/9801
+#![allow(clippy::borrow_interior_mutable_const)]
+#![allow(clippy::declare_interior_mutable_const)]
+
+use super::assert_stream_eq;
+
+use bytes::Bytes;
 use bytestring::ByteString;
 use once_cell::sync::Lazy;
 use restate_storage_api::invocation_status_table::{
@@ -16,9 +22,7 @@ use restate_storage_api::invocation_status_table::{
     StatusTimestamps,
 };
 use restate_storage_rocksdb::RocksDBStorage;
-use restate_types::identifiers::{
-    FullInvocationId, InvocationId, InvocationUuid, ServiceId, WithPartitionKey,
-};
+use restate_types::identifiers::{InvocationId, ServiceId};
 use restate_types::invocation::{
     HandlerType, InvocationTarget, ServiceInvocationSpanContext, Source,
 };
@@ -26,40 +30,37 @@ use restate_types::time::MillisSinceEpoch;
 use std::collections::HashSet;
 use std::time::Duration;
 
-static SERVICE_ID_1: Lazy<ServiceId> = Lazy::new(|| ServiceId::new("abc", "1"));
-static INVOCATION_ID_1: Lazy<InvocationId> = Lazy::new(|| {
-    InvocationId::new(
-        SERVICE_ID_1.partition_key(),
-        InvocationUuid::from_parts(1706027034946, 12345678900001),
-    )
-});
+const INVOCATION_TARGET_1: InvocationTarget = InvocationTarget::VirtualObject {
+    name: ByteString::from_static("abc"),
+    key: ByteString::from_static("1"),
+    handler: ByteString::from_static("myhandler"),
+    handler_ty: HandlerType::Exclusive,
+};
+static INVOCATION_ID_1: Lazy<InvocationId> =
+    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_1, None::<String>));
 
-static SERVICE_ID_2: Lazy<ServiceId> = Lazy::new(|| ServiceId::new("abc", "2"));
-static INVOCATION_ID_2: Lazy<InvocationId> = Lazy::new(|| {
-    InvocationId::new(
-        SERVICE_ID_2.partition_key(),
-        InvocationUuid::from_parts(1706027034946, 12345678900002),
-    )
-});
+const INVOCATION_TARGET_2: InvocationTarget = InvocationTarget::VirtualObject {
+    name: ByteString::from_static("abc"),
+    key: ByteString::from_static("2"),
+    handler: ByteString::from_static("myhandler"),
+    handler_ty: HandlerType::Exclusive,
+};
+static INVOCATION_ID_2: Lazy<InvocationId> =
+    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_2, None::<String>));
 
-static SERVICE_ID_3: Lazy<ServiceId> = Lazy::new(|| ServiceId::new("abc", "3"));
-static INVOCATION_ID_3: Lazy<InvocationId> = Lazy::new(|| {
-    InvocationId::new(
-        SERVICE_ID_3.partition_key(),
-        InvocationUuid::from_parts(1706027034946, 12345678900003),
-    )
-});
+const INVOCATION_TARGET_3: InvocationTarget = InvocationTarget::VirtualObject {
+    name: ByteString::from_static("abc"),
+    key: ByteString::from_static("3"),
+    handler: ByteString::from_static("myhandler"),
+    handler_ty: HandlerType::Exclusive,
+};
+static INVOCATION_ID_3: Lazy<InvocationId> =
+    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_3, None::<String>));
 
-fn invoked_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
-    let service_id = service_id.into();
+fn invoked_status(invocation_target: InvocationTarget) -> InvocationStatus {
     InvocationStatus::Invoked(InFlightInvocationMetadata {
-        invocation_target: InvocationTarget::virtual_object(
-            service_id.service_name.clone(),
-            ByteString::try_from(service_id.key.clone()).unwrap(),
-            "service",
-            HandlerType::Exclusive,
-        ),
-        service_id,
+        invocation_target,
+        service_id: ServiceId::new("bla", Bytes::from_static(b"bla")),
         journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
         deployment_id: None,
         method: "service".into(),
@@ -71,17 +72,11 @@ fn invoked_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
     })
 }
 
-fn suspended_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
-    let service_id = service_id.into();
+fn suspended_status(invocation_target: InvocationTarget) -> InvocationStatus {
     InvocationStatus::Suspended {
         metadata: InFlightInvocationMetadata {
-            invocation_target: InvocationTarget::virtual_object(
-                service_id.service_name.clone(),
-                ByteString::try_from(service_id.key.clone()).unwrap(),
-                "service",
-                HandlerType::Exclusive,
-            ),
-            service_id,
+            invocation_target,
+            service_id: ServiceId::new("bla", Bytes::from_static(b"bla")),
             journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
             deployment_id: None,
             method: "service".into(),
@@ -96,14 +91,23 @@ fn suspended_status(service_id: impl Into<ServiceId>) -> InvocationStatus {
 }
 
 async fn populate_data<T: InvocationStatusTable>(txn: &mut T) {
-    txn.put_invocation_status(&INVOCATION_ID_1, invoked_status(SERVICE_ID_1.clone()))
-        .await;
+    txn.put_invocation_status(
+        &INVOCATION_ID_1,
+        invoked_status(INVOCATION_TARGET_1.clone()),
+    )
+    .await;
 
-    txn.put_invocation_status(&INVOCATION_ID_2, invoked_status(SERVICE_ID_2.clone()))
-        .await;
+    txn.put_invocation_status(
+        &INVOCATION_ID_2,
+        invoked_status(INVOCATION_TARGET_2.clone()),
+    )
+    .await;
 
-    txn.put_invocation_status(&INVOCATION_ID_3, suspended_status(SERVICE_ID_3.clone()))
-        .await;
+    txn.put_invocation_status(
+        &INVOCATION_ID_3,
+        suspended_status(INVOCATION_TARGET_3.clone()),
+    )
+    .await;
 }
 
 async fn verify_point_lookups<T: InvocationStatusTable>(txn: &mut T) {
@@ -112,15 +116,15 @@ async fn verify_point_lookups<T: InvocationStatusTable>(txn: &mut T) {
         .await
         .expect("should not fail");
 
-    assert_eq!(status, invoked_status(SERVICE_ID_1.clone()));
+    assert_eq!(status, invoked_status(INVOCATION_TARGET_1.clone()));
 }
 
 async fn verify_all_svc_with_status_invoked<T: InvocationStatusTable>(txn: &mut T) {
     let stream = txn.invoked_invocations(0..=u64::MAX);
 
     let expected = vec![
-        FullInvocationId::combine(SERVICE_ID_1.clone(), *INVOCATION_ID_1),
-        FullInvocationId::combine(SERVICE_ID_2.clone(), *INVOCATION_ID_2),
+        (*INVOCATION_ID_1, INVOCATION_TARGET_1.clone()),
+        (*INVOCATION_ID_2, INVOCATION_TARGET_2.clone()),
     ];
 
     assert_stream_eq(stream, expected).await;

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -641,7 +641,7 @@ impl IdempotencyId {
 
     pub fn new_combine(
         invocation_id: InvocationId,
-        invocation_target: InvocationTarget,
+        invocation_target: &InvocationTarget,
         idempotency_key: ByteString,
     ) -> Self {
         IdempotencyId {

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -534,12 +534,12 @@ pub enum SpanRelation {
 
 impl SpanRelation {
     /// Attach this [`SpanRelation`] to the given [`Span`]
-    pub fn attach_to_span(self, span: &Span) {
+    pub fn attach_to_span(&self, span: &Span) {
         match self {
             SpanRelation::Parent(span_context) => {
-                span.set_parent(Context::new().with_remote_span_context(span_context))
+                span.set_parent(Context::new().with_remote_span_context(span_context.clone()))
             }
-            SpanRelation::Linked(span_context) => span.add_link(span_context),
+            SpanRelation::Linked(span_context) => span.add_link(span_context.clone()),
             SpanRelation::None => (),
         };
     }

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -524,7 +524,7 @@ pub enum SpanRelationCause {
     ),
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub enum SpanRelation {
     #[default]
     None,

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -15,7 +15,9 @@ use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::timer_table::TimerKey;
 use restate_types::identifiers::{EntryIndex, FullInvocationId, InvocationId};
 use restate_types::ingress::IngressResponse;
-use restate_types::invocation::{ServiceInvocationResponseSink, ServiceInvocationSpanContext};
+use restate_types::invocation::{
+    InvocationTarget, ServiceInvocationResponseSink, ServiceInvocationSpanContext,
+};
 use restate_types::journal::Completion;
 use restate_types::message::MessageIndex;
 use restate_wal_protocol::timer::TimerValue;
@@ -24,7 +26,8 @@ use std::time::Duration;
 #[derive(Debug)]
 pub enum Action {
     Invoke {
-        full_invocation_id: FullInvocationId,
+        invocation_id: InvocationId,
+        invocation_target: InvocationTarget,
         invoke_input_journal: InvokeInputJournal,
     },
     InvokeBuiltInService {

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -213,13 +213,14 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                 mut metadata,
             } => {
                 metadata.timestamps.update();
-                let service_id = metadata.service_id.clone();
+                let invocation_target = metadata.invocation_target.clone();
                 state_storage
                     .store_invocation_status(&invocation_id, InvocationStatus::Invoked(metadata))
                     .await?;
 
                 collector.push(Action::Invoke {
-                    full_invocation_id: FullInvocationId::combine(service_id, invocation_id),
+                    invocation_id,
+                    invocation_target,
                     invoke_input_journal: InvokeInputJournal::NoCachedJournal,
                 });
             }
@@ -601,7 +602,8 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
             let (entry_header, serialized_entry) = input_entry.into_inner();
 
             collector.push(Action::Invoke {
-                full_invocation_id,
+                invocation_id,
+                invocation_target: in_flight_invocation_metadata.invocation_target,
                 invoke_input_journal: InvokeInputJournal::CachedJournal(
                     restate_invoker_api::JournalMetadata::new(
                         in_flight_invocation_metadata.journal_metadata.length,

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -1017,7 +1017,7 @@ impl Effects {
         }
 
         // Create span and enter it
-        self.related_span.clone().attach_to_span(&span);
+        self.related_span.attach_to_span(&span);
         let _enter = span.enter();
 
         // Log all the effects

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -65,11 +65,11 @@ impl<Codec: RawEntryCodec> StateMachine<Codec> {
     ) -> Result<(), Error> {
         // Handle the command, returns the span_relation to use to log effects
         let command_type = command.name();
-        let (fid, span_relation) = self.0.on_apply(command, effects, transaction).await?;
+        self.0.on_apply(command, effects, transaction).await?;
         counter!(PARTITION_APPLY_COMMAND, "command" => command_type).increment(1);
 
         // Log the effects
-        effects.log(is_leader, fid, span_relation);
+        effects.log(is_leader);
 
         // Interpret effects
         effect_interpreter::EffectInterpreter::<Codec>::interpret_effects(
@@ -388,7 +388,7 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::Invoke {
-                full_invocation_id: eq(fid.clone()),
+                invocation_id: eq(invocation_id)
             }))
         );
 
@@ -690,7 +690,7 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::Invoke {
-                full_invocation_id: eq(fid.clone()),
+                invocation_id: eq(invocation_id),
                 invoke_input_journal: pat!(InvokeInputJournal::CachedJournal(_, _))
             }))
         );
@@ -799,7 +799,7 @@ mod tests {
             assert_that!(
                 actions,
                 contains(pat!(Action::Invoke {
-                    full_invocation_id: eq(fid.clone()),
+                    invocation_id: eq(invocation_id),
                     invoke_input_journal: pat!(InvokeInputJournal::CachedJournal(_, _))
                 }))
             );
@@ -1050,7 +1050,7 @@ mod tests {
             assert_that!(
                 actions,
                 contains(pat!(Action::Invoke {
-                    full_invocation_id: eq(original_request_fid.clone()),
+                    invocation_id: eq(original_invocation_id),
                     invoke_input_journal: pat!(InvokeInputJournal::CachedJournal(_, _))
                 }))
             );
@@ -1205,7 +1205,7 @@ mod tests {
         let actions = state_machine
             .apply(Command::Invoke(ServiceInvocation {
                 invocation_id,
-                invocation_target,
+                invocation_target: invocation_target.clone(),
                 fid: fid.clone(),
                 method_name: ByteString::from("MyMethod"),
                 argument: Default::default(),
@@ -1221,7 +1221,8 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::Invoke {
-                full_invocation_id: eq(fid.clone()),
+                invocation_id: eq(invocation_id),
+                invocation_target: eq(invocation_target),
                 invoke_input_journal: pat!(InvokeInputJournal::CachedJournal(_, _))
             }))
         );
@@ -1252,7 +1253,7 @@ mod tests {
                 fid: fid.clone(),
                 method_name: invocation_target.handler_name().clone(),
                 invocation_id,
-                invocation_target,
+                invocation_target: invocation_target.clone(),
                 argument: Default::default(),
                 source: Source::Ingress,
                 response_sink: None,
@@ -1266,7 +1267,8 @@ mod tests {
         assert_that!(
             actions,
             contains(pat!(Action::Invoke {
-                full_invocation_id: eq(fid.clone()),
+                invocation_id: eq(invocation_id),
+                invocation_target: eq(invocation_target),
                 invoke_input_journal: pat!(InvokeInputJournal::CachedJournal(_, _))
             }))
         );

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -33,9 +33,9 @@ use restate_storage_api::Result as StorageResult;
 use restate_storage_api::StorageError;
 use restate_timer::TimerReader;
 use restate_types::identifiers::{
-    EntryIndex, FullInvocationId, IdempotencyId, InvocationId, PartitionId, PartitionKey,
-    ServiceId, WithPartitionKey,
+    EntryIndex, IdempotencyId, InvocationId, PartitionId, PartitionKey, ServiceId, WithPartitionKey,
 };
+use restate_types::invocation::InvocationTarget;
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::CompletionResult;
 use restate_types::logs::Lsn;
@@ -138,7 +138,8 @@ where
 
     pub fn scan_invoked_invocations(
         &mut self,
-    ) -> impl Stream<Item = Result<FullInvocationId, StorageError>> + Send + '_ {
+    ) -> impl Stream<Item = Result<(InvocationId, InvocationTarget), StorageError>> + Send + '_
+    {
         self.storage
             .invoked_invocations(self.partition_key_range.clone())
     }
@@ -608,7 +609,7 @@ where
     fn invoked_invocations(
         &mut self,
         partition_key_range: RangeInclusive<PartitionKey>,
-    ) -> impl Stream<Item = StorageResult<FullInvocationId>> + Send {
+    ) -> impl Stream<Item = StorageResult<(InvocationId, InvocationTarget)>> + Send {
         self.inner.invoked_invocations(partition_key_range)
     }
 }

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -22,6 +22,11 @@ use restate_wal_protocol::Command;
 pub(crate) type InvokerEffect = restate_invoker_api::Effect;
 pub(crate) type InvokerEffectKind = restate_invoker_api::EffectKind;
 
+/// This type carries together invocation id and target.
+/// Use this type only when you need to group together id and target,
+/// and generally use only InvocationId for identifying an invocation.
+pub(crate) type InvocationIdAndTarget = (InvocationId, InvocationTarget);
+
 // Extension methods to the OutboxMessage type
 pub(crate) trait OutboxMessageExt {
     fn from_awakeable_completion(


### PR DESCRIPTION
Part of #1329

* Removed the usage of FullInvocationId for tracing the state machine effects. We now also try to provide more tracing info whenever possible (e.g. in case there's an InvocationId but not an InvocationTarget available)
* Removed the usage of ServiceId in Action::Invoke
* Now InvocationStatusTable#invoked_invocations returns tuple (invocation_id, invocation_target)