### PR TITLE
Avoid using the default timeout during cli registration

### DIFF
--- a/cli/src/clients/metas_client.rs
+++ b/cli/src/clients/metas_client.rs
@@ -109,6 +109,10 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 impl MetasClient {
     pub fn new(env: &CliEnv) -> anyhow::Result<Self> {
+        Self::new_with_timeout(env, None)
+    }
+
+    pub fn new_with_timeout(env: &CliEnv, timeout: Option<Duration>) -> anyhow::Result<Self> {
         let raw_client = reqwest::Client::builder()
             .user_agent(format!(
                 "{}/{} {}-{}",
@@ -127,7 +131,9 @@ impl MetasClient {
             inner: raw_client,
             base_url,
             bearer_token,
-            request_timeout: env.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
+            request_timeout: timeout
+                .or(env.request_timeout)
+                .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
         })
     }
 

--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -11,6 +11,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::str::FromStr;
+use std::time::Duration;
 
 use crate::cli_env::CliEnv;
 use crate::clients::{MetaClientInterface, MetasClient, MetasClientError};
@@ -127,7 +128,9 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
     });
 
     // Preparing the discovery request
-    let client = crate::clients::MetasClient::new(&env)?;
+    // Discovery happens in a retry loop and can take 66 seconds presuming instant failures
+    let client =
+        crate::clients::MetasClient::new_with_timeout(&env, Some(Duration::from_secs(120)))?;
 
     let mk_request_body = |force, dry_run| match &discover_opts.deployment {
         DeploymentEndpoint::Uri(uri) => RegisterDeploymentRequest::Http {


### PR DESCRIPTION
On failed registrations this means that you never see the error, because the runtime retries take much longer than the 10 second default.