### PR TITLE
Use updateable config in networking

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,4 @@
 # https://github.com/rust-lang/rust-clippy/issues/9801
 ignore-interior-mutability = ["bytes::Bytes", "bytestring::ByteString", "http::header::HeaderName", "http::header::HeaderValue"]
+# Sometimes we want to keep the mod.rs file clean
+allow-private-module-inception = true

--- a/crates/admin/src/cluster_controller/cluster_state.rs
+++ b/crates/admin/src/cluster_controller/cluster_state.rs
@@ -106,7 +106,7 @@ where
                     last_state.nodes_config_version,
                 )
                 .await;
-            let nodes_config = metadata.nodes_config();
+            let nodes_config = metadata.nodes_config_snapshot();
 
             let mut nodes = BTreeMap::new();
             let mut join_set = tokio::task::JoinSet::new();

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -21,7 +21,7 @@ use tokio::time::MissedTickBehavior;
 use tokio::time::{Instant, Interval};
 use tracing::{debug, warn};
 
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::{AdminOptions, Configuration};
 use restate_types::net::cluster_controller::{Action, AttachRequest, AttachResponse, RunPartition};
 use restate_types::net::RequestId;
@@ -56,7 +56,7 @@ pub struct Service<N> {
     command_tx: mpsc::Sender<ClusterControllerCommand>,
     command_rx: mpsc::Receiver<ClusterControllerCommand>,
 
-    configuration: Box<dyn Updateable<AdminOptions> + Send + Sync>,
+    configuration: Box<dyn CachingUpdateable<AdminOptions> + Send + Sync>,
     heartbeat_interval: time::Interval,
     log_trim_interval: Option<time::Interval>,
     log_trim_threshold: Lsn,
@@ -67,7 +67,7 @@ where
     N: NetworkSender + 'static,
 {
     pub fn new(
-        mut configuration: impl Updateable<AdminOptions> + Send + Sync + 'static,
+        mut configuration: impl CachingUpdateable<AdminOptions> + Send + Sync + 'static,
         task_center: TaskCenter,
         metadata: Metadata,
         networking: N,

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -372,13 +372,14 @@ mod tests {
             builder.network_sender.clone(),
             &mut builder.router_builder,
         );
+        let metadata = builder.metadata.clone();
         let svc_handle = svc.handle();
 
         let node_env = builder.build().await;
 
-        let mut bifrost = node_env
+        let bifrost = node_env
             .tc
-            .run_in_scope("init", None, Bifrost::init())
+            .run_in_scope("init", None, Bifrost::init(metadata))
             .await;
 
         node_env.tc.spawn(
@@ -446,6 +447,7 @@ mod tests {
     async fn auto_log_trim() -> anyhow::Result<()> {
         let mut builder = TestCoreEnvBuilder::new_with_mock_network();
 
+        let metadata = builder.metadata.clone();
         let mut admin_options = AdminOptions::default();
         admin_options.log_trim_threshold = 5;
         let interval_duration = Duration::from_secs(10);
@@ -479,9 +481,9 @@ mod tests {
             .build()
             .await;
 
-        let mut bifrost = node_env
+        let bifrost = node_env
             .tc
-            .run_in_scope("init", None, Bifrost::init())
+            .run_in_scope("init", None, Bifrost::init(metadata))
             .await;
 
         node_env.tc.spawn(

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use axum::error_handling::HandleErrorLayer;
 use http::StatusCode;
 use restate_bifrost::Bifrost;
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::AdminOptions;
 use tonic::transport::Channel;
 use tower::ServiceBuilder;
@@ -59,7 +59,7 @@ where
 
     pub async fn run(
         self,
-        mut updateable_config: impl Updateable<AdminOptions> + Send + 'static,
+        mut updateable_config: impl CachingUpdateable<AdminOptions> + Send + 'static,
         node_svc_client: NodeSvcClient<Channel>,
         bifrost: Bifrost,
     ) -> anyhow::Result<()> {

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -28,7 +28,7 @@ async fn append_records_multi_log(bifrost: Bifrost, log_id_range: Range<u64>, co
     let mut appends = FuturesUnordered::new();
     for log_id in log_id_range {
         for _ in 0..count_per_log {
-            let mut bifrost = bifrost.clone();
+            let bifrost = bifrost.clone();
             appends.push(async move {
                 let _ = bifrost
                     .append(LogId::from(log_id), Payload::default())
@@ -43,13 +43,13 @@ async fn append_records_multi_log(bifrost: Bifrost, log_id_range: Range<u64>, co
 async fn append_records_concurrent_single_log(bifrost: Bifrost, log_id: LogId, count_per_log: u64) {
     let mut appends = FuturesOrdered::new();
     for _ in 0..count_per_log {
-        let mut bifrost = bifrost.clone();
+        let bifrost = bifrost.clone();
         appends.push_back(async move { bifrost.append(log_id, Payload::default()).await.unwrap() })
     }
     while appends.next().await.is_some() {}
 }
 
-async fn append_seq(mut bifrost: Bifrost, log_id: LogId, count: u64) {
+async fn append_seq(bifrost: Bifrost, log_id: LogId, count: u64) {
     for _ in 1..=count {
         let _ = bifrost
             .append(log_id, Payload::default())

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -9,7 +9,8 @@
 // by the Apache License, Version 2.0.
 
 use restate_core::{
-    spawn_metadata_manager, MetadataManager, MockNetworkSender, TaskCenter, TaskCenterBuilder,
+    spawn_metadata_manager, MetadataBuilder, MetadataManager, MockNetworkSender, TaskCenter,
+    TaskCenterBuilder,
 };
 use restate_metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
@@ -32,10 +33,14 @@ pub async fn spawn_environment(
     let network_sender = MockNetworkSender::default();
 
     let metadata_store_client = MetadataStoreClient::new_in_memory();
-    let metadata_manager =
-        MetadataManager::build(network_sender.clone(), metadata_store_client.clone());
+    let metadata_builder = MetadataBuilder::default();
+    let metadata = metadata_builder.to_metadata();
+    let metadata_manager = MetadataManager::new(
+        metadata_builder,
+        network_sender.clone(),
+        metadata_store_client.clone(),
+    );
 
-    let metadata = metadata_manager.metadata();
     let metadata_writer = metadata_manager.writer();
     tc.try_set_global_metadata(metadata.clone());
 

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -30,10 +30,10 @@ pub async fn spawn_environment(
         .expect("task_center builds");
 
     restate_types::config::set_current_config(config.clone());
-    let network_sender = MockNetworkSender::default();
+    let metadata_builder = MetadataBuilder::default();
+    let network_sender = MockNetworkSender::new(metadata_builder.to_metadata());
 
     let metadata_store_client = MetadataStoreClient::new_in_memory();
-    let metadata_builder = MetadataBuilder::default();
     let metadata = metadata_builder.to_metadata();
     let metadata_manager = MetadataManager::new(
         metadata_builder,

--- a/crates/bifrost/src/loglets/local_loglet/log_store.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use restate_rocksdb::{
     CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
 };
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::{LocalLogletOptions, RocksDbOptions};
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use rocksdb::{BoundColumnFamily, DBCompressionType, SliceTransform, DB};
@@ -55,7 +55,7 @@ pub struct RocksDbLogStore {
 impl RocksDbLogStore {
     pub fn new(
         options: &LocalLogletOptions,
-        updateable_options: impl Updateable<RocksDbOptions> + Send + 'static,
+        updateable_options: impl CachingUpdateable<RocksDbOptions> + Send + 'static,
     ) -> Result<Self, LogStoreError> {
         let db_manager = RocksDbManager::get();
 

--- a/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/loglets/local_loglet/log_store_writer.rs
@@ -23,7 +23,7 @@ use tokio_stream::StreamExt as TokioStreamExt;
 use tracing::{debug, error, trace, warn};
 
 use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::LocalLogletOptions;
 use restate_types::logs::SequenceNumber;
 
@@ -76,7 +76,7 @@ impl LogStoreWriter {
     /// Must be called from task_center context
     pub fn start(
         mut self,
-        mut updateable: impl Updateable<LocalLogletOptions> + Send + 'static,
+        mut updateable: impl CachingUpdateable<LocalLogletOptions> + Send + 'static,
     ) -> Result<RocksDbLogWriterHandle, ShutdownError> {
         // big enough to allows a second full batch to queue up while the existing one is being processed
         let batch_size = std::cmp::max(1, updateable.load().writer_batch_commit_count);

--- a/crates/bifrost/src/loglets/local_loglet/provider.rs
+++ b/crates/bifrost/src/loglets/local_loglet/provider.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, OnceLock};
 
 use anyhow::Context;
 use async_trait::async_trait;
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::{Configuration, LocalLogletOptions, RocksDbOptions};
 use restate_types::logs::metadata::LogletParams;
 use tokio::sync::Mutex as AsyncMutex;
@@ -35,7 +35,7 @@ pub struct LocalLogletProvider {
 impl LocalLogletProvider {
     pub fn new(
         options: &LocalLogletOptions,
-        updateable_rocksdb_options: impl Updateable<RocksDbOptions> + Send + 'static,
+        updateable_rocksdb_options: impl CachingUpdateable<RocksDbOptions> + Send + 'static,
     ) -> Result<Arc<Self>, ProviderError> {
         let log_store = RocksDbLogStore::new(options, updateable_rocksdb_options)
             .context("RocksDb LogStore")?;

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -161,7 +161,7 @@ mod tests {
     use super::*;
     use googletest::prelude::*;
 
-    use restate_core::{TaskKind, TestCoreEnvBuilder};
+    use restate_core::{metadata, TaskKind, TestCoreEnvBuilder};
     use restate_rocksdb::RocksDbManager;
     use restate_types::arc_util::Constant;
     use restate_types::config::CommonOptions;
@@ -193,7 +193,7 @@ mod tests {
             RocksDbManager::init(Constant::new(CommonOptions::default()));
 
             let read_after = Lsn::from(5);
-            let mut bifrost = Bifrost::init().await;
+            let bifrost = Bifrost::init(metadata()).await;
 
             let log_id = LogId::from(0);
             let mut reader = bifrost.create_reader(log_id, read_after, Lsn::MAX).await?;
@@ -282,7 +282,7 @@ mod tests {
                 RocksDbManager::init(Constant::new(CommonOptions::default()));
 
                 let log_id = LogId::from(0);
-                let mut bifrost = Bifrost::init().await;
+                let bifrost = Bifrost::init(metadata()).await;
 
                 assert!(bifrost.get_trim_point(log_id).await?.is_none());
 

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -26,8 +26,8 @@ pub struct BifrostService {
 impl BifrostService {
     pub fn new(metadata: Metadata) -> Self {
         let (watchdog_sender, watchdog_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let inner = Arc::new(BifrostInner::new(metadata, watchdog_sender));
-        let bifrost = Bifrost::new(inner.clone());
+        let inner = Arc::new(BifrostInner::new(metadata.clone(), watchdog_sender));
+        let bifrost = Bifrost::new(inner.clone(), metadata);
         let watchdog = Watchdog::new(inner.clone(), watchdog_receiver);
         Self {
             inner,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,7 +17,8 @@ mod task_center_types;
 pub mod worker_api;
 
 pub use metadata::{
-    spawn_metadata_manager, Metadata, MetadataKind, MetadataManager, MetadataWriter, SyncError,
+    spawn_metadata_manager, Metadata, MetadataBuilder, MetadataKind, MetadataManager,
+    MetadataWriter, SyncError,
 };
 pub use task_center::*;
 pub use task_center_types::*;

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -332,8 +332,7 @@ where
     }
 
     fn update_nodes_configuration(&mut self, config: NodesConfiguration) {
-        let maybe_new_version =
-            Self::update_option_internal(&self.metadata.inner.nodes_config, config);
+        let maybe_new_version = Self::update_internal(&self.metadata.inner.nodes_config, config);
 
         self.notify_watches(maybe_new_version, MetadataKind::NodesConfiguration);
     }

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -33,6 +33,9 @@ use crate::metadata_store::ReadError;
 use crate::network::NetworkSender;
 use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
 
+#[derive(Clone, derive_more::From)]
+pub struct UpdateableNodesConfiguration(Arc<ArcSwap<NodesConfiguration>>);
+
 #[derive(Debug, thiserror::Error)]
 pub enum SyncError {
     #[error("failed syncing with metadata store: {0}")]
@@ -74,9 +77,12 @@ pub struct Metadata {
 
 impl Metadata {
     /// Panics if nodes configuration is not loaded yet.
-    #[track_caller]
     pub fn nodes_config(&self) -> Arc<NodesConfiguration> {
-        self.inner.nodes_config.load_full().unwrap()
+        self.inner.nodes_config.load_full()
+    }
+
+    pub fn updateable_nodes_config(&self) -> UpdateableNodesConfiguration {
+        UpdateableNodesConfiguration::from(self.inner.nodes_config.clone())
     }
 
     #[track_caller]
@@ -86,11 +92,7 @@ impl Metadata {
 
     /// Returns Version::INVALID if nodes configuration has not been loaded yet.
     pub fn nodes_config_version(&self) -> Version {
-        let c = self.inner.nodes_config.load();
-        match c.as_deref() {
-            Some(c) => c.version(),
-            None => Version::INVALID,
-        }
+        self.inner.nodes_config.load().version()
     }
 
     pub fn partition_table(&self) -> Option<Arc<FixedPartitionTable>> {
@@ -181,7 +183,7 @@ impl Metadata {
 #[derive(Default)]
 struct MetadataInner {
     my_node_id: OnceLock<GenerationalNodeId>,
-    nodes_config: ArcSwapOption<NodesConfiguration>,
+    nodes_config: Arc<ArcSwap<NodesConfiguration>>,
     partition_table: ArcSwapOption<FixedPartitionTable>,
     logs: ArcSwapOption<Logs>,
     schema: Arc<ArcSwap<Schema>>,

--- a/crates/core/src/network/networking.rs
+++ b/crates/core/src/network/networking.rs
@@ -34,7 +34,7 @@ pub struct Networking {
 impl Networking {
     pub fn new(metadata: Metadata) -> Self {
         Self {
-            connections: Default::default(),
+            connections: ConnectionManager::new(metadata.clone()),
             metadata,
         }
     }
@@ -47,12 +47,11 @@ impl Networking {
     /// messages.
     pub async fn node_connection(&self, node: NodeId) -> Result<ConnectionSender, NetworkError> {
         // find latest generation if this is not generational node id
-
         let node = match node.as_generational() {
             Some(node) => node,
             None => {
                 self.metadata
-                    .nodes_config()
+                    .nodes_config_ref()
                     .find_node_by_id(node)?
                     .current_generation
             }
@@ -76,7 +75,7 @@ impl NetworkSender for Networking {
             // to ensure we get the latest if it has been updated since last attempt.
             let to = match to.as_generational() {
                 Some(to) => to,
-                None => match self.metadata.nodes_config().find_node_by_id(to) {
+                None => match self.metadata.nodes_config_ref().find_node_by_id(to) {
                     Ok(node) => node.current_generation,
                     Err(e) => return Err(NetworkError::UnknownNode(e)),
                 },
@@ -93,7 +92,7 @@ impl NetworkSender for Networking {
                 sleep_with_jitter(SEND_RETRY_BASE_DURATION).await;
             }
 
-            let sender = match self.connections.get_node_sender(to).await {
+            let mut sender = match self.connections.get_node_sender(to).await {
                 Ok(sender) => sender,
                 // retryable errors
                 Err(

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 use futures::{Future, FutureExt};
 use metrics::counter;
 use restate_types::config::CommonOptions;
+use restate_types::GenerationalNodeId;
 use tokio::runtime::RuntimeMetrics;
 use tokio::task::JoinHandle;
 use tokio::task_local;
@@ -774,13 +775,22 @@ pub fn current_task_id() -> Option<TaskId> {
     CURRENT_TASK.try_with(|ct| ct.id).ok()
 }
 
-/// Accepss to global metadata handle. This available in task-center tasks only!
+/// Access to global metadata handle. This available in task-center tasks only!
 #[track_caller]
 pub fn metadata() -> Metadata {
     METADATA
         .try_with(|m| m.clone())
         .expect("metadata() called outside task-center scope")
         .expect("metadata() called before global metadata was set")
+}
+
+/// Access to this node id. This available in task-center tasks only!
+#[track_caller]
+pub fn my_node_id() -> GenerationalNodeId {
+    METADATA
+        .try_with(|m| m.as_ref().map(|m| m.my_node_id()))
+        .expect("my_node_id() called outside task-center scope")
+        .expect("my_node_id() called before global metadata was set")
 }
 
 /// The current partition Id associated to the running task-center task.

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -34,7 +34,9 @@ use crate::network::{
     Handler, MessageHandler, MessageRouter, MessageRouterBuilder, NetworkError, NetworkSender,
     ProtocolError,
 };
-use crate::{cancellation_watcher, metadata, spawn_metadata_manager, ShutdownError, TaskId};
+use crate::{
+    cancellation_watcher, metadata, spawn_metadata_manager, MetadataBuilder, ShutdownError, TaskId,
+};
 use crate::{Metadata, MetadataManager, MetadataWriter};
 use crate::{TaskCenter, TaskCenterBuilder};
 
@@ -170,9 +172,13 @@ where
 
         let my_node_id = GenerationalNodeId::new(1, 1);
         let metadata_store_client = MetadataStoreClient::new_in_memory();
-        let metadata_manager =
-            MetadataManager::build(network_sender.clone(), metadata_store_client.clone());
-        let metadata = metadata_manager.metadata();
+        let metadata_builder = MetadataBuilder::default();
+        let metadata = metadata_builder.to_metadata();
+        let metadata_manager = MetadataManager::new(
+            metadata_builder,
+            network_sender.clone(),
+            metadata_store_client.clone(),
+        );
         let metadata_writer = metadata_manager.writer();
         let router_builder = MessageRouterBuilder::default();
         let nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -40,9 +40,19 @@ use crate::{
 use crate::{Metadata, MetadataManager, MetadataWriter};
 use crate::{TaskCenter, TaskCenterBuilder};
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct MockNetworkSender {
     sender: Option<mpsc::UnboundedSender<(GenerationalNodeId, Message)>>,
+    metadata: Metadata,
+}
+
+impl MockNetworkSender {
+    pub fn new(metadata: Metadata) -> Self {
+        Self {
+            sender: None,
+            metadata,
+        }
+    }
 }
 
 impl NetworkSender for MockNetworkSender {
@@ -57,7 +67,7 @@ impl NetworkSender for MockNetworkSender {
 
         let to = match to.as_generational() {
             Some(to) => to,
-            None => match metadata().nodes_config().find_node_by_id(to) {
+            None => match self.metadata.nodes_config_ref().find_node_by_id(to) {
                 Ok(node) => node.current_generation,
                 Err(e) => return Err(NetworkError::UnknownNode(e)),
             },
@@ -118,9 +128,13 @@ impl NetworkReceiver {
 }
 
 impl MockNetworkSender {
-    pub fn from_sender(sender: mpsc::UnboundedSender<(GenerationalNodeId, Message)>) -> Self {
+    pub fn from_sender(
+        sender: mpsc::UnboundedSender<(GenerationalNodeId, Message)>,
+        metadata: Metadata,
+    ) -> Self {
         Self {
             sender: Some(sender),
+            metadata,
         }
     }
     pub fn inner_sender(&self) -> Option<mpsc::UnboundedSender<(GenerationalNodeId, Message)>> {
@@ -146,9 +160,10 @@ pub struct TestCoreEnvBuilder<N> {
 impl TestCoreEnvBuilder<MockNetworkSender> {
     pub fn new_with_mock_network() -> TestCoreEnvBuilder<MockNetworkSender> {
         let (tx, rx) = mpsc::unbounded_channel();
-        let network_sender = MockNetworkSender::from_sender(tx);
+        let metadata_builder = MetadataBuilder::default();
+        let network_sender = MockNetworkSender::from_sender(tx, metadata_builder.to_metadata());
 
-        TestCoreEnvBuilder::new_with_network_tx_rx(network_sender, Some(rx))
+        TestCoreEnvBuilder::new_with_network_tx_rx(network_sender, Some(rx), metadata_builder)
     }
 }
 
@@ -157,12 +172,14 @@ where
     N: NetworkSender + 'static,
 {
     pub fn new(network_sender: N) -> Self {
-        TestCoreEnvBuilder::new_with_network_tx_rx(network_sender, None)
+        let metadata_builder = MetadataBuilder::default();
+        TestCoreEnvBuilder::new_with_network_tx_rx(network_sender, None, metadata_builder)
     }
 
     fn new_with_network_tx_rx(
         network_sender: N,
         network_rx: Option<mpsc::UnboundedReceiver<(GenerationalNodeId, Message)>>,
+        metadata_builder: MetadataBuilder,
     ) -> Self {
         let tc = TaskCenterBuilder::default()
             .default_runtime_handle(tokio::runtime::Handle::current())
@@ -172,7 +189,6 @@ where
 
         let my_node_id = GenerationalNodeId::new(1, 1);
         let metadata_store_client = MetadataStoreClient::new_in_memory();
-        let metadata_builder = MetadataBuilder::default();
         let metadata = metadata_builder.to_metadata();
         let metadata_manager = MetadataManager::new(
             metadata_builder,

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -16,7 +16,7 @@ use crate::subscription_controller::task_orchestrator::TaskOrchestrator;
 use rdkafka::error::KafkaError;
 use restate_core::cancellation_watcher;
 use restate_ingress_dispatcher::IngressDispatcher;
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::IngressOptions;
 use restate_types::identifiers::SubscriptionId;
 use restate_types::retries::RetryPolicy;
@@ -63,7 +63,7 @@ impl Service {
 
     pub async fn run(
         mut self,
-        mut updateable_config: impl Updateable<IngressOptions> + Send + 'static,
+        mut updateable_config: impl CachingUpdateable<IngressOptions> + Send + 'static,
     ) -> anyhow::Result<()> {
         let shutdown = cancellation_watcher();
         tokio::pin!(shutdown);

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -30,7 +30,7 @@ use restate_invoker_api::{
 };
 use restate_queue::SegmentQueue;
 use restate_timer_queue::TimerQueue;
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::{InvokerOptions, ServiceClientOptions};
 use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey, WithPartitionKey};
 use restate_types::identifiers::{EntryIndex, PartitionLeaderEpoch};
@@ -249,7 +249,7 @@ where
 
     pub async fn run(
         self,
-        mut updateable_options: impl Updateable<InvokerOptions> + Send + 'static,
+        mut updateable_options: impl CachingUpdateable<InvokerOptions> + Send + 'static,
     ) -> anyhow::Result<()> {
         let Service {
             tmp_dir,

--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -10,7 +10,7 @@
 
 use restate_core::network::grpc_util;
 use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::{MetadataStoreOptions, RocksDbOptions};
 use restate_types::net::BindAddress;
 use tonic::server::NamedService;
@@ -45,7 +45,7 @@ impl LocalMetadataStoreService {
     }
     pub fn from_options(
         opts: &MetadataStoreOptions,
-        rocksdb_options: impl Updateable<RocksDbOptions> + Send + Sync + Clone + 'static,
+        rocksdb_options: impl CachingUpdateable<RocksDbOptions> + Send + Sync + Clone + 'static,
     ) -> Result<Self, BuildError> {
         let store = LocalMetadataStore::new(opts, rocksdb_options)?;
         Ok(LocalMetadataStoreService::new(

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -17,7 +17,7 @@ use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
 };
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::{MetadataStoreOptions, RocksDbOptions};
 use restate_types::storage::{
     StorageCodec, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError,
@@ -102,7 +102,7 @@ pub enum BuildError {
 pub struct LocalMetadataStore {
     db: Arc<DB>,
     rocksdb: Arc<RocksDb>,
-    rocksdb_options: Box<dyn Updateable<RocksDbOptions> + Send + Sync>,
+    rocksdb_options: Box<dyn CachingUpdateable<RocksDbOptions> + Send + Sync>,
     request_rx: RequestReceiver,
     buffer: BytesMut,
 
@@ -113,7 +113,11 @@ pub struct LocalMetadataStore {
 impl LocalMetadataStore {
     pub fn new(
         options: &MetadataStoreOptions,
-        updateable_rocksdb_options: impl Updateable<RocksDbOptions> + Clone + Send + Sync + 'static,
+        updateable_rocksdb_options: impl CachingUpdateable<RocksDbOptions>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
     ) -> std::result::Result<Self, BuildError> {
         let (request_tx, request_rx) = mpsc::channel(options.request_queue_length());
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -24,7 +24,7 @@ use restate_bifrost::BifrostService;
 use restate_core::metadata_store::{MetadataStoreClientError, ReadWriteError};
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::Networking;
-use restate_core::{spawn_metadata_manager, MetadataKind, MetadataManager};
+use restate_core::{spawn_metadata_manager, MetadataBuilder, MetadataKind, MetadataManager};
 use restate_core::{task_center, TaskKind};
 use restate_metadata_store::local::LocalMetadataStoreService;
 use restate_metadata_store::MetadataStoreClient;
@@ -144,11 +144,15 @@ impl Node {
         );
 
         let mut router_builder = MessageRouterBuilder::default();
-        let networking = Networking::default();
-        let metadata_manager =
-            MetadataManager::build(networking.clone(), metadata_store_client.clone());
+        let metadata_builder = MetadataBuilder::default();
+        let metadata = metadata_builder.to_metadata();
+        let networking = Networking::new(metadata_builder.to_metadata());
+        let metadata_manager = MetadataManager::new(
+            metadata_builder,
+            networking.clone(),
+            metadata_store_client.clone(),
+        );
         metadata_manager.register_in_message_router(&mut router_builder);
-        let metadata = metadata_manager.metadata();
         let updating_schema_information = metadata.schema_updateable();
         let bifrost = BifrostService::new(metadata.clone());
 
@@ -255,7 +259,7 @@ impl Node {
         );
 
         let metadata_writer = self.metadata_manager.writer();
-        let metadata = self.metadata_manager.metadata();
+        let metadata = self.metadata_manager.metadata().clone();
         let is_set = tc.try_set_global_metadata(metadata.clone());
         debug_assert!(is_set, "Global metadata was already set");
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -296,7 +296,7 @@ impl Node {
         // fetch the latest schema information
         metadata.sync(MetadataKind::Schema).await?;
 
-        let nodes_config = metadata.nodes_config();
+        let nodes_config = metadata.nodes_config_ref();
 
         // Find my node in nodes configuration.
         let my_node_config = nodes_config

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -19,7 +19,7 @@ use restate_core::ShutdownError;
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
 };
-use restate_types::arc_util::Updateable;
+use restate_types::arc_util::CachingUpdateable;
 use restate_types::config::RocksDbOptions;
 use restate_types::config::StorageOptions;
 use restate_types::identifiers::PartitionId;
@@ -53,8 +53,8 @@ struct PartitionLookup {
 
 impl PartitionStoreManager {
     pub async fn create(
-        mut storage_opts: impl Updateable<StorageOptions> + Send + 'static,
-        updateable_opts: impl Updateable<RocksDbOptions> + Send + 'static,
+        mut storage_opts: impl CachingUpdateable<StorageOptions> + Send + 'static,
+        updateable_opts: impl CachingUpdateable<RocksDbOptions> + Send + 'static,
         initial_partition_set: &[(PartitionId, RangeInclusive<PartitionKey>)],
     ) -> std::result::Result<Self, RocksError> {
         let options = storage_opts.load();

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -47,7 +47,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use super::arc_util::{ArcSwapExt, Pinned, Updateable};
+use super::arc_util::{ArcSwapExt, CachingUpdateable, Pinned};
 use crate::errors::GenericError;
 use crate::nodes_config::Role;
 
@@ -182,20 +182,20 @@ impl Configuration {
     /// exclusive reference. This should be the preferred method for accessing the updateable, but
     /// avoid using `to_updateable()` or `snapshot()` in tight loops. Instead, get a new updateable,
     /// and pass it down to the loop by value for very efficient access.
-    pub fn updateable() -> impl Updateable<Self> {
-        CONFIGURATION.to_updateable()
+    pub fn updateable() -> impl CachingUpdateable<Self> {
+        CONFIGURATION.to_caching_updateable()
     }
 
-    pub fn updateable_common() -> impl Updateable<CommonOptions> {
+    pub fn updateable_common() -> impl CachingUpdateable<CommonOptions> {
         CONFIGURATION.map_as_updateable(|c| &c.common)
     }
 
-    pub fn updateable_worker() -> impl Updateable<WorkerOptions> {
+    pub fn updateable_worker() -> impl CachingUpdateable<WorkerOptions> {
         CONFIGURATION.map_as_updateable(|c| &c.worker)
     }
 
     /// Create an updateable that projects a part of the config
-    pub fn mapped_updateable<F, U>(f: F) -> impl Updateable<U>
+    pub fn mapped_updateable<F, U>(f: F) -> impl CachingUpdateable<U>
     where
         F: FnMut(&Arc<Configuration>) -> &U,
     {

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -12,17 +12,13 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use arc_swap::ArcSwap;
 use enumset::{EnumSet, EnumSetType};
 use serde_with::serde_as;
 
 use crate::net::AdvertisedAddress;
 use crate::{flexbuffers_storage_encode_decode, GenerationalNodeId, NodeId, PlainNodeId};
 use crate::{Version, Versioned};
-
-pub type UpdateableNodesConfiguration = Arc<ArcSwap<NodesConfiguration>>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum NodesConfigError {
@@ -63,6 +59,17 @@ pub struct NodesConfiguration {
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
     nodes: HashMap<PlainNodeId, MaybeNode>,
     name_lookup: HashMap<String, PlainNodeId>,
+}
+
+impl Default for NodesConfiguration {
+    fn default() -> Self {
+        Self {
+            version: Version::INVALID,
+            cluster_name: "Unspecified".to_owned(),
+            nodes: Default::default(),
+            name_lookup: Default::default(),
+        }
+    }
 }
 
 #[derive(

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -12,13 +12,17 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use enumset::{EnumSet, EnumSetType};
 use serde_with::serde_as;
 
 use crate::net::AdvertisedAddress;
 use crate::{flexbuffers_storage_encode_decode, GenerationalNodeId, NodeId, PlainNodeId};
 use crate::{Version, Versioned};
+
+pub type UpdateableNodesConfiguration = Arc<ArcSwap<NodesConfiguration>>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum NodesConfigError {

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -36,12 +36,6 @@ impl Version {
     }
 }
 
-impl Default for Version {
-    fn default() -> Self {
-        Self::MIN
-    }
-}
-
 impl From<crate::protobuf::common::Version> for Version {
     fn from(version: crate::protobuf::common::Version) -> Self {
         crate::Version::from(version.value)
@@ -60,6 +54,11 @@ impl From<Version> for crate::protobuf::common::Version {
 pub trait Versioned {
     /// Returns the version of the versioned value
     fn version(&self) -> Version;
+
+    /// Is this a valid version?
+    fn valid(&self) -> bool {
+        self.version() >= Version::MIN
+    }
 }
 
 impl<T: Versioned> Versioned for &T {

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -101,7 +101,7 @@ impl ActionEffectHandler {
 
         // Attempt to write batches to different log ids concurrently
         for (log_id, payloads) in buffer {
-            let mut bifrost = self.bifrost.clone();
+            let bifrost = self.bifrost.clone();
             batches.push(async move {
                 bifrost.append_batch(log_id, &payloads).await?;
                 anyhow::Ok(())

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -637,7 +637,9 @@ mod tests {
 
         let (truncation_tx, _truncation_rx) = mpsc::channel(1);
 
-        let bifrost = tc.run_in_scope("init bifrost", None, Bifrost::init()).await;
+        let bifrost = tc
+            .run_in_scope("init bifrost", None, Bifrost::init(env.metadata.clone()))
+            .await;
         let shuffle = Shuffle::new(metadata, outbox_reader, truncation_tx, 1, bifrost.clone());
 
         ShuffleEnv {

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -31,7 +31,7 @@ pub async fn run(
     _common_args: &Arguments,
     opts: &AppendLatencyOpts,
     _tc: TaskCenter,
-    mut bifrost: Bifrost,
+    bifrost: Bifrost,
 ) -> anyhow::Result<()> {
     let log_id = LogId::from(0);
     let mut bytes = BytesMut::default();

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -137,9 +137,9 @@ fn spawn_environment(config: Configuration, num_logs: u64) -> (TaskCenter, Bifro
     restate_types::config::set_current_config(config.clone());
     let task_center = tc.clone();
     let bifrost = tc.block_on("spawn", None, async move {
-        let network_sender = MockNetworkSender::default();
-        let metadata_store_client = MetadataStoreClient::new_in_memory();
         let metadata_builder = MetadataBuilder::default();
+        let network_sender = MockNetworkSender::new(metadata_builder.to_metadata());
+        let metadata_store_client = MetadataStoreClient::new_in_memory();
         let metadata = metadata_builder.to_metadata();
         let metadata_manager = MetadataManager::new(
             metadata_builder,

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -19,7 +19,8 @@ use bifrost_benchpress::{append_latency, write_to_read, Arguments, Command};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use restate_bifrost::{Bifrost, BifrostService};
 use restate_core::{
-    spawn_metadata_manager, MetadataManager, MockNetworkSender, TaskCenter, TaskCenterBuilder,
+    spawn_metadata_manager, MetadataBuilder, MetadataManager, MockNetworkSender, TaskCenter,
+    TaskCenterBuilder,
 };
 use restate_errors::fmt::RestateCode;
 use restate_metadata_store::{MetadataStoreClient, Precondition};
@@ -138,10 +139,14 @@ fn spawn_environment(config: Configuration, num_logs: u64) -> (TaskCenter, Bifro
     let bifrost = tc.block_on("spawn", None, async move {
         let network_sender = MockNetworkSender::default();
         let metadata_store_client = MetadataStoreClient::new_in_memory();
-        let metadata_manager =
-            MetadataManager::build(network_sender.clone(), metadata_store_client.clone());
+        let metadata_builder = MetadataBuilder::default();
+        let metadata = metadata_builder.to_metadata();
+        let metadata_manager = MetadataManager::new(
+            metadata_builder,
+            network_sender.clone(),
+            metadata_store_client.clone(),
+        );
 
-        let metadata = metadata_manager.metadata();
         let metadata_writer = metadata_manager.writer();
         task_center.try_set_global_metadata(metadata.clone());
 

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -86,7 +86,7 @@ pub async fn run(
     })?;
 
     let writer_task = tc.spawn(TaskKind::TestRunner, "test-log-appender", None, {
-        let mut bifrost = bifrost.clone();
+        let bifrost = bifrost.clone();
         let clock = clock.clone();
         async move {
             let mut append_latencies = Histogram::<u64>::new(3)?;

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -107,7 +107,11 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
     let node_env = TestCoreEnv::create_with_mock_nodes_config(1, 1).await;
     let bifrost = node_env
         .tc
-        .run_in_scope("bifrost init", None, Bifrost::init())
+        .run_in_scope(
+            "bifrost init",
+            None,
+            Bifrost::init(node_env.metadata.clone()),
+        )
         .await;
 
     let admin_service = AdminService::new(


### PR DESCRIPTION
Use updateable config in networking

Efficient access to metadata and nodes configuration in performance-sensitive networking code

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1667).
* __->__ #1667
* #1666
* #1665
* #1664