### PR TITLE
Introduce TimerKind to support different types of timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,6 +6066,7 @@ dependencies = [
  "prost-types",
  "restate-types",
  "serde",
+ "strum 0.26.2",
  "strum_macros 0.26.2",
  "thiserror",
 ]

--- a/crates/partition-store/src/timer_table/mod.rs
+++ b/crates/partition-store/src/timer_table/mod.rs
@@ -69,31 +69,36 @@ fn exclusive_start_key_range(
 ) -> TableScan<TimersKey> {
     if let Some(timer_key) = timer_key {
         let next_timer_key = match timer_key.kind {
-            TimerKind::Invocation { invocation_uuid } => {
-                let invocation_uuid_value: u128 = invocation_uuid.into();
+            TimerKind::Invoke { invocation_uuid } => {
+                let incremented_invocation_uuid = increment_invocation_uuid(invocation_uuid);
                 TimerKey {
                     timestamp: timer_key.timestamp,
-                    kind: TimerKind::Invocation {
-                        invocation_uuid: InvocationUuid::from(
-                            invocation_uuid_value
-                                .checked_add(1)
-                                .expect("invocation_uuid should be smaller than u128::MAX"),
-                        ),
+                    kind: TimerKind::Invoke {
+                        invocation_uuid: incremented_invocation_uuid,
                     },
                 }
             }
-            TimerKind::Journal {
+            TimerKind::CompleteJournalEntry {
                 invocation_uuid,
                 journal_index,
             } => TimerKey {
                 timestamp: timer_key.timestamp,
-                kind: TimerKind::Journal {
+                kind: TimerKind::CompleteJournalEntry {
                     invocation_uuid,
                     journal_index: journal_index
                         .checked_add(1)
                         .expect("journal index should be smaller than u64::MAX"),
                 },
             },
+            TimerKind::CleanInvocationStatus { invocation_uuid } => {
+                let incremented_invocation_uuid = increment_invocation_uuid(invocation_uuid);
+                TimerKey {
+                    timestamp: timer_key.timestamp,
+                    kind: TimerKind::CleanInvocationStatus {
+                        invocation_uuid: incremented_invocation_uuid,
+                    },
+                }
+            }
         };
 
         let lower_bound = write_timer_key(partition_id, &next_timer_key);
@@ -106,6 +111,15 @@ fn exclusive_start_key_range(
     } else {
         TableScan::SinglePartition(partition_id)
     }
+}
+
+fn increment_invocation_uuid(invocation_uuid: InvocationUuid) -> InvocationUuid {
+    let invocation_uuid_value: u128 = invocation_uuid.into();
+    InvocationUuid::from(
+        invocation_uuid_value
+            .checked_add(1)
+            .expect("invocation_uuid should be smaller than u128::MAX"),
+    )
 }
 
 fn add_timer<S: StorageAccess>(
@@ -203,9 +217,9 @@ mod tests {
         InvocationUuid::from_parts(1706027034946, 12345678900001);
 
     #[test]
-    fn round_trip_journal_kind() {
+    fn round_trip_complete_journal_entry_kind() {
         let key = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION,
                 journal_index: 1448,
             },
@@ -219,9 +233,24 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_invocation_kind() {
+    fn round_trip_invoke_kind() {
         let key = TimerKey {
-            kind: TimerKind::Invocation {
+            kind: TimerKind::Invoke {
+                invocation_uuid: FIXTURE_INVOCATION,
+            },
+            timestamp: 87654321,
+        };
+
+        let key_bytes = write_timer_key(PartitionId::from(1337), &key).serialize();
+        let got = timer_key_from_key_slice(&key_bytes).expect("should not fail");
+
+        assert_eq!(got, key);
+    }
+
+    #[test]
+    fn round_trip_clean_invocation_status_kind() {
+        let key = TimerKey {
+            kind: TimerKind::CleanInvocationStatus {
                 invocation_uuid: FIXTURE_INVOCATION,
             },
             timestamp: 87654321,
@@ -236,11 +265,14 @@ mod tests {
     #[test]
     fn test_lexicographical_sorting_by_timestamp() {
         let kinds = [
-            TimerKind::Journal {
+            TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION,
                 journal_index: 0,
             },
-            TimerKind::Invocation {
+            TimerKind::Invoke {
+                invocation_uuid: FIXTURE_INVOCATION,
+            },
+            TimerKind::CleanInvocationStatus {
                 invocation_uuid: FIXTURE_INVOCATION,
             },
         ];
@@ -255,117 +287,152 @@ mod tests {
                     kind: second_kind.clone(),
                     timestamp: 301,
                 };
-                assert_in_range(a, b);
+                assert_in_range(&a, &b);
             }
         }
     }
 
     #[test]
-    fn test_lexicographical_sorting_by_invocation_journal_kind() {
+    fn test_lexicographical_sorting_by_invocation_uuid_complete_journal_entry_kind() {
         // Higher random part should be sorted correctly in bytes
         let a = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION,
                 journal_index: 0,
             },
             timestamp: 300,
         };
         let b = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION.increment_random(),
                 journal_index: 0,
             },
             timestamp: 300,
         };
-        assert_in_range(a.clone(), b);
+        assert_in_range(&a, &b);
 
         // Also ensure that higher timestamp is sorted correctly
         let b = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION.increment_timestamp(),
                 journal_index: 0,
             },
             timestamp: 300,
         };
-        assert_in_range(a, b);
+        assert_in_range(&a, &b);
     }
 
     #[test]
-    fn test_lexicographical_sorting_by_invocation_invocation_kind() {
+    fn test_lexicographical_sorting_by_invocation_uuid_invoke_kind() {
         // Higher random part should be sorted correctly in bytes
         let a = TimerKey {
-            kind: TimerKind::Invocation {
+            kind: TimerKind::Invoke {
                 invocation_uuid: FIXTURE_INVOCATION,
             },
             timestamp: 300,
         };
         let b = TimerKey {
-            kind: TimerKind::Invocation {
+            kind: TimerKind::Invoke {
                 invocation_uuid: FIXTURE_INVOCATION.increment_random(),
             },
             timestamp: 300,
         };
-        assert_in_range(a.clone(), b);
+        assert_in_range(&a, &b);
 
         // Also ensure that higher timestamp is sorted correctly
         let b = TimerKey {
-            kind: TimerKind::Invocation {
+            kind: TimerKind::Invoke {
                 invocation_uuid: FIXTURE_INVOCATION.increment_timestamp(),
             },
             timestamp: 300,
         };
-        assert_in_range(a, b);
+        assert_in_range(&a, &b);
+    }
+
+    #[test]
+    fn test_lexicographical_sorting_by_invocation_uuid_clean_invoation_status_kind() {
+        // Higher random part should be sorted correctly in bytes
+        let a = TimerKey {
+            kind: TimerKind::CleanInvocationStatus {
+                invocation_uuid: FIXTURE_INVOCATION,
+            },
+            timestamp: 300,
+        };
+        let b = TimerKey {
+            kind: TimerKind::CleanInvocationStatus {
+                invocation_uuid: FIXTURE_INVOCATION.increment_random(),
+            },
+            timestamp: 300,
+        };
+        assert_in_range(&a, &b);
+
+        // Also ensure that higher timestamp is sorted correctly
+        let b = TimerKey {
+            kind: TimerKind::CleanInvocationStatus {
+                invocation_uuid: FIXTURE_INVOCATION.increment_timestamp(),
+            },
+            timestamp: 300,
+        };
+        assert_in_range(&a, &b);
     }
 
     #[test]
     fn test_lexicographical_sorting_by_journal_index() {
         let a = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION,
                 journal_index: 0,
             },
             timestamp: 300,
         };
         let b = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION,
                 journal_index: 1,
             },
             timestamp: 300,
         };
-        assert_in_range(a, b);
+        assert_in_range(&a, &b);
     }
 
     #[test]
-    fn test_lexicographical_sorting_journal_invocation_kind() {
+    fn test_lexicographical_sorting_timer_kind() {
         let a = TimerKey {
-            kind: TimerKind::Invocation {
+            kind: TimerKind::Invoke {
                 invocation_uuid: FIXTURE_INVOCATION,
             },
             timestamp: 300,
         };
 
         let b = TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION,
                 journal_index: 0,
             },
             timestamp: 300,
         };
 
-        assert_in_range(a, b);
+        let c = TimerKey {
+            kind: TimerKind::CleanInvocationStatus {
+                invocation_uuid: FIXTURE_INVOCATION,
+            },
+            timestamp: 300,
+        };
+
+        assert_in_range(&a, &b);
+        assert_in_range(&b, &c);
     }
 
     #[track_caller]
-    fn assert_in_range(key_a: TimerKey, key_b: TimerKey) {
+    fn assert_in_range(key_a: &TimerKey, key_b: &TimerKey) {
         assert!(key_a < key_b);
 
-        let key_a_bytes = write_timer_key(PartitionId::from(1), &key_a).serialize();
-        let key_b_bytes = write_timer_key(PartitionId::from(1), &key_b).serialize();
+        let key_a_bytes = write_timer_key(PartitionId::from(1), key_a).serialize();
+        let key_b_bytes = write_timer_key(PartitionId::from(1), key_b).serialize();
 
         assert!(less_than(&key_a_bytes, &key_b_bytes));
 
-        let (low, high) = match exclusive_start_key_range(PartitionId::from(1), Some(&key_a)) {
+        let (low, high) = match exclusive_start_key_range(PartitionId::from(1), Some(key_a)) {
             TableScan::KeyRangeInclusiveInSinglePartition(p, low, high) if *p == 1 => (low, high),
             _ => panic!(""),
         };
@@ -411,12 +478,15 @@ mod tests {
             match TimerKindDiscriminants::VARIANTS
                 [rand::thread_rng().gen_range(0..TimerKindDiscriminants::VARIANTS.len())]
             {
-                TimerKindDiscriminants::Invocation => TimerKind::Invocation {
+                TimerKindDiscriminants::Invoke => TimerKind::Invoke {
                     invocation_uuid: InvocationUuid::new(),
                 },
-                TimerKindDiscriminants::Journal => TimerKind::Journal {
+                TimerKindDiscriminants::CompleteJournalEntry => TimerKind::CompleteJournalEntry {
                     invocation_uuid: InvocationUuid::new(),
                     journal_index: rand::thread_rng().gen_range(0..2 ^ 16),
+                },
+                TimerKindDiscriminants::CleanInvocationStatus => TimerKind::CleanInvocationStatus {
+                    invocation_uuid: InvocationUuid::new(),
                 },
             }
         };

--- a/crates/partition-store/tests/timer_table_test/mod.rs
+++ b/crates/partition-store/tests/timer_table_test/mod.rs
@@ -29,26 +29,26 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION.invocation_uuid(),
                 journal_index: 0,
             },
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(FIXTURE_INVOCATION, 0),
+        Timer::CompleteJournalEntry(FIXTURE_INVOCATION, 0),
     )
     .await;
 
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION.invocation_uuid(),
                 journal_index: 1,
             },
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(FIXTURE_INVOCATION, 1),
+        Timer::CompleteJournalEntry(FIXTURE_INVOCATION, 1),
     )
     .await;
 
@@ -58,7 +58,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::Invocation {
+            kind: TimerKind::Invoke {
                 invocation_uuid: service_invocation.invocation_id.invocation_uuid(),
             },
             timestamp: 1,
@@ -73,26 +73,26 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION_UUID,
                 journal_index: 0,
             },
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(InvocationId::from_parts(1336, FIXTURE_INVOCATION_UUID), 0),
+        Timer::CompleteJournalEntry(InvocationId::from_parts(1336, FIXTURE_INVOCATION_UUID), 0),
     )
     .await;
 
     txn.add_timer(
         PartitionId::from(1338),
         &TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION_UUID,
                 journal_index: 0,
             },
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(InvocationId::from_parts(1338, FIXTURE_INVOCATION_UUID), 0),
+        Timer::CompleteJournalEntry(InvocationId::from_parts(1338, FIXTURE_INVOCATION_UUID), 0),
     )
     .await;
 }
@@ -110,7 +110,7 @@ async fn demo_how_to_find_first_timers_in_a_partition<T: TimerTable>(txn: &mut T
 
 async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
     let timer_key = &TimerKey {
-        kind: TimerKind::Journal {
+        kind: TimerKind::CompleteJournalEntry {
             invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
         },
@@ -123,7 +123,7 @@ async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
         // take a look at populate_data once again.
         assert_that!(
             key.kind,
-            pat!(TimerKind::Journal {
+            pat!(TimerKind::CompleteJournalEntry {
                 journal_index: eq(1),
             })
         );
@@ -132,7 +132,7 @@ async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
     }
 
     if let Some(Ok((key, _))) = stream.next().await {
-        assert_that!(key.kind, pat!(TimerKind::Invocation { .. }));
+        assert_that!(key.kind, pat!(TimerKind::Invoke { .. }));
         assert_eq!(key.timestamp, 1);
     } else {
         panic!("test failure");
@@ -143,7 +143,7 @@ async fn delete_the_first_timer<T: TimerTable>(txn: &mut T) {
     txn.delete_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::Journal {
+            kind: TimerKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION_UUID,
                 journal_index: 0,
             },
@@ -155,7 +155,7 @@ async fn delete_the_first_timer<T: TimerTable>(txn: &mut T) {
 
 async fn verify_next_timer_after_deletion<T: TimerTable>(txn: &mut T) {
     let timer_key = &TimerKey {
-        kind: TimerKind::Journal {
+        kind: TimerKind::CompleteJournalEntry {
             invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
         },
@@ -167,7 +167,7 @@ async fn verify_next_timer_after_deletion<T: TimerTable>(txn: &mut T) {
     if let Some(Ok((key, _))) = stream.next().await {
         assert_that!(
             key.kind,
-            pat!(TimerKind::Journal {
+            pat!(TimerKind::CompleteJournalEntry {
                 journal_index: eq(1)
             })
         );

--- a/crates/partition-store/tests/timer_table_test/mod.rs
+++ b/crates/partition-store/tests/timer_table_test/mod.rs
@@ -13,12 +13,13 @@ use futures_util::StreamExt;
 use restate_partition_store::PartitionStore;
 use restate_storage_api::timer_table::{Timer, TimerKey, TimerTable};
 use restate_storage_api::Transaction;
-use restate_types::identifiers::{InvocationUuid, PartitionId, ServiceId};
+use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionId, ServiceId};
 use restate_types::invocation::ServiceInvocation;
 use std::pin::pin;
 
-const FIXTURE_INVOCATION: InvocationUuid =
+const FIXTURE_INVOCATION_UUID: InvocationUuid =
     InvocationUuid::from_parts(1706027034946, 12345678900001);
+const FIXTURE_INVOCATION: InvocationId = InvocationId::from_parts(1337, FIXTURE_INVOCATION_UUID);
 
 const PARTITION1337: PartitionId = PartitionId::new_unchecked(1337);
 
@@ -26,22 +27,22 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            invocation_uuid: FIXTURE_INVOCATION,
+            invocation_uuid: FIXTURE_INVOCATION.invocation_uuid(),
             journal_index: 0,
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(1337),
+        Timer::CompleteSleepEntry(FIXTURE_INVOCATION, 0),
     )
     .await;
 
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            invocation_uuid: FIXTURE_INVOCATION,
+            invocation_uuid: FIXTURE_INVOCATION.invocation_uuid(),
             journal_index: 1,
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(1337),
+        Timer::CompleteSleepEntry(FIXTURE_INVOCATION, 1),
     )
     .await;
 
@@ -51,7 +52,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            invocation_uuid: FIXTURE_INVOCATION,
+            invocation_uuid: service_invocation.invocation_id.invocation_uuid(),
             journal_index: 2,
             timestamp: 1,
         },
@@ -65,22 +66,22 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            invocation_uuid: FIXTURE_INVOCATION,
+            invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(1336),
+        Timer::CompleteSleepEntry(InvocationId::from_parts(1336, FIXTURE_INVOCATION_UUID), 0),
     )
     .await;
 
     txn.add_timer(
         PartitionId::from(1338),
         &TimerKey {
-            invocation_uuid: FIXTURE_INVOCATION,
+            invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
             timestamp: 0,
         },
-        Timer::CompleteSleepEntry(1338),
+        Timer::CompleteSleepEntry(InvocationId::from_parts(1338, FIXTURE_INVOCATION_UUID), 0),
     )
     .await;
 }
@@ -98,7 +99,7 @@ async fn demo_how_to_find_first_timers_in_a_partition<T: TimerTable>(txn: &mut T
 
 async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
     let timer_key = &TimerKey {
-        invocation_uuid: FIXTURE_INVOCATION,
+        invocation_uuid: FIXTURE_INVOCATION_UUID,
         journal_index: 0,
         timestamp: 0,
     };
@@ -123,7 +124,7 @@ async fn delete_the_first_timer<T: TimerTable>(txn: &mut T) {
     txn.delete_timer(
         PARTITION1337,
         &TimerKey {
-            invocation_uuid: FIXTURE_INVOCATION,
+            invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
             timestamp: 0,
         },
@@ -133,7 +134,7 @@ async fn delete_the_first_timer<T: TimerTable>(txn: &mut T) {
 
 async fn verify_next_timer_after_deletion<T: TimerTable>(txn: &mut T) {
     let timer_key = &TimerKey {
-        invocation_uuid: FIXTURE_INVOCATION,
+        invocation_uuid: FIXTURE_INVOCATION_UUID,
         journal_index: 0,
         timestamp: 0,
     };

--- a/crates/partition-store/tests/timer_table_test/mod.rs
+++ b/crates/partition-store/tests/timer_table_test/mod.rs
@@ -13,7 +13,7 @@ use futures_util::StreamExt;
 use googletest::matchers::eq;
 use googletest::{assert_that, pat};
 use restate_partition_store::PartitionStore;
-use restate_storage_api::timer_table::{Timer, TimerKey, TimerKind, TimerTable};
+use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable};
 use restate_storage_api::Transaction;
 use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionId, ServiceId};
 use restate_types::invocation::ServiceInvocation;
@@ -29,7 +29,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::CompleteJournalEntry {
+            kind: TimerKeyKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION.invocation_uuid(),
                 journal_index: 0,
             },
@@ -42,7 +42,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::CompleteJournalEntry {
+            kind: TimerKeyKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION.invocation_uuid(),
                 journal_index: 1,
             },
@@ -58,7 +58,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::Invoke {
+            kind: TimerKeyKind::Invoke {
                 invocation_uuid: service_invocation.invocation_id.invocation_uuid(),
             },
             timestamp: 1,
@@ -73,7 +73,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::CompleteJournalEntry {
+            kind: TimerKeyKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION_UUID,
                 journal_index: 0,
             },
@@ -86,7 +86,7 @@ async fn populate_data<T: TimerTable>(txn: &mut T) {
     txn.add_timer(
         PartitionId::from(1338),
         &TimerKey {
-            kind: TimerKind::CompleteJournalEntry {
+            kind: TimerKeyKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION_UUID,
                 journal_index: 0,
             },
@@ -110,7 +110,7 @@ async fn demo_how_to_find_first_timers_in_a_partition<T: TimerTable>(txn: &mut T
 
 async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
     let timer_key = &TimerKey {
-        kind: TimerKind::CompleteJournalEntry {
+        kind: TimerKeyKind::CompleteJournalEntry {
             invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
         },
@@ -123,7 +123,7 @@ async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
         // take a look at populate_data once again.
         assert_that!(
             key.kind,
-            pat!(TimerKind::CompleteJournalEntry {
+            pat!(TimerKeyKind::CompleteJournalEntry {
                 journal_index: eq(1),
             })
         );
@@ -132,7 +132,7 @@ async fn find_timers_greater_than<T: TimerTable>(txn: &mut T) {
     }
 
     if let Some(Ok((key, _))) = stream.next().await {
-        assert_that!(key.kind, pat!(TimerKind::Invoke { .. }));
+        assert_that!(key.kind, pat!(TimerKeyKind::Invoke { .. }));
         assert_eq!(key.timestamp, 1);
     } else {
         panic!("test failure");
@@ -143,7 +143,7 @@ async fn delete_the_first_timer<T: TimerTable>(txn: &mut T) {
     txn.delete_timer(
         PARTITION1337,
         &TimerKey {
-            kind: TimerKind::CompleteJournalEntry {
+            kind: TimerKeyKind::CompleteJournalEntry {
                 invocation_uuid: FIXTURE_INVOCATION_UUID,
                 journal_index: 0,
             },
@@ -155,7 +155,7 @@ async fn delete_the_first_timer<T: TimerTable>(txn: &mut T) {
 
 async fn verify_next_timer_after_deletion<T: TimerTable>(txn: &mut T) {
     let timer_key = &TimerKey {
-        kind: TimerKind::CompleteJournalEntry {
+        kind: TimerKeyKind::CompleteJournalEntry {
             invocation_uuid: FIXTURE_INVOCATION_UUID,
             journal_index: 0,
         },
@@ -167,7 +167,7 @@ async fn verify_next_timer_after_deletion<T: TimerTable>(txn: &mut T) {
     if let Some(Ok((key, _))) = stream.next().await {
         assert_that!(
             key.kind,
-            pat!(TimerKind::CompleteJournalEntry {
+            pat!(TimerKeyKind::CompleteJournalEntry {
                 journal_index: eq(1)
             })
         );

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -23,6 +23,7 @@ opentelemetry = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 serde = { workspace = true, optional = true }
+strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -433,7 +433,8 @@ message OutboxMessage {
 message Timer {
 
     message CompleteSleepEntry {
-        uint64 partition_key = 1;
+        InvocationId invocation_id = 1;
+        uint32 entry_index = 2;
     }
 
     message CleanInvocationStatus {

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -68,7 +68,7 @@ message JournalMeta {
 
 message Source {
     message Service {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         InvocationTarget invocation_target = 2;
     }
 
@@ -221,7 +221,7 @@ message Header {
 }
 
 message ServiceInvocation {
-    bytes invocation_id = 1;
+    InvocationId invocation_id = 1;
     InvocationTarget invocation_target = 2;
     bytes argument = 3;
     ServiceInvocationResponseSink response_sink = 4;
@@ -240,7 +240,7 @@ message StateMutation {
 
 message InboxEntry {
     message Invocation {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         ServiceId service_id = 2;
     }
 
@@ -252,7 +252,7 @@ message InboxEntry {
 
 message InvocationResolutionResult {
     message Success {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         InvocationTarget invocation_target = 2;
         SpanContext span_context = 3;
     }
@@ -264,7 +264,7 @@ message InvocationResolutionResult {
 }
 
 message BackgroundCallResolutionResult {
-    bytes invocation_id = 1;
+    InvocationId invocation_id = 1;
     InvocationTarget invocation_target = 2;
     SpanContext span_context = 3;
 }
@@ -311,7 +311,7 @@ message EnrichedEntryHeader {
     }
 
     message CompleteAwakeable {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         uint32 entry_index = 2;
     }
 
@@ -404,17 +404,17 @@ message OutboxMessage {
     }
 
     message OutboxServiceInvocationResponse {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
         uint32 entry_index = 2;
         ResponseResult response_result = 3;
     }
 
     message OutboxKill {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
     }
 
     message OutboxCancel {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
     }
 
     oneof outbox_message {
@@ -437,7 +437,7 @@ message Timer {
     }
 
     message CleanInvocationStatus {
-        bytes invocation_id = 1;
+        InvocationId invocation_id = 1;
     }
 
     oneof value {
@@ -478,7 +478,7 @@ message DedupSequenceNumber {
 // ---------------------------------------------------------------------
 
 message IdempotencyMetadata {
-    bytes invocation_id = 1;
+    InvocationId invocation_id = 1;
 }
 
 message IdempotentRequestMetadata {

--- a/crates/storage-api/src/storage.rs
+++ b/crates/storage-api/src/storage.rs
@@ -1920,7 +1920,7 @@ pub mod v1 {
                 Ok(
                     match value.value.ok_or(ConversionError::missing_field("value"))? {
                         timer::Value::CompleteSleepEntry(cse) => {
-                            crate::timer_table::Timer::CompleteSleepEntry(
+                            crate::timer_table::Timer::CompleteJournalEntry(
                                 restate_types::identifiers::InvocationId::try_from(
                                     cse.invocation_id
                                         .ok_or(ConversionError::missing_field("invocation_id"))?,
@@ -1949,7 +1949,7 @@ pub mod v1 {
             fn from(value: crate::timer_table::Timer) -> Self {
                 Timer {
                     value: Some(match value {
-                        crate::timer_table::Timer::CompleteSleepEntry(
+                        crate::timer_table::Timer::CompleteJournalEntry(
                             invocation_id,
                             entry_index,
                         ) => timer::Value::CompleteSleepEntry(timer::CompleteSleepEntry {

--- a/crates/storage-api/src/timer_table/mod.rs
+++ b/crates/storage-api/src/timer_table/mod.rs
@@ -42,7 +42,7 @@ impl Ord for TimerKey {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Timer {
-    CompleteSleepEntry(PartitionKey),
+    CompleteSleepEntry(InvocationId, u32),
     Invoke(ServiceInvocation),
     CleanInvocationStatus(InvocationId),
 }
@@ -50,7 +50,7 @@ pub enum Timer {
 impl WithPartitionKey for Timer {
     fn partition_key(&self) -> PartitionKey {
         match self {
-            Timer::CompleteSleepEntry(partition_key) => *partition_key,
+            Timer::CompleteSleepEntry(invocation_id, _) => invocation_id.partition_key(),
             Timer::Invoke(service_invocation) => service_invocation.partition_key(),
             Timer::CleanInvocationStatus(invocation_id) => invocation_id.partition_key(),
         }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -294,6 +294,12 @@ impl From<u128> for InvocationUuid {
     }
 }
 
+impl From<InvocationUuid> for u128 {
+    fn from(value: InvocationUuid) -> Self {
+        value.0.into()
+    }
+}
+
 impl From<InvocationUuid> for opentelemetry::trace::TraceId {
     fn from(value: InvocationUuid) -> Self {
         Self::from_bytes(value.to_bytes())

--- a/crates/types/src/timer.rs
+++ b/crates/types/src/timer.rs
@@ -19,7 +19,7 @@ pub trait Timer: Hash + Eq + Borrow<Self::TimerKey> {
     fn timer_key(&self) -> &Self::TimerKey;
 }
 
-/// Timer key establishes an absolute order on [`Timer`]. Naturally, this should be key under
+/// Timer key establishes an absolute order on [`Timer`]. Naturally, this should be the key under
 /// which the timer value is stored and can be retrieved.
 pub trait TimerKey: Ord + Clone + Hash + Debug {
     fn wake_up_time(&self) -> MillisSinceEpoch;

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -20,7 +20,7 @@ use restate_types::{flexbuffers_storage_encode_decode, Version};
 
 use crate::control::AnnounceLeader;
 use crate::effects::BuiltinServiceEffects;
-use crate::timer::TimerValue;
+use crate::timer::TimerKeyValue;
 use restate_types::logs::{LogId, Lsn, Payload};
 use restate_types::partition_table::{FindPartition, PartitionTableError};
 use restate_types::storage::{StorageCodec, StorageDecodeError, StorageEncodeError};
@@ -134,9 +134,9 @@ pub enum Command {
     /// Invoker is reporting effect(s) from an ongoing invocation.
     InvokerEffect(restate_invoker_api::Effect),
     /// Timer has fired
-    Timer(TimerValue),
+    Timer(TimerKeyValue),
     /// Schedule timer
-    ScheduleTimer(TimerValue),
+    ScheduleTimer(TimerKeyValue),
     /// Another partition processor is reporting a response of an invocation we requested.
     InvocationResponse(InvocationResponse),
     /// A built-in invoker reporting effects from an invocation.

--- a/crates/wal-protocol/src/timer.rs
+++ b/crates/wal-protocol/src/timer.rs
@@ -28,12 +28,12 @@ impl TimerValue {
         Self { timer_key, value }
     }
 
-    pub fn new_sleep(
+    pub fn complete_journal_entry(
         invocation_id: InvocationId,
         wake_up_time: MillisSinceEpoch,
         entry_index: EntryIndex,
     ) -> Self {
-        let timer_key = TimerKey::new_journal_entry(
+        let timer_key = TimerKey::complete_journal_entry(
             wake_up_time.as_u64(),
             invocation_id.invocation_uuid(),
             entry_index,
@@ -41,17 +41,16 @@ impl TimerValue {
 
         Self {
             timer_key,
-            value: Timer::CompleteSleepEntry(invocation_id, entry_index),
+            value: Timer::CompleteJournalEntry(invocation_id, entry_index),
         }
     }
 
-    pub fn new_invoke(
+    pub fn invoke(
         invocation_id: InvocationId,
         wake_up_time: MillisSinceEpoch,
         service_invocation: ServiceInvocation,
     ) -> Self {
-        let timer_key =
-            TimerKey::new_invocation(wake_up_time.as_u64(), invocation_id.invocation_uuid());
+        let timer_key = TimerKey::invoke(wake_up_time.as_u64(), invocation_id.invocation_uuid());
 
         Self {
             timer_key,
@@ -59,12 +58,12 @@ impl TimerValue {
         }
     }
 
-    pub fn new_clean_invocation_status(
+    pub fn clean_invocation_status(
         invocation_id: InvocationId,
         wake_up_time: MillisSinceEpoch,
     ) -> Self {
         TimerValue {
-            timer_key: TimerKey::new_invocation(
+            timer_key: TimerKey::clean_invocation_status(
                 wake_up_time.as_u64(),
                 invocation_id.invocation_uuid(),
             ),
@@ -132,11 +131,20 @@ pub struct TimerKeyDisplay<'a>(pub &'a TimerKey);
 impl<'a> fmt::Display for TimerKeyDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0.kind {
-            TimerKind::Invocation { invocation_uuid } => write!(f, "{}", invocation_uuid),
-            TimerKind::Journal {
+            TimerKind::Invoke { invocation_uuid } => {
+                write!(f, "Delayed invocation '{}'", invocation_uuid)
+            }
+            TimerKind::CompleteJournalEntry {
                 invocation_uuid,
                 journal_index,
-            } => write!(f, "{}[{}]", invocation_uuid, journal_index),
+            } => write!(
+                f,
+                "Complete journal entry [{}] for '{}'",
+                journal_index, invocation_uuid
+            ),
+            TimerKind::CleanInvocationStatus { invocation_uuid } => {
+                write!(f, "Clean invocation status '{}'", invocation_uuid)
+            }
         }
     }
 }

--- a/crates/wal-protocol/src/timer.rs
+++ b/crates/wal-protocol/src/timer.rs
@@ -44,7 +44,7 @@ impl TimerValue {
 
         Self {
             timer_key,
-            value: Timer::CompleteSleepEntry(invocation_id.partition_key()),
+            value: Timer::CompleteSleepEntry(invocation_id, entry_index),
         }
     }
 

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -14,7 +14,7 @@ use restate_core::metadata;
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
 use restate_types::time::MillisSinceEpoch;
-use restate_wal_protocol::timer::TimerValue;
+use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{
     append_envelope_to_bifrost, Command, Destination, Envelope, Header, Source,
 };
@@ -81,9 +81,9 @@ impl ActionEffectHandler {
                     &mut self.bifrost,
                     Envelope::new(
                         header.clone(),
-                        Command::ScheduleTimer(TimerValue::clean_invocation_status(
-                            invocation_id,
+                        Command::ScheduleTimer(TimerKeyValue::clean_invocation_status(
                             MillisSinceEpoch::from(SystemTime::now() + duration),
+                            invocation_id,
                         )),
                     ),
                 )

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -81,7 +81,7 @@ impl ActionEffectHandler {
                     &mut self.bifrost,
                     Envelope::new(
                         header.clone(),
-                        Command::ScheduleTimer(TimerValue::new_clean_invocation_status(
+                        Command::ScheduleTimer(TimerValue::clean_invocation_status(
                             invocation_id,
                             MillisSinceEpoch::from(SystemTime::now() + duration),
                         )),

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -12,7 +12,6 @@ use super::leadership::ActionEffect;
 use restate_bifrost::Bifrost;
 use restate_core::metadata;
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
-use restate_storage_api::timer_table::{Timer, TimerKey};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
 use restate_types::time::MillisSinceEpoch;
 use restate_wal_protocol::timer::TimerValue;
@@ -82,14 +81,9 @@ impl ActionEffectHandler {
                     &mut self.bifrost,
                     Envelope::new(
                         header.clone(),
-                        Command::ScheduleTimer(TimerValue::new(
-                            TimerKey {
-                                timestamp: MillisSinceEpoch::from(SystemTime::now() + duration)
-                                    .as_u64(),
-                                invocation_uuid: invocation_id.invocation_uuid(),
-                                journal_index: 0,
-                            },
-                            Timer::CleanInvocationStatus(invocation_id),
+                        Command::ScheduleTimer(TimerValue::new_clean_invocation_status(
+                            invocation_id,
+                            MillisSinceEpoch::from(SystemTime::now() + duration),
                         )),
                     ),
                 )

--- a/crates/worker/src/partition/leadership/action_collector.rs
+++ b/crates/worker/src/partition/leadership/action_collector.rs
@@ -11,7 +11,7 @@
 use crate::partition::shuffle;
 use futures::{Stream, StreamExt};
 use restate_types::identifiers::InvocationId;
-use restate_wal_protocol::timer::TimerValue;
+use restate_wal_protocol::timer::TimerKeyValue;
 use std::ops::DerefMut;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -46,7 +46,7 @@ impl ActionEffectStream {
 pub(crate) enum ActionEffect {
     Invoker(restate_invoker_api::Effect),
     Shuffle(shuffle::OutboxTruncation),
-    Timer(TimerValue),
+    Timer(TimerKeyValue),
     ScheduleCleanupTimer(InvocationId, Duration),
 }
 

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -37,12 +37,12 @@ use restate_partition_store::PartitionStore;
 use restate_storage_api::deduplication_table::EpochSequenceNumber;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
-use restate_wal_protocol::timer::TimerValue;
+use restate_wal_protocol::timer::TimerKeyValue;
 
 use super::storage::invoker::InvokerStorageReader;
 
 type PartitionStorage = storage::PartitionStorage<PartitionStore>;
-type TimerService = restate_timer::TimerService<TimerValue, TokioClock, PartitionStorage>;
+type TimerService = restate_timer::TimerService<TimerKeyValue, TokioClock, PartitionStorage>;
 
 pub(crate) struct LeaderState {
     leader_epoch: LeaderEpoch,
@@ -294,7 +294,7 @@ where
         }
     }
 
-    pub(crate) async fn run_timer(&mut self) -> TimerValue {
+    pub(crate) async fn run_timer(&mut self) -> TimerKeyValue {
         match self {
             LeadershipState::Follower { .. } => future::pending().await,
             LeadershipState::Leader {

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -364,9 +364,7 @@ where
                 message,
             } => shuffle_hint_tx.send(shuffle::NewOutboxMessage::new(seq_number, message)),
             Action::RegisterTimer { timer_value } => timer_service.as_mut().add_timer(timer_value),
-            Action::DeleteTimer { timer_key } => {
-                timer_service.as_mut().remove_timer(timer_key.into())
-            }
+            Action::DeleteTimer { timer_key } => timer_service.as_mut().remove_timer(timer_key),
             Action::AckStoredEntry {
                 invocation_id,
                 entry_index,

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -16,7 +16,7 @@ use restate_types::ingress::IngressResponse;
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal::Completion;
 use restate_types::message::MessageIndex;
-use restate_wal_protocol::timer::TimerValue;
+use restate_wal_protocol::timer::TimerKeyValue;
 use std::time::Duration;
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ pub enum Action {
         message: OutboxMessage,
     },
     RegisterTimer {
-        timer_value: TimerValue,
+        timer_value: TimerKeyValue,
     },
     DeleteTimer {
         timer_key: TimerKey,

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -253,8 +253,6 @@ where
                 TimerValue::new_invoke(
                     service_invocation.invocation_id,
                     execution_time,
-                    // This entry_index here makes little sense
-                    0,
                     service_invocation,
                 ),
                 span_context,
@@ -754,11 +752,11 @@ where
                                 ProtobufRawEntryCodec::deserialize(EntryType::Sleep, entry)?
                         );
 
-                        let timer_key = TimerKey {
-                            invocation_uuid: invocation_id.invocation_uuid(),
+                        let timer_key = TimerKey::new_journal_entry(
+                            wake_up_time,
+                            invocation_id.invocation_uuid(),
                             journal_index,
-                            timestamp: wake_up_time,
-                        };
+                        );
 
                         effects.delete_timer(timer_key);
                     }

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -809,15 +809,12 @@ where
         effects: &mut Effects,
     ) -> Result<(), Error> {
         let (key, value) = timer_value.into_inner();
-        let invocation_uuid = key.invocation_uuid;
-        let entry_index = key.journal_index;
-
         effects.delete_timer(key);
 
         match value {
-            Timer::CompleteSleepEntry(partition_key) => {
+            Timer::CompleteSleepEntry(invocation_id, entry_index) => {
                 Self::handle_completion(
-                    InvocationId::from_parts(partition_key, invocation_uuid),
+                    invocation_id,
                     Completion {
                         entry_index,
                         result: CompletionResult::Empty,

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -250,7 +250,7 @@ where
         if let Some(execution_time) = service_invocation.execution_time {
             let span_context = service_invocation.span_context.clone();
             effects.register_timer(
-                TimerValue::new_invoke(
+                TimerValue::invoke(
                     service_invocation.invocation_id,
                     execution_time,
                     service_invocation,
@@ -752,7 +752,7 @@ where
                                 ProtobufRawEntryCodec::deserialize(EntryType::Sleep, entry)?
                         );
 
-                        let timer_key = TimerKey::new_journal_entry(
+                        let timer_key = TimerKey::complete_journal_entry(
                             wake_up_time,
                             invocation_id.invocation_uuid(),
                             journal_index,
@@ -810,7 +810,7 @@ where
         effects.delete_timer(key);
 
         match value {
-            Timer::CompleteSleepEntry(invocation_id, entry_index) => {
+            Timer::CompleteJournalEntry(invocation_id, entry_index) => {
                 Self::handle_completion(
                     invocation_id,
                     Completion {
@@ -1301,7 +1301,7 @@ where
                         journal_entry.deserialize_entry_ref::<Codec>()?
                 );
                 effects.register_timer(
-                    TimerValue::new_sleep(
+                    TimerValue::complete_journal_entry(
                         invocation_id,
                         MillisSinceEpoch::new(wake_up_time),
                         entry_index,

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -12,6 +12,7 @@ use restate_service_protocol::pb::protocol::SleepEntryMessage;
 use restate_storage_api::idempotency_table::IdempotencyMetadata;
 use restate_storage_api::inbox_table::SequenceNumberInboxEntry;
 use restate_storage_api::invocation_status_table::{JournalMetadata, StatusTimestamps};
+use restate_storage_api::timer_table::TimerKind;
 use restate_storage_api::{Result as StorageResult, StorageError};
 use restate_test_util::matchers::*;
 use restate_test_util::{assert_eq, let_assert};
@@ -762,7 +763,9 @@ fn forward_canceled_completion_matcher(entry_index: EntryIndex) -> impl Matcher<
 
 fn delete_timer(entry_index: EntryIndex) -> impl Matcher<ActualT = Effect> {
     pat!(Effect::DeleteTimer(pat!(TimerKey {
-        journal_index: eq(entry_index),
+        kind: pat!(TimerKind::Journal {
+            journal_index: eq(entry_index),
+        }),
         timestamp: eq(1337),
     })))
 }

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -763,7 +763,7 @@ fn forward_canceled_completion_matcher(entry_index: EntryIndex) -> impl Matcher<
 
 fn delete_timer(entry_index: EntryIndex) -> impl Matcher<ActualT = Effect> {
     pat!(Effect::DeleteTimer(pat!(TimerKey {
-        kind: pat!(TimerKind::Journal {
+        kind: pat!(TimerKind::CompleteJournalEntry {
             journal_index: eq(entry_index),
         }),
         timestamp: eq(1337),

--- a/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/tests.rs
@@ -12,7 +12,7 @@ use restate_service_protocol::pb::protocol::SleepEntryMessage;
 use restate_storage_api::idempotency_table::IdempotencyMetadata;
 use restate_storage_api::inbox_table::SequenceNumberInboxEntry;
 use restate_storage_api::invocation_status_table::{JournalMetadata, StatusTimestamps};
-use restate_storage_api::timer_table::TimerKind;
+use restate_storage_api::timer_table::{TimerKey, TimerKeyKind};
 use restate_storage_api::{Result as StorageResult, StorageError};
 use restate_test_util::matchers::*;
 use restate_test_util::{assert_eq, let_assert};
@@ -763,7 +763,7 @@ fn forward_canceled_completion_matcher(entry_index: EntryIndex) -> impl Matcher<
 
 fn delete_timer(entry_index: EntryIndex) -> impl Matcher<ActualT = Effect> {
     pat!(Effect::DeleteTimer(pat!(TimerKey {
-        kind: pat!(TimerKind::CompleteJournalEntry {
+        kind: pat!(TimerKeyKind::CompleteJournalEntry {
             journal_index: eq(entry_index),
         }),
         timestamp: eq(1337),

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -416,7 +416,7 @@ impl Effect {
                 span_context,
                 ..
             } => match timer_value.value() {
-                Timer::CompleteSleepEntry(invocation_id, entry_index) => {
+                Timer::CompleteJournalEntry(_, entry_index) => {
                     info_span_if_leader!(
                         is_leader,
                         span_context.is_sampled(),
@@ -450,7 +450,7 @@ impl Effect {
                         "Effect: Register background invoke timer"
                     )
                 }
-                Timer::CleanInvocationStatus(invocation_id) => {
+                Timer::CleanInvocationStatus(_) => {
                     debug_if_leader!(
                         is_leader,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -422,7 +422,6 @@ impl Effect {
                         span_context.is_sampled(),
                         span_context.as_parent(),
                         "sleep",
-                        restate.invocation.id = %invocation_id,
                         restate.journal.index = entry_index,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
                         restate.timer.key = %TimerKeyDisplay(timer_value.key()),
@@ -434,7 +433,6 @@ impl Effect {
                     debug_if_leader!(
                         is_leader,
                         restate.journal.index = entry_index,
-                        restate.invocation.id = %invocation_id,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
                         restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         "Effect: Register Sleep timer"
@@ -446,7 +444,6 @@ impl Effect {
                         is_leader,
                         rpc.service = %service_invocation.invocation_target.service_name(),
                         rpc.method = %service_invocation.invocation_target.handler_name(),
-                        restate.invocation.id = %service_invocation.invocation_id,
                         restate.invocation.target = %service_invocation.invocation_target,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
                         restate.timer.key = %TimerKeyDisplay(timer_value.key()),
@@ -456,7 +453,6 @@ impl Effect {
                 Timer::CleanInvocationStatus(invocation_id) => {
                     debug_if_leader!(
                         is_leader,
-                        restate.invocation.id = %invocation_id,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
                         restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         "Effect: Register cleanup invocation status timer"

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -416,15 +416,16 @@ impl Effect {
                 span_context,
                 ..
             } => match timer_value.value() {
-                Timer::CompleteSleepEntry(_) => {
+                Timer::CompleteSleepEntry(invocation_id, entry_index) => {
                     info_span_if_leader!(
                         is_leader,
                         span_context.is_sampled(),
                         span_context.as_parent(),
                         "sleep",
-                        restate.invocation.id = %timer_value.invocation_id(),
-                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
+                        restate.invocation.id = %invocation_id,
+                        restate.journal.index = entry_index,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
+                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         // without converting to i64 this field will encode as a string
                         // however, overflowing i64 seems unlikely
                         restate.internal.end_time = i64::try_from(timer_value.wake_up_time().as_u64()).expect("wake up time should fit into i64"),
@@ -432,8 +433,10 @@ impl Effect {
 
                     debug_if_leader!(
                         is_leader,
-                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
+                        restate.journal.index = entry_index,
+                        restate.invocation.id = %invocation_id,
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
+                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         "Effect: Register Sleep timer"
                     )
                 }
@@ -445,8 +448,8 @@ impl Effect {
                         rpc.method = %service_invocation.invocation_target.handler_name(),
                         restate.invocation.id = %service_invocation.invocation_id,
                         restate.invocation.target = %service_invocation.invocation_target,
-                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
+                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         "Effect: Register background invoke timer"
                     )
                 }
@@ -454,8 +457,8 @@ impl Effect {
                     debug_if_leader!(
                         is_leader,
                         restate.invocation.id = %invocation_id,
-                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         restate.timer.wake_up_time = %timer_value.wake_up_time(),
+                        restate.timer.key = %TimerKeyDisplay(timer_value.key()),
                         "Effect: Register cleanup invocation status timer"
                     )
                 }

--- a/crates/worker/src/partition/state_machine/effects.rs
+++ b/crates/worker/src/partition/state_machine/effects.rs
@@ -33,7 +33,7 @@ use restate_types::message::MessageIndex;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_types::time::MillisSinceEpoch;
 use restate_wal_protocol::timer::TimerKeyDisplay;
-use restate_wal_protocol::timer::TimerValue;
+use restate_wal_protocol::timer::TimerKeyValue;
 use std::collections::HashSet;
 use std::fmt;
 use std::time::Duration;
@@ -99,7 +99,7 @@ pub(crate) enum Effect {
 
     // Timers
     RegisterTimer {
-        timer_value: TimerValue,
+        timer_value: TimerKeyValue,
         span_context: ServiceInvocationSpanContext,
     },
     DeleteTimer(TimerKey),
@@ -827,7 +827,7 @@ impl Effects {
 
     pub(crate) fn register_timer(
         &mut self,
-        timer_value: TimerValue,
+        timer_value: TimerKeyValue,
         span_context: ServiceInvocationSpanContext,
     ) {
         self.effects.push(Effect::RegisterTimer {

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -729,11 +729,11 @@ mod tests {
             IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
         };
         use restate_storage_api::invocation_status_table::{CompletedInvocation, StatusTimestamps};
-        use restate_storage_api::timer_table::{Timer, TimerKey, TimerKind};
+        use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind};
         use restate_types::errors::GONE_INVOCATION_ERROR;
         use restate_types::identifiers::IdempotencyId;
         use restate_types::invocation::{Idempotency, InvocationTarget};
-        use restate_wal_protocol::timer::TimerValue;
+        use restate_wal_protocol::timer::TimerKeyValue;
         use test_log::test;
 
         #[test(tokio::test)]
@@ -1120,9 +1120,9 @@ mod tests {
 
             // Send timer fired command
             let _ = state_machine
-                .apply(Command::Timer(TimerValue::new(
+                .apply(Command::Timer(TimerKeyValue::new(
                     TimerKey {
-                        kind: TimerKind::Invoke {
+                        kind: TimerKeyKind::Invoke {
                             invocation_uuid: invocation_id.invocation_uuid(),
                         },
                         timestamp: 0,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -1122,7 +1122,7 @@ mod tests {
             let _ = state_machine
                 .apply(Command::Timer(TimerValue::new(
                     TimerKey {
-                        kind: TimerKind::Invocation {
+                        kind: TimerKind::Invoke {
                             invocation_uuid: invocation_id.invocation_uuid(),
                         },
                         timestamp: 0,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -729,7 +729,7 @@ mod tests {
             IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
         };
         use restate_storage_api::invocation_status_table::{CompletedInvocation, StatusTimestamps};
-        use restate_storage_api::timer_table::{Timer, TimerKey};
+        use restate_storage_api::timer_table::{Timer, TimerKey, TimerKind};
         use restate_types::errors::GONE_INVOCATION_ERROR;
         use restate_types::identifiers::IdempotencyId;
         use restate_types::invocation::{Idempotency, InvocationTarget};
@@ -1122,9 +1122,10 @@ mod tests {
             let _ = state_machine
                 .apply(Command::Timer(TimerValue::new(
                     TimerKey {
+                        kind: TimerKind::Invocation {
+                            invocation_uuid: invocation_id.invocation_uuid(),
+                        },
                         timestamp: 0,
-                        invocation_uuid: invocation_id.invocation_uuid(),
-                        journal_index: 0,
                     },
                     Timer::CleanInvocationStatus(invocation_id),
                 )))

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -40,7 +40,7 @@ use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::CompletionResult;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
-use restate_wal_protocol::timer::{TimerKeyWrapper, TimerValue};
+use restate_wal_protocol::timer::TimerValue;
 use std::future::Future;
 use std::ops::RangeInclusive;
 
@@ -673,14 +673,10 @@ where
     async fn get_timers(
         &mut self,
         num_timers: usize,
-        previous_timer_key: Option<TimerKeyWrapper>,
+        previous_timer_key: Option<TimerKey>,
     ) -> Vec<TimerValue> {
         self.storage
-            .next_timers_greater_than(
-                self.partition_id,
-                previous_timer_key.map(|t| t.into_inner()).as_ref(),
-                num_timers,
-            )
+            .next_timers_greater_than(self.partition_id, previous_timer_key.as_ref(), num_timers)
             .map(|result| result.map(|(timer_key, timer)| TimerValue::new(timer_key, timer)))
             // TODO: Update timer service to maintain transaction while reading the timer stream: See https://github.com/restatedev/restate/issues/273
             // have to collect the stream because it depends on the local transaction

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -40,7 +40,7 @@ use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::CompletionResult;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
-use restate_wal_protocol::timer::TimerValue;
+use restate_wal_protocol::timer::TimerKeyValue;
 use std::future::Future;
 use std::ops::RangeInclusive;
 
@@ -666,7 +666,7 @@ where
     }
 }
 
-impl<Storage> TimerReader<TimerValue> for PartitionStorage<Storage>
+impl<Storage> TimerReader<TimerKeyValue> for PartitionStorage<Storage>
 where
     for<'a> Storage: TimerTable + Send + Sync + 'a,
 {
@@ -674,10 +674,10 @@ where
         &mut self,
         num_timers: usize,
         previous_timer_key: Option<TimerKey>,
-    ) -> Vec<TimerValue> {
+    ) -> Vec<TimerKeyValue> {
         self.storage
             .next_timers_greater_than(self.partition_id, previous_timer_key.as_ref(), num_timers)
-            .map(|result| result.map(|(timer_key, timer)| TimerValue::new(timer_key, timer)))
+            .map(|result| result.map(|(timer_key, timer)| TimerKeyValue::new(timer_key, timer)))
             // TODO: Update timer service to maintain transaction while reading the timer stream: See https://github.com/restatedev/restate/issues/273
             // have to collect the stream because it depends on the local transaction
             .try_collect::<Vec<_>>()


### PR DESCRIPTION
The TimerKind is used to store differently typed timers. Currently,
we support journal scoped timers that are scoped to a certain journal
entry. Additionally, we support invocation scoped timers that are scoped
to an invocation (e.g. only a single timer for a given wake up time for
a given invocation can exist).

This fixes https://github.com/restatedev/restate/issues/1417.

Only the commits starting from 6ab9fdf are relevant for this PR.