### PR TITLE
[RocksDb] shared env and config updates

### DIFF
--- a/crates/bifrost/src/loglets/local_loglet/log_store.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store.rs
@@ -107,8 +107,6 @@ fn db_options() -> rocksdb::Options {
     // no need to retain 1000 log files by default.
     //
     opts.set_keep_log_file_num(10);
-    // Use Direct I/O for reads, do not use OS page cache to cache compressed blocks.
-    opts.set_use_direct_reads(true);
     opts
 }
 

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -15,17 +15,15 @@ use std::time::Instant;
 
 use bytesize::ByteSize;
 use dashmap::DashMap;
-use rocksdb::{Cache, WriteBufferManager};
+use rocksdb::{BlockBasedOptions, Cache, WriteBufferManager};
 
 use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
 use restate_types::arc_util::Updateable;
-use restate_types::config::{CommonOptions, Configuration, RocksDbOptions};
+use restate_types::config::{CommonOptions, Configuration, RocksDbOptions, StatisticsLevel};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
-use crate::{
-    amend_cf_options, amend_db_options, DbName, DbSpec, Owner, RocksAccess, RocksDb, RocksError,
-};
+use crate::{CfName, DbName, DbSpec, Owner, RocksAccess, RocksDb, RocksError};
 
 static DB_MANAGER: OnceLock<RocksDbManager> = OnceLock::new();
 
@@ -40,6 +38,7 @@ enum WatchdogCommand {
 ///
 /// It doesn't try to limit rocksdb use-cases from accessing the raw rocksdb.
 pub struct RocksDbManager {
+    env: rocksdb::Env,
     /// a shared rocksdb block cache
     cache: Cache,
     // auto updates to changes in common.rocksdb_memory_limit and common.rocksdb_memtable_total_size_limit
@@ -76,12 +75,19 @@ impl RocksDbManager {
             true,
             cache.clone(),
         );
+
+        // Setup the shared rocksdb environment
+        let mut env = rocksdb::Env::new().expect("rocksdb env is created");
+        env.set_low_priority_background_threads(opts.rocksdb_bg_threads().get() as i32);
+        env.set_high_priority_background_threads(opts.rocksdb_high_priority_bg_threads.get() as i32);
+
         let dbs = DashMap::default();
 
         // unbounded channel since commands are rare and we don't want to block
         let (watchdog_tx, watchdog_rx) = mpsc::unbounded_channel();
 
         let manager = Self {
+            env,
             cache,
             write_buffer_manager,
             dbs,
@@ -125,16 +131,25 @@ impl RocksDbManager {
         let name = db_spec.name.clone();
         let owner = db_spec.owner;
         // use the spec default options as base then apply the config from the updateable.
-        amend_db_options(&mut db_spec.db_options, &options);
-        // write butter is controlled by write buffer manager
-        db_spec
-            .db_options
-            .set_write_buffer_manager(&self.write_buffer_manager);
-        // todo: set avoid_unnecessary_blocking_io = true;
+        self.amend_db_options(&mut db_spec.db_options, &options);
 
         // for every column family, generate cf_options with the same strategy
         for (_, cf_opts) in &mut db_spec.column_families {
-            amend_cf_options(cf_opts, &options, &self.cache);
+            self.amend_cf_options(cf_opts, &options);
+        }
+
+        // make sure default column family uses the global cache so that it doesn't create
+        // its own cache (wastes ~32MB RSS per db)
+        if !db_spec
+            .column_families
+            .iter()
+            .any(|(c, _)| c.as_str() == "default")
+        {
+            let mut cf_opts = rocksdb::Options::default();
+            self.amend_cf_options(&mut cf_opts, &options);
+            db_spec
+                .column_families
+                .push((CfName::new("default"), cf_opts));
         }
 
         let db = Arc::new(RocksAccess::open_db(&db_spec)?);
@@ -263,6 +278,69 @@ impl RocksDbManager {
         }
         info!("Rocksdb shutdown took {:?}", start.elapsed());
     }
+
+    fn amend_db_options(&self, db_options: &mut rocksdb::Options, opts: &RocksDbOptions) {
+        db_options.set_env(&self.env);
+        db_options.create_if_missing(true);
+        db_options.create_missing_column_families(true);
+        db_options.set_max_background_jobs(opts.rocksdb_max_background_jobs().get() as i32);
+
+        // write buffer is controlled by write buffer manager
+        db_options.set_write_buffer_manager(&self.write_buffer_manager);
+
+        // todo: set avoid_unnecessary_blocking_io = true;
+
+        if !opts.rocksdb_disable_statistics() {
+            db_options.enable_statistics();
+            db_options
+                .set_statistics_level(convert_statistics_level(opts.rocksdb_statistics_level()));
+        }
+
+        // Disable WAL archiving.
+        // the following two options has to be both 0 to disable WAL log archive.
+        db_options.set_wal_size_limit_mb(0);
+        db_options.set_wal_ttl_seconds(0);
+
+        if !opts.rocksdb_disable_wal() {
+            // Disable automatic WAL flushing.
+            // We will call flush manually, when we commit a storage transaction.
+            //
+            db_options.set_manual_wal_flush(opts.rocksdb_batch_wal_flushes());
+            // Once the WAL logs exceed this size, rocksdb will start flush memtables to disk.
+            db_options.set_max_total_wal_size(opts.rocksdb_max_total_wal_size());
+        }
+        //
+        // Let rocksdb decide for level sizes.
+        //
+        db_options.set_level_compaction_dynamic_level_bytes(true);
+        db_options.set_compaction_readahead_size(opts.rocksdb_compaction_readahead_size());
+        //
+        // [Not important setting, consider removing], allows to shard compressed
+        // block cache to up to 64 shards in memory.
+        //
+        db_options.set_table_cache_num_shard_bits(6);
+
+        // Use Direct I/O for reads, do not use OS page cache to cache compressed blocks.
+        db_options.set_use_direct_reads(true);
+        db_options.set_use_direct_io_for_flush_and_compaction(true);
+    }
+
+    fn amend_cf_options(&self, cf_options: &mut rocksdb::Options, opts: &RocksDbOptions) {
+        // write buffer
+        //
+        cf_options.set_write_buffer_size(opts.rocksdb_write_buffer_size());
+        //
+        // bloom filters and block cache.
+        //
+        let mut block_opts = BlockBasedOptions::default();
+        block_opts.set_bloom_filter(10.0, true);
+        // use the latest Rocksdb table format.
+        // https://github.com/facebook/rocksdb/blob/f059c7d9b96300091e07429a60f4ad55dac84859/include/rocksdb/table.h#L275
+        block_opts.set_format_version(5);
+        block_opts.set_cache_index_and_filter_blocks(true);
+        block_opts.set_block_cache(&self.cache);
+        cf_options.set_block_based_table_factory(&block_opts);
+    }
 }
 
 #[allow(dead_code)]
@@ -388,6 +466,18 @@ impl DbWatchdog {
 
         // todo: Apply other changes to the databases.
         // e.g. set write_buffer_size
+    }
+}
+
+fn convert_statistics_level(input: StatisticsLevel) -> rocksdb::statistics::StatsLevel {
+    use rocksdb::statistics::StatsLevel;
+    match input {
+        StatisticsLevel::DisableAll => StatsLevel::DisableAll,
+        StatisticsLevel::ExceptHistogramOrTimers => StatsLevel::ExceptHistogramOrTimers,
+        StatisticsLevel::ExceptTimers => StatsLevel::ExceptTimers,
+        StatisticsLevel::ExceptDetailedTimers => StatsLevel::ExceptDetailedTimers,
+        StatisticsLevel::ExceptTimeForMutex => StatsLevel::ExceptTimeForMutex,
+        StatisticsLevel::All => StatsLevel::All,
     }
 }
 

--- a/crates/storage-rocksdb/src/lib.rs
+++ b/crates/storage-rocksdb/src/lib.rs
@@ -184,16 +184,9 @@ impl Clone for RocksDBStorage {
 
 fn db_options() -> rocksdb::Options {
     let mut db_options = rocksdb::Options::default();
-    db_options.set_atomic_flush(true);
-    //
     // no need to retain 1000 log files by default.
     //
     db_options.set_keep_log_file_num(1);
-    //
-    // Allow mmap read and write.
-    //
-    db_options.set_allow_mmap_reads(true);
-    db_options.set_allow_mmap_writes(true);
 
     db_options
 }

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -8,24 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::{NonZeroU32, NonZeroUsize};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "schemars",
-    schemars(rename = "WorkerRocksDbOptions", default)
-)]
+#[cfg_attr(feature = "schemars", schemars(rename = "RocksDbOptions", default))]
 #[serde(rename_all = "kebab-case")]
 #[builder(default)]
 // NOTE: Prefix with rocksdb_
 pub struct RocksDbOptions {
-    /// # Threads
-    ///
-    /// The number of threads to reserve to Rocksdb background tasks.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_num_threads: Option<usize>,
-
     /// # Write Buffer size
     ///
     /// The size of a single memtable. Once memtable exceeds this size, it is marked
@@ -62,14 +55,36 @@ pub struct RocksDbOptions {
     /// Default: False (statistics enabled)
     #[serde(skip_serializing_if = "Option::is_none")]
     rocksdb_disable_statistics: Option<bool>,
+
+    /// # RocksDB max background jobs (flushes and compactions)
+    ///
+    /// Default: the number of CPU cores on this node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rocksdb_max_background_jobs: Option<NonZeroU32>,
+
+    /// # RocksDB compaction readahead size in bytes
+    ///
+    /// If non-zero, we perform bigger reads when doing compaction. If you're
+    /// running RocksDB on spinning disks, you should set this to at least 2MB.
+    /// That way RocksDB's compaction is doing sequential instead of random reads.
+    ///
+    /// Default: 2MB (2 * 1024 * 1024)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rocksdb_compaction_readahead_size: Option<usize>,
+
+    /// # RocksDB statistics level
+    ///
+    /// StatsLevel can be used to reduce statistics overhead by skipping certain
+    /// types of stats in the stats collection process.
+    ///
+    /// Default: "except-detailed-timers"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rocksdb_statistics_level: Option<StatisticsLevel>,
 }
 
 impl RocksDbOptions {
     pub fn apply_common(&mut self, common: &RocksDbOptions) {
         // apply memory limits?
-        if self.rocksdb_num_threads.is_none() {
-            self.rocksdb_num_threads = Some(common.rocksdb_num_threads());
-        }
         if self.rocksdb_write_buffer_size.is_none() {
             self.rocksdb_write_buffer_size = Some(common.rocksdb_write_buffer_size());
         }
@@ -82,10 +97,16 @@ impl RocksDbOptions {
         if self.rocksdb_disable_statistics.is_none() {
             self.rocksdb_disable_statistics = Some(common.rocksdb_disable_statistics());
         }
-    }
-
-    pub fn rocksdb_num_threads(&self) -> usize {
-        self.rocksdb_num_threads.unwrap_or(10)
+        if self.rocksdb_max_background_jobs.is_none() {
+            self.rocksdb_max_background_jobs = Some(common.rocksdb_max_background_jobs());
+        }
+        if self.rocksdb_compaction_readahead_size.is_none() {
+            self.rocksdb_compaction_readahead_size =
+                Some(common.rocksdb_compaction_readahead_size());
+        }
+        if self.rocksdb_statistics_level.is_none() {
+            self.rocksdb_statistics_level = Some(common.rocksdb_statistics_level());
+        }
     }
 
     pub fn rocksdb_write_buffer_size(&self) -> usize {
@@ -107,4 +128,46 @@ impl RocksDbOptions {
     pub fn rocksdb_batch_wal_flushes(&self) -> bool {
         self.rocksdb_batch_wal_flushes.unwrap_or(true)
     }
+
+    pub fn rocksdb_max_background_jobs(&self) -> NonZeroU32 {
+        self.rocksdb_max_background_jobs.unwrap_or(
+            std::thread::available_parallelism()
+                .unwrap_or(NonZeroUsize::new(2).unwrap())
+                .try_into()
+                .expect("number of cpu cores fits in u32"),
+        )
+    }
+
+    pub fn rocksdb_compaction_readahead_size(&self) -> usize {
+        self.rocksdb_compaction_readahead_size
+            .unwrap_or(2 * 1024 * 1024)
+    }
+
+    pub fn rocksdb_statistics_level(&self) -> StatisticsLevel {
+        self.rocksdb_statistics_level
+            .unwrap_or(StatisticsLevel::ExceptDetailedTimers)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(rename = "RocksbStatistics"))]
+#[serde(rename_all = "kebab-case")]
+pub enum StatisticsLevel {
+    /// Disable all metrics
+    DisableAll,
+    /// Disable timer stats, and skip histogram stats
+    ExceptHistogramOrTimers,
+    /// Skip timer stats
+    ExceptTimers,
+    /// Collect all stats except time inside mutex lock AND time spent on
+    /// compression.
+    ExceptDetailedTimers,
+    /// Collect all stats except the counters requiring to get time inside the
+    /// mutex lock.
+    ExceptTimeForMutex,
+    /// Collect all stats, including measuring duration of mutex operations.
+    /// If getting time is expensive on the platform to run, it can
+    /// reduce scalability to more threads, especially for writes.
+    All,
 }


### PR DESCRIPTION
[RocksDb] shared env and config updates

- Move rocksdb sizing to the environment instead of per-database control (they used to override each other anyway)
- Enable Direct IO
- StatisticsLevel is configurable
- default column family explicit attachement to global block cache (saves 32MB of RSS per database)
- More configuration keys

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1424).
* #1433
* #1432
* #1431
* #1427
* __->__ #1424