### PR TITLE
Start ingress only after all partitions have a leader

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state.rs
+++ b/crates/admin/src/cluster_controller/cluster_state.rs
@@ -11,9 +11,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use arc_swap::ArcSwap;
 use restate_types::cluster::cluster_state::{AliveNode, ClusterState, DeadNode, NodeState};
 use std::time::Instant;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use restate_core::network::rpc_router::RpcRouter;
@@ -29,8 +29,9 @@ pub struct ClusterStateRefresher<N> {
     task_center: TaskCenter,
     metadata: Metadata,
     get_state_router: RpcRouter<GetProcessorsState, N>,
-    updateable_cluster_state: Arc<ArcSwap<ClusterState>>,
     in_flight_refresh: Option<JoinHandle<()>>,
+    cluster_state_update_rx: watch::Receiver<Arc<ClusterState>>,
+    cluster_state_update_tx: Arc<watch::Sender<Arc<ClusterState>>>,
 }
 
 impl<N> ClusterStateRefresher<N>
@@ -51,19 +52,35 @@ where
             partition_table_version: Version::INVALID,
             nodes: BTreeMap::new(),
         };
-        let updateable_cluster_state = Arc::new(ArcSwap::from_pointee(initial_state));
+        let (cluster_state_update_tx, cluster_state_update_rx) =
+            watch::channel(Arc::from(initial_state));
 
         Self {
             task_center,
             metadata,
             get_state_router,
-            updateable_cluster_state,
             in_flight_refresh: None,
+            cluster_state_update_rx,
+            cluster_state_update_tx: Arc::new(cluster_state_update_tx),
         }
     }
 
     pub fn get_cluster_state(&self) -> Arc<ClusterState> {
-        self.updateable_cluster_state.load_full()
+        Arc::clone(&self.cluster_state_update_rx.borrow())
+    }
+
+    pub fn cluster_state_watcher(&self) -> ClusterStateWatcher {
+        ClusterStateWatcher {
+            cluster_state_watcher: self.cluster_state_update_rx.clone(),
+        }
+    }
+
+    pub async fn next_cluster_state_update(&mut self) -> Arc<ClusterState> {
+        self.cluster_state_update_rx
+            .changed()
+            .await
+            .expect("sender should always exist");
+        Arc::clone(&self.cluster_state_update_rx.borrow_and_update())
     }
 
     pub fn schedule_refresh(&mut self) -> Result<(), ShutdownError> {
@@ -80,7 +97,7 @@ where
         self.in_flight_refresh = Self::start_refresh_task(
             self.task_center.clone(),
             self.get_state_router.clone(),
-            self.updateable_cluster_state.clone(),
+            Arc::clone(&self.cluster_state_update_tx),
             self.metadata.clone(),
         )?;
 
@@ -90,12 +107,12 @@ where
     fn start_refresh_task(
         tc: TaskCenter,
         get_state_router: RpcRouter<GetProcessorsState, N>,
-        updateable_cluster_state: Arc<ArcSwap<ClusterState>>,
+        cluster_state_tx: Arc<watch::Sender<Arc<ClusterState>>>,
         metadata: Metadata,
     ) -> Result<Option<JoinHandle<()>>, ShutdownError> {
         let task_center = tc.clone();
         let refresh = async move {
-            let last_state = updateable_cluster_state.load();
+            let last_state = Arc::clone(&cluster_state_tx.borrow());
             // make sure we have a partition table that equals or newer than last refresh
             let partition_table = metadata
                 .wait_for_partition_table(last_state.partition_table_version)
@@ -182,7 +199,7 @@ where
             };
 
             // publish the new state
-            updateable_cluster_state.store(Arc::new(state));
+            cluster_state_tx.send(Arc::new(state))?;
             Ok(())
         };
 
@@ -196,5 +213,20 @@ where
         // If this returned None, it means that the task completed or has been
         // cancelled before we get to this point.
         Ok(task_center.take_task(task_id))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ClusterStateWatcher {
+    cluster_state_watcher: watch::Receiver<Arc<ClusterState>>,
+}
+
+impl ClusterStateWatcher {
+    pub async fn next_cluster_state(&mut self) -> Result<Arc<ClusterState>, ShutdownError> {
+        self.cluster_state_watcher
+            .changed()
+            .await
+            .map_err(|_| ShutdownError)?;
+        Ok(Arc::clone(&self.cluster_state_watcher.borrow_and_update()))
     }
 }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -17,8 +17,7 @@ use futures::future::OptionFuture;
 use futures::{Stream, StreamExt};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time;
-use tokio::time::MissedTickBehavior;
-use tokio::time::{Instant, Interval};
+use tokio::time::{Instant, Interval, MissedTickBehavior};
 use tracing::{debug, warn};
 
 use restate_types::config::{AdminOptions, Configuration};
@@ -29,15 +28,16 @@ use restate_types::partition_table::{FixedPartitionTable, KeyRange};
 
 use restate_bifrost::Bifrost;
 use restate_core::network::{MessageRouterBuilder, NetworkSender};
-use restate_core::{cancellation_watcher, Metadata, ShutdownError, TaskCenter};
+use restate_core::{cancellation_watcher, Metadata, ShutdownError, TaskCenter, TaskKind};
 use restate_types::cluster::cluster_state::RunMode;
 use restate_types::cluster::cluster_state::{AliveNode, ClusterState, NodeState};
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
+use restate_types::net::metadata::MetadataKind;
 use restate_types::net::MessageEnvelope;
 use restate_types::{GenerationalNodeId, Version};
 
-use super::cluster_state::ClusterStateRefresher;
+use super::cluster_state::{ClusterStateRefresher, ClusterStateWatcher};
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum Error {
@@ -180,12 +180,32 @@ where
         }
     }
 
-    pub async fn run(mut self, bifrost: Bifrost) -> anyhow::Result<()> {
+    pub async fn run(
+        mut self,
+        bifrost: Bifrost,
+        all_partitions_started_tx: Option<oneshot::Sender<()>>,
+    ) -> anyhow::Result<()> {
         // Make sure we have partition table before starting
         let _ = self.metadata.wait_for_partition_table(Version::MIN).await?;
 
         let mut shutdown = std::pin::pin!(cancellation_watcher());
         let mut config_watcher = Configuration::watcher();
+        let cluster_state_watcher = self.cluster_state_refresher.cluster_state_watcher();
+
+        // todo: This is a temporary band-aid for https://github.com/restatedev/restate/issues/1651
+        //  Remove once it is properly fixed.
+        if let Some(all_partition_started_tx) = all_partitions_started_tx {
+            self.task_center.spawn_child(
+                TaskKind::SystemBoot,
+                "signal-all-partitions-started",
+                None,
+                signal_all_partitions_started(
+                    cluster_state_watcher,
+                    self.metadata.clone(),
+                    all_partition_started_tx,
+                ),
+            )?;
+        }
 
         loop {
             tokio::select! {
@@ -337,6 +357,48 @@ where
     }
 }
 
+async fn signal_all_partitions_started(
+    mut cluster_state_watcher: ClusterStateWatcher,
+    metadata: Metadata,
+    all_partitions_started_tx: oneshot::Sender<()>,
+) -> anyhow::Result<()> {
+    loop {
+        let cluster_state = cluster_state_watcher.next_cluster_state().await?;
+
+        if cluster_state.partition_table_version != metadata.partition_table_version()
+            || metadata.partition_table_version() == Version::INVALID
+        {
+            // syncing of PartitionTable since we obviously don't have up-to-date information
+            metadata.sync(MetadataKind::PartitionTable).await?;
+        } else {
+            let partition_table = metadata
+                .partition_table()
+                .expect("valid partition table must be present");
+
+            let mut pending_partitions_wo_leader = partition_table.num_partitions();
+
+            for alive_node in cluster_state.alive_nodes() {
+                alive_node
+                    .partitions
+                    .iter()
+                    .for_each(|(_, partition_state)| {
+                        // currently, there can only be a single leader per partition
+                        if partition_state.is_effective_leader() {
+                            pending_partitions_wo_leader =
+                                pending_partitions_wo_leader.saturating_sub(1);
+                        }
+                    })
+            }
+
+            if pending_partitions_wo_leader == 0 {
+                // send result can be ignored because rx should only go away in case of a shutdown
+                let _ = all_partitions_started_tx.send(());
+                return Ok(());
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Service;
@@ -386,7 +448,7 @@ mod tests {
             TaskKind::SystemService,
             "cluster-controller",
             None,
-            svc.run(bifrost.clone()),
+            svc.run(bifrost.clone(), None),
         )?;
 
         let log_id = LogId::from(0);
@@ -490,7 +552,7 @@ mod tests {
             TaskKind::SystemService,
             "cluster-controller",
             None,
-            svc.run(bifrost.clone()),
+            svc.run(bifrost.clone(), None),
         )?;
 
         let log_id = LogId::from(0);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -14,6 +14,7 @@ mod roles;
 
 use std::future::Future;
 use std::time::Duration;
+use tokio::sync::oneshot;
 
 use codederror::CodedError;
 #[cfg(feature = "replicated-loglet")]
@@ -367,21 +368,35 @@ impl Node {
             )?;
         }
 
-        if let Some(admin_role) = self.admin_role {
+        let all_partitions_started_rx = if let Some(admin_role) = self.admin_role {
+            // todo: This is a temporary fix for https://github.com/restatedev/restate/issues/1651
+            let (all_partitions_started_tx, all_partitions_started_rx) = oneshot::channel();
             tc.spawn(
                 TaskKind::SystemBoot,
                 "admin-init",
                 None,
-                admin_role.start(config.common.allow_bootstrap, bifrost.clone()),
+                admin_role.start(
+                    config.common.allow_bootstrap,
+                    bifrost.clone(),
+                    all_partitions_started_tx,
+                ),
             )?;
-        }
+
+            all_partitions_started_rx
+        } else {
+            // We don't wait for all partitions being the leader if we are not co-located with the
+            // admin role which should not be the normal deployment today.
+            let (all_partitions_started_tx, all_partitions_started_rx) = oneshot::channel();
+            let _ = all_partitions_started_tx.send(());
+            all_partitions_started_rx
+        };
 
         if let Some(worker_role) = self.worker_role {
             tc.spawn(
                 TaskKind::SystemBoot,
                 "worker-init",
                 None,
-                worker_role.start(),
+                worker_role.start(all_partitions_started_rx),
             )?;
         }
 

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use codederror::CodedError;
+use tokio::sync::oneshot;
 use tonic::transport::Channel;
 
 use restate_admin::cluster_controller::ClusterControllerHandle;
@@ -96,6 +97,7 @@ impl AdminRole {
         self,
         _bootstrap_cluster: bool,
         bifrost: Bifrost,
+        all_partitions_started_tx: oneshot::Sender<()>,
     ) -> Result<(), anyhow::Error> {
         let tc = task_center();
 
@@ -103,7 +105,8 @@ impl AdminRole {
             TaskKind::SystemService,
             "cluster-controller-service",
             None,
-            self.controller.run(bifrost.clone()),
+            self.controller
+                .run(bifrost.clone(), Some(all_partitions_started_tx)),
         )?;
 
         // todo: Make address configurable

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -41,6 +41,13 @@ impl ClusterState {
             .map(|last_refreshed| last_refreshed.elapsed().as_secs() < 10)
             .unwrap_or(false)
     }
+
+    pub fn alive_nodes(&self) -> impl Iterator<Item = &AliveNode> {
+        self.nodes.values().flat_map(|node| match node {
+            NodeState::Alive(alive_node) => Some(alive_node),
+            NodeState::Dead(_) => None,
+        })
+    }
 }
 
 fn instant_to_proto(t: Instant) -> prost_types::Duration {

--- a/deny.toml
+++ b/deny.toml
@@ -111,9 +111,6 @@ skip = [
     # Clash between datafusion and arrow
     { name = "hashbrown"},
 
-    # Clash between datafusion and opentelemetry
-    { name = "thrift"},
-
     # Clash between datafusion and invoker
     { name = "tokio-rustls"},
 


### PR DESCRIPTION
This is a temporary band-aid to solve the problem that at start-up
we might not respond to some invocations if the partition processors
are slow at claiming leadership. See https://github.com/restatedev/restate/issues/1651
for more details.

The band-aid introduces a oneshot which is being completed by the cluster
controller when it has seen for every partition a leader. The ingress will
wait for the oneshot to be completed before starting it. Note, this band-aid
only works for single process setups where the Admin role is colocated with
the Worker role. This should cover the normal deployment right now.

This fixes https://github.com/restatedev/restate/issues/1684.