### PR TITLE
[rocksdb] Make perf level configurable

### DIFF
--- a/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
@@ -252,7 +252,13 @@ impl LogStoreWriter {
         );
         let result = self
             .rocksdb
-            .write_batch(Priority::High, IoMode::default(), write_opts, write_batch)
+            .write_batch(
+                "local-loglet-write-batch",
+                Priority::High,
+                IoMode::default(),
+                write_opts,
+                write_batch,
+            )
             .await;
 
         if let Err(e) = result {

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -286,7 +286,13 @@ impl LocalMetadataStore {
         wb.put_cf(&cf_handle, key, self.buffer.as_ref());
         Ok(self
             .rocksdb
-            .write_batch(Priority::High, IoMode::default(), write_options, wb)
+            .write_batch(
+                "local-metadata-write-batch",
+                Priority::High,
+                IoMode::default(),
+                write_options,
+                wb,
+            )
             .await?)
     }
 

--- a/crates/partition-store/src/deduplication_table/mod.rs
+++ b/crates/partition-store/src/deduplication_table/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::deduplication_table::{
     DedupInformation, DedupSequenceNumber, DeduplicationTable, ProducerId,
     ReadOnlyDeduplicationTable,
@@ -35,6 +36,7 @@ fn get_dedup_sequence_number<S: StorageAccess>(
     partition_id: PartitionId,
     producer_id: &ProducerId,
 ) -> Result<Option<DedupSequenceNumber>> {
+    let _x = RocksDbPerfGuard::new("get-dedup-seq");
     let key = DeduplicationKey::default()
         .partition_id(partition_id)
         .producer_id(producer_id.clone());

--- a/crates/partition-store/src/inbox_table/mod.rs
+++ b/crates/partition-store/src/inbox_table/mod.rs
@@ -15,6 +15,7 @@ use crate::{TableScan, TableScanIterationDecision};
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::inbox_table::{InboxEntry, InboxTable, SequenceNumberInboxEntry};
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
@@ -86,6 +87,8 @@ impl<'a> InboxTable for RocksDBTransaction<'a> {
         &mut self,
         service_id: &ServiceId,
     ) -> Result<Option<SequenceNumberInboxEntry>> {
+        // safe since delete_inbox_entry is not really async.
+        let _x = RocksDbPerfGuard::new("pop-inbox");
         let result = self.peek_inbox(service_id).await;
 
         if let Ok(Some(inbox_entry)) = &result {

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -15,6 +15,7 @@ use crate::{PartitionStore, TableKind, TableScanIterationDecision};
 use crate::{RocksDBTransaction, StorageAccess};
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, InvocationStatusTable, ReadOnlyInvocationStatusTable,
 };
@@ -70,6 +71,7 @@ fn get_invocation_status<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
 ) -> Result<InvocationStatus> {
+    let _x = RocksDbPerfGuard::new("get-invocation-status");
     let key = write_invocation_status_key(invocation_id);
 
     storage
@@ -86,6 +88,7 @@ fn invoked_invocations<S: StorageAccess>(
     storage: &mut S,
     partition_key_range: RangeInclusive<PartitionKey>,
 ) -> Vec<Result<(InvocationId, InvocationTarget)>> {
+    let _x = RocksDbPerfGuard::new("invoked-invocations");
     storage.for_each_key_value_in_place(
         FullScanPartitionKeyRange::<InvocationStatusKey>(partition_key_range),
         |mut k, mut v| {

--- a/crates/partition-store/src/journal_table/mod.rs
+++ b/crates/partition-store/src/journal_table/mod.rs
@@ -17,6 +17,7 @@ use crate::{PartitionStore, RocksDBTransaction, StorageAccess};
 use crate::{TableScan, TableScanIterationDecision};
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::journal_table::{JournalEntry, JournalTable, ReadOnlyJournalTable};
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{
@@ -69,6 +70,7 @@ fn get_journal<S: StorageAccess>(
     invocation_id: &InvocationId,
     journal_length: EntryIndex,
 ) -> Vec<Result<(EntryIndex, JournalEntry)>> {
+    let _x = RocksDbPerfGuard::new("get-journal");
     let key = JournalKey::default()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
@@ -116,6 +118,7 @@ impl ReadOnlyJournalTable for PartitionStore {
         invocation_id: &InvocationId,
         journal_index: u32,
     ) -> Result<Option<JournalEntry>> {
+        let _x = RocksDbPerfGuard::new("get-journal-entry");
         get_journal_entry(self, invocation_id, journal_index)
     }
 
@@ -134,6 +137,7 @@ impl<'a> ReadOnlyJournalTable for RocksDBTransaction<'a> {
         invocation_id: &InvocationId,
         journal_index: u32,
     ) -> Result<Option<JournalEntry>> {
+        let _x = RocksDbPerfGuard::new("get-journal-entry");
         get_journal_entry(self, invocation_id, journal_index)
     }
 
@@ -157,6 +161,7 @@ impl<'a> JournalTable for RocksDBTransaction<'a> {
     }
 
     async fn delete_journal(&mut self, invocation_id: &InvocationId, journal_length: EntryIndex) {
+        let _x = RocksDbPerfGuard::new("delete-journal");
         delete_journal(self, invocation_id, journal_length)
     }
 }

--- a/crates/partition-store/src/outbox_table/mod.rs
+++ b/crates/partition-store/src/outbox_table/mod.rs
@@ -12,6 +12,7 @@ use crate::keys::{define_table_key, KeyKind, TableKey};
 use crate::TableKind::Outbox;
 use crate::{PartitionStore, RocksDBTransaction, StorageAccess, TableScan};
 
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::outbox_table::{OutboxMessage, OutboxTable};
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::PartitionId;
@@ -43,6 +44,7 @@ fn get_next_outbox_message<S: StorageAccess>(
     partition_id: PartitionId,
     next_sequence_number: u64,
 ) -> Result<Option<(u64, OutboxMessage)>> {
+    let _x = RocksDbPerfGuard::new("get-next-outbox");
     let start = OutboxKey::default()
         .partition_id(partition_id)
         .message_index(next_sequence_number);
@@ -69,6 +71,7 @@ fn get_outbox_message<S: StorageAccess>(
     partition_id: PartitionId,
     sequence_number: u64,
 ) -> Result<Option<OutboxMessage>> {
+    let _x = RocksDbPerfGuard::new("get-outbox");
     let outbox_key = OutboxKey::default()
         .partition_id(partition_id)
         .message_index(sequence_number);

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -462,7 +462,6 @@ impl<'a> RocksDBTransaction<'a> {
         let mut opts = ReadOptions::default();
         opts.set_iterate_range(PrefixRange(prefix.clone()));
         opts.set_prefix_same_as_start(true);
-        //opts.set_async_io(true);
         opts.set_total_order_seek(false);
 
         let mut it = self.txn.raw_iterator_cf_opt(table, opts);
@@ -484,7 +483,6 @@ impl<'a> RocksDBTransaction<'a> {
         // binding.
         opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
         opts.set_iterate_range(from.clone()..to);
-        //opts.set_async_io(true);
         let mut it = self.txn.raw_iterator_cf_opt(table, opts);
         it.seek(from);
         it

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -18,6 +18,7 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::promise_table::{
     OwnedPromiseRow, Promise, PromiseTable, ReadOnlyPromiseTable,
 };
@@ -50,6 +51,7 @@ fn get_promise<S: StorageAccess>(
     service_id: &ServiceId,
     key: &ByteString,
 ) -> Result<Option<Promise>> {
+    let _x = RocksDbPerfGuard::new("get-promise");
     storage.get_value(create_key(service_id, key))
 }
 

--- a/crates/partition-store/src/service_status_table/mod.rs
+++ b/crates/partition-store/src/service_status_table/mod.rs
@@ -14,6 +14,7 @@ use crate::TableScan::FullScanPartitionKeyRange;
 use crate::{PartitionStore, TableKind};
 use crate::{RocksDBTransaction, StorageAccess};
 use bytestring::ByteString;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::service_status_table::{
     ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus, VirtualObjectStatusTable,
 };
@@ -60,6 +61,7 @@ fn get_virtual_object_status<S: StorageAccess>(
     storage: &mut S,
     service_id: &ServiceId,
 ) -> Result<VirtualObjectStatus> {
+    let _x = RocksDbPerfGuard::new("get-virtual-obj-status");
     let key = ServiceStatusKey::default()
         .partition_key(service_id.partition_key())
         .service_name(service_id.service_name.clone())

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -17,6 +17,7 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::state_table::{ReadOnlyStateTable, StateTable};
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
@@ -96,6 +97,7 @@ fn get_user_state<S: StorageAccess>(
     service_id: &ServiceId,
     state_key: impl AsRef<[u8]>,
 ) -> Result<Option<Bytes>> {
+    let _x = RocksDbPerfGuard::new("get-user-state");
     let key = write_state_entry_key(service_id, state_key);
     storage.get_kv_raw(key, move |_k, v| Ok(v.map(Bytes::copy_from_slice)))
 }
@@ -104,6 +106,7 @@ fn get_all_user_states<S: StorageAccess>(
     storage: &mut S,
     service_id: &ServiceId,
 ) -> Vec<Result<(Bytes, Bytes)>> {
+    let _x = RocksDbPerfGuard::new("get-all-user-state");
     let key = StateKey::default()
         .partition_key(service_id.partition_key())
         .service_name(service_id.service_name.clone())

--- a/crates/partition-store/src/timer_table/mod.rs
+++ b/crates/partition-store/src/timer_table/mod.rs
@@ -15,6 +15,7 @@ use crate::{PartitionStore, RocksDBTransaction, StorageAccess};
 use crate::{TableScan, TableScanIterationDecision};
 use futures::Stream;
 use futures_util::stream;
+use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable};
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{InvocationUuid, PartitionId};
@@ -144,6 +145,7 @@ fn next_timers_greater_than<S: StorageAccess>(
     exclusive_start: Option<&TimerKey>,
     limit: usize,
 ) -> Vec<Result<(TimerKey, Timer)>> {
+    let _x = RocksDbPerfGuard::new("get-next-timers");
     let scan = exclusive_start_key_range(partition_id, exclusive_start);
     let mut produced = 0;
     storage.for_each_key_value_in_place(scan, move |k, v| {

--- a/crates/rocksdb/src/metric_definitions.rs
+++ b/crates/rocksdb/src/metric_definitions.rs
@@ -21,10 +21,19 @@ pub const STORAGE_BG_TASK_RUN_DURATION: &str =
 pub const STORAGE_BG_TASK_TOTAL_DURATION: &str =
     "restate.rocksdb_manager.bg_task_total_duration.seconds";
 
-pub const BLOCK_READ_COUNT: &str = "restate.rocksdb.perf.num_block_read.total";
+// Perf guard metrics
 pub const BLOCK_READ_BYTES: &str = "restate.rocksdb.perf.block_read_bytes.total";
+pub const BLOCK_READ_DURATION: &str = "restate.rocksdb.perf.block_read_duration.seconds";
+pub const BLOCK_DECOMPRESS_DURATION: &str =
+    "restate.rocksdb.perf.block_decompress_duration.seconds";
+pub const GET_FROM_MEMTABLE_DURATION: &str =
+    "restate.rocksdb.perf.get_from_memtable_duration.seconds";
 pub const WRITE_WAL_DURATION: &str = "restate.rocksdb.perf.write_wal_duration.seconds";
 pub const WRITE_MEMTABLE_DURATION: &str = "restate.rocksdb.perf.write_memtable_duration.seconds";
+pub const TOTAL_DURATION: &str = "restate.rocksdb.perf.total_duration.seconds";
+pub const SEEK_ON_MEMTABLE: &str = "restate.rocksdb.perf.seek_on_memtable.seconds";
+pub const NEXT_ON_MEMTABLE: &str = "restate.rocksdb.perf.next_on_memtable.total";
+pub const FIND_NEXT_USER_ENTRY: &str = "restate.rocksdb.perf.find_next_user_entry.seconds";
 pub const WRITE_PRE_AND_POST_DURATION: &str =
     "restate.rocksdb.perf.write_pre_and_post_duration.seconds";
 pub const WRITE_ARTIFICIAL_DELAY_DURATION: &str =
@@ -34,6 +43,7 @@ pub const ROCKSDB_STALL_FLARE: &str = "restate.rocksdb_stall_flare";
 pub const ROCKSDB_STALL_DURATION: &str = "restate.rocksdb_stall_duration.seconds";
 
 pub const OP_TYPE: &str = "operation";
+pub const OP_NAME: &str = "name";
 pub const PRIORITY: &str = "priority";
 
 pub const DISPOSITION: &str = "disposition";
@@ -64,15 +74,15 @@ pub fn describe_metrics() {
     );
 
     describe_counter!(
-        BLOCK_READ_COUNT,
-        Unit::Count,
-        "Number of rocksdb blocks read from disk"
-    );
-
-    describe_counter!(
         BLOCK_READ_BYTES,
         Unit::Bytes,
         "Total number of bytes read from disk during this operation"
+    );
+
+    describe_counter!(
+        NEXT_ON_MEMTABLE,
+        Unit::Count,
+        "Number of next() issued on memtables"
     );
 
     describe_histogram!(
@@ -121,5 +131,34 @@ pub fn describe_metrics() {
         WRITE_ARTIFICIAL_DELAY_DURATION,
         Unit::Seconds,
         "Extra write delay introduced by rocksdb to meet target write rates"
+    );
+
+    describe_histogram!(
+        SEEK_ON_MEMTABLE,
+        Unit::Seconds,
+        "Total time spent seeking on memtable"
+    );
+    describe_histogram!(
+        BLOCK_READ_DURATION,
+        Unit::Seconds,
+        "Total time spent reading blocks"
+    );
+
+    describe_histogram!(
+        BLOCK_DECOMPRESS_DURATION,
+        Unit::Seconds,
+        "Total time spent block decompression"
+    );
+
+    describe_histogram!(
+        GET_FROM_MEMTABLE_DURATION,
+        Unit::Seconds,
+        "Total time spent on querying memtables"
+    );
+
+    describe_histogram!(
+        FIND_NEXT_USER_ENTRY,
+        Unit::Seconds,
+        "Total time spent on iterating internal entries to find the next user entry"
     );
 }

--- a/crates/rocksdb/src/perf.rs
+++ b/crates/rocksdb/src/perf.rs
@@ -9,13 +9,15 @@
 // by the Apache License, Version 2.0.
 
 use std::cell::RefCell;
+use std::time::Instant;
 
 use metrics::{counter, histogram};
-use rocksdb::{PerfContext, PerfMetric, PerfStatsLevel};
+use restate_types::config::{Configuration, PerfStatsLevel};
+use rocksdb::{PerfContext, PerfMetric};
 
-use crate::background::StorageTaskKind;
 use crate::{
-    BLOCK_READ_BYTES, BLOCK_READ_COUNT, OP_TYPE, WRITE_ARTIFICIAL_DELAY_DURATION,
+    BLOCK_DECOMPRESS_DURATION, BLOCK_READ_BYTES, BLOCK_READ_DURATION, GET_FROM_MEMTABLE_DURATION,
+    NEXT_ON_MEMTABLE, OP_NAME, SEEK_ON_MEMTABLE, TOTAL_DURATION, WRITE_ARTIFICIAL_DELAY_DURATION,
     WRITE_MEMTABLE_DURATION, WRITE_PRE_AND_POST_DURATION, WRITE_WAL_DURATION,
 };
 
@@ -23,11 +25,25 @@ thread_local! {
     static ROCKSDB_PERF_CONTEXT: RefCell<PerfContext>  = RefCell::new(PerfContext::default());
 }
 
+fn convert_perf_level(input: PerfStatsLevel) -> rocksdb::perf::PerfStatsLevel {
+    use rocksdb::perf::PerfStatsLevel as RocksLevel;
+    match input {
+        PerfStatsLevel::Disable => RocksLevel::Disable,
+        PerfStatsLevel::EnableCount => RocksLevel::EnableCount,
+        PerfStatsLevel::EnableTimeExceptForMutex => RocksLevel::EnableTimeExceptForMutex,
+        PerfStatsLevel::EnableTimeAndCPUTimeExceptForMutex => {
+            RocksLevel::EnableTimeAndCPUTimeExceptForMutex
+        }
+        PerfStatsLevel::EnableTime => RocksLevel::EnableTime,
+    }
+}
+
 /// This guard must be created and dropped in the same thread, you should never use the same
 /// guard across .await points. This should strictly be used within the bounds of the sync
 /// RocksAccess layer.
 pub struct RocksDbPerfGuard {
-    kind: StorageTaskKind,
+    start: Instant,
+    name: &'static str,
 }
 
 impl RocksDbPerfGuard {
@@ -35,51 +51,110 @@ impl RocksDbPerfGuard {
     /// that the guard is not insta-dropped. Binding to something like `_x = ...` works, just don't
     /// use the special `_` variable and you'll be fine. Unfortunately, rust/clippy doesn't have a
     /// mechanism to enforce this at the moment.
+    ///
+    /// This guard should not be used across await points. Stats are thread local.
     #[must_use]
-    pub fn new(kind: StorageTaskKind) -> Self {
-        rocksdb::perf::set_perf_stats(PerfStatsLevel::EnableTimeExceptForMutex);
+    pub fn new(name: &'static str) -> Self {
+        let rocks_level = convert_perf_level(Configuration::pinned().common.rocksdb_perf_level);
+        rocksdb::perf::set_perf_stats(rocks_level);
         ROCKSDB_PERF_CONTEXT.with(|context| {
             context.borrow_mut().reset();
         });
-        RocksDbPerfGuard { kind }
+        RocksDbPerfGuard {
+            name,
+            start: Instant::now(),
+        }
+    }
+
+    /// Drops the guard without reporting any metrics.
+    pub fn forget(self) {
+        rocksdb::perf::set_perf_stats(rocksdb::perf::PerfStatsLevel::Disable);
+        let _ = std::mem::ManuallyDrop::new(self);
     }
 }
 
 impl Drop for RocksDbPerfGuard {
     fn drop(&mut self) {
-        rocksdb::perf::set_perf_stats(PerfStatsLevel::Disable);
+        rocksdb::perf::set_perf_stats(rocksdb::perf::PerfStatsLevel::Disable);
         // report collected metrics
         ROCKSDB_PERF_CONTEXT.with(|context| {
             // Note to future visitors of this code. RocksDb reports times in nanoseconds in this
             // API compared to microseconds in Statistics/Properties. Use n_to_s() to convert to
             // standard prometheus unit (second).
             let context = context.borrow();
-            let v = context.metric(PerfMetric::BlockReadCount);
+            histogram!(TOTAL_DURATION,
+                 OP_NAME => self.name,
+            )
+            .record(self.start.elapsed());
+
+            // iterators-related
+            let v = context.metric(PerfMetric::NextOnMemtableCount);
             if v != 0 {
-                counter!(BLOCK_READ_COUNT,
-                     OP_TYPE => self.kind.as_static_str(),
+                counter!(NEXT_ON_MEMTABLE,
+                     OP_NAME => self.name,
                 )
-                .increment(v);
+                .increment(v)
+            };
+            let v = context.metric(PerfMetric::SeekOnMemtableTime);
+            if v != 0 {
+                histogram!(SEEK_ON_MEMTABLE,
+                     OP_NAME => self.name,
+                )
+                .record(n_to_s(v));
             }
+            let v = context.metric(PerfMetric::FindNextUserEntryTime);
+            if v != 0 {
+                histogram!(SEEK_ON_MEMTABLE,
+                     OP_NAME => self.name,
+                )
+                .record(n_to_s(v));
+            }
+
+            // read-related
             let v = context.metric(PerfMetric::BlockReadByte);
             if v != 0 {
                 counter!(BLOCK_READ_BYTES,
-                     OP_TYPE => self.kind.as_static_str(),
+                     OP_NAME => self.name,
                 )
                 .increment(v)
             };
 
+            let v = context.metric(PerfMetric::BlockReadTime);
+            if v != 0 {
+                histogram!(BLOCK_READ_DURATION,
+                     OP_NAME => self.name,
+                )
+                .record(n_to_s(v));
+            }
+
+            let v = context.metric(PerfMetric::GetFromMemtableTime);
+            if v != 0 {
+                histogram!(GET_FROM_MEMTABLE_DURATION,
+                     OP_NAME => self.name,
+                )
+                .record(n_to_s(v));
+            }
+
+            let v = context.metric(PerfMetric::BlockDecompressTime);
+            if v != 0 {
+                histogram!(BLOCK_DECOMPRESS_DURATION,
+                     OP_NAME => self.name,
+                )
+                .record(n_to_s(v));
+            }
+
+            // write-related
             let v = context.metric(PerfMetric::WriteWalTime);
             if v != 0 {
                 histogram!(WRITE_WAL_DURATION,
-                     OP_TYPE => self.kind.as_static_str(),
+                     OP_NAME => self.name,
                 )
                 .record(n_to_s(v));
             }
             let v = context.metric(PerfMetric::WriteMemtableTime);
             if v != 0 {
                 histogram!(WRITE_MEMTABLE_DURATION,
-                     OP_TYPE => self.kind.as_static_str(),
+                     OP_NAME => self.name,
                 )
                 .record(n_to_s(v));
             }
@@ -87,7 +162,7 @@ impl Drop for RocksDbPerfGuard {
             let v = context.metric(PerfMetric::WritePreAndPostProcessTime);
             if v != 0 {
                 histogram!(WRITE_PRE_AND_POST_DURATION,
-                     OP_TYPE => self.kind.as_static_str(),
+                     OP_NAME => self.name,
                 )
                 .record(n_to_s(v));
             }
@@ -95,7 +170,7 @@ impl Drop for RocksDbPerfGuard {
             let v = context.metric(PerfMetric::WriteDelayTime);
             if v != 0 {
                 histogram!(WRITE_ARTIFICIAL_DELAY_DURATION,
-                     OP_TYPE => self.kind.as_static_str(),
+                     OP_NAME => self.name,
                 )
                 .record(n_to_s(v));
             }

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -16,8 +16,6 @@ use rocksdb::ColumnFamilyDescriptor;
 use rocksdb::MultiThreaded;
 use tracing::trace;
 
-use crate::background::StorageTaskKind;
-use crate::perf::RocksDbPerfGuard;
 use crate::BoxedCfMatcher;
 use crate::BoxedCfOptionUpdater;
 use crate::CfName;
@@ -163,7 +161,6 @@ impl RocksAccess for rocksdb::DB {
     }
 
     fn flush_memtables(&self, cfs: &[CfName], wait: bool) -> Result<(), RocksError> {
-        let _x = RocksDbPerfGuard::new(StorageTaskKind::FlushMemtables);
         let mut flushopts = rocksdb::FlushOptions::default();
         flushopts.set_wait(wait);
         let cfs = cfs
@@ -176,7 +173,6 @@ impl RocksAccess for rocksdb::DB {
     }
 
     fn flush_wal(&self, sync: bool) -> Result<(), RocksError> {
-        let _x = RocksDbPerfGuard::new(StorageTaskKind::FlushWal);
         Ok(self.flush_wal(sync)?)
     }
 
@@ -211,7 +207,6 @@ impl RocksAccess for rocksdb::DB {
         batch: &rocksdb::WriteBatch,
         write_options: &rocksdb::WriteOptions,
     ) -> Result<(), rocksdb::Error> {
-        let _x = RocksDbPerfGuard::new(StorageTaskKind::WriteBatch);
         self.write_opt(batch, write_options)
     }
 
@@ -282,7 +277,6 @@ impl RocksAccess for rocksdb::OptimisticTransactionDB<MultiThreaded> {
     }
 
     fn flush_memtables(&self, cfs: &[CfName], wait: bool) -> Result<(), RocksError> {
-        let _x = RocksDbPerfGuard::new(StorageTaskKind::FlushMemtables);
         let mut flushopts = rocksdb::FlushOptions::default();
         flushopts.set_wait(wait);
         let cfs = cfs
@@ -295,7 +289,6 @@ impl RocksAccess for rocksdb::OptimisticTransactionDB<MultiThreaded> {
     }
 
     fn flush_wal(&self, sync: bool) -> Result<(), RocksError> {
-        let _x = RocksDbPerfGuard::new(StorageTaskKind::FlushWal);
         Ok(self.flush_wal(sync)?)
     }
 
@@ -338,7 +331,6 @@ impl RocksAccess for rocksdb::OptimisticTransactionDB<MultiThreaded> {
         batch: &rocksdb::WriteBatchWithTransaction<true>,
         write_options: &rocksdb::WriteOptions,
     ) -> Result<(), rocksdb::Error> {
-        let _x = RocksDbPerfGuard::new(StorageTaskKind::WriteBatch);
         self.write_opt(batch, write_options)
     }
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -24,7 +24,7 @@ use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::PlainNodeId;
 
-use super::{AwsOptions, HttpOptions, RocksDbOptions};
+use super::{AwsOptions, HttpOptions, PerfStatsLevel, RocksDbOptions};
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 
@@ -218,6 +218,13 @@ pub struct CommonOptions {
     /// will recover from this without intervention.
     pub rocksdb_enable_stall_on_memory_limit: bool,
 
+    /// # Rocksdb performance statistics level
+    ///
+    /// Defines the level of PerfContext used internally by rocksdb. Default is `enable-count`
+    /// which should be sufficient for most users. Note that higher levels incur a CPU cost and
+    /// might slow down the critical path.
+    pub rocksdb_perf_level: PerfStatsLevel,
+
     /// RocksDb base settings and memory limits that get applied on every database
     #[serde(flatten)]
     pub rocksdb: RocksDbOptions,
@@ -344,6 +351,7 @@ impl Default for CommonOptions {
             rocksdb_high_priority_bg_threads: NonZeroU32::new(2).unwrap(),
             rocksdb_write_stall_threshold: std::time::Duration::from_secs(3).into(),
             rocksdb_enable_stall_on_memory_limit: false,
+            rocksdb_perf_level: PerfStatsLevel::EnableCount,
             rocksdb: Default::default(),
         }
     }

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -141,7 +141,7 @@ impl RocksDbOptions {
 
     pub fn rocksdb_statistics_level(&self) -> StatisticsLevel {
         self.rocksdb_statistics_level
-            .unwrap_or(StatisticsLevel::ExceptDetailedTimers)
+            .unwrap_or(StatisticsLevel::ExceptTimers)
     }
 }
 

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -167,3 +167,21 @@ pub enum StatisticsLevel {
     /// reduce scalability to more threads, especially for writes.
     All,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(rename = "RocksbPerfStatisticsLevel"))]
+#[serde(rename_all = "kebab-case")]
+pub enum PerfStatsLevel {
+    /// Disable perf stats
+    Disable,
+    /// Enables only count stats
+    EnableCount,
+    /// Count stats and enable time stats except for mutexes
+    EnableTimeExceptForMutex,
+    /// Other than time, also measure CPU time counters. Still don't measure
+    /// time (neither wall time nor CPU time) for mutexes
+    EnableTimeAndCPUTimeExceptForMutex,
+    /// Enables count and time stats
+    EnableTime,
+}


### PR DESCRIPTION
[rocksdb] Make perf level configurable

This is now controlled by `common.rocksdb-perf-level`. Default is `enable-count`

Also adds detailed rocksdb instrumentation

***

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1591).
* #1593
* #1592
* __->__ #1591
* #1588