### PR TITLE
Improve modified_at field in invocation status

### DIFF
--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -239,11 +239,6 @@ impl InboxedInvocation {
             idempotency: service_invocation.idempotency,
         }
     }
-
-    pub fn append_response_sink(&mut self, new_sink: ServiceInvocationResponseSink) {
-        self.response_sinks.insert(new_sink);
-        self.timestamps.update();
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -242,6 +242,7 @@ impl InboxedInvocation {
 
     pub fn append_response_sink(&mut self, new_sink: ServiceInvocationResponseSink) {
         self.response_sinks.insert(new_sink);
+        self.timestamps.update();
     }
 }
 
@@ -285,12 +286,14 @@ impl InFlightInvocationMetadata {
     }
 
     pub fn from_inboxed_invocation(
-        inboxed_invocation: InboxedInvocation,
+        mut inboxed_invocation: InboxedInvocation,
     ) -> (Self, InvocationInput) {
         let (completion_retention_time, idempotency_key) = inboxed_invocation
             .idempotency
             .map(|idempotency| (idempotency.retention, Some(idempotency.key)))
             .unwrap_or((Duration::ZERO, None));
+
+        inboxed_invocation.timestamps.update();
 
         (
             Self {
@@ -309,6 +312,15 @@ impl InFlightInvocationMetadata {
             },
         )
     }
+
+    pub fn set_deployment_id(&mut self, deployment_id: DeploymentId) {
+        debug_assert_eq!(
+            self.deployment_id, None,
+            "No deployment_id should be fixed for the current invocation"
+        );
+        self.deployment_id = Some(deployment_id);
+        self.timestamps.update();
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -322,9 +334,11 @@ pub struct CompletedInvocation {
 
 impl CompletedInvocation {
     pub fn from_in_flight_invocation_metadata(
-        in_flight_invocation_metadata: InFlightInvocationMetadata,
+        mut in_flight_invocation_metadata: InFlightInvocationMetadata,
         response_result: ResponseResult,
     ) -> (Self, Duration) {
+        in_flight_invocation_metadata.timestamps.update();
+
         (
             Self {
                 invocation_target: in_flight_invocation_metadata.invocation_target,

--- a/crates/worker/src/partition/state_machine/effect_interpreter.rs
+++ b/crates/worker/src/partition/state_machine/effect_interpreter.rs
@@ -336,11 +336,8 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                 deployment_id,
                 mut metadata,
             } => {
-                debug_assert_eq!(
-                    metadata.deployment_id, None,
-                    "No deployment_id should be fixed for the current invocation"
-                );
-                metadata.deployment_id = Some(deployment_id);
+                metadata.set_deployment_id(deployment_id);
+
                 // We recreate the InvocationStatus in Invoked state as the invoker can notify the
                 // chosen deployment_id only when the invocation is in-flight.
                 state_storage
@@ -404,6 +401,8 @@ impl<Codec: RawEntryCodec> EffectInterpreter<Codec> {
                     .get_response_sinks_mut()
                     .expect("No response sinks available")
                     .insert(additional_response_sink);
+                previous_invocation_status.update_timestamps();
+
                 state_storage
                     .store_invocation_status(&invocation_id, previous_invocation_status)
                     .await?;


### PR DESCRIPTION
Fix #1447. Now we update timestamps when:

* transitioning from inboxed to in-flight
* transitioning from in-flight to completed
* adding response sinks
* setting the deployment id