### PR TITLE
[restatectl] dump cluster-state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5439,7 +5439,6 @@ dependencies = [
  "tower",
  "tracing",
  "typify 0.1.0",
- "unicode-width",
  "url",
  "uuid",
  "vergen",
@@ -5466,6 +5465,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5838,6 +5838,7 @@ dependencies = [
  "metrics-tracing-context",
  "metrics-util",
  "once_cell",
+ "prost-types",
  "restate-admin",
  "restate-bifrost",
  "restate-cluster-controller",
@@ -6336,6 +6337,7 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-build",
+ "prost-types",
  "rand",
  "regress 0.9.1",
  "restate-base64-util",
@@ -6464,18 +6466,26 @@ name = "restatectl"
 version = "1.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clap-verbosity-flag",
  "cling",
  "crossterm 0.27.0",
  "ctrlc",
+ "prost-types",
  "restate-cli-util",
+ "restate-node-protocol",
+ "restate-node-services",
+ "restate-types",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tonic 0.10.2",
+ "tower",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "url",
  "vergen",
 ]
 
@@ -7601,6 +7611,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
+ "flate2",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ tracing-opentelemetry = { version = "0.23.0" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-test = { version = "0.2.4" }
 ulid = { version = "1.1.0" }
+url = { version = "2.5" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 
 [profile.release]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -68,8 +68,7 @@ toml_edit = "0.22.12"
 tower = { workspace = true }
 tracing = { workspace = true }
 typify = "0.1.0"
-unicode-width = { version = "0.1.11" }
-url = { version = "2.4.1" }
+url = { workspace = true }
 uuid = { workspace = true }
 zip = "0.6"
 

--- a/crates/cli-util/Cargo.toml
+++ b/crates/cli-util/Cargo.toml
@@ -28,3 +28,4 @@ tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }
+unicode-width = { version = "0.1.11" }

--- a/crates/cli-util/src/context.rs
+++ b/crates/cli-util/src/context.rs
@@ -18,7 +18,7 @@ use dotenvy::dotenv;
 use tracing::info;
 use tracing_log::AsTrace;
 
-use crate::opts::{CommonOpts, ConfirmMode, NetworkOpts, TableStyle, UiOpts};
+use crate::opts::{CommonOpts, ConfirmMode, NetworkOpts, TableStyle, TimeFormat, UiOpts};
 use crate::os_env::OsEnv;
 
 static GLOBAL_CLI_CONTEXT: OnceLock<ArcSwap<CliContext>> = OnceLock::new();
@@ -138,6 +138,10 @@ impl CliContext {
 
     pub fn table_style(&self) -> TableStyle {
         self.ui.table_style
+    }
+
+    pub fn time_format(&self) -> TimeFormat {
+        self.ui.time_format
     }
 
     pub fn colors_enabled(&self) -> bool {

--- a/crates/cli-util/src/opts.rs
+++ b/crates/cli-util/src/opts.rs
@@ -24,6 +24,18 @@ pub enum TableStyle {
     Borders,
 }
 
+#[derive(ValueEnum, Clone, Copy, Eq, PartialEq, Default, Debug)]
+#[clap(rename_all = "kebab-case")]
+pub enum TimeFormat {
+    /// Human friendly timestamps and durations
+    #[default]
+    Human,
+    /// RFC-3339/ISO-8601 formatted (1996-12-19T16:39:57-08:00)
+    Iso8601,
+    /// RFC-2822 formatted (Tue, 1 Jul 2003 10:52:37 +0200)
+    Rfc2822,
+}
+
 /// Silent (no) logging by default in CLI
 #[derive(Clone, Default)]
 pub(crate) struct Quiet;
@@ -38,6 +50,9 @@ pub(crate) struct UiOpts {
     /// Which table output style to use
     #[arg(long, default_value = "compact", global = true)]
     pub table_style: TableStyle,
+
+    #[arg(long, default_value = "human", global = true)]
+    pub time_format: TimeFormat,
 }
 
 #[derive(Args, Clone, Default)]

--- a/crates/cli-util/src/ui/console.rs
+++ b/crates/cli-util/src/ui/console.rs
@@ -164,7 +164,7 @@ macro_rules! _gecho {
     (@title, ($icon:expr), $where:tt, $($arg:tt)*) => {
         {
             use std::fmt::Write;
-            use unicode_width::UnicodeWidthStr;
+            use $crate::_unicode_width::UnicodeWidthStr;
 
             let mut _lock = $crate::ui::output::$where();
             let _icon = $crate::ui::console::Icon($icon, "");

--- a/crates/cli-util/src/ui/mod.rs
+++ b/crates/cli-util/src/ui/mod.rs
@@ -8,22 +8,49 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use chrono::Duration;
-use chrono_humanize::{Accuracy, Tense};
+use chrono::{DateTime, TimeDelta};
+pub use chrono_humanize::{Accuracy, Tense};
+
+use crate::CliContext;
 
 pub mod console;
 pub mod output;
 pub mod stylesheet;
 pub mod watcher;
 
-pub fn duration_to_human_precise(duration: Duration, tense: Tense) -> String {
-    let duration = chrono_humanize::HumanTime::from(
-        Duration::try_milliseconds(duration.num_milliseconds()).expect("valid milliseconds"),
-    );
-    duration.to_text_en(Accuracy::Precise, tense)
+pub fn timestamp_as_human_duration<Tz: chrono::TimeZone>(ts: DateTime<Tz>, tense: Tense) -> String {
+    match CliContext::get().time_format() {
+        crate::opts::TimeFormat::Human => {
+            let since = ts.signed_duration_since(chrono::Local::now());
+            duration_to_human_precise(since, tense)
+        }
+        crate::opts::TimeFormat::Iso8601 => ts.to_rfc3339(),
+        crate::opts::TimeFormat::Rfc2822 => ts.to_rfc2822(),
+    }
 }
 
-pub fn duration_to_human_rough(duration: Duration, tense: Tense) -> String {
-    let duration = chrono_humanize::HumanTime::from(duration);
-    duration.to_text_en(Accuracy::Rough, tense)
+pub fn duration_to_human_precise(duration: TimeDelta, tense: Tense) -> String {
+    match CliContext::get().time_format() {
+        crate::opts::TimeFormat::Iso8601 => duration.to_string(),
+        crate::opts::TimeFormat::Rfc2822 => duration.to_string(),
+        crate::opts::TimeFormat::Human => {
+            let duration = chrono_humanize::HumanTime::from(
+                // truncate nanos
+                TimeDelta::try_milliseconds(duration.num_milliseconds())
+                    .expect("valid milliseconds"),
+            );
+            duration.to_text_en(Accuracy::Precise, tense)
+        }
+    }
+}
+
+pub fn duration_to_human_rough(duration: TimeDelta, tense: Tense) -> String {
+    match CliContext::get().time_format() {
+        crate::opts::TimeFormat::Iso8601 => duration.to_string(),
+        crate::opts::TimeFormat::Rfc2822 => duration.to_string(),
+        crate::opts::TimeFormat::Human => {
+            let duration = chrono_humanize::HumanTime::from(duration);
+            duration.to_text_en(Accuracy::Rough, tense)
+        }
+    }
 }

--- a/crates/cluster-controller/src/lib.rs
+++ b/crates/cluster-controller/src/lib.rs
@@ -11,4 +11,5 @@
 mod cluster_state;
 mod service;
 
+pub use cluster_state::NodeState;
 pub use service::{ClusterControllerHandle, Error, Service};

--- a/crates/node-protocol/proto/common.proto
+++ b/crates/node-protocol/proto/common.proto
@@ -21,6 +21,12 @@ message NodeId {
   optional uint32 generation = 2;
 }
 
+// Partition Processor leadershop epoch number
+message LeaderEpoch { uint64 value = 1; }
+
+// Log sequence number
+message Lsn { uint64 value = 1; }
+
 // A generic type for versioned metadata
 message Version { uint32 value = 1; }
 

--- a/crates/node-protocol/src/common.rs
+++ b/crates/node-protocol/src/common.rs
@@ -120,6 +120,42 @@ impl From<KeyRange> for RangeInclusive<PartitionKey> {
     }
 }
 
+impl From<restate_types::logs::Lsn> for Lsn {
+    fn from(lsn: restate_types::logs::Lsn) -> Self {
+        let value: u64 = lsn.into();
+        Lsn { value }
+    }
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(generation) = self.generation {
+            write!(f, "N{}:{}", self.id, generation)
+        } else {
+            write!(f, "N{}", self.id)
+        }
+    }
+}
+
+impl std::fmt::Display for Lsn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl std::fmt::Display for LeaderEpoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "e{}", self.value)
+    }
+}
+
+impl From<restate_types::identifiers::LeaderEpoch> for LeaderEpoch {
+    fn from(epoch: restate_types::identifiers::LeaderEpoch) -> Self {
+        let value: u64 = epoch.into();
+        LeaderEpoch { value }
+    }
+}
+
 // write tests for RequestId
 #[cfg(test)]
 mod tests {

--- a/crates/node-services/Cargo.toml
+++ b/crates/node-services/Cargo.toml
@@ -21,7 +21,7 @@ bytes = { workspace = true, optional = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 thiserror = { workspace = true, optional = true }
-tonic = { workspace = true, features = ["transport", "codegen", "prost"] }
+tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip"] }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/node-services/proto/cluster_ctrl_svc.proto
+++ b/crates/node-services/proto/cluster_ctrl_svc.proto
@@ -11,6 +11,8 @@ syntax = "proto3";
 
 import "common.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 package dev.restate.cluster_ctrl;
 
@@ -22,7 +24,54 @@ service ClusterCtrlSvc {
 
 message ClusterStateRequest {}
 
-message ClusterStateResponse {}
+message ClusterStateResponse {
+  google.protobuf.Duration last_refreshed = 1;
+  dev.restate.common.Version nodes_config_version = 2;
+  map<uint32, NodeState> nodes = 3;
+}
+
+message NodeState {
+  oneof state {
+    AliveNode alive = 1;
+    DeadNode dead = 2;
+  }
+}
+
+message AliveNode {
+  dev.restate.common.NodeId generational_node_id = 1;
+  google.protobuf.Timestamp last_heartbeat_at = 2;
+  map<uint64, PartitionProcessorStatus> partitions = 3;
+}
+
+message DeadNode { google.protobuf.Timestamp last_seen_alive = 1; }
+
+enum RunMode {
+  RunMode_UNKNOWN = 0;
+  LEADER = 1;
+  FOLLOWER = 2;
+}
+
+enum ReplayStatus {
+  ReplayStatus_UNKNOWN = 0;
+  STARTING = 1;
+  ACTIVE = 2;
+  CATCHING_UP = 3;
+}
+
+message PartitionProcessorStatus {
+  google.protobuf.Timestamp updated_at = 1;
+  RunMode planned_mode = 2;
+  optional RunMode effective_mode = 3;
+  optional dev.restate.common.LeaderEpoch last_observed_leader_epoch = 4;
+  optional dev.restate.common.NodeId last_observed_leader_node = 5;
+  optional dev.restate.common.Lsn last_applied_log_lsn = 6;
+  optional google.protobuf.Timestamp last_record_applied_at = 7;
+  uint64 num_skipped_records = 8;
+  ReplayStatus replay_status = 9;
+  optional dev.restate.common.Lsn last_persisted_log_lsn = 10;
+  // Set if replay_status is CATCHING_UP
+  optional dev.restate.common.Lsn target_tail_lsn = 11;
+}
 
 message TrimLogRequest {
   uint64 log_id = 1;

--- a/crates/node-services/src/lib.rs
+++ b/crates/node-services/src/lib.rs
@@ -13,6 +13,17 @@ pub mod cluster_ctrl {
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("cluster_ctrl_svc_descriptor");
+
+    impl std::fmt::Display for RunMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let o = match self {
+                RunMode::Unknown => "UNKNOWN",
+                RunMode::Leader => "Leader",
+                RunMode::Follower => "Follower",
+            };
+            write!(f, "{}", o)
+        }
+    }
 }
 
 pub mod node_svc {

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -57,6 +57,7 @@ metrics-exporter-prometheus = { workspace = true }
 metrics-tracing-context = { version = "0.15.0" }
 metrics-util = { version = "0.16.0" }
 once_cell = { workspace = true }
+prost-types = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 semver = {  version = "1.0", features = ["serde"] }

--- a/crates/node/src/network_server/handler/cluster_ctrl.rs
+++ b/crates/node/src/network_server/handler/cluster_ctrl.rs
@@ -8,16 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::{BTreeMap, HashMap};
+
 use tonic::{async_trait, Request, Response, Status};
 use tracing::info;
 
 use restate_cluster_controller::ClusterControllerHandle;
+use restate_cluster_controller::NodeState;
 use restate_metadata_store::MetadataStoreClient;
 use restate_node_services::cluster_ctrl::cluster_ctrl_svc_server::ClusterCtrlSvc;
+use restate_node_services::cluster_ctrl::node_state;
+use restate_node_services::cluster_ctrl::AliveNode;
+use restate_node_services::cluster_ctrl::DeadNode;
 use restate_node_services::cluster_ctrl::{
     ClusterStateRequest, ClusterStateResponse, TrimLogRequest,
 };
+use restate_types::identifiers::PartitionId;
 use restate_types::logs::{LogId, Lsn};
+use restate_types::processors::PartitionProcessorStatus;
+use restate_types::processors::RunMode;
+use restate_types::PlainNodeId;
 
 use crate::network_server::AdminDependencies;
 
@@ -47,10 +57,14 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             .await
             .map_err(|_| tonic::Status::aborted("Node is shutting down"))?;
 
-        // todo: remove this and return the actual state via protobuf
-        info!("Cluster state: {:?}", cluster_state);
-
-        Ok(Response::new(ClusterStateResponse::default()))
+        let resp = ClusterStateResponse {
+            last_refreshed: cluster_state
+                .last_refreshed
+                .and_then(|r| r.elapsed().try_into().ok()),
+            nodes_config_version: Some(cluster_state.nodes_config_version.into()),
+            nodes: to_protobuf_nodes(&cluster_state.nodes),
+        };
+        Ok(Response::new(resp))
     }
 
     /// Internal operations API to trigger the log truncation
@@ -69,4 +83,83 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         }
         Ok(Response::new(()))
     }
+}
+
+fn to_protobuf_nodes(
+    nodes: &BTreeMap<PlainNodeId, NodeState>,
+) -> HashMap<u32, restate_node_services::cluster_ctrl::NodeState> {
+    fn to_proto(node: &NodeState) -> restate_node_services::cluster_ctrl::NodeState {
+        let state = Some(match node {
+            NodeState::Alive {
+                last_heartbeat_at,
+                generation,
+                partitions,
+            } => {
+                let alive_node = AliveNode {
+                    last_heartbeat_at: Some((*last_heartbeat_at).into()),
+                    generational_node_id: Some((*generation).into()),
+                    partitions: to_protobuf_partitions(partitions),
+                };
+                node_state::State::Alive(alive_node)
+            }
+            NodeState::Dead { last_seen_alive } => {
+                let dead_node = DeadNode {
+                    last_seen_alive: last_seen_alive.map(Into::into),
+                };
+                node_state::State::Dead(dead_node)
+            }
+        });
+        restate_node_services::cluster_ctrl::NodeState { state }
+    }
+
+    let mut out = HashMap::with_capacity(nodes.len());
+    for (id, node) in nodes {
+        out.insert((*id).into(), to_proto(node));
+    }
+    out
+}
+
+fn to_protobuf_partitions(
+    pps: &BTreeMap<PartitionId, PartitionProcessorStatus>,
+) -> HashMap<u64, restate_node_services::cluster_ctrl::PartitionProcessorStatus> {
+    fn to_proto(
+        pp: &PartitionProcessorStatus,
+    ) -> restate_node_services::cluster_ctrl::PartitionProcessorStatus {
+        let mut out = restate_node_services::cluster_ctrl::PartitionProcessorStatus::default();
+        out.updated_at = Some(pp.updated_at.into());
+        out.planned_mode = match pp.planned_mode {
+            RunMode::Leader => restate_node_services::cluster_ctrl::RunMode::Leader as i32,
+            RunMode::Follower => restate_node_services::cluster_ctrl::RunMode::Follower as i32,
+        };
+        out.effective_mode = pp.effective_mode.map(|m| match m {
+            RunMode::Leader => restate_node_services::cluster_ctrl::RunMode::Leader as i32,
+            RunMode::Follower => restate_node_services::cluster_ctrl::RunMode::Follower as i32,
+        });
+        out.last_observed_leader_epoch = pp.last_observed_leader_epoch.map(|e| e.into());
+        out.last_observed_leader_node = pp.last_observed_leader_node.map(|e| e.into());
+        out.last_applied_log_lsn = pp.last_applied_log_lsn.map(|l| l.into());
+        out.last_record_applied_at = pp.last_record_applied_at.map(Into::into);
+        out.num_skipped_records = pp.num_skipped_records;
+        out.replay_status = match pp.replay_status {
+            restate_types::processors::ReplayStatus::Starting => {
+                restate_node_services::cluster_ctrl::ReplayStatus::Starting as i32
+            }
+            restate_types::processors::ReplayStatus::Active => {
+                restate_node_services::cluster_ctrl::ReplayStatus::Active as i32
+            }
+            restate_types::processors::ReplayStatus::CatchingUp { target_tail_lsn } => {
+                out.target_tail_lsn = Some(target_tail_lsn.into());
+                restate_node_services::cluster_ctrl::ReplayStatus::CatchingUp as i32
+            }
+        };
+        out.last_persisted_log_lsn = pp.last_persisted_log_lsn.map(|l| l.into());
+
+        out
+    }
+
+    let mut out = HashMap::with_capacity(pps.len());
+    for (id, node) in pps {
+        out.insert((*id).into(), to_proto(node));
+    }
+    out
 }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -36,6 +36,7 @@ num-traits = { version = "0.2.17" }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true }
 prost = { workspace = true }
+prost-types = { workspace = true }
 rand = { workspace = true }
 regress = { version = "0.9" }
 schemars = { workspace = true, optional = true }

--- a/crates/types/src/processors/mod.rs
+++ b/crates/types/src/processors/mod.rs
@@ -37,7 +37,7 @@ pub struct PartitionProcessorStatus {
     pub last_observed_leader_node: Option<GenerationalNodeId>,
     pub last_applied_log_lsn: Option<Lsn>,
     pub last_record_applied_at: Option<MillisSinceEpoch>,
-    pub skipped_records: u64,
+    pub num_skipped_records: u64,
     pub replay_status: ReplayStatus,
     pub last_persisted_log_lsn: Option<Lsn>,
 }
@@ -58,7 +58,7 @@ impl PartitionProcessorStatus {
             last_observed_leader_node: None,
             last_applied_log_lsn: None,
             last_record_applied_at: None,
-            skipped_records: 0,
+            num_skipped_records: 0,
             replay_status: ReplayStatus::Starting,
             last_persisted_log_lsn: None,
         }

--- a/crates/types/src/time.rs
+++ b/crates/types/src/time.rs
@@ -63,6 +63,24 @@ impl From<SystemTime> for MillisSinceEpoch {
     }
 }
 
+/// # Panics
+/// If timestamp is out of range (e.g. older than UNIX_EPOCH) this conversion will panic.
+impl From<prost_types::Timestamp> for MillisSinceEpoch {
+    fn from(value: prost_types::Timestamp) -> Self {
+        // safest approach is to convert into SystemTime first, then calculate distance to
+        // UNIX_EPOCH
+        Self::from(std::time::SystemTime::try_from(value).expect("Timestamp is after UNIX_EPOCH"))
+    }
+}
+
+impl From<MillisSinceEpoch> for prost_types::Timestamp {
+    fn from(value: MillisSinceEpoch) -> Self {
+        // safest approach is to convert into SystemTime first, then calculate distance to
+        // UNIX_EPOCH
+        Self::from(std::time::SystemTime::from(value))
+    }
+}
+
 impl Display for MillisSinceEpoch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ms since epoch", self.0)
@@ -124,6 +142,17 @@ impl From<SystemTime> for NanosSinceEpoch {
             )
             .expect("nanos since Unix epoch should fit in u64"),
         )
+    }
+}
+
+/// # Panics
+/// If timestamp is out of range (e.g. older than UNIX_EPOCH) this conversion will panic.
+impl From<prost_types::Timestamp> for NanosSinceEpoch {
+    fn from(value: prost_types::Timestamp) -> Self {
+        // safest approach is to convert into SystemTime first, then calculate distance to
+        // UNIX_EPOCH
+        let ts = std::time::SystemTime::try_from(value).expect("Timestamp is after UNIX_EPOCH");
+        Self::from(ts)
     }
 }
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -390,7 +390,7 @@ where
                     .await?;
             }
         } else {
-            status.skipped_records += 1;
+            status.num_skipped_records += 1;
             trace!(
                 "Ignore message which is not targeted to me: {:?}",
                 envelope.header

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -9,19 +9,27 @@ publish = false
 
 [dependencies]
 restate-cli-util = { workspace = true } 
+restate-node-protocol = { workspace = true }
+restate-node-services = { workspace = true, features = ["clients"] }
+restate-types = { workspace = true }
 
 anyhow = { workspace = true }
+chrono = { workspace = true }
 clap = { version = "4.1", features = ["derive", "env", "wrap_help", "color"] }
 clap-verbosity-flag = { version = "2.0.1" }
 cling = { version = "0.1.0", default-features = false, features = ["derive"] }
 crossterm = { version = "0.27.0" }
 ctrlc = { version = "3.4" }
+prost-types = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tonic = { workspace = true, features = ["transport", "prost"] }
+tower = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 tracing-log = { version = "0.2" }
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 vergen = { version = "8", default-features = false, features = [

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -8,11 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use cling::prelude::*;
+use std::str::FromStr;
 
-use restate_cli_util::c_tip;
+use cling::prelude::*;
+use restate_types::net::AdvertisedAddress;
+
 use restate_cli_util::CliContext;
 use restate_cli_util::CommonOpts;
+
+use crate::commands::dump::Dump;
 
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]
@@ -20,20 +24,26 @@ use restate_cli_util::CommonOpts;
 pub struct CliApp {
     #[clap(flatten)]
     pub common_opts: CommonOpts,
+    #[clap(flatten)]
+    pub connection: ConnectionInfo,
     #[clap(subcommand)]
     pub cmd: Command,
 }
 
+#[derive(Parser, Collect, Debug, Clone)]
+pub struct ConnectionInfo {
+    /// Cluster Controller host:port (e.g. http://localhost:5122/)
+    #[clap(long, value_hint= clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(), global = true)]
+    pub cluster_controller: AdvertisedAddress,
+}
+
 #[derive(Run, Subcommand, Clone)]
 pub enum Command {
-    #[cling(run = "hello")]
-    Hello,
+    /// Dump various metadata from the cluster controller
+    #[clap(subcommand)]
+    Dump(Dump),
 }
 
 fn init(common_opts: &CommonOpts) {
     CliContext::new(common_opts.clone()).set_as_global();
-}
-
-async fn hello() {
-    c_tip!("Placeholder");
 }

--- a/tools/restatectl/src/commands/dump/cluster_state.rs
+++ b/tools/restatectl/src/commands/dump/cluster_state.rs
@@ -1,0 +1,193 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::time::SystemTime;
+
+use anyhow::Context;
+use chrono::{DateTime, Local};
+use cling::prelude::*;
+use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::{timestamp_as_human_duration, Tense};
+use restate_node_protocol::common::Lsn;
+use restate_node_services::cluster_ctrl::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
+
+use restate_cli_util::{c_println, c_title};
+use restate_node_services::cluster_ctrl::{
+    node_state, ClusterStateRequest, DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode,
+};
+use restate_types::{GenerationalNodeId, PlainNodeId};
+use tonic::codec::CompressionEncoding;
+
+use crate::app::ConnectionInfo;
+use crate::util::grpc_connect;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap(visible_alias = "cluster")]
+#[cling(run = "dump_cluster_state")]
+pub struct ClusterStateOpts {}
+
+struct PartitionDetails {
+    host_node: GenerationalNodeId,
+    status: PartitionProcessorStatus,
+}
+
+async fn dump_cluster_state(
+    connection: &ConnectionInfo,
+    _opts: &ClusterStateOpts,
+) -> anyhow::Result<()> {
+    let channel = grpc_connect(connection.cluster_controller.clone())
+        .await
+        .with_context(|| {
+            format!(
+                "cannot connect to cluster controller at {}",
+                connection.cluster_controller
+            )
+        })?;
+    let mut client =
+        ClusterCtrlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
+
+    let req = ClusterStateRequest::default();
+    let state = client.get_cluster_state(req).await?.into_inner();
+
+    let mut processors: BTreeMap<u64, PartitionDetails> = BTreeMap::new();
+    let mut dead_nodes: BTreeMap<PlainNodeId, DeadNode> = BTreeMap::new();
+    for (node_id, node_state) in state.nodes {
+        match node_state.state.expect("node state is set") {
+            node_state::State::Dead(dead_node) => {
+                dead_nodes.insert(PlainNodeId::from(node_id), dead_node);
+            }
+            node_state::State::Alive(alive_node) => {
+                for (partition_id, status) in alive_node.partitions {
+                    let host = alive_node
+                        .generational_node_id
+                        .as_ref()
+                        .expect("alive partition has a node id");
+                    let host_node =
+                        GenerationalNodeId::new(host.id, host.generation.expect("generation"));
+                    let details = PartitionDetails { host_node, status };
+                    processors.insert(partition_id, details);
+                }
+            }
+        }
+    }
+    // Show information organized by partition
+    let mut partitions_table = Table::new_styled();
+    partitions_table.set_styled_header(vec![
+        "P-ID",
+        "NODE",
+        "RUN MODE",
+        "REPLAY",
+        "APPLIED LSN",
+        "PERSISTED LSN",
+        "OBSERVED LEADER",
+        "# SKIPS",
+        "LAST REFRESH",
+    ]);
+    for (partition_id, details) in processors {
+        partitions_table.add_row(vec![
+            Cell::new(partition_id),
+            Cell::new(details.host_node),
+            render_mode(
+                details.status.planned_mode(),
+                details.status.effective_mode(),
+            ),
+            render_replay_status(
+                details.status.replay_status(),
+                details.status.target_tail_lsn,
+            ),
+            Cell::new(
+                details
+                    .status
+                    .last_applied_log_lsn
+                    .map(|x| x.to_string())
+                    .unwrap_or("??".to_owned()),
+            ),
+            Cell::new(
+                details
+                    .status
+                    .last_persisted_log_lsn
+                    .map(|x| x.to_string())
+                    .unwrap_or("??".to_owned()),
+            ),
+            Cell::new(format!(
+                "{} - {}",
+                details
+                    .status
+                    .last_observed_leader_node
+                    .map(|x| x.to_string())
+                    .unwrap_or("??".to_owned()),
+                details
+                    .status
+                    .last_observed_leader_epoch
+                    .map(|x| x.to_string())
+                    .unwrap_or("??".to_owned()),
+            )),
+            Cell::new(details.status.num_skipped_records),
+            render_as_duration(details.status.updated_at, Tense::Past),
+        ]);
+    }
+    c_println!("{}", partitions_table);
+
+    if !dead_nodes.is_empty() {
+        c_title!("☠️", "DEAD NODES");
+        let mut dead_nodes_table = Table::new_styled();
+        dead_nodes_table.set_styled_header(vec!["NODE", "LAST SEEN ALIVE"]);
+        for (node_id, dead_node) in dead_nodes {
+            dead_nodes_table.add_row(vec![
+                Cell::new(node_id),
+                render_as_duration(dead_node.last_seen_alive, Tense::Past),
+            ]);
+        }
+        c_println!("{}", dead_nodes_table);
+    }
+
+    Ok(())
+}
+
+fn render_mode(planned: RunMode, effective: RunMode) -> Cell {
+    if planned == RunMode::Unknown {
+        return Cell::new("UNKNOWN").fg(Color::Red);
+    }
+    if planned == effective {
+        return Cell::new(planned)
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Green);
+    }
+    // We are in a transitional state
+    Cell::new(format!("{}->{}", effective, planned)).fg(Color::Magenta)
+}
+
+fn render_replay_status(status: ReplayStatus, target_lsn: Option<Lsn>) -> Cell {
+    match status {
+        ReplayStatus::Unknown => Cell::new("UNKNOWN").fg(Color::Red),
+        ReplayStatus::Starting => Cell::new("Starting").fg(Color::Yellow),
+        ReplayStatus::Active => Cell::new("Active").fg(Color::Green),
+        ReplayStatus::CatchingUp => Cell::new(format!(
+            "Catching Up ({})",
+            target_lsn.map(|x| x.to_string()).unwrap_or("??".to_owned())
+        ))
+        .fg(Color::Magenta),
+    }
+}
+
+fn render_as_duration(ts: Option<prost_types::Timestamp>, tense: Tense) -> Cell {
+    let ts: Option<SystemTime> = ts
+        .map(TryInto::try_into)
+        .transpose()
+        .expect("valid timestamp");
+    if let Some(ts) = ts {
+        let ts: DateTime<Local> = ts.into();
+        Cell::new(timestamp_as_human_duration(ts, tense))
+    } else {
+        Cell::new("??").fg(Color::Red)
+    }
+}

--- a/tools/restatectl/src/commands/dump/mod.rs
+++ b/tools/restatectl/src/commands/dump/mod.rs
@@ -8,15 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod context;
-mod opts;
-mod os_env;
-pub mod ui;
+mod cluster_state;
 
-pub use context::CliContext;
-pub use opts::CommonOpts;
-pub use os_env::OsEnv;
+use cling::prelude::*;
 
-// Re-export comfy-table for console c_* macros
-pub use comfy_table as _comfy_table;
-pub use unicode_width as _unicode_width;
+#[derive(Run, Subcommand, Clone)]
+pub enum Dump {
+    /// Dump the latest cluster state
+    ClusterState(cluster_state::ClusterStateOpts),
+}

--- a/tools/restatectl/src/commands/mod.rs
+++ b/tools/restatectl/src/commands/mod.rs
@@ -8,15 +8,4 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod context;
-mod opts;
-mod os_env;
-pub mod ui;
-
-pub use context::CliContext;
-pub use opts::CommonOpts;
-pub use os_env::OsEnv;
-
-// Re-export comfy-table for console c_* macros
-pub use comfy_table as _comfy_table;
-pub use unicode_width as _unicode_width;
+pub mod dump;

--- a/tools/restatectl/src/lib.rs
+++ b/tools/restatectl/src/lib.rs
@@ -9,5 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod app;
+pub(crate) mod commands;
+pub(crate) mod util;
 pub use app::CliApp;
 mod build_info;

--- a/tools/restatectl/src/util.rs
+++ b/tools/restatectl/src/util.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_cli_util::CliContext;
+use restate_types::net::AdvertisedAddress;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+pub async fn grpc_connect(address: AdvertisedAddress) -> Result<Channel, tonic::transport::Error> {
+    let ctx = CliContext::get();
+    match address {
+        AdvertisedAddress::Uds(uds_path) => {
+            // dummy endpoint required to specify an uds connector, it is not used anywhere
+            Endpoint::try_from("http://127.0.0.1")
+                .expect("/ should be a valid Uri")
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    UnixStream::connect(uds_path.clone())
+                }))
+                .await
+        }
+        AdvertisedAddress::Http(uri) => {
+            Channel::builder(uri)
+                .connect_timeout(ctx.connect_timeout())
+                .timeout(ctx.request_timeout())
+                .http2_adaptive_window(true)
+                .connect()
+                .await
+        }
+    }
+}


### PR DESCRIPTION
[restatectl] dump cluster-state

Allow dumping current view of ClusterState in a table format.

```shell
❯ cargo run -q --bin restatectl --  dump cluster-state                                                                                                                                                                                                                                                                                                                                                                                ✘ 1
 P-ID  NODE   RUN MODE  REPLAY  APPLIED LSN  PERSISTED LSN  OBSERVED LEADER  # SKIPS  LAST REFRESH
 0     N0:24  Leader    Active  494          ??             N0:24 - e24      0        1 second and 56 ms ago
 1     N0:24  Leader    Active  554          ??             N0:24 - e24      0        1 second and 29 ms ago
 2     N0:24  Leader    Active  354          ??             N0:24 - e24      0        513 ms ago
 3     N0:24  Leader    Active  494          ??             N0:24 - e24      0        555 ms ago
 4     N0:24  Leader    Active  359          ??             N0:24 - e24      0        474 ms ago
 5     N0:24  Leader    Active  434          ??             N0:24 - e24      0        952 ms ago
 6     N0:24  Leader    Active  599          ??             N0:24 - e24      0        824 ms ago
 7     N0:24  Leader    Active  484          ??             N0:24 - e24      0        829 ms ago
 8     N0:24  Leader    Active  434          ??             N0:24 - e24      0        608 ms ago
 9     N0:24  Leader    Active  454          ??             N0:24 - e24      0        589 ms ago
 10    N0:24  Leader    Active  494          ??             N0:24 - e24      0        589 ms ago
 11    N0:24  Leader    Active  364          ??             N0:24 - e24      0        633 ms ago
 12    N0:24  Leader    Active  434          ??             N0:24 - e24      0        924 ms ago
 13    N0:24  Leader    Active  439          ??             N0:24 - e24      0        685 ms ago
 14    N0:24  Leader    Active  504          ??             N0:24 - e24      0        1 second and 121 ms ago
 15    N0:24  Leader    Active  444          ??             N0:24 - e24      0        493 ms ago
 16    N0:24  Leader    Active  514          ??             N0:24 - e24      0        723 ms ago
 17    N0:24  Leader    Active  474          ??             N0:24 - e24      0        908 ms ago
 18    N0:24  Leader    Active  329          ??             N0:24 - e24      0        991 ms ago
 19    N0:24  Leader    Active  604          ??             N0:24 - e24      0        589 ms ago
 20    N0:24  Leader    Active  469          ??             N0:24 - e24      0        1 second and 135 ms ago
 21    N0:24  Leader    Active  534          ??             N0:24 - e24      0        669 ms ago
 22    N0:24  Leader    Active  409          ??             N0:24 - e24      0        655 ms ago
 23    N0:24  Leader    Active  474          ??             N0:24 - e24      0        741 ms ago

```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1638).
* #1652
* #1647
* #1645
* #1644
* #1643
* __->__ #1638