### PR TITLE
Use restate's rust-rocksdb writebatch by ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,9 +3609,8 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+version = "0.17.0+9.0.0"
+source = "git+https://github.com/restatedev/rust-rocksdb?branch=next#caec8ab62cf053679f409c69a4ee72483a8b9688"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6405,11 +6404,12 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+source = "git+https://github.com/restatedev/rust-rocksdb?branch=next#caec8ab62cf053679f409c69a4ee72483a8b9688"
 dependencies = [
  "libc",
  "librocksdb-sys",
+ "parking_lot",
+ "smartstring",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ prost = "0.12.1"
 prost-build = "0.12.1"
 prost-types = "0.12.1"
 rand = "0.8.5"
-rocksdb = { version = "0.22.0" }
+rocksdb = { version = "0.22.0", features = ["multi-threaded-cf"] }
 rustls = "0.21.6"
 schemars = { version = "0.8", features = ["bytes"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ prost = "0.12.1"
 prost-build = "0.12.1"
 prost-types = "0.12.1"
 rand = "0.8.5"
-rocksdb = { version = "0.22.0", features = ["multi-threaded-cf"] }
+rocksdb = { version = "0.22.0", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", branch="next" }
 rustls = "0.21.6"
 schemars = { version = "0.8", features = ["bytes"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/bifrost/src/loglets/local_loglet/log_store.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store.rs
@@ -16,7 +16,7 @@ use restate_rocksdb::{
 };
 use restate_types::arc_util::Updateable;
 use restate_types::config::RocksDbOptions;
-use rocksdb::{DBCompressionType, DB};
+use rocksdb::{BoundColumnFamily, DBCompressionType, DB};
 
 use super::keys::{MetadataKey, MetadataKind};
 use super::log_state::{log_state_full_merge, log_state_partial_merge, LogState};
@@ -70,18 +70,18 @@ impl RocksDbLogStore {
         })
     }
 
-    pub fn data_cf(&self) -> &rocksdb::ColumnFamily {
+    pub fn data_cf(&self) -> Arc<BoundColumnFamily> {
         self.db.cf_handle(DATA_CF).expect("DATA_CF exists")
     }
 
-    pub fn metadata_cf(&self) -> &rocksdb::ColumnFamily {
+    pub fn metadata_cf(&self) -> Arc<BoundColumnFamily> {
         self.db.cf_handle(METADATA_CF).expect("METADATA_CF exists")
     }
 
     pub fn get_log_state(&self, log_id: u64) -> Result<Option<LogState>, LogStoreError> {
         let metadata_cf = self.metadata_cf();
         let value = self.db.get_pinned_cf(
-            metadata_cf,
+            &metadata_cf,
             MetadataKey::new(log_id, MetadataKind::LogState).to_bytes(),
         )?;
 

--- a/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
@@ -170,7 +170,7 @@ impl LogStoreWriter {
             write_batch.len(),
         );
 
-        if let Err(e) = self.db.write_opt(write_batch, &rocksdb_write_options) {
+        if let Err(e) = self.db.write_opt(&write_batch, &rocksdb_write_options) {
             error!("Failed to commit local loglet write batch: {}", e);
             self.send_acks(Err(Error::LogStoreError(e.into())));
             return;

--- a/crates/bifrost/src/loglets/local_loglet/mod.rs
+++ b/crates/bifrost/src/loglets/local_loglet/mod.rs
@@ -116,7 +116,7 @@ impl LocalLoglet {
             read_opts.set_iterate_upper_bound(RecordKey::upper_bound(self.log_id).to_bytes());
 
             let mut iter = self.log_store.db().iterator_cf_opt(
-                data_cf,
+                &data_cf,
                 read_opts,
                 rocksdb::IteratorMode::From(&key.to_bytes(), rocksdb::Direction::Forward),
             );

--- a/crates/node/src/network_server/handler/mod.rs
+++ b/crates/node/src/network_server/handler/mod.rs
@@ -216,7 +216,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
 
         // Properties (Gauges)
         // For properties, we need to get them for each column family.
-        for cf in db.cfs() {
+        for cf in &db.cfs() {
             let sanitized_cf_name = formatting::sanitize_label_value(cf);
             let mut cf_labels = Vec::with_capacity(labels.len() + 1);
             labels.clone_into(&mut cf_labels);

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -133,11 +133,13 @@ impl RocksDbManager {
         // use the spec default options as base then apply the config from the updateable.
         self.amend_db_options(&mut db_spec.db_options, &options);
 
-        let (db, cfs) = RocksAccess::open_db(&db_spec, self.default_cf_options(&options))?;
-        let db = Arc::new(db);
+        let db = Arc::new(RocksAccess::open_db(
+            &db_spec,
+            self.default_cf_options(&options),
+        )?);
 
         let path = db_spec.path.clone();
-        let wrapper = Arc::new(RocksDb::new(db_spec, db.clone(), cfs));
+        let wrapper = Arc::new(RocksDb::new(db_spec, db.clone()));
 
         self.dbs.insert((owner, name.clone()), wrapper);
 

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -112,7 +112,8 @@ impl RocksAccess for rocksdb::DB {
             .iter()
             .filter_map(|name| self.cf_handle(name))
             .collect::<Vec<_>>();
-        Ok(self.flush_cfs_opt(&cfs, &flushopts)?)
+        let cf_refs = cfs.iter().collect::<Vec<_>>();
+        Ok(self.flush_cfs_opt(&cf_refs, &flushopts)?)
     }
 
     fn flush_wal(&self, sync: bool) -> Result<(), RocksError> {
@@ -127,14 +128,14 @@ impl RocksAccess for rocksdb::DB {
         let Some(handle) = self.cf_handle(cf) else {
             return Err(RocksError::UnknownColumnFamily(cf.clone()));
         };
-        Ok(self.set_options_cf(handle, opts)?)
+        Ok(self.set_options_cf(&handle, opts)?)
     }
 
     fn get_property_int_cf(&self, cf: &CfName, property: &str) -> Result<Option<u64>, RocksError> {
         let Some(handle) = self.cf_handle(cf) else {
             return Err(RocksError::UnknownColumnFamily(cf.clone()));
         };
-        Ok(self.property_int_value_cf(handle, property)?)
+        Ok(self.property_int_value_cf(&handle, property)?)
     }
 
     fn record_memory_stats(&self, builder: &mut MemoryUsageBuilder) {
@@ -191,7 +192,8 @@ impl RocksAccess for rocksdb::OptimisticTransactionDB {
             .iter()
             .filter_map(|name| self.cf_handle(name))
             .collect::<Vec<_>>();
-        Ok(self.flush_cfs_opt(&cfs, &flushopts)?)
+        let cf_refs = cfs.iter().collect::<Vec<_>>();
+        Ok(self.flush_cfs_opt(&cf_refs, &flushopts)?)
     }
 
     fn flush_wal(&self, sync: bool) -> Result<(), RocksError> {
@@ -206,14 +208,14 @@ impl RocksAccess for rocksdb::OptimisticTransactionDB {
         let Some(handle) = self.cf_handle(cf) else {
             return Err(RocksError::UnknownColumnFamily(cf.clone()));
         };
-        Ok(self.set_options_cf(handle, opts)?)
+        Ok(self.set_options_cf(&handle, opts)?)
     }
 
     fn get_property_int_cf(&self, cf: &CfName, property: &str) -> Result<Option<u64>, RocksError> {
         let Some(handle) = self.cf_handle(cf) else {
             return Err(RocksError::UnknownColumnFamily(cf.clone()));
         };
-        Ok(self.property_int_value_cf(handle, property)?)
+        Ok(self.property_int_value_cf(&handle, property)?)
     }
 
     fn record_memory_stats(&self, builder: &mut MemoryUsageBuilder) {

--- a/crates/storage-rocksdb/src/lib.rs
+++ b/crates/storage-rocksdb/src/lib.rs
@@ -40,20 +40,20 @@ use restate_storage_api::{Storage, StorageError, Transaction};
 use restate_types::arc_util::Updateable;
 use restate_types::config::RocksDbOptions;
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
-use rocksdb::ColumnFamily;
+use rocksdb::BoundColumnFamily;
 use rocksdb::DBCompressionType;
 use rocksdb::DBPinnableSlice;
 use rocksdb::DBRawIteratorWithThreadMode;
+use rocksdb::MultiThreaded;
 use rocksdb::PrefixRange;
 use rocksdb::ReadOptions;
-use rocksdb::SingleThreaded;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 pub use writer::JoinHandle as RocksDBWriterJoinHandle;
 pub use writer::Writer as RocksDBWriter;
 
-pub type DB = rocksdb::OptimisticTransactionDB<SingleThreaded>;
+pub type DB = rocksdb::OptimisticTransactionDB<MultiThreaded>;
 type TransactionDB<'a> = rocksdb::Transaction<'a, DB>;
 
 pub type DBIterator<'b> = DBRawIteratorWithThreadMode<'b, DB>;
@@ -280,7 +280,7 @@ impl RocksDBStorage {
         ))
     }
 
-    fn table_handle(&self, table_kind: TableKind) -> &ColumnFamily {
+    fn table_handle(&self, table_kind: TableKind) -> Arc<BoundColumnFamily> {
         self.db.cf_handle(cf_name(table_kind)).expect(
             "This should not happen, this is a Restate bug. Please contact the restate developers.",
         )
@@ -385,13 +385,13 @@ impl StorageAccess for RocksDBStorage {
     #[inline]
     fn put_cf(&mut self, table: TableKind, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) {
         let table = self.table_handle(table);
-        self.db.put_cf(table, key, value).unwrap();
+        self.db.put_cf(&table, key, value).unwrap();
     }
 
     #[inline]
     fn delete_cf(&mut self, table: TableKind, key: impl AsRef<[u8]>) {
         let table = self.table_handle(table);
-        self.db.delete_cf(table, key).unwrap();
+        self.db.delete_cf(&table, key).unwrap();
     }
 }
 
@@ -427,7 +427,7 @@ impl<'a> RocksDBTransaction<'a> {
         self.txn.raw_iterator_cf_opt(&table, opts)
     }
 
-    fn table_handle(&self, table_kind: TableKind) -> &ColumnFamily {
+    fn table_handle(&self, table_kind: TableKind) -> Arc<BoundColumnFamily> {
         self.db.cf_handle(cf_name(table_kind)).expect(
             "This should not happen, this is a Restate bug. Please contact the restate developers.",
         )
@@ -497,13 +497,13 @@ impl<'a> StorageAccess for RocksDBTransaction<'a> {
     #[inline]
     fn put_cf(&mut self, table: TableKind, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) {
         let table = self.table_handle(table);
-        self.txn.put_cf(table, key, value).unwrap();
+        self.txn.put_cf(&table, key, value).unwrap();
     }
 
     #[inline]
     fn delete_cf(&mut self, table: TableKind, key: impl AsRef<[u8]>) {
         let table = self.table_handle(table);
-        self.txn.delete_cf(table, key).unwrap();
+        self.txn.delete_cf(&table, key).unwrap();
     }
 }
 

--- a/crates/storage-rocksdb/src/writer.rs
+++ b/crates/storage-rocksdb/src/writer.rs
@@ -111,7 +111,7 @@ impl Writer {
         replies: &mut Vec<Sender<Result<(), StorageError>>>,
     ) -> Result<(), Error> {
         replies.push(response_tx);
-        if !try_write_batch(&self.db, replies, write_batch) {
+        if !try_write_batch(&self.db, replies, &write_batch) {
             return Ok(());
         }
         //
@@ -123,7 +123,7 @@ impl Writer {
         }) = self.rx.try_recv()
         {
             replies.push(response_tx);
-            if !try_write_batch(&self.db, replies, write_batch) {
+            if !try_write_batch(&self.db, replies, &write_batch) {
                 return Ok(());
             }
         }
@@ -145,7 +145,7 @@ impl Writer {
 fn try_write_batch(
     db: &Arc<DB>,
     futures: &mut Vec<Sender<Result<(), StorageError>>>,
-    batch: WriteBatch,
+    batch: &WriteBatch,
 ) -> bool {
     let result = db
         .write(batch)


### PR DESCRIPTION
Use restate's rust-rocksdb writebatch by ref

In this PR we start to use our own fork of rust-rocksdb, it seems that the number of changes we will need over time might cause us to diverge significantly, but we will try and contribute back as much as possible. For now, I've added the following optimizations:
- Use writebatch by ref, this enables retries when sync writes might block on IO
- Use parking_lot's RwLock (a couple orders of magnitude faster than std's RwLock in non-contended case which is our common path
- Use smartstring for the BTreeMap, a small allocation optimization but worth doing on this hot access path since we might run a large number of Cfs.
- Allow rocksdb to return the list of open column families to avoid our own copy.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1432).
* #1435
* #1433
* __->__ #1432
* #1431