### PR TITLE
Use lossy string to log signing key path, as debug would add quotes/escapes

### DIFF
--- a/crates/service-client/src/request_identity/v1.rs
+++ b/crates/service-client/src/request_identity/v1.rs
@@ -42,7 +42,11 @@ impl SigningKey {
         );
         let key = jsonwebtoken::EncodingKey::from_ed_der(pem_bytes.as_slice());
 
-        info!(kid, path = ?request_identity_private_key_pem_file, "Loaded request identity key");
+        info!(
+            kid,
+            path = request_identity_private_key_pem_file.to_string_lossy(),
+            "Loaded request identity key"
+        );
 
         Ok(Self {
             header: jsonwebtoken::Header {

--- a/crates/service-client/src/request_identity/v1.rs
+++ b/crates/service-client/src/request_identity/v1.rs
@@ -44,7 +44,7 @@ impl SigningKey {
 
         info!(
             kid,
-            path = request_identity_private_key_pem_file.to_string_lossy(),
+            path = %request_identity_private_key_pem_file.display(),
             "Loaded request identity key"
         );
 


### PR DESCRIPTION
One of those cases where rust is very exact but very unhelpful :) 