### PR TITLE
Update CLI hyper/http dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,9 +1092,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2494,15 +2492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,7 +3166,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5278,49 +5267,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-rustls 0.24.1",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.11",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
@@ -5329,6 +5275,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5359,8 +5306,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.3",
- "winreg 0.52.0",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
@@ -5451,7 +5398,7 @@ dependencies = [
  "http 1.1.0",
  "pprof",
  "rand",
- "reqwest 0.12.5",
+ "reqwest",
  "restate-core",
  "restate-node",
  "restate-rocksdb",
@@ -5514,7 +5461,7 @@ dependencies = [
  "arc-swap",
  "arrow 51.0.0",
  "arrow_convert",
- "axum 0.6.20",
+ "axum 0.7.5",
  "base62",
  "base64 0.22.0",
  "bs58",
@@ -5532,10 +5479,10 @@ dependencies = [
  "dirs",
  "figment",
  "futures",
- "http 0.2.12",
  "http 1.1.0",
- "hyper 0.14.30",
- "hyper-rustls 0.24.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "indicatif",
  "indoc",
@@ -5543,8 +5490,8 @@ dependencies = [
  "jsonwebtoken",
  "octocrab",
  "open",
- "reqwest 0.11.27",
- "reqwest 0.12.5",
+ "pin-project",
+ "reqwest",
  "restate-admin-rest-model",
  "restate-cli-util",
  "restate-serde-util",
@@ -5554,6 +5501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.2",
+ "sync_wrapper 1.0.1",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -7276,6 +7224,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -7287,27 +7238,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -8295,12 +8225,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
@@ -8522,16 +8446,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
@@ -8551,7 +8465,7 @@ name = "xtask"
 version = "1.1.0"
 dependencies = [
  "anyhow",
- "reqwest 0.12.5",
+ "reqwest",
  "restate-admin",
  "restate-bifrost",
  "restate-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { workspace = true }
 arc-swap = { workspace = true }
 arrow = { version = "51.0.0", features = ["ipc", "prettyprint", "json"] }
 arrow_convert = { version = "0.6.6" }
-axum-0-6 = { package = "axum", version = "0.6.20", default-features = false, features = ["http1", "http2", "query", "tokio"] }
+axum = { version = "0.7.5", default-features = false, features = ["http1", "http2", "query", "tokio"] }
 bytes = { workspace = true }
 base62 = { version = "2.0.2" }
 base64 = { workspace = true }
@@ -44,9 +44,9 @@ dirs = { version = "5.0" }
 figment = { version = "0.10.8", features = ["env", "toml"] }
 futures = { workspace = true }
 http = { workspace = true }
-http-0-2 = { package = "http", version = "0.2" }
-hyper-0-14 = { package = "hyper", version = "0.14", features = ["server", "http2"] }
-hyper-rustls-0-24 = { package = "hyper-rustls", version = "0.24.1", features = ["http2"] }
+http-body-util = "0.1"
+hyper = { version = "1", features = ["server", "http2"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "http2", "ring", "native-tokio", "tls12", "logging"]  }
 hyper-util = { workspace = true, features = ["client-legacy", "http2", "server", "client", "tokio"] }
 indicatif = "0.17.7"
 indoc = { version = "2.0.4" }
@@ -54,12 +54,13 @@ itertools = { workspace = true }
 jsonwebtoken = { version = "9.1.0" }
 octocrab = { version = "0.32.0", features = ["stream"] }
 open = "5.1.2"
-reqwest = { workspace = true }
-reqwest-0-11 = { package = "reqwest", version = "0.11.22", default-features = false, features = ["json", "rustls-tls", "stream"] }
+pin-project = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["json", "rustls-tls", "stream", "http2"] }
 ring = { version = "0.17.8" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
+sync_wrapper = { workspace = true, features = ["futures"] }
 termcolor = { version = "1.4.0" }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { workspace = true }
 arc-swap = { workspace = true }
 arrow = { version = "51.0.0", features = ["ipc", "prettyprint", "json"] }
 arrow_convert = { version = "0.6.6" }
-axum = { version = "0.7.5", default-features = false, features = ["http1", "http2", "query", "tokio"] }
+axum = { workspace = true, default-features = false, features = ["http1", "http2", "query", "tokio"] }
 bytes = { workspace = true }
 base62 = { version = "2.0.2" }
 base64 = { workspace = true }
@@ -44,9 +44,9 @@ dirs = { version = "5.0" }
 figment = { version = "0.10.8", features = ["env", "toml"] }
 futures = { workspace = true }
 http = { workspace = true }
-http-body-util = "0.1"
-hyper = { version = "1", features = ["server", "http2"] }
-hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "http2", "ring", "native-tokio", "tls12", "logging"]  }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["server", "http2"] }
+hyper-rustls = { workspace = true, default-features = false, features = ["http1", "http2", "ring", "native-tokio", "tls12", "logging"]  }
 hyper-util = { workspace = true, features = ["client-legacy", "http2", "server", "client", "tokio"] }
 indicatif = "0.17.7"
 indoc = { version = "2.0.4" }

--- a/cli/src/commands/cloud/environments/tunnel/local.rs
+++ b/cli/src/commands/cloud/environments/tunnel/local.rs
@@ -27,7 +27,7 @@ use restate_cli_util::CliContext;
 use restate_types::retries::RetryPolicy;
 use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
 use tokio_util::sync::CancellationToken;
-use tower::Service as _;
+use tower::Service;
 use tracing::{error, info};
 use url::Url;
 
@@ -330,13 +330,7 @@ where
             Err(ServeError::ServerClosed(this.status.to_string()))
         }
     }
-}
 
-impl<Proxy, ProxyFut> Handler<Proxy>
-where
-    Proxy: Fn(Arc<HandlerInner>, reqwest::Request) -> ProxyFut + Send + Sync + 'static,
-    ProxyFut: Future<Output = Result<Response<Body>, StartError>> + Send + 'static,
-{
     fn process_start(
         mut this: OwnedRwLockWriteGuard<Self>,
         req: Request<Incoming>,

--- a/cli/src/commands/cloud/environments/tunnel/mod.rs
+++ b/cli/src/commands/cloud/environments/tunnel/mod.rs
@@ -95,7 +95,7 @@ pub async fn run_tunnel(State(env): State<CliEnv>, opts: &Tunnel) -> Result<()> 
         .into_body()
         .await?;
 
-    let client = reqwest_0_11::Client::builder()
+    let client = reqwest::Client::builder()
         .user_agent(format!(
             "{}/{} {}-{}",
             env!("CARGO_PKG_NAME"),

--- a/cli/src/commands/cloud/environments/tunnel/remote.rs
+++ b/cli/src/commands/cloud/environments/tunnel/remote.rs
@@ -46,7 +46,7 @@ impl From<RemotePort> for u16 {
 
 #[derive(Clone)]
 struct HandlerState {
-    client: reqwest_0_11::Client,
+    client: reqwest::Client,
     base_url: Url,
     bearer_token: String,
     tunnel_renderer: Arc<TunnelRenderer>,
@@ -55,20 +55,20 @@ struct HandlerState {
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ServeError {
     #[error("Failed to create local server")]
-    Hyper(#[from] hyper_0_14::Error),
+    Io(#[from] std::io::Error),
     #[error("Local server closed unexpectedly")]
     ServerClosed,
 }
 
 pub async fn run_remote(
     remote_port: RemotePort,
-    client: reqwest_0_11::Client,
+    client: reqwest::Client,
     base_url: &Url,
     bearer_token: &str,
     tunnel_renderer: Arc<TunnelRenderer>,
 ) -> Result<(), ServeError> {
-    let router = axum_0_6::Router::new()
-        .fallback(axum_0_6::routing::any(handler))
+    let router = axum::Router::new()
+        .fallback(axum::routing::any(handler))
         .with_state(HandlerState {
             client: client.clone(),
             base_url: base_url.clone(),
@@ -76,23 +76,25 @@ pub async fn run_remote(
             tunnel_renderer: tunnel_renderer.clone(),
         });
 
-    let server =
-        axum_0_6::Server::try_bind(&SocketAddr::from(([127, 0, 0, 1], u16::from(remote_port))))?;
-
-    server.serve(router.into_make_service()).await?;
+    axum::serve(
+        tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], u16::from(remote_port))))
+            .await?,
+        router.into_make_service(),
+    )
+    .await?;
 
     Err(ServeError::ServerClosed)
 }
 
 async fn handler(
-    axum_0_6::extract::State(state): axum_0_6::extract::State<HandlerState>,
-    req: axum_0_6::http::Request<axum_0_6::body::Body>,
-) -> Result<axum_0_6::response::Response, Infallible> {
+    axum::extract::State(state): axum::extract::State<HandlerState>,
+    req: axum::http::Request<axum::body::Body>,
+) -> Result<axum::response::Response, Infallible> {
     let res: Result<_, anyhow::Error> = async {
         let (mut head, body) = req.into_parts();
         head.headers.insert(
-            http_0_2::header::HOST,
-            http_0_2::HeaderValue::from_str(state.base_url.authority())?,
+            http::header::HOST,
+            http::HeaderValue::from_str(state.base_url.authority())?,
         );
         let url = if let Some(path) = head.uri.path_and_query() {
             state.base_url.join(path.as_str())?
@@ -103,19 +105,21 @@ async fn handler(
         let request = state
             .client
             .request(head.method, url)
-            .body(body)
+            .body(reqwest::Body::wrap_stream(sync_wrapper::SyncStream::new(
+                body.into_data_stream(),
+            )))
             .headers(head.headers)
             .bearer_auth(&state.bearer_token)
             .build()?;
         let mut result = state.client.execute(request).await?;
 
-        let mut response = axum_0_6::http::Response::builder().status(result.status());
+        let mut response = axum::http::Response::builder().status(result.status());
         if let Some(headers) = response.headers_mut() {
             std::mem::swap(headers, result.headers_mut())
         };
 
-        let body = axum_0_6::body::Body::wrap_stream(result.bytes_stream());
-        Ok(response.body(axum_0_6::body::boxed(body))?)
+        let body = axum::body::Body::from_stream(result.bytes_stream());
+        Ok(response.body(body)?)
     }
     .await;
 
@@ -126,9 +130,9 @@ async fn handler(
         }
         Err(err) => {
             state.tunnel_renderer.store_error(err);
-            Ok(axum_0_6::response::Response::builder()
-                .status(http_0_2::status::StatusCode::BAD_GATEWAY)
-                .body(axum_0_6::body::boxed(axum_0_6::body::Body::empty()))
+            Ok(axum::response::Response::builder()
+                .status(http::status::StatusCode::BAD_GATEWAY)
+                .body(axum::body::Body::empty())
                 .expect("failed to create http error response"))
         }
     }

--- a/cli/src/commands/cloud/environments/tunnel/request_identity.rs
+++ b/cli/src/commands/cloud/environments/tunnel/request_identity.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use http_0_2::HeaderMap;
+use http::HeaderMap;
 use serde::Deserialize;
 use std::collections::HashSet;
 

--- a/cli/src/commands/cloud/login.rs
+++ b/cli/src/commands/cloud/login.rs
@@ -103,7 +103,10 @@ async fn auth_flow(env: &CliEnv, _opts: &Login) -> Result<String> {
         i += 1
     };
 
-    let port = listener.local_addr().unwrap().port();
+    let port = listener
+        .local_addr()
+        .expect("failed to get local address of login http listener")
+        .port();
     let redirect_uri = format!("http://localhost:{port}/callback");
 
     let (result_send, mut result_recv) = mpsc::channel(1);


### PR DESCRIPTION
I will admit that this PR nearly broke me. Tunnel was *heavily* relying on the tower::Service semantics where poll_ready would be called repeatedly between HTTP requests, to process the trailers handshake that forms part of the protocol. To replace it I have used a tokio RWLock and a cancellation token

![image](https://github.com/user-attachments/assets/9b09e413-1929-4c6e-a6a7-7ae1a14294a1)
