### PR TITLE
New infra state machine

### DIFF
--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -407,4 +407,16 @@ mod mocks {
             }
         }
     }
+
+    impl CompletedInvocation {
+        pub fn mock() -> Self {
+            Self {
+                invocation_target: InvocationTarget::mock_service(),
+                source: Source::Ingress,
+                idempotency_key: None,
+                timestamps: StatusTimestamps::now(),
+                response_result: ResponseResult::Success(Bytes::new()),
+            }
+        }
+    }
 }

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -20,6 +20,22 @@ use restate_types::message::MessageIndex;
 use restate_wal_protocol::timer::TimerKeyValue;
 use std::time::Duration;
 
+pub trait ActionCollector {
+    fn append(&mut self, action: Action);
+}
+
+impl ActionCollector for Vec<Action> {
+    fn append(&mut self, action: Action) {
+        self.push(action)
+    }
+}
+
+impl ActionCollector for () {
+    fn append(&mut self, _: Action) {
+        // No-op
+    }
+}
+
 #[derive(Debug, strum_macros::IntoStaticStr)]
 pub enum Action {
     Invoke {

--- a/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
+++ b/crates/worker/src/partition/state_machine/command_interpreter/mod.rs
@@ -110,9 +110,9 @@ pub trait StateReader {
 
 pub(crate) struct CommandInterpreter<Codec> {
     // initialized from persistent storage
-    inbox_seq_number: MessageIndex,
-    outbox_seq_number: MessageIndex,
-    partition_key_range: RangeInclusive<PartitionKey>,
+    pub(super) inbox_seq_number: MessageIndex,
+    pub(super) outbox_seq_number: MessageIndex,
+    pub(super) partition_key_range: RangeInclusive<PartitionKey>,
     latency: Histogram,
 
     _codec: PhantomData<Codec>,

--- a/crates/worker/src/partition/state_machine/commands/invoker/mod.rs
+++ b/crates/worker/src/partition/state_machine/commands/invoker/mod.rs
@@ -1,4 +1,12 @@
-mod pinned_deployment;
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
 
 use crate::metric_definitions::PARTITION_HANDLE_INVOKER_EFFECT_COMMAND;
 use crate::partition::state_machine::actions::ActionCollector;
@@ -17,6 +25,8 @@ use restate_types::identifiers::InvocationId;
 use restate_types::journal::raw::RawEntryCodec;
 use std::time::Instant;
 use tracing::trace;
+
+mod pinned_deployment;
 
 struct InvokerEffectCommand {
     invocation_id: InvocationId,

--- a/crates/worker/src/partition/state_machine/commands/invoker/mod.rs
+++ b/crates/worker/src/partition/state_machine/commands/invoker/mod.rs
@@ -1,0 +1,109 @@
+mod pinned_deployment;
+
+use crate::metric_definitions::PARTITION_HANDLE_INVOKER_EFFECT_COMMAND;
+use crate::partition::state_machine::actions::ActionCollector;
+use crate::partition::state_machine::commands::{
+    ApplicableCommand, CommandContext, Error, MaybeApplicableCommand,
+};
+use crate::partition::state_machine::Action;
+use crate::partition::types::{InvokerEffect, InvokerEffectKind};
+use metrics::histogram;
+use restate_storage_api::invocation_status_table::{
+    InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
+};
+use restate_storage_api::Transaction;
+use restate_types::deployment::PinnedDeployment;
+use restate_types::identifiers::InvocationId;
+use restate_types::journal::raw::RawEntryCodec;
+use std::time::Instant;
+use tracing::trace;
+
+struct InvokerEffectCommand {
+    invocation_id: InvocationId,
+    in_flight_invocation_metadata: InFlightInvocationMetadata,
+    effect_kind: InvokerEffectKind,
+}
+
+impl<Storage, Actions, Codec> MaybeApplicableCommand<Storage, Actions, Codec> for InvokerEffect
+where
+    Storage: Transaction + Send,
+    Actions: ActionCollector,
+    Codec: RawEntryCodec,
+{
+    async fn apply(
+        self,
+        mut ctx: CommandContext<'_, Storage, Actions, Codec>,
+    ) -> Result<Result<(), Error>, Self> {
+        let start = Instant::now();
+        let status = match ctx.get_invocation_status(&self.invocation_id).await {
+            Ok(is) => is,
+            Err(e) => {
+                histogram!(PARTITION_HANDLE_INVOKER_EFFECT_COMMAND).record(start.elapsed());
+                return Ok(Err(e));
+            }
+        };
+
+        match status {
+            InvocationStatus::Invoked(invocation_metadata) => {
+                let res = InvokerEffectCommand {
+                    invocation_id: self.invocation_id,
+                    in_flight_invocation_metadata: invocation_metadata,
+                    effect_kind: self.kind,
+                }
+                .apply(ctx)
+                .await;
+                match res {
+                    Ok(res) => {
+                        // Record the histogram only in the success case
+                        histogram!(PARTITION_HANDLE_INVOKER_EFFECT_COMMAND).record(start.elapsed());
+                        Ok(res)
+                    }
+                    Err(cmd) => Err(InvokerEffect {
+                        invocation_id: cmd.invocation_id,
+                        kind: cmd.effect_kind,
+                    }),
+                }
+            }
+            _ => {
+                trace!("Received invoker effect for unknown service invocation. Ignoring the effect and aborting.");
+                ctx.actions
+                    .append(Action::AbortInvocation(self.invocation_id));
+                histogram!(PARTITION_HANDLE_INVOKER_EFFECT_COMMAND).record(start.elapsed());
+                Ok(Ok(()))
+            }
+        }
+    }
+}
+
+struct InvokerPinnedDeploymentCommand {
+    invocation_id: InvocationId,
+    in_flight_invocation_metadata: InFlightInvocationMetadata,
+    pinned_deployment: PinnedDeployment,
+}
+
+impl<Storage: InvocationStatusTable, Actions, Codec> MaybeApplicableCommand<Storage, Actions, Codec>
+    for InvokerEffectCommand
+{
+    async fn apply(
+        self,
+        ctx: CommandContext<'_, Storage, Actions, Codec>,
+    ) -> Result<Result<(), Error>, Self> {
+        match self.effect_kind {
+            InvokerEffectKind::PinnedDeployment(pinned_deployment) => {
+                Ok(InvokerPinnedDeploymentCommand {
+                    invocation_id: self.invocation_id,
+                    in_flight_invocation_metadata: self.in_flight_invocation_metadata,
+                    pinned_deployment,
+                }
+                .apply(ctx)
+                .await
+                .map_err(Error::from))
+            }
+            effect_kind => Err(InvokerEffectCommand {
+                invocation_id: self.invocation_id,
+                in_flight_invocation_metadata: self.in_flight_invocation_metadata,
+                effect_kind,
+            }),
+        }
+    }
+}

--- a/crates/worker/src/partition/state_machine/commands/invoker/pinned_deployment.rs
+++ b/crates/worker/src/partition/state_machine/commands/invoker/pinned_deployment.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use crate::partition::state_machine::commands::invoker::InvokerPinnedDeploymentCommand;
 use crate::partition::state_machine::commands::{ApplicableCommand, CommandContext, Error};
 use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};

--- a/crates/worker/src/partition/state_machine/commands/invoker/pinned_deployment.rs
+++ b/crates/worker/src/partition/state_machine/commands/invoker/pinned_deployment.rs
@@ -1,0 +1,86 @@
+use crate::partition::state_machine::commands::invoker::InvokerPinnedDeploymentCommand;
+use crate::partition::state_machine::commands::{ApplicableCommand, CommandContext, Error};
+use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use tracing::trace;
+
+impl<Storage: InvocationStatusTable, Actions, Codec> ApplicableCommand<Storage, Actions, Codec>
+    for InvokerPinnedDeploymentCommand
+{
+    async fn apply(
+        mut self,
+        ctx: CommandContext<'_, Storage, Actions, Codec>,
+    ) -> Result<(), Error> {
+        trace!(
+            restate.deployment.id = %self.pinned_deployment.deployment_id,
+            restate.deployment.service_protocol_version = %self.pinned_deployment.service_protocol_version.as_repr(),
+            "Storing chosen deployment to storage"
+        );
+
+        self.in_flight_invocation_metadata.pinned_deployment = Some(self.pinned_deployment);
+        ctx.transaction
+            .put_invocation_status(
+                &self.invocation_id,
+                InvocationStatus::Invoked(self.in_flight_invocation_metadata),
+            )
+            .await;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::partition::state_machine::commands::mocks::MockStateMachine;
+    use crate::partition::types::{InvokerEffect, InvokerEffectKind};
+    use googletest::prelude::*;
+    use restate_storage_api::invocation_status_table::{
+        InFlightInvocationMetadata, ReadOnlyInvocationStatusTable,
+    };
+    use restate_storage_api::Transaction;
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{DeploymentId, InvocationId};
+    use restate_types::service_protocol::ServiceProtocolVersion;
+    use test_log::test;
+
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+    async fn invoker_pinned_deployment_command() {
+        let (_tc, mut state_machine) = MockStateMachine::init().await;
+
+        // Let's put an invocation status
+        let mut txn = state_machine.storage().transaction();
+        let invocation_id = InvocationId::mock_random();
+        txn.put_invocation_status(
+            &invocation_id,
+            InvocationStatus::Invoked(InFlightInvocationMetadata {
+                pinned_deployment: None,
+                ..InFlightInvocationMetadata::mock()
+            }),
+        )
+        .await;
+        txn.commit().await.unwrap();
+
+        let pinned_deployment =
+            PinnedDeployment::new(DeploymentId::new(), ServiceProtocolVersion::V1);
+        let actions = state_machine
+            .maybe_apply(InvokerEffect {
+                invocation_id,
+                kind: InvokerEffectKind::PinnedDeployment(pinned_deployment.clone()),
+            })
+            .await;
+
+        assert_that!(actions, empty());
+        assert_that!(
+            state_machine
+                .storage()
+                .get_invocation_status(&invocation_id)
+                .await,
+            ok(pat!(InvocationStatus::Invoked(pat!(
+                InFlightInvocationMetadata {
+                    pinned_deployment: some(eq(pinned_deployment))
+                }
+            ))))
+        );
+    }
+}

--- a/crates/worker/src/partition/state_machine/commands/mod.rs
+++ b/crates/worker/src/partition/state_machine/commands/mod.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use super::actions::ActionCollector;
 use crate::metric_definitions::PARTITION_APPLY_COMMAND;
 use crate::partition::state_machine::tracing::{

--- a/crates/worker/src/partition/state_machine/commands/mod.rs
+++ b/crates/worker/src/partition/state_machine/commands/mod.rs
@@ -1,0 +1,252 @@
+use super::actions::ActionCollector;
+use crate::metric_definitions::PARTITION_APPLY_COMMAND;
+use crate::partition::state_machine::tracing::{
+    state_machine_apply_command_span, StateMachineSpanExt,
+};
+use crate::partition::state_machine::StateMachineContext;
+use metrics::histogram;
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadOnlyInvocationStatusTable,
+};
+use restate_storage_api::Transaction;
+use restate_types::identifiers::InvocationId;
+use restate_types::journal::raw::{RawEntryCodec, RawEntryCodecError};
+use restate_wal_protocol::Command;
+use std::marker::PhantomData;
+use std::time::Instant;
+use tracing::{Instrument, Span};
+
+mod invoker;
+mod purge_invocation_request;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to deserialize entry: {0}")]
+    Codec(#[from] RawEntryCodecError),
+    #[error(transparent)]
+    Storage(#[from] restate_storage_api::StorageError),
+}
+
+/// Command context, used by the [`ApplicableCommand`] trait to access storage, generate actions and update the state machine context.
+///
+/// This also contains some helpers used by different [`ApplicableCommand`] implementations.
+pub(super) struct CommandContext<'a, Storage, Actions, Codec> {
+    pub(super) state_machine: &'a mut StateMachineContext,
+    pub(super) transaction: &'a mut Storage,
+    pub(super) actions: &'a mut Actions,
+
+    _codec: PhantomData<Codec>,
+}
+
+impl<'a, Storage, Actions, Codec> CommandContext<'a, Storage, Actions, Codec> {
+    pub(super) fn prepare(
+        state_machine: &'a mut StateMachineContext,
+        transaction: &'a mut Storage,
+        actions: &'a mut Actions,
+    ) -> Self {
+        Self {
+            state_machine,
+            transaction,
+            actions,
+            _codec: Default::default(),
+        }
+    }
+}
+
+impl<'a, Storage: ReadOnlyInvocationStatusTable, Actions, Codec>
+    CommandContext<'a, Storage, Actions, Codec>
+{
+    async fn get_invocation_status(
+        &mut self,
+        invocation_id: &InvocationId,
+    ) -> Result<InvocationStatus, Error> {
+        Span::record_invocation_id(invocation_id);
+        let status = self
+            .transaction
+            .get_invocation_status(invocation_id)
+            .await?;
+        if let Some(invocation_target) = status.invocation_target() {
+            Span::record_invocation_target(invocation_target);
+        }
+        Ok(status)
+    }
+}
+
+// TODO we need this trait only to workaround the fact that not all the FSM business logic has been moved to ApplicableCommand.
+pub(super) trait MaybeApplicableCommand<Storage, Actions, Codec>
+where
+    Self: Sized,
+{
+    /// This returns another layer of result, where the first error case means that the new infra still cannot process the command.
+    async fn apply(
+        self,
+        ctx: CommandContext<Storage, Actions, Codec>,
+    ) -> Result<Result<(), Error>, Self>;
+}
+
+/// A command implementing this trait can be applied to the state machine.
+pub(super) trait ApplicableCommand<Storage, Actions, Codec> {
+    async fn apply(self, ctx: CommandContext<Storage, Actions, Codec>) -> Result<(), Error>;
+}
+
+impl<Storage, Actions, Codec> MaybeApplicableCommand<Storage, Actions, Codec> for Command
+where
+    Storage: Transaction + Send,
+    Actions: ActionCollector,
+    Codec: RawEntryCodec,
+{
+    async fn apply(
+        self,
+        ctx: CommandContext<'_, Storage, Actions, Codec>,
+    ) -> Result<Result<(), Error>, Self> {
+        let span = state_machine_apply_command_span(ctx.state_machine, &self);
+        async {
+            let start = Instant::now();
+            let command_type = self.name();
+            let res = match self {
+                Command::PurgeInvocation(cmd) => Ok(cmd.apply(ctx).await),
+                Command::InvokerEffect(cmd) => cmd.apply(ctx).await.map_err(Command::InvokerEffect),
+                cmd => return Err(cmd),
+            };
+            histogram!(PARTITION_APPLY_COMMAND, "command" => command_type).record(start.elapsed());
+            res
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+#[cfg(test)]
+mod mocks {
+    use super::*;
+
+    use crate::partition::state_machine::Action;
+    use restate_core::{task_center, TaskCenter, TaskCenterBuilder};
+    use restate_partition_store::{
+        OpenMode, PartitionStore, PartitionStoreManager, RocksDBTransaction,
+    };
+    use restate_rocksdb::RocksDbManager;
+    use restate_service_protocol::codec::ProtobufRawEntryCodec;
+    use restate_storage_api::Transaction;
+    use restate_types::arc_util::Constant;
+    use restate_types::config::{CommonOptions, WorkerOptions};
+    use restate_types::identifiers::{PartitionId, PartitionKey};
+    use std::fmt;
+    use std::ops::RangeInclusive;
+    use tracing::info;
+
+    pub struct MockStateMachine {
+        state_machine_context: StateMachineContext,
+        // TODO for the time being we use rocksdb storage because we have no mocks for storage interfaces.
+        //  Perhaps we could make these tests faster by having those.
+        rocksdb_storage: PartitionStore,
+    }
+
+    impl MockStateMachine {
+        pub async fn init() -> (TaskCenter, MockStateMachine) {
+            let tc = TaskCenterBuilder::default()
+                .default_runtime_handle(tokio::runtime::Handle::current())
+                .build()
+                .expect("task_center builds");
+            let state_machine = tc
+                .run_in_scope("mock-state-machine", None, MockStateMachine::new())
+                .await;
+
+            (tc, state_machine)
+        }
+
+        async fn new() -> Self {
+            task_center().run_in_scope_sync("db-manager-init", None, || {
+                RocksDbManager::init(Constant::new(CommonOptions::default()))
+            });
+            let worker_options = WorkerOptions::default();
+            info!(
+                "Using RocksDB temp directory {}",
+                worker_options.storage.data_dir().display()
+            );
+            let manager = PartitionStoreManager::create(
+                Constant::new(worker_options.storage.clone()),
+                Constant::new(worker_options.storage.rocksdb.clone()),
+                &[],
+            )
+            .await
+            .unwrap();
+            let rocksdb_storage = manager
+                .open_partition_store(
+                    PartitionId::MIN,
+                    RangeInclusive::new(PartitionKey::MIN, PartitionKey::MAX),
+                    OpenMode::CreateIfMissing,
+                    &worker_options.storage.rocksdb,
+                )
+                .await
+                .unwrap();
+
+            Self {
+                state_machine_context: StateMachineContext {
+                    inbox_seq_number: 0,
+                    outbox_seq_number: 0,
+                    partition_key_range: PartitionKey::MIN..=PartitionKey::MAX,
+                    is_leader: false,
+                },
+                rocksdb_storage,
+            }
+        }
+
+        pub async fn maybe_apply<
+            Cmd: for<'a> MaybeApplicableCommand<
+                    RocksDBTransaction<'a>,
+                    Vec<Action>,
+                    ProtobufRawEntryCodec,
+                > + fmt::Debug,
+        >(
+            &mut self,
+            cmd: Cmd,
+        ) -> Vec<Action> {
+            let mut transaction = self.rocksdb_storage.transaction();
+            let mut action_collector = vec![];
+            MaybeApplicableCommand::<_, _, ProtobufRawEntryCodec>::apply(
+                cmd,
+                CommandContext::prepare(
+                    &mut self.state_machine_context,
+                    &mut transaction,
+                    &mut action_collector,
+                ),
+            )
+            .await
+            .expect("This command is not yet supported by the new test infra")
+            .unwrap();
+
+            transaction.commit().await.unwrap();
+
+            action_collector
+        }
+
+        pub async fn apply<
+            Cmd: for<'a> ApplicableCommand<RocksDBTransaction<'a>, Vec<Action>, ProtobufRawEntryCodec>,
+        >(
+            &mut self,
+            cmd: Cmd,
+        ) -> Vec<Action> {
+            let mut transaction = self.rocksdb_storage.transaction();
+            let mut action_collector = vec![];
+            ApplicableCommand::<_, _, ProtobufRawEntryCodec>::apply(
+                cmd,
+                CommandContext::prepare(
+                    &mut self.state_machine_context,
+                    &mut transaction,
+                    &mut action_collector,
+                ),
+            )
+            .await
+            .unwrap();
+
+            transaction.commit().await.unwrap();
+
+            action_collector
+        }
+
+        pub fn storage(&mut self) -> &mut PartitionStore {
+            &mut self.rocksdb_storage
+        }
+    }
+}

--- a/crates/worker/src/partition/state_machine/commands/purge_invocation_request.rs
+++ b/crates/worker/src/partition/state_machine/commands/purge_invocation_request.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use crate::partition::state_machine::actions::ActionCollector;
 use crate::partition::state_machine::commands::{ApplicableCommand, CommandContext, Error};
 use restate_storage_api::idempotency_table::IdempotencyTable;

--- a/crates/worker/src/partition/state_machine/commands/purge_invocation_request.rs
+++ b/crates/worker/src/partition/state_machine/commands/purge_invocation_request.rs
@@ -1,0 +1,151 @@
+use crate::partition::state_machine::actions::ActionCollector;
+use crate::partition::state_machine::commands::{ApplicableCommand, CommandContext, Error};
+use restate_storage_api::idempotency_table::IdempotencyTable;
+use restate_storage_api::invocation_status_table::{
+    CompletedInvocation, InvocationStatus, InvocationStatusTable,
+};
+use restate_storage_api::promise_table::PromiseTable;
+use restate_storage_api::service_status_table::{VirtualObjectStatus, VirtualObjectStatusTable};
+use restate_storage_api::state_table::StateTable;
+use restate_types::identifiers::IdempotencyId;
+use restate_types::invocation::{
+    InvocationTargetType, PurgeInvocationRequest, WorkflowHandlerType,
+};
+use restate_types::journal::raw::RawEntryCodec;
+use tracing::trace;
+
+impl<Storage, Actions, Codec> ApplicableCommand<Storage, Actions, Codec> for PurgeInvocationRequest
+where
+    Storage: InvocationStatusTable
+        + VirtualObjectStatusTable
+        + IdempotencyTable
+        + StateTable
+        + PromiseTable
+        + Send,
+    Actions: ActionCollector,
+    Codec: RawEntryCodec,
+{
+    async fn apply(
+        self,
+        mut ctx: CommandContext<'_, Storage, Actions, Codec>,
+    ) -> Result<(), Error> {
+        match ctx.get_invocation_status(&self.invocation_id).await? {
+            InvocationStatus::Completed(CompletedInvocation {
+                invocation_target,
+                idempotency_key,
+                ..
+            }) => {
+                trace!("Freeing invocation");
+                ctx.transaction
+                    .put_invocation_status(&self.invocation_id, InvocationStatus::Free)
+                    .await;
+
+                // Also cleanup the associated idempotency key if any
+                if let Some(idempotency_key) = idempotency_key {
+                    trace!(
+                        restate.idempotency.key = ?idempotency_key,
+                        "Deleting idempotency key"
+                    );
+                    ctx.transaction
+                        .delete_idempotency_metadata(&IdempotencyId::combine(
+                            self.invocation_id,
+                            &invocation_target,
+                            idempotency_key,
+                        ))
+                        .await;
+                }
+
+                // For workflow, we should also clean up the service lock, associated state and promises.
+                if invocation_target.invocation_target_ty()
+                    == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow)
+                {
+                    let service_id = invocation_target
+                        .as_keyed_service_id()
+                        .expect("Workflow methods must have keyed service id");
+
+                    trace!("Clearing service status, state entries and promises");
+                    ctx.transaction
+                        .put_virtual_object_status(&service_id, VirtualObjectStatus::Unlocked)
+                        .await;
+                    ctx.transaction.delete_all_user_state(&service_id).await?;
+                    ctx.transaction.delete_all_promises(&service_id).await;
+                }
+            }
+            InvocationStatus::Free => {
+                trace!(
+                    "Received purge command for unknown invocation with id '{}'.",
+                    self.invocation_id
+                );
+                // Nothing to do
+            }
+            _ => {
+                trace!(
+                    "Ignoring purge command as the invocation '{}' is still ongoing.",
+                    self.invocation_id
+                );
+            }
+        };
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::partition::state_machine::commands::mocks::MockStateMachine;
+    use bytestring::ByteString;
+    use googletest::prelude::*;
+    use restate_storage_api::idempotency_table::{IdempotencyMetadata, ReadOnlyIdempotencyTable};
+    use restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable;
+    use restate_storage_api::Transaction;
+    use restate_types::identifiers::InvocationId;
+    use restate_types::invocation::{InvocationTarget, PurgeInvocationRequest};
+    use test_log::test;
+
+    #[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+    async fn purge_invocation_idempotent_request() {
+        let (_tc, mut state_machine) = MockStateMachine::init().await;
+
+        // Let's put an idempotent invocation
+        let mut txn = state_machine.storage().transaction();
+        let invocation_id = InvocationId::mock_random();
+        let invocation_target = InvocationTarget::mock_service();
+        let idempotency_key = ByteString::from_static("123");
+        let idempotency_id =
+            IdempotencyId::combine(invocation_id, &invocation_target, idempotency_key.clone());
+        txn.put_invocation_status(
+            &invocation_id,
+            InvocationStatus::Completed(CompletedInvocation {
+                invocation_target: invocation_target.clone(),
+                idempotency_key: Some(idempotency_key.clone()),
+                ..CompletedInvocation::mock()
+            }),
+        )
+        .await;
+        txn.put_idempotency_metadata(&idempotency_id, IdempotencyMetadata { invocation_id })
+            .await;
+        txn.commit().await.unwrap();
+
+        let actions = state_machine
+            .apply(PurgeInvocationRequest { invocation_id })
+            .await;
+
+        assert_that!(actions, empty());
+        assert_that!(
+            state_machine
+                .storage()
+                .get_invocation_status(&invocation_id)
+                .await,
+            ok(pat!(InvocationStatus::Free))
+        );
+        assert_that!(
+            state_machine
+                .storage()
+                .get_idempotency_metadata(&idempotency_id)
+                .await,
+            ok(none())
+        )
+    }
+}

--- a/crates/worker/src/partition/state_machine/tracing.rs
+++ b/crates/worker/src/partition/state_machine/tracing.rs
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use super::StateMachineContext;
 
 use restate_types::identifiers::InvocationId;

--- a/crates/worker/src/partition/state_machine/tracing.rs
+++ b/crates/worker/src/partition/state_machine/tracing.rs
@@ -1,0 +1,67 @@
+use super::StateMachineContext;
+
+use restate_types::identifiers::InvocationId;
+use restate_types::invocation::InvocationTarget;
+use restate_wal_protocol::Command;
+use tracing::{debug_span, event_enabled, trace_span, Level, Span};
+
+pub(super) trait StateMachineSpanExt {
+    fn record_invocation_id(invocation_id: &InvocationId);
+
+    fn record_invocation_target(invocation_target: &InvocationTarget);
+}
+
+impl StateMachineSpanExt for Span {
+    fn record_invocation_id(invocation_id: &InvocationId) {
+        Span::current().record(
+            "restate.invocation.id",
+            tracing::field::display(invocation_id),
+        );
+    }
+
+    fn record_invocation_target(invocation_target: &InvocationTarget) {
+        Span::current()
+            .record(
+                "rpc.service",
+                tracing::field::display(invocation_target.service_name()),
+            )
+            .record(
+                "rpc.method",
+                tracing::field::display(invocation_target.handler_name()),
+            )
+            .record(
+                "restate.invocation.target",
+                tracing::field::display(invocation_target),
+            );
+    }
+}
+
+pub(super) fn state_machine_apply_command_span(
+    state_machine_context: &StateMachineContext,
+    cmd: &Command,
+) -> Span {
+    let span = if state_machine_context.is_leader {
+        debug_span!(
+            "apply_command",
+            restate.invocation.id = tracing::field::Empty,
+            restate.invocation.target = tracing::field::Empty,
+            rpc.service = tracing::field::Empty,
+            rpc.method = tracing::field::Empty,
+            restate.state_machine.command = tracing::field::Empty,
+        )
+    } else {
+        trace_span!(
+            "apply_command",
+            restate.invocation.id = tracing::field::Empty,
+            restate.invocation.target = tracing::field::Empty,
+            rpc.service = tracing::field::Empty,
+            rpc.method = tracing::field::Empty,
+            restate.state_machine.command = tracing::field::Empty,
+        )
+    };
+    if event_enabled!(Level::TRACE) {
+        span.record("restate.state_machine.command", tracing::field::debug(cmd));
+    }
+
+    span
+}

--- a/crates/worker/src/partition/storage/mod.rs
+++ b/crates/worker/src/partition/storage/mod.rs
@@ -248,6 +248,10 @@ where
 
         Ok(())
     }
+
+    pub fn inner(&mut self) -> &mut TransactionType {
+        &mut self.inner
+    }
 }
 
 // Avoid adding methods here, but rather use directly the storage_api traits!!!


### PR DESCRIPTION
Introduce new state machine infra and related test infra, in order to improve the code organization around the FSM and commands.

The new infra uses `StateMachineContext` as entrypoint, and from there every command struct implements `ApplicableCommand`. `ApplicableCommand` applies the command by using the `CommandContext`, which contains storage and actions collector.

To facilitate the transition, I've introduced a MaybeApplicableCommand which is implemented for `Command`, and returns the command in case the new infra doesn't yet support that specific command.

The PR also shows two commands ported to the new infra.