### PR TITLE
Show invocation completion in CLI

### DIFF
--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -276,6 +276,26 @@ pub async fn find_active_invocations_simple(
 }
 
 #[derive(Debug, Clone)]
+pub enum InvocationCompletion {
+    Success,
+    Failure(String),
+}
+
+impl InvocationCompletion {
+    fn from_sql(
+        completion_result: Option<String>,
+        completion_failure: Option<String>,
+    ) -> Option<InvocationCompletion> {
+        match (completion_result.as_deref(), completion_failure) {
+            (Some("success"), None) => Some(InvocationCompletion::Success),
+            (Some("failure"), None) => Some(InvocationCompletion::Failure("Unknown".to_owned())),
+            (Some("failure"), Some(failure)) => Some(InvocationCompletion::Failure(failure)),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Invocation {
     pub id: String,
     pub target: String,
@@ -285,6 +305,7 @@ pub struct Invocation {
     pub invoked_by_id: Option<String>,
     pub invoked_by_target: Option<String>,
     pub status: InvocationState,
+    pub completion: Option<InvocationCompletion>,
     pub trace_id: Option<String>,
 
     // If it **requires** this deployment.
@@ -747,6 +768,8 @@ struct InvocationRowResult {
     target: Option<String>,
     target_service_ty: Option<String>,
     status: String,
+    completion_result: Option<String>,
+    completion_failure: Option<String>,
     created_at: Option<RestateDateTime>,
     modified_at: Option<RestateDateTime>,
     pinned_deployment_id: Option<String>,
@@ -774,6 +797,20 @@ pub async fn find_active_invocations(
     order: &str,
     limit: usize,
 ) -> Result<(Vec<Invocation>, usize)> {
+    // Check if columns completion_result and completion_failure are available.
+    // Those were introduced in Restate 1.1
+    let has_restate_1_1_completion_columns = client
+        .check_columns_exists(
+            "sys_invocation",
+            &["completion_result", "completion_failure"],
+        )
+        .await?;
+    let select_completion_columns = if has_restate_1_1_completion_columns {
+        "inv.completion_result, inv.completion_failure"
+    } else {
+        "NULL AS completion_result, NULL AS completion_failure"
+    };
+
     let mut full_count = 0;
     let mut active = vec![];
     let query = format!(
@@ -799,7 +836,8 @@ pub async fn find_active_invocations(
             inv.invoked_by_target,
             svc.deployment_id as comp_latest_deployment,
             dp.id as known_deployment_id,
-            inv.trace_id
+            inv.trace_id,
+            {select_completion_columns}
         FROM sys_invocation inv
         LEFT JOIN sys_service svc ON svc.name = inv.target_service_name
         LEFT JOIN sys_deployment dp ON dp.id = inv.pinned_deployment_id
@@ -853,6 +891,10 @@ pub async fn find_active_invocations(
             current_attempt_duration,
             last_attempt_started_at,
             last_failure_entry_ty: row.last_failure_related_entry_type,
+            completion: InvocationCompletion::from_sql(
+                row.completion_result,
+                row.completion_failure,
+            ),
         });
 
         full_count = row.full_count.expect("full_count") as usize;

--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -768,8 +768,6 @@ struct InvocationRowResult {
     target: Option<String>,
     target_service_ty: Option<String>,
     status: String,
-    completion_result: Option<String>,
-    completion_failure: Option<String>,
     created_at: Option<RestateDateTime>,
     modified_at: Option<RestateDateTime>,
     pinned_deployment_id: Option<String>,
@@ -787,6 +785,8 @@ struct InvocationRowResult {
     comp_latest_deployment: Option<String>,
     known_deployment_id: Option<String>,
     trace_id: Option<String>,
+    completion_result: Option<String>,
+    completion_failure: Option<String>,
     full_count: Option<i64>,
 }
 
@@ -808,7 +808,7 @@ pub async fn find_active_invocations(
     let select_completion_columns = if has_restate_1_1_completion_columns {
         "inv.completion_result, inv.completion_failure"
     } else {
-        "NULL AS completion_result, NULL AS completion_failure"
+        "CAST(NULL as STRING) AS completion_result, CAST(NULL as STRING) AS completion_failure"
     };
 
     let mut full_count = 0;

--- a/cli/src/clients/datafusion_http_client.rs
+++ b/cli/src/clients/datafusion_http_client.rs
@@ -22,6 +22,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_convert::deserialize::{arrow_array_deserialize_iterator, ArrowDeserialize};
 use arrow_convert::field::ArrowField;
 use bytes::Buf;
+use itertools::Itertools;
 use serde::Serialize;
 use thiserror::Error;
 use tracing::{debug, info};
@@ -133,6 +134,24 @@ impl DataFusionHttpClient {
             .map(|v| **v)
             .unwrap_or(0))
     }
+
+    pub async fn check_columns_exists(&self, table: &str, columns: &[&str]) -> Result<bool, Error> {
+        let expected_count = columns.len();
+
+        let actual_count = self
+            .run_count_agg_query(format!(
+                "SELECT COUNT(*) FROM information_schema.columns
+            WHERE
+                table_name = '{table}'
+                AND column_name IN ({})",
+                columns.iter().map(|s| format!("'{s}'")).join(", ")
+            ))
+            .await?;
+
+        Ok(actual_count as usize == expected_count)
+    }
+
+    // check if column exists: SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'sys_invocation' AND column_name IN ('completion_result', 'completion_failure')
 }
 
 fn get_column_as<T>(

--- a/cli/src/clients/datafusion_http_client.rs
+++ b/cli/src/clients/datafusion_http_client.rs
@@ -150,8 +150,6 @@ impl DataFusionHttpClient {
 
         Ok(actual_count as usize == expected_count)
     }
-
-    // check if column exists: SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'sys_invocation' AND column_name IN ('completion_result', 'completion_failure')
 }
 
 fn get_column_as<T>(

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -67,7 +67,9 @@ const SYS_INVOCATION_VIEW: &str = "CREATE VIEW sys_invocation as SELECT
                 WHEN sis.in_flight THEN 'running'
                 WHEN ss.status = 'invoked' AND retry_count > 0 THEN 'backing-off'
                 ELSE 'ready'
-            END AS status
+            END AS status,
+            ss.completion_result,
+            ss.completion_failure
         FROM sys_invocation_status ss
         LEFT JOIN sys_invocation_state sis ON ss.id = sis.id";
 

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -14,7 +14,7 @@ use restate_storage_api::invocation_status_table::{
     InFlightInvocationMetadata, InvocationStatus, JournalMetadata, StatusTimestamps,
 };
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
-use restate_types::invocation::{ServiceType, Source, TraceId};
+use restate_types::invocation::{ResponseResult, ServiceType, Source, TraceId};
 
 #[inline]
 pub(crate) fn append_invocation_status_row(
@@ -77,6 +77,15 @@ pub(crate) fn append_invocation_status_row(
         InvocationStatus::Completed(completed) => {
             row.status("completed");
             fill_invoked_by(&mut row, output, completed.source);
+            match completed.response_result {
+                ResponseResult::Success(_) => {
+                    row.completion_result("success");
+                }
+                ResponseResult::Failure(failure) => {
+                    row.completion_result("failure");
+                    row.completion_failure(format_using(output, &failure));
+                }
+            }
         }
     };
 }

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -24,6 +24,12 @@ define_table!(sys_invocation_status(
     /// Either `inboxed` or `invoked` or `suspended` or `completed`
     status: DataType::LargeUtf8,
 
+    /// If `status = 'completed'`, this contains either `success` or `failure`
+    completion_result: DataType::LargeUtf8,
+
+    /// If `status = 'completed' AND completion_result = 'failure'`, this contains the error cause
+    completion_failure: DataType::LargeUtf8,
+
     /// Invocation Target. Format for plain services: `ServiceName/HandlerName`, e.g.
     /// `Greeter/greet`. Format for virtual objects/workflows: `VirtualObjectName/Key/HandlerName`,
     /// e.g. `Greeter/Francesco/greet`.

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -122,6 +122,8 @@ pub fn sys_invocation_table_docs() -> OwnedTableDocs {
             column_type: "Utf8",
             description: "Either `pending` or `ready` or `running` or `backing-off` or `suspended` or `completed`.",
         },
+        sys_invocation_status.remove("completion_result").expect("completion_result should exist"),
+        sys_invocation_status.remove("completion_failure").expect("completion_failure should exist"),
     ];
 
     OwnedTableDocs {


### PR DESCRIPTION
Fix #1712

Using restate 1.0:

```
  ❯ [2024-07-18 09:22:21.760 +02:00] inv_1eQGNqArQ5Hz78SmQy5dvDqYgj7lxjQp1L
     Target:      WorkflowTest/c/run                                                
     Status:      backing-off  (12 minutes, 21 seconds and 606 ms. Retried   
                  66 time(s). Next retry in in 7 seconds and 134 ms))        
     Deployment:  id: dp_13sgmJ9OIJWO79hTDuusMQF, service protocol version: 1       
                  [ZOMBIE] using restate-sdk-java/1.1.0-SNAPSHOT_fbfb16cc 
     Error:       [2024-07-18 09:34:39.353 +02:00]                            
                  [500] error trying to connect: tcp connect error: Connection  
                  refused (os error 111)                                         
     Caused by:   UNKNOWN                                                           

  ❯ [2024-07-18 09:21:55.534 +02:00] inv_174rq2A9bm3T5ULE0nBRhDSHXY9sW3YBk5
     Target:  WorkflowTest/b/run 
     Status:  completed   

  ❯ [2024-07-18 09:21:10.097 +02:00] inv_1dceKvwtEc2n1psdzgswxMZsRxdZ6x5unf
     Target:  WorkflowTest/a/run 
     Status:  completed  
```

Using this branch:

![Screenshot from 2024-07-18 09-37-16](https://github.com/user-attachments/assets/73710159-9e59-4abc-ab80-c724903cc11c)
