### PR TITLE
[rocksdb] Make perf level configurable

### DIFF
--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -24,7 +24,7 @@ use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::PlainNodeId;
 
-use super::{AwsOptions, HttpOptions, RocksDbOptions};
+use super::{AwsOptions, HttpOptions, PerfStatsLevel, RocksDbOptions};
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 
@@ -218,6 +218,13 @@ pub struct CommonOptions {
     /// will recover from this without intervention.
     pub rocksdb_enable_stall_on_memory_limit: bool,
 
+    /// # Rocksdb performance statistics level
+    ///
+    /// Defines the level of PerfContext used internally by rocksdb. Default is `enable-count`
+    /// which should be sufficient for most users. Note that higher levels incur a CPU cost and
+    /// might slow down the critical path.
+    pub rocksdb_perf_level: PerfStatsLevel,
+
     /// RocksDb base settings and memory limits that get applied on every database
     #[serde(flatten)]
     pub rocksdb: RocksDbOptions,
@@ -344,6 +351,7 @@ impl Default for CommonOptions {
             rocksdb_high_priority_bg_threads: NonZeroU32::new(2).unwrap(),
             rocksdb_write_stall_threshold: std::time::Duration::from_secs(3).into(),
             rocksdb_enable_stall_on_memory_limit: false,
+            rocksdb_perf_level: PerfStatsLevel::EnableCount,
             rocksdb: Default::default(),
         }
     }

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -141,7 +141,7 @@ impl RocksDbOptions {
 
     pub fn rocksdb_statistics_level(&self) -> StatisticsLevel {
         self.rocksdb_statistics_level
-            .unwrap_or(StatisticsLevel::ExceptDetailedTimers)
+            .unwrap_or(StatisticsLevel::ExceptTimers)
     }
 }
 

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -167,3 +167,21 @@ pub enum StatisticsLevel {
     /// reduce scalability to more threads, especially for writes.
     All,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(rename = "RocksbPerfStatisticsLevel"))]
+#[serde(rename_all = "kebab-case")]
+pub enum PerfStatsLevel {
+    /// Disable perf stats
+    Disable,
+    /// Enables only count stats
+    EnableCount,
+    /// Count stats and enable time stats except for mutexes
+    EnableTimeExceptForMutex,
+    /// Other than time, also measure CPU time counters. Still don't measure
+    /// time (neither wall time nor CPU time) for mutexes
+    EnableTimeAndCPUTimeExceptForMutex,
+    /// Enables count and time stats
+    EnableTime,
+}


### PR DESCRIPTION
[rocksdb] Make perf level configurable

This is now controlled by `common.rocksdb-perf-level`. Default is `enable-count`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1589).
* #1590
* __->__ #1589
* #1588