### PR TITLE
[Bifrost] minor cleanups

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -372,13 +372,14 @@ mod tests {
             builder.network_sender.clone(),
             &mut builder.router_builder,
         );
+        let metadata = builder.metadata.clone();
         let svc_handle = svc.handle();
 
         let node_env = builder.build().await;
 
-        let mut bifrost = node_env
+        let bifrost = node_env
             .tc
-            .run_in_scope("init", None, Bifrost::init())
+            .run_in_scope("init", None, Bifrost::init(metadata))
             .await;
 
         node_env.tc.spawn(
@@ -446,6 +447,7 @@ mod tests {
     async fn auto_log_trim() -> anyhow::Result<()> {
         let mut builder = TestCoreEnvBuilder::new_with_mock_network();
 
+        let metadata = builder.metadata.clone();
         let mut admin_options = AdminOptions::default();
         admin_options.log_trim_threshold = 5;
         let interval_duration = Duration::from_secs(10);
@@ -479,9 +481,9 @@ mod tests {
             .build()
             .await;
 
-        let mut bifrost = node_env
+        let bifrost = node_env
             .tc
-            .run_in_scope("init", None, Bifrost::init())
+            .run_in_scope("init", None, Bifrost::init(metadata))
             .await;
 
         node_env.tc.spawn(

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -28,7 +28,7 @@ async fn append_records_multi_log(bifrost: Bifrost, log_id_range: Range<u64>, co
     let mut appends = FuturesUnordered::new();
     for log_id in log_id_range {
         for _ in 0..count_per_log {
-            let mut bifrost = bifrost.clone();
+            let bifrost = bifrost.clone();
             appends.push(async move {
                 let _ = bifrost
                     .append(LogId::from(log_id), Payload::default())
@@ -43,13 +43,13 @@ async fn append_records_multi_log(bifrost: Bifrost, log_id_range: Range<u64>, co
 async fn append_records_concurrent_single_log(bifrost: Bifrost, log_id: LogId, count_per_log: u64) {
     let mut appends = FuturesOrdered::new();
     for _ in 0..count_per_log {
-        let mut bifrost = bifrost.clone();
+        let bifrost = bifrost.clone();
         appends.push_back(async move { bifrost.append(log_id, Payload::default()).await.unwrap() })
     }
     while appends.next().await.is_some() {}
 }
 
-async fn append_seq(mut bifrost: Bifrost, log_id: LogId, count: u64) {
+async fn append_seq(bifrost: Bifrost, log_id: LogId, count: u64) {
     for _ in 1..=count {
         let _ = bifrost
             .append(log_id, Payload::default())

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -161,7 +161,7 @@ mod tests {
     use super::*;
     use googletest::prelude::*;
 
-    use restate_core::{TaskKind, TestCoreEnvBuilder};
+    use restate_core::{metadata, TaskKind, TestCoreEnvBuilder};
     use restate_rocksdb::RocksDbManager;
     use restate_types::arc_util::Constant;
     use restate_types::config::CommonOptions;
@@ -193,7 +193,7 @@ mod tests {
             RocksDbManager::init(Constant::new(CommonOptions::default()));
 
             let read_after = Lsn::from(5);
-            let mut bifrost = Bifrost::init().await;
+            let bifrost = Bifrost::init(metadata()).await;
 
             let log_id = LogId::from(0);
             let mut reader = bifrost.create_reader(log_id, read_after, Lsn::MAX).await?;
@@ -282,7 +282,7 @@ mod tests {
                 RocksDbManager::init(Constant::new(CommonOptions::default()));
 
                 let log_id = LogId::from(0);
-                let mut bifrost = Bifrost::init().await;
+                let bifrost = Bifrost::init(metadata()).await;
 
                 assert!(bifrost.get_trim_point(log_id).await?.is_none());
 

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -26,8 +26,8 @@ pub struct BifrostService {
 impl BifrostService {
     pub fn new(metadata: Metadata) -> Self {
         let (watchdog_sender, watchdog_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let inner = Arc::new(BifrostInner::new(metadata, watchdog_sender));
-        let bifrost = Bifrost::new(inner.clone());
+        let inner = Arc::new(BifrostInner::new(metadata.clone(), watchdog_sender));
+        let bifrost = Bifrost::new(inner.clone(), metadata);
         let watchdog = Watchdog::new(inner.clone(), watchdog_receiver);
         Self {
             inner,

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -101,7 +101,7 @@ impl ActionEffectHandler {
 
         // Attempt to write batches to different log ids concurrently
         for (log_id, payloads) in buffer {
-            let mut bifrost = self.bifrost.clone();
+            let bifrost = self.bifrost.clone();
             batches.push(async move {
                 bifrost.append_batch(log_id, &payloads).await?;
                 anyhow::Ok(())

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -637,7 +637,9 @@ mod tests {
 
         let (truncation_tx, _truncation_rx) = mpsc::channel(1);
 
-        let bifrost = tc.run_in_scope("init bifrost", None, Bifrost::init()).await;
+        let bifrost = tc
+            .run_in_scope("init bifrost", None, Bifrost::init(env.metadata.clone()))
+            .await;
         let shuffle = Shuffle::new(metadata, outbox_reader, truncation_tx, 1, bifrost.clone());
 
         ShuffleEnv {

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -31,7 +31,7 @@ pub async fn run(
     _common_args: &Arguments,
     opts: &AppendLatencyOpts,
     _tc: TaskCenter,
-    mut bifrost: Bifrost,
+    bifrost: Bifrost,
 ) -> anyhow::Result<()> {
     let log_id = LogId::from(0);
     let mut bytes = BytesMut::default();

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -86,7 +86,7 @@ pub async fn run(
     })?;
 
     let writer_task = tc.spawn(TaskKind::TestRunner, "test-log-appender", None, {
-        let mut bifrost = bifrost.clone();
+        let bifrost = bifrost.clone();
         let clock = clock.clone();
         async move {
             let mut append_latencies = Histogram::<u64>::new(3)?;

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -107,7 +107,11 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
     let node_env = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
     let bifrost = node_env
         .tc
-        .run_in_scope("bifrost init", None, Bifrost::init())
+        .run_in_scope(
+            "bifrost init",
+            None,
+            Bifrost::init(node_env.metadata.clone()),
+        )
         .await;
 
     let admin_service = AdminService::new(


### PR DESCRIPTION
[Bifrost] minor cleanups
- Bifrost doesn't need to be mutable for normal appends
- Progress towards removing global access to metadata()

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1664).
* #1671
* #1668
* #1665
* __->__ #1664