### PR TITLE
Replace custom InvocationId encoding with Protobuf in storage

### DIFF
--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -68,7 +68,7 @@ message JournalMeta {
 
 message Source {
     message Service {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         InvocationTarget invocation_target = 2;
     }
 
@@ -221,7 +221,7 @@ message Header {
 }
 
 message ServiceInvocation {
-    bytes invocation_id = 1;
+    InvocationId invocation_id = 1;
     InvocationTarget invocation_target = 2;
     bytes argument = 3;
     ServiceInvocationResponseSink response_sink = 4;
@@ -240,7 +240,7 @@ message StateMutation {
 
 message InboxEntry {
     message Invocation {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         ServiceId service_id = 2;
     }
 
@@ -252,7 +252,7 @@ message InboxEntry {
 
 message InvocationResolutionResult {
     message Success {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         InvocationTarget invocation_target = 2;
         SpanContext span_context = 3;
     }
@@ -264,7 +264,7 @@ message InvocationResolutionResult {
 }
 
 message BackgroundCallResolutionResult {
-    bytes invocation_id = 1;
+    InvocationId invocation_id = 1;
     InvocationTarget invocation_target = 2;
     SpanContext span_context = 3;
 }
@@ -311,7 +311,7 @@ message EnrichedEntryHeader {
     }
 
     message CompleteAwakeable {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         uint32 entry_index = 2;
     }
 
@@ -404,17 +404,17 @@ message OutboxMessage {
     }
 
     message OutboxServiceInvocationResponse {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         uint32 entry_index = 2;
         ResponseResult response_result = 3;
     }
 
     message OutboxKill {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
     }
 
     message OutboxCancel {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
     }
 
     oneof outbox_message {
@@ -437,7 +437,7 @@ message Timer {
     }
 
     message CleanInvocationStatus {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
     }
 
     oneof value {
@@ -478,7 +478,7 @@ message DedupSequenceNumber {
 // ---------------------------------------------------------------------
 
 message IdempotencyMetadata {
-    bytes invocation_id = 1;
+    InvocationId invocation_id = 1;
 }
 
 message IdempotentRequestMetadata {


### PR DESCRIPTION
This commit changes how we store the InvocationId in the partition storage from a custom encoding to using Protobuf. Thereby, we will be able to evolve the InvocationId in the future if needed.

This fixes #1478.