### PR TITLE
Update integration with RocksDbManager

### DIFF
--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -21,7 +21,7 @@ use crate::{Error, LogRecord, LsnExt, ProviderError};
 pub fn create_provider(kind: ProviderKind) -> Result<Arc<dyn LogletProvider>, ProviderError> {
     match kind {
         ProviderKind::Local => Ok(crate::loglets::local_loglet::LocalLogletProvider::new(
-            Configuration::current().load().bifrost.local.data_dir(),
+            &Configuration::current().load().bifrost.local,
             Configuration::mapped_updateable(|c| &c.bifrost.local.rocksdb),
         )?),
         ProviderKind::InMemory => Ok(crate::loglets::memory_loglet::MemoryLogletProvider::new()?),

--- a/crates/bifrost/src/loglets/local_loglet/log_store.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store.rs
@@ -122,6 +122,10 @@ fn db_options(options: &LocalLogletOptions) -> rocksdb::Options {
         opts.set_manual_wal_flush(options.batch_wal_flushes);
     }
 
+    // unconditionally enable atomic flushes to not persist inconsistent data in case WAL
+    // is disabled
+    opts.set_atomic_flush(true);
+
     opts
 }
 

--- a/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
@@ -182,7 +182,7 @@ impl LogStoreWriter {
         write_opts.disable_wal(opts.rocksdb.rocksdb_disable_wal());
 
         if !self.manual_wal_flush && !opts.rocksdb.rocksdb_disable_wal() {
-             // if we are not manually flushing the wal, we need to configure the sync behaviour
+            // if we are not manually flushing the wal, we need to configure the sync behaviour
             // for the write operation explicitly
             write_opts.set_sync(opts.sync_wal_before_ack);
         }

--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -42,11 +42,14 @@ impl LocalMetadataStoreService {
             bind_address,
         }
     }
-
-    pub fn from_options(
+    pub fn from_options<F, V>(
         opts: &MetadataStoreOptions,
-        rocksdb_options: impl Updateable<RocksDbOptions> + Send + 'static,
-    ) -> Result<Self, BuildError> {
+        rocksdb_options: F,
+    ) -> Result<Self, BuildError>
+    where
+        F: Fn() -> V,
+        V: Updateable<RocksDbOptions> + Send + 'static,
+    {
         let store = LocalMetadataStore::new(
             opts.data_dir(),
             opts.request_queue_length(),

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -99,7 +99,7 @@ pub enum BuildError {
 /// store in a single thread.
 pub struct LocalMetadataStore {
     db: Arc<DB>,
-    write_opts: WriteOptions,
+    opts: Box<dyn Updateable<RocksDbOptions> + Send + 'static>,
     request_rx: RequestReceiver,
     buffer: BytesMut,
 
@@ -108,11 +108,15 @@ pub struct LocalMetadataStore {
 }
 
 impl LocalMetadataStore {
-    pub fn new(
+    pub fn new<F, V>(
         data_dir: impl AsRef<Path>,
         request_queue_length: usize,
-        mut rocksdb_options: impl Updateable<RocksDbOptions> + Send + 'static,
-    ) -> std::result::Result<Self, BuildError> {
+        rocksdb_options: F,
+    ) -> std::result::Result<Self, BuildError>
+    where
+        F: Fn() -> V,
+        V: Updateable<RocksDbOptions> + Send + 'static,
+    {
         let (request_tx, request_rx) = mpsc::channel(request_queue_length);
 
         let db_manager = RocksDbManager::get();
@@ -127,21 +131,19 @@ impl LocalMetadataStore {
         .ensure_column_families(cfs)
         .build_as_db();
 
-        let options = rocksdb_options.load();
-        let write_opts = Self::write_options(options);
-
-        let db = db_manager.open_db(rocksdb_options, db_spec)?;
+        let db = db_manager.open_db(rocksdb_options(), db_spec)?;
 
         Ok(Self {
             db,
-            write_opts,
+            opts: Box::new(rocksdb_options()),
             buffer: BytesMut::default(),
             request_rx,
             request_tx,
         })
     }
 
-    fn write_options(rocks_db_options: &RocksDbOptions) -> WriteOptions {
+    fn write_options(&mut self) -> WriteOptions {
+        let rocks_db_options = self.opts.load();
         let mut write_opts = WriteOptions::default();
 
         write_opts.disable_wal(rocks_db_options.rocksdb_disable_wal());
@@ -273,14 +275,15 @@ impl LocalMetadataStore {
         self.buffer.clear();
         Self::encode(value, &mut self.buffer)?;
 
+        let write_options = self.write_options();
         let cf_handle = self.kv_cf_handle();
         self.db
-            .put_cf_opt(&cf_handle, key, self.buffer.as_ref(), &self.write_opts)?;
+            .put_cf_opt(&cf_handle, key, self.buffer.as_ref(), &write_options)?;
 
         Ok(())
     }
 
-    fn delete(&self, key: &ByteString, precondition: Precondition) -> Result<()> {
+    fn delete(&mut self, key: &ByteString, precondition: Precondition) -> Result<()> {
         match precondition {
             Precondition::None => self.delete_kv_pair(key),
             // this condition does not really make sense for the delete operation
@@ -306,9 +309,10 @@ impl LocalMetadataStore {
         }
     }
 
-    fn delete_kv_pair(&self, key: &ByteString) -> Result<()> {
+    fn delete_kv_pair(&mut self, key: &ByteString) -> Result<()> {
+        let write_options = self.write_options();
         self.db
-            .delete_cf_opt(&self.kv_cf_handle(), key, &self.write_opts)
+            .delete_cf_opt(&self.kv_cf_handle(), key, &write_options)
             .map_err(Into::into)
     }
 

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -299,11 +299,9 @@ async fn start_metadata_store(
     rocksdb_path: impl AsRef<Path> + Sized,
     task_center: &TaskCenter,
 ) -> anyhow::Result<MetadataStoreClient> {
-    let store = LocalMetadataStore::new(
-        rocksdb_path,
-        32,
-        Configuration::mapped_updateable(|config| &config.common.rocksdb),
-    )?;
+    let store = LocalMetadataStore::new(rocksdb_path, 32, || {
+        Configuration::mapped_updateable(|config| &config.common.rocksdb)
+    })?;
 
     let uds_path = tempfile::tempdir()?.into_path().join("grpc-server");
     let bind_address = BindAddress::Uds(uds_path.clone());

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -119,9 +119,11 @@ impl Node {
         let metadata_store_role = if config.has_role(Role::MetadataStore) {
             Some(LocalMetadataStoreService::from_options(
                 &config.metadata_store,
-                updateable_config
-                    .clone()
-                    .map_as_updateable_owned(|config| &config.common.rocksdb),
+                || {
+                    updateable_config
+                        .clone()
+                        .map_as_updateable_owned(|config| &config.common.rocksdb)
+                },
             )?)
         } else {
             None

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -289,10 +289,6 @@ impl RocksDbManager {
         db_options.set_wal_ttl_seconds(0);
 
         if !opts.rocksdb_disable_wal() {
-            // Disable automatic WAL flushing.
-            // We will call flush manually, when we commit a storage transaction.
-            //
-            db_options.set_manual_wal_flush(opts.rocksdb_batch_wal_flushes());
             // Once the WAL logs exceed this size, rocksdb will start flush memtables to disk.
             db_options.set_max_total_wal_size(opts.rocksdb_max_total_wal_size().get() as u64);
         }

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -94,8 +94,8 @@ impl MockQueryEngine {
         });
         let worker_options = WorkerOptions::default();
         let (rocksdb, writer) = RocksDBStorage::open(
-            worker_options.data_dir(),
-            Constant::new(worker_options.rocksdb),
+            Constant::new(worker_options.storage.clone()),
+            Constant::new(worker_options.storage.rocksdb),
         )
         .await
         .expect("RocksDB storage creation should succeed");

--- a/crates/storage-rocksdb/benches/basic_benchmark.rs
+++ b/crates/storage-rocksdb/benches/basic_benchmark.rs
@@ -25,8 +25,8 @@ async fn writing_to_rocksdb(worker_options: WorkerOptions) {
     // setup
     //
     let (mut rocksdb, writer) = RocksDBStorage::open(
-        worker_options.data_dir(),
-        Constant::new(worker_options.rocksdb),
+        Constant::new(worker_options.storage.clone()),
+        Constant::new(worker_options.storage.rocksdb),
     )
     .await
     .expect("RocksDB storage creation should succeed");

--- a/crates/storage-rocksdb/tests/integration_test.rs
+++ b/crates/storage-rocksdb/tests/integration_test.rs
@@ -47,8 +47,8 @@ async fn storage_test_environment() -> (RocksDBStorage, impl Future<Output = ()>
     });
     let worker_options = WorkerOptions::default();
     let (rocksdb, writer) = RocksDBStorage::open(
-        worker_options.data_dir(),
-        Constant::new(worker_options.rocksdb),
+        Constant::new(worker_options.storage.clone()),
+        Constant::new(worker_options.storage.rocksdb),
     )
     .await
     .expect("RocksDB storage creation should succeed");

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -67,6 +67,14 @@ pub struct LocalLogletOptions {
     /// prior to the background sync, the write is still durable if the OS didn't crash.
     pub sync_wal_before_ack: bool,
 
+    /// # Flush WAL in batches
+    ///
+    /// when WAL is enabled, this allows Restate server to control WAL flushes in batches.
+    /// This trades off latency for IO throughput.
+    ///
+    /// Default: True.
+    pub batch_wal_flushes: bool,
+
     #[cfg(any(test, feature = "test-util"))]
     #[serde(skip, default = "super::default_arc_tmp")]
     data_dir: std::sync::Arc<tempfile::TempDir>,
@@ -92,6 +100,7 @@ impl Default for LocalLogletOptions {
             .unwrap();
         Self {
             rocksdb,
+            batch_wal_flushes: true,
             sync_wal_before_ack: true,
             writer_batch_commit_count: 500,
             writer_batch_commit_duration: Duration::from_nanos(5).into(),

--- a/crates/types/src/config/metadata_store.rs
+++ b/crates/types/src/config/metadata_store.rs
@@ -47,7 +47,6 @@ impl Default for MetadataStoreOptions {
     fn default() -> Self {
         let rocksdb = RocksDbOptionsBuilder::default()
             .rocksdb_disable_wal(Some(false))
-            .rocksdb_batch_wal_flushes(Some(false))
             .build()
             .expect("valid RocksDbOptions");
         Self {

--- a/crates/types/src/config/metadata_store.rs
+++ b/crates/types/src/config/metadata_store.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use super::{data_dir, RocksDbOptions};
+use super::{data_dir, RocksDbOptions, RocksDbOptionsBuilder};
 use crate::net::BindAddress;
 
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
@@ -45,10 +45,15 @@ impl MetadataStoreOptions {
 
 impl Default for MetadataStoreOptions {
     fn default() -> Self {
+        let rocksdb = RocksDbOptionsBuilder::default()
+            .rocksdb_disable_wal(Some(false))
+            .rocksdb_batch_wal_flushes(Some(false))
+            .build()
+            .expect("valid RocksDbOptions");
         Self {
             bind_address: "0.0.0.0:5123".parse().expect("valid bind address"),
             request_queue_length: NonZeroUsize::new(32).unwrap(),
-            rocksdb: Default::default(),
+            rocksdb,
         }
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -181,7 +181,10 @@ impl Configuration {
     }
 
     pub fn apply_rocksdb_common(mut self) -> Self {
-        self.worker.rocksdb.apply_common(&self.common.rocksdb);
+        self.worker
+            .storage
+            .rocksdb
+            .apply_common(&self.common.rocksdb);
         self.bifrost
             .local
             .rocksdb

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -48,13 +48,6 @@ pub struct RocksDbOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     rocksdb_disable_wal: Option<bool>,
 
-    /// # Flush WAL in batches
-    ///
-    /// when WAL is enabled, this allows Restate server to control WAL flushes in batches.
-    /// This trades off latency for IO throughput.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_batch_wal_flushes: Option<bool>,
-
     /// Disable rocksdb statistics collection
     ///
     /// Default: False (statistics enabled)
@@ -130,10 +123,6 @@ impl RocksDbOptions {
 
     pub fn rocksdb_disable_statistics(&self) -> bool {
         self.rocksdb_disable_statistics.unwrap_or(false)
-    }
-
-    pub fn rocksdb_batch_wal_flushes(&self) -> bool {
-        self.rocksdb_batch_wal_flushes.unwrap_or(true)
     }
 
     pub fn rocksdb_max_background_jobs(&self) -> NonZeroU32 {

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -35,8 +35,7 @@ pub struct WorkerOptions {
     /// The number of timers in memory limit is used to bound the amount of timers loaded in memory. If this limit is set, when exceeding it, the timers farther in the future will be spilled to disk.
     num_timers_in_memory_limit: Option<NonZeroUsize>,
 
-    #[serde(flatten)]
-    pub rocksdb: RocksDbOptions,
+    pub storage: StorageOptions,
 
     pub invoker: InvokerOptions,
 
@@ -50,23 +49,9 @@ pub struct WorkerOptions {
     ///
     /// Cannot be higher than `4611686018427387903` (You should almost never need as many partitions anyway)
     bootstrap_num_partitions: NonZeroU64,
-
-    #[cfg(any(test, feature = "test-util"))]
-    #[serde(skip, default = "super::default_arc_tmp")]
-    data_dir: std::sync::Arc<tempfile::TempDir>,
 }
 
 impl WorkerOptions {
-    #[cfg(not(any(test, feature = "test-util")))]
-    pub fn data_dir(&self) -> PathBuf {
-        super::data_dir("db")
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn data_dir(&self) -> PathBuf {
-        self.data_dir.path().join("db")
-    }
-
     pub fn internal_queue_length(&self) -> usize {
         self.internal_queue_length.into()
     }
@@ -82,19 +67,12 @@ impl WorkerOptions {
 
 impl Default for WorkerOptions {
     fn default() -> Self {
-        let rocksdb = RocksDbOptionsBuilder::default()
-            .rocksdb_disable_wal(Some(true))
-            .build()
-            .unwrap();
-
         Self {
             internal_queue_length: NonZeroUsize::new(64).unwrap(),
             num_timers_in_memory_limit: None,
-            rocksdb,
+            storage: StorageOptions::default(),
             invoker: Default::default(),
             bootstrap_num_partitions: NonZeroU64::new(64).unwrap(),
-            #[cfg(any(test, feature = "test-util"))]
-            data_dir: super::default_arc_tmp(),
         }
     }
 }
@@ -205,6 +183,52 @@ impl Default for InvokerOptions {
             tmp_dir: None,
             concurrent_invocations_limit: None,
             disable_eager_state: false,
+        }
+    }
+}
+
+/// Storage options
+#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(rename = "StorageOptions", default))]
+#[serde(rename_all = "kebab-case")]
+#[builder(default)]
+pub struct StorageOptions {
+    #[serde(flatten)]
+    pub rocksdb: RocksDbOptions,
+
+    /// If WAL is enabled, this option defines whether the WAL will also be synced on flushes.
+    pub sync_wal_on_flush: bool,
+
+    #[cfg(any(test, feature = "test-util"))]
+    #[serde(skip, default = "super::default_arc_tmp")]
+    data_dir: std::sync::Arc<tempfile::TempDir>,
+}
+
+impl StorageOptions {
+    #[cfg(not(any(test, feature = "test-util")))]
+    pub fn data_dir(&self) -> PathBuf {
+        super::data_dir("db")
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn data_dir(&self) -> PathBuf {
+        self.data_dir.path().join("db")
+    }
+}
+
+impl Default for StorageOptions {
+    fn default() -> Self {
+        let rocksdb = RocksDbOptionsBuilder::default()
+            .rocksdb_disable_wal(Some(true))
+            .build()
+            .expect("valid RocksDbOptions");
+
+        StorageOptions {
+            rocksdb,
+            sync_wal_on_flush: false,
+            #[cfg(any(test, feature = "test-util"))]
+            data_dir: super::default_arc_tmp(),
         }
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -166,10 +166,12 @@ impl Worker {
         // from worker creation, or we make worker creation async. This is a stop gap
         // to avoid unraveling the entire worker creation process to be async in this change.
         let (rocksdb_storage, rocksdb_writer) = futures::executor::block_on(RocksDBStorage::open(
-            config.worker.data_dir(),
             updateable_config
                 .clone()
-                .map_as_updateable_owned(|c| &c.worker.rocksdb),
+                .map_as_updateable_owned(|c| &c.worker.storage),
+            updateable_config
+                .clone()
+                .map_as_updateable_owned(|c| &c.worker.storage.rocksdb),
         ))?;
 
         let invoker_storage_reader = InvokerStorageReader::new(rocksdb_storage.clone());

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -150,11 +150,11 @@ mod tests {
             let worker_options = WorkerOptions::default();
             info!(
                 "Using RocksDB temp directory {}",
-                worker_options.data_dir().display()
+                worker_options.storage.data_dir().display()
             );
             let (rocksdb_storage, writer) = restate_storage_rocksdb::RocksDBStorage::open(
-                worker_options.data_dir(),
-                Constant::new(worker_options.rocksdb),
+                Constant::new(worker_options.storage.clone()),
+                Constant::new(worker_options.storage.rocksdb),
             )
             .await
             .unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -211,7 +211,7 @@ fn main() {
 
                 WipeMode::wipe(
                     cli_args.wipe.as_ref(),
-                    config.worker.data_dir(),
+                    config.worker.storage.data_dir(),
                     config.bifrost.local.data_dir(),
                     config.metadata_store.data_dir(),
                 )


### PR DESCRIPTION
This PR updates the integration of our components with the RocksDbManager.

The PR does a few things:

1. Moves the rocksdb_batch_wal_flushes to the LocalLoglet configuration since not all users want to batch wal flushes
2. Updates the MetadataStore to respect the RocksDbOptions and enables WAL and syncing by default.
3. Updates the RocksDBStorage to respect the RocksDbOptions and to allow configuring the syncing behavior.