### PR TITLE
Fix invocation_id returned in case we return the completed result of an already existing invocation

### DIFF
--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -424,7 +424,7 @@ where
                         effects,
                         response_sink.cloned(),
                         completed.response_result,
-                        Some(*caller_id),
+                        Some(original_invocation_id),
                         Some(&completed.invocation_target),
                     );
                 }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -970,7 +970,7 @@ mod tests {
                         target_node: eq(GenerationalNodeId::new(1, 1)),
                         inner: pat!(ingress::InvocationResponse {
                             request_id: eq(request_id),
-                            invocation_id: some(eq(second_invocation_id)),
+                            invocation_id: some(eq(invocation_id)),
                             response: eq(IngressResponseResult::Success(
                                 invocation_target.clone(),
                                 response_bytes.clone()


### PR DESCRIPTION
Just a little case where we returned the wrong invocation id. Followup of https://github.com/restatedev/restate/pull/1559