### PR TITLE
Update opentelemetry libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
  "bytes",
  "futures",
  "paste",
- "prost 0.12.3",
+ "prost",
  "tokio",
  "tonic 0.10.2",
 ]
@@ -1468,7 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
 dependencies = [
  "futures-core",
- "prost 0.12.3",
+ "prost",
  "prost-types",
  "tonic 0.10.2",
  "tracing-core",
@@ -3971,92 +3971,12 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-contrib"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717e7a7b45ef1c0664715a85a8e91ff966b58ffaaccb4d4cc7ff8f15cffd98a"
-dependencies = [
- "async-trait",
  "futures-core",
- "futures-util",
- "once_cell",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
-dependencies = [
- "async-trait",
- "bytes",
- "http 0.2.12",
- "opentelemetry_api",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_api",
- "opentelemetry_sdk",
- "prost 0.11.9",
- "thiserror",
- "tokio",
- "tonic 0.9.2",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
- "prost 0.11.9",
- "tonic 0.9.2",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-sink",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -4065,23 +3985,88 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
+name = "opentelemetry-contrib"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "1d4c267ff82b3e9e9f548199267c3f722d9cffe3bfe4318b05fcf56fd5357aad"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "futures-util",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic 0.11.0",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.2",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
- "regex",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4098,15 +4083,6 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "3.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
 ]
@@ -4583,22 +4559,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4615,25 +4581,12 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.55",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4655,7 +4608,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.12.3",
+ "prost",
 ]
 
 [[package]]
@@ -5082,7 +5035,7 @@ dependencies = [
  "tiny-gradient",
  "tokio",
  "tracing",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "unicode-width",
  "url",
@@ -5213,7 +5166,7 @@ dependencies = [
  "dashmap",
  "drain",
  "googletest",
- "prost 0.12.3",
+ "prost",
  "restate-bifrost",
  "restate-core",
  "restate-node-protocol",
@@ -5249,8 +5202,9 @@ dependencies = [
  "iso8601",
  "metrics",
  "opentelemetry",
+ "opentelemetry_sdk",
  "pin-project-lite",
- "prost 0.12.3",
+ "prost",
  "restate-core",
  "restate-errors",
  "restate-futures-util",
@@ -5284,8 +5238,8 @@ dependencies = [
  "bytes",
  "derive_builder",
  "drain",
- "opentelemetry_api",
- "prost 0.12.3",
+ "opentelemetry",
+ "prost",
  "rdkafka",
  "restate-core",
  "restate-errors",
@@ -5341,7 +5295,8 @@ dependencies = [
  "metrics",
  "opentelemetry",
  "opentelemetry-http",
- "prost 0.12.3",
+ "opentelemetry_sdk",
+ "prost",
  "restate-core",
  "restate-errors",
  "restate-fs-util",
@@ -5398,7 +5353,7 @@ dependencies = [
  "googletest",
  "humantime",
  "hyper 0.14.28",
- "prost 0.12.3",
+ "prost",
  "prost-types",
  "restate-core",
  "restate-grpc-util",
@@ -5537,7 +5492,7 @@ dependencies = [
  "bytestring",
  "derive_more",
  "enum-map",
- "prost 0.12.3",
+ "prost",
  "prost-build",
  "prost-types",
  "restate-schema",
@@ -5554,7 +5509,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
- "prost 0.12.3",
+ "prost",
  "prost-types",
  "restate-node-protocol",
  "restate-types",
@@ -5568,7 +5523,7 @@ name = "restate-pb"
 version = "0.9.0"
 dependencies = [
  "convert_case 0.6.0",
- "prost 0.12.3",
+ "prost",
  "prost-build",
  "prost-types",
  "restate-types",
@@ -5658,7 +5613,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "http 0.2.12",
- "prost 0.12.3",
+ "prost",
  "schemars",
  "serde",
  "serde_json",
@@ -5753,7 +5708,7 @@ dependencies = [
  "jsonptr",
  "paste",
  "prettyplease",
- "prost 0.12.3",
+ "prost",
  "prost-build",
  "regress 0.9.0",
  "restate-base64-util",
@@ -5796,8 +5751,8 @@ dependencies = [
  "anyhow",
  "bytes",
  "bytestring",
- "opentelemetry_api",
- "prost 0.12.3",
+ "opentelemetry",
+ "prost",
  "prost-build",
  "prost-types",
  "restate-storage-api",
@@ -5822,7 +5777,7 @@ dependencies = [
  "futures",
  "googletest",
  "paste",
- "prost 0.12.3",
+ "prost",
  "restate-core",
  "restate-invoker-api",
  "restate-rocksdb",
@@ -5856,7 +5811,7 @@ dependencies = [
  "futures",
  "paste",
  "pgwire",
- "prost 0.12.3",
+ "prost",
  "restate-core",
  "restate-errors",
  "restate-storage-api",
@@ -5890,7 +5845,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "paste",
- "prost 0.12.3",
+ "prost",
  "rand",
  "restate-core",
  "restate-errors",
@@ -5917,7 +5872,7 @@ dependencies = [
  "assert2",
  "googletest",
  "pretty_assertions",
- "prost 0.12.3",
+ "prost",
  "prost-types",
 ]
 
@@ -5965,12 +5920,12 @@ dependencies = [
  "opentelemetry-contrib",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "restate-types",
  "schemars",
  "serde",
  "thiserror",
  "tokio",
- "tonic 0.9.2",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5998,7 +5953,7 @@ dependencies = [
  "humantime",
  "num-traits",
  "once_cell",
- "opentelemetry_api",
+ "opentelemetry",
  "rand",
  "restate-base64-util",
  "restate-test-util",
@@ -6075,9 +6030,9 @@ dependencies = [
  "googletest",
  "humantime",
  "metrics",
- "opentelemetry_api",
+ "opentelemetry",
  "pin-project",
- "prost 0.12.3",
+ "prost",
  "restate-bifrost",
  "restate-core",
  "restate-errors",
@@ -7196,34 +7151,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
@@ -7240,7 +7167,34 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
@@ -7269,7 +7223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
 dependencies = [
  "async-stream",
- "prost 0.12.3",
+ "prost",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -7281,7 +7235,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
 dependencies = [
- "prost 0.12.3",
+ "prost",
  "prost-types",
  "tokio",
  "tokio-stream",
@@ -7392,17 +7346,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -7414,18 +7357,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -7465,7 +7410,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,9 +111,9 @@ hyper-rustls = { version = "0.24.1", features = ["http2"] }
 itertools = "0.11.0"
 metrics = { version = "0.22" }
 once_cell = "1.18"
-opentelemetry = { version = "0.20.0" }
-opentelemetry-http = { version = "0.9.0" }
-opentelemetry_api = { version = "0.20.0" }
+opentelemetry = { version = "0.22.0" }
+opentelemetry-http = { version = "0.11.1" }
+opentelemetry_sdk = { version = "0.22.1" }
 paste = "1.0"
 pin-project = "1.0"
 prost = "0.12.1"
@@ -147,7 +147,7 @@ tonic-build = "0.11.0"
 tower = "0.4"
 tower-http = { version = "0.4", default-features = false }
 tracing = "0.1"
-tracing-opentelemetry = { version = "0.21.0" }
+tracing-opentelemetry = { version = "0.23.0" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-test = { version = "0.2.4" }
 ulid = { version = "1.1.0" }

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -51,6 +51,7 @@ http-old = { package = "http", version = "0.2.12" }
 
 # Tracing
 opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 

--- a/crates/ingress-http/src/layers/tracing_context_extractor.rs
+++ b/crates/ingress-http/src/layers/tracing_context_extractor.rs
@@ -10,7 +10,7 @@
 
 use http::{HeaderMap, Request};
 use opentelemetry::propagation::{Extractor, TextMapPropagator};
-use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use std::task::{Context, Poll};
 use tower::{Layer, Service};
 

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -26,7 +26,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 derive_builder = { workspace = true }
 drain = { workspace = true }
-opentelemetry_api = { workspace = true }
+opentelemetry = { workspace = true }
 prost = { workspace = true }
 rdkafka = { version = "0.34", features = ["libz-static", "cmake-build"] }
 schemars = { workspace = true, optional = true }
@@ -45,4 +45,3 @@ restate-types = { workspace = true, features = ["test-util"] }
 
 base64 = { workspace = true }
 serde_json = { workspace = true }
-

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -10,7 +10,7 @@
 
 use base64::Engine;
 use bytes::Bytes;
-use opentelemetry_api::trace::TraceContextExt;
+use opentelemetry::trace::TraceContextExt;
 use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
 use rdkafka::error::KafkaError;
 use rdkafka::message::BorrowedMessage;

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -37,6 +37,7 @@ hyper = { workspace = true, features = ["http1", "http2", "client", "tcp", "stre
 itertools = { workspace = true }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 opentelemetry-http = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -18,8 +18,8 @@ use hyper::http::response::Parts as ResponseParts;
 use hyper::http::HeaderValue;
 use hyper::{http, Body, HeaderMap, Response};
 use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry_http::HeaderInjector;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use restate_errors::warn_it;
 use restate_invoker_api::{
     EagerState, EntryEnricher, InvokeInputJournal, JournalReader, StateReader,

--- a/crates/storage-proto/Cargo.toml
+++ b/crates/storage-proto/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = []
-conversion = ["dep:restate-types", "dep:restate-storage-api", "dep:thiserror", "dep:anyhow", "dep:bytes", "dep:bytestring", "dep:opentelemetry_api"]
+conversion = ["dep:restate-types", "dep:restate-storage-api", "dep:thiserror", "dep:anyhow", "dep:bytes", "dep:bytestring", "dep:opentelemetry"]
 
 [dependencies]
 restate-types = { workspace = true, optional = true }
@@ -18,7 +18,7 @@ restate-storage-api = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 bytestring = { workspace = true, optional = true }
-opentelemetry_api = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 thiserror = { workspace = true, optional = true }

--- a/crates/storage-proto/src/lib.rs
+++ b/crates/storage-proto/src/lib.rs
@@ -53,7 +53,7 @@ pub mod storage {
             use anyhow::anyhow;
             use bytes::{Buf, Bytes};
             use bytestring::ByteString;
-            use opentelemetry_api::trace::TraceState;
+            use opentelemetry::trace::TraceState;
             use restate_storage_api::StorageError;
             use restate_types::errors::{IdDecodeError, InvocationError};
             use restate_types::invocation::{InvocationTermination, TerminationFlavor};
@@ -1151,9 +1151,8 @@ pub mod storage {
                     } = value;
 
                     let trace_id = try_bytes_into_trace_id(trace_id)?;
-                    let span_id =
-                        opentelemetry_api::trace::SpanId::from_bytes(span_id.to_be_bytes());
-                    let trace_flags = opentelemetry_api::trace::TraceFlags::new(
+                    let span_id = opentelemetry::trace::SpanId::from_bytes(span_id.to_be_bytes());
+                    let trace_flags = opentelemetry::trace::TraceFlags::new(
                         u8::try_from(trace_flags).map_err(ConversionError::invalid_data)?,
                     );
 
@@ -1167,7 +1166,7 @@ pub mod storage {
 
                     Ok(
                         restate_types::invocation::ServiceInvocationSpanContext::new(
-                            opentelemetry_api::trace::SpanContext::new(
+                            opentelemetry::trace::SpanContext::new(
                                 trace_id,
                                 span_id,
                                 trace_flags,
@@ -1210,7 +1209,7 @@ pub mod storage {
                     match value.kind.ok_or(ConversionError::missing_field("kind"))? {
                         span_relation::Kind::Parent(span_relation::Parent { span_id }) => {
                             let span_id =
-                                opentelemetry_api::trace::SpanId::from_bytes(span_id.to_be_bytes());
+                                opentelemetry::trace::SpanId::from_bytes(span_id.to_be_bytes());
                             Ok(Self::Parent(span_id))
                         }
                         span_relation::Kind::Linked(span_relation::Linked {
@@ -1219,7 +1218,7 @@ pub mod storage {
                         }) => {
                             let trace_id = try_bytes_into_trace_id(trace_id)?;
                             let span_id =
-                                opentelemetry_api::trace::SpanId::from_bytes(span_id.to_be_bytes());
+                                opentelemetry::trace::SpanId::from_bytes(span_id.to_be_bytes());
                             Ok(Self::Linked(trace_id, span_id))
                         }
                     }
@@ -1246,7 +1245,7 @@ pub mod storage {
 
             fn try_bytes_into_trace_id(
                 mut bytes: Bytes,
-            ) -> Result<opentelemetry_api::trace::TraceId, ConversionError> {
+            ) -> Result<opentelemetry::trace::TraceId, ConversionError> {
                 if bytes.len() != 16 {
                     return Err(ConversionError::InvalidData(anyhow!(
                         "trace id pb definition needs to contain exactly 16 bytes"
@@ -1256,7 +1255,7 @@ pub mod storage {
                 let mut bytes_array = [0; 16];
                 bytes.copy_to_slice(&mut bytes_array);
 
-                Ok(opentelemetry_api::trace::TraceId::from_bytes(bytes_array))
+                Ok(opentelemetry::trace::TraceId::from_bytes(bytes_array))
             }
 
             impl TryFrom<ServiceInvocationResponseSink>

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -20,17 +20,15 @@ console-subscriber = { version = "0.2.0", optional = true }
 derive_builder = { workspace = true }
 nu-ansi-term = "0.46.0"
 once_cell = { workspace = true }
-opentelemetry = { workspace = true, features = ["rt-tokio"] }
-opentelemetry-contrib = { version = "0.12.0", features = ["jaeger_json_exporter", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.13.0" }
-opentelemetry-semantic-conventions = "0.12.0"
+opentelemetry = { workspace = true }
+opentelemetry-contrib = { version = "0.14.0", features = ["jaeger_json_exporter", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.15.0" }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-semantic-conventions = "0.14.0"
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
-# pin the version that opentelemetry-otlp uses; this dependency can be removed when otlp crate is released with
-# support for building tonic metadata from env vars
-tonic = { version = "0.9.2" }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -53,7 +53,6 @@ pub enum Error {
 fn build_tracing_layer<S>(
     common_opts: &CommonOptions,
     service_name: String,
-    instance_id: impl Display,
 ) -> Result<
     Option<
         Filtered<tracing_opentelemetry::OpenTelemetryLayer<S, SpanModifyingTracer>, EnvFilter, S>,
@@ -79,7 +78,7 @@ where
         ),
         KeyValue::new(
             opentelemetry_semantic_conventions::resource::SERVICE_INSTANCE_ID,
-            instance_id.to_string(),
+            format!("{}/{}", common_opts.cluster_name(), common_opts.node_name()),
         ),
         KeyValue::new(
             opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
@@ -182,7 +181,6 @@ where
 pub fn init_tracing_and_logging(
     common_opts: &CommonOptions,
     service_name: impl Display,
-    instance_id: impl Display,
 ) -> Result<TracingGuard, Error> {
     let restate_service_name = format!("Restate service: {service_name}");
 
@@ -205,7 +203,6 @@ pub fn init_tracing_and_logging(
     let layers = layers.with(build_tracing_layer(
         common_opts,
         restate_service_name.clone(),
-        instance_id,
     )?);
 
     layers.init();

--- a/crates/tracing-instrumentation/src/processor.rs
+++ b/crates/tracing-instrumentation/src/processor.rs
@@ -8,11 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry::sdk::trace::Span;
-use opentelemetry::sdk::Resource;
 use opentelemetry::trace::TraceResult;
 use opentelemetry::{Context, Key, KeyValue};
+use opentelemetry_sdk::export::trace::SpanData;
+use opentelemetry_sdk::trace::Span;
+use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use std::borrow::Cow;
 
@@ -33,7 +33,7 @@ impl<T> ResourceModifyingSpanProcessor<T> {
     }
 }
 
-impl<T: opentelemetry::sdk::trace::SpanProcessor> opentelemetry::sdk::trace::SpanProcessor
+impl<T: opentelemetry_sdk::trace::SpanProcessor> opentelemetry_sdk::trace::SpanProcessor
     for ResourceModifyingSpanProcessor<T>
 {
     fn on_start(&self, span: &mut Span, cx: &Context) {
@@ -43,9 +43,11 @@ impl<T: opentelemetry::sdk::trace::SpanProcessor> opentelemetry::sdk::trace::Spa
     fn on_end(&self, data: SpanData) {
         let mut data = data;
 
-        if let Some(service_name) = data.attributes.get(&RPC_SERVICE) {
+        if let Some(service_name_attribute) =
+            data.attributes.iter().find(|kv| kv.key == RPC_SERVICE)
+        {
             data.resource = Cow::Owned(data.resource.merge(&Resource::new(std::iter::once(
-                KeyValue::new(SERVICE_NAME, service_name.clone()),
+                KeyValue::new(SERVICE_NAME, service_name_attribute.value.clone()),
             ))));
         };
 

--- a/crates/tracing-instrumentation/src/tracer.rs
+++ b/crates/tracing-instrumentation/src/tracer.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use opentelemetry::trace::{OrderMap, TraceId};
+use opentelemetry::trace::TraceId;
 use opentelemetry::trace::{SpanBuilder, SpanId};
 use opentelemetry::{Context, Key, Value};
 use std::cmp;
@@ -41,17 +41,17 @@ static KEYS: Lazy<HashSet<Key>> = Lazy::new(|| {
 // using attribute fields when spans are created.
 #[derive(Debug)]
 pub(crate) struct SpanModifyingTracer {
-    inner: opentelemetry::sdk::trace::Tracer,
+    inner: opentelemetry_sdk::trace::Tracer,
 }
 
 impl SpanModifyingTracer {
-    pub(crate) fn new(inner: opentelemetry::sdk::trace::Tracer) -> Self {
+    pub(crate) fn new(inner: opentelemetry_sdk::trace::Tracer) -> Self {
         Self { inner }
     }
 }
 
 impl opentelemetry::trace::Tracer for SpanModifyingTracer {
-    type Span = opentelemetry::sdk::trace::Span;
+    type Span = opentelemetry_sdk::trace::Span;
 
     fn build_with_context(&self, mut builder: SpanBuilder, parent_cx: &Context) -> Self::Span {
         let attributes = if let Some(attributes) = &mut builder.attributes {
@@ -60,24 +60,45 @@ impl opentelemetry::trace::Tracer for SpanModifyingTracer {
             return self.inner.build_with_context(builder, parent_cx);
         };
 
-        builder.trace_id = attributes
-            .get(&TRACE_ID)
+        let mut trace_id: Option<&Value> = None;
+        let mut span_id: Option<&Value> = None;
+        let mut start_time: Option<&Value> = None;
+        let mut end_time: Option<&Value> = None;
+
+        for attr in attributes.iter() {
+            if trace_id.is_none() && attr.key == TRACE_ID {
+                trace_id = Some(&attr.value);
+            } else if span_id.is_none() && attr.key == SPAN_ID {
+                span_id = Some(&attr.value);
+            } else if start_time.is_none() && attr.key == START_TIME {
+                start_time = Some(&attr.value);
+            } else if end_time.is_none() && attr.key == END_TIME {
+                end_time = Some(&attr.value);
+            } else if trace_id.is_some()
+                && span_id.is_some()
+                && start_time.is_some()
+                && end_time.is_some()
+            {
+                break;
+            }
+        }
+
+        builder.trace_id = trace_id
             .map(|trace_id| {
                 TraceId::from_hex(trace_id.as_str().as_ref())
                     .expect("restate.internal.trace_id must be a valid hex string")
             })
             .or(builder.trace_id);
 
-        builder.span_id = attributes
-            .get(&SPAN_ID)
+        builder.span_id = span_id
             .map(|span_id| {
                 SpanId::from_hex(span_id.as_str().as_ref())
                     .expect("restate.internal.span_id must be a valid hex string")
             })
             .or(builder.span_id);
 
-        fn time(key: Key, attributes: &mut OrderMap<Key, Value>) -> Option<SystemTime> {
-            attributes.get(&key).map(|value| -> SystemTime {
+        fn time(key: Key, attribute: Option<&Value>) -> Option<SystemTime> {
+            attribute.map(|value| -> SystemTime {
                 match value {
                     Value::I64(value) => {
                         SystemTime::UNIX_EPOCH.add(Duration::from_millis(*value as u64))
@@ -91,18 +112,18 @@ impl opentelemetry::trace::Tracer for SpanModifyingTracer {
             })
         }
 
-        builder.start_time = time(START_TIME, attributes).or(builder.start_time);
+        builder.start_time = time(START_TIME, start_time).or(builder.start_time);
         // Because we might be messing up with the start/end time due to the fact that we set some of these manually in the attributes,
         // and not enforce them through the API, we use this additional check to make sure that we don't generate spans with negative duration.
         builder.end_time = cmp::max(
-            time(END_TIME, attributes).or(builder.end_time),
+            time(END_TIME, end_time).or(builder.end_time),
             builder.start_time,
         );
 
         // now that we no longer hold references to the values, we can remove all the keys we used from attributes
         // by using retain, we can do this in a single O(n) scan, which is better than calling delete 1-4 times,
         // as a delete is also O(n)
-        attributes.retain(|k, _| !KEYS.contains(k));
+        attributes.retain(|kv| !KEYS.contains(&kv.key));
 
         self.inner.build_with_context(builder, parent_cx)
     }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -29,7 +29,7 @@ hostname = { workspace = true }
 http = { workspace = true }
 humantime = { workspace = true }
 once_cell = { workspace = true }
-opentelemetry_api = { workspace = true }
+opentelemetry = { workspace = true }
 rand = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -258,13 +258,13 @@ impl From<u128> for InvocationUuid {
     }
 }
 
-impl From<InvocationUuid> for opentelemetry_api::trace::TraceId {
+impl From<InvocationUuid> for opentelemetry::trace::TraceId {
     fn from(value: InvocationUuid) -> Self {
         Self::from_bytes(value.to_bytes())
     }
 }
 
-impl From<InvocationUuid> for opentelemetry_api::trace::SpanId {
+impl From<InvocationUuid> for opentelemetry::trace::SpanId {
     fn from(value: InvocationUuid) -> Self {
         let raw_be_bytes = value.to_bytes();
         let last8: [u8; 8] = std::convert::TryInto::try_into(&raw_be_bytes[8..16]).unwrap();

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -18,8 +18,8 @@ use crate::time::MillisSinceEpoch;
 use crate::GenerationalNodeId;
 use bytes::Bytes;
 use bytestring::ByteString;
-use opentelemetry_api::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceState};
-use opentelemetry_api::Context;
+use opentelemetry::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceState};
+use opentelemetry::Context;
 use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;
@@ -30,7 +30,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use serde_with::{serde_as, FromInto};
 
 // Re-exporting opentelemetry [`TraceId`] to avoid having to import opentelemetry in all crates.
-pub use opentelemetry_api::trace::TraceId;
+pub use opentelemetry::trace::TraceId;
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -58,7 +58,7 @@ drain = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 metrics =  { workspace = true }
-opentelemetry_api = { workspace = true }
+opentelemetry = { workspace = true }
 pin-project = { workspace = true }
 prost = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -10,7 +10,7 @@
 
 use bytes::Bytes;
 use bytestring::ByteString;
-use opentelemetry_api::trace::SpanId;
+use opentelemetry::trace::SpanId;
 use restate_storage_api::inbox_table::InboxEntry;
 use restate_storage_api::invocation_status_table::{
     CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -153,12 +153,9 @@ fn main() {
         async move {
             // Apply tracing config globally
             // We need to apply this first to log correctly
-            let tracing_guard = init_tracing_and_logging(
-                &Configuration::pinned().common,
-                "Restate binary",
-                std::process::id(),
-            )
-            .expect("failed to configure logging and tracing!");
+            let tracing_guard =
+                init_tracing_and_logging(&Configuration::pinned().common, "Restate binary")
+                    .expect("failed to configure logging and tracing!");
 
             // Log panics as tracing errors if possible
             let prev_hook = std::panic::take_hook();


### PR DESCRIPTION
otel has been released with the changes we needed, we can now avoid parsing header env var manually.

Fixes #1217