### PR TITLE
[RocksDb] Dispatch bifrost writes to bg threads automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5848,6 +5848,7 @@ dependencies = [
  "derive_more",
  "futures",
  "futures-util",
+ "metrics",
  "once_cell",
  "parking_lot",
  "rayon",

--- a/crates/bifrost/src/loglets/local_loglet/log_store.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use restate_rocksdb::{
-    CfExactPattern, CfName, DbName, DbSpecBuilder, Owner, RocksDbManager, RocksError,
+    CfExactPattern, CfName, DbName, DbSpecBuilder, Owner, RocksDb, RocksDbManager, RocksError,
 };
 use restate_types::arc_util::Updateable;
 use restate_types::config::RocksDbOptions;
@@ -45,7 +45,7 @@ pub enum LogStoreError {
 
 #[derive(Debug, Clone)]
 pub struct RocksDbLogStore {
-    db: Arc<DB>,
+    rocksdb: Arc<RocksDb>,
 }
 
 impl RocksDbLogStore {
@@ -66,22 +66,26 @@ impl RocksDbLogStore {
                 .add_to_flush_on_shutdown(CfExactPattern::new(METADATA_CF))
                 .ensure_column_families(cfs)
                 .build_as_db();
-        Ok(Self {
-            db: db_manager.open_db(updateable_options, db_spec)?,
-        })
+        let db_name = db_spec.name().clone();
+        // todo: use the returned rocksdb object when open_db returns Arc<RocksDb>
+        let _ = db_manager.open_db(updateable_options, db_spec)?;
+        let rocksdb = db_manager.get_db(Owner::Bifrost, db_name).unwrap();
+        Ok(Self { rocksdb })
     }
 
     pub fn data_cf(&self) -> Arc<BoundColumnFamily> {
-        self.db.cf_handle(DATA_CF).expect("DATA_CF exists")
+        self.rocksdb.cf_handle(DATA_CF).expect("DATA_CF exists")
     }
 
     pub fn metadata_cf(&self) -> Arc<BoundColumnFamily> {
-        self.db.cf_handle(METADATA_CF).expect("METADATA_CF exists")
+        self.rocksdb
+            .cf_handle(METADATA_CF)
+            .expect("METADATA_CF exists")
     }
 
     pub fn get_log_state(&self, log_id: u64) -> Result<Option<LogState>, LogStoreError> {
         let metadata_cf = self.metadata_cf();
-        let value = self.db.get_pinned_cf(
+        let value = self.rocksdb.as_raw_db().get_pinned_cf(
             &metadata_cf,
             MetadataKey::new(log_id, MetadataKind::LogState).to_bytes(),
         )?;
@@ -94,11 +98,11 @@ impl RocksDbLogStore {
     }
 
     pub fn create_writer(&self, manual_wal_flush: bool) -> LogStoreWriter {
-        LogStoreWriter::new(self.db.clone(), manual_wal_flush)
+        LogStoreWriter::new(self.rocksdb.clone(), manual_wal_flush)
     }
 
     pub fn db(&self) -> &DB {
-        &self.db
+        self.rocksdb.as_raw_db()
     }
 }
 

--- a/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
@@ -11,9 +11,10 @@
 use std::sync::Arc;
 
 use bytes::{Bytes, BytesMut};
+use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::arc_util::Updateable;
 use restate_types::config::LocalLogletOptions;
-use rocksdb::{BoundColumnFamily, WriteBatch, DB};
+use rocksdb::{BoundColumnFamily, WriteBatch};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
@@ -43,16 +44,16 @@ enum DataUpdate {
 }
 
 pub(crate) struct LogStoreWriter {
-    db: Arc<DB>,
+    rocksdb: Arc<RocksDb>,
     batch_acks_buf: Vec<Ack>,
     manual_wal_flush: bool,
     buffer: BytesMut,
 }
 
 impl LogStoreWriter {
-    pub(crate) fn new(db: Arc<DB>, manual_wal_flush: bool) -> Self {
+    pub(crate) fn new(rocksdb: Arc<RocksDb>, manual_wal_flush: bool) -> Self {
         Self {
-            db,
+            rocksdb,
             batch_acks_buf: Vec::default(),
             manual_wal_flush,
             buffer: BytesMut::default(),
@@ -65,7 +66,8 @@ impl LogStoreWriter {
         mut updateable: impl Updateable<LocalLogletOptions> + Send + 'static,
     ) -> Result<RocksDbLogWriterHandle, ShutdownError> {
         // big enough to allows a second full batch to queue up while the existing one is being processed
-        let (sender, receiver) = mpsc::channel(updateable.load().writer_batch_commit_count * 2);
+        let batch_size = std::cmp::max(1, updateable.load().writer_batch_commit_count);
+        let (sender, receiver) = mpsc::channel(batch_size * 2);
 
         task_center().spawn_child(
             TaskKind::LogletProvider,
@@ -87,7 +89,7 @@ impl LogStoreWriter {
                         }
                         Some(cmds) = receiver.next() => {
                                 let opts = updateable.load();
-                                self.handle_commands(opts, cmds);
+                                self.handle_commands(opts, cmds).await;
                         }
                     }
                 }
@@ -98,7 +100,11 @@ impl LogStoreWriter {
         Ok(RocksDbLogWriterHandle { sender })
     }
 
-    fn handle_commands(&mut self, opts: &LocalLogletOptions, commands: Vec<LogStoreWriteCommand>) {
+    async fn handle_commands(
+        &mut self,
+        opts: &LocalLogletOptions,
+        commands: Vec<LogStoreWriteCommand>,
+    ) {
         let mut write_batch = WriteBatch::default();
         self.batch_acks_buf.clear();
         self.batch_acks_buf.reserve(commands.len());
@@ -107,8 +113,11 @@ impl LogStoreWriter {
         buffer.clear();
 
         {
-            let data_cf = self.db.cf_handle(DATA_CF).expect("data cf exists");
-            let metadata_cf = self.db.cf_handle(METADATA_CF).expect("metadata cf exists");
+            let data_cf = self.rocksdb.cf_handle(DATA_CF).expect("data cf exists");
+            let metadata_cf = self
+                .rocksdb
+                .cf_handle(METADATA_CF)
+                .expect("metadata cf exists");
 
             for command in commands {
                 if let Some(data_command) = command.data_update {
@@ -139,7 +148,7 @@ impl LogStoreWriter {
             }
         }
 
-        self.commit(opts, write_batch);
+        self.commit(opts, write_batch).await;
     }
 
     fn update_log_state(
@@ -168,26 +177,35 @@ impl LogStoreWriter {
         write_batch.put_cf(data_cf, &key.to_bytes(), data);
     }
 
-    fn commit(&mut self, opts: &LocalLogletOptions, write_batch: WriteBatch) {
-        let mut rocksdb_write_options = rocksdb::WriteOptions::new();
-        rocksdb_write_options.disable_wal(opts.rocksdb.rocksdb_disable_wal());
+    async fn commit(&mut self, opts: &LocalLogletOptions, write_batch: WriteBatch) {
+        let mut write_opts = rocksdb::WriteOptions::new();
+        write_opts.disable_wal(opts.rocksdb.rocksdb_disable_wal());
 
         trace!(
             "Committing local loglet current write batch: {} items",
             write_batch.len(),
         );
+        let result = self
+            .rocksdb
+            .write_batch(Priority::High, IoMode::Default, write_opts, write_batch)
+            .await;
 
-        if let Err(e) = self.db.write_opt(&write_batch, &rocksdb_write_options) {
+        if let Err(e) = result {
             error!("Failed to commit local loglet write batch: {}", e);
             self.send_acks(Err(Error::LogStoreError(e.into())));
             return;
         }
 
         if self.manual_wal_flush {
-            if let Err(e) = self.db.flush_wal(true) {
+            // WAL flush is done in the forground, but sync will happen in the background to avoid
+            // blocking IO.
+            if let Err(e) = self.rocksdb.flush_wal(opts.sync_wal_before_ack) {
                 warn!("Failed to flush rocksdb WAL in local loglet : {}", e);
                 self.send_acks(Err(Error::LogStoreError(e.into())));
                 return;
+            }
+            if !opts.sync_wal_before_ack {
+                self.rocksdb.run_bg_wal_sync();
             }
         }
 

--- a/crates/rocksdb/Cargo.toml
+++ b/crates/rocksdb/Cargo.toml
@@ -26,6 +26,7 @@ derive_builder = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
+metrics = {workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }

--- a/crates/rocksdb/src/background.rs
+++ b/crates/rocksdb/src/background.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Instant;
+
+use derive_builder::Builder;
+use metrics::histogram;
+
+use crate::metric_definitions::{
+    STORAGE_BG_TASK_RUN_DURATION, STORAGE_BG_TASK_TOTAL_DURATION, STORAGE_BG_TASK_WAIT_DURATION,
+};
+use crate::{DbName, Owner, Priority};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum StorageTaskKind {
+    WriteBatch,
+    OpenColumnFamily,
+    FlushWal,
+    Shutdown,
+    OpenDb,
+}
+
+#[derive(Builder)]
+#[builder(pattern = "owned")]
+#[builder(name = "StorageTask")]
+pub struct ReadyStorageTask<OP> {
+    op: OP,
+    #[builder(setter(into))]
+    db_name: DbName,
+    #[builder(default)]
+    owner: Owner,
+    #[builder(default)]
+    pub(crate) priority: Priority,
+    /// required
+    kind: StorageTaskKind,
+    #[builder(setter(skip))]
+    #[builder(default = "Instant::now()")]
+    enqueue_at: Instant,
+}
+
+impl<OP, R> ReadyStorageTask<OP>
+where
+    OP: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    pub fn run(self) -> R {
+        let start = Instant::now();
+        let kind: &'static str = self.kind.into();
+        let owner: &'static str = self.owner.into();
+        let priority: &'static str = self.priority.into();
+        histogram!(
+            STORAGE_BG_TASK_WAIT_DURATION,
+            "kind" => kind,
+            "db" => self.db_name.to_string(),
+            "owner" => owner,
+            "priority" => priority,
+        )
+        .record(self.enqueue_at.elapsed());
+        let res = (self.op)();
+        histogram!(STORAGE_BG_TASK_RUN_DURATION,
+            "kind" => kind,
+            "db" => self.db_name.to_string(),
+            "owner" => owner,
+            "priority" => priority,
+        )
+        .record(start.elapsed());
+        histogram!(STORAGE_BG_TASK_TOTAL_DURATION,
+            "kind" => kind,
+            "db" => self.db_name.to_string(),
+            "owner" => owner,
+            "priority" => priority,
+        )
+        .record(self.enqueue_at.elapsed());
+        res
+    }
+}

--- a/crates/rocksdb/src/db_spec.rs
+++ b/crates/rocksdb/src/db_spec.rs
@@ -27,9 +27,13 @@ type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
     Eq,
     PartialEq,
     Hash,
+    Default,
 )]
 #[strum(serialize_all = "kebab-case")]
 pub enum Owner {
+    #[default]
+    // A system-wide database, or represents an operation that has no specific owner.
+    None,
     PartitionProcessor,
     Bifrost,
     MetadataStore,

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -8,15 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod background;
 mod db_manager;
 mod db_spec;
 mod error;
+mod metric_definitions;
 mod rock_access;
 
+use metrics::counter;
 use restate_types::config::RocksDbOptions;
 use tracing::debug;
+use tracing::error;
+use tracing::info;
 use tracing::warn;
 
+use std::fmt;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -25,30 +31,37 @@ use rocksdb::statistics::Histogram;
 use rocksdb::statistics::HistogramData;
 use rocksdb::statistics::Ticker;
 
+// re-exports
 pub use self::db_manager::RocksDbManager;
 pub use self::db_spec::*;
 pub use self::error::*;
 pub use self::rock_access::RocksAccess;
 
+use self::background::StorageTask;
+use self::background::StorageTaskKind;
+use self::metric_definitions::*;
+
 type BoxedCfMatcher = Box<dyn CfNameMatch + Send + Sync>;
 type BoxedCfOptionUpdater = Box<dyn Fn(rocksdb::Options) -> rocksdb::Options + Send + Sync>;
 
 /// Denotes whether an operation is considered latency sensitive or not
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, strum_macros::IntoStaticStr)]
 pub enum Priority {
     High,
+    #[default]
     Low,
 }
 
 /// Defines how to perform a potentially blocking rocksdb IO operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IoMode {
     /// [Dangerous] Allow blocking IO operation to happen in the worker thread (tokio)
     AllowBlockingIO,
     /// Fail the operation if operation needs to block on IO
-    NoBlockingIO,
+    OnlyIfNonBlocking,
     /// Attempts to perform the operation without blocking IO in worker thread, if it's not
     /// possible, it'll spawn work in the background thread pool.
-    Auto,
+    Default,
 }
 
 #[derive(derive_more::Display, Clone)]
@@ -71,6 +84,18 @@ impl Deref for RocksDb {
 
     fn deref(&self) -> &Self::Target {
         &self.db
+    }
+}
+
+impl fmt::Debug for RocksDb {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RocksDb({}::{} at {})",
+            self.owner,
+            self.name,
+            self.path.display()
+        )
     }
 }
 
@@ -101,6 +126,95 @@ impl RocksDb {
         self.db.cfs()
     }
 
+    pub async fn write_batch(
+        &self,
+        priority: Priority,
+        io_mode: IoMode,
+        mut write_options: rocksdb::WriteOptions,
+        write_batch: rocksdb::WriteBatch,
+    ) -> Result<(), RocksError> {
+        //  depending on the IoMode, we decide how to do the write.
+        match io_mode {
+            IoMode::AllowBlockingIO => {
+                write_options.set_no_slowdown(false);
+                self.db.write_batch(&write_batch, &write_options)?;
+                counter!(STORAGE_IO_OP, DISPOSITION => DISPOSITION_MAYBE_BLOCKING, OP_TYPE =>
+                    OP_WRITE)
+                .increment(1);
+                return Ok(());
+            }
+            IoMode::OnlyIfNonBlocking => {
+                write_options.set_no_slowdown(true);
+                self.db.write_batch(&write_batch, &write_options)?;
+                counter!(STORAGE_IO_OP, DISPOSITION => DISPOSITION_NON_BLOCKING, OP_TYPE =>
+                    OP_WRITE)
+                .increment(1);
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        // Auto...
+        // First, attempt to write without blocking
+        write_options.set_no_slowdown(true);
+        let result = self.db.write_batch(&write_batch, &write_options);
+        match result {
+            Ok(_) => {
+                counter!(STORAGE_IO_OP, DISPOSITION => DISPOSITION_NON_BLOCKING, OP_TYPE => OP_WRITE).increment(1);
+                Ok(())
+            }
+            Err(e) if is_retryable_error(e.kind()) => {
+                counter!(STORAGE_IO_OP, DISPOSITION => DISPOSITION_MOVED_TO_BG, OP_TYPE =>
+                    OP_WRITE)
+                .increment(1);
+                let start = std::time::Instant::now();
+                // Operation will block, dispatch to background.
+                let db = self.db.clone();
+                // In the background thread pool we can block on IO
+                write_options.set_no_slowdown(false);
+                let task = StorageTask::default()
+                    .db_name(self.name.clone())
+                    .owner(self.owner)
+                    .priority(priority)
+                    .kind(StorageTaskKind::WriteBatch)
+                    .op(move || {
+                        db.write_batch(&write_batch, &write_options)?;
+                        info!(
+                            "background write completed, completed in {:?}",
+                            start.elapsed()
+                        );
+                        Ok(())
+                    })
+                    .build()
+                    .unwrap();
+
+                self.manager.async_spawn(task).await?
+            }
+            Err(e) => {
+                counter!(STORAGE_IO_OP, DISPOSITION => DISPOSITION_FAILED, OP_TYPE => OP_WRITE)
+                    .increment(1);
+                Err(e.into())
+            }
+        }
+    }
+
+    pub fn run_bg_wal_sync(&self) {
+        let db = self.db.clone();
+        let task = StorageTask::default()
+            .db_name(self.name.clone())
+            .owner(self.owner)
+            .kind(StorageTaskKind::FlushWal)
+            .op(move || {
+                if let Err(e) = db.flush_wal(true) {
+                    error!("Failed to flush rocksdb WAL in local loglet : {}", e);
+                }
+            })
+            .build()
+            .unwrap();
+        // always spawn wal flushes.
+        self.manager.spawn_unchecked(task);
+    }
+
     pub fn get_histogram_data(&self, histogram: Histogram) -> HistogramData {
         self.db_options.get_histogram_data(histogram)
     }
@@ -117,59 +231,78 @@ impl RocksDb {
         let default_cf_options = self.manager.default_cf_options(opts);
         let db = self.db.clone();
         let cf_patterns = self.cf_patterns.clone();
-        self.manager
-            .async_spawn(Priority::Low, move || {
-                db.open_cf(name, default_cf_options, cf_patterns)
-            })
-            .await?
+        let task = StorageTask::default()
+            .db_name(self.name.clone())
+            .owner(self.owner)
+            .kind(StorageTaskKind::OpenColumnFamily)
+            .op(move || db.open_cf(name, default_cf_options, cf_patterns))
+            .build()
+            .unwrap();
+
+        self.manager.async_spawn(task).await?
     }
 
     pub async fn shutdown(self: Arc<Self>) {
-        // intentionally ignore scheduling error
-        let _ = self
-            .manager
-            .async_spawn_unchecked(Priority::Low, move || {
-                if let Err(e) = self.flush_wal(true) {
-                    warn!(
-                        db = %self.name,
-                        owner = %self.owner,
-                        "Failed to flush local loglet rocksdb WAL: {}",
-                        e
-                    );
-                }
+        let db_name = self.name.clone();
+        let owner = self.owner;
+        let manager = self.manager;
+        let op = move || {
+            if let Err(e) = self.flush_wal(true) {
+                warn!(
+                    db = %self.name,
+                    owner = %self.owner,
+                    "Failed to flush local loglet rocksdb WAL: {}",
+                    e
+                );
+            }
 
-                let cfs_to_flush = self
-                    .cfs()
-                    .into_iter()
-                    .filter(|c| {
-                        self.flush_on_shutdown
-                            .iter()
-                            .any(|matcher| matcher.cf_matches(c))
-                    })
-                    .collect::<Vec<_>>();
-                if cfs_to_flush.is_empty() {
-                    debug!(
-                        db = %self.name,
-                        owner = %self.owner,
-                        "No column families to flush for db on shutdown"
-                    );
-                    return;
-                }
-
+            let cfs_to_flush = self
+                .cfs()
+                .into_iter()
+                .filter(|c| {
+                    self.flush_on_shutdown
+                        .iter()
+                        .any(|matcher| matcher.cf_matches(c))
+                })
+                .collect::<Vec<_>>();
+            if cfs_to_flush.is_empty() {
                 debug!(
+                    db = %self.name,
+                    owner = %self.owner,
+                    "No column families to flush for db on shutdown"
+                );
+                return;
+            }
+
+            debug!(
             db = %self.name,
             owner = %self.owner,
             "Numbre of column families to flush on shutdown: {}", cfs_to_flush.len());
-                if let Err(e) = self.db.flush_memtables(cfs_to_flush.as_slice(), true) {
-                    warn!(
-                        db = %self.name,
-                        owner = %self.owner,
-                        "Failed to flush memtables: {}",
-                        e
-                    );
-                }
-                self.db.cancel_all_background_work(true);
-            })
-            .await;
+            if let Err(e) = self.db.flush_memtables(cfs_to_flush.as_slice(), true) {
+                warn!(
+                    db = %self.name,
+                    owner = %self.owner,
+                    "Failed to flush memtables: {}",
+                    e
+                );
+            }
+            self.db.cancel_all_background_work(true);
+        };
+        // intentionally ignore scheduling error
+        let task = StorageTask::default()
+            .db_name(db_name)
+            .owner(owner)
+            .kind(StorageTaskKind::Shutdown)
+            .op(op)
+            .build()
+            .unwrap();
+        let _ = manager.async_spawn_unchecked(task).await;
     }
+}
+
+fn is_retryable_error(error_kind: rocksdb::ErrorKind) -> bool {
+    matches!(
+        error_kind,
+        rocksdb::ErrorKind::Incomplete | rocksdb::ErrorKind::TryAgain | rocksdb::ErrorKind::Busy
+    )
 }

--- a/crates/rocksdb/src/metric_definitions.rs
+++ b/crates/rocksdb/src/metric_definitions.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics::{describe_counter, describe_histogram, Unit};
+
+pub const STORAGE_BG_TASK_SPAWNED: &str = "restate.rocksdb_manager.bg_task_spawned.total";
+pub const STORAGE_IO_OP: &str = "restate.rocksdb_manager.io_operation.total";
+pub const STORAGE_BG_TASK_WAIT_DURATION: &str =
+    "restate.rocksdb_manager.bg_task_wait_duration.seconds";
+
+pub const STORAGE_BG_TASK_RUN_DURATION: &str =
+    "restate.rocksdb_manager.bg_task_run_duration.seconds";
+
+pub const STORAGE_BG_TASK_TOTAL_DURATION: &str =
+    "restate.rocksdb_manager.bg_task_total_duration.seconds";
+
+pub const OP_TYPE: &str = "operation";
+pub const OP_WRITE: &str = "write-batch";
+
+pub const DISPOSITION: &str = "disposition";
+
+pub const DISPOSITION_MAYBE_BLOCKING: &str = "maybe-blocking";
+pub const DISPOSITION_NON_BLOCKING: &str = "non-blocking";
+pub const DISPOSITION_MOVED_TO_BG: &str = "moved-to-bg";
+pub const DISPOSITION_FAILED: &str = "failed";
+
+pub fn describe_metrics() {
+    describe_counter!(
+        STORAGE_BG_TASK_SPAWNED,
+        Unit::Count,
+        "Number of background storage tasks spawned"
+    );
+
+    describe_counter!(
+        STORAGE_IO_OP,
+        Unit::Count,
+        "Number of forground rocksdb operations, label 'disposition' defines how IO was actually handled.
+Options are 'maybe-blocking', 'non-blocking', 'moved-to-bg'"
+    );
+
+    describe_histogram!(
+        STORAGE_BG_TASK_WAIT_DURATION,
+        Unit::Seconds,
+        "Queueing time of storage task queues, with 'priority' label"
+    );
+
+    describe_histogram!(
+        STORAGE_BG_TASK_RUN_DURATION,
+        Unit::Seconds,
+        "Run time of storage tasks, with 'priority' label"
+    );
+
+    describe_histogram!(
+        STORAGE_BG_TASK_TOTAL_DURATION,
+        Unit::Seconds,
+        "Total time to queue+run a storage task, with 'priority' label"
+    );
+}


### PR DESCRIPTION
[RocksDb] Dispatch bifrost writes to bg threads automatically

This introduces the first step to make rocksdb async-friendly. The new RocksDb struct will be the main entry point for future rocksdb access, it
provides _async_ APIs that can perform in-thread blocking or non-blocking IO based on inputs `IoMode`. If the operation needs to happen on the background
thread pool, the `Priority` type specifies which pool to use for that.


Note 1: This PR moves the wal sync to the background, but wal flushes are still required before bifrost writes are acknowleged. Because we dispatch syncs immediately after the write,
it's extremely unlikely to lose the write _after_ bifrost caller has used the acknowledgement to do anything useful. Note that WAL flushes mean that even if the daemon crashed,
the OS will still flush the WAL to disk.

Note 2: At the moment, a major friction point in interacting with rocksdb binding is the mismatch between transaction/optimistic-tx db and
CommonDB interface and that there is no shared trait between them, RocksAccess trait attempts to hide this behind dynamic dispatch. This comes
at the cost of duplicated code and _admittedly small_ performance overhead. That said, this should be a transitional phase until we remove the
use of transaction db.

Example metrics collected:

```
❯ http localhost:5122/metrics  | grep rocksdb_manager

# TYPE restate_rocksdb_manager_io_operation_total counter
restate_rocksdb_manager_io_operation_total{disposition="non-blocking",operation="write-batch"} 70
# TYPE restate_rocksdb_manager_bg_task_wait_duration_seconds summary
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0"} 0.000005584
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.5"} 0.000018250829236145783
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.9"} 0.00009354199894710612
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.95"} 0.0001130477756442004
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.99"} 0.00013215963172609225
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.999"} 0.00013215963172609225
restate_rocksdb_manager_bg_task_wait_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="1"} 0.00016775
restate_rocksdb_manager_bg_task_wait_duration_seconds_sum{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low"} 0.002412709000000001
restate_rocksdb_manager_bg_task_wait_duration_seconds_count{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low"} 70
# TYPE restate_rocksdb_manager_bg_task_run_duration_seconds summary
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0"} 0.000010167
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.5"} 0.00006399535616308496
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.9"} 0.00028980564997366476
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.95"} 0.0005180182782044605
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.99"} 0.00099965531037426
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.999"} 0.00099965531037426
restate_rocksdb_manager_bg_task_run_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="1"} 0.001
restate_rocksdb_manager_bg_task_run_duration_seconds_sum{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low"} 0.009591167000000003
restate_rocksdb_manager_bg_task_run_duration_seconds_count{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low"} 70
# TYPE restate_rocksdb_manager_bg_task_total_duration_seconds summary
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0"} 0.000045208
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.5"} 0.00008054455596404992
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.9"} 0.00037308658596224597
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.95"} 0.0005723842479955937
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.99"} 0.001026602956509328
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="0.999"} 0.001026602956509328
restate_rocksdb_manager_bg_task_total_duration_seconds{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low",quantile="1"} 0.001124834
restate_rocksdb_manager_bg_task_total_duration_seconds_sum{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low"} 0.011636377999999998
restate_rocksdb_manager_bg_task_total_duration_seconds_count{kind="flush-wal",db="local-loglet",owner="bifrost",priority="Low"} 70
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1438).
* #1455
* __->__ #1438