### PR TITLE
[Bifrost] Eager providers initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6179,6 +6179,7 @@ dependencies = [
  "clap",
  "derive_builder",
  "derive_more",
+ "dyn-clone",
  "enum-map",
  "enumset",
  "flexbuffers",

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -379,7 +379,7 @@ mod tests {
 
         let bifrost = node_env
             .tc
-            .run_in_scope("init", None, Bifrost::init(metadata))
+            .run_in_scope("init", None, Bifrost::init_in_memory(metadata))
             .await;
 
         node_env.tc.spawn(
@@ -483,7 +483,7 @@ mod tests {
 
         let bifrost = node_env
             .tc
-            .run_in_scope("init", None, Bifrost::init(metadata))
+            .run_in_scope("init", None, Bifrost::init_in_memory(metadata))
             .await;
 
         node_env.tc.spawn(

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -98,7 +98,7 @@ fn write_throughput_local_loglet(c: &mut Criterion) {
 
     let bifrost = tc.block_on("bifrost-init", None, async {
         let metadata = metadata();
-        let bifrost_svc = BifrostService::new(metadata);
+        let bifrost_svc = BifrostService::new(restate_core::task_center(), metadata);
         let bifrost = bifrost_svc.handle();
 
         // start bifrost service in the background

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[error("failed syncing logs metadata: {0}")]
     // unfortunately, we have to use Arc here, because the SyncError is not Clone.
     MetadataSync(#[from] Arc<SyncError>),
+    /// Provider is unknown or disabled
+    #[error("bifrost provider '{0}' is disabled or unrecognized")]
+    Disabled(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -11,7 +11,8 @@
 mod bifrost;
 mod error;
 mod loglet;
-mod loglets;
+pub mod loglets;
+mod provider;
 mod read_stream;
 mod record;
 mod service;
@@ -20,6 +21,7 @@ mod watchdog;
 
 pub use bifrost::Bifrost;
 pub use error::{Error, ProviderError, Result};
+pub use provider::*;
 pub use read_stream::LogReadStream;
 pub use record::*;
 pub use service::BifrostService;

--- a/crates/bifrost/src/loglets/local_loglet/mod.rs
+++ b/crates/bifrost/src/loglets/local_loglet/mod.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 pub use log_store::LogStoreError;
 use metrics::{counter, histogram, Histogram};
-pub use provider::LocalLogletProvider;
+pub use provider::Factory;
 use restate_core::ShutdownError;
 use restate_types::logs::SequenceNumber;
 use tokio::sync::Mutex;
@@ -43,7 +43,7 @@ use self::metric_definitions::{BIFROST_LOCAL_APPEND, BIFROST_LOCAL_APPEND_DURATI
 use self::read_stream::LocalLogletReadStream;
 use self::utils::OffsetWatch;
 
-pub struct LocalLoglet {
+struct LocalLoglet {
     log_id: u64,
     log_store: RocksDbLogStore,
     log_writer: RocksDbLogWriterHandle,

--- a/crates/bifrost/src/provider.rs
+++ b/crates/bifrost/src/provider.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use restate_types::logs::metadata::{LogletParams, ProviderKind};
+
+use crate::loglet::Loglet;
+use crate::ProviderError;
+use crate::Result;
+
+#[async_trait]
+/// Factory for creating loglet providers.
+pub trait LogletProviderFactory: Send + 'static {
+    /// Factory creates providers of `kind`.
+    fn kind(&self) -> ProviderKind;
+    /// Initialize provider.
+    async fn create(self: Box<Self>) -> Result<Arc<dyn LogletProvider + 'static>, ProviderError>;
+}
+
+#[async_trait]
+pub trait LogletProvider: Send + Sync {
+    /// Create a loglet client for a given segment and configuration.
+    async fn get_loglet(&self, params: &LogletParams) -> Result<Arc<dyn Loglet>>;
+
+    /// A hook that's called after provider is started.
+    async fn post_start(&self) {}
+
+    /// Hook for handling graceful shutdown
+    async fn shutdown(&self) -> Result<(), ProviderError> {
+        Ok(())
+    }
+}

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -8,32 +8,69 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context;
-use restate_core::{task_center, Metadata, TaskKind};
+use enum_map::EnumMap;
+use restate_types::config::Configuration;
+use restate_types::live::Live;
+use tracing::{debug, error, trace};
+
+use restate_core::{cancellation_watcher, Metadata, TaskCenter, TaskKind};
+use restate_types::logs::metadata::ProviderKind;
 
 use crate::bifrost::BifrostInner;
-use crate::watchdog::Watchdog;
-use crate::Bifrost;
+use crate::loglets::{local_loglet, memory_loglet};
+use crate::watchdog::{Watchdog, WatchdogCommand};
+use crate::{Bifrost, LogletProviderFactory};
 
 pub struct BifrostService {
+    task_center: TaskCenter,
     inner: Arc<BifrostInner>,
     bifrost: Bifrost,
     watchdog: Watchdog,
+    factories: HashMap<ProviderKind, Box<dyn LogletProviderFactory>>,
 }
 
 impl BifrostService {
-    pub fn new(metadata: Metadata) -> Self {
+    pub fn new(task_center: TaskCenter, metadata: Metadata) -> Self {
         let (watchdog_sender, watchdog_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let inner = Arc::new(BifrostInner::new(metadata.clone(), watchdog_sender));
+        let inner = Arc::new(BifrostInner::new(metadata.clone(), watchdog_sender.clone()));
         let bifrost = Bifrost::new(inner.clone(), metadata);
-        let watchdog = Watchdog::new(inner.clone(), watchdog_receiver);
+        let watchdog = Watchdog::new(
+            task_center.clone(),
+            inner.clone(),
+            watchdog_sender,
+            watchdog_receiver,
+        );
         Self {
+            task_center,
             inner,
             bifrost,
             watchdog,
+            factories: HashMap::new(),
         }
+    }
+
+    pub fn with_factory(mut self, factory: impl LogletProviderFactory) -> Self {
+        self.factories.insert(factory.kind(), Box::new(factory));
+        self
+    }
+
+    pub fn enable_in_memory_loglet(mut self) -> Self {
+        let factory = memory_loglet::Factory::default();
+        self.factories.insert(factory.kind(), Box::new(factory));
+        self
+    }
+
+    pub fn enable_local_loglet(mut self, config: &Live<Configuration>) -> Self {
+        let factory = local_loglet::Factory::new(
+            config.clone().map(|c| &c.bifrost.local),
+            config.clone().map(|c| &c.bifrost.local.rocksdb),
+        );
+        self.factories.insert(factory.kind(), Box::new(factory));
+        self
     }
 
     pub fn handle(&self) -> Bifrost {
@@ -52,9 +89,75 @@ impl BifrostService {
             .await
             .context("Initial bifrost metadata sync has failed!")?;
 
-        // we spawn the watchdog as a task to ensure cancellation safety if the outer
-        // future was dropped in the select loop.
-        task_center().spawn(
+        // initialize all enabled providers.
+        if self.factories.is_empty() {
+            anyhow::bail!("No loglet providers enabled!");
+        }
+
+        // TODO (asoli): Validate that we can operate with current log metadata.
+        let mut tasks = tokio::task::JoinSet::new();
+        // Start all enabled providers.
+        for (kind, factory) in self.factories {
+            let tc = self.task_center.clone();
+            let watchdog = self.watchdog.sender();
+            tasks.spawn(async move {
+                tc.run_in_scope("loglet-provider-start", None, async move {
+                    trace!("Starting loglet provider {}", kind);
+                    match factory.create().await {
+                        Err(e) => {
+                            error!("Failed to start loglet provider {}: {}", kind, e);
+                            Err(anyhow::anyhow!(
+                                "Failed to start loglet provider {}: {}",
+                                kind,
+                                e
+                            ))
+                        }
+                        Ok(provider) => {
+                            // tell watchdog about it.
+                            // We can always send because we own both sender and receiver.
+                            watchdog
+                                .send(WatchdogCommand::WatchProvider(provider.clone()))
+                                .expect("watchdog sends always succeed");
+                            Ok((kind, provider))
+                        }
+                    }
+                })
+                .await
+            });
+        }
+        let mut shutdown = std::pin::pin!(cancellation_watcher());
+
+        // Wait until all providers have started.
+        let mut providers = EnumMap::default();
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => {
+                    return Err(anyhow::anyhow!("Bifrost initialization cancelled"));
+                }
+                maybe_res = tasks.join_next() => {
+                    match maybe_res {
+                        None => {
+                            // No more tasks.
+                            break;
+                        },
+                        Some(maybe_res) => {
+                            // We are only allowed to continue if all providers started successfully.
+                            let (kind, provider) = maybe_res??;
+                            providers[kind] = Some(provider);
+                        }
+                    }
+                }
+            }
+        }
+        debug!("All loglet providers started successfully!");
+
+        self.inner
+            .providers
+            .set(providers.clone())
+            .map_err(|_| anyhow::anyhow!("bifrost must be initialized only once"))?;
+
+        // We spawn the watchdog as a background long-running task
+        self.task_center.spawn(
             TaskKind::BifrostBackgroundHighPriority,
             "bifrost-watchdog",
             None,

--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -277,7 +277,11 @@ mod tests {
             .add_mock_nodes_config()
             .with_partition_table(FixedPartitionTable::new(Version::MIN, 1));
 
-        let bifrost_svc = restate_bifrost::BifrostService::new(env_builder.metadata.clone());
+        let bifrost_svc = restate_bifrost::BifrostService::new(
+            env_builder.tc.clone(),
+            env_builder.metadata.clone(),
+        )
+        .enable_in_memory_loglet();
         let bifrost = bifrost_svc.handle();
         let dispatcher = IngressDispatcher::new(bifrost.clone());
 
@@ -386,7 +390,11 @@ mod tests {
             .add_mock_nodes_config()
             .with_partition_table(FixedPartitionTable::new(Version::MIN, 1));
 
-        let bifrost_svc = restate_bifrost::BifrostService::new(env_builder.metadata.clone());
+        let bifrost_svc = restate_bifrost::BifrostService::new(
+            env_builder.tc.clone(),
+            env_builder.metadata.clone(),
+        )
+        .enable_in_memory_loglet();
         let bifrost = bifrost_svc.handle();
         let dispatcher = IngressDispatcher::new(bifrost.clone());
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -27,6 +27,7 @@ bytestring = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"], optional = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
+dyn-clone = { version = "1.0" }
 enum-map = { workspace = true }
 enumset = { workspace = true, features = ["serde"] }
 flexbuffers = { workspace = true }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -192,7 +192,8 @@ impl Configuration {
     /// Create an updateable that projects a part of the config
     pub fn mapped_updateable<F, U>(f: F) -> impl LiveLoad<U>
     where
-        F: FnMut(&Configuration) -> &U + 'static,
+        F: FnMut(&Configuration) -> &U + 'static + Clone,
+        U: Clone,
     {
         Configuration::updateable().map(f)
     }

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -75,6 +75,7 @@ pub struct LogletParams(String);
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum ProviderKind {
     /// A local rocksdb-backed loglet.
     Local,

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -638,7 +638,11 @@ mod tests {
         let (truncation_tx, _truncation_rx) = mpsc::channel(1);
 
         let bifrost = tc
-            .run_in_scope("init bifrost", None, Bifrost::init(env.metadata.clone()))
+            .run_in_scope(
+                "init bifrost",
+                None,
+                Bifrost::init_in_memory(env.metadata.clone()),
+            )
             .await;
         let shuffle = Shuffle::new(metadata, outbox_reader, truncation_tx, 1, bifrost.clone());
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -110,7 +110,7 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
         .run_in_scope(
             "bifrost init",
             None,
-            Bifrost::init(node_env.metadata.clone()),
+            Bifrost::init_in_memory(node_env.metadata.clone()),
         )
         .await;
 


### PR DESCRIPTION
[Bifrost] Eager providers initialization

Bifrost providers are now initialized in two stages. An initialization that happens on startup to ensure all critical initialization and validation happens before server startup.
After initialization, loglets will get a notification from watchdog to perform any background lazy initialization work if necessary.

Benefits:
- Removes the need to always "check if initialized" internally, or the use of "OnceLock" and other techniques to check if it's initialized or not.
- Allows a potential validation step before server startup. Potentially fetching the metadata and validating all `LogletParams` for each provider in metadata against providers to reduce the chance of validation errors at construction time.
- Allows construction of providers to be async without impacting providers' map access performance

This PR also allows bifrost to be supplied a set of "Factories" to externalize how a loglet is constructed. This is crucial for the replicated-loglet since it depends on networking and other components that bifrost interface doesn't need to know about. A side benefit of this is that we can be very precise on which providers are _enabled_ for a given Bifrost instance. For example, InMemory loglet is now not allowed by default in restate-server binary (debateable if we should put it back or not)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1681).
* #1683
* #1682
* __->__ #1681