### PR TITLE
[rocksdb] Change default statistics level

### DIFF
--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -141,7 +141,7 @@ impl RocksDbOptions {
 
     pub fn rocksdb_statistics_level(&self) -> StatisticsLevel {
         self.rocksdb_statistics_level
-            .unwrap_or(StatisticsLevel::ExceptDetailedTimers)
+            .unwrap_or(StatisticsLevel::ExceptTimers)
     }
 }
 


### PR DESCRIPTION
[rocksdb] Change default statistics level

We don't currently make use of the fidelity of this level.
