### PR TITLE
Disable metric label extraction from tracing due to high cpu cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "metrics",
- "metrics-exporter-prometheus 0.14.0",
+ "metrics-exporter-prometheus",
  "once_cell",
  "quanta",
  "restate-bifrost",
@@ -3814,22 +3814,6 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
-dependencies = [
- "base64 0.21.7",
- "hyper 0.14.28",
- "indexmap 2.2.6",
- "metrics",
- "metrics-util",
- "quanta",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d58e362dc7206e9456ddbcdbd53c71ba441020e62104703075a69151e38d85f"
@@ -5370,6 +5354,7 @@ dependencies = [
  "humantime",
  "metrics",
  "once_cell",
+ "pin-project",
  "restate-core",
  "restate-metadata-store",
  "restate-rocksdb",
@@ -5389,6 +5374,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -5816,7 +5802,7 @@ dependencies = [
  "humantime",
  "hyper 0.14.28",
  "metrics",
- "metrics-exporter-prometheus 0.13.1",
+ "metrics-exporter-prometheus",
  "metrics-tracing-context",
  "metrics-util",
  "once_cell",
@@ -7463,6 +7449,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock-service-endpoint"
+version = "0.9.1"
+dependencies = [
+ "assert2",
+ "async-stream",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "prost",
+ "restate-service-protocol",
+ "restate-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ hyper = { version = "0.14.24", default-features = false }
 hyper-rustls = { version = "0.24.1", features = ["http2"] }
 itertools = "0.11.0"
 metrics = { version = "0.22" }
+metrics-exporter-prometheus = { version = "0.14", default-features = false, features = ["async-runtime"] }
 once_cell = "1.18"
 opentelemetry = { version = "0.22.0" }
 opentelemetry-http = { version = "0.11.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/*",
     "crates/codederror/derive",
     "server",
+    "tools/mock-service-endpoint",
     "tools/service-protocol-wireshark-dissector",
     "tools/xtask",
     "tools/bifrost-benchpress",

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -28,6 +28,7 @@ futures = { workspace = true }
 humantime = { workspace = true }
 metrics = { workspace = true }
 once_cell = { workspace = true }
+pin-project = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
@@ -39,7 +40,8 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { workspace = true }
+tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -29,7 +29,9 @@ use restate_types::Version;
 
 use crate::loglet::{LogletBase, LogletProvider, LogletWrapper};
 use crate::watchdog::{WatchdogCommand, WatchdogSender};
-use crate::{Error, FindTailAttributes, LogReadStream, LogRecord, SMALL_BATCH_THRESHOLD_COUNT};
+use crate::{
+    Error, FindTailAttributes, LogReadStream, LogRecord, Result, SMALL_BATCH_THRESHOLD_COUNT,
+};
 
 /// Bifrost is Restate's durable interconnect system
 ///
@@ -65,7 +67,7 @@ impl Bifrost {
     /// Appends a single record to a log. The log id must exist, otherwise the
     /// operation fails with [`Error::UnknownLogId`]
     #[instrument(level = "debug", skip(self, payload), err)]
-    pub async fn append(&mut self, log_id: LogId, payload: Payload) -> Result<Lsn, Error> {
+    pub async fn append(&mut self, log_id: LogId, payload: Payload) -> Result<Lsn> {
         self.inner.append(log_id, payload).await
     }
 
@@ -73,11 +75,7 @@ impl Bifrost {
     /// operation fails with [`Error::UnknownLogId`]. The returned Lsn is the Lsn of the first
     /// record in this batch. This will only return after all records have been stored.
     #[instrument(level = "debug", skip(self, payloads), err)]
-    pub async fn append_batch(
-        &mut self,
-        log_id: LogId,
-        payloads: &[Payload],
-    ) -> Result<Lsn, Error> {
+    pub async fn append_batch(&mut self, log_id: LogId, payloads: &[Payload]) -> Result<Lsn> {
         self.inner.append_batch(log_id, payloads).await
     }
 
@@ -85,7 +83,7 @@ impl Bifrost {
     /// read after. This means that the record returned will have a LSN strictly greater than
     /// `after`. If no records are committed yet after this LSN, this read operation will "wait"
     /// for such records to appear.
-    pub async fn read_next_single(&self, log_id: LogId, after: Lsn) -> Result<LogRecord, Error> {
+    pub async fn read_next_single(&self, log_id: LogId, after: Lsn) -> Result<LogRecord> {
         self.inner.read_next_single(log_id, after).await
     }
 
@@ -96,12 +94,19 @@ impl Bifrost {
         &self,
         log_id: LogId,
         after: Lsn,
-    ) -> Result<Option<LogRecord>, Error> {
+    ) -> Result<Option<LogRecord>> {
         self.inner.read_next_single_opt(log_id, after).await
     }
 
-    pub fn create_reader(&self, log_id: LogId, after: Lsn) -> LogReadStream {
-        LogReadStream::new(self.inner.clone(), log_id, after)
+    /// Create a read stream. Until is inclusive. Pass [[`Lsn::Max`]] for a tailing stream. Use
+    /// Lsn::INVALID in _after_ to read from the start (head) of the log.
+    pub async fn create_reader(
+        &self,
+        log_id: LogId,
+        after: Lsn,
+        until: Lsn,
+    ) -> Result<LogReadStream> {
+        LogReadStream::create(self.inner.clone(), log_id, after, until).await
     }
 
     /// Finds the current readable tail LSN of a log.
@@ -110,8 +115,8 @@ impl Bifrost {
         &self,
         log_id: LogId,
         attributes: FindTailAttributes,
-    ) -> Result<Option<Lsn>, Error> {
-        self.inner.find_tail(log_id, attributes).await
+    ) -> Result<Option<Lsn>> {
+        Ok(self.inner.find_tail(log_id, attributes).await?.1)
     }
 
     /// The lsn of the slot **before** the first readable record (if it exists), or the offset
@@ -138,16 +143,22 @@ impl Bifrost {
 
     /// Read a full log with the given id. To be used only in tests!!!
     #[cfg(any(test, feature = "test-util"))]
-    pub async fn read_all(&self, log_id: LogId) -> Result<Vec<LogRecord>, Error> {
+    pub async fn read_all(&self, log_id: LogId) -> Result<Vec<LogRecord>> {
+        use futures::TryStreamExt;
+
         self.inner.fail_if_shutting_down()?;
 
-        let mut v = vec![];
-        let mut reader = self.create_reader(log_id, Lsn::INVALID);
-        while let Some(r) = reader.read_next_opt().await? {
-            v.push(r);
-        }
+        let current_tail = self
+            .find_tail(log_id, FindTailAttributes::default())
+            .await?;
+        let Some(current_tail) = current_tail else {
+            return Ok(Vec::default());
+        };
 
-        Ok(v)
+        let reader = self
+            .create_reader(log_id, Lsn::INVALID, current_tail)
+            .await?;
+        reader.try_collect().await
     }
 }
 
@@ -182,7 +193,7 @@ impl BifrostInner {
 
     /// Appends a single record to a log. The log id must exist, otherwise the
     /// operation fails with [`Error::UnknownLogId`]
-    pub async fn append(&self, log_id: LogId, payload: Payload) -> Result<Lsn, Error> {
+    pub async fn append(&self, log_id: LogId, payload: Payload) -> Result<Lsn> {
         self.fail_if_shutting_down()?;
         let loglet = self.writeable_loglet(log_id).await?;
         let mut buf = BytesMut::default();
@@ -190,7 +201,7 @@ impl BifrostInner {
         loglet.append(buf.freeze()).await
     }
 
-    pub async fn append_batch(&self, log_id: LogId, payloads: &[Payload]) -> Result<Lsn, Error> {
+    pub async fn append_batch(&self, log_id: LogId, payloads: &[Payload]) -> Result<Lsn> {
         let loglet = self.writeable_loglet(log_id).await?;
         let raw_payloads: SmallVec<[_; SMALL_BATCH_THRESHOLD_COUNT]> = payloads
             .iter()
@@ -204,7 +215,7 @@ impl BifrostInner {
         loglet.append_batch(&raw_payloads).await
     }
 
-    pub async fn read_next_single(&self, log_id: LogId, after: Lsn) -> Result<LogRecord, Error> {
+    pub async fn read_next_single(&self, log_id: LogId, after: Lsn) -> Result<LogRecord> {
         self.fail_if_shutting_down()?;
 
         let loglet = self.find_loglet_for_lsn(log_id, after.next()).await?;
@@ -219,7 +230,7 @@ impl BifrostInner {
         &self,
         log_id: LogId,
         after: Lsn,
-    ) -> Result<Option<LogRecord>, Error> {
+    ) -> Result<Option<LogRecord>> {
         self.fail_if_shutting_down()?;
 
         let loglet = self.find_loglet_for_lsn(log_id, after.next()).await?;
@@ -234,10 +245,11 @@ impl BifrostInner {
         &self,
         log_id: LogId,
         _attributes: FindTailAttributes,
-    ) -> Result<Option<Lsn>, Error> {
+    ) -> Result<(LogletWrapper, Option<Lsn>)> {
         self.fail_if_shutting_down()?;
         let loglet = self.writeable_loglet(log_id).await?;
-        loglet.find_tail().await
+        let tail = loglet.find_tail().await?;
+        Ok((loglet, tail))
     }
 
     async fn get_trim_point(&self, log_id: LogId) -> Result<Option<Lsn>, Error> {
@@ -291,7 +303,7 @@ impl BifrostInner {
     }
 
     #[inline]
-    fn fail_if_shutting_down(&self) -> Result<(), Error> {
+    fn fail_if_shutting_down(&self) -> Result<()> {
         if self.shutting_down.load(Ordering::Relaxed) {
             Err(Error::Shutdown(restate_core::ShutdownError))
         } else {
@@ -300,7 +312,7 @@ impl BifrostInner {
     }
 
     /// Immediately fetch new metadata from metadata store.
-    pub async fn sync_metadata(&self) -> Result<(), Error> {
+    pub async fn sync_metadata(&self) -> Result<()> {
         self.fail_if_shutting_down()?;
         self.metadata
             .sync(MetadataKind::Logs)
@@ -342,7 +354,7 @@ impl BifrostInner {
         assert!(self.providers[kind].try_insert(provider).is_ok());
     }
 
-    async fn writeable_loglet(&self, log_id: LogId) -> Result<LogletWrapper, Error> {
+    async fn writeable_loglet(&self, log_id: LogId) -> Result<LogletWrapper> {
         let tail_segment = self
             .metadata
             .logs()
@@ -351,7 +363,11 @@ impl BifrostInner {
         self.get_loglet(&tail_segment).await
     }
 
-    async fn find_loglet_for_lsn(&self, log_id: LogId, lsn: Lsn) -> Result<LogletWrapper, Error> {
+    pub(crate) async fn find_loglet_for_lsn(
+        &self,
+        log_id: LogId,
+        lsn: Lsn,
+    ) -> Result<LogletWrapper> {
         let segment = self
             .metadata
             .logs()
@@ -390,7 +406,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn test_append_smoke() -> Result<()> {
+    async fn test_append_smoke() -> googletest::Result<()> {
         let num_partitions = 5;
         let node_env = TestCoreEnvBuilder::new_with_mock_network()
             .with_partition_table(FixedPartitionTable::new(Version::MIN, num_partitions))
@@ -464,7 +480,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_lazy_initialization() -> Result<()> {
+    async fn test_lazy_initialization() -> googletest::Result<()> {
         let node_env = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
         let tc = node_env.tc;
         tc.run_in_scope("test", None, async {
@@ -491,7 +507,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn trim_log_smoke_test() -> Result<()> {
+    async fn trim_log_smoke_test() -> googletest::Result<()> {
         let node_env = TestCoreEnvBuilder::new_with_mock_network()
             .set_provider_kind(ProviderKind::Local)
             .build()

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -10,14 +10,16 @@
 
 use restate_core::{ShutdownError, SyncError};
 use std::sync::Arc;
-use thiserror::Error;
 
 use restate_types::logs::{LogId, Lsn};
 
 use crate::loglets::local_loglet::LogStoreError;
 use crate::types::SealReason;
 
-#[derive(Error, Debug, Clone)]
+/// Result type for bifrost operations.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("log '{0}' is sealed")]
     LogSealed(LogId, SealReason),

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -19,7 +19,7 @@ mod types;
 mod watchdog;
 
 pub use bifrost::Bifrost;
-pub use error::{Error, ProviderError};
+pub use error::{Error, ProviderError, Result};
 pub use read_stream::LogReadStream;
 pub use record::*;
 pub use service::BifrostService;

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -9,16 +9,20 @@
 // by the Apache License, Version 2.0.
 
 use std::ops::Add;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Poll;
 
 use async_trait::async_trait;
 
 use bytes::Bytes;
+use futures::Stream;
 use restate_types::config::Configuration;
 use restate_types::logs::metadata::{LogletParams, ProviderKind};
 use restate_types::logs::{Lsn, SequenceNumber};
 
-use crate::{Error, LogRecord, LsnExt, ProviderError};
+use crate::Result;
+use crate::{LogRecord, LsnExt, ProviderError};
 
 pub fn create_provider(kind: ProviderKind) -> Result<Arc<dyn LogletProvider>, ProviderError> {
     match kind {
@@ -74,7 +78,7 @@ impl SequenceNumber for LogletOffset {
 #[async_trait]
 pub trait LogletProvider: Send + Sync {
     /// Create a loglet client for a given segment and configuration.
-    async fn get_loglet(&self, params: &LogletParams) -> Result<Arc<dyn Loglet>, Error>;
+    async fn get_loglet(&self, params: &LogletParams) -> Result<Arc<dyn Loglet>>;
 
     // Hook for handling lazy initialization
     fn start(&self) -> Result<(), ProviderError>;
@@ -89,7 +93,7 @@ pub trait Loglet: LogletBase<Offset = LogletOffset> {}
 impl<T> Loglet for T where T: LogletBase<Offset = LogletOffset> {}
 
 /// Wraps loglets with the base LSN of the segment
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LogletWrapper {
     pub(crate) base_lsn: Lsn,
     loglet: Arc<dyn Loglet>,
@@ -98,6 +102,22 @@ pub struct LogletWrapper {
 impl LogletWrapper {
     pub fn new(base_lsn: Lsn, loglet: Arc<dyn Loglet>) -> Self {
         Self { base_lsn, loglet }
+    }
+
+    pub async fn create_wrapped_read_stream(self, after: Lsn) -> Result<LogletReadStreamWrapper> {
+        // Translates LSN to loglet offset
+        Ok(LogletReadStreamWrapper::new(
+            self.loglet
+                .create_read_stream(after.into_offset(self.base_lsn))
+                .await?,
+            self.base_lsn,
+        ))
+    }
+}
+
+impl PartialEq for LogletWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.base_lsn == other.base_lsn && Arc::ptr_eq(&self.loglet, &other.loglet)
     }
 }
 
@@ -110,71 +130,88 @@ impl LogletWrapper {
 /// - Loglets are allowed to buffer writes internally as long as the order of records
 ///   follows the order of append calls.
 #[async_trait]
-pub trait LogletBase: Send + Sync {
+pub trait LogletBase: Send + Sync + std::fmt::Debug {
     type Offset: SequenceNumber;
 
     /// Append a record to the loglet.
-    async fn append(&self, data: Bytes) -> Result<Self::Offset, Error>;
+    async fn create_read_stream(
+        self: Arc<Self>,
+        after: Self::Offset,
+    ) -> Result<SendableLogletReadStream<Self::Offset>>;
+
+    /// Append a record to the loglet.
+    async fn append(&self, data: Bytes) -> Result<Self::Offset>;
 
     /// Append a batch of records to the loglet. The returned offset (on success) if the offset of
     /// the first record in the batch)
-    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Self::Offset, Error>;
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Self::Offset>;
 
     /// Find the tail of the loglet. If the loglet is empty or have been trimmed, the loglet should
     /// return `None`.
-    async fn find_tail(&self) -> Result<Option<Self::Offset>, Error>;
+    async fn find_tail(&self) -> Result<Option<Self::Offset>>;
 
     /// The offset of the slot **before** the first readable record (if it exists), or the offset
     /// before the next slot that will be written to.
-    async fn get_trim_point(&self) -> Result<Option<Self::Offset>, Error>;
+    async fn get_trim_point(&self) -> Result<Option<Self::Offset>>;
 
-    async fn trim(&self, trim_point: Self::Offset) -> Result<(), Error>;
+    async fn trim(&self, trim_point: Self::Offset) -> Result<()>;
 
     /// Read or wait for the record at `from` offset, or the next available record if `from` isn't
     /// defined for the loglet.
-    async fn read_next_single(
-        &self,
-        after: Self::Offset,
-    ) -> Result<LogRecord<Self::Offset, Bytes>, Error>;
+    async fn read_next_single(&self, after: Self::Offset)
+        -> Result<LogRecord<Self::Offset, Bytes>>;
 
     /// Read the next record if it's been committed, otherwise, return None without waiting.
     async fn read_next_single_opt(
         &self,
         after: Self::Offset,
-    ) -> Result<Option<LogRecord<Self::Offset, Bytes>>, Error>;
+    ) -> Result<Option<LogRecord<Self::Offset, Bytes>>>;
 }
+
+/// A stream of log records from a single loglet. Loglet streams are _always_ tailing streams.
+pub trait LogletReadStream<S: SequenceNumber>: Stream<Item = Result<LogRecord<S, Bytes>>> {}
+
+pub type SendableLogletReadStream<S = Lsn> = Pin<Box<dyn LogletReadStream<S> + Send>>;
 
 #[async_trait]
 impl LogletBase for LogletWrapper {
     type Offset = Lsn;
 
-    async fn append(&self, data: Bytes) -> Result<Lsn, Error> {
+    /// This should never be used directly. Instead, use `create_wrapped_read_stream()` instead.
+    async fn create_read_stream(
+        self: Arc<Self>,
+        _after: Self::Offset,
+    ) -> Result<SendableLogletReadStream<Self::Offset>> {
+        unreachable!("create_read_stream on LogletWrapper should never be used directly")
+    }
+
+    async fn append(&self, data: Bytes) -> Result<Lsn> {
         let offset = self.loglet.append(data).await?;
         // Return the LSN given the loglet offset.
         Ok(self.base_lsn.offset_by(offset))
     }
 
-    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Lsn, Error> {
+    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Lsn> {
         let offset = self.loglet.append_batch(payloads).await?;
         Ok(self.base_lsn.offset_by(offset))
     }
 
-    async fn find_tail(&self) -> Result<Option<Lsn>, Error> {
+    async fn find_tail(&self) -> Result<Option<Lsn>> {
         let offset = self.loglet.find_tail().await?;
         Ok(offset.map(|o| self.base_lsn.offset_by(o)))
     }
 
-    async fn get_trim_point(&self) -> Result<Option<Lsn>, Error> {
+    async fn get_trim_point(&self) -> Result<Option<Lsn>> {
         let offset = self.loglet.get_trim_point().await?;
         Ok(offset.map(|o| self.base_lsn.offset_by(o)))
     }
 
-    async fn trim(&self, trim_point: Self::Offset) -> Result<(), Error> {
+    async fn trim(&self, trim_point: Self::Offset) -> Result<()> {
         let trim_point = trim_point.into_offset(self.base_lsn);
         self.loglet.trim(trim_point).await
     }
 
-    async fn read_next_single(&self, after: Lsn) -> Result<LogRecord<Lsn, Bytes>, Error> {
+    async fn read_next_single(&self, after: Lsn) -> Result<LogRecord<Lsn, Bytes>> {
         // convert LSN to loglet offset
         let offset = after.into_offset(self.base_lsn);
         self.loglet
@@ -186,12 +223,42 @@ impl LogletBase for LogletWrapper {
     async fn read_next_single_opt(
         &self,
         after: Self::Offset,
-    ) -> Result<Option<LogRecord<Self::Offset, Bytes>>, Error> {
+    ) -> Result<Option<LogRecord<Self::Offset, Bytes>>> {
         let offset = after.into_offset(self.base_lsn);
         self.loglet
             .read_next_single_opt(offset)
             .await
             .map(|maybe_record| maybe_record.map(|record| record.with_base_lsn(self.base_lsn)))
+    }
+}
+
+/// Wraps loglet read streams with the base LSN of the segment
+pub struct LogletReadStreamWrapper {
+    pub(crate) base_lsn: Lsn,
+    inner: SendableLogletReadStream<LogletOffset>,
+}
+
+impl LogletReadStreamWrapper {
+    pub fn new(inner: SendableLogletReadStream<LogletOffset>, base_lsn: Lsn) -> Self {
+        Self { inner, base_lsn }
+    }
+}
+
+impl Stream for LogletReadStreamWrapper {
+    type Item = Result<LogRecord<Lsn, Bytes>>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(record))) => {
+                Poll::Ready(Some(Ok(record.with_base_lsn(self.base_lsn))))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 

--- a/crates/bifrost/src/loglets/local_loglet/keys.rs
+++ b/crates/bifrost/src/loglets/local_loglet/keys.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Write;
 use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -16,6 +15,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use restate_types::logs::SequenceNumber;
 
 use crate::loglet::LogletOffset;
+
+pub(crate) const DATA_KEY_PREFIX_LENGTH: usize = size_of::<u8>() + size_of::<u64>();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RecordKey {
@@ -37,7 +38,7 @@ impl RecordKey {
 
     pub fn to_bytes(self) -> Bytes {
         let mut buf = BytesMut::with_capacity(size_of::<Self>() + 1);
-        buf.write_char('d').expect("enough key buffer");
+        buf.put_u8(b'd');
         buf.put_u64(self.log_id);
         buf.put_u64(self.offset.into());
         buf.freeze()
@@ -75,7 +76,7 @@ impl MetadataKey {
     pub fn to_bytes(self) -> Bytes {
         let mut buf = BytesMut::with_capacity(size_of::<Self>() + 1);
         // m for metadata
-        buf.write_char('m').expect("enough key buffer");
+        buf.put_u8(b'm');
         buf.put_u64(self.log_id);
         buf.put_u8(self.kind as u8);
         buf.freeze()

--- a/crates/bifrost/src/loglets/local_loglet/log_store.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store.rs
@@ -133,7 +133,7 @@ fn cf_data_options(mut opts: rocksdb::Options) -> rocksdb::Options {
     //
     // Set compactions per level
     //
-    opts.set_max_write_buffer_number(2);
+    opts.set_max_write_buffer_number(10);
     opts.set_num_levels(7);
     opts.set_compression_per_level(&[
         DBCompressionType::None,
@@ -164,7 +164,7 @@ fn cf_metadata_options(mut opts: rocksdb::Options) -> rocksdb::Options {
         DBCompressionType::Snappy,
         DBCompressionType::Zstd,
     ]);
-    opts.set_max_write_buffer_number(2);
+    opts.set_max_write_buffer_number(10);
     opts.set_max_successive_merges(10);
     // Merge operator for log state updates
     opts.set_merge_operator(

--- a/crates/bifrost/src/loglets/local_loglet/provider.rs
+++ b/crates/bifrost/src/loglets/local_loglet/provider.rs
@@ -26,7 +26,7 @@ use crate::loglet::{Loglet, LogletOffset, LogletProvider};
 use crate::Error;
 use crate::ProviderError;
 
-#[derive(Debug)]
+//#[derive(Debug)]
 pub struct LocalLogletProvider {
     log_store: RocksDbLogStore,
     active_loglets: AsyncMutex<HashMap<String, Arc<LocalLoglet>>>,

--- a/crates/bifrost/src/loglets/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/loglets/local_loglet/read_stream.rs
@@ -1,0 +1,218 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::pin::pin;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::{ready, Poll};
+
+use bytes::{BufMut, Bytes, BytesMut};
+use futures::{Stream, StreamExt};
+use pin_project::pin_project;
+use restate_core::ShutdownError;
+use restate_types::logs::SequenceNumber;
+use rocksdb::{DBRawIteratorWithThreadMode, DB};
+use tokio_stream::wrappers::WatchStream;
+use tracing::{debug, error, warn};
+
+use crate::loglet::{LogletOffset, LogletReadStream};
+use crate::loglets::local_loglet::LogStoreError;
+use crate::{Error, LogRecord, Result};
+
+use super::keys::RecordKey;
+use super::LocalLoglet;
+
+#[pin_project]
+pub(crate) struct LocalLogletReadStream {
+    log_id: u64,
+    loglet: Arc<LocalLoglet>,
+    // the last record this stream has returned
+    read_pointer: LogletOffset,
+    release_pointer: LogletOffset,
+    #[pin]
+    iterator: DBRawIteratorWithThreadMode<'static, DB>,
+    #[pin]
+    release_watch: WatchStream<LogletOffset>,
+    #[pin]
+    terminated: bool,
+}
+
+// ## Safety
+// The iterator is guaranteed to be dropped before the loglet is dropped, we hold to the
+// loglet in this struct for as long as the stream is alive.
+unsafe fn ignore_iterator_lifetime<'a>(
+    iter: DBRawIteratorWithThreadMode<'a, DB>,
+) -> DBRawIteratorWithThreadMode<'static, DB> {
+    std::mem::transmute::<
+        DBRawIteratorWithThreadMode<'a, DB>,
+        DBRawIteratorWithThreadMode<'static, DB>,
+    >(iter)
+}
+
+impl LocalLogletReadStream {
+    pub(crate) async fn create(loglet: Arc<LocalLoglet>, after: LogletOffset) -> Result<Self> {
+        let key = RecordKey::new(loglet.log_id, after.next());
+        let mut read_opts = rocksdb::ReadOptions::default();
+        read_opts.set_tailing(true);
+        read_opts.set_prefix_same_as_start(true);
+        read_opts.set_total_order_seek(false);
+        read_opts.set_iterate_lower_bound(key.to_bytes());
+        read_opts.set_iterate_upper_bound(RecordKey::upper_bound(loglet.log_id).to_bytes());
+
+        let log_store = &loglet.log_store;
+        let mut release_watch = loglet.release_watch.to_stream();
+        let release_pointer = release_watch
+            .next()
+            .await
+            .expect("loglet watch returns release pointer");
+        //
+        // ## Safety:
+        // the iterator is guaranteed to be dropped before the loglet is dropped, we hold to the
+        // loglet in this struct for as long as the stream is alive.
+        let iter = {
+            let data_cf = log_store.data_cf();
+            let iter = loglet
+                .log_store
+                .db()
+                .raw_iterator_cf_opt(&data_cf, read_opts);
+            // todo: potentially blocking but we don't create read streams often.
+            unsafe { ignore_iterator_lifetime(iter) }
+        };
+
+        Ok(Self {
+            log_id: loglet.log_id,
+            loglet,
+            read_pointer: after,
+            iterator: iter,
+            terminated: false,
+            release_watch,
+            release_pointer,
+        })
+    }
+}
+
+impl LogletReadStream<LogletOffset> for LocalLogletReadStream {}
+
+impl Stream for LocalLogletReadStream {
+    type Item = Result<LogRecord<LogletOffset, Bytes>>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.terminated {
+            return Poll::Ready(None);
+        }
+
+        let next_offset = self.read_pointer.next();
+
+        loop {
+            let mut this = self.as_mut().project();
+
+            // Are we reading after commit offset?
+            // We are at tail. We need to wait until new records have been released.
+            if next_offset > *this.release_pointer {
+                let updated_release_pointer = ready!(this.release_watch.poll_next(cx));
+
+                match updated_release_pointer {
+                    Some(updated_release_pointer) => {
+                        *this.release_pointer = updated_release_pointer;
+                        continue;
+                    }
+                    None => {
+                        // system shutdown. Or that the loglet has been unexpectedly shutdown.
+                        this.terminated.set(true);
+                        println!("Shutdown error");
+                        return Poll::Ready(Some(Err(Error::Shutdown(ShutdownError))));
+                    }
+                }
+            }
+            // release_pointer has been updated.
+            let release_pointer = *this.release_pointer;
+
+            // assert that we are newer
+            assert!(release_pointer >= next_offset);
+
+            // trim point might have been updated since last time.
+            let trim_point = LogletOffset(this.loglet.trim_point_offset.load(Ordering::Relaxed));
+
+            // Trim point is the the slot **before** the first readable record (if it exists), or the offset
+            // before the next slot that will be written to.
+            //
+            // Are we reading after before the trim point? Note that if `trim_point` ==
+            // `next_offset` then we don't return a trim gap, because the next record
+            // is potentially a data record.
+            assert!(next_offset > LogletOffset::from(0));
+            if trim_point >= next_offset {
+                let trim_gap = LogRecord::new_trim_gap(next_offset, trim_point);
+                self.read_pointer = trim_point;
+                let key = RecordKey::new(self.log_id, trim_point);
+                self.iterator.seek(key.to_bytes());
+                return Poll::Ready(Some(Ok(trim_gap)));
+            }
+
+            let key = RecordKey::new(*this.log_id, next_offset);
+            if this.iterator.valid() {
+                // can move to next.
+                this.iterator.next();
+            } else {
+                this.iterator.seek(key.to_bytes());
+            }
+            //  todo: If status is not ok(), we should retry
+            if let Err(e) = this.iterator.status() {
+                this.terminated.set(true);
+                return Poll::Ready(Some(Err(Error::LogStoreError(LogStoreError::Rocksdb(e)))));
+            }
+
+            if !this.iterator.valid() || this.iterator.key().is_none() {
+                // trim point might have been updated.
+                let potentially_different_trim_point =
+                    LogletOffset(this.loglet.trim_point_offset.load(Ordering::Relaxed));
+                if potentially_different_trim_point != trim_point {
+                    debug!("Trim point has been updated, fast-forwarding the stream");
+                    continue;
+                }
+                // We have a bug! we shouldn't be in this location where the record
+                // doesn't exist but we expect it to!
+                error!(
+                    log_id = *this.log_id,
+                    next_offset = %next_offset,
+                    trim_point = %potentially_different_trim_point,
+                    release_pointer = %this.release_pointer,
+                    "poll_next() has moved to a non-existent record, that should not happen!"
+                );
+                panic!("poll_next() has moved to a non-existent record, that should not happen!");
+            }
+
+            assert!(this.iterator.valid());
+            let loaded_key = RecordKey::from_slice(this.iterator.key().expect("log record exists"));
+            debug_assert_eq!(loaded_key.offset, key.offset);
+
+            // Defensive, the upper_bound set on the iterator should prevent this.
+            if loaded_key.log_id != *this.log_id {
+                warn!(
+                    log_id = *this.log_id,
+                    "read_after moved to the adjacent log {}, that should not happen.\
+                    This is harmless but needs to be investigated!",
+                    key.log_id,
+                );
+                this.terminated.set(true);
+                return Poll::Ready(None);
+            }
+
+            let raw_value = this.iterator.value().expect("log record exists");
+            let mut buf = BytesMut::with_capacity(raw_value.len());
+            buf.put_slice(raw_value);
+            *this.read_pointer = loaded_key.offset;
+
+            return Poll::Ready(Some(Ok(LogRecord::new_data(key.offset, buf.freeze()))));
+        }
+    }
+}

--- a/crates/bifrost/src/loglets/local_loglet/utils.rs
+++ b/crates/bifrost/src/loglets/local_loglet/utils.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use tokio::sync::watch;
+use tokio_stream::wrappers::WatchStream;
 
 use restate_core::ShutdownError;
 
@@ -49,5 +50,9 @@ impl OffsetWatch {
             .await
             .map_err(|_| ShutdownError)?;
         Ok(())
+    }
+
+    pub fn to_stream(&self) -> WatchStream<LogletOffset> {
+        WatchStream::new(self.receive.clone())
     }
 }

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -8,65 +8,92 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::ready;
+use std::task::Poll;
 
-use restate_types::logs::{LogId, Lsn};
+use futures::stream::FusedStream;
+use futures::Stream;
+use pin_project::pin_project;
+use restate_types::logs::{LogId, Lsn, SequenceNumber};
 
 use crate::bifrost::BifrostInner;
-use crate::{Error, LogRecord};
+use crate::loglet::LogletReadStreamWrapper;
+use crate::loglet::LogletWrapper;
+use crate::FindTailAttributes;
+use crate::LogRecord;
+use crate::Result;
 
+#[pin_project]
 pub struct LogReadStream {
+    #[pin]
+    current_loglet_stream: LogletReadStreamWrapper,
+    current_loglet: LogletWrapper,
     inner: Arc<BifrostInner>,
+    _last_known_tail: Lsn,
     log_id: LogId,
+    // inclusive max lsn to read to
+    until_lsn: Lsn,
+    terminated: bool,
+    /// Represents the _current_ record (or the last lsn that was returned from this stream).
+    //  This is akin to the lsn that can be passed to `read_next_single(after)` to read the
+    //  next record in the log.
     read_pointer: Lsn,
 }
 
 impl LogReadStream {
-    pub(crate) fn new(inner: Arc<BifrostInner>, log_id: LogId, after: Lsn) -> Self {
-        Self {
+    pub(crate) async fn create(
+        inner: Arc<BifrostInner>,
+        log_id: LogId,
+        after: Lsn,
+        // Inclusive. Use Lsn::MAX for a tailing stream. Once reached, stream will terminate
+        // (return Ready(None)).
+        until_lsn: Lsn,
+    ) -> Result<Self> {
+        // todo: support switching loglets. At the moment, this is hard-wired to a single loglet
+        // implementation.
+        let current_loglet = inner
+            // find the loglet where the _next_ lsn resides.
+            .find_loglet_for_lsn(log_id, after.next())
+            .await?;
+        let (last_loglet, last_known_tail) = inner
+            .find_tail(log_id, FindTailAttributes::default())
+            .await?;
+        debug_assert_eq!(last_loglet, current_loglet);
+
+        let current_loglet_stream = current_loglet.create_wrapped_read_stream(after).await?;
+        Ok(Self {
+            current_loglet_stream,
+            // reserved for future use
+            current_loglet: last_loglet,
+            // reserved for future use
+            _last_known_tail: last_known_tail.unwrap_or(Lsn::INVALID),
             inner,
             log_id,
             read_pointer: after,
-        }
+            until_lsn,
+            terminated: false,
+        })
     }
 
-    fn seek_to(&mut self, record: &LogRecord) {
-        let read_pointer = match &record.record {
+    pub fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+
+    pub fn read_pointer(&self) -> Lsn {
+        self.read_pointer
+    }
+
+    fn calculate_read_pointer(record: &LogRecord) -> Lsn {
+        match &record.record {
             // On trim gaps, we fast-forward the read pointer to the end of the gap. We do
             // this after delivering a TrimGap record. This means that the next read operation
             // skips over the boundary of the gap.
             crate::Record::TrimGap(trim_gap) => trim_gap.until,
             crate::Record::Data(_) => record.offset,
             crate::Record::Seal(_) => record.offset,
-        };
-        self.read_pointer = read_pointer;
-    }
-
-    /// Read the next record from the log after the current read pointer. The future will resolve
-    /// after the record is available to read, this will async-block indefinitely if no records are
-    /// ever written to the log beyond the read pointer.
-    ///
-    /// This future is "Cancellation" safe.
-    pub async fn read_next(&mut self) -> Result<LogRecord, Error> {
-        let record = self
-            .inner
-            .read_next_single(self.log_id, self.read_pointer)
-            .await?;
-
-        self.seek_to(&record);
-        Ok(record)
-    }
-
-    /// Like `read_next` but returns `None` if there are no more records to read.
-    pub async fn read_next_opt(&mut self) -> Result<Option<LogRecord>, Error> {
-        let record_opt = self
-            .inner
-            .read_next_single_opt(self.log_id, self.read_pointer)
-            .await?;
-        if let Some(ref record) = record_opt {
-            self.seek_to(record);
         }
-        Ok(record_opt)
     }
 
     /// Current read pointer. This is the LSN of the last read record, or the
@@ -76,15 +103,68 @@ impl LogReadStream {
     }
 }
 
+impl FusedStream for LogReadStream {
+    fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+}
+
+/// Read the next record from the log after the current read pointer. The stream will yield
+/// after the record is available to read, this will async-block indefinitely if no records are
+/// ever written to the log beyond the read pointer.
+impl Stream for LogReadStream {
+    type Item = Result<LogRecord>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.read_pointer >= self.until_lsn {
+            self.as_mut().terminated = true;
+            return Poll::Ready(None);
+        }
+        // Are we after the known tail?
+        // todo: refresh the tail (in a multi-loglet universe)
+        let maybe_record = ready!(self
+            .as_mut()
+            .project()
+            .current_loglet_stream
+            .as_mut()
+            .poll_next(cx));
+        match maybe_record {
+            Some(Ok(record)) => {
+                let record = record
+                    .decode()
+                    .expect("decoding a bifrost envelope succeeds");
+                let new_pointer = Self::calculate_read_pointer(&record);
+                debug_assert!(new_pointer > self.read_pointer);
+                self.read_pointer = new_pointer;
+                Poll::Ready(Some(Ok(record)))
+            }
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            None => {
+                // todo: check if we should switch the loglet.
+                self.as_mut().terminated = true;
+                Poll::Ready(None)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
-    use crate::Bifrost;
+    use crate::{Bifrost, Record, TrimGap};
 
     use super::*;
-
     use googletest::prelude::*;
-    use restate_core::{TaskKind, TestCoreEnv};
+
+    use restate_core::{TaskKind, TestCoreEnvBuilder};
+    use restate_rocksdb::RocksDbManager;
+    use restate_types::arc_util::Constant;
+    use restate_types::config::CommonOptions;
+    use restate_types::logs::metadata::ProviderKind;
+    use tokio_stream::StreamExt;
     use tracing::info;
     use tracing_test::traced_test;
 
@@ -92,32 +172,48 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn test_basic_readstream() -> Result<()> {
-        let node_env = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
+    async fn test_basic_readstream() -> anyhow::Result<()> {
+        // Make sure that panics exits the process.
+        let orig_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            // invoke the default handler and exit the process
+            orig_hook(panic_info);
+            std::process::exit(1);
+        }));
+
+        let node_env = TestCoreEnvBuilder::new_with_mock_network()
+            .set_provider_kind(ProviderKind::Local)
+            .build()
+            .await;
+
         let tc = node_env.tc;
         tc.run_in_scope("test", None, async {
-            let read_after = Lsn::from(5);
+            RocksDbManager::init(Constant::new(CommonOptions::default()));
 
+            let read_after = Lsn::from(5);
             let mut bifrost = Bifrost::init().await;
 
-            let mut reader = bifrost.create_reader(LogId::from(0), Lsn::from(5));
-            assert_eq!(read_after, reader.current_read_pointer());
+            let log_id = LogId::from(0);
+            let mut reader = bifrost.create_reader(log_id, read_after, Lsn::MAX).await?;
 
-            // We have not written anything yet, this should return None.
-            assert!(reader.read_next_opt().await?.is_none());
-            // read points should not change, nothing has been read.
+            let tail = bifrost
+                .find_tail(log_id, FindTailAttributes::default())
+                .await?;
+            // no records have been written
+            assert!(tail.is_none());
             assert_eq!(read_after, reader.current_read_pointer());
 
             // spawn a reader that reads 5 records and exits.
-            let id = tc.spawn(TaskKind::Disposable, "read-records", None, async move {
+            let id = tc.spawn(TaskKind::TestRunner, "read-records", None, async move {
                 for i in 1..=5 {
-                    let record = reader.read_next().await?;
+                    let record = reader.next().await.expect("to never terminate")?;
                     let expected_lsn = Lsn::from(i) + read_after;
+                    assert_eq!(expected_lsn, reader.current_read_pointer());
                     info!(?record, "read record");
                     assert_eq!(expected_lsn, record.offset);
                     assert_eq!(
-                        Payload::new(format!("record{}", expected_lsn)),
-                        record.record.into_payload_unchecked()
+                        Payload::new(format!("record{}", expected_lsn)).body(),
+                        record.record.into_payload_unchecked().body()
                     );
                     assert_eq!(expected_lsn, reader.current_read_pointer());
                 }
@@ -155,8 +251,115 @@ mod tests {
             reader_bg_handle.await?;
             assert!(logs_contain("read record"));
 
-            Ok(())
+            anyhow::Ok(())
         })
-        .await
+        .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_stream_with_trim() -> anyhow::Result<()> {
+        // Make sure that panics exits the process.
+        let orig_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            // invoke the default handler and exit the process
+            orig_hook(panic_info);
+            std::process::exit(1);
+        }));
+
+        let node_env = TestCoreEnvBuilder::new_with_mock_network()
+            .set_provider_kind(ProviderKind::Local)
+            .build()
+            .await;
+        node_env
+            .tc
+            .run_in_scope("test", None, async {
+                RocksDbManager::init(Constant::new(CommonOptions::default()));
+
+                let log_id = LogId::from(0);
+                let mut bifrost = Bifrost::init().await;
+
+                assert!(bifrost.get_trim_point(log_id).await?.is_none());
+
+                for _ in 1..=10 {
+                    bifrost.append(log_id, Payload::default()).await?;
+                }
+
+                bifrost.trim(log_id, Lsn::from(5)).await?;
+
+                assert_eq!(
+                    Some(Lsn::from(10)),
+                    bifrost
+                        .find_tail(log_id, FindTailAttributes::default())
+                        .await?,
+                );
+                assert_eq!(Some(Lsn::from(5)), bifrost.get_trim_point(log_id).await?);
+
+                let mut read_stream = bifrost
+                    .create_reader(log_id, Lsn::INVALID, Lsn::MAX)
+                    .await?;
+
+                let record = read_stream.next().await.unwrap()?;
+                assert_that!(
+                    record,
+                    pat!(LogRecord {
+                        offset: eq(Lsn::from(1)),
+                        record: pat!(Record::TrimGap(pat!(TrimGap {
+                            until: eq(Lsn::from(5)),
+                        })))
+                    })
+                );
+
+                for lsn in 5..7 {
+                    let record = read_stream.next().await.unwrap()?;
+                    assert_that!(
+                        record,
+                        pat!(LogRecord {
+                            offset: eq(Lsn::from(lsn + 1)),
+                            record: pat!(Record::Data(_))
+                        })
+                    );
+                }
+                assert!(!read_stream.is_terminated());
+                assert_eq!(Lsn::from(7), read_stream.read_pointer());
+
+                // trimming beyond the release point will fall back to the release point
+                bifrost.trim(log_id, Lsn::from(u64::MAX)).await?;
+                assert_eq!(bifrost.get_trim_point(log_id).await?, Some(Lsn::from(10)));
+
+                for _ in 0..10 {
+                    bifrost.append(log_id, Payload::default()).await?;
+                }
+
+                // read stream should send a gap from 8->10
+                let record = read_stream.next().await.unwrap()?;
+                assert_that!(
+                    record,
+                    pat!(LogRecord {
+                        offset: eq(Lsn::from(8)),
+                        record: pat!(Record::TrimGap(pat!(TrimGap {
+                            until: eq(Lsn::from(10)),
+                        })))
+                    })
+                );
+
+                for lsn in 10..20 {
+                    let record = read_stream.next().await.unwrap()?;
+                    assert_that!(
+                        record,
+                        pat!(LogRecord {
+                            offset: eq(Lsn::from(lsn + 1)),
+                            record: pat!(Record::Data(_))
+                        })
+                    );
+                }
+                // we are at tail. polling should return pending.
+                let pinned = std::pin::pin!(read_stream.next());
+                let next_is_pending = futures::poll!(pinned);
+                assert!(matches!(next_is_pending, Poll::Pending));
+
+                Ok(())
+            })
+            .await
     }
 }

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -127,9 +127,7 @@ fn tokio_builder(common_opts: &CommonOptions) -> tokio::runtime::Builder {
         format!("rs:worker-{}", id)
     });
 
-    if let Some(worker_threads) = common_opts.default_thread_pool_size {
-        builder.worker_threads(worker_threads);
-    }
+    builder.worker_threads(common_opts.default_thread_pool_size());
 
     builder
 }

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -123,7 +123,7 @@ fn tokio_builder(common_opts: &CommonOptions) -> tokio::runtime::Builder {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all().thread_name_fn(|| {
         static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-        let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+        let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
         format!("rs:worker-{}", id)
     });
 
@@ -157,7 +157,7 @@ impl TaskCenter {
 
     /// The exit code that the process should exit with.
     pub fn exit_code(&self) -> i32 {
-        self.inner.current_exit_code.load(Ordering::Acquire)
+        self.inner.current_exit_code.load(Ordering::Relaxed)
     }
 
     /// Triggers a shutdown of the system. All running tasks will be asked gracefully
@@ -168,14 +168,14 @@ impl TaskCenter {
         let inner = self.inner.clone();
         if inner
             .shutdown_requested
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .unwrap_or_else(|e| e)
         {
             // already shutting down....
             return;
         }
         let start = Instant::now();
-        inner.current_exit_code.store(exit_code, Ordering::Release);
+        inner.current_exit_code.store(exit_code, Ordering::Relaxed);
 
         if exit_code != 0 {
             warn!("** Shutdown requested");
@@ -207,7 +207,7 @@ impl TaskCenter {
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
         let inner = self.inner.clone();
-        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
         let task = Arc::new(Task {
             id,
             name,
@@ -262,7 +262,7 @@ impl TaskCenter {
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
         let inner = self.inner.clone();
-        if inner.shutdown_requested.load(Ordering::Acquire) {
+        if inner.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
         Ok(self.spawn_unchecked(kind, name, partition_id, future))
@@ -300,7 +300,7 @@ impl TaskCenter {
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
         let inner = self.inner.clone();
-        if inner.shutdown_requested.load(Ordering::Acquire) {
+        if inner.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
 
@@ -431,7 +431,7 @@ impl TaskCenter {
         F: Future<Output = O>,
     {
         let cancel_token = CancellationToken::new();
-        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
         let task = Arc::new(Task {
             id,
             name,
@@ -469,7 +469,7 @@ impl TaskCenter {
         F: FnOnce() -> O,
     {
         let cancel_token = CancellationToken::new();
-        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::SeqCst));
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
         let task = Arc::new(Task {
             id,
             name,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -53,7 +53,7 @@ http = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 metrics = { workspace = true }
-metrics-exporter-prometheus = { version = "0.13", default-features = false, features = ["async-runtime"] }
+metrics-exporter-prometheus = { workspace = true }
 metrics-tracing-context = { version = "0.15.0" }
 metrics-util = { version = "0.16.0" }
 once_cell = { workspace = true }

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -182,7 +182,7 @@ pub(crate) fn cf_options(mut cf_options: rocksdb::Options) -> rocksdb::Options {
     // Most of the changes are highly temporal, we try to delay flushing
     // As much as we can to increase the chances to observe a deletion.
     //
-    cf_options.set_max_write_buffer_number(3);
+    cf_options.set_max_write_buffer_number(10);
     cf_options.set_min_write_buffer_number_to_merge(2);
     //
     // Set compactions per level

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -328,6 +328,8 @@ impl RocksDbManager {
         // https://github.com/facebook/rocksdb/blob/f059c7d9b96300091e07429a60f4ad55dac84859/include/rocksdb/table.h#L275
         block_opts.set_format_version(5);
         block_opts.set_cache_index_and_filter_blocks(true);
+        block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+
         block_opts.set_block_cache(&self.cache);
         cf_options.set_block_based_table_factory(&block_opts);
 

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -164,7 +164,9 @@ impl RocksDb {
         // Auto...
         // First, attempt to write without blocking
         write_options.set_no_slowdown(true);
-        let result = self.db.write_batch(&write_batch, &write_options);
+
+        let result =
+            tokio::task::block_in_place(|| self.db.write_batch(&write_batch, &write_options));
         match result {
             Ok(_) => {
                 counter!(STORAGE_IO_OP,
@@ -247,7 +249,8 @@ impl RocksDb {
         // Auto...
         // First, attempt to write without blocking
         write_options.set_no_slowdown(true);
-        let result = self.db.write_tx_batch(&write_batch, &write_options);
+        let result =
+            tokio::task::block_in_place(|| self.db.write_tx_batch(&write_batch, &write_options));
         match result {
             Ok(_) => {
                 counter!(STORAGE_IO_OP,

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -87,9 +87,9 @@ pub struct CommonOptions {
     /// # Default async runtime thread pool
     ///
     /// Size of the default thread pool used to perform internal tasks.
-    /// If not set, it defaults to the number of CPU cores.
+    /// If not set, it defaults to twice the number of CPU cores.
     #[builder(setter(strip_option))]
-    pub default_thread_pool_size: Option<usize>,
+    default_thread_pool_size: Option<usize>,
 
     /// # Tracing Endpoint
     ///
@@ -246,19 +246,20 @@ impl CommonOptions {
     }
 
     pub fn storage_high_priority_bg_threads(&self) -> NonZeroUsize {
-        self.storage_high_priority_bg_threads.unwrap_or(
+        NonZeroUsize::new(4).unwrap()
+    }
+
+    pub fn default_thread_pool_size(&self) -> usize {
+        2 * self.default_thread_pool_size.unwrap_or(
             std::thread::available_parallelism()
                 // Shouldn't really fail, but just in case.
-                .unwrap_or(NonZeroUsize::new(4).unwrap()),
+                .unwrap_or(NonZeroUsize::new(4).unwrap())
+                .get(),
         )
     }
 
     pub fn storage_low_priority_bg_threads(&self) -> NonZeroUsize {
-        self.storage_low_priority_bg_threads.unwrap_or(
-            std::thread::available_parallelism()
-                // Shouldn't really fail, but just in case.
-                .unwrap_or(NonZeroUsize::new(4).unwrap()),
-        )
+        NonZeroUsize::new(4).unwrap()
     }
 
     pub fn rocksdb_bg_threads(&self) -> NonZeroU32 {
@@ -301,8 +302,8 @@ impl Default for CommonOptions {
             default_thread_pool_size: None,
             storage_high_priority_bg_threads: None,
             storage_low_priority_bg_threads: None,
-            rocksdb_total_memtables_ratio: 0.5, // (50% of rocksdb-total-memory-size)
-            rocksdb_total_memory_size: NonZeroUsize::new(4_000_000_000).unwrap(), // 4GB
+            rocksdb_total_memtables_ratio: 0.6, // (60% of rocksdb-total-memory-size)
+            rocksdb_total_memory_size: NonZeroUsize::new(6_000_000_000).unwrap(), // 4GB
             rocksdb_bg_threads: None,
             rocksdb_high_priority_bg_threads: NonZeroU32::new(2).unwrap(),
             rocksdb_write_stall_threshold: std::time::Duration::from_secs(3).into(),

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -123,6 +123,8 @@ impl RocksDbOptions {
             // Assuming 256MB for bifrost's data cf (2 memtables * 128MB default write buffer size)
             // Assuming 256MB for bifrost's metadata cf (2 memtables * 128MB default write buffer size)
             let buffer_size = (all_memtables - 512_000_000) / (num_partitions * 3) as usize;
+            // reduce the buffer_size by 10% for safety
+            let buffer_size = (buffer_size as f64 * 0.9) as usize;
             NonZeroUsize::new(buffer_size).unwrap()
         })
     }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -68,7 +68,7 @@ impl WorkerOptions {
 impl Default for WorkerOptions {
     fn default() -> Self {
         Self {
-            internal_queue_length: NonZeroUsize::new(64).unwrap(),
+            internal_queue_length: NonZeroUsize::new(6400).unwrap(),
             num_timers_in_memory_limit: None,
             storage: StorageOptions::default(),
             invoker: Default::default(),

--- a/tools/bifrost-benchpress/Cargo.toml
+++ b/tools/bifrost-benchpress/Cargo.toml
@@ -27,7 +27,7 @@ figment = { version = "0.10.8", features = ["env", "toml"] }
 futures = { workspace = true }
 hdrhistogram = { version = "7.5.4" }
 metrics = { workspace = true }
-metrics-exporter-prometheus = { version = "0.14", default-features = false, features = ["async-runtime"] }
+metrics-exporter-prometheus = { workspace = true }
 once_cell = { workspace = true }
 quanta = { version = "0.12.3" }
 rocksdb = { workspace = true }

--- a/tools/mock-service-endpoint/Cargo.toml
+++ b/tools/mock-service-endpoint/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "mock-service-endpoint"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+assert2 = { workspace = true }
+async-stream = "0.3.5"
+bytes = { workspace = true }
+futures = { workspace = true }
+http = {workspace = true}
+http-body-util = "0.1"
+hyper = { version = "1", features = ["server"] }
+hyper-util = { version = "0.1", features = ["full"] }
+restate-service-protocol = { workspace = true, features = ["message", "codec"] }
+restate-types = { workspace = true }
+prost = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+thiserror = { workspace = true }

--- a/tools/mock-service-endpoint/src/main.rs
+++ b/tools/mock-service-endpoint/src/main.rs
@@ -1,0 +1,432 @@
+use std::convert::Infallible;
+use std::fmt::{Display, Formatter};
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use assert2::let_assert;
+use async_stream::{stream, try_stream};
+use bytes::Bytes;
+use futures::{pin_mut, Stream, StreamExt};
+use http_body_util::{BodyStream, Either, Empty, Full, StreamBody};
+use hyper::body::{Frame, Incoming};
+use hyper::server::conn::http2;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+use prost::Message;
+use tokio::net::TcpListener;
+use tracing::{debug, error, info};
+use tracing_subscriber::filter::LevelFilter;
+
+use restate_service_protocol::codec::ProtobufRawEntryCodec;
+use restate_service_protocol::message::{Decoder, Encoder, EncodingError, ProtocolMessage};
+use restate_types::errors::codes;
+use restate_types::journal::raw::{EntryHeader, PlainRawEntry, RawEntryCodecError};
+use restate_types::journal::{Entry, EntryType, InputEntry};
+use restate_types::service_protocol::start_message::StateEntry;
+use restate_types::service_protocol::{
+    self, get_state_entry_message, output_entry_message, ServiceProtocolVersion, StartMessage,
+};
+
+#[derive(Debug, thiserror::Error)]
+enum FrameError {
+    #[error(transparent)]
+    EncodingError(EncodingError),
+    #[error(transparent)]
+    Hyper(hyper::Error),
+    #[error("Stream ended before finished replay")]
+    UnexpectedEOF,
+    #[error("Journal does not contain expected messages")]
+    InvalidJournal,
+    #[error(transparent)]
+    RawEntryCodecError(#[from] RawEntryCodecError),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+async fn serve(
+    req: Request<Incoming>,
+) -> Result<
+    Response<
+        Either<Empty<Bytes>, StreamBody<impl Stream<Item = Result<Frame<Bytes>, Infallible>>>>,
+    >,
+    Infallible,
+> {
+    let (req_head, req_body) = req.into_parts();
+    let mut split = req_head.uri.path().rsplit('/');
+    let handler_name = if let Some(handler_name) = split.next() {
+        handler_name
+    } else {
+        return Ok(Response::builder()
+            .status(404)
+            .body(Either::Left(Empty::new()))
+            .unwrap());
+    };
+    if let Some("Counter") = split.next() {
+    } else {
+        return Ok(Response::builder()
+            .status(404)
+            .body(Either::Left(Empty::new()))
+            .unwrap());
+    };
+    if let Some("invoke") = split.next() {
+    } else {
+        return Ok(Response::builder()
+            .status(404)
+            .body(Either::Left(Empty::new()))
+            .unwrap());
+    };
+
+    let req_body = BodyStream::new(req_body);
+    let mut decoder = Decoder::new(ServiceProtocolVersion::V1, usize::MAX, None);
+    let encoder = Encoder::new(ServiceProtocolVersion::V1);
+
+    let incoming = stream! {
+        for await frame in req_body {
+           match frame {
+              Ok(frame) => {
+                    if let Ok(data) = frame.into_data() {
+                        decoder.push(data);
+                        loop {
+                            match decoder.consume_next() {
+                                Ok(Some((_header, message))) => yield Ok(message),
+                                Ok(None) => {
+                                    break
+                                },
+                                Err(err) => yield Err(FrameError::EncodingError(err)),
+                            }
+                        }
+                 }
+              },
+              Err(err) => yield Err(FrameError::Hyper(err)),
+           };
+        }
+    };
+
+    let handler: Handler = match handler_name.parse() {
+        Ok(handler) => handler,
+        Err(_err) => {
+            return Ok(Response::builder()
+                .status(404)
+                .body(Either::Left(Empty::new()))
+                .unwrap());
+        }
+    };
+
+    let outgoing = handler.handle(incoming).map(move |message| match message {
+        Ok(message) => Ok(Frame::data(encoder.encode(message))),
+        Err(err) => {
+            error!("Error handling stream: {err:?}");
+            Ok(Frame::data(encoder.encode(error(err))))
+        }
+    });
+
+    Ok(Response::builder()
+        .status(200)
+        .header("content-type", "application/vnd.restate.invocation.v1")
+        .body(Either::Right(StreamBody::new(outgoing)))
+        .unwrap())
+}
+
+enum Handler {
+    Get,
+    Add,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid handler")]
+struct InvalidHandler;
+
+impl FromStr for Handler {
+    type Err = InvalidHandler;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "get" => Ok(Self::Get),
+            "add" => Ok(Self::Add),
+            _ => Err(InvalidHandler),
+        }
+    }
+}
+
+impl Display for Handler {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Get => write!(f, "get"),
+            Self::Add => write!(f, "add"),
+        }
+    }
+}
+
+impl Handler {
+    fn handle(
+        self,
+        incoming: impl Stream<Item = Result<ProtocolMessage, FrameError>>,
+    ) -> impl Stream<Item = Result<ProtocolMessage, FrameError>> {
+        try_stream! {
+            pin_mut!(incoming);
+            match (incoming.next().await, incoming.next().await) {
+                (Some(Ok(ProtocolMessage::Start(start_message))), Some(Ok(ProtocolMessage::UnparsedEntry(input)))) if input.ty() == EntryType::Input => {
+                    let input = input.deserialize_entry_ref::<ProtobufRawEntryCodec>()?;
+                    let_assert!(
+                        Entry::Input(input) = input
+                    );
+
+                    let replay_count =  start_message.known_entries as usize - 1;
+                    let mut replayed = Vec::with_capacity(replay_count);
+                    for _ in 0..replay_count {
+                        let message = incoming.next().await.ok_or(FrameError::UnexpectedEOF)??;
+                        replayed.push(message);
+                    }
+
+                    debug!("Handling request to {self} with {} known entries",  start_message.known_entries);
+
+                    match self {
+                        Handler::Get => {
+                            for await message in Self::handle_get(start_message, input, replayed, incoming) {
+                                yield message?
+                            }
+                        },
+                        Handler::Add => {
+                            for await message in Self::handle_add(start_message, input, replayed, incoming) {
+                                yield message?
+                            }
+                        },
+                    };
+                },
+                _ => {Err(FrameError::InvalidJournal)?; return},
+            };
+        }
+    }
+
+    fn handle_get(
+        start_message: StartMessage,
+        _input: InputEntry,
+        replayed: Vec<ProtocolMessage>,
+        _incoming: impl Stream<Item = Result<ProtocolMessage, FrameError>>,
+    ) -> impl Stream<Item = Result<ProtocolMessage, FrameError>> {
+        try_stream! {
+            let counter = read_counter(&start_message.state_map);
+            match replayed.len() {
+                0 => {
+                    yield get_state(counter.clone());
+                    yield output(counter.unwrap_or("0".into()));
+                    yield end();
+                },
+                1 => {
+                    yield output(counter.unwrap_or("0".into()));
+                    yield end();
+                }
+                2=> {
+                    yield end();
+                }
+                _ => {Err(FrameError::InvalidJournal)?; return},
+            }
+        }
+    }
+
+    fn handle_add(
+        start_message: StartMessage,
+        input: InputEntry,
+        replayed: Vec<ProtocolMessage>,
+        _incoming: impl Stream<Item = Result<ProtocolMessage, FrameError>>,
+    ) -> impl Stream<Item = Result<ProtocolMessage, FrameError>> {
+        try_stream! {
+                let counter = read_counter(&start_message.state_map);
+                match replayed.len() {
+                    0 => {
+                        yield get_state(counter.clone());
+
+                        let next_value = match counter {
+                            Some(ref counter) => {
+                                let to_add: i32 = serde_json::from_slice(input.value.as_ref())?;
+                                let current: i32 = serde_json::from_slice(counter.as_ref())?;
+
+                                serde_json::to_vec(&(to_add + current))?.into()
+                            }
+                            None => input.value,
+                        };
+
+                        yield set_state(next_value.clone());
+                        yield output(next_value);
+                        yield end();
+                    },
+                    1 => {
+                        let next_value = match counter {
+                            Some(ref counter) => {
+                                let to_add: i32 = serde_json::from_slice(input.value.as_ref())?;
+                                let current: i32 = serde_json::from_slice(counter.as_ref())?;
+
+                                serde_json::to_vec(&(to_add + current))?.into()
+                            }
+                            None => input.value,
+                        };
+
+                        yield set_state(next_value.clone());
+                        yield output(next_value);
+                        yield end();
+                    }
+                    2 => {
+                        let set_value = match &replayed[1] {
+                            ProtocolMessage::UnparsedEntry(set) if set.ty() == EntryType::SetState => {
+                                let set = set.deserialize_entry_ref::<ProtobufRawEntryCodec>()?;
+                                let_assert!(
+                                  Entry::SetState(set) = set
+                                );
+                                set.value.clone()
+                            },
+                             _ => {Err(FrameError::InvalidJournal)?; return},
+                        };
+                        yield output(set_value);
+                        yield end();
+                    }
+                    3 => {
+                        yield end();
+                    }
+                    _ => {Err(FrameError::InvalidJournal)?; return},
+                }
+        }
+    }
+}
+
+fn read_counter(state_map: &[StateEntry]) -> Option<Bytes> {
+    let entry = state_map
+        .iter()
+        .find(|entry| entry.key.as_ref() == b"counter")?;
+    Some(entry.value.clone())
+}
+
+fn get_state(counter: Option<Bytes>) -> ProtocolMessage {
+    debug!(
+        "Yielding GetStateEntryMessage with value {}",
+        LossyDisplay(counter.as_deref())
+    );
+
+    ProtocolMessage::UnparsedEntry(PlainRawEntry::new(
+        EntryHeader::GetState { is_completed: true },
+        service_protocol::GetStateEntryMessage {
+            name: String::new(),
+            key: "counter".into(),
+            result: Some(match counter {
+                Some(ref counter) => get_state_entry_message::Result::Value(counter.clone()),
+                None => get_state_entry_message::Result::Empty(service_protocol::Empty {}),
+            }),
+        }
+        .encode_to_vec()
+        .into(),
+    ))
+}
+
+fn set_state(value: Bytes) -> ProtocolMessage {
+    debug!(
+        "Yielding SetStateEntryMessage with value {}",
+        LossyDisplay(Some(&value))
+    );
+
+    ProtocolMessage::UnparsedEntry(PlainRawEntry::new(
+        EntryHeader::SetState,
+        service_protocol::SetStateEntryMessage {
+            name: String::new(),
+            key: "counter".into(),
+            value: value.clone(),
+        }
+        .encode_to_vec()
+        .into(),
+    ))
+}
+
+fn output(value: Bytes) -> ProtocolMessage {
+    debug!(
+        "Yielding OutputEntryMessage with result {}",
+        LossyDisplay(Some(&value))
+    );
+
+    ProtocolMessage::UnparsedEntry(PlainRawEntry::new(
+        EntryHeader::Output,
+        service_protocol::OutputEntryMessage {
+            name: String::new(),
+            result: Some(output_entry_message::Result::Value(value)),
+        }
+        .encode_to_vec()
+        .into(),
+    ))
+}
+
+fn end() -> ProtocolMessage {
+    debug!("Yielding EndMessage");
+
+    ProtocolMessage::End(service_protocol::EndMessage {})
+}
+
+fn error(err: FrameError) -> ProtocolMessage {
+    let code = match err {
+        FrameError::EncodingError(_) => codes::PROTOCOL_VIOLATION,
+        FrameError::Hyper(_) => codes::INTERNAL,
+        FrameError::UnexpectedEOF => codes::PROTOCOL_VIOLATION,
+        FrameError::InvalidJournal => codes::JOURNAL_MISMATCH,
+        FrameError::RawEntryCodecError(_) => codes::PROTOCOL_VIOLATION,
+        FrameError::Serde(_) => codes::INTERNAL,
+    };
+    ProtocolMessage::Error(service_protocol::ErrorMessage {
+        code: code.into(),
+        description: err.to_string(),
+        message: String::new(),
+        related_entry_index: None,
+        related_entry_name: None,
+        related_entry_type: None,
+    })
+}
+
+struct LossyDisplay<'a>(Option<&'a [u8]>);
+impl<'a> Display for LossyDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(bytes) => write!(f, "{}", String::from_utf8_lossy(bytes)),
+            None => write!(f, "<empty>"),
+        }
+    }
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let format = tracing_subscriber::fmt::format().compact();
+
+    tracing_subscriber::fmt()
+        .event_format(format)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let addr: SocketAddr = ([127, 0, 0, 1], 9080).into();
+
+    let listener = TcpListener::bind(addr).await?;
+    info!("Listening on http://{}", addr);
+    loop {
+        let (tcp, _) = listener.accept().await?;
+        let io = TokioIo::new(tcp);
+
+        tokio::task::spawn(async move {
+            if let Err(err) = http2::Builder::new(TokioExecutor::new())
+                .timer(TokioTimer::new())
+                .serve_connection(io, service_fn(|req| async {
+                    if req.uri().path() == "/discover" {
+                        return Ok(Response::builder()
+                            .header("content-type", "application/vnd.restate.endpointmanifest.v1+json")
+                            .body(Either::Left(Full::new(Bytes::from(
+                                r#"{"protocolMode":"BIDI_STREAM","minProtocolVersion":1,"maxProtocolVersion":2,"services":[{"name":"Counter","ty":"VIRTUAL_OBJECT","handlers":[{"name":"add","input":{"required":false,"contentType":"application/json"},"output":{"setContentTypeIfEmpty":false,"contentType":"application/json"},"ty":"EXCLUSIVE"},{"name":"get","input":{"required":false,"contentType":"application/json"},"output":{"setContentTypeIfEmpty":false,"contentType":"application/json"},"ty":"EXCLUSIVE"}]}]}"#
+                            )))).unwrap());
+                    }
+
+                    let (head, body) = serve(req).await?.into_parts();
+                    Result::<_, Infallible>::Ok(Response::from_parts(head, Either::Right(body)))
+                }))
+                .await
+            {
+                println!("Error serving connection: {:?}", err);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Disable metric label extraction from tracing due to high cpu cost

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1564).
* __->__ #1564
* #1565
* #1563
* #1558
* #1557
* #1556