### PR TITLE
Update compatibility map to include 1.0.0 as a new breaking version

### DIFF
--- a/crates/node/src/cluster_marker.rs
+++ b/crates/node/src/cluster_marker.rs
@@ -29,10 +29,16 @@ const TMP_CLUSTER_MARKER_FILE_NAME: &str = ".tmp-cluster-marker";
 /// This map needs to be updated whenever we release a version that is no longer compatible with
 /// previous versions.
 static COMPATIBILITY_MAP: Lazy<BTreeMap<Version, CompatibilityInformation>> = Lazy::new(|| {
-    BTreeMap::from([(
-        Version::new(0, 9, 0),
-        CompatibilityInformation::new(Version::new(0, 9, 0)),
-    )])
+    BTreeMap::from([
+        (
+            Version::new(0, 9, 0),
+            CompatibilityInformation::new(Version::new(0, 9, 0)),
+        ),
+        (
+            Version::new(1, 0, 0),
+            CompatibilityInformation::new(Version::new(1, 0, 0)),
+        ),
+    ])
 });
 
 /// Compatibility information define the minimum supported Restate version that is compatible with

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -32,7 +32,8 @@ https://github.com/issues?q=is%3Aopen+org%3Arestatedev+label%3Arelease-blocker
 
 ## Releasing the Restate runtime
 
-1. Make sure that the version field in the [Cargo.toml](/Cargo.toml) and [Chart.yaml](/charts/restate-helm/Chart.yaml) is set to the new release version `X.Y.Z`. 
+1. Make sure that the version field in the [Cargo.toml](/Cargo.toml) and [Chart.yaml](/charts/restate-helm/Chart.yaml) is set to the new release version `X.Y.Z`.
+1. Make sure that [COMPATIBILITY_MAP](/crates/node/src/cluster_marker.rs) is updated if `X.Y.Z` changes the requirements for backward/forward compatible Restate versions.
 1. Create a tag of the form `vX.Y.Z` and push it to the repository. The tag will trigger the [release.yml](/.github/workflows/release.yml) workflow which runs the unit tests, the e2e tests, creates the docker image of the runtime, builds the CLI/runtime binaries, and prepares a Github draft release.
 1. Manually publish the draft release created by the release automation [here](https://github.com/restatedev/restate/releases).
 1. In case you're creating a MAJOR or MINOR release, create the branch with the name `release-MAJOR.MINOR` as well.


### PR DESCRIPTION
Update compatibility map to include 1.0.0 as a new breaking version so that incompatible cluster versions are properly detected.

This fixes #1615.