### PR TITLE
CLI should respect that not just virtual objects are stateful

### DIFF
--- a/cli/src/commands/services/status/agg_status.rs
+++ b/cli/src/commands/services/status/agg_status.rs
@@ -11,7 +11,6 @@
 use anyhow::Result;
 use indicatif::ProgressBar;
 
-use restate_admin_rest_model::services::ServiceType;
 use restate_cli_util::{c_error, c_title};
 
 use super::{render_locked_keys, render_services_status, Status};
@@ -48,7 +47,7 @@ pub async fn run_aggregated_status(
 
     let keyed: Vec<_> = services
         .iter()
-        .filter(|svc| svc.ty == ServiceType::VirtualObject)
+        .filter(|svc| svc.ty.is_keyed())
         .cloned()
         .collect();
 

--- a/cli/src/commands/services/status/detailed_status.rs
+++ b/cli/src/commands/services/status/detailed_status.rs
@@ -40,7 +40,7 @@ pub async fn run_detailed_status(
         .into_body()
         .await?;
 
-    let is_object = service.ty == ServiceType::VirtualObject;
+    let is_stateful = service.ty.has_state();
 
     // Print summary table first.
     let status_map = get_service_status(&sql_client, vec![service_name]).await?;
@@ -52,7 +52,7 @@ pub async fn run_detailed_status(
     c_title!("📷", "Summary");
     render_services_status(vec![service], status_map).await?;
 
-    if is_object {
+    if is_stateful {
         let locked_keys = get_locked_keys_status(&sql_client, vec![service_name]).await?;
         if !locked_keys.is_empty() {
             c_title!("📨", "Active Keys");

--- a/cli/src/commands/services/status/detailed_status.rs
+++ b/cli/src/commands/services/status/detailed_status.rs
@@ -11,7 +11,6 @@
 use anyhow::Result;
 use indicatif::ProgressBar;
 
-use restate_admin_rest_model::services::ServiceType;
 use restate_cli_util::c_title;
 
 use super::{render_locked_keys, render_services_status, Status};

--- a/cli/src/commands/state/util.rs
+++ b/cli/src/commands/state/util.rs
@@ -45,8 +45,9 @@ pub(crate) async fn get_current_state(
     //
     let client = AdminClient::new(env).await?;
     let service_meta = client.get_service(service).await?.into_body().await?;
-    if service_meta.ty != ServiceType::VirtualObject {
-        bail!("Only virtual objects support state");
+    match service_meta.ty {
+        ServiceType::VirtualObject | ServiceType::Workflow => {}
+        ServiceType::Service => bail!("Only virtual objects and workflows support state"),
     }
     //
     // 1. get the key-value pairs


### PR DESCRIPTION
There is a bug where `state get` doesn't work on workflows. This PR tightens up a few places where we do an equality check instead of a match or using the method on the service type.