### PR TITLE
[BP] Only emit admin API incompatibility warning if cluster is running 

### DIFF
--- a/cli/src/clients/admin_interface.rs
+++ b/cli/src/clients/admin_interface.rs
@@ -14,6 +14,7 @@ use super::AdminClient;
 
 use restate_admin_rest_model::deployments::*;
 use restate_admin_rest_model::services::*;
+use restate_admin_rest_model::version::VersionInformation;
 
 pub trait AdminClientInterface {
     /// Check if the admin service is healthy by invoking /health
@@ -41,6 +42,8 @@ pub trait AdminClientInterface {
         service: &str,
         req: ModifyServiceStateRequest,
     ) -> reqwest::Result<Envelope<()>>;
+
+    async fn version(&self) -> reqwest::Result<Envelope<VersionInformation>>;
 }
 
 impl AdminClientInterface for AdminClient {
@@ -134,5 +137,11 @@ impl AdminClientInterface for AdminClient {
             .expect("Bad url!");
 
         self.run_with_body(reqwest::Method::POST, url, req).await
+    }
+
+    async fn version(&self) -> reqwest::Result<Envelope<VersionInformation>> {
+        let url = self.base_url.join("/version").expect("Bad url!");
+
+        self.run(reqwest::Method::GET, url).await
     }
 }

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -68,6 +68,7 @@ macro_rules! define_primitive_trait {
     };
 }
 
+#[cfg(feature = "table_docs")]
 macro_rules! document_type {
     (DataType::Utf8) => {
         "Utf8"
@@ -499,4 +500,5 @@ macro_rules! define_table {
 pub(crate) use define_builder;
 pub(crate) use define_primitive_trait;
 pub(crate) use define_table;
+#[cfg(feature = "table_docs")]
 pub(crate) use document_type;


### PR DESCRIPTION
Backport of #1659 to `release-1.0`.