### PR TITLE
Check whether the state entry types are valid for the given InvocationTarget

### DIFF
--- a/crates/invoker-api/src/entry_enricher.rs
+++ b/crates/invoker-api/src/entry_enricher.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use restate_types::errors::InvocationError;
-use restate_types::invocation::ServiceInvocationSpanContext;
+use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::raw::PlainRawEntry;
 
@@ -17,7 +17,8 @@ pub trait EntryEnricher {
     fn enrich_entry(
         &self,
         entry: PlainRawEntry,
-        invocation_span_context: &ServiceInvocationSpanContext,
+        current_invocation_target: &InvocationTarget,
+        current_invocation_span_context: &ServiceInvocationSpanContext,
     ) -> Result<EnrichedRawEntry, InvocationError>;
 }
 
@@ -38,10 +39,11 @@ pub mod mocks {
     impl EntryEnricher for MockEntryEnricher {
         fn enrich_entry(
             &self,
-            raw_entry: PlainRawEntry,
-            invocation_span_context: &ServiceInvocationSpanContext,
+            entry: PlainRawEntry,
+            _current_invocation_target: &InvocationTarget,
+            current_invocation_span_context: &ServiceInvocationSpanContext,
         ) -> Result<EnrichedRawEntry, InvocationError> {
-            let (header, entry) = raw_entry.into_inner();
+            let (header, entry) = entry.into_inner();
             let enriched_header = match header {
                 PlainEntryHeader::Input {} => EnrichedEntryHeader::Input {},
                 PlainEntryHeader::Output {} => EnrichedEntryHeader::Output {},
@@ -65,7 +67,7 @@ pub mod mocks {
                                 invocation_id: InvocationId::mock_random(),
                                 invocation_target: InvocationTarget::service("", ""),
                                 service_key: Default::default(),
-                                span_context: invocation_span_context.clone(),
+                                span_context: current_invocation_span_context.clone(),
                             }),
                         }
                     } else {
@@ -82,7 +84,7 @@ pub mod mocks {
                             invocation_id: InvocationId::mock_random(),
                             invocation_target: InvocationTarget::service("", ""),
                             service_key: Default::default(),
-                            span_context: invocation_span_context.clone(),
+                            span_context: current_invocation_span_context.clone(),
                         },
                     }
                 }

--- a/crates/invoker-impl/src/invocation_task.rs
+++ b/crates/invoker-impl/src/invocation_task.rs
@@ -714,7 +714,7 @@ where
                 let entry_type = entry.header().as_entry_type();
                 let enriched_entry = shortcircuit!(self
                     .entry_enricher
-                    .enrich_entry(entry, parent_span_context)
+                    .enrich_entry(entry, &self.invocation_target, parent_span_context)
                     .map_err(|e| InvocationTaskError::EntryEnrichment(
                         self.next_journal_index,
                         entry_type,

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1142,7 +1142,7 @@ mod tests {
 
         let partition_leader_epoch = (0, LeaderEpoch::INITIAL);
         let invocation_target = InvocationTarget::mock_service();
-        let invocation_id = InvocationId::generate(&invocation_target, None::<String>);
+        let invocation_id = InvocationId::generate(&invocation_target);
 
         let (output_tx, mut output_rx) = mpsc::channel(1);
 

--- a/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/invocation_status_table_test/mod.rs
@@ -37,7 +37,7 @@ const INVOCATION_TARGET_1: InvocationTarget = InvocationTarget::VirtualObject {
     handler_ty: HandlerType::Exclusive,
 };
 static INVOCATION_ID_1: Lazy<InvocationId> =
-    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_1, None::<String>));
+    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_1));
 
 const INVOCATION_TARGET_2: InvocationTarget = InvocationTarget::VirtualObject {
     name: ByteString::from_static("abc"),
@@ -46,7 +46,7 @@ const INVOCATION_TARGET_2: InvocationTarget = InvocationTarget::VirtualObject {
     handler_ty: HandlerType::Exclusive,
 };
 static INVOCATION_ID_2: Lazy<InvocationId> =
-    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_2, None::<String>));
+    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_2));
 
 const INVOCATION_TARGET_3: InvocationTarget = InvocationTarget::VirtualObject {
     name: ByteString::from_static("abc"),
@@ -55,7 +55,7 @@ const INVOCATION_TARGET_3: InvocationTarget = InvocationTarget::VirtualObject {
     handler_ty: HandlerType::Exclusive,
 };
 static INVOCATION_ID_3: Lazy<InvocationId> =
-    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_3, None::<String>));
+    Lazy::new(|| InvocationId::generate(&INVOCATION_TARGET_3));
 
 fn invoked_status(invocation_target: InvocationTarget) -> InvocationStatus {
     InvocationStatus::Invoked(InFlightInvocationMetadata {

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -358,7 +358,11 @@ impl InvocationId {
         }
     }
 
-    pub fn generate<IKey: Hash>(
+    pub fn generate(invocation_target: &InvocationTarget) -> Self {
+        InvocationId::generate_with_idempotency_key(invocation_target, None::<String>)
+    }
+
+    pub fn generate_with_idempotency_key<IKey: Hash>(
         invocation_target: &InvocationTarget,
         idempotency_key: Option<IKey>,
     ) -> Self {

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -20,14 +20,13 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use opentelemetry::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceState};
 use opentelemetry::Context;
+use serde_with::{serde_as, FromInto};
 use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;
 use std::time::Duration;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-
-use serde_with::{serde_as, FromInto};
 
 // Re-exporting opentelemetry [`TraceId`] to avoid having to import opentelemetry in all crates.
 pub use opentelemetry::trace::TraceId;
@@ -40,8 +39,18 @@ pub enum ComponentType {
 }
 
 impl ComponentType {
-    pub fn requires_key(&self) -> bool {
+    pub fn is_keyed(&self) -> bool {
         matches!(self, ComponentType::VirtualObject)
+    }
+
+    pub fn has_state(&self) -> bool {
+        self.is_keyed()
+    }
+}
+
+impl fmt::Display for ComponentType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 
@@ -58,6 +67,12 @@ impl HandlerType {
             ComponentType::Service => HandlerType::Shared,
             ComponentType::VirtualObject => HandlerType::Exclusive,
         }
+    }
+}
+
+impl fmt::Display for HandlerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -66,7 +66,7 @@ impl StateReaderMock {
         invocation_target: InvocationTarget,
         journal: Vec<JournalEntry>,
     ) -> InvocationId {
-        let invocation_id = InvocationId::generate(&invocation_target, None::<String>);
+        let invocation_id = InvocationId::generate(&invocation_target);
 
         let service_id = ServiceId::with_partition_key(
             invocation_id.partition_key(),
@@ -101,7 +101,7 @@ impl StateReaderMock {
         waiting_for_completed_entries: impl IntoIterator<Item = EntryIndex>,
         journal: Vec<JournalEntry>,
     ) -> InvocationId {
-        let invocation_id = InvocationId::generate(&invocation_target, None::<String>);
+        let invocation_id = InvocationId::generate(&invocation_target);
 
         let service_id = ServiceId::with_partition_key(
             invocation_id.partition_key(),

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -1234,7 +1234,7 @@ mod tests {
         state_machine: &mut MockStateMachine,
         invocation_target: InvocationTarget,
     ) -> InvocationId {
-        let invocation_id = InvocationId::generate(&invocation_target, None::<String>);
+        let invocation_id = InvocationId::generate(&invocation_target);
         let fid = FullInvocationId::combine(
             ServiceId::with_partition_key(
                 invocation_id.partition_key(),


### PR DESCRIPTION
With the new `InvocationTarget` introduced with https://github.com/restatedev/restate/issues/1329, we now face the issue that we won't have a `ServiceId` every time for any invocation, even the ones targeting regular services. This means that in case a GetState is sent from the sdk for a service, the runtime won't know what to do with it. This adds a check to verify that no SDK misbehaves, hence in the PartitionProcessor we can assume we always have a `ServiceId` once when we see a state related journal entry.

Also massages a bit the constructors of `InvocationId`.

Related (old) issue: https://github.com/restatedev/restate/issues/287

Based on https://github.com/restatedev/restate/pull/1405