### PR TITLE
[invoker] Add x-restate-invocation-id header

### DIFF
--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -489,6 +489,13 @@ fn service_protocol_version_to_header_value(
     }
 }
 
+fn invocation_id_to_header_value(invocation_id: &InvocationId) -> HeaderValue {
+    let value = invocation_id.to_string();
+
+    HeaderValue::try_from(value)
+        .unwrap_or_else(|_| unreachable!("invocation id should be always valid"))
+}
+
 enum ResponseChunk {
     Parts(ResponseParts),
     Data(Bytes),


### PR DESCRIPTION
This PR adds an `invoker->sdk` header with the invocation id as a value. The reason for this change is to support load balancers that can do stickiness based on custom headers. Like `Envoy` for example.

Here is an example of the headers as seen by the SDK
```
 ':method' => 'POST',
  ':scheme' => 'http',
  ':authority' => 'localhost:9080',
  ':path' => '/invoke/greeter/greet',
  'content-type' => 'application/vnd.restate.invocation.v1',
  'accept' => 'application/vnd.restate.invocation.v1',
  'x-restate-invocation-id' => 'inv_1io2uvfWZsS15WzdIspsM8XFlKPOUPNAIx'
}

```