### PR TITLE
[Bifrost] Loglet read stream with known tail lsn

### DIFF
--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -123,7 +123,7 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
 
     /// An optional optimization that loglets can implement. Offsets returned by this call **MUST**
     /// be offsets that were observed before a sealing point. For instance, the maximum acknowleged
-    /// append offset, or, the cached result of the last `find_tail` call that returned an Open
+    /// append offset + 1, or the result of the last `find_tail` call that returned a `TailState::Open(tail)`
     /// result.
     fn last_known_unsealed_tail(&self) -> Option<Self::Offset> {
         // default implementation that will require upper layers to call find_tail or do their own


### PR DESCRIPTION
[Bifrost] Loglet read stream with known tail lsn

Loglet wrapper now limits reads if the loglet sealed tail is known

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1742).
* #1757
* #1753
* #1747
* #1744
* #1743
* __->__ #1742