### PR TITLE
[Bifrost] Support append_batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6327,6 +6327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "tempfile",
  "test-log",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ static_assertions = { version = "1.1.0" }
 strum = { version = "0.26.1" }
 strum_macros = { version = "0.26.1" }
 sync_wrapper = "0.1.2"
+smallvec = { version = "1.13.2", features = ["serde"] }
 tempfile = "3.6.0"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 # tikv-jemallocator has not yet been released with musl target support, so we pin a main commit

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -24,6 +24,7 @@ codederror = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }
+futures = { workspace = true }
 humantime = { workspace = true }
 metrics = { workspace = true }
 once_cell = { workspace = true }
@@ -32,7 +33,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-smallvec = { version = "1.13.2", features = ["serde"] }
+smallvec = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
@@ -48,7 +49,6 @@ restate-metadata-store = { workspace = true }
 restate-test-util = { workspace = true }
 
 criterion = { workspace = true, features = ["async_tokio"] }
-futures = { workspace = true }
 googletest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -24,3 +24,5 @@ pub use read_stream::LogReadStream;
 pub use record::*;
 pub use service::BifrostService;
 pub use types::*;
+
+pub const SMALL_BATCH_THRESHOLD_COUNT: usize = 4;

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::Add;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -43,6 +44,14 @@ pub fn create_provider(kind: ProviderKind) -> Result<Arc<dyn LogletProvider>, Pr
     derive_more::Display,
 )]
 pub struct LogletOffset(pub(crate) u64);
+
+impl Add<usize> for LogletOffset {
+    type Output = Self;
+    fn add(self, rhs: usize) -> Self {
+        // we always assume that we are running on a 64bit cpu arch.
+        Self(self.0.saturating_add(rhs as u64))
+    }
+}
 
 impl SequenceNumber for LogletOffset {
     const MAX: Self = LogletOffset(u64::MAX);
@@ -107,6 +116,10 @@ pub trait LogletBase: Send + Sync {
     /// Append a record to the loglet.
     async fn append(&self, data: Bytes) -> Result<Self::Offset, Error>;
 
+    /// Append a batch of records to the loglet. The returned offset (on success) if the offset of
+    /// the first record in the batch)
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Self::Offset, Error>;
+
     /// Find the tail of the loglet. If the loglet is empty or have been trimmed, the loglet should
     /// return `None`.
     async fn find_tail(&self) -> Result<Option<Self::Offset>, Error>;
@@ -136,6 +149,11 @@ impl LogletBase for LogletWrapper {
     async fn append(&self, data: Bytes) -> Result<Lsn, Error> {
         let offset = self.loglet.append(data).await?;
         // Return the LSN given the loglet offset.
+        Ok(self.base_lsn.offset_by(offset))
+    }
+
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Lsn, Error> {
+        let offset = self.loglet.append_batch(payloads).await?;
         Ok(self.base_lsn.offset_by(offset))
     }
 

--- a/crates/bifrost/src/loglets/local_loglet/metric_definitions.rs
+++ b/crates/bifrost/src/loglets/local_loglet/metric_definitions.rs
@@ -17,12 +17,31 @@ pub(crate) const BIFROST_LOCAL_APPEND: &str = "restate.bifrost.localloglet.appen
 pub(crate) const BIFROST_LOCAL_APPEND_DURATION: &str =
     "restate.bifrost.localloglet.append_duration.seconds";
 
+pub(crate) const BIFROST_LOCAL_WRITE_BATCH_COUNT: &str =
+    "restate.bifrost.localloglet.write_batch_count";
+
+pub(crate) const BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES: &str =
+    "restate.bifrost.localloglet.write_batch_size_bytes";
+
 pub(crate) fn describe_metrics() {
     describe_counter!(
         BIFROST_LOCAL_APPEND,
         Unit::Count,
         "Number of append requests to bifrost's local loglet"
     );
+
+    describe_histogram!(
+        BIFROST_LOCAL_WRITE_BATCH_COUNT,
+        Unit::Count,
+        "Histogram of the number of records in each append request to local loglet"
+    );
+
+    describe_histogram!(
+        BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES,
+        Unit::Bytes,
+        "Histogram of size in bytes of local loglet write batches"
+    );
+
     describe_histogram!(
         BIFROST_LOCAL_APPEND_DURATION,
         Unit::Seconds,

--- a/crates/bifrost/src/loglets/local_loglet/mod.rs
+++ b/crates/bifrost/src/loglets/local_loglet/mod.rs
@@ -159,18 +159,48 @@ impl LogletBase for LocalLoglet {
         let (receiver, offset) = {
             let mut next_offset_guard = self.next_write_offset.lock().await;
             // lock acquired
-            let offset = next_offset_guard.next();
+            let offset = *next_offset_guard;
             let receiver = self
                 .log_writer
-                .enqueue_put_record(
-                    self.log_id,
-                    offset,
-                    payload,
-                    true, /* release_immediately */
-                )
+                .enqueue_put_record(self.log_id, offset, payload)
                 .await?;
-            *next_offset_guard = offset;
+            // next offset points to the next available slot.
+            *next_offset_guard = offset.next();
             (receiver, offset)
+            // lock dropped
+        };
+
+        let _ = receiver.await.unwrap_or_else(|_| {
+            warn!("Unsure if the local loglet record was written, the ack channel was dropped");
+            Err(Error::Shutdown(ShutdownError))
+        })?;
+
+        self.last_committed_offset
+            .fetch_max(offset.into(), Ordering::Relaxed);
+        self.notify_readers();
+        histogram!(BIFROST_LOCAL_APPEND_DURATION).record(start_time.elapsed());
+        Ok(offset)
+    }
+
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<LogletOffset, Error> {
+        let num_payloads = payloads.len();
+        counter!(BIFROST_LOCAL_APPEND).increment(num_payloads as u64);
+        let start_time = std::time::Instant::now();
+        // We hold the lock to ensure that offsets are enqueued in the order of
+        // their offsets in the logstore writer. This means that acknowledgements
+        // that an offset N from the writer imply that all previous offsets have
+        // been durably committed, therefore, such offsets can be released to readers.
+        let (receiver, offset) = {
+            let mut next_offset_guard = self.next_write_offset.lock().await;
+            let offset = *next_offset_guard;
+            // lock acquired
+            let receiver = self
+                .log_writer
+                .enqueue_put_records(self.log_id, *next_offset_guard, payloads)
+                .await?;
+            // next offset points to the next available slot.
+            *next_offset_guard = offset + num_payloads;
+            (receiver, next_offset_guard.prev())
             // lock dropped
         };
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -63,6 +63,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -9,17 +9,22 @@
 // by the Apache License, Version 2.0.
 
 use super::leadership::ActionEffect;
-use restate_bifrost::Bifrost;
-use restate_core::metadata;
+use futures::stream::FuturesUnordered;
+use restate_bifrost::{Bifrost, SMALL_BATCH_THRESHOLD_COUNT};
+use restate_core::{metadata, Metadata};
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
+use restate_types::logs::{LogId, Payload};
+use restate_types::partition_table::FindPartition;
 use restate_types::time::MillisSinceEpoch;
+use restate_types::Version;
 use restate_wal_protocol::timer::TimerKeyValue;
-use restate_wal_protocol::{
-    append_envelope_to_bifrost, Command, Destination, Envelope, Header, Source,
-};
+use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
+use smallvec::SmallVec;
+use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::time::SystemTime;
+use tokio_stream::StreamExt;
 
 /// Responsible for proposing [ActionEffect].
 pub(super) struct ActionEffectHandler {
@@ -27,6 +32,7 @@ pub(super) struct ActionEffectHandler {
     epoch_sequence_number: EpochSequenceNumber,
     partition_key_range: RangeInclusive<PartitionKey>,
     bifrost: Bifrost,
+    metadata: Metadata,
 }
 
 impl ActionEffectHandler {
@@ -35,62 +41,78 @@ impl ActionEffectHandler {
         epoch_sequence_number: EpochSequenceNumber,
         partition_key_range: RangeInclusive<PartitionKey>,
         bifrost: Bifrost,
+        metadata: Metadata,
     ) -> Self {
         Self {
             partition_id,
             epoch_sequence_number,
             partition_key_range,
             bifrost,
+            metadata,
         }
     }
 
-    pub(super) async fn handle(&mut self, actuator_output: ActionEffect) -> anyhow::Result<()> {
-        match actuator_output {
-            ActionEffect::Invoker(invoker_output) => {
-                let header = self.create_header(invoker_output.invocation_id.partition_key());
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
-                    Envelope::new(header, Command::InvokerEffect(invoker_output)),
-                )
-                .await?;
-            }
-            ActionEffect::Shuffle(outbox_truncation) => {
-                // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
-                //  specific destination messages that are identified by a partition_id
-                let header = self.create_header(*self.partition_key_range.start());
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
-                    Envelope::new(header, Command::TruncateOutbox(outbox_truncation.index())),
-                )
-                .await?;
-            }
-            ActionEffect::Timer(timer) => {
-                let partition_key = timer.invocation_id().partition_key();
-                let header = self.create_header(partition_key);
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
-                    Envelope::new(header, Command::Timer(timer)),
-                )
-                .await?;
-            }
-            ActionEffect::ScheduleCleanupTimer(invocation_id, duration) => {
-                // We need this self proposal because we need to agree between leaders and followers on the wakeup time.
-                //  We can get rid of this once we'll have a synchronized clock between leaders/followers.
-                let header = self.create_header(invocation_id.partition_key());
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
+    pub(super) async fn handle(
+        &mut self,
+        effects: impl IntoIterator<Item = ActionEffect>,
+    ) -> anyhow::Result<()> {
+        let partition_table = self.metadata.wait_for_partition_table(Version::MIN).await?;
+        // groups envelopes write to Bifrost in batches
+        let mut buffer: BTreeMap<LogId, SmallVec<[Payload; SMALL_BATCH_THRESHOLD_COUNT]>> =
+            Default::default();
+
+        for actuator_output in effects {
+            let envelope = match actuator_output {
+                ActionEffect::Invoker(invoker_output) => {
+                    let header = self.create_header(invoker_output.invocation_id.partition_key());
+                    Envelope::new(header, Command::InvokerEffect(invoker_output))
+                }
+                ActionEffect::Shuffle(outbox_truncation) => {
+                    // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
+                    //  specific destination messages that are identified by a partition_id
+                    let header = self.create_header(*self.partition_key_range.start());
+                    Envelope::new(header, Command::TruncateOutbox(outbox_truncation.index()))
+                }
+                ActionEffect::Timer(timer) => {
+                    let header = self.create_header(timer.invocation_id().partition_key());
+                    Envelope::new(header, Command::Timer(timer))
+                }
+                ActionEffect::ScheduleCleanupTimer(invocation_id, duration) => {
+                    //  We need this self proposal because we need to agree between leaders and followers on the wakeup time.
+                    //  We can get rid of this once we'll have a synchronized clock between leaders/followers.
+                    let header = self.create_header(invocation_id.partition_key());
                     Envelope::new(
-                        header.clone(),
+                        header,
                         Command::ScheduleTimer(TimerKeyValue::clean_invocation_status(
                             MillisSinceEpoch::from(SystemTime::now() + duration),
                             invocation_id,
                         )),
-                    ),
-                )
-                .await?;
-            }
-        };
+                    )
+                }
+            };
+            let log_id = LogId::from(partition_table.find_partition_id(envelope.partition_key())?);
+            buffer
+                .entry(log_id)
+                .or_default()
+                .push(Payload::new(envelope.to_bytes()?));
+        }
 
+        let mut batches = FuturesUnordered::new();
+
+        // Attempt to write batches to different log ids concurrently
+        for (log_id, payloads) in buffer {
+            let mut bifrost = self.bifrost.clone();
+            batches.push(async move {
+                bifrost.append_batch(log_id, &payloads).await?;
+                anyhow::Ok(())
+            });
+        }
+        while let Some(o) = batches.next().await {
+            // fail if any write fails. This is not the best approach to handle write errors,
+            // however this is how it was.
+            // todo: we should implement a better error handling mechanism
+            o?
+        }
         Ok(())
     }
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -240,14 +240,14 @@ where
                         histogram!(PP_APPLY_ACTIONS_DURATION).record(actions_start.elapsed());
                     }
                 },
-                action_effect = action_effect_stream.next() => {
-                    counter!(PARTITION_ACTUATOR_HANDLED).increment(1);
-                    let action_effect = action_effect.ok_or_else(|| anyhow::anyhow!("action effect stream is closed"))?;
-                    state.handle_action_effect(action_effect).await?;
+                action_effects = action_effect_stream.next() => {
+                    let action_effects = action_effects.ok_or_else(|| anyhow::anyhow!("action effect stream is closed"))?;
+                    counter!(PARTITION_ACTUATOR_HANDLED).increment(action_effects.len() as u64);
+                    state.handle_action_effect(action_effects).await?;
                 },
                 timer = state.run_timer() => {
                     counter!(PARTITION_TIMER_DUE_HANDLED).increment(1);
-                    state.handle_action_effect(ActionEffect::Timer(timer)).await?;
+                    state.handle_action_effect([ActionEffect::Timer(timer)]).await?;
                 },
             }
         }


### PR DESCRIPTION
[Bifrost] Support append_batch

This introduces a new append_batch API to bifrost that accepts a batch of payloads. In addition, we make use of this API to handle batches of action effects when consuming the effect stream. We attempt to batch up to 10 items (hardcoded at the moment) before sending them to bifrost.

Impact: For small invocations, we now average ~4 records (+1 for metadata) per batch since invoker emits input/get_state/output etc. in bursts. This reduces the overhead of handling the happy path of small handlers.

This also address a small issue where the the initial offsets leave an unnecessary gap on re-instantiation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1536).
* #1545
* #1546
* #1544
* __->__ #1536