### PR TITLE
Configuration support for human-readable bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.0+9.0.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?branch=next#caec8ab62cf053679f409c69a4ee72483a8b9688"
+source = "git+https://github.com/restatedev/rust-rocksdb?branch=next#c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5840,7 +5840,6 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
- "bytesize",
  "bytestring",
  "codederror",
  "derive-getters",
@@ -5854,6 +5853,7 @@ dependencies = [
  "rayon",
  "restate-core",
  "restate-errors",
+ "restate-serde-util",
  "restate-test-util",
  "restate-types",
  "rocksdb",
@@ -5910,6 +5910,7 @@ version = "0.9.0"
 dependencies = [
  "base64 0.21.7",
  "bytes",
+ "bytesize",
  "http 0.2.12",
  "prost",
  "schemars",
@@ -6246,6 +6247,7 @@ dependencies = [
  "opentelemetry",
  "rand",
  "restate-base64-util",
+ "restate-serde-util",
  "restate-test-util",
  "schemars",
  "serde",
@@ -6406,7 +6408,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?branch=next#caec8ab62cf053679f409c69a4ee72483a8b9688"
+source = "git+https://github.com/restatedev/rust-rocksdb?branch=next#c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -6529,6 +6531,7 @@ checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "bytes",
  "dyn-clone",
+ "enumset",
  "indexmap 1.9.3",
  "schemars_derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ base64 = "0.21"
 bincode = { version = "2.0.0-rc", default-features = false, features = ["std", "serde", ] }
 bytes = { version = "1.3", features = ["serde"] }
 bytes-utils = "0.1.3"
-bytesize = { version = "1.3.0" }
 bytestring = { version = "1.2", features = ["serde"] }
 clap = { version = "4", default-features = false }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
@@ -124,7 +123,7 @@ rand = "0.8.5"
 rayon = { version = "1.10" }
 rocksdb = { version = "0.22.0", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", branch="next" }
 rustls = "0.21.6"
-schemars = { version = "0.8", features = ["bytes"] }
+schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2"

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -81,7 +81,7 @@ where
                     }))
                     .layer(tower::load_shed::LoadShedLayer::new())
                     .layer(tower::limit::GlobalConcurrencyLimitLayer::new(
-                        opts.concurrent_api_requests_limit,
+                        opts.concurrent_api_requests_limit(),
                     )),
             );
 

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -10,6 +10,7 @@
 // by the Apache License, Version 2.0.
 
 //! Utilities for benchmarking the Restate runtime
+use std::num::NonZeroU64;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
@@ -33,7 +34,7 @@ use restate_types::retries::RetryPolicy;
 pub fn discover_deployment(current_thread_rt: &Runtime, address: Uri) {
     let discovery_payload = serde_json::json!({"uri": address.to_string()}).to_string();
     let discovery_result = current_thread_rt.block_on(async {
-        RetryPolicy::fixed_delay(Duration::from_millis(200), 50)
+        RetryPolicy::fixed_delay(Duration::from_millis(200), Some(50))
             .retry(|| {
                 hyper::Client::new()
                     .request(
@@ -62,7 +63,7 @@ pub fn discover_deployment(current_thread_rt: &Runtime, address: Uri) {
     // wait for ingress being available
     // todo replace with node get_ident/status once it signals that the node is fully up and running
     let health_response = current_thread_rt.block_on(async {
-        RetryPolicy::fixed_delay(Duration::from_millis(200), 50)
+        RetryPolicy::fixed_delay(Duration::from_millis(200), Some(50))
             .retry(|| {
                 hyper::Client::new()
                     .request(
@@ -126,7 +127,7 @@ pub fn restate_configuration() -> Configuration {
         .expect("building common options should work");
 
     let worker_options = WorkerOptionsBuilder::default()
-        .bootstrap_num_partitions(10)
+        .bootstrap_num_partitions(NonZeroU64::new(10).unwrap())
         .build()
         .expect("building worker options should work");
 

--- a/crates/core/src/metadata_store/mod.rs
+++ b/crates/core/src/metadata_store/mod.rs
@@ -220,13 +220,8 @@ impl MetadataStoreClient {
     }
 
     fn exponential_retry_policy(max_backoff: Duration) -> RetryIter {
-        RetryPolicy::exponential(
-            Duration::from_millis(10),
-            2.0,
-            usize::MAX,
-            Some(max_backoff),
-        )
-        .into_iter()
+        RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, Some(max_backoff))
+            .into_iter()
     }
 
     /// Reads the value under the given key from the metadata store, then modifies it and writes

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -75,7 +75,7 @@ where
         crate::metric_definitions::describe_metrics();
         let (hyper_ingress_server, _) = HyperServerIngress::new(
             ingress_options.bind_address,
-            ingress_options.concurrent_api_requests_limit,
+            ingress_options.concurrent_api_requests_limit(),
             schemas,
             dispatcher,
         );

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -71,7 +71,7 @@ impl Service {
         let mut task_orchestrator = TaskOrchestrator::new(RetryPolicy::exponential(
             Duration::from_millis(200),
             2.0,
-            usize::MAX,
+            None,
             Some(Duration::from_secs(10)),
         ));
 

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -337,7 +337,7 @@ mod tests {
     fn handle_error_when_waiting_for_retry() {
         let mut invocation_state_machine = InvocationStateMachine::create(
             InvocationTarget::mock_virtual_object(),
-            RetryPolicy::fixed_delay(Duration::from_secs(1), 10),
+            RetryPolicy::fixed_delay(Duration::from_secs(1), Some(10)),
         );
 
         assert!(invocation_state_machine.handle_task_error().is_some());
@@ -354,7 +354,7 @@ mod tests {
     async fn handle_requires_ack() {
         let mut invocation_state_machine = InvocationStateMachine::create(
             InvocationTarget::mock_virtual_object(),
-            RetryPolicy::fixed_delay(Duration::from_secs(1), 10),
+            RetryPolicy::fixed_delay(Duration::from_secs(1), Some(10)),
         );
 
         let abort_handle = tokio::spawn(async {}).abort_handle();

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -126,8 +126,8 @@ where
                 opts.inactivity_timeout.into(),
                 opts.abort_timeout.into(),
                 opts.disable_eager_state,
-                opts.message_size_warning,
-                opts.message_size_limit,
+                opts.message_size_warning.get(),
+                opts.message_size_limit(),
                 self.journal_reader.clone(),
                 self.state_reader.clone(),
                 self.entry_enricher.clone(),
@@ -193,7 +193,7 @@ impl<JR, SR, EE, DMR> Service<JR, SR, EE, DMR> {
                 },
                 invocation_tasks: Default::default(),
                 retry_timers: Default::default(),
-                quota: quota::InvokerConcurrencyQuota::new(options.concurrent_invocations_limit),
+                quota: quota::InvokerConcurrencyQuota::new(options.concurrent_invocations_limit()),
                 status_store: Default::default(),
                 invocation_state_machine_manager: Default::default(),
             },
@@ -991,6 +991,7 @@ mod tests {
     use super::*;
 
     use std::future::{pending, ready};
+    use std::num::NonZeroUsize;
     use std::time::Duration;
 
     use bytes::Bytes;
@@ -1102,11 +1103,11 @@ mod tests {
         let tc = node_env.tc;
         let invoker_options = InvokerOptionsBuilder::default()
             // fixed amount of retries so that an invocation eventually completes with a failure
-            .retry_policy(RetryPolicy::fixed_delay(Duration::ZERO, 1))
+            .retry_policy(RetryPolicy::fixed_delay(Duration::ZERO, Some(1)))
             .inactivity_timeout(Duration::ZERO.into())
             .abort_timeout(Duration::ZERO.into())
             .disable_eager_state(false)
-            .message_size_warning(1024)
+            .message_size_warning(NonZeroUsize::new(1024).unwrap())
             .message_size_limit(None)
             .build()
             .unwrap();
@@ -1167,11 +1168,11 @@ mod tests {
     async fn quota_allows_one_concurrent_invocation() {
         let invoker_options = InvokerOptionsBuilder::default()
             // fixed amount of retries so that an invocation eventually completes with a failure
-            .retry_policy(RetryPolicy::fixed_delay(Duration::ZERO, 1))
+            .retry_policy(RetryPolicy::fixed_delay(Duration::ZERO, Some(1)))
             .inactivity_timeout(Duration::ZERO.into())
             .abort_timeout(Duration::ZERO.into())
             .disable_eager_state(false)
-            .message_size_warning(1024)
+            .message_size_warning(NonZeroUsize::new(1024).unwrap())
             .message_size_limit(None)
             .build()
             .unwrap();
@@ -1263,11 +1264,11 @@ mod tests {
     async fn reclaim_quota_after_abort() {
         let invoker_options = InvokerOptionsBuilder::default()
             // fixed amount of retries so that an invocation eventually completes with a failure
-            .retry_policy(RetryPolicy::fixed_delay(Duration::ZERO, 1))
+            .retry_policy(RetryPolicy::fixed_delay(Duration::ZERO, Some(1)))
             .inactivity_timeout(Duration::ZERO.into())
             .abort_timeout(Duration::ZERO.into())
             .disable_eager_state(false)
-            .message_size_warning(1024)
+            .message_size_warning(NonZeroUsize::new(1024).unwrap())
             .message_size_limit(None)
             .build()
             .unwrap();

--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -42,12 +42,16 @@ impl LocalMetadataStoreService {
             bind_address,
         }
     }
+
     pub fn from_options(
         opts: &MetadataStoreOptions,
         rocksdb_options: impl Updateable<RocksDbOptions> + Send + 'static,
     ) -> Result<Self, BuildError> {
-        let store =
-            LocalMetadataStore::new(opts.data_dir(), opts.request_queue_length, rocksdb_options)?;
+        let store = LocalMetadataStore::new(
+            opts.data_dir(),
+            opts.request_queue_length(),
+            rocksdb_options,
+        )?;
         Ok(LocalMetadataStoreService::new(
             store,
             opts.bind_address.clone(),

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -325,7 +325,7 @@ async fn start_metadata_store(
     let health_client = HealthClient::new(create_grpc_channel_from_advertised_address(
         advertised_address.clone(),
     )?);
-    let retry_policy = RetryPolicy::exponential(Duration::from_millis(10), 2.0, usize::MAX, None);
+    let retry_policy = RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, None);
 
     retry_policy
         .retry(|| async {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -362,7 +362,7 @@ impl Node {
     ) -> Result<FixedPartitionTable, Error> {
         Self::retry_on_network_error(|| {
             metadata_store_client.get_or_insert(PARTITION_TABLE_KEY.clone(), || {
-                FixedPartitionTable::new(Version::MIN, config.worker.bootstrap_num_partitions)
+                FixedPartitionTable::new(Version::MIN, config.worker.bootstrap_num_partitions())
             })
         })
         .await
@@ -478,7 +478,7 @@ impl Node {
         let retry_policy = RetryPolicy::exponential(
             Duration::from_millis(10),
             2.0,
-            15,
+            Some(15),
             Some(Duration::from_secs(5)),
         );
         let upsert_start = Instant::now();

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -57,7 +57,7 @@ impl AdminRole {
         let retry_policy = RetryPolicy::exponential(
             Duration::from_millis(100),
             2.0,
-            10,
+            Some(10),
             Some(Duration::from_secs(20)),
         );
         let client =

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -8,30 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::config::UpdateableConfiguration;
 use std::time::Duration;
 
 use codederror::CodedError;
-use restate_core::network::MessageRouterBuilder;
-use restate_network::Networking;
+use tracing::info;
 
 use restate_bifrost::Bifrost;
+use restate_core::network::MessageRouterBuilder;
 use restate_core::{cancellation_watcher, metadata, task_center};
 use restate_core::{ShutdownError, TaskKind};
 use restate_grpc_util::create_grpc_channel_from_advertised_address;
 use restate_metadata_store::MetadataStoreClient;
+use restate_network::Networking;
 use restate_node_protocol::metadata::MetadataKind;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_node_services::cluster_ctrl::AttachmentRequest;
 use restate_schema::UpdateableSchema;
 use restate_schema_api::subscription::SubscriptionResolver;
 use restate_storage_query_datafusion::context::QueryContext;
+use restate_types::config::UpdateableConfiguration;
 use restate_types::net::AdvertisedAddress;
 use restate_types::retries::RetryPolicy;
 use restate_types::Version;
 use restate_worker::SubscriptionController;
 use restate_worker::{SubscriptionControllerHandle, Worker};
-use tracing::info;
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum WorkerRoleError {
@@ -137,7 +137,7 @@ impl WorkerRole {
 
         let cc_client = ClusterCtrlSvcClient::new(channel);
 
-        let _response = RetryPolicy::exponential(Duration::from_millis(50), 2.0, 10, None)
+        let _response = RetryPolicy::exponential(Duration::from_millis(50), 2.0, Some(10), None)
             .retry(|| async {
                 cc_client
                     .clone()

--- a/crates/rocksdb/Cargo.toml
+++ b/crates/rocksdb/Cargo.toml
@@ -12,13 +12,13 @@ default = []
 test-util = ["restate-types/test-util"]
 
 [dependencies]
-restate-errors = { workspace = true }
-restate-types = { workspace = true }
 restate-core = { workspace = true }
+restate-errors = { workspace = true }
+restate-serde-util = { workspace = true }
+restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 bytes = { workspace = true }
-bytesize = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
 derive-getters = { workspace = true }

--- a/crates/serde-util/Cargo.toml
+++ b/crates/serde-util/Cargo.toml
@@ -15,6 +15,7 @@ proto = ["dep:prost", "dep:bytes"]
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true, optional = true }
+bytesize = { version = "1.3.0" }
 http = { workspace = true }
 prost = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }

--- a/crates/serde-util/src/byte_count.rs
+++ b/crates/serde-util/src/byte_count.rs
@@ -1,0 +1,383 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::{self, Display};
+use std::num::{NonZeroU64, NonZeroUsize};
+use std::str::FromStr;
+
+use bytesize::ByteSize;
+use serde::de::Visitor;
+use serde::{de, de::Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy, Hash)]
+pub struct ByteCount<const CAN_BE_ZERO: bool = true>(u64);
+pub type NonZeroByteCount = ByteCount<false>;
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for ByteCount<true> {
+    fn schema_name() -> String {
+        "HumanBytes".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Owned(std::concat!(std::module_path!(), "::", "HumanBytes").to_owned())
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut schema: schemars::schema::SchemaObject = gen.subschema_for::<String>().into();
+        schema.format = Some("human-bytes".to_owned());
+        let validation = schema.string();
+        validation.pattern = Some(r"^\d+(\.\d+)? ?[KMG]B$".to_string());
+        validation.min_length = Some(1);
+        let validation = schema.number();
+        validation.minimum = Some(1.0);
+        let metadata = schema.metadata();
+        metadata.title = Some("Human-readable bytes".to_owned());
+        metadata.description = Some("Human-readable bytes".to_owned());
+        schema.into()
+    }
+}
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for ByteCount<false> {
+    fn schema_name() -> String {
+        "NonZeroHumanBytes".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Owned(
+            std::concat!(std::module_path!(), "::", "NonZeroHumanBytes").to_owned(),
+        )
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut schema: schemars::schema::SchemaObject = gen.subschema_for::<String>().into();
+        schema.format = Some("non-zero human-bytes".to_owned());
+        let validation = schema.string();
+        validation.pattern = Some(r"^\d+(\.\d+)? ?[KMG]B$".to_string());
+        validation.min_length = Some(1);
+        let validation = schema.number();
+        validation.minimum = Some(1.0);
+        let metadata = schema.metadata();
+        metadata.title = Some("Non-zero human-readable bytes".to_owned());
+        metadata.description = Some("Non-zero human-readable bytes".to_owned());
+        schema.into()
+    }
+}
+
+impl ByteCount<true> {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl ByteCount<false> {
+    pub fn new(value: NonZeroUsize) -> Self {
+        Self(usize::from(value) as u64)
+    }
+
+    pub fn as_non_zero_usize(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.0 as usize).expect("ByteCount is not zero")
+    }
+}
+
+impl<const CAN_BE_ZERO: bool> Display for ByteCount<CAN_BE_ZERO> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        ByteSize(self.0).fmt(f)
+    }
+}
+
+impl<const CAN_BE_ZERO: bool> ByteCount<CAN_BE_ZERO> {
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+
+    pub fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl FromStr for ByteCount<true> {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s: ByteSize = s.parse()?;
+        Ok(ByteCount(s.0))
+    }
+}
+
+impl From<NonZeroUsize> for ByteCount<false> {
+    fn from(value: NonZeroUsize) -> Self {
+        let v: usize = value.into();
+        ByteCount(v as u64)
+    }
+}
+
+impl From<NonZeroU64> for ByteCount<false> {
+    fn from(value: NonZeroU64) -> Self {
+        ByteCount(value.into())
+    }
+}
+
+impl From<u64> for ByteCount<true> {
+    fn from(value: u64) -> Self {
+        ByteCount(value)
+    }
+}
+
+impl From<usize> for ByteCount<true> {
+    fn from(value: usize) -> Self {
+        ByteCount(value as u64)
+    }
+}
+
+impl<const CAN_BE_ZERO: bool> From<ByteCount<CAN_BE_ZERO>> for u64 {
+    fn from(value: ByteCount<CAN_BE_ZERO>) -> Self {
+        value.0
+    }
+}
+
+impl<const CAN_BE_ZERO: bool> Serialize for ByteCount<CAN_BE_ZERO> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&ByteSize(self.0).to_string())
+        } else {
+            // raw u64 num of bytes
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de, const CAN_BE_ZERO: bool> Deserialize<'de> for ByteCount<CAN_BE_ZERO> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_any::<ByteCountVisitor<CAN_BE_ZERO>>(ByteCountVisitor)
+        } else {
+            deserializer.deserialize_u64::<ByteCountVisitor<CAN_BE_ZERO>>(ByteCountVisitor)
+        }
+    }
+}
+
+struct ByteCountVisitor<const CAN_BE_ZERO: bool>;
+
+// Because we do what appears to be runtime-check of the const CAN_BE_ZERO but
+// it's actually compile-time, compiler will inline the comparison but we need
+// to make clippy happy.
+#[allow(clippy::absurd_extreme_comparisons)]
+impl<'de, const CAN_BE_ZERO: bool> Visitor<'de> for ByteCountVisitor<CAN_BE_ZERO> {
+    type Value = ByteCount<CAN_BE_ZERO>;
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an integer or string")
+    }
+
+    // TOML Integer(i64) - toml doesn't support u64
+    fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+        if let Ok(val) = u64::try_from(value) {
+            if val <= 0 && !CAN_BE_ZERO {
+                return Err(E::invalid_value(
+                    de::Unexpected::Signed(value),
+                    &"non-zero value",
+                ));
+            }
+            Ok(ByteCount(val))
+        } else {
+            Err(E::invalid_value(
+                de::Unexpected::Signed(value),
+                &"i64 overflow",
+            ))
+        }
+    }
+
+    // JSON Integer(u64)
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+        if value <= 0 && !CAN_BE_ZERO {
+            return Err(E::invalid_value(
+                de::Unexpected::Unsigned(value),
+                &"non-zero value",
+            ));
+        }
+        Ok(ByteCount(value))
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        let val: Result<ByteSize, _> = value.parse();
+
+        if let Ok(val) = val {
+            if val.0 <= 0 && !CAN_BE_ZERO {
+                return Err(E::invalid_value(
+                    de::Unexpected::Str(value),
+                    &"non-zero value",
+                ));
+            }
+            Ok(ByteCount(val.0))
+        } else {
+            Err(E::invalid_value(
+                de::Unexpected::Str(value),
+                &"a human-readable byte count string",
+            ))
+        }
+    }
+}
+
+impl SerializeAs<u64> for ByteCount<true> {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self(*source).serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, u64> for ByteCount<true> {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::deserialize(deserializer)?.0)
+    }
+}
+
+impl SerializeAs<usize> for ByteCount<true> {
+    fn serialize_as<S>(source: &usize, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self(*source as u64).serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, usize> for ByteCount<true> {
+    fn deserialize_as<D>(deserializer: D) -> Result<usize, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::deserialize(deserializer)?.0 as usize)
+    }
+}
+
+impl SerializeAs<NonZeroUsize> for ByteCount<false> {
+    fn serialize_as<S>(source: &NonZeroUsize, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self::from(*source).serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, NonZeroUsize> for ByteCount<false> {
+    fn deserialize_as<D>(deserializer: D) -> Result<NonZeroUsize, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::deserialize(deserializer)?.as_non_zero_usize())
+    }
+}
+
+impl SerializeAs<NonZeroU64> for ByteCount<false> {
+    fn serialize_as<S>(source: &NonZeroU64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Self::from(*source).serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, NonZeroU64> for ByteCount<false> {
+    fn deserialize_as<D>(deserializer: D) -> Result<NonZeroU64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw_value = Self::deserialize(deserializer)?.0;
+        Ok(NonZeroU64::new(raw_value).expect("ByteCount is not zero"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde::Deserialize;
+
+    #[derive(Serialize, Deserialize)]
+    struct Config(ByteCount<true>);
+
+    #[derive(Serialize, Debug, Deserialize)]
+    struct Config2(Option<NonZeroByteCount>);
+
+    #[test]
+    fn deserialize_byte_count() {
+        #[track_caller]
+        fn check_str(s: &str) {
+            assert_eq!(
+                serde_json::from_str::<Config>(&format!("{:?}", s))
+                    .unwrap()
+                    .0,
+                s.parse().unwrap()
+            );
+        }
+
+        #[track_caller]
+        fn check(s: &str) {
+            assert_eq!(
+                serde_json::from_str::<Config>(s).unwrap().0,
+                s.parse().unwrap()
+            );
+        }
+
+        check_str("5 MB");
+        check_str("5MB");
+        check_str("5mb");
+        check_str("5m");
+        check_str("12.34 KB");
+        check_str("123");
+        check("123");
+        // zero is allowed
+        check("0");
+    }
+
+    #[test]
+    fn serialize_byte_count() {
+        #[track_caller]
+        fn check_ser(v: &Config) {
+            assert_eq!(
+                serde_json::to_string(v).unwrap(),
+                format!("{:?}", v.0.to_string())
+            );
+        }
+
+        check_ser(&Config(ByteCount(5_000_000)));
+    }
+
+    #[test]
+    fn deserialize_non_zero_opt_byte_count() {
+        assert_eq!(
+            serde_json::from_str::<Config2>("\"5 MB\"").unwrap().0,
+            Some(ByteCount(5_000_000)),
+        );
+        assert_eq!(
+            serde_json::from_str::<Config2>("\"5\"").unwrap().0,
+            Some(ByteCount(5)),
+        );
+
+        assert_eq!(serde_json::from_str::<Config2>("null").unwrap().0, None,);
+
+        assert_eq!(
+            serde_json::from_str::<Config2>("\"0\"")
+                .unwrap_err()
+                .to_string(),
+            "invalid value: string \"0\", expected non-zero value at line 1 column 3"
+        );
+    }
+}

--- a/crates/serde-util/src/lib.rs
+++ b/crates/serde-util/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod byte_count;
 mod header_map;
 #[cfg(feature = "proto")]
 mod proto;
@@ -15,6 +16,7 @@ mod proto;
 pub mod default;
 pub mod header_value;
 
+pub use byte_count::*;
 pub use header_map::SerdeableHeaderHashMap;
 pub use header_value::HeaderValueSerde;
 #[cfg(feature = "proto")]

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -97,9 +97,9 @@ impl QueryContext {
             + 'static,
     ) -> Result<QueryContext, BuildError> {
         let ctx = QueryContext::new(
-            options.memory_limit,
+            options.memory_size(),
             options.tmp_dir.clone(),
-            options.query_parallelism,
+            options.query_parallelism(),
         );
         crate::invocation_status::register_self(&ctx, rocksdb.clone())?;
         crate::keyed_service_status::register_self(&ctx, rocksdb.clone())?;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,10 +10,12 @@ publish = false
 [features]
 default = []
 
+schemars = ["dep:schemars", "restate-serde-util/schema"]
 test-util = ["dep:tempfile"]
 
 [dependencies]
 restate-base64-util = { workspace = true }
+restate-serde-util = { workspace = true }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -26,7 +26,6 @@ use super::{RocksDbOptions, RocksDbOptionsBuilder};
 #[builder(default)]
 pub struct BifrostOptions {
     /// # The default kind of loglet to be used
-    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub default_provider: ProviderKind,
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     /// Configuration of local loglet provider
@@ -52,8 +51,9 @@ pub struct LocalLogletOptions {
     #[serde(flatten)]
     pub rocksdb: RocksDbOptions,
 
-    /// Trigger a commit when the batch size exceeds this threshold. Set to 0 or 1 to commit the
-    /// write batch on every command.
+    /// Trigger a commit when the batch size exceeds this threshold.
+    ///
+    /// Set to 0 or 1 to commit the write batch on every command.
     pub writer_batch_commit_count: usize,
     /// Trigger a commit when the time since the last commit exceeds this threshold.
     #[serde_as(as = "serde_with::DisplayFromStr")]

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -18,6 +18,8 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
+use restate_serde_util::{ByteCount, NonZeroByteCount};
+
 use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::PlainNodeId;
@@ -35,7 +37,6 @@ const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 pub struct CommonOptions {
     /// Defines the roles which this Restate node should run, by default the node
     /// starts with all roles.
-    #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
     pub roles: EnumSet<Role>,
 
     /// # Node Name
@@ -161,11 +162,13 @@ pub struct CommonOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_low_priority_bg_threads: Option<NonZeroUsize>,
 
-    /// # Total memory limit for rocksdb caches and memtables. This includes memory
-    /// for uncompressed block cache and all memtables by all open databases.
+    /// # Total memory limit for rocksdb caches and memtables.
     ///
-    /// The memory size used for rocksdb caches. Default is 4GB.
-    pub rocksdb_total_memory_limit: u64,
+    /// This includes memory for uncompressed block cache and all memtables by all open databases.
+    /// The memory size used for rocksdb caches.
+    #[serde_as(as = "NonZeroByteCount")]
+    #[cfg_attr(feature = "schemars", schemars(with = "NonZeroByteCount"))]
+    pub rocksdb_total_memory_size: NonZeroUsize,
 
     /// # Rocksdb total memtable size limit
     ///
@@ -173,9 +176,9 @@ pub struct CommonOptions {
     /// memtables can eat up from the value in rocksdb_total_memory_limit. When
     /// set to 0, memtables can take all available memory up to the value specified
     /// in rocksdb_total_memory_limit.
-    ///
-    /// Default is 0
-    pub rocksdb_total_memtables_size_limit: u64,
+    #[serde_as(as = "ByteCount")]
+    #[cfg_attr(feature = "schemars", schemars(with = "ByteCount"))]
+    pub rocksdb_total_memtables_size: usize,
 
     /// # Rocksdb Background Threads
     ///
@@ -187,7 +190,6 @@ pub struct CommonOptions {
     /// # Rocksdb High Priority Background Threads
     ///
     /// The number of threads to reserve to high priority Rocksdb background tasks.
-    /// Defaults to 2.
     pub rocksdb_high_priority_bg_threads: NonZeroU32,
 
     /// RocksDb base settings and memory limits that get applied on every database
@@ -279,8 +281,8 @@ impl Default for CommonOptions {
             default_thread_pool_size: None,
             storage_high_priority_bg_threads: None,
             storage_low_priority_bg_threads: None,
-            rocksdb_total_memtables_size_limit: 0,
-            rocksdb_total_memory_limit: 4_000_000_000, // 4GB
+            rocksdb_total_memtables_size: 0,
+            rocksdb_total_memory_size: NonZeroUsize::new(4_000_000_000).unwrap(), // 4GB
             rocksdb_bg_threads: None,
             rocksdb_high_priority_bg_threads: NonZeroU32::new(2).unwrap(),
             rocksdb: Default::default(),

--- a/crates/types/src/config/metadata_store.rs
+++ b/crates/types/src/config/metadata_store.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -28,7 +29,7 @@ pub struct MetadataStoreOptions {
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub bind_address: BindAddress,
     /// Number of in-flight metadata store requests.
-    pub request_queue_length: usize,
+    request_queue_length: NonZeroUsize,
     pub rocksdb: RocksDbOptions,
 }
 
@@ -36,13 +37,17 @@ impl MetadataStoreOptions {
     pub fn data_dir(&self) -> PathBuf {
         data_dir("local-metadata-store")
     }
+
+    pub fn request_queue_length(&self) -> usize {
+        self.request_queue_length.get()
+    }
 }
 
 impl Default for MetadataStoreOptions {
     fn default() -> Self {
         Self {
             bind_address: "0.0.0.0:5123".parse().expect("valid bind address"),
-            request_queue_length: 32,
+            request_queue_length: NonZeroUsize::new(32).unwrap(),
             rocksdb: Default::default(),
         }
     }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -111,15 +111,7 @@ pub fn set_current_config(config: Configuration) {
 
 /// # Restate configuration file
 ///
-/// Configuration for the Restate single binary deployment.
-///
-/// You can specify the configuration file to use through the `--config-file <PATH>` argument or
-/// with `RESTATE_CONFIG=<PATH>` environment variable.
-///
-/// Each configuration entry can be overridden using environment variables,
-/// prefixing them with `RESTATE_` and separating nested structs with `__` (double underscore).
-///
-/// For example, to configure `admin.bind_address`, the corresponding environment variable is `RESTATE_ADMIN__BIND_ADDRESS`.
+/// Configuration for Restate server.
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -9,20 +9,27 @@
 // by the Apache License, Version 2.0.
 
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use restate_serde_util::NonZeroByteCount;
 
 /// # Storage query engine options
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(rename = "QueryEngineOptions"))]
 #[cfg_attr(feature = "schemars", schemars(default))]
 #[serde(rename_all = "kebab-case")]
 pub struct QueryEngineOptions {
-    /// # Memory limit
+    /// # Memory size limit
     ///
     /// The total memory in bytes that can be used to preform sql queries
-    pub memory_limit: Option<usize>,
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
+    #[serde_as(as = "Option<NonZeroByteCount>")]
+    pub memory_size: Option<NonZeroUsize>,
 
     /// # Temp folder to use for spill
     ///
@@ -32,7 +39,7 @@ pub struct QueryEngineOptions {
     /// # Default query parallelism
     ///
     /// The number of parallel partitions to use for a query execution
-    pub query_parallelism: Option<usize>,
+    query_parallelism: Option<NonZeroUsize>,
 
     /// # Pgsql Bind address
     ///
@@ -40,10 +47,19 @@ pub struct QueryEngineOptions {
     pub pgsql_bind_address: SocketAddr,
 }
 
+impl QueryEngineOptions {
+    pub fn query_parallelism(&self) -> Option<usize> {
+        self.query_parallelism.map(Into::into)
+    }
+
+    pub fn memory_size(&self) -> Option<usize> {
+        self.memory_size.map(Into::into)
+    }
+}
 impl Default for QueryEngineOptions {
     fn default() -> Self {
         Self {
-            memory_limit: None,
+            memory_size: None,
             tmp_dir: None,
             query_parallelism: None,
             pgsql_bind_address: "0.0.0.0:9071".parse().unwrap(),

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -11,7 +11,11 @@
 use std::num::{NonZeroU32, NonZeroUsize};
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+use restate_serde_util::NonZeroByteCount;
+
+#[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(rename = "RocksDbOptions", default))]
@@ -24,14 +28,17 @@ pub struct RocksDbOptions {
     /// The size of a single memtable. Once memtable exceeds this size, it is marked
     /// immutable and a new one is created. Default is 256MB per memtable.
     #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_write_buffer_size: Option<usize>,
+    #[serde_as(as = "Option<NonZeroByteCount>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
+    rocksdb_write_buffer_size: Option<NonZeroUsize>,
 
     /// # Maximum total WAL size
     ///
     /// Max WAL size, that after this Rocksdb start flushing mem tables to disk.
-    /// Default is 2GB.
     #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_max_total_wal_size: Option<u64>,
+    #[serde_as(as = "Option<NonZeroByteCount>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
+    rocksdb_max_total_wal_size: Option<NonZeroUsize>,
 
     /// # Disable WAL
     ///
@@ -45,8 +52,6 @@ pub struct RocksDbOptions {
     ///
     /// when WAL is enabled, this allows Restate server to control WAL flushes in batches.
     /// This trades off latency for IO throughput.
-    ///
-    /// Default: True.
     #[serde(skip_serializing_if = "Option::is_none")]
     rocksdb_batch_wal_flushes: Option<bool>,
 
@@ -67,10 +72,10 @@ pub struct RocksDbOptions {
     /// If non-zero, we perform bigger reads when doing compaction. If you're
     /// running RocksDB on spinning disks, you should set this to at least 2MB.
     /// That way RocksDB's compaction is doing sequential instead of random reads.
-    ///
-    /// Default: 2MB (2 * 1024 * 1024)
     #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_compaction_readahead_size: Option<usize>,
+    #[serde_as(as = "Option<NonZeroByteCount>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
+    rocksdb_compaction_readahead_size: Option<NonZeroUsize>,
 
     /// # RocksDB statistics level
     ///
@@ -109,12 +114,14 @@ impl RocksDbOptions {
         }
     }
 
-    pub fn rocksdb_write_buffer_size(&self) -> usize {
-        self.rocksdb_write_buffer_size.unwrap_or(256_000_000) // 256MB
+    pub fn rocksdb_write_buffer_size(&self) -> NonZeroUsize {
+        self.rocksdb_write_buffer_size
+            .unwrap_or(NonZeroUsize::new(256_000_000).unwrap()) // 256MB
     }
 
-    pub fn rocksdb_max_total_wal_size(&self) -> u64 {
-        self.rocksdb_max_total_wal_size.unwrap_or(2 * (1 << 30))
+    pub fn rocksdb_max_total_wal_size(&self) -> NonZeroUsize {
+        self.rocksdb_max_total_wal_size
+            .unwrap_or(NonZeroUsize::new(2_000_000_000).unwrap())
     }
 
     pub fn rocksdb_disable_wal(&self) -> bool {
@@ -138,9 +145,9 @@ impl RocksDbOptions {
         )
     }
 
-    pub fn rocksdb_compaction_readahead_size(&self) -> usize {
+    pub fn rocksdb_compaction_readahead_size(&self) -> NonZeroUsize {
         self.rocksdb_compaction_readahead_size
-            .unwrap_or(2 * 1024 * 1024)
+            .unwrap_or(NonZeroUsize::new(2_000_000).unwrap())
     }
 
     pub fn rocksdb_statistics_level(&self) -> StatisticsLevel {

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -73,6 +73,7 @@ pub struct LogletParams(String);
     strum_macros::EnumIter,
     strum_macros::Display,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum ProviderKind {
     /// A local rocksdb-backed loglet.

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -66,8 +66,9 @@ pub struct GenerationalNodeId(PlainNodeId, u32);
     serde::Deserialize,
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
 #[display(fmt = "N{}", _0)]
-pub struct PlainNodeId(#[cfg_attr(feature = "schemars", schemars(default))] u32);
+pub struct PlainNodeId(u32);
 
 impl NodeId {
     pub fn new(id: u32, generation: Option<u32>) -> NodeId {

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -34,6 +34,7 @@ pub enum NodesConfigError {
 
 // PartialEq+Eq+Clone+Copy are implemented by EnumSetType
 #[derive(Debug, Hash, EnumSetType, strum_macros::Display, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[enumset(serialize_repr = "list")]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -146,8 +146,8 @@ impl PartitionProcessorManager {
         PartitionProcessor::new(
             partition_id,
             partition_key_range,
-            options.num_timers_in_memory_limit,
-            options.internal_queue_length,
+            options.num_timers_in_memory_limit(),
+            options.internal_queue_length(),
             self.invoker_handle.clone(),
             self.rocksdb_storage.clone(),
         )

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -127,7 +127,7 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
         ),
     )?;
 
-    let res = RetryPolicy::fixed_delay(Duration::from_millis(100), 20)
+    let res = RetryPolicy::fixed_delay(Duration::from_millis(100), Some(20))
         .retry(|| async {
             reqwest::Client::builder()
                 .build()?


### PR DESCRIPTION
Configuration support for human-readable bytes

- Add human-readable bytes support to the configuration
- Full review of naming
- Remove values the default to MAX and use Option instead
- Various fixes for better default values and hiding some internal options

Default config:

```toml
roles = [
    "worker",
    "admin",
    "metadata-store",
]
cluster-name = "localcluster"
allow-bootstrap = true
metadata-store-address = "http://127.0.0.1:5123/"
bind-address = "0.0.0.0:5122"
advertised-address = "http://127.0.0.1:5122/"
shutdown-timeout = "1m"
tracing-filter = "info"
log-filter = "info"
log-format = "pretty"
log-disable-ansi-codes = false
disable-prometheus = false
rocksdb-total-memory-size = "4.0 GB"
rocksdb-total-memtables-size = "0 B"
rocksdb-high-priority-bg-threads = 2

[http-keep-alive-options]
interval = "40s"
timeout = "20s"

[worker]
internal-queue-length = 64
rocksdb-write-buffer-size = "256.0 MB"
rocksdb-max-total-wal-size = "2.0 GB"
rocksdb-disable-wal = true
rocksdb-disable-statistics = false
rocksdb-max-background-jobs = 12
rocksdb-compaction-readahead-size = "2.0 MB"
rocksdb-statistics-level = "except-detailed-timers"
bootstrap-num-partitions = 64

[worker.invoker]
inactivity-timeout = "1m"
abort-timeout = "1m"
message-size-warning = "10.0 MB"

[worker.invoker.retry-policy]
type = "exponential"
initial-interval = "50ms"
factor = 2.0
max-interval = "10s"

[admin]
bind-address = "0.0.0.0:9070"

[admin.query-engine]
pgsql-bind-address = "0.0.0.0:9071"

[ingress]
bind-address = "0.0.0.0:8080"
kafka-clusters = []

[bifrost]
default-provider = "local"

[bifrost.local]
rocksdb-write-buffer-size = "256.0 MB"
rocksdb-max-total-wal-size = "2.0 GB"
rocksdb-disable-wal = false
rocksdb-disable-statistics = false
rocksdb-max-background-jobs = 12
rocksdb-compaction-readahead-size = "2.0 MB"
rocksdb-statistics-level = "except-detailed-timers"
writer-batch-commit-count = 500
writer-batch-commit-duration = "5ns"
sync-wal-before-ack = true

[metadata-store]
bind-address = "0.0.0.0:5123"
request-queue-length = 32

[metadata-store.rocksdb]
rocksdb-write-buffer-size = "256.0 MB"
rocksdb-max-total-wal-size = "2.0 GB"
rocksdb-disable-wal = true
rocksdb-disable-statistics = false
rocksdb-max-background-jobs = 12
rocksdb-compaction-readahead-size = "2.0 MB"
rocksdb-statistics-level = "except-detailed-timers"
```
