### PR TITLE
Remove RocksDb writer thread and disable WAL

### DIFF
--- a/crates/storage-query-datafusion/src/idempotency/tests.rs
+++ b/crates/storage-query-datafusion/src/idempotency/tests.rs
@@ -27,7 +27,7 @@ async fn get_idempotency_key() {
         .default_runtime_handle(tokio::runtime::Handle::current())
         .build()
         .expect("task_center builds");
-    let (mut engine, shutdown) = tc
+    let mut engine = tc
         .run_in_scope("mock-query-engine", None, MockQueryEngine::create())
         .await;
 
@@ -96,6 +96,4 @@ async fn get_idempotency_key() {
             )
         )
     );
-
-    shutdown.await;
 }

--- a/crates/storage-query-datafusion/src/journal/tests.rs
+++ b/crates/storage-query-datafusion/src/journal/tests.rs
@@ -34,7 +34,7 @@ async fn get_entries() {
         .default_runtime_handle(tokio::runtime::Handle::current())
         .build()
         .expect("task_center builds");
-    let (mut engine, shutdown) = tc
+    let mut engine = tc
         .run_in_scope("mock-query-engine", None, MockQueryEngine::create())
         .await;
 
@@ -127,6 +127,4 @@ async fn get_entries() {
             )
         )
     );
-
-    shutdown.await;
 }

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -28,7 +28,6 @@ use restate_types::config::{CommonOptions, QueryEngineOptions, WorkerOptions};
 use restate_types::identifiers::{DeploymentId, ServiceRevision};
 use restate_types::invocation::ServiceType;
 use std::fmt::Debug;
-use std::future::Future;
 use std::marker::PhantomData;
 
 #[derive(Default, Clone, Debug)]
@@ -87,35 +86,27 @@ impl MockQueryEngine {
             + Debug
             + Clone
             + 'static,
-    ) -> (Self, impl Future<Output = ()>) {
+    ) -> Self {
         // Prepare Rocksdb
         task_center().run_in_scope_sync("db-manager-init", None, || {
             RocksDbManager::init(Constant::new(CommonOptions::default()))
         });
         let worker_options = WorkerOptions::default();
-        let (rocksdb, writer) = RocksDBStorage::open(
+        let rocksdb = RocksDBStorage::open(
             Constant::new(worker_options.storage.clone()),
             Constant::new(worker_options.storage.rocksdb),
         )
         .await
         .expect("RocksDB storage creation should succeed");
-        let (signal, watch) = drain::channel();
-        let writer_join_handle = writer.run(watch);
 
-        let query_engine = Self(
+        Self(
             rocksdb.clone(),
             QueryContext::from_options(&QueryEngineOptions::default(), rocksdb, status, schemas)
                 .unwrap(),
-        );
-
-        // Return shutdown future
-        (query_engine, async {
-            signal.drain().await;
-            writer_join_handle.await.unwrap().unwrap();
-        })
+        )
     }
 
-    pub async fn create() -> (Self, impl Future<Output = ()>) {
+    pub async fn create() -> Self {
         Self::create_with(MockStatusHandle::default(), MockSchemas::default()).await
     }
 

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -39,7 +39,7 @@ async fn query_sys_invocation() {
         .default_runtime_handle(tokio::runtime::Handle::current())
         .build()
         .expect("task_center builds");
-    let (mut engine, shutdown) = tc
+    let mut engine = tc
         .run_in_scope(
             "mock-query-engine",
             None,
@@ -117,6 +117,4 @@ async fn query_sys_invocation() {
             }
         ))
     );
-
-    shutdown.await;
 }

--- a/crates/storage-rocksdb/benches/basic_benchmark.rs
+++ b/crates/storage-rocksdb/benches/basic_benchmark.rs
@@ -24,15 +24,12 @@ async fn writing_to_rocksdb(worker_options: WorkerOptions) {
     //
     // setup
     //
-    let (mut rocksdb, writer) = RocksDBStorage::open(
+    let mut rocksdb = RocksDBStorage::open(
         Constant::new(worker_options.storage.clone()),
         Constant::new(worker_options.storage.rocksdb),
     )
     .await
     .expect("RocksDB storage creation should succeed");
-
-    let (signal, watch) = drain::channel();
-    let writer_join_handler = writer.run(watch);
 
     //
     // write
@@ -45,9 +42,6 @@ async fn writing_to_rocksdb(worker_options: WorkerOptions) {
         }
         txn.commit().await.unwrap();
     }
-
-    signal.drain().await;
-    writer_join_handler.await.unwrap().unwrap();
 }
 
 fn basic_writing_reading_benchmark(c: &mut Criterion) {

--- a/crates/storage-rocksdb/src/lib.rs
+++ b/crates/storage-rocksdb/src/lib.rs
@@ -21,11 +21,9 @@ pub mod scan;
 pub mod service_status_table;
 pub mod state_table;
 pub mod timer_table;
-mod writer;
 
 use crate::keys::TableKey;
 use crate::scan::{PhysicalScan, TableScan};
-use crate::writer::{Writer, WriterHandle};
 use crate::TableKind::{
     Deduplication, Idempotency, Inbox, InvocationStatus, Journal, Outbox, PartitionStateMachine,
     ServiceStatus, State, Timers,
@@ -49,16 +47,11 @@ use rocksdb::PrefixRange;
 use rocksdb::ReadOptions;
 use std::sync::Arc;
 
-pub use writer::JoinHandle as RocksDBWriterJoinHandle;
-pub use writer::Writer as RocksDBWriter;
-
 pub type DB = rocksdb::OptimisticTransactionDB<MultiThreaded>;
 type TransactionDB<'a> = rocksdb::Transaction<'a, DB>;
 
 pub type DBIterator<'b> = DBRawIteratorWithThreadMode<'b, DB>;
 pub type DBIteratorTransaction<'b> = DBRawIteratorWithThreadMode<'b, rocksdb::Transaction<'b, DB>>;
-
-type WriteBatch = rocksdb::WriteBatchWithTransaction<true>;
 
 // matches the default directory name
 const DB_NAME: &str = "db";
@@ -156,7 +149,6 @@ pub enum BuildError {
 
 pub struct RocksDBStorage {
     db: Arc<DB>,
-    writer_handle: WriterHandle,
     key_buffer: BytesMut,
     value_buffer: BytesMut,
 }
@@ -165,7 +157,6 @@ impl std::fmt::Debug for RocksDBStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RocksDBStorage")
             .field("db", &self.db)
-            .field("writer_handle", &self.writer_handle)
             .field("key_buffer", &self.key_buffer)
             .field("value_buffer", &self.value_buffer)
             .finish()
@@ -176,7 +167,6 @@ impl Clone for RocksDBStorage {
     fn clone(&self) -> Self {
         RocksDBStorage {
             db: self.db.clone(),
-            writer_handle: self.writer_handle.clone(),
             key_buffer: BytesMut::default(),
             value_buffer: BytesMut::default(),
         }
@@ -231,7 +221,7 @@ impl RocksDBStorage {
     pub async fn open(
         mut storage_opts: impl Updateable<StorageOptions> + Send + 'static,
         updateable_opts: impl Updateable<RocksDbOptions> + Send + 'static,
-    ) -> std::result::Result<(Self, Writer), BuildError> {
+    ) -> std::result::Result<Self, BuildError> {
         let cfs = vec![
             //
             // keyed by partition key + user key
@@ -272,18 +262,11 @@ impl RocksDBStorage {
         .await
         .map_err(|_| ShutdownError)??;
 
-        let writer = Writer::new(rdb.clone(), storage_opts);
-        let writer_handle = writer.create_writer_handle();
-
-        Ok((
-            Self {
-                db: rdb,
-                writer_handle,
-                key_buffer: BytesMut::default(),
-                value_buffer: BytesMut::default(),
-            },
-            writer,
-        ))
+        Ok(Self {
+            db: rdb,
+            key_buffer: BytesMut::default(),
+            value_buffer: BytesMut::default(),
+        })
     }
 
     fn table_handle(&self, table_kind: TableKind) -> Arc<BoundColumnFamily> {
@@ -341,7 +324,6 @@ impl RocksDBStorage {
             db,
             key_buffer: &mut self.key_buffer,
             value_buffer: &mut self.value_buffer,
-            writer_handle: &self.writer_handle,
         }
     }
 }
@@ -406,7 +388,6 @@ pub struct RocksDBTransaction<'a> {
     db: Arc<DB>,
     key_buffer: &'a mut BytesMut,
     value_buffer: &'a mut BytesMut,
-    writer_handle: &'a WriterHandle,
 }
 
 impl<'a> RocksDBTransaction<'a> {
@@ -446,8 +427,16 @@ impl<'a> Transaction for RocksDBTransaction<'a> {
         // writes to RocksDB. However, it is safe to write the WriteBatch for a given partition,
         // because there can only be a single writer (the leading PartitionProcessor).
         let write_batch = self.txn.get_writebatch();
-
-        self.writer_handle.write(write_batch).await
+        // todo: make async and use configuration to control use of WAL
+        if write_batch.is_empty() {
+            return Ok(());
+        }
+        let mut opts = rocksdb::WriteOptions::default();
+        // We disable WAL since bifrost is our durable distributed log.
+        opts.disable_wal(true);
+        self.db
+            .write_opt(&write_batch, &rocksdb::WriteOptions::default())
+            .map_err(|error| StorageError::Generic(error.into()))
     }
 }
 

--- a/crates/storage-rocksdb/tests/idempotency_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/idempotency_table_test/mod.rs
@@ -35,7 +35,7 @@ const IDEMPOTENCY_ID_3: IdempotencyId =
 
 #[tokio::test]
 async fn test_idempotency_key() {
-    let (mut rocksdb, close) = storage_test_environment().await;
+    let mut rocksdb = storage_test_environment().await;
 
     // Fill in some data
     let mut txn = rocksdb.transaction();
@@ -114,6 +114,4 @@ async fn test_idempotency_key() {
             .unwrap(),
         None
     );
-
-    close.await;
 }

--- a/crates/storage-rocksdb/tests/state_table_test/mod.rs
+++ b/crates/storage-rocksdb/tests/state_table_test/mod.rs
@@ -112,7 +112,7 @@ pub(crate) async fn run_tests(mut rocksdb: RocksDBStorage) {
 
 #[tokio::test]
 async fn test_delete_all() {
-    let (mut rocksdb, close) = storage_test_environment().await;
+    let mut rocksdb = storage_test_environment().await;
 
     let mut txn = rocksdb.transaction();
 
@@ -143,6 +143,4 @@ async fn test_delete_all() {
         .await
         .expect("should not fail")
         .is_some());
-
-    close.await;
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -29,7 +29,7 @@ pub use subscription_integration::SubscriptionControllerHandle;
 use codederror::CodedError;
 use restate_bifrost::Bifrost;
 use restate_core::network::MessageRouterBuilder;
-use restate_core::{cancellation_watcher, metadata, task_center, TaskKind};
+use restate_core::{metadata, task_center, TaskKind};
 use restate_ingress_dispatcher::IngressDispatcher;
 use restate_ingress_http::HyperServerIngress;
 use restate_ingress_kafka::Service as IngressKafkaService;
@@ -42,8 +42,7 @@ use restate_schema::UpdateableSchema;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_query_postgres::service::PostgresQueryService;
-use restate_storage_rocksdb::{RocksDBStorage, RocksDBWriter};
-use tracing::debug;
+use restate_storage_rocksdb::RocksDBStorage;
 
 use crate::invoker_integration::EntryEnricher;
 use crate::partition::storage::invoker::InvokerStorageReader;
@@ -83,15 +82,6 @@ pub enum Error {
         thread: &'static str,
         cause: restate_types::errors::ThreadJoinError,
     },
-    #[error("rocksdb writer failed: {0}")]
-    #[code(unknown)]
-    RocksDBWriter(#[from] anyhow::Error),
-}
-
-impl Error {
-    fn thread_panic(thread: &'static str, cause: restate_types::errors::ThreadJoinError) -> Self {
-        Error::ThreadPanic { thread, cause }
-    }
 }
 
 pub struct Worker {
@@ -110,7 +100,6 @@ pub struct Worker {
     external_client_ingress: ExternalClientIngress,
     ingress_kafka: IngressKafkaService,
     subscription_controller_handle: SubscriptionControllerHandle,
-    rocksdb_writer: RocksDBWriter,
     rocksdb_storage: RocksDBStorage,
 }
 
@@ -165,7 +154,7 @@ impl Worker {
         // a really ugly hack (I'm ashamed) until we can decouple opening database(s)
         // from worker creation, or we make worker creation async. This is a stop gap
         // to avoid unraveling the entire worker creation process to be async in this change.
-        let (rocksdb_storage, rocksdb_writer) = futures::executor::block_on(RocksDBStorage::open(
+        let rocksdb_storage = futures::executor::block_on(RocksDBStorage::open(
             updateable_config
                 .clone()
                 .map_as_updateable_owned(|c| &c.worker.storage),
@@ -204,7 +193,6 @@ impl Worker {
             external_client_ingress: ingress_http,
             ingress_kafka,
             subscription_controller_handle,
-            rocksdb_writer,
             rocksdb_storage,
             metadata_store_client,
         })
@@ -224,16 +212,6 @@ impl Worker {
 
     pub async fn run(self, bifrost: Bifrost) -> anyhow::Result<()> {
         let tc = task_center();
-        let (shutdown_signal, shutdown_watch) = drain::channel();
-
-        // RocksDB Writer
-        tc.spawn_child(TaskKind::SystemService, "rocksdb-writer", None, async {
-            let handle = self.rocksdb_writer.run(shutdown_watch);
-            Ok(handle
-                .await
-                .map_err(|err| Error::thread_panic("rocksdb writer", err))?
-                .map_err(Error::RocksDBWriter)?)
-        })?;
 
         // Ingress RPC server
         tc.spawn_child(
@@ -277,8 +255,6 @@ impl Worker {
             ),
         )?;
 
-        let shutdown = cancellation_watcher();
-
         let mut partition_processor_manager = PartitionProcessorManager::new(
             self.updateable_config.clone(),
             metadata().my_node_id(),
@@ -298,16 +274,6 @@ impl Worker {
                 .collect(),
         );
         partition_processor_manager.apply_plan(plan).await?;
-
-        tokio::select! {
-            _ = shutdown => {
-                debug!("Initiating shutdown of worker");
-
-                // This will only shutdown rocksdb writer thread. Everything else will respond to
-                // the cancellation signal independently.
-                shutdown_signal.drain().await;
-            },
-        }
 
         Ok(())
     }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -134,8 +134,6 @@ mod tests {
         //  Perhaps we could make these tests faster by having those.
         rocksdb_storage: RocksDBStorage,
         effects_buffer: Effects,
-        signal: drain::Signal,
-        writer_join_handle: restate_storage_rocksdb::RocksDBWriterJoinHandle,
     }
 
     impl MockStateMachine {
@@ -152,15 +150,12 @@ mod tests {
                 "Using RocksDB temp directory {}",
                 worker_options.storage.data_dir().display()
             );
-            let (rocksdb_storage, writer) = restate_storage_rocksdb::RocksDBStorage::open(
+            let rocksdb_storage = restate_storage_rocksdb::RocksDBStorage::open(
                 Constant::new(worker_options.storage.clone()),
                 Constant::new(worker_options.storage.rocksdb),
             )
             .await
             .unwrap();
-
-            let (signal, watch) = drain::channel();
-            let writer_join_handle = writer.run(watch);
 
             Self {
                 state_machine: StateMachine::new(
@@ -170,8 +165,6 @@ mod tests {
                 ),
                 rocksdb_storage,
                 effects_buffer: Default::default(),
-                signal,
-                writer_join_handle,
             }
         }
 
@@ -213,13 +206,6 @@ mod tests {
         pub fn storage(&mut self) -> &mut RocksDBStorage {
             &mut self.rocksdb_storage
         }
-
-        async fn shutdown(self) -> Result<(), anyhow::Error> {
-            self.signal.drain().await;
-            self.writer_join_handle.await??;
-
-            Ok(())
-        }
     }
 
     type TestResult = Result<(), anyhow::Error>;
@@ -242,8 +228,7 @@ mod tests {
             .await
             .unwrap();
         assert_that!(invocation_status, pat!(InvocationStatus::Invoked(_)));
-
-        state_machine.shutdown().await
+        Ok(())
     }
 
     #[test(tokio::test)]
@@ -290,8 +275,7 @@ mod tests {
                 }
             )))
         );
-
-        state_machine.shutdown().await
+        Ok(())
     }
 
     #[test(tokio::test)]
@@ -381,8 +365,7 @@ mod tests {
                 invocation_id: eq(invocation_id)
             }))
         );
-
-        state_machine.shutdown().await
+        Ok(())
     }
 
     #[test(tokio::test)]
@@ -477,7 +460,7 @@ mod tests {
             some((ge(0), outbox_message_matcher(caller_id)))
         );
 
-        state_machine.shutdown().await
+        Ok(())
     }
 
     #[test(tokio::test)]
@@ -639,8 +622,7 @@ mod tests {
                 ))
             }))
         );
-
-        state_machine.shutdown().await
+        Ok(())
     }
 
     #[test(tokio::test)]
@@ -726,7 +708,7 @@ mod tests {
             )
         );
 
-        state_machine.shutdown().await
+        Ok(())
     }
 
     mod idempotency {
@@ -847,8 +829,6 @@ mod tests {
                     response_result: eq(ResponseResult::Success(response_bytes))
                 })))
             );
-
-            state_machine.shutdown().await.unwrap();
         }
 
         #[test(tokio::test)]
@@ -924,8 +904,6 @@ mod tests {
                     .unwrap(),
                 pat!(InvocationStatus::Free)
             );
-
-            state_machine.shutdown().await.unwrap();
         }
 
         #[test(tokio::test)]
@@ -989,8 +967,6 @@ mod tests {
                     .unwrap(),
                 pat!(InvocationStatus::Free)
             );
-
-            state_machine.shutdown().await.unwrap();
         }
 
         #[test(tokio::test)]
@@ -1091,8 +1067,6 @@ mod tests {
                     })))),
                 )
             );
-
-            state_machine.shutdown().await.unwrap();
         }
 
         #[test(tokio::test)]
@@ -1163,8 +1137,6 @@ mod tests {
                     .unwrap(),
                 none()
             );
-
-            state_machine.shutdown().await.unwrap();
         }
     }
 


### PR DESCRIPTION
Remove RocksDb writer thread and disable WAL

Writes are not "sync" temporarily until we use the new RocksDb async abstraction in the follow up PRs.
WAL is disabled as well, this will be configurable follow up PRs.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1456).
* #1466
* __->__ #1456