### PR TITLE
Add commands to view and edit/patch service configuration

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ clap = { workspace = true, features = ["derive", "env", "wrap_help", "color"] }
 clap-verbosity-flag = { workspace = true }
 cling = { workspace = true }
 comfy-table = { workspace = true }
+const_format = "0.2.32"
 convert_case = "0.6"
 crossterm = { workspace = true }
 ctrlc = { version = "3.4.1" }
@@ -48,6 +49,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["server", "http2"] }
 hyper-rustls = { workspace = true, default-features = false, features = ["http1", "http2", "ring", "native-tokio", "tls12", "logging"]  }
 hyper-util = { workspace = true, features = ["client-legacy", "http2", "server", "client", "tokio"] }
+humantime = { workspace = true }
 indicatif = "0.17.7"
 indoc = { version = "2.0.4" }
 itertools = { workspace = true }
@@ -66,6 +68,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true }
+toml = "0.8.15"
 toml_edit = "0.22.12"
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/cli/src/clients/admin_interface.rs
+++ b/cli/src/clients/admin_interface.rs
@@ -22,6 +22,11 @@ pub trait AdminClientInterface {
     async fn health(&self) -> reqwest::Result<Envelope<()>>;
     async fn get_services(&self) -> reqwest::Result<Envelope<ListServicesResponse>>;
     async fn get_service(&self, name: &str) -> reqwest::Result<Envelope<ServiceMetadata>>;
+    async fn patch_service(
+        &self,
+        name: &str,
+        modify_service_request: ModifyServiceRequest,
+    ) -> reqwest::Result<Envelope<ServiceMetadata>>;
     async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentsResponse>>;
     async fn get_deployment<D: Display>(
         &self,
@@ -65,6 +70,20 @@ impl AdminClientInterface for AdminClient {
             .expect("Bad url!");
 
         self.run(reqwest::Method::GET, url).await
+    }
+
+    async fn patch_service(
+        &self,
+        name: &str,
+        modify_service_request: ModifyServiceRequest,
+    ) -> reqwest::Result<Envelope<ServiceMetadata>> {
+        let url = self
+            .base_url
+            .join(&format!("/services/{}", name))
+            .expect("Bad url!");
+
+        self.run_with_body(reqwest::Method::PATCH, url, modify_service_request)
+            .await
     }
 
     async fn get_deployments(&self) -> reqwest::Result<Envelope<ListDeploymentsResponse>> {

--- a/cli/src/commands/services/config/edit.rs
+++ b/cli/src/commands/services/config/edit.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use anyhow::{Context, Result};
+use cling::prelude::*;
+use restate_admin_rest_model::services::ModifyServiceRequest;
+use restate_types::invocation::ServiceType;
+use std::fs::File;
+use std::io;
+use tempfile::tempdir;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_edit")]
+pub struct Edit {
+    /// Service name
+    service: String,
+}
+
+pub async fn run_edit(State(env): State<CliEnv>, opts: &Edit) -> Result<()> {
+    edit(&env, opts).await
+}
+
+async fn edit(env: &CliEnv, opts: &Edit) -> Result<()> {
+    let admin_client = AdminClient::new(env).await?;
+    let svc = admin_client
+        .get_service(&opts.service)
+        .await?
+        .into_body()
+        .await?;
+
+    // Prepare file to edit
+    let tempdir = tempdir().context("unable to create a temporary directory")?;
+    let edit_file_path = tempdir.path().join(".restate_edit");
+    write_out_edit_toml(
+        &mut File::create(edit_file_path.clone()).context("Failed to create a temp file")?,
+        svc.ty,
+    )?;
+
+    // Edit file
+    env.open_default_editor(&edit_file_path)?;
+
+    // Now load back file into string and parse it
+    let modify_request: ModifyServiceRequest = toml::from_str(
+        &std::fs::read_to_string(edit_file_path).context("Cannot read the edited config file")?,
+    )
+    .context("Cannot parse the edited config file")?;
+
+    super::patch::apply_service_configuration_patch(
+        opts.service.clone(),
+        admin_client,
+        modify_request,
+    )
+    .await
+}
+
+// TODO generate this file from the JsonSchema
+fn write_out_edit_toml(w: &mut impl io::Write, service_type: ServiceType) -> Result<()> {
+    write_prefixed_lines(w, "# ", super::view::PUBLIC_DESCRIPTION)?;
+    writeln!(w, "# Example:")?;
+    writeln!(w, "# public = true")?;
+    writeln!(w)?;
+
+    write_prefixed_lines(
+        w,
+        "# ",
+        super::patch::IDEMPOTENCY_RETENTION_EDIT_DESCRIPTION,
+    )?;
+    writeln!(w, "# Example:")?;
+    writeln!(w, "# idempotency_retention = \"10hours\"")?;
+    writeln!(w)?;
+
+    if service_type == ServiceType::Workflow {
+        write_prefixed_lines(w, "# ", super::patch::WORKFLOW_RETENTION_EDIT_DESCRIPTION)?;
+        writeln!(w, "# Example:")?;
+        writeln!(w, "# workflow_completion_retention = \"10days\"")?;
+        writeln!(w)?;
+    }
+
+    Ok(())
+}
+
+fn write_prefixed_lines(w: &mut impl io::Write, prefix: &str, lines: &str) -> io::Result<()> {
+    for line in lines.lines() {
+        writeln!(w, "{prefix}{line}")?;
+    }
+    Ok(())
+}

--- a/cli/src/commands/services/config/mod.rs
+++ b/cli/src/commands/services/config/mod.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod edit;
+mod patch;
+mod view;
+
+use cling::prelude::*;
+
+#[derive(Run, Subcommand, Clone)]
+pub enum Config {
+    /// Dump the current service configuration
+    #[clap(name = "view", alias = "get")]
+    View(view::View),
+    /// Interactively edit the service configuration
+    Edit(edit::Edit),
+    /// Patch the service configuration either with a file or with the provided arguments
+    Patch(patch::Patch),
+}

--- a/cli/src/commands/services/config/patch.rs
+++ b/cli/src/commands/services/config/patch.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use anyhow::{Context, Result};
+use cling::prelude::*;
+use comfy_table::Table;
+use const_format::concatcp;
+use restate_admin_rest_model::services::ModifyServiceRequest;
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
+use restate_serde_util::DurationString;
+
+pub(super) const DURATION_EDIT_DESCRIPTION: &str = "Can be configured using the humantime format (https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) or the ISO8601.";
+pub(super) const IDEMPOTENCY_RETENTION_EDIT_DESCRIPTION: &str = concatcp!(
+    super::view::IDEMPOTENCY_RETENTION,
+    "\n",
+    DURATION_EDIT_DESCRIPTION
+);
+pub(super) const WORKFLOW_RETENTION_EDIT_DESCRIPTION: &str = concatcp!(
+    super::view::WORKFLOW_RETENTION,
+    "\n",
+    DURATION_EDIT_DESCRIPTION
+);
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_patch")]
+pub struct Patch {
+    #[clap(long, help = super::view::PUBLIC_DESCRIPTION)]
+    public: Option<bool>,
+
+    #[clap(long, alias = "idempotency_retention", help = IDEMPOTENCY_RETENTION_EDIT_DESCRIPTION)]
+    idempotency_retention: Option<String>,
+
+    #[clap(long, alias = "workflow_completion_retention", help = WORKFLOW_RETENTION_EDIT_DESCRIPTION)]
+    workflow_completion_retention: Option<String>,
+
+    /// Service name
+    service: String,
+}
+
+pub async fn run_patch(State(env): State<CliEnv>, opts: &Patch) -> Result<()> {
+    patch(&env, opts).await
+}
+
+async fn patch(env: &CliEnv, opts: &Patch) -> Result<()> {
+    let admin_client = AdminClient::new(env).await?;
+    let modify_request = ModifyServiceRequest {
+        public: opts.public,
+        idempotency_retention: opts
+            .idempotency_retention
+            .as_ref()
+            .map(|s| {
+                DurationString::parse_duration(s).context("Cannot parse idempotency_retention")
+            })
+            .transpose()?,
+        workflow_completion_retention: opts
+            .workflow_completion_retention
+            .as_ref()
+            .map(|s| {
+                DurationString::parse_duration(s)
+                    .context("Cannot parse workflow_completion_retention")
+            })
+            .transpose()?,
+    };
+
+    apply_service_configuration_patch(opts.service.clone(), admin_client, modify_request).await
+}
+
+pub(super) async fn apply_service_configuration_patch(
+    service_name: String,
+    admin_client: AdminClient,
+    modify_request: ModifyServiceRequest,
+) -> Result<()> {
+    // Check if any change was made
+    if modify_request.public.is_none()
+        && modify_request.workflow_completion_retention.is_none()
+        && modify_request.idempotency_retention.is_none()
+    {
+        c_println!("No changes requested");
+        return Ok(());
+    }
+
+    // Print requested changes, ask for confirmation
+    let mut table = Table::new_styled();
+    if let Some(public) = &modify_request.public {
+        table.add_kv_row("Public:", public);
+    }
+    if let Some(idempotency_retention) = &modify_request.idempotency_retention {
+        table.add_kv_row(
+            "Idempotent requests retention:",
+            humantime::Duration::from(*idempotency_retention),
+        );
+    }
+    if let Some(workflow_completion_retention) = &modify_request.workflow_completion_retention {
+        table.add_kv_row(
+            "Workflow retention time:",
+            humantime::Duration::from(*workflow_completion_retention),
+        );
+    }
+    c_println!("{table}");
+    confirm_or_exit("Are you sure you want to apply these changes?")?;
+
+    let _ = admin_client
+        .patch_service(&service_name, modify_request)
+        .await?
+        .into_body()
+        .await?;
+
+    Ok(())
+}

--- a/cli/src/commands/services/config/view.rs
+++ b/cli/src/commands/services/config/view.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::Table;
+use indoc::indoc;
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::{c_println, c_tip};
+use restate_types::invocation::ServiceType;
+
+// TODO we could infer this text from the OpenAPI docs!
+pub(super) const PUBLIC_DESCRIPTION: &str = indoc! {
+    "Whether the service is publicly available or not.
+    If true, the service can be invoked through the ingress.
+    If false, the service can be invoked only from another Restate service."
+};
+pub(super) const IDEMPOTENCY_RETENTION: &str = indoc! {
+    "The retention duration of idempotent requests for this service.
+    The retention period starts once the invocation completes (with either success or failure).
+    After the retention period, the invocation response and the idempotency key will be forgotten."
+};
+pub(super) const WORKFLOW_RETENTION: &str = indoc! {
+    "The retention duration of workflows.
+    The retention period starts once the invocation completes (with either success or failure).
+    After the retention period, the invocation response together with the workflow state and promises will be forgotten."
+};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_view")]
+pub struct View {
+    /// Service name
+    service: String,
+}
+
+pub async fn run_view(State(env): State<CliEnv>, opts: &View) -> Result<()> {
+    view(&env, opts).await
+}
+
+async fn view(env: &CliEnv, opts: &View) -> Result<()> {
+    let client = AdminClient::new(env).await?;
+    let service = client.get_service(&opts.service).await?.into_body().await?;
+
+    let mut table = Table::new_styled();
+    table.add_kv_row("Name:", &service.name);
+    table.add_kv_row("Service type:", &format!("{:?}", service.ty));
+    c_println!("{table}");
+    c_println!();
+
+    let mut table = Table::new_styled();
+    table.add_kv_row("Public:", service.public);
+    c_println!("{table}");
+    c_tip!("{}", PUBLIC_DESCRIPTION);
+    c_println!();
+
+    let mut table = Table::new_styled();
+    table.add_kv_row(
+        "Idempotent requests retention:",
+        service.idempotency_retention,
+    );
+    c_println!("{table}");
+    c_tip!("{}", IDEMPOTENCY_RETENTION);
+    c_println!();
+
+    if service.ty == ServiceType::Workflow {
+        let mut table = Table::new_styled();
+        table.add_kv_row(
+            "Workflow retention time:",
+            service
+                .workflow_completion_retention
+                .expect("Workflows must have a well defined retention"),
+        );
+        c_println!("{table}");
+        c_tip!("{}", WORKFLOW_RETENTION);
+        c_println!();
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/services/mod.rs
+++ b/cli/src/commands/services/mod.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod config;
 mod describe;
 mod list;
 mod status;
@@ -23,4 +24,8 @@ pub enum Services {
     Describe(describe::Describe),
     /// Prints activity information about a given service (and method)
     Status(status::Status),
+    /// Configure a service
+    #[clap(name = "config", alias = "conf")]
+    #[clap(subcommand)]
+    Config(config::Config),
 }

--- a/crates/serde-util/src/duration.rs
+++ b/crates/serde-util/src/duration.rs
@@ -18,9 +18,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::de::Error;
+use serde::de::{Error, IntoDeserializer};
 use serde::{Deserialize, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
+use std::time::Duration;
 
 /// Serializable/Deserializable duration to use with serde_with.
 ///
@@ -31,6 +32,12 @@ use serde_with::{DeserializeAs, SerializeAs};
 /// * ISO8601 durations
 /// * Humantime durations
 pub struct DurationString;
+
+impl DurationString {
+    pub fn parse_duration(s: &str) -> Result<Duration, serde::de::value::Error> {
+        serde_with::As::<DurationString>::deserialize(s.into_deserializer())
+    }
+}
 
 impl<'de> DeserializeAs<'de, std::time::Duration> for DurationString {
     fn deserialize_as<D>(deserializer: D) -> Result<std::time::Duration, D::Error>

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
     "OpenSSL",
     "MPL-2.0",
     "CC0-1.0",
+    "Zlib"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
Fix #1672

This PR adds 3 new commands:

* `restate service config view <SVC>`: View the current service configuration
* `restate service config patch <SVC> --config-entry=new_value`: Patch the service configuration
* `restate service config edit <SVC>`: Patch the service configuration interactively (similar to state edit and config edit) 

Example of the new `view` command:

```
 Name:          LoanWorkflowMockBank 
 Service type:  Service              

 Public:  false 
  💡   Whether the service is publicly available or not.                       
       If true, the service can be invoked through the ingress.                
       If false, the service can be invoked only from another Restate service. 

 Idempotent requests retention:  10s 
  💡   The retention duration of idempotent requests for this service.                                
       The retention period starts once the invocation completes (with either success or failure).    
       After the retention period, the invocation response and the idempotency key will be forgotten. 
```