### PR TITLE
Add missing fedora local dev env protobuf dependency

### DIFF
--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -21,7 +21,7 @@ Optionally, you can install [just](https://github.com/casey/just) to make use of
 To setup these on Fedora, run:
 
 ```
-sudo dnf install clang lld lldb libcxx cmake openssl-devel rocksdb-devel protobuf-compiler just liburing-devel
+sudo dnf install clang lld lldb libcxx cmake openssl-devel rocksdb-devel protobuf-compiler protobuf-devel just liburing-devel
 ```
 
 On MacOS, you can use [homebrew](https://brew.sh)


### PR DESCRIPTION
I was getting started with local development of restate on my fedora setup and it failed to compile 
```bash
error: failed to run custom build command for `restate-core v1.1.0 (/home/aradwan/Documents/repos/restate/crates/core)`

Caused by:
  process didn't exit successfully: `/home/aradwan/Documents/repos/restate/target/debug/build/restate-core-6e6184d6ff0d784f/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=./protobuf/node_svc.proto
  cargo:rerun-if-changed=protobuf
  cargo:rerun-if-changed=../types/protobuf

  --- stderr
  Error: Custom { kind: Other, error: "protoc failed: google/protobuf/empty.proto: File not found.\nnode_svc.proto:12:1: Import \"google/protobuf/empty.proto\" was not found or had errors.\nnode_svc.proto:20:16: \"google.protobuf.Empty\" is not defined.\n" }
warning: build failed, waiting for other jobs to finish...
```

Error was solved by installing `protobuf-devel`

#### Why Both Are Needed
Compiling .proto Files: The `protobuf-compiler` is used during the build process to convert your .proto files into source code. This step is critical for generating the classes and methods you will use in your application.

Building Your Application: Once you have the generated source code, you need the `protobuf-devel` package because it provides the headers and libraries required to compile and link your application against the Protocol Buffers library. This allows your application to use the generated code properly.


Without protobuf-devel, you would not have the necessary components to compile your application, even if you have already generated the source code with protobuf-compiler.

