### PR TITLE
Default to low-latency local loglet configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6327,6 +6327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "tempfile",
  "test-log",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "bifrost-benchpress"
+version = "0.9.1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "bytestring",
+ "clap",
+ "codederror",
+ "figment",
+ "futures",
+ "hdrhistogram",
+ "metrics",
+ "metrics-exporter-prometheus 0.14.0",
+ "once_cell",
+ "quanta",
+ "restate-bifrost",
+ "restate-core",
+ "restate-errors",
+ "restate-metadata-store",
+ "restate-rocksdb",
+ "restate-server",
+ "restate-test-util",
+ "restate-tracing-instrumentation",
+ "restate-types",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "static_assertions",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
+ "tempfile",
+ "thiserror",
+ "tikv-jemallocator",
+ "tokio",
+ "tokio-stream",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,6 +3002,7 @@ checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
+ "crossbeam-channel",
  "flate2",
  "nom",
  "num-traits",
@@ -3776,6 +3820,22 @@ checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
  "hyper 0.14.28",
+ "indexmap 2.2.6",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d58e362dc7206e9456ddbcdbd53c71ba441020e62104703075a69151e38d85f"
+dependencies = [
+ "base64 0.22.0",
+ "hyper-util",
  "indexmap 2.2.6",
  "metrics",
  "metrics-util",
@@ -4911,9 +4971,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -5721,7 +5781,7 @@ dependencies = [
  "humantime",
  "hyper 0.14.28",
  "metrics",
- "metrics-exporter-prometheus",
+ "metrics-exporter-prometheus 0.13.1",
  "metrics-tracing-context",
  "metrics-util",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ restate-admin = { path = "crates/admin" }
 restate-base64-util = { path = "crates/base64-util" }
 restate-benchmarks = { path = "crates/benchmarks" }
 restate-bifrost = { path = "crates/bifrost" }
+restate-bifrost-benchpress = { path = "crates/bifrost-benchpress" }
 restate-cluster-controller = { path = "crates/cluster-controller" }
 restate-core = { path = "crates/core" }
 restate-errors = { path = "crates/errors" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ static_assertions = { version = "1.1.0" }
 strum = { version = "0.26.1" }
 strum_macros = { version = "0.26.1" }
 sync_wrapper = "0.1.2"
+smallvec = { version = "1.13.2", features = ["serde"] }
 tempfile = "3.6.0"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 # tikv-jemallocator has not yet been released with musl target support, so we pin a main commit

--- a/crates/bifrost-benchpress/Cargo.toml
+++ b/crates/bifrost-benchpress/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "bifrost-benchpress"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+restate-bifrost = { workspace = true, features = ["test-util"] }
+restate-core = { workspace = true, features = ["test-util"] }
+restate-errors = { workspace = true }
+restate-metadata-store = { workspace = true }
+restate-rocksdb = { workspace = true }
+restate-server = { workspace = true }
+restate-test-util = { workspace = true }
+restate-tracing-instrumentation = { workspace = true, features = ["console-subscriber"] }
+restate-types = { workspace = true, features = ["test-util"] }
+
+anyhow = { workspace = true }
+bytes = { workspace = true }
+bytestring = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["derive", "env", "color", "help", "wrap_help", "usage", "suggestions", "error-context", "std"] }
+codederror = { workspace = true }
+figment = { version = "0.10.8", features = ["env", "toml"] }
+futures = { workspace = true }
+hdrhistogram = { version = "7.5.4" }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { version = "0.14", default-features = false, features = ["async-runtime"] }
+once_cell = { workspace = true }
+quanta = { version = "0.12.3" }
+rocksdb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+smallvec = { workspace = true }
+static_assertions = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
+tokio-stream = { workspace = true }
+toml = { version = "0.8" }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, features = ["unprefixed_malloc_on_supported_platforms"] }

--- a/crates/bifrost-benchpress/src/append_latency.rs
+++ b/crates/bifrost-benchpress/src/append_latency.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Instant;
+
+use bytes::{BufMut, BytesMut};
+use hdrhistogram::Histogram;
+use tracing::info;
+
+use restate_bifrost::Bifrost;
+use restate_core::TaskCenter;
+use restate_types::logs::{LogId, Payload};
+
+use crate::util::print_latencies;
+use crate::Arguments;
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct AppendLatencyOpts {
+    #[arg(long, default_value = "5000")]
+    pub num_records: u64,
+}
+
+pub async fn run(
+    _common_args: &Arguments,
+    opts: &AppendLatencyOpts,
+    _tc: TaskCenter,
+    mut bifrost: Bifrost,
+) -> anyhow::Result<()> {
+    let log_id = LogId::from(0);
+    let mut bytes = BytesMut::default();
+    let raw_data = [1u8; 1024];
+    bytes.put_slice(&raw_data);
+    let mut append_latencies = Histogram::<u64>::new(3)?;
+    let mut counter = 0;
+    loop {
+        if counter >= opts.num_records {
+            break;
+        }
+        counter += 1;
+        let start = Instant::now();
+        let payload = Payload::new(bytes.clone());
+        let _ = bifrost.append(log_id, payload).await?;
+        append_latencies.record(start.elapsed().as_nanos() as u64)?;
+        if counter % 1000 == 0 {
+            info!("Appended {} records", counter);
+        }
+    }
+    println!("Total records written: {}", counter);
+    print_latencies("append latency", append_latencies);
+    Ok(())
+}

--- a/crates/bifrost-benchpress/src/lib.rs
+++ b/crates/bifrost-benchpress/src/lib.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+
+use restate_types::config::CommonOptionCliOverride;
+
+use self::append_latency::AppendLatencyOpts;
+use self::read_to_write::WriteToReadOpts;
+
+pub mod append_latency;
+pub mod read_to_write;
+pub mod util;
+
+#[derive(Debug, Clone, clap::Parser)]
+#[command(author, version, about)]
+pub struct Arguments {
+    /// Set a configuration file to use for Restate.
+    /// For more details, check the documentation.
+    #[arg(
+        short,
+        long = "config-file",
+        env = "RESTATE_CONFIG",
+        value_name = "FILE"
+    )]
+    pub config_file: Option<PathBuf>,
+
+    #[arg(long)]
+    pub no_prometheus_stats: bool,
+
+    #[arg(long)]
+    pub no_rocksdb_stats: bool,
+
+    #[arg(long)]
+    pub retain_test_dir: bool,
+
+    #[clap(flatten)]
+    pub opts_overrides: CommonOptionCliOverride,
+
+    /// Choose the benchmark to run
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Clone, clap::Parser)]
+pub enum Command {
+    /// Measures the write-to-read latency for a single log
+    WriteToRead(WriteToReadOpts),
+    /// Measures the append latency for a single log
+    AppendLatency(AppendLatencyOpts),
+}

--- a/crates/bifrost-benchpress/src/main.rs
+++ b/crates/bifrost-benchpress/src/main.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use bifrost_benchpress::util::{print_prometheus_stats, print_rocksdb_stats};
+use clap::Parser;
+use codederror::CodedError;
+use tracing::trace;
+
+use bifrost_benchpress::{append_latency, read_to_write, Arguments, Command};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use restate_bifrost::{Bifrost, BifrostService};
+use restate_core::{
+    spawn_metadata_manager, MetadataManager, MockNetworkSender, TaskCenter, TaskCenterBuilder,
+};
+use restate_errors::fmt::RestateCode;
+use restate_metadata_store::{MetadataStoreClient, Precondition};
+use restate_rocksdb::RocksDbManager;
+use restate_server::config_loader::ConfigLoaderBuilder;
+use restate_tracing_instrumentation::init_tracing_and_logging;
+use restate_types::arc_util::Constant;
+use restate_types::config::{reset_base_temp_dir, reset_base_temp_dir_and_retain, Configuration};
+use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
+
+// Configure jemalloc similar to mimic restate server
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+fn main() -> anyhow::Result<()> {
+    let cli_args = Arguments::parse();
+    let tmp_base = if cli_args.retain_test_dir {
+        reset_base_temp_dir_and_retain()
+    } else {
+        reset_base_temp_dir()
+    };
+
+    // We capture the absolute path of the config file on startup before we change the current
+    // working directory (base-dir arg)
+    let config_path = cli_args
+        .config_file
+        .as_ref()
+        .map(|p| std::fs::canonicalize(p).expect("config-file path is valid"));
+
+    // Initial configuration loading
+    let config_loader = ConfigLoaderBuilder::default()
+        .load_env(true)
+        .path(config_path.clone())
+        .cli_override(cli_args.opts_overrides.clone())
+        .build()
+        .unwrap();
+
+    let mut config = match config_loader.load_once() {
+        Ok(c) => c,
+        Err(e) => {
+            // We cannot use tracing here as it's not configured yet
+            eprintln!("{}", e.decorate());
+            eprintln!("{:#?}", RestateCode::from(&e));
+            std::process::exit(1);
+        }
+    };
+
+    // just in case anything reads directly the base dir and it's not set correctly for any random
+    // reason.
+    config.common.set_base_dir(tmp_base.clone());
+
+    restate_types::config::set_current_config(config.clone());
+
+    let recorder = PrometheusBuilder::new().install_recorder().unwrap();
+    let (tc, bifrost) = spawn_environment(config.clone(), 1);
+    let task_center = tc.clone();
+    let args = cli_args.clone();
+    tc.block_on("benchpress", None, async move {
+        let tracing_guard = init_tracing_and_logging(&config.common, "Bifrost benchpress")
+            .expect("failed to configure logging and tracing!");
+
+        match args.command {
+            Command::WriteToRead(ref opts) => {
+                read_to_write::run(&args, opts, task_center.clone(), bifrost).await?;
+            }
+            Command::AppendLatency(ref opts) => {
+                append_latency::run(&args, opts, task_center.clone(), bifrost).await?;
+            }
+        }
+        task_center.shutdown_node("completed", 0).await;
+        // print prometheus if asked.
+        if !args.no_prometheus_stats {
+            print_prometheus_stats(&recorder);
+        }
+
+        // print rocksdb stats if asked.
+        if !args.no_rocksdb_stats {
+            print_rocksdb_stats("local-loglet");
+        }
+
+        // We shutdown the database after stats to avoid enclosing the shutdown process in our
+        // metrics.
+        RocksDbManager::get().shutdown().await;
+        // Make sure that all pending spans are flushed
+        let shutdown_tracing_with_timeout =
+            tokio::time::timeout(Duration::from_secs(10), tracing_guard.async_shutdown());
+        let shutdown_result = shutdown_tracing_with_timeout.await;
+
+        if shutdown_result.is_err() {
+            trace!("Failed to fully flush pending spans, terminating now.");
+        }
+        anyhow::Ok(())
+    })?;
+
+    if cli_args.retain_test_dir {
+        println!("Keeping the base_dir in {}", tmp_base.display());
+    } else {
+        println!("Removing test dir at {}", tmp_base.display());
+    }
+
+    Ok(())
+}
+
+fn spawn_environment(config: Configuration, num_logs: u64) -> (TaskCenter, Bifrost) {
+    let tc = TaskCenterBuilder::default()
+        .options(config.common.clone())
+        .build()
+        .expect("task_center builds");
+
+    restate_types::config::set_current_config(config.clone());
+    let task_center = tc.clone();
+    let bifrost = tc.block_on("spawn", None, async move {
+        let network_sender = MockNetworkSender::default();
+        let metadata_store_client = MetadataStoreClient::new_in_memory();
+        let metadata_manager =
+            MetadataManager::build(network_sender.clone(), metadata_store_client.clone());
+
+        let metadata = metadata_manager.metadata();
+        let metadata_writer = metadata_manager.writer();
+        task_center.try_set_global_metadata(metadata.clone());
+
+        RocksDbManager::init(Constant::new(config.common));
+
+        let logs = restate_types::logs::metadata::create_static_metadata(
+            config.bifrost.default_provider,
+            num_logs,
+        );
+
+        metadata_store_client
+            .put(BIFROST_CONFIG_KEY.clone(), logs.clone(), Precondition::None)
+            .await
+            .expect("to store bifrost config in metadata store");
+        metadata_writer.submit(logs);
+        spawn_metadata_manager(&task_center, metadata_manager).expect("metadata manager starts");
+
+        let bifrost_svc = BifrostService::new(metadata);
+        let bifrost = bifrost_svc.handle();
+
+        // start bifrost service in the background
+        bifrost_svc.start().await.expect("bifrost starts");
+        bifrost
+    });
+    (tc, bifrost)
+}

--- a/crates/bifrost-benchpress/src/read_to_write.rs
+++ b/crates/bifrost-benchpress/src/read_to_write.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::{Duration, Instant};
+
+use bytes::{Buf, BufMut, BytesMut};
+use hdrhistogram::Histogram;
+use tracing::info;
+
+use restate_bifrost::{Bifrost, Error as BifrostError};
+use restate_bifrost::{LogRecord, Record};
+use restate_core::{cancellation_watcher, TaskCenter, TaskKind};
+use restate_types::logs::{LogId, Lsn, Payload, SequenceNumber};
+
+use crate::util::print_latencies;
+use crate::Arguments;
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct WriteToReadOpts {}
+
+pub async fn run(
+    _common_args: &Arguments,
+    _args: &WriteToReadOpts,
+    tc: TaskCenter,
+    bifrost: Bifrost,
+) -> anyhow::Result<()> {
+    let log_id = LogId::from(0);
+    let clock = quanta::Clock::new();
+    // Create two tasks, one that writes to the log continously and another one that reads from the
+    // log and measures the latency. Collect latencies in a histogram and print the histogram
+    // before the test ends.
+    let reader_task = tc.spawn(TaskKind::TestRunner, "test-log-reader", None, {
+        let bifrost = bifrost.clone();
+        let clock = clock.clone();
+        async move {
+            let mut read_stream = bifrost.create_reader(log_id, Lsn::OLDEST);
+            let mut counter = 0;
+            let mut cancel = std::pin::pin!(cancellation_watcher());
+            let mut lag_latencies = Histogram::<u64>::new(3)?;
+            let mut on_record = |record: Result<LogRecord, BifrostError>| {
+                if let Ok(record) = record {
+                    if let Record::Data(data) = record.record {
+                        let latency_raw = data.into_body().get_u64();
+                        let latency = clock.scaled(latency_raw).elapsed();
+                        lag_latencies.record(latency.as_nanos() as u64)?;
+                    } else {
+                        panic!("Unexpected non-data record");
+                    }
+                } else {
+                    panic!("Unexpected error");
+                }
+                anyhow::Ok(())
+            };
+            loop {
+                counter += 1;
+                tokio::select! {
+                    _ = &mut cancel =>  {
+                        // test is over. print histogram
+                        info!("Reader stopping");
+                        break;
+                    }
+                    record = read_stream.read_next() => {
+                        on_record(record)?;
+                    }
+                }
+                if counter % 1000 == 0 {
+                    info!("Read {} records", counter);
+                }
+            }
+
+            println!("Total records read: {}", counter);
+            print_latencies("read lag", lag_latencies);
+            Ok(())
+        }
+    })?;
+
+    let writer_task = tc.spawn(TaskKind::TestRunner, "test-log-appender", None, {
+        let mut bifrost = bifrost.clone();
+        let clock = clock.clone();
+        async move {
+            let mut append_latencies = Histogram::<u64>::new(3)?;
+            let mut counter = 0;
+            loop {
+                counter += 1;
+                let start = Instant::now();
+                let mut bytes = BytesMut::default();
+                bytes.put_u64(clock.raw());
+                let payload = Payload::new(bytes);
+                if let Err(_) = bifrost.append(log_id, payload).await {
+                    println!("Total records written: {}", counter);
+                    print_latencies("append latency", append_latencies);
+                    break;
+                };
+
+                append_latencies.record(start.elapsed().as_nanos() as u64)?;
+                if counter % 1000 == 0 {
+                    info!("Appended {} records", counter);
+                }
+            }
+            anyhow::Ok(())
+        }
+    })?;
+
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    tc.cancel_task(reader_task).unwrap().await?;
+    info!("Reader stopped");
+    let _ = tc.cancel_task(writer_task);
+    Ok(())
+}

--- a/crates/bifrost-benchpress/src/util.rs
+++ b/crates/bifrost-benchpress/src/util.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::Write;
+use std::time::Duration;
+
+use hdrhistogram::Histogram;
+use metrics_exporter_prometheus::PrometheusHandle;
+use restate_rocksdb::{DbName, RocksDbManager};
+
+pub fn print_latencies(title: &str, histogram: Histogram<u64>) {
+    let mut stdout = std::io::stdout().lock();
+    let _ = writeln!(&mut stdout, "Histogram of {}", title);
+    let _ = writeln!(
+        &mut stdout,
+        "P50: {:?}",
+        Duration::from_nanos(histogram.value_at_percentile(50.0))
+    );
+    let _ = writeln!(
+        &mut stdout,
+        "P90: {:?}",
+        Duration::from_nanos(histogram.value_at_percentile(90.0))
+    );
+    let _ = writeln!(
+        &mut stdout,
+        "P99: {:?}",
+        Duration::from_nanos(histogram.value_at_percentile(99.0))
+    );
+    let _ = writeln!(
+        &mut stdout,
+        "P999: {:?}",
+        Duration::from_nanos(histogram.value_at_percentile(99.9))
+    );
+    let _ = writeln!(
+        &mut stdout,
+        "P100: {:?}",
+        Duration::from_nanos(histogram.value_at_percentile(100.0))
+    );
+    let _ = writeln!(&mut stdout, "# of samples: {}", histogram.len());
+    let _ = writeln!(&mut stdout);
+}
+
+pub fn print_rocksdb_stats(db_name: &str) {
+    let db_manager = RocksDbManager::get();
+    let db = db_manager.get_db(DbName::new(db_name)).unwrap();
+    let stats = db.get_statistics_str();
+    let total_wb_usage = db_manager.get_total_write_buffer_usage();
+    let wb_capacity = db_manager.get_total_write_buffer_capacity();
+    let memory = db_manager
+        .get_memory_usage_stats(&[DbName::new(db_name)])
+        .unwrap();
+    let mut stdout = std::io::stdout().lock();
+
+    let _ = writeln!(&mut stdout);
+    let _ = writeln!(&mut stdout, "==========================");
+    let _ = writeln!(&mut stdout, "Rocksdb Stats of {}", db_name);
+    let _ = writeln!(&mut stdout, "{}", stats.unwrap());
+
+    let _ = writeln!(
+        &mut stdout,
+        "RocksDB approximate memory usage for all mem-tables: {}",
+        memory.approximate_mem_table_total(),
+    );
+    let _ = writeln!(
+        &mut stdout,
+        "RocksDB approximate memory usage of un-flushed mem-tables: {}",
+        memory.approximate_mem_table_unflushed(),
+    );
+
+    let _ = writeln!(
+        &mut stdout,
+        "RocksDB approximate memory usage of all the table readers: {}",
+        memory.approximate_mem_table_readers_total(),
+    );
+
+    let _ = writeln!(
+        &mut stdout,
+        "RocksDB approximate memory usage by cache: {}",
+        memory.approximate_cache_total(),
+    );
+
+    let _ = writeln!(
+        &mut stdout,
+        "RocksDB total write buffers usage (from write buffers manager): {}",
+        total_wb_usage
+    );
+
+    let _ = writeln!(
+        &mut stdout,
+        "RocksDB total write buffers capacity (from write buffers manager): {}",
+        wb_capacity
+    );
+}
+
+pub fn print_prometheus_stats(handle: &PrometheusHandle) {
+    let mut stdout = std::io::stdout().lock();
+    let _ = writeln!(&mut stdout);
+    let _ = writeln!(&mut stdout, "==========================");
+    let _ = writeln!(&mut stdout, "Prometheus Stats");
+    let metrics = handle.render();
+
+    // print the metrics to the terminal.
+    let _ = writeln!(&mut stdout, "{}", metrics);
+}

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -24,6 +24,7 @@ codederror = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }
+futures = { workspace = true }
 humantime = { workspace = true }
 metrics = { workspace = true }
 once_cell = { workspace = true }
@@ -32,7 +33,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-smallvec = { version = "1.13.2", features = ["serde"] }
+smallvec = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
@@ -48,7 +49,6 @@ restate-metadata-store = { workspace = true }
 restate-test-util = { workspace = true }
 
 criterion = { workspace = true, features = ["async_tokio"] }
-futures = { workspace = true }
 googletest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -21,9 +21,9 @@ use crate::types::SealReason;
 pub enum Error {
     #[error("log '{0}' is sealed")]
     LogSealed(LogId, SealReason),
-    #[error("unknown log '{0}")]
+    #[error("unknown log '{0}'")]
     UnknownLogId(LogId),
-    #[error("invalid log sequence number '{0}")]
+    #[error("invalid log sequence number '{0}'")]
     InvalidLsn(Lsn),
     #[error("operation failed due to an ongoing shutdown")]
     Shutdown(#[from] ShutdownError),

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -24,3 +24,5 @@ pub use read_stream::LogReadStream;
 pub use record::*;
 pub use service::BifrostService;
 pub use types::*;
+
+pub const SMALL_BATCH_THRESHOLD_COUNT: usize = 4;

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::Add;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -43,6 +44,14 @@ pub fn create_provider(kind: ProviderKind) -> Result<Arc<dyn LogletProvider>, Pr
     derive_more::Display,
 )]
 pub struct LogletOffset(pub(crate) u64);
+
+impl Add<usize> for LogletOffset {
+    type Output = Self;
+    fn add(self, rhs: usize) -> Self {
+        // we always assume that we are running on a 64bit cpu arch.
+        Self(self.0.saturating_add(rhs as u64))
+    }
+}
 
 impl SequenceNumber for LogletOffset {
     const MAX: Self = LogletOffset(u64::MAX);
@@ -107,6 +116,10 @@ pub trait LogletBase: Send + Sync {
     /// Append a record to the loglet.
     async fn append(&self, data: Bytes) -> Result<Self::Offset, Error>;
 
+    /// Append a batch of records to the loglet. The returned offset (on success) if the offset of
+    /// the first record in the batch)
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Self::Offset, Error>;
+
     /// Find the tail of the loglet. If the loglet is empty or have been trimmed, the loglet should
     /// return `None`.
     async fn find_tail(&self) -> Result<Option<Self::Offset>, Error>;
@@ -136,6 +149,11 @@ impl LogletBase for LogletWrapper {
     async fn append(&self, data: Bytes) -> Result<Lsn, Error> {
         let offset = self.loglet.append(data).await?;
         // Return the LSN given the loglet offset.
+        Ok(self.base_lsn.offset_by(offset))
+    }
+
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Lsn, Error> {
+        let offset = self.loglet.append_batch(payloads).await?;
         Ok(self.base_lsn.offset_by(offset))
     }
 

--- a/crates/bifrost/src/loglets/local_loglet/metric_definitions.rs
+++ b/crates/bifrost/src/loglets/local_loglet/metric_definitions.rs
@@ -17,12 +17,31 @@ pub(crate) const BIFROST_LOCAL_APPEND: &str = "restate.bifrost.localloglet.appen
 pub(crate) const BIFROST_LOCAL_APPEND_DURATION: &str =
     "restate.bifrost.localloglet.append_duration.seconds";
 
+pub(crate) const BIFROST_LOCAL_WRITE_BATCH_COUNT: &str =
+    "restate.bifrost.localloglet.write_batch_count";
+
+pub(crate) const BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES: &str =
+    "restate.bifrost.localloglet.write_batch_size_bytes";
+
 pub(crate) fn describe_metrics() {
     describe_counter!(
         BIFROST_LOCAL_APPEND,
         Unit::Count,
         "Number of append requests to bifrost's local loglet"
     );
+
+    describe_histogram!(
+        BIFROST_LOCAL_WRITE_BATCH_COUNT,
+        Unit::Count,
+        "Histogram of the number of records in each append request to local loglet"
+    );
+
+    describe_histogram!(
+        BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES,
+        Unit::Bytes,
+        "Histogram of size in bytes of local loglet write batches"
+    );
+
     describe_histogram!(
         BIFROST_LOCAL_APPEND_DURATION,
         Unit::Seconds,

--- a/crates/bifrost/src/loglets/local_loglet/mod.rs
+++ b/crates/bifrost/src/loglets/local_loglet/mod.rs
@@ -159,18 +159,48 @@ impl LogletBase for LocalLoglet {
         let (receiver, offset) = {
             let mut next_offset_guard = self.next_write_offset.lock().await;
             // lock acquired
-            let offset = next_offset_guard.next();
+            let offset = *next_offset_guard;
             let receiver = self
                 .log_writer
-                .enqueue_put_record(
-                    self.log_id,
-                    offset,
-                    payload,
-                    true, /* release_immediately */
-                )
+                .enqueue_put_record(self.log_id, offset, payload)
                 .await?;
-            *next_offset_guard = offset;
+            // next offset points to the next available slot.
+            *next_offset_guard = offset.next();
             (receiver, offset)
+            // lock dropped
+        };
+
+        let _ = receiver.await.unwrap_or_else(|_| {
+            warn!("Unsure if the local loglet record was written, the ack channel was dropped");
+            Err(Error::Shutdown(ShutdownError))
+        })?;
+
+        self.last_committed_offset
+            .fetch_max(offset.into(), Ordering::Relaxed);
+        self.notify_readers();
+        histogram!(BIFROST_LOCAL_APPEND_DURATION).record(start_time.elapsed());
+        Ok(offset)
+    }
+
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<LogletOffset, Error> {
+        let num_payloads = payloads.len();
+        counter!(BIFROST_LOCAL_APPEND).increment(num_payloads as u64);
+        let start_time = std::time::Instant::now();
+        // We hold the lock to ensure that offsets are enqueued in the order of
+        // their offsets in the logstore writer. This means that acknowledgements
+        // that an offset N from the writer imply that all previous offsets have
+        // been durably committed, therefore, such offsets can be released to readers.
+        let (receiver, offset) = {
+            let mut next_offset_guard = self.next_write_offset.lock().await;
+            let offset = *next_offset_guard;
+            // lock acquired
+            let receiver = self
+                .log_writer
+                .enqueue_put_records(self.log_id, *next_offset_guard, payloads)
+                .await?;
+            // next offset points to the next available slot.
+            *next_offset_guard = offset + num_payloads;
+            (receiver, next_offset_guard.prev())
             // lock dropped
         };
 

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -37,10 +37,6 @@ pub struct AdminOptions {
     concurrent_api_requests_limit: Option<NonZeroUsize>,
     pub query_engine: QueryEngineOptions,
 
-    #[cfg(any(test, feature = "test-util"))]
-    #[serde(skip, default = "super::default_arc_tmp")]
-    data_dir: std::sync::Arc<tempfile::TempDir>,
-
     /// # Controller heartbeats
     ///
     /// Controls the interval at which cluster controller polls nodes of the cluster.
@@ -50,14 +46,8 @@ pub struct AdminOptions {
 }
 
 impl AdminOptions {
-    #[cfg(not(any(test, feature = "test-util")))]
     pub fn data_dir(&self) -> PathBuf {
         super::data_dir("registry")
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn data_dir(&self) -> PathBuf {
-        self.data_dir.path().join("registry")
     }
 
     pub fn concurrent_api_requests_limit(&self) -> usize {
@@ -77,8 +67,6 @@ impl Default for AdminOptions {
             // max is limited by Tower's LoadShedLayer.
             concurrent_api_requests_limit: None,
             query_engine: Default::default(),
-            #[cfg(any(test, feature = "test-util"))]
-            data_dir: super::default_arc_tmp(),
             heartbeat_interval: Duration::from_millis(1500).into(),
         }
     }

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -75,21 +75,11 @@ pub struct LocalLogletOptions {
     ///
     /// Default: True.
     pub batch_wal_flushes: bool,
-
-    #[cfg(any(test, feature = "test-util"))]
-    #[serde(skip, default = "super::default_arc_tmp")]
-    data_dir: std::sync::Arc<tempfile::TempDir>,
 }
 
 impl LocalLogletOptions {
-    #[cfg(not(any(test, feature = "test-util")))]
     pub fn data_dir(&self) -> PathBuf {
         super::data_dir("local-loglet")
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn data_dir(&self) -> PathBuf {
-        self.data_dir.path().join("local-loglet")
     }
 }
 
@@ -106,8 +96,6 @@ impl Default for LocalLogletOptions {
             sync_wal_before_ack: true,
             writer_batch_commit_count: 500,
             writer_batch_commit_duration: Duration::from_nanos(5).into(),
-            #[cfg(any(test, feature = "test-util"))]
-            data_dir: super::default_arc_tmp(),
         }
     }
 }

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -95,7 +95,7 @@ impl Default for LocalLogletOptions {
             batch_wal_flushes: true,
             sync_wal_before_ack: true,
             writer_batch_commit_count: 500,
-            writer_batch_commit_duration: Duration::from_nanos(5).into(),
+            writer_batch_commit_duration: Duration::ZERO.into(),
         }
     }
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -225,6 +225,12 @@ impl CommonOptions {
     pub fn cluster_name(&self) -> &str {
         &self.cluster_name
     }
+
+    #[cfg(feature = "test-util")]
+    pub fn set_base_dir(&mut self, path: PathBuf) {
+        self.base_dir = Some(path);
+    }
+
     pub fn base_dir(&self) -> PathBuf {
         self.base_dir.clone().unwrap_or_else(|| {
             std::env::current_dir()

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -52,8 +52,9 @@ use crate::errors::GenericError;
 use crate::nodes_config::Role;
 
 #[cfg(any(test, feature = "test-util"))]
-pub(crate) fn default_arc_tmp() -> std::sync::Arc<tempfile::TempDir> {
-    std::sync::Arc::new(tempfile::TempDir::new().unwrap())
+enum TempOrPath {
+    Temp(tempfile::TempDir),
+    Path(PathBuf),
 }
 
 static CONFIGURATION: Lazy<Arc<ArcSwap<Configuration>>> = Lazy::new(Arc::default);
@@ -61,8 +62,8 @@ static CONFIGURATION: Lazy<Arc<ArcSwap<Configuration>>> = Lazy::new(Arc::default
 static NODE_BASE_DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
 
 #[cfg(any(test, feature = "test-util"))]
-static NODE_BASE_DIR: Lazy<std::sync::RwLock<tempfile::TempDir>> =
-    Lazy::new(|| std::sync::RwLock::new(tempfile::TempDir::new().unwrap()));
+static NODE_BASE_DIR: Lazy<std::sync::RwLock<TempOrPath>> =
+    Lazy::new(|| std::sync::RwLock::new(TempOrPath::Temp(tempfile::TempDir::new().unwrap())));
 
 pub type UpdateableConfiguration = Arc<ArcSwap<Configuration>>;
 
@@ -77,7 +78,10 @@ fn data_dir(dir: &str) -> PathBuf {
 #[cfg(any(test, feature = "test-util"))]
 pub fn data_dir(dir: &str) -> PathBuf {
     let guard = NODE_BASE_DIR.read().unwrap();
-    guard.path().join(dir)
+    match &*guard {
+        TempOrPath::Temp(temp) => temp.path().join(dir),
+        TempOrPath::Path(path) => path.join(dir),
+    }
 }
 
 pub fn node_filepath(filename: &str) -> PathBuf {
@@ -88,8 +92,17 @@ pub fn node_filepath(filename: &str) -> PathBuf {
 pub fn reset_base_temp_dir() -> PathBuf {
     let mut guard = NODE_BASE_DIR.write().unwrap();
     let new = tempfile::TempDir::new().unwrap();
-    *guard = new;
-    PathBuf::from(guard.path())
+    let path = PathBuf::from(new.path());
+    *guard = TempOrPath::Temp(new);
+    path
+}
+
+#[cfg(any(test, feature = "test-util"))]
+pub fn reset_base_temp_dir_and_retain() -> PathBuf {
+    let mut guard = NODE_BASE_DIR.write().unwrap();
+    let path = tempfile::TempDir::new().unwrap().into_path();
+    *guard = TempOrPath::Path(path.clone());
+    path
 }
 
 /// Set the current configuration, this is temporary until we have a dedicated configuration loader

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -196,21 +196,11 @@ impl Default for InvokerOptions {
 pub struct StorageOptions {
     #[serde(flatten)]
     pub rocksdb: RocksDbOptions,
-
-    #[cfg(any(test, feature = "test-util"))]
-    #[serde(skip, default = "super::default_arc_tmp")]
-    data_dir: std::sync::Arc<tempfile::TempDir>,
 }
 
 impl StorageOptions {
-    #[cfg(not(any(test, feature = "test-util")))]
     pub fn data_dir(&self) -> PathBuf {
         super::data_dir("db")
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn data_dir(&self) -> PathBuf {
-        self.data_dir.path().join("db")
     }
 }
 
@@ -221,10 +211,6 @@ impl Default for StorageOptions {
             .build()
             .expect("valid RocksDbOptions");
 
-        StorageOptions {
-            rocksdb,
-            #[cfg(any(test, feature = "test-util"))]
-            data_dir: super::default_arc_tmp(),
-        }
+        StorageOptions { rocksdb }
     }
 }

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::flexbuffers_storage_encode_decode;
 use crate::identifiers::PartitionId;
-use crate::time::MillisSinceEpoch;
+use crate::time::NanosSinceEpoch;
 
 pub mod metadata;
 
@@ -111,17 +111,13 @@ where
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Header {
-    created_at: MillisSinceEpoch,
-    // additional custom headers can be added here. Those should be somewhat
-    // generic and values must be optional.
-    pub custom_data_1: Option<u64>,
+    pub created_at: NanosSinceEpoch,
 }
 
 impl Default for Header {
     fn default() -> Self {
         Self {
-            created_at: MillisSinceEpoch::now(),
-            custom_data_1: None,
+            created_at: NanosSinceEpoch::now(),
         }
     }
 }
@@ -147,12 +143,6 @@ impl Payload {
             header: Header::default(),
             body: body.into(),
         }
-    }
-
-    /// Sets the custom data 1 field on the record header
-    pub fn with_custom_data_1(mut self, value: u64) -> Self {
-        self.header.custom_data_1 = Some(value);
-        self
     }
 
     pub fn body(&self) -> &Bytes {

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -63,6 +63,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -9,17 +9,22 @@
 // by the Apache License, Version 2.0.
 
 use super::leadership::ActionEffect;
-use restate_bifrost::Bifrost;
-use restate_core::metadata;
+use futures::stream::FuturesUnordered;
+use restate_bifrost::{Bifrost, SMALL_BATCH_THRESHOLD_COUNT};
+use restate_core::{metadata, Metadata};
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
+use restate_types::logs::{LogId, Payload};
+use restate_types::partition_table::FindPartition;
 use restate_types::time::MillisSinceEpoch;
+use restate_types::Version;
 use restate_wal_protocol::timer::TimerKeyValue;
-use restate_wal_protocol::{
-    append_envelope_to_bifrost, Command, Destination, Envelope, Header, Source,
-};
+use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
+use smallvec::SmallVec;
+use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::time::SystemTime;
+use tokio_stream::StreamExt;
 
 /// Responsible for proposing [ActionEffect].
 pub(super) struct ActionEffectHandler {
@@ -27,6 +32,7 @@ pub(super) struct ActionEffectHandler {
     epoch_sequence_number: EpochSequenceNumber,
     partition_key_range: RangeInclusive<PartitionKey>,
     bifrost: Bifrost,
+    metadata: Metadata,
 }
 
 impl ActionEffectHandler {
@@ -35,62 +41,78 @@ impl ActionEffectHandler {
         epoch_sequence_number: EpochSequenceNumber,
         partition_key_range: RangeInclusive<PartitionKey>,
         bifrost: Bifrost,
+        metadata: Metadata,
     ) -> Self {
         Self {
             partition_id,
             epoch_sequence_number,
             partition_key_range,
             bifrost,
+            metadata,
         }
     }
 
-    pub(super) async fn handle(&mut self, actuator_output: ActionEffect) -> anyhow::Result<()> {
-        match actuator_output {
-            ActionEffect::Invoker(invoker_output) => {
-                let header = self.create_header(invoker_output.invocation_id.partition_key());
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
-                    Envelope::new(header, Command::InvokerEffect(invoker_output)),
-                )
-                .await?;
-            }
-            ActionEffect::Shuffle(outbox_truncation) => {
-                // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
-                //  specific destination messages that are identified by a partition_id
-                let header = self.create_header(*self.partition_key_range.start());
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
-                    Envelope::new(header, Command::TruncateOutbox(outbox_truncation.index())),
-                )
-                .await?;
-            }
-            ActionEffect::Timer(timer) => {
-                let partition_key = timer.invocation_id().partition_key();
-                let header = self.create_header(partition_key);
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
-                    Envelope::new(header, Command::Timer(timer)),
-                )
-                .await?;
-            }
-            ActionEffect::ScheduleCleanupTimer(invocation_id, duration) => {
-                // We need this self proposal because we need to agree between leaders and followers on the wakeup time.
-                //  We can get rid of this once we'll have a synchronized clock between leaders/followers.
-                let header = self.create_header(invocation_id.partition_key());
-                append_envelope_to_bifrost(
-                    &mut self.bifrost,
+    pub(super) async fn handle(
+        &mut self,
+        effects: impl IntoIterator<Item = ActionEffect>,
+    ) -> anyhow::Result<()> {
+        let partition_table = self.metadata.wait_for_partition_table(Version::MIN).await?;
+        // groups envelopes write to Bifrost in batches
+        let mut buffer: BTreeMap<LogId, SmallVec<[Payload; SMALL_BATCH_THRESHOLD_COUNT]>> =
+            Default::default();
+
+        for actuator_output in effects {
+            let envelope = match actuator_output {
+                ActionEffect::Invoker(invoker_output) => {
+                    let header = self.create_header(invoker_output.invocation_id.partition_key());
+                    Envelope::new(header, Command::InvokerEffect(invoker_output))
+                }
+                ActionEffect::Shuffle(outbox_truncation) => {
+                    // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
+                    //  specific destination messages that are identified by a partition_id
+                    let header = self.create_header(*self.partition_key_range.start());
+                    Envelope::new(header, Command::TruncateOutbox(outbox_truncation.index()))
+                }
+                ActionEffect::Timer(timer) => {
+                    let header = self.create_header(timer.invocation_id().partition_key());
+                    Envelope::new(header, Command::Timer(timer))
+                }
+                ActionEffect::ScheduleCleanupTimer(invocation_id, duration) => {
+                    //  We need this self proposal because we need to agree between leaders and followers on the wakeup time.
+                    //  We can get rid of this once we'll have a synchronized clock between leaders/followers.
+                    let header = self.create_header(invocation_id.partition_key());
                     Envelope::new(
-                        header.clone(),
+                        header,
                         Command::ScheduleTimer(TimerKeyValue::clean_invocation_status(
                             MillisSinceEpoch::from(SystemTime::now() + duration),
                             invocation_id,
                         )),
-                    ),
-                )
-                .await?;
-            }
-        };
+                    )
+                }
+            };
+            let log_id = LogId::from(partition_table.find_partition_id(envelope.partition_key())?);
+            buffer
+                .entry(log_id)
+                .or_default()
+                .push(Payload::new(envelope.to_bytes()?));
+        }
 
+        let mut batches = FuturesUnordered::new();
+
+        // Attempt to write batches to different log ids concurrently
+        for (log_id, payloads) in buffer {
+            let mut bifrost = self.bifrost.clone();
+            batches.push(async move {
+                bifrost.append_batch(log_id, &payloads).await?;
+                anyhow::Ok(())
+            });
+        }
+        while let Some(o) = batches.next().await {
+            // fail if any write fails. This is not the best approach to handle write errors,
+            // however this is how it was.
+            // todo: we should implement a better error handling mechanism
+            o?
+        }
         Ok(())
     }
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -240,14 +240,14 @@ where
                         histogram!(PP_APPLY_ACTIONS_DURATION).record(actions_start.elapsed());
                     }
                 },
-                action_effect = action_effect_stream.next() => {
-                    counter!(PARTITION_ACTUATOR_HANDLED).increment(1);
-                    let action_effect = action_effect.ok_or_else(|| anyhow::anyhow!("action effect stream is closed"))?;
-                    state.handle_action_effect(action_effect).await?;
+                action_effects = action_effect_stream.next() => {
+                    let action_effects = action_effects.ok_or_else(|| anyhow::anyhow!("action effect stream is closed"))?;
+                    counter!(PARTITION_ACTUATOR_HANDLED).increment(action_effects.len() as u64);
+                    state.handle_action_effect(action_effects).await?;
                 },
                 timer = state.run_timer() => {
                     counter!(PARTITION_TIMER_DUE_HANDLED).increment(1);
-                    state.handle_action_effect(ActionEffect::Timer(timer)).await?;
+                    state.handle_action_effect([ActionEffect::Timer(timer)]).await?;
                 },
             }
         }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,7 +32,6 @@ restate-errors = { workspace = true, features = ["include_doc"] }
 restate-fs-util = { workspace = true }
 restate-node = { workspace = true }
 restate-rocksdb = { workspace = true }
-#restate-partition-store = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
 restate-types = { workspace = true, features = ["clap"] }
 restate-worker = { workspace = true }


### PR DESCRIPTION
Default to low-latency local loglet configuration


This PR changes the default configuration of the local loglet to disable time-based batching. Most users's first impressions and general use will expect interactive low-latency experience and we want this to be the default case.
A major performance win is the change in local loglet implementation. Tokio has 1ms timer resolution, so even if batching duration is set to zero, the runtime will still sleep an arbitrary amound between 0 and 1ms to resume the stream. The change switches to chunking ready items by default if time-based batching is zero. This results in 6X lower append path latency in my tests (even with fdatasync running on fast nvme)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1546).
* __->__ #1546
* #1545
* #1544
* #1536