### PR TITLE
Use static LZMA to prevent dependency path leak

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Compile Mac binaries
         if: ${{ matrix.build.os == 'macos-latest' }}
         env:
+          # Use the static version of the lzma library, instead of the path to lzma on the build host
+          LZMA_API_STATIC: true
           MACOSX_DEPLOYMENT_TARGET: 10.14.0
         run: cargo build --release --bins --target ${{ matrix.build.target }}
 


### PR DESCRIPTION
When I tried to kick the tires on restate a few weeks ago, I downloaded `restate.aarch64-apple-darwin.tar.gz` (for version 1.0.2) and running it resulted in 

```
dyld[85983]: Library not loaded: /opt/homebrew/opt/xz/lib/liblzma.5.dylib
  Referenced from: <14488145-9A41-31F8-B993-BB4C9F3379A7> /Users/edude03/Downloads/restate.aarch64-apple-darwin/restate-server
  Reason: tried: '/opt/homebrew/opt/xz/lib/liblzma.5.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/xz/lib/liblzma.5.dylib' (no such file), '/opt/homebrew/opt/xz/lib/liblzma.5.dylib' (no such file)
zsh: abort      ~/Downloads/restate.aarch64-apple-darwin/restate-server
```

I don't have homebrew installed and so of course, this file won't be found. 

The instructions could be updated to ask users to install liblzma via homebrew, but instead, I think we should use the static build of liblzma (the default when [lzma is not found in your build environment](https://github.com/alexcrichton/xz2-rs/blob/main/lzma-sys/build.rs#L21)) as it provides a better user experience
