### PR TITLE
Lazily calculate value when using StyledTable::add_kv_row_if and predicate is true

### DIFF
--- a/cli/src/commands/invocations/describe.rs
+++ b/cli/src/commands/invocations/describe.rs
@@ -62,7 +62,7 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     table.add_kv_row_if(
         || inv.state_modified_at.is_some(),
         "Modified at:",
-        format!("{}", &inv.state_modified_at.unwrap()),
+        || format!("{}", &inv.state_modified_at.unwrap()),
     );
 
     c_title!("📜", "Invocation Information");

--- a/cli/src/ui/deployments.rs
+++ b/cli/src/ui/deployments.rs
@@ -136,7 +136,7 @@ pub fn add_deployment_to_kv_table(deployment: &Deployment, table: &mut Table) {
                 table.add_kv_row_if(
                     || assume_role_arn.is_some(),
                     "Deployment Assume Role ARN:",
-                    assume_role_arn.as_ref().unwrap(),
+                    || assume_role_arn.as_ref().unwrap(),
                 );
 
                 table.add_kv_row("Endpoint:", arn);

--- a/crates/cli-util/src/ui/console.rs
+++ b/crates/cli-util/src/ui/console.rs
@@ -84,14 +84,14 @@ pub trait StyledTable {
     fn new_styled() -> Self;
     fn set_styled_header<T: ToString>(&mut self, headers: Vec<T>) -> &mut Self;
     fn add_kv_row<V: Into<comfy_table::Cell>>(&mut self, key: &str, value: V) -> &mut Self;
-    fn add_kv_row_if<P: Fn() -> bool, V: Display>(
+    fn add_kv_row_if<P: Fn() -> bool, V: Fn() -> D, D: Display>(
         &mut self,
         predicate: P,
         key: &str,
         value: V,
     ) -> &mut Self {
         if predicate() {
-            self.add_kv_row(key, value)
+            self.add_kv_row(key, value())
         } else {
             self
         }


### PR DESCRIPTION
We use `StyledTable::add_kv_row_if` to check if a value exists. We should only access the value if the predicate passes. That's why this command changes the value parameter into a closure that is evaluated if the predicate is true.

This fixes #1631.