### PR TITLE
Send x-restate-id header back on each request

### DIFF
--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -234,6 +234,7 @@ impl MessageHandler for IngressDispatcher {
                         // TODO we need to add back the expiration time for idempotent results
                         idempotency_expiry_time: None,
                         result: invocation_response.response.clone(),
+                        invocation_id: invocation_response.correlation_ids.invocation_id,
                     };
                     if let Err(response) = sender.send(dispatcher_response) {
                         debug!(

--- a/crates/ingress-dispatcher/src/lib.rs
+++ b/crates/ingress-dispatcher/src/lib.rs
@@ -116,6 +116,7 @@ pub struct IngressDispatcherRequest {
 pub struct IngressInvocationResponse {
     pub idempotency_expiry_time: Option<String>,
     pub result: IngressResponseResult,
+    pub invocation_id: Option<InvocationId>,
 }
 
 pub type IngressDeduplicationId = (String, MessageIndex);

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -98,6 +98,7 @@ where
 
         Self::reply_with_invocation_response(
             response.result,
+            Some(invocation_id),
             response.idempotency_expiry_time.as_deref(),
             move |invocation_target| {
                 self.schemas
@@ -141,13 +142,18 @@ where
             }
         };
 
-        Self::reply_with_invocation_response(response.response, None, move |invocation_target| {
-            self.schemas
-                .resolve_latest_invocation_target(
-                    invocation_target.service_name(),
-                    invocation_target.handler_name(),
-                )
-                .ok_or(HandlerError::NotFound)
-        })
+        Self::reply_with_invocation_response(
+            response.response,
+            Some(invocation_id),
+            None,
+            move |invocation_target| {
+                self.schemas
+                    .resolve_latest_invocation_target(
+                        invocation_target.service_name(),
+                        invocation_target.handler_name(),
+                    )
+                    .ok_or(HandlerError::NotFound)
+            },
+        )
     }
 }

--- a/crates/ingress-http/src/handler/responses.rs
+++ b/crates/ingress-http/src/handler/responses.rs
@@ -20,6 +20,7 @@ use restate_types::invocation::InvocationTarget;
 use tracing::{info, trace};
 
 pub(crate) const IDEMPOTENCY_EXPIRES: HeaderName = HeaderName::from_static("idempotency-expires");
+/// Contains the string representation of the invocation id
 pub(crate) const X_RESTATE_ID: HeaderName = HeaderName::from_static("x-restate-id");
 
 impl<Schemas, Dispatcher, StorageReader> Handler<Schemas, Dispatcher, StorageReader> {

--- a/crates/ingress-http/src/handler/workflow.rs
+++ b/crates/ingress-http/src/handler/workflow.rs
@@ -94,6 +94,7 @@ where
 
         Self::reply_with_invocation_response(
             response.result,
+            response.invocation_id,
             response.idempotency_expiry_time.as_deref(),
             move |invocation_target| {
                 self.schemas
@@ -137,13 +138,18 @@ where
             }
         };
 
-        Self::reply_with_invocation_response(response.response, None, move |invocation_target| {
-            self.schemas
-                .resolve_latest_invocation_target(
-                    invocation_target.service_name(),
-                    invocation_target.handler_name(),
-                )
-                .ok_or(HandlerError::NotFound)
-        })
+        Self::reply_with_invocation_response(
+            response.response,
+            response.correlation_ids.invocation_id,
+            None,
+            move |invocation_target| {
+                self.schemas
+                    .resolve_latest_invocation_target(
+                        invocation_target.service_name(),
+                        invocation_target.handler_name(),
+                    )
+                    .ok_or(HandlerError::NotFound)
+            },
+        )
     }
 }

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -249,6 +249,7 @@ mod tests {
     use restate_ingress_dispatcher::mocks::MockDispatcher;
     use restate_ingress_dispatcher::{IngressDispatcherRequest, IngressInvocationResponse};
     use restate_test_util::assert_eq;
+    use restate_types::identifiers::InvocationId;
     use restate_types::ingress::IngressResponseResult;
     use serde::{Deserialize, Serialize};
     use std::net::SocketAddr;
@@ -287,6 +288,7 @@ mod tests {
             response_tx
                 .send(IngressInvocationResponse {
                     idempotency_expiry_time: None,
+                    invocation_id: Some(InvocationId::mock_random()),
                     result: IngressResponseResult::Success(
                         service_invocation.invocation_target,
                         serde_json::to_vec(&crate::mocks::GreetingResponse {


### PR DESCRIPTION
Fix #1258

I'm gonna use this header in the java sdk to remove the parsing of the json object for the /send requests.