### PR TITLE
Check for backward compatibility when validating the cluster marker 

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -33,7 +33,7 @@ https://github.com/issues?q=is%3Aopen+org%3Arestatedev+label%3Arelease-blocker
 ## Releasing the Restate runtime
 
 1. Make sure that the version field in the [Cargo.toml](/Cargo.toml) and [Chart.yaml](/charts/restate-helm/Chart.yaml) is set to the new release version `X.Y.Z`.
-1. Make sure that [COMPATIBILITY_MAP](/crates/node/src/cluster_marker.rs) is updated if `X.Y.Z` changes the requirements for backward/forward compatible Restate versions.
+1. Make sure that [COMPATIBILITY_INFORMATION](/crates/node/src/cluster_marker.rs) is updated if `X.Y.Z` changes the requirements for backward/forward compatible Restate versions.
 1. Create a tag of the form `vX.Y.Z` and push it to the repository. The tag will trigger the [release.yml](/.github/workflows/release.yml) workflow which runs the unit tests, the e2e tests, creates the docker image of the runtime, builds the CLI/runtime binaries, and prepares a Github draft release.
 1. Manually publish the draft release created by the release automation [here](https://github.com/restatedev/restate/releases).
 1. In case you're creating a MAJOR or MINOR release, create the branch with the name `release-MAJOR.MINOR` as well.


### PR DESCRIPTION
Now the server checks whether it is backward-compatible with the data
directory. If it encounters a version that either needs migration or
cannot be migrated from, then it fails with a BackwardIncompatibility
error.

This fixes https://github.com/restatedev/restate/issues/1617.

This PR is based on #1616.