### PR TITLE
[Perf] Rocksdb performance tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.0+9.0.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7#c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=64a3c698910380e4fcbd8e56ce459779932cf1ff#64a3c698910380e4fcbd8e56ce459779932cf1ff"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6465,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7#c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=64a3c698910380e4fcbd8e56ce459779932cf1ff#64a3c698910380e4fcbd8e56ce459779932cf1ff"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ prost-build = "0.12.1"
 prost-types = "0.12.1"
 rand = "0.8.5"
 rayon = { version = "1.10" }
-rocksdb = { version = "0.22.0", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev="c2181f2b5da6d7bc201dc858433ed9e1c4bba4b7" }
+rocksdb = { version = "0.22.0", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev="64a3c698910380e4fcbd8e56ce459779932cf1ff" }
 rustls = "0.21.6"
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -126,11 +126,11 @@ pub fn flamegraph_options<'a>() -> Options<'a> {
 pub fn restate_configuration() -> Configuration {
     let common_options = CommonOptionsBuilder::default()
         .base_dir(tempfile::tempdir().expect("tempdir failed").into_path())
+        .bootstrap_num_partitions(NonZeroU64::new(10).unwrap())
         .build()
         .expect("building common options should work");
 
     let worker_options = WorkerOptionsBuilder::default()
-        .bootstrap_num_partitions(NonZeroU64::new(10).unwrap())
         .build()
         .expect("building worker options should work");
 

--- a/crates/bifrost/src/loglets/local_loglet/provider.rs
+++ b/crates/bifrost/src/loglets/local_loglet/provider.rs
@@ -26,7 +26,6 @@ use crate::loglet::{Loglet, LogletOffset, LogletProvider};
 use crate::Error;
 use crate::ProviderError;
 
-//#[derive(Debug)]
 pub struct LocalLogletProvider {
     log_store: RocksDbLogStore,
     active_loglets: AsyncMutex<HashMap<String, Arc<LocalLoglet>>>,
@@ -90,13 +89,8 @@ impl LogletProvider for LocalLogletProvider {
     }
 
     fn start(&self) -> Result<(), ProviderError> {
-        let mut updateable = Configuration::mapped_updateable(|c| &c.bifrost.local);
-        let opts = updateable.load();
-        let manual_wal_flush = opts.batch_wal_flushes && !opts.rocksdb.rocksdb_disable_wal();
-        let log_writer = self
-            .log_store
-            .create_writer(manual_wal_flush)
-            .start(updateable)?;
+        let updateable = Configuration::mapped_updateable(|c| &c.bifrost.local);
+        let log_writer = self.log_store.create_writer().start(updateable)?;
         self.log_writer
             .set(log_writer)
             .expect("local loglet started once");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -372,7 +372,7 @@ impl Node {
     ) -> Result<FixedPartitionTable, Error> {
         Self::retry_on_network_error(|| {
             metadata_store_client.get_or_insert(PARTITION_TABLE_KEY.clone(), || {
-                FixedPartitionTable::new(Version::MIN, config.worker.bootstrap_num_partitions())
+                FixedPartitionTable::new(Version::MIN, config.common.bootstrap_num_partitions())
             })
         })
         .await

--- a/crates/node/src/network_server/handler/mod.rs
+++ b/crates/node/src/network_server/handler/mod.rs
@@ -145,6 +145,7 @@ const ROCKSDB_DB_PROPERTIES: &[(&str, MetricUnit)] = &[
 const ROCKSDB_CF_PROPERTIES: &[(&str, MetricUnit)] = &[
     ("rocksdb.num-immutable-mem-table", MetricUnit::Count),
     ("rocksdb.mem-table-flush-pending", MetricUnit::Count),
+    ("rocksdb.is-write-stopped", MetricUnit::Count),
     ("rocksdb.compaction-pending", MetricUnit::Count),
     ("rocksdb.background-errors", MetricUnit::Count),
     ("rocksdb.cur-size-active-mem-table", MetricUnit::Bytes),
@@ -171,6 +172,9 @@ const ROCKSDB_CF_PROPERTIES: &[(&str, MetricUnit)] = &[
     // Add more as needed.
     ("rocksdb.num-files-at-level2", MetricUnit::Count),
     ("rocksdb.num-files-at-level3", MetricUnit::Count),
+    ("rocksdb.num-files-at-level4", MetricUnit::Count),
+    ("rocksdb.num-files-at-level5", MetricUnit::Count),
+    ("rocksdb.num-files-at-level6", MetricUnit::Count),
 ];
 
 // -- Direct HTTP Handlers --

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -174,31 +174,49 @@ impl Clone for PartitionStore {
     }
 }
 
-pub(crate) fn cf_options(mut cf_options: rocksdb::Options) -> rocksdb::Options {
-    // Actually, we would love to use CappedPrefixExtractor but unfortunately it's neither exposed
-    // in the C API nor the rust binding. That's okay and we can change it later.
-    cf_options.set_prefix_extractor(SliceTransform::create_fixed_prefix(DB_PREFIX_LENGTH));
-    cf_options.set_memtable_prefix_bloom_ratio(0.2);
-    // Most of the changes are highly temporal, we try to delay flushing
-    // As much as we can to increase the chances to observe a deletion.
-    //
-    cf_options.set_max_write_buffer_number(10);
-    cf_options.set_min_write_buffer_number_to_merge(2);
-    //
-    // Set compactions per level
-    //
-    cf_options.set_num_levels(7);
-    cf_options.set_compression_per_level(&[
-        DBCompressionType::None,
-        DBCompressionType::Snappy,
-        DBCompressionType::Snappy,
-        DBCompressionType::Snappy,
-        DBCompressionType::Snappy,
-        DBCompressionType::Snappy,
-        DBCompressionType::Zstd,
-    ]);
+pub(crate) fn cf_options(
+    memory_budget: usize,
+) -> impl Fn(rocksdb::Options) -> rocksdb::Options + Send + Sync + 'static {
+    move |mut cf_options| {
+        set_memory_related_opts(&mut cf_options, memory_budget);
+        // Actually, we would love to use CappedPrefixExtractor but unfortunately it's neither exposed
+        // in the C API nor the rust binding. That's okay and we can change it later.
+        cf_options.set_prefix_extractor(SliceTransform::create_fixed_prefix(DB_PREFIX_LENGTH));
+        cf_options.set_memtable_prefix_bloom_ratio(0.2);
+        cf_options.set_memtable_whole_key_filtering(true);
+        // Most of the changes are highly temporal, we try to delay flushing
+        // As much as we can to increase the chances to observe a deletion.
+        //
+        cf_options.set_num_levels(7);
+        cf_options.set_compression_per_level(&[
+            DBCompressionType::None,
+            DBCompressionType::None,
+            DBCompressionType::Lz4,
+            DBCompressionType::Lz4,
+            DBCompressionType::Lz4,
+            DBCompressionType::Lz4,
+            DBCompressionType::Zstd,
+        ]);
 
-    cf_options
+        cf_options
+    }
+}
+
+fn set_memory_related_opts(opts: &mut rocksdb::Options, memtables_budget: usize) {
+    // We set the budget to allow 1 mutable + 3 immutable.
+    opts.set_write_buffer_size(memtables_budget / 4);
+
+    // merge 2 memtables when flushing to L0
+    opts.set_min_write_buffer_number_to_merge(2);
+    opts.set_max_write_buffer_number(4);
+    // start flushing L0->L1 as soon as possible. each file on level0 is
+    // (memtable_memory_budget / 2). This will flush level 0 when it's bigger than
+    // memtable_memory_budget.
+    opts.set_level_zero_file_num_compaction_trigger(2);
+    // doesn't really matter much, but we don't want to create too many files
+    opts.set_target_file_size_base(memtables_budget as u64 / 8);
+    // make Level1 size equal to Level0 size, so that L0->L1 compactions are fast
+    opts.set_max_bytes_for_level_base(memtables_budget as u64);
 }
 
 impl PartitionStore {
@@ -444,7 +462,7 @@ impl<'a> RocksDBTransaction<'a> {
         let mut opts = ReadOptions::default();
         opts.set_iterate_range(PrefixRange(prefix.clone()));
         opts.set_prefix_same_as_start(true);
-        opts.set_async_io(true);
+        //opts.set_async_io(true);
         opts.set_total_order_seek(false);
 
         let mut it = self.txn.raw_iterator_cf_opt(table, opts);
@@ -466,7 +484,7 @@ impl<'a> RocksDBTransaction<'a> {
         // binding.
         opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
         opts.set_iterate_range(from.clone()..to);
-        opts.set_async_io(true);
+        //opts.set_async_io(true);
         let mut it = self.txn.raw_iterator_cf_opt(table, opts);
         it.seek(from);
         it
@@ -491,7 +509,7 @@ impl<'a> Transaction for RocksDBTransaction<'a> {
         // We disable WAL since bifrost is our durable distributed log.
         opts.disable_wal(true);
         self.rocksdb
-            .write_tx_batch(Priority::High, IoMode::default(), opts, write_batch)
+            .write_tx_batch(Priority::High, IoMode::AlwaysBackground, opts, write_batch)
             .await
             .map_err(|error| StorageError::Generic(error.into()))
     }

--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroU64;
 use std::path::PathBuf;
 
 use humantime::Duration;
@@ -68,6 +69,18 @@ pub struct CommonOptionCliOverride {
     /// unset. e.g. `http://127.0.0.1:5122/`
     #[clap(long)]
     advertise_address: Option<AdvertisedAddress>,
+
+    /// # Partitions
+    ///
+    /// Number of partitions that will be provisioned during cluster bootstrap,
+    /// partitions used to process messages.
+    ///
+    /// NOTE: This config entry only impacts the initial number of partitions, the
+    /// value of this entry is ignored for bootstrapped nodes/clusters.
+    ///
+    /// Cannot be higher than `4611686018427387903` (You should almost never need as many partitions anyway)
+    #[clap(long)]
+    bootstrap_num_partitions: Option<NonZeroU64>,
 
     /// This timeout is used when shutting down the various Restate components to drain all the internal queues.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]

--- a/crates/types/src/config/metadata_store.rs
+++ b/crates/types/src/config/metadata_store.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use super::{data_dir, RocksDbOptions, RocksDbOptionsBuilder};
+use super::{data_dir, CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
 use crate::net::BindAddress;
 
 /// # Metadata store options
@@ -26,6 +26,10 @@ use crate::net::BindAddress;
 #[serde(rename_all = "kebab-case")]
 #[builder(default)]
 pub struct MetadataStoreOptions {
+    /// The memory budget for rocksdb memtables in bytes
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(skip)]
+    pub rocksdb_memory_budget: usize,
     /// # Bind address of the metadata store
     ///
     /// Address to which the metadata store will bind to.
@@ -44,6 +48,14 @@ pub struct MetadataStoreOptions {
 }
 
 impl MetadataStoreOptions {
+    pub fn apply_common(&mut self, common: &CommonOptions) {
+        self.rocksdb.apply_common(&common.rocksdb);
+        // let's assume we are taking 1/32 of the budget (for now)
+        self.rocksdb_memory_budget =
+            // 1MB minimum
+            std::cmp::max(1024 * 1024, common.rocksdb_safe_total_memtables_size());
+    }
+
     pub fn data_dir(&self) -> PathBuf {
         data_dir("local-metadata-store")
     }
@@ -60,6 +72,8 @@ impl Default for MetadataStoreOptions {
             .build()
             .expect("valid RocksDbOptions");
         Self {
+            // set by apply_common in runtime
+            rocksdb_memory_budget: 0,
             bind_address: "0.0.0.0:5123".parse().expect("valid bind address"),
             request_queue_length: NonZeroUsize::new(32).unwrap(),
             rocksdb,

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -190,18 +190,10 @@ impl Configuration {
         ConfigWatch::new(CONFIG_UPDATE.subscribe())
     }
 
-    pub fn apply_rocksdb_common(mut self) -> Self {
-        self.worker
-            .storage
-            .rocksdb
-            .apply_common(&self.common.rocksdb);
-        self.bifrost
-            .local
-            .rocksdb
-            .apply_common(&self.common.rocksdb);
-        self.metadata_store
-            .rocksdb
-            .apply_common(&self.common.rocksdb);
+    pub fn apply_cascading_values(mut self) -> Self {
+        self.worker.storage.apply_common(&self.common);
+        self.bifrost.local.apply_common(&self.common);
+        self.metadata_store.apply_common(&self.common);
         self
     }
 

--- a/server/src/config_loader.rs
+++ b/server/src/config_loader.rs
@@ -59,7 +59,7 @@ impl ConfigLoader {
         }
 
         let config: Configuration = figment.extract()?;
-        Ok(config.apply_rocksdb_common())
+        Ok(config.apply_cascading_values())
     }
 
     fn merge_with_env(figment: Figment) -> Figment {
@@ -147,7 +147,7 @@ impl ConfigLoader {
         let mut should_update = false;
         for event in events.iter().filter(|e| e.kind == DebouncedEventKind::Any) {
             should_update = true;
-            info!("Detected configuration file changes: {:?}", event.path);
+            warn!("Detected configuration file changes: {:?}", event.path);
         }
 
         if should_update {

--- a/server/src/signal.rs
+++ b/server/src/signal.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::io::Write;
+
 use tokio::signal::unix::{signal, SignalKind};
 use tracing::{info, warn};
 
@@ -30,11 +32,14 @@ pub(super) async fn sigusr_dump_config() {
 
     loop {
         stream.recv().await;
-        info!("Received SIGUSR1, dumping configuration");
+        warn!("Received SIGUSR1, dumping configuration");
         let config = Configuration::pinned().dump();
         match config {
             Err(e) => warn!("Failed to dump configuration: {}", e),
-            Ok(config) => info!("{}", config),
+            Ok(config) => {
+                let mut stderr = std::io::stderr().lock();
+                let _ = writeln!(&mut stderr, "{}", config);
+            }
         }
     }
 }


### PR DESCRIPTION
[Perf] Rocksdb performance tuning

This also introduces a change to how memory budgeting is configured and the default number of partitions is now 24

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1572).
* #1575
* #1573
* __->__ #1572