### PR TITLE
[Bifrost] Introduces SegmentIndex to identify segments in the log chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5439,6 +5439,7 @@ dependencies = [
  "humantime",
  "metrics 0.23.0",
  "once_cell",
+ "parking_lot",
  "pin-project",
  "restate-core",
  "restate-metadata-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ test-log = { version = "0.2.11", default-features = false, features = ["trace"] 
 # tikv-jemallocator has not yet been released with musl target support, so we pin a main commit
 tikv-jemallocator = { git = "https://github.com/restatedev/jemallocator", rev = "7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0", default-features = false }
 thiserror = "1.0"
-tokio = { version = "1.39.1", default-features = false, features = ["rt-multi-thread", "signal", "macros", ] }
+tokio = { version = "1.39.1", default-features = false, features = ["rt-multi-thread", "signal", "macros", "parking_lot" ] }
 tokio-stream = "0.1.15"
 tokio-util = { version = "0.7.11" }
 tonic = { version = "0.12.1", default-features = false }

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -31,6 +31,7 @@ futures = { workspace = true }
 humantime = { workspace = true }
 metrics = { workspace = true }
 once_cell = { workspace = true }
+parking_lot = { workspace = true }
 pin-project = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -128,15 +128,15 @@ impl Bifrost {
     ///        log_id,
     ///        bifrost.get_trim_point(log_id).await.next(),
     ///        bifrost.find_tail(log_id).await().offset().prev(),
-    ///     ).await;
+    ///     );
     /// ```
-    pub async fn create_reader(
+    pub fn create_reader(
         &self,
         log_id: LogId,
         start_lsn: Lsn,
         end_lsn: Lsn,
     ) -> Result<LogReadStream> {
-        LogReadStream::create(self.inner.clone(), log_id, start_lsn, end_lsn).await
+        LogReadStream::create(self.inner.clone(), log_id, start_lsn, end_lsn)
     }
 
     /// The tail is *the first unwritten LSN* in the log
@@ -200,9 +200,7 @@ impl Bifrost {
             return Ok(Vec::default());
         }
 
-        let reader = self
-            .create_reader(log_id, Lsn::OLDEST, current_tail.offset().prev())
-            .await?;
+        let reader = self.create_reader(log_id, Lsn::OLDEST, current_tail.offset().prev())?;
         reader.try_collect().await
     }
 }
@@ -213,7 +211,7 @@ static_assertions::assert_impl_all!(Bifrost: Send, Sync, Clone);
 // Locks in this data-structure are held for very short time and should never be
 // held across an async boundary.
 pub struct BifrostInner {
-    metadata: Metadata,
+    pub(crate) metadata: Metadata,
     #[allow(unused)]
     watchdog: WatchdogSender,
     // Initialized after BifrostService::start completes.

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -27,3 +27,14 @@ pub use service::BifrostService;
 pub use types::*;
 
 pub const SMALL_BATCH_THRESHOLD_COUNT: usize = 4;
+
+#[cfg(test)]
+pub(crate) fn setup_panic_handler() {
+    // Make sure that panics exits the process.
+    let orig_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        // invoke the default handler and exit the process
+        orig_hook(panic_info);
+        std::process::exit(1);
+    }));
+}

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -25,17 +25,7 @@ use tracing::info;
 
 use super::{Loglet, LogletOffset};
 use crate::loglet::AppendError;
-use crate::{LogRecord, Record, TailState, TrimGap};
-
-fn setup() {
-    // Make sure that panics exits the process.
-    let orig_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panic_info| {
-        // invoke the default handler and exit the process
-        orig_hook(panic_info);
-        std::process::exit(1);
-    }));
-}
+use crate::{setup_panic_handler, LogRecord, Record, TailState, TrimGap};
 
 async fn wait_for_trim(
     loglet: &Arc<dyn Loglet>,
@@ -65,7 +55,7 @@ async fn wait_for_trim(
 /// is started, initialized, and ready for reads and writes. It also assumes that this loglet
 /// provide contiguous offsets that start from LogletOffset::OLDEST.
 pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
-    setup();
+    setup_panic_handler();
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -211,7 +201,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
 /// is started, initialized, and ready for reads and writes. It also assumes that this loglet
 /// starts from LogletOffset::OLDEST.
 pub async fn single_loglet_readstream_test(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
-    setup();
+    setup_panic_handler();
 
     let read_from_offset = LogletOffset::from(6);
     let mut reader = loglet
@@ -283,7 +273,7 @@ pub async fn single_loglet_readstream_test(loglet: Arc<dyn Loglet>) -> googletes
 pub async fn single_loglet_readstream_test_with_trims(
     loglet: Arc<dyn Loglet>,
 ) -> googletest::Result<()> {
-    setup();
+    setup_panic_handler();
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -397,7 +387,7 @@ pub async fn single_loglet_readstream_test_with_trims(
 
 /// Validates that appends fail after find_tail() returned Sealed()
 pub async fn loglet_test_append_after_seal(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
-    setup();
+    setup_panic_handler();
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -435,7 +425,7 @@ pub async fn loglet_test_append_after_seal_concurrent(
     const WARMUP_APPENDS: usize = 200;
     const CONCURRENT_APPENDERS: usize = 20;
 
-    setup();
+    setup_panic_handler();
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -123,7 +123,7 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
 
     /// An optional optimization that loglets can implement. Offsets returned by this call **MUST**
     /// be offsets that were observed before a sealing point. For instance, the maximum acknowleged
-    /// append offset, or, the cached result of the last `find_tail` call that returned an Open
+    /// append offset + 1, or the result of the last `find_tail` call that returned a `TailState::Open(tail)`
     /// result.
     fn last_known_unsealed_tail(&self) -> Option<Self::Offset> {
         // default implementation that will require upper layers to call find_tail or do their own

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod util;
 
 // exports
 pub use error::*;
+use futures::stream::BoxStream;
 pub use provider::{LogletProvider, LogletProviderFactory};
 
 use std::ops::Add;
@@ -130,6 +131,19 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
         // caching.
         None
     }
+
+    /// Create a stream watching the state of tail for this loglet
+    ///
+    /// The stream will return the last known TailState with seal notification semantics
+    /// similar to `find_tail()` except that it won't trigger a linearizable tail check when
+    /// polled. This can be used as a trailing tail indicator.
+    ///
+    /// Note that it's legal to observe the last unsealed tail becoming sealed. The
+    /// last_known_unsealed (or the last unsealed offset emitted on this stream) defines the
+    /// point at which readers should stop **before**, therefore, when reading, if the next offset
+    /// to read == the tail, it means that you can only read this offset if the tail watch moves
+    /// beyond it to a higher tail while remaining unsealed.
+    fn watch_tail(&self) -> BoxStream<'static, TailState<Self::Offset>>;
 
     /// Append a batch of records to the loglet. The returned offset (on success) if the offset of
     /// the first record in the batch)

--- a/crates/bifrost/src/loglet/provider.rs
+++ b/crates/bifrost/src/loglet/provider.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use restate_types::logs::metadata::{LogletParams, ProviderKind};
+use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::LogId;
 
 use super::{Loglet, OperationError};
 use crate::Result;
@@ -29,7 +30,12 @@ pub trait LogletProviderFactory: Send + 'static {
 #[async_trait]
 pub trait LogletProvider: Send + Sync {
     /// Create a loglet client for a given segment and configuration.
-    async fn get_loglet(&self, params: &LogletParams) -> Result<Arc<dyn Loglet>>;
+    async fn get_loglet(
+        &self,
+        log_id: LogId,
+        segment_index: SegmentIndex,
+        params: &LogletParams,
+    ) -> Result<Arc<dyn Loglet>>;
 
     /// A hook that's called after provider is started.
     async fn post_start(&self) {}

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -208,7 +208,6 @@ impl LogletBase for LogletWrapper {
 /// Wraps loglet read streams with the base LSN of the segment
 pub struct LogletReadStreamWrapper {
     pub(crate) base_lsn: Lsn,
-    #[allow(dead_code)]
     loglet: LogletWrapper,
     inner_read_stream: SendableLogletReadStream<LogletOffset>,
 }
@@ -228,18 +227,15 @@ impl LogletReadStreamWrapper {
 
     /// The first LSN outside the boundary of this stream (bifrost's tail semantics)
     /// The read stream will return None and terminate before it reads this LSN
-    #[allow(dead_code)]
     #[inline(always)]
     pub fn tail_lsn(&self) -> Option<Lsn> {
         self.loglet.tail_lsn
     }
 
-    #[allow(dead_code)]
     pub fn set_tail_lsn(&mut self, tail_lsn: Lsn) {
         self.loglet.set_tail_lsn(tail_lsn)
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     pub fn loglet(&self) -> &LogletWrapper {
         &self.loglet

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -18,6 +18,7 @@ mod read_stream;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::BoxStream;
 pub use log_store::LogStoreError;
 use metrics::{counter, histogram, Histogram};
 pub use provider::Factory;
@@ -42,7 +43,7 @@ use self::log_store::RocksDbLogStore;
 use self::log_store_writer::RocksDbLogWriterHandle;
 use self::metric_definitions::{BIFROST_LOCAL_APPEND, BIFROST_LOCAL_APPEND_DURATION};
 use self::read_stream::LocalLogletReadStream;
-use crate::loglet::util::OffsetWatch;
+use crate::loglet::util::TailOffsetWatch;
 
 struct LocalLoglet {
     loglet_id: u64,
@@ -56,7 +57,8 @@ struct LocalLoglet {
     last_committed_offset: AtomicU64,
     next_write_offset: Mutex<LogletOffset>,
     sealed: AtomicBool,
-    release_watch: OffsetWatch,
+    // watches the tail state of this loglet
+    tail_watch: TailOffsetWatch,
     append_latency: Histogram,
 }
 
@@ -101,7 +103,10 @@ impl LocalLoglet {
             next_write_offset,
             last_committed_offset,
             sealed,
-            release_watch: OffsetWatch::new(release_pointer),
+            tail_watch: TailOffsetWatch::new(TailState::new(
+                log_state.seal,
+                release_pointer.next(),
+            )),
             append_latency,
         };
         debug!(
@@ -115,8 +120,9 @@ impl LocalLoglet {
     }
 
     #[inline]
-    fn notify_readers(&self, release_pointer: LogletOffset) {
-        self.release_watch.notify(release_pointer);
+    fn notify_readers(&self, sealed: bool, release_pointer: LogletOffset) {
+        // tail is beyond the release pointer
+        self.tail_watch.notify(sealed, release_pointer.next());
     }
 
     fn read_from(
@@ -200,6 +206,10 @@ impl LogletBase for LocalLoglet {
         ))
     }
 
+    fn watch_tail(&self) -> BoxStream<'static, TailState<Self::Offset>> {
+        Box::pin(self.tail_watch.to_stream())
+    }
+
     async fn append(&self, payload: Bytes) -> Result<LogletOffset, AppendError> {
         // An initial check if we are sealed or not, we are not worried about accepting an
         // append while sealing is taking place. We only care about *not* acknowledging
@@ -240,10 +250,11 @@ impl LogletBase for LocalLoglet {
                 .fetch_max(offset.into(), Ordering::AcqRel)
                 .max(offset.into()),
         );
-        self.notify_readers(release_pointer);
+        let is_sealed = self.sealed.load(Ordering::Relaxed);
+        self.notify_readers(is_sealed, release_pointer);
         // Ensure that we don't acknowledge the append (even that it has happened) if the loglet
         // has been sealed already.
-        if self.sealed.load(Ordering::Relaxed) {
+        if is_sealed {
             return Err(AppendError::Sealed);
         }
         self.append_latency.record(start_time.elapsed());
@@ -291,10 +302,11 @@ impl LogletBase for LocalLoglet {
                 .fetch_max(offset.into(), Ordering::AcqRel)
                 .max(offset.into()),
         );
-        self.notify_readers(release_pointer);
-        // Ensure that we don't acknowledge the append (albeit durable) if the loglet
+        let is_sealed = self.sealed.load(Ordering::Relaxed);
+        self.notify_readers(is_sealed, release_pointer);
+        // Ensure that we don't acknowledge the append (even that it has happened) if the loglet
         // has been sealed already.
-        if self.sealed.load(Ordering::Relaxed) {
+        if is_sealed {
             return Err(AppendError::Sealed);
         }
         self.append_latency.record(start_time.elapsed());
@@ -370,6 +382,8 @@ impl LogletBase for LocalLoglet {
             Err(ShutdownError.into())
         })?;
         self.sealed.store(true, Ordering::Relaxed);
+        self.tail_watch.notify_seal();
+
         Ok(())
     }
 
@@ -383,7 +397,7 @@ impl LogletBase for LocalLoglet {
                 break Ok(next_record);
             }
             // Wait and respond when available.
-            self.release_watch.wait_for(from).await?;
+            self.tail_watch.wait_for(from).await?;
         }
     }
 

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -75,7 +75,7 @@ impl std::fmt::Debug for LocalLoglet {
 }
 
 impl LocalLoglet {
-    pub async fn create(
+    pub fn create(
         loglet_id: u64,
         log_store: RocksDbLogStore,
         log_writer: RocksDbLogWriterHandle,
@@ -445,17 +445,14 @@ mod tests {
                     .create_writer()
                     .start(config.clone().map(|c| &c.bifrost.local).boxed())?;
 
-                let loglet = Arc::new(
-                    LocalLoglet::create(
-                        params
-                            .as_str()
-                            .parse()
-                            .expect("loglet params can be converted into u64"),
-                        log_store,
-                        log_writer,
-                    )
-                    .await?,
-                );
+                let loglet = Arc::new(LocalLoglet::create(
+                    params
+                        .as_str()
+                        .parse()
+                        .expect("loglet params can be converted into u64"),
+                    log_store,
+                    log_writer,
+                )?);
 
                 gapless_loglet_smoke_test(loglet).await?;
                 Ok(())
@@ -487,17 +484,14 @@ mod tests {
                     .create_writer()
                     .start(config.clone().map(|c| &c.bifrost.local).boxed())?;
 
-                let loglet = Arc::new(
-                    LocalLoglet::create(
-                        params
-                            .as_str()
-                            .parse()
-                            .expect("loglet params can be converted into u64"),
-                        log_store,
-                        log_writer,
-                    )
-                    .await?,
-                );
+                let loglet = Arc::new(LocalLoglet::create(
+                    params
+                        .as_str()
+                        .parse()
+                        .expect("loglet params can be converted into u64"),
+                    log_store,
+                    log_writer,
+                )?);
 
                 single_loglet_readstream_test(loglet).await?;
                 Ok(())
@@ -529,17 +523,14 @@ mod tests {
                     .create_writer()
                     .start(config.clone().map(|c| &c.bifrost.local).boxed())?;
 
-                let loglet = Arc::new(
-                    LocalLoglet::create(
-                        params
-                            .as_str()
-                            .parse()
-                            .expect("loglet params can be converted into u64"),
-                        log_store,
-                        log_writer,
-                    )
-                    .await?,
-                );
+                let loglet = Arc::new(LocalLoglet::create(
+                    params
+                        .as_str()
+                        .parse()
+                        .expect("loglet params can be converted into u64"),
+                    log_store,
+                    log_writer,
+                )?);
 
                 single_loglet_readstream_test_with_trims(loglet).await?;
                 Ok(())
@@ -570,17 +561,14 @@ mod tests {
                     .create_writer()
                     .start(config.clone().map(|c| &c.bifrost.local).boxed())?;
 
-                let loglet = Arc::new(
-                    LocalLoglet::create(
-                        params
-                            .as_str()
-                            .parse()
-                            .expect("loglet params can be converted into u64"),
-                        log_store,
-                        log_writer,
-                    )
-                    .await?,
-                );
+                let loglet = Arc::new(LocalLoglet::create(
+                    params
+                        .as_str()
+                        .parse()
+                        .expect("loglet params can be converted into u64"),
+                    log_store,
+                    log_writer,
+                )?);
 
                 loglet_test_append_after_seal(loglet).await?;
                 Ok(())
@@ -613,9 +601,11 @@ mod tests {
 
                 // Run the test 10 times
                 for i in 1..=10 {
-                    let loglet = Arc::new(
-                        LocalLoglet::create(i, log_store.clone(), log_writer.clone()).await?,
-                    );
+                    let loglet = Arc::new(LocalLoglet::create(
+                        i,
+                        log_store.clone(),
+                        log_writer.clone(),
+                    )?);
                     loglet_test_append_after_seal_concurrent(loglet).await?;
                 }
 

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -12,7 +12,7 @@ use std::collections::{hash_map, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::sync::Mutex as AsyncMutex;
+use parking_lot::Mutex;
 use tracing::debug;
 
 use restate_types::config::{LocalLogletOptions, RocksDbOptions};
@@ -71,7 +71,7 @@ impl LogletProviderFactory for Factory {
 
 pub(crate) struct LocalLogletProvider {
     log_store: RocksDbLogStore,
-    active_loglets: AsyncMutex<HashMap<String, Arc<LocalLoglet>>>,
+    active_loglets: Mutex<HashMap<String, Arc<LocalLoglet>>>,
     log_writer: RocksDbLogWriterHandle,
 }
 
@@ -81,7 +81,7 @@ impl LogletProvider for LocalLogletProvider {
         &self,
         params: &LogletParams,
     ) -> Result<Arc<dyn Loglet<Offset = LogletOffset>>, Error> {
-        let mut guard = self.active_loglets.lock().await;
+        let mut guard = self.active_loglets.lock();
         let loglet = match guard.entry(params.as_str().to_owned()) {
             hash_map::Entry::Vacant(entry) => {
                 // Create loglet
@@ -93,8 +93,7 @@ impl LogletProvider for LocalLogletProvider {
                         .expect("loglet params can be converted into u64"),
                     self.log_store.clone(),
                     self.log_writer.clone(),
-                )
-                .await?;
+                )?;
                 let loglet = entry.insert(Arc::new(loglet));
                 Arc::clone(loglet)
             }

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -17,7 +17,8 @@ use tracing::debug;
 
 use restate_types::config::{LocalLogletOptions, RocksDbOptions};
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::metadata::{LogletParams, ProviderKind};
+use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::LogId;
 
 use super::log_store::RocksDbLogStore;
 use super::log_store_writer::RocksDbLogWriterHandle;
@@ -71,7 +72,7 @@ impl LogletProviderFactory for Factory {
 
 pub(crate) struct LocalLogletProvider {
     log_store: RocksDbLogStore,
-    active_loglets: Mutex<HashMap<String, Arc<LocalLoglet>>>,
+    active_loglets: Mutex<HashMap<(LogId, SegmentIndex), Arc<LocalLoglet>>>,
     log_writer: RocksDbLogWriterHandle,
 }
 
@@ -79,10 +80,12 @@ pub(crate) struct LocalLogletProvider {
 impl LogletProvider for LocalLogletProvider {
     async fn get_loglet(
         &self,
+        log_id: LogId,
+        segment_index: SegmentIndex,
         params: &LogletParams,
     ) -> Result<Arc<dyn Loglet<Offset = LogletOffset>>, Error> {
         let mut guard = self.active_loglets.lock();
-        let loglet = match guard.entry(params.as_str().to_owned()) {
+        let loglet = match guard.entry((log_id, segment_index)) {
             hash_map::Entry::Vacant(entry) => {
                 // Create loglet
                 // NOTE: local-loglet expects params to be a `u64` string-encoded unique identifier under the hood.

--- a/crates/bifrost/src/providers/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/providers/local_loglet/read_stream.rs
@@ -14,19 +14,19 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use bytes::{BufMut, Bytes, BytesMut};
+use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use pin_project::pin_project;
 use rocksdb::{DBRawIteratorWithThreadMode, DB};
-use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, warn};
 
 use restate_core::ShutdownError;
 use restate_rocksdb::RocksDbPerfGuard;
 use restate_types::logs::SequenceNumber;
 
-use crate::loglet::{LogletOffset, LogletReadStream, OperationError};
+use crate::loglet::{LogletBase, LogletOffset, LogletReadStream, OperationError};
 use crate::providers::local_loglet::LogStoreError;
-use crate::{LogRecord, Result};
+use crate::{LogRecord, Result, TailState};
 
 use super::keys::RecordKey;
 use super::LocalLoglet;
@@ -34,18 +34,21 @@ use super::LocalLoglet;
 #[pin_project]
 pub(crate) struct LocalLogletReadStream {
     log_id: u64,
-    loglet: Arc<LocalLoglet>,
     // the next record this stream will attempt to read
     read_pointer: LogletOffset,
-    release_pointer: LogletOffset,
+    /// stop when read_pointer is at or beyond this offset
+    last_known_tail: LogletOffset,
     /// Last offset to read before terminating the stream. None means "tailing" reader.
     read_to: Option<LogletOffset>,
     #[pin]
     iterator: DBRawIteratorWithThreadMode<'static, DB>,
     #[pin]
-    release_watch: WatchStream<LogletOffset>,
+    tail_watch: BoxStream<'static, TailState<LogletOffset>>,
     #[pin]
     terminated: bool,
+    // IMPORTANT: Do not reorder, this should be dropped last since `iterator` holds a reference
+    // into the underlying database.
+    loglet: Arc<LocalLoglet>,
 }
 
 // ## Safety
@@ -87,11 +90,12 @@ impl LocalLogletReadStream {
         read_opts.set_iterate_upper_bound(RecordKey::upper_bound(loglet.loglet_id).to_bytes());
 
         let log_store = &loglet.log_store;
-        let mut release_watch = loglet.release_watch.to_stream();
-        let release_pointer = release_watch
+        let mut tail_watch = loglet.watch_tail();
+        let last_known_tail = tail_watch
             .next()
             .await
-            .expect("loglet watch returns release pointer");
+            .expect("loglet watch returns tail pointer")
+            .offset();
 
         // ## Safety:
         // the iterator is guaranteed to be dropped before the loglet is dropped, we hold to the
@@ -112,8 +116,8 @@ impl LocalLogletReadStream {
             read_pointer: from_offset,
             iterator: iter,
             terminated: false,
-            release_watch,
-            release_pointer,
+            tail_watch,
+            last_known_tail,
             read_to: to,
         })
     }
@@ -154,8 +158,8 @@ impl Stream for LocalLogletReadStream {
             }
             // Are we reading after commit offset?
             // We are at tail. We need to wait until new records have been released.
-            if next_offset > *this.release_pointer {
-                let updated_release_pointer = match this.release_watch.poll_next(cx) {
+            if next_offset >= *this.last_known_tail {
+                let maybe_tail_state = match this.tail_watch.poll_next(cx) {
                     Poll::Ready(t) => t,
                     Poll::Pending => {
                         perf_guard.forget();
@@ -163,9 +167,9 @@ impl Stream for LocalLogletReadStream {
                     }
                 };
 
-                match updated_release_pointer {
-                    Some(updated_release_pointer) => {
-                        *this.release_pointer = updated_release_pointer;
+                match maybe_tail_state {
+                    Some(tail_state) => {
+                        *this.last_known_tail = tail_state.offset();
                         continue;
                     }
                     None => {
@@ -175,11 +179,11 @@ impl Stream for LocalLogletReadStream {
                     }
                 }
             }
-            // release_pointer has been updated.
-            let release_pointer = *this.release_pointer;
+            // tail has been updated.
+            let last_known_tail = *this.last_known_tail;
 
-            // assert that we are newer
-            assert!(release_pointer >= next_offset);
+            // assert that we are behind tail
+            assert!(last_known_tail > next_offset);
 
             // Trim point is the the slot **before** the first readable record (if it exists)
             // trim point might have been updated since last time.
@@ -225,7 +229,7 @@ impl Stream for LocalLogletReadStream {
                     log_id = *this.log_id,
                     next_offset = %next_offset,
                     trim_point = %potentially_different_trim_point,
-                    release_pointer = %this.release_pointer,
+                    last_known_tail = %this.last_known_tail,
                     "poll_next() has moved to a non-existent record, that should not happen!"
                 );
                 panic!("poll_next() has moved to a non-existent record, that should not happen!");

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -11,23 +11,24 @@
 use std::collections::{hash_map, HashMap};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::task::ready;
 use std::task::Poll;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::BoxStream;
 use futures::Stream;
 use pin_project::pin_project;
 use restate_core::ShutdownError;
 use tokio::sync::Mutex as AsyncMutex;
-use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamExt;
 use tracing::{debug, info};
 
 use restate_types::logs::metadata::{LogletParams, ProviderKind};
 use restate_types::logs::SequenceNumber;
 
-use crate::loglet::util::OffsetWatch;
+use crate::loglet::util::TailOffsetWatch;
 use crate::loglet::{
     AppendError, Loglet, LogletBase, LogletOffset, LogletProvider, LogletProviderFactory,
     LogletReadStream, OperationError, SendableLogletReadStream,
@@ -110,7 +111,8 @@ pub struct MemoryLoglet {
     trim_point_offset: AtomicU64,
     last_committed_offset: AtomicU64,
     sealed: AtomicBool,
-    release_watch: OffsetWatch,
+    // watches the tail state of ths loglet
+    tail_watch: TailOffsetWatch,
 }
 
 impl MemoryLoglet {
@@ -122,7 +124,7 @@ impl MemoryLoglet {
             trim_point_offset: AtomicU64::new(0),
             last_committed_offset: AtomicU64::new(0),
             sealed: AtomicBool::new(false),
-            release_watch: OffsetWatch::new(LogletOffset::INVALID),
+            tail_watch: TailOffsetWatch::new(TailState::new(false, LogletOffset::OLDEST)),
         })
     }
 
@@ -144,7 +146,9 @@ impl MemoryLoglet {
 
     fn notify_readers(&self) {
         let release_pointer = LogletOffset(self.last_committed_offset.load(Ordering::Relaxed));
-        self.release_watch.notify(release_pointer);
+        // Note: We always notify with false here and the watcher will ignore it if it has observed
+        // a previous seal.
+        self.tail_watch.notify(false, release_pointer.next());
     }
 
     fn read_from(
@@ -179,9 +183,9 @@ struct MemoryReadStream {
     /// The next offset to read from
     read_pointer: LogletOffset,
     #[pin]
-    release_watch: WatchStream<LogletOffset>,
-    /// how far we are allowed to read in the loglet
-    release_pointer: LogletOffset,
+    tail_watch: BoxStream<'static, TailState<LogletOffset>>,
+    /// stop when read_pointer is at or beyond this offset
+    last_known_tail: LogletOffset,
     /// Last offset to read before terminating the stream. None means "tailing" reader.
     read_to: Option<LogletOffset>,
     #[pin]
@@ -194,17 +198,18 @@ impl MemoryReadStream {
         from_offset: LogletOffset,
         to: Option<LogletOffset>,
     ) -> Self {
-        let mut release_watch = loglet.release_watch.to_stream();
-        let release_pointer = release_watch
+        let mut tail_watch = loglet.watch_tail();
+        let last_known_tail = tail_watch
             .next()
             .await
-            .expect("loglet watch returns release pointer");
+            .expect("loglet watch returns tail pointer")
+            .offset();
 
         Self {
             loglet,
             read_pointer: from_offset,
-            release_watch,
-            release_pointer,
+            tail_watch,
+            last_known_tail,
             read_to: to,
             terminated: false,
         }
@@ -246,17 +251,10 @@ impl Stream for MemoryReadStream {
 
             // Are we reading after commit offset?
             // We are at tail. We need to wait until new records have been released.
-            if next_offset > *this.release_pointer {
-                let updated_release_pointer = match this.release_watch.poll_next(cx) {
-                    Poll::Ready(t) => t,
-                    Poll::Pending => {
-                        return Poll::Pending;
-                    }
-                };
-
-                match updated_release_pointer {
-                    Some(updated_release_pointer) => {
-                        *this.release_pointer = updated_release_pointer;
+            if next_offset >= *this.last_known_tail {
+                match ready!(this.tail_watch.poll_next(cx)) {
+                    Some(tail_state) => {
+                        *this.last_known_tail = tail_state.offset();
                         continue;
                     }
                     None => {
@@ -267,11 +265,11 @@ impl Stream for MemoryReadStream {
                 }
             }
 
-            // release_pointer has been updated.
-            let release_pointer = *this.release_pointer;
+            // tail has been updated.
+            let last_known_tail = *this.last_known_tail;
 
-            // assert that we are newer
-            assert!(release_pointer >= next_offset);
+            // assert that we are behind tail
+            assert!(last_known_tail > next_offset);
 
             // Trim point is the the slot **before** the first readable record (if it exists)
             // trim point might have been updated since last time.
@@ -313,6 +311,10 @@ impl LogletBase for MemoryLoglet {
         Ok(Box::pin(MemoryReadStream::create(self, from, to).await))
     }
 
+    fn watch_tail(&self) -> BoxStream<'static, TailState<Self::Offset>> {
+        Box::pin(self.tail_watch.to_stream())
+    }
+
     async fn append(&self, payload: Bytes) -> Result<LogletOffset, AppendError> {
         let mut log = self.log.lock().unwrap();
         if self.sealed.load(Ordering::Relaxed) {
@@ -352,8 +354,8 @@ impl LogletBase for MemoryLoglet {
 
     async fn find_tail(&self) -> Result<TailState<LogletOffset>, OperationError> {
         let _guard = self.log.lock().unwrap();
-        let sealed = self.sealed.load(Ordering::Relaxed);
         let committed = LogletOffset(self.last_committed_offset.load(Ordering::Relaxed)).next();
+        let sealed = self.sealed.load(Ordering::Relaxed);
         Ok(if sealed {
             TailState::Sealed(committed)
         } else {
@@ -397,6 +399,7 @@ impl LogletBase for MemoryLoglet {
         // Ensures no in-flight operations are taking place.
         let _guard = self.log.lock().unwrap();
         self.sealed.store(true, Ordering::Relaxed);
+        self.tail_watch.notify_seal();
         Ok(())
     }
 
@@ -410,7 +413,7 @@ impl LogletBase for MemoryLoglet {
                 break Ok(next_record);
             }
             // Wait and respond when available.
-            self.release_watch.wait_for(from).await?;
+            self.tail_watch.wait_for(from).await?;
         }
     }
 

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -21,7 +21,8 @@ use restate_core::Metadata;
 use restate_metadata_store::MetadataStoreClient;
 use restate_types::config::ReplicatedLogletOptions;
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::metadata::{LogletParams, ProviderKind};
+use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::LogId;
 
 use super::metric_definitions;
 use crate::loglet::{Loglet, LogletOffset, LogletProvider, LogletProviderFactory, OperationError};
@@ -70,6 +71,8 @@ impl LogletProvider for ReplicatedLogletProvider {
     async fn get_loglet(
         &self,
         // todo: we need richer params
+        _log_id: LogId,
+        _segment_index: SegmentIndex,
         _params: &LogletParams,
     ) -> Result<Arc<dyn Loglet<Offset = LogletOffset>>, Error> {
         todo!("Not implemented yet")

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -8,81 +8,115 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::ready;
 use std::task::Poll;
 
+use futures::future::BoxFuture;
+use futures::stream::BoxStream;
 use futures::stream::FusedStream;
 use futures::Stream;
 use pin_project::pin_project;
 
+use restate_core::MetadataKind;
+use restate_core::ShutdownError;
+use restate_types::logs::metadata::MaybeSegment;
 use restate_types::logs::SequenceNumber;
 use restate_types::logs::{LogId, Lsn};
+use restate_types::Version;
+use restate_types::Versioned;
 
 use crate::bifrost::BifrostInner;
+use crate::loglet::LogletBase;
 use crate::loglet_wrapper::LogletReadStreamWrapper;
 use crate::loglet_wrapper::LogletWrapper;
-use crate::FindTailAttributes;
+use crate::Error;
 use crate::LogRecord;
 use crate::Result;
+use crate::TailState;
 
+/// A read stream reads from the virtual log. The stream provides a unified view over
+/// the virtual log addressing space in the face of seals, reconfiguration, and trims.
+///
+// The use of [pin_project] is not strictly necessary but it's left to allow future
+// substream implementations to be !Unpin without changing the read_stream.
+#[must_use = "streams do nothing unless polled"]
 #[pin_project]
 pub struct LogReadStream {
-    #[pin]
-    current_loglet_stream: LogletReadStreamWrapper,
-    current_loglet: LogletWrapper,
-    inner: Arc<BifrostInner>,
-    _last_known_tail: Lsn,
     log_id: LogId,
-    // inclusive max lsn to read to
+    /// inclusive max LSN to read to
     end_lsn: Lsn,
-    terminated: bool,
-    /// Represents the next possible record to be read.
-    //  This is akin to the lsn that can be passed to `read(from)` to read the
-    //  next record in the log.
+    /// Represents the next record to read.
+    ///
+    ///  This is akin to the lsn that can be passed to `read(from)` to read the
+    ///  next record in the log.
     read_pointer: Lsn,
+    #[pin]
+    state: State,
+    /// Current substream we are reading from
+    #[pin]
+    substream: Option<LogletReadStreamWrapper>,
+    // IMPORTANT: Do not re-order this field. `inner` must be dropped last. This allows
+    // `state` to reference its lifetime as 'static.
+    bifrost_inner: Arc<BifrostInner>,
+}
+
+/// The state machine encodes the necessary state changes in the read stream.
+/// The order of variants roughly reflects the order of transitions in a typical case.
+///
+#[pin_project(project = StateProj)]
+enum State {
+    /// Initial state of the stream. No work has been done at this point
+    New,
+    /// Stream is waiting for bifrost to get a loglet that maps to the `read_pointer`
+    FindingLoglet {
+        /// The future to continue finding the loglet instance via Bifrost
+        #[pin]
+        find_loglet_fut: BoxFuture<'static, Result<LogletWrapper>>,
+    },
+    /// Waiting for the loglet read stream (substream) to be initialized
+    CreatingSubstream {
+        /// Future to continue creating the substream
+        #[pin]
+        create_stream_fut: BoxFuture<'static, Result<LogletReadStreamWrapper>>,
+    },
+    /// Reading records from `substream`
+    Reading {
+        /// The tail LSN which is safe to use when the loglet is unsealed
+        safe_known_tail: Option<Lsn>,
+        #[pin]
+        tail_watch: Option<BoxStream<'static, TailState>>,
+    },
+    /// Waiting for the tail LSN of the substream's loglet to be determined (sealing in-progress)
+    AwaitingReconfiguration {
+        /// Future to continue waiting on log metadata updates
+        #[pin]
+        log_metadata_watch_fut: Option<BoxFuture<'static, Result<Version, ShutdownError>>>,
+    },
+    Terminated,
 }
 
 impl LogReadStream {
-    pub(crate) async fn create(
-        inner: Arc<BifrostInner>,
+    pub(crate) fn create(
+        bifrost_inner: Arc<BifrostInner>,
         log_id: LogId,
         start_lsn: Lsn,
-        // Inclusive. Use Lsn::MAX for a tailing stream. Once reached, stream will terminate
-        // (return Ready(None)).
+        // Inclusive. Use [`Lsn::MAX`] for a tailing stream.
+        // Once reached, the stream terminates.
         end_lsn: Lsn,
     ) -> Result<Self> {
         // Accidental reads from Lsn::INVALID are reset to Lsn::OLDEST
         let start_lsn = std::cmp::max(Lsn::OLDEST, start_lsn);
-        // todo: support switching loglets. At the moment, this is hard-wired to a single loglet
-        // implementation.
-        let current_loglet = inner
-            // find the loglet where the _next_ lsn resides.
-            .find_loglet_for_lsn(log_id, start_lsn)
-            .await?;
-        let (last_loglet, last_known_tail) = inner
-            .find_tail(log_id, FindTailAttributes::default())
-            .await?;
-        debug_assert_eq!(last_loglet, current_loglet);
-
-        let current_loglet_stream = current_loglet.create_wrapped_read_stream(start_lsn).await?;
         Ok(Self {
-            current_loglet_stream,
-            // reserved for future use
-            current_loglet: last_loglet,
-            // reserved for future use
-            _last_known_tail: last_known_tail.offset(),
-            inner,
+            bifrost_inner,
             log_id,
             read_pointer: start_lsn,
             end_lsn,
-            terminated: false,
+            substream: None,
+            state: State::New,
         })
-    }
-
-    pub fn is_terminated(&self) -> bool {
-        self.terminated
     }
 
     /// Current read pointer. This is the next (possible) record to be read.
@@ -90,8 +124,13 @@ impl LogReadStream {
         self.read_pointer
     }
 
-    /// The read pointer will point to the potential next LSN that we will read from on the next
-    /// poll_next() call.
+    /// Inclusive max LSN to read to
+    pub fn end_lsn(&self) -> Lsn {
+        self.end_lsn
+    }
+
+    /// The read pointer points to the next LSN will be attempted on the next
+    /// `poll_next()`.
     fn calculate_read_pointer(record: &LogRecord) -> Lsn {
         match &record.record {
             // On trim gaps, we fast-forward the read pointer beyond the end of the gap. We do
@@ -106,13 +145,13 @@ impl LogReadStream {
 
 impl FusedStream for LogReadStream {
     fn is_terminated(&self) -> bool {
-        self.terminated
+        matches!(self.state, State::Terminated)
     }
 }
 
-/// Read the next record from the log after the current read pointer. The stream will yield
+/// Read the next record from the log at the current read pointer. The stream will yield
 /// after the record is available to read, this will async-block indefinitely if no records are
-/// ever written to the log beyond the read pointer.
+/// ever written and released at the read pointer.
 impl Stream for LogReadStream {
     type Item = Result<LogRecord>;
 
@@ -120,33 +159,244 @@ impl Stream for LogReadStream {
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        if self.read_pointer > self.end_lsn {
-            self.as_mut().terminated = true;
-            return Poll::Ready(None);
-        }
-        // Are we after the known tail?
-        // todo: refresh the tail (in a multi-loglet universe)
-        let maybe_record = ready!(self
-            .as_mut()
-            .project()
-            .current_loglet_stream
-            .as_mut()
-            .poll_next(cx));
-        match maybe_record {
-            Some(Ok(record)) => {
-                let record = record
-                    .decode()
-                    .expect("decoding a bifrost envelope succeeds");
-                let new_pointer = Self::calculate_read_pointer(&record);
-                debug_assert!(new_pointer > self.read_pointer);
-                self.read_pointer = new_pointer;
-                Poll::Ready(Some(Ok(record)))
+        // # Safety
+        // BifrostInner is dropped last, we can safely lift it's lifetime to 'static as
+        // long as we don't leak this externally. External users should not see any `'static`
+        // lifetime as a result.
+        let bifrost_inner = unsafe { &*Arc::as_ptr(&self.bifrost_inner) };
+
+        let mut this = self.as_mut().project();
+        loop {
+            let state = this.state.as_mut().project();
+            // We have reached the end of the stream.
+            if *this.read_pointer == Lsn::MAX || *this.read_pointer > *this.end_lsn {
+                this.state.set(State::Terminated);
+                return Poll::Ready(None);
             }
-            Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
-            None => {
-                // todo: check if we should switch the loglet.
-                self.as_mut().terminated = true;
-                Poll::Ready(None)
+
+            match state {
+                StateProj::New => {
+                    let find_loglet_fut = Box::pin(
+                        bifrost_inner.find_loglet_for_lsn(*this.log_id, *this.read_pointer),
+                    );
+                    // => Find Loglet
+                    this.state.set(State::FindingLoglet { find_loglet_fut });
+                }
+
+                // Finding a loglet and creating the loglet instance through the provider
+                StateProj::FindingLoglet { find_loglet_fut } => {
+                    let loglet = match ready!(find_loglet_fut.poll(cx)) {
+                        Ok(loglet) => loglet,
+                        Err(e) => {
+                            this.state.set(State::Terminated);
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    };
+                    // create sub-stream to read from this loglet.
+                    let create_stream_fut =
+                        Box::pin(loglet.create_wrapped_read_stream(*this.read_pointer));
+                    // => Create Substream
+                    this.state
+                        .set(State::CreatingSubstream { create_stream_fut });
+                }
+
+                // Creating a new substream
+                StateProj::CreatingSubstream { create_stream_fut } => {
+                    let substream = match ready!(create_stream_fut.poll(cx)) {
+                        Ok(substream) => substream,
+                        Err(e) => {
+                            this.state.set(State::Terminated);
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    };
+                    let safe_known_tail = substream.tail_lsn();
+                    // If the substream's tail is unknown, we will need to watch the tail updates.
+                    let tail_watch = if safe_known_tail.is_none() {
+                        Some(substream.loglet().watch_tail())
+                    } else {
+                        None
+                    };
+                    // => Start Reading
+                    this.substream.set(Some(substream));
+                    this.state.set(State::Reading {
+                        safe_known_tail,
+                        tail_watch,
+                    });
+                }
+
+                // Reading from the current substream
+                StateProj::Reading {
+                    safe_known_tail,
+                    tail_watch,
+                } => {
+                    // Continue driving the substream
+                    //
+                    // This depends on whether we know its tail (if sealed), or if the value of
+                    // `safe_known_tail` is higher than the `read_pointer` of the substream.
+                    let Some(substream) = this.substream.as_mut().as_pin_mut() else {
+                        panic!("substream must be set at this point");
+                    };
+
+                    // If the loglet's `tail_lsn` is known, this is the tail we should always respect.
+                    match substream.tail_lsn() {
+                        // Next LSN is beyond the boundaries of this substream
+                        Some(tail) if *this.read_pointer >= tail => {
+                            // Switch loglets.
+                            let find_loglet_fut = Box::pin(
+                                bifrost_inner.find_loglet_for_lsn(*this.log_id, *this.read_pointer),
+                            );
+                            // => Find the next loglet. We know we _probably_ have one, otherwise
+                            // `stream_tail_lsn` wouldn't have been set.
+                            this.substream.set(None);
+                            this.state.set(State::FindingLoglet { find_loglet_fut });
+                            continue;
+                        }
+                        // Unsealed loglet, we can only read as far as the safe unsealed tail.
+                        None => {
+                            if safe_known_tail.is_none()
+                                || safe_known_tail
+                                    .is_some_and(|known_tail| *this.read_pointer >= known_tail)
+                            {
+                                // Wait for tail update...
+                                let Some(tail_watch) = tail_watch.as_pin_mut() else {
+                                    panic!("tail_watch must be set on non-sealed read streams");
+                                };
+                                // If the loglet is being sealed, we must wait for reconfiguration to complete.
+                                let maybe_tail = ready!(tail_watch.poll_next(cx));
+                                match maybe_tail {
+                                    None => {
+                                        // Shutdown....
+                                        this.substream.set(None);
+                                        this.state.set(State::Terminated);
+                                        return Poll::Ready(Some(Err(ShutdownError.into())));
+                                    }
+                                    Some(TailState::Open(tail)) => {
+                                        // Safe to consider this as a tail.
+                                        *safe_known_tail = Some(tail);
+                                    }
+                                    Some(TailState::Sealed(_)) => {
+                                        // Wait for reconfiguration to complete.
+                                        //
+                                        // Note that we don't reset the substream here because
+                                        // reconfiguration might bring us back to Reading on the
+                                        // same substream, we don't want to lose the resources
+                                        // allocated by underlying the stream.
+                                        this.state.set(State::AwaitingReconfiguration {
+                                            log_metadata_watch_fut: None,
+                                        });
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        // We are well within the bounds of this loglet. Continue reading.
+                        Some(_) => { /* fall-through */ }
+                    }
+                    let maybe_record = ready!(substream.poll_next(cx));
+                    match maybe_record {
+                        Some(Ok(record)) => {
+                            let record = record
+                                .decode()
+                                .expect("decoding a bifrost envelope succeeds");
+                            let new_pointer = Self::calculate_read_pointer(&record);
+                            debug_assert!(new_pointer > *this.read_pointer);
+                            *this.read_pointer = new_pointer;
+                            return Poll::Ready(Some(Ok(record)));
+                        }
+                        // The assumption here is that underlying stream won't move its read
+                        // pointer on error.
+                        Some(Err(e)) => return Poll::Ready(Some(Err(e.into()))),
+                        None => {
+                            // We should, almost never, reach this.
+                            this.substream.set(None);
+                            this.state.set(State::Terminated);
+                            return Poll::Ready(None);
+                        }
+                    }
+                }
+
+                // Waiting for the substream's loglet to be sealed
+                StateProj::AwaitingReconfiguration {
+                    mut log_metadata_watch_fut,
+                } => {
+                    // If a metadata watch is set, poll it.
+                    if let Some(watch_fut) = log_metadata_watch_fut.as_mut().as_pin_mut() {
+                        let _ = ready!(watch_fut.poll(cx))?;
+                    }
+
+                    let Some(mut substream) = this.substream.as_mut().as_pin_mut() else {
+                        panic!("substream must be set at this point");
+                    };
+
+                    let log_metadata = bifrost_inner.metadata.logs();
+                    // Does metadata indicate that the `base_lsn` of the current substream
+                    // points to a sealed segment?
+                    //
+                    // Why do we use `base_lsn` instead of `read_pointer`? Because if the loglet is
+                    // sealed, the read_pointer might end up being the `base_lsn` of the next
+                    // segment. We don't need to handle the transition to the next segment here
+                    // since we have this handled in Reading state. We just need to set the
+                    // `tail_lsn` on the substream once we determine it.
+                    //
+                    // todo (asoli): Handle empty sealed loglets. Ideally, we want to compare the segment returned
+                    // with the one backing the current loglet, if they are different, we should
+                    // recreate the substream and let the normal flow take over to move to the
+                    // replacement loglet. Unfortunately, at the moment we don't have a reliable
+                    // way to do that.
+                    //
+                    // The log is gone!
+                    let Some(chain) = log_metadata.chain(this.log_id) else {
+                        this.substream.set(None);
+                        this.state.set(State::Terminated);
+                        return Poll::Ready(Some(Err(Error::UnknownLogId(*this.log_id))));
+                    };
+
+                    match chain.find_segment_for_lsn(substream.base_lsn) {
+                        MaybeSegment::Some(segment) if segment.tail_lsn.is_some() => {
+                            let sealed_tail = segment.tail_lsn.unwrap();
+                            substream.set_tail_lsn(segment.tail_lsn.unwrap());
+                            // go back to reading.
+                            this.state.set(State::Reading {
+                                safe_known_tail: Some(sealed_tail),
+                                // No need for the tail watch since we know the tail already.
+                                tail_watch: None,
+                            });
+                            continue;
+                        }
+                        // Oh, we have a prefix trim, deliver the trim-gap and fast-forward.
+                        MaybeSegment::Trim { next_base_lsn } => {
+                            let read_pointer = *this.read_pointer;
+                            let record = LogRecord::new_trim_gap(read_pointer, next_base_lsn);
+                            // fast-forward.
+                            *this.read_pointer = next_base_lsn;
+                            let find_loglet_fut = Box::pin(
+                                bifrost_inner.find_loglet_for_lsn(*this.log_id, *this.read_pointer),
+                            );
+                            // => Find Loglet
+                            this.substream.set(None);
+                            this.state.set(State::FindingLoglet { find_loglet_fut });
+                            // Deliver the trim gap
+                            return Poll::Ready(Some(Ok(record)));
+                        }
+                        // Segment is not sealed yet.
+                        MaybeSegment::Some(_) => { /* fall-through */ }
+                    };
+
+                    // Reconfiguration still ongoing...
+                    let metadata_version = log_metadata.version();
+
+                    // No hope at this metadata version, wait for the next update.
+                    let metadata_watch_fut = Box::pin(
+                        bifrost_inner
+                            .metadata
+                            .wait_for_version(MetadataKind::Logs, metadata_version.next()),
+                    );
+                    log_metadata_watch_fut.set(Some(metadata_watch_fut));
+                    continue;
+                }
+                StateProj::Terminated => {
+                    return Poll::Ready(None);
+                }
             }
         }
     }
@@ -157,17 +407,22 @@ mod tests {
 
     use std::sync::atomic::AtomicUsize;
 
-    use crate::{BifrostService, Record, TrimGap};
+    use crate::loglet::LogletBase;
+    use crate::{setup_panic_handler, BifrostService, FindTailAttributes, Record, TrimGap};
 
     use super::*;
     use bytes::Bytes;
     use googletest::prelude::*;
 
-    use restate_core::{metadata, task_center, TaskKind, TestCoreEnvBuilder};
+    use restate_core::{
+        metadata, task_center, MetadataKind, TargetVersion, TaskKind, TestCoreEnvBuilder,
+    };
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::{CommonOptions, Configuration};
     use restate_types::live::{Constant, Live};
-    use restate_types::logs::metadata::ProviderKind;
+    use restate_types::logs::metadata::{new_single_node_loglet_params, ProviderKind};
+    use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
+    use restate_types::Versioned;
     use tokio_stream::StreamExt;
     use tracing::info;
     use tracing_test::traced_test;
@@ -177,13 +432,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[traced_test]
     async fn test_readstream_one_loglet() -> anyhow::Result<()> {
-        // Make sure that panics exits the process.
-        let orig_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |panic_info| {
-            // invoke the default handler and exit the process
-            orig_hook(panic_info);
-            std::process::exit(1);
-        }));
+        setup_panic_handler();
 
         let node_env = TestCoreEnvBuilder::new_with_mock_network()
             .set_provider_kind(ProviderKind::Local)
@@ -202,7 +451,7 @@ mod tests {
             let bifrost = svc.handle();
             svc.start().await.expect("loglet must start");
 
-            let mut reader = bifrost.create_reader(log_id, read_from, Lsn::MAX).await?;
+            let mut reader = bifrost.create_reader(log_id, read_from, Lsn::MAX)?;
 
             let tail = bifrost
                 .find_tail(log_id, FindTailAttributes::default())
@@ -274,13 +523,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[traced_test]
     async fn test_read_stream_with_trim() -> anyhow::Result<()> {
-        // Make sure that panics exits the process.
-        let orig_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |panic_info| {
-            // invoke the default handler and exit the process
-            orig_hook(panic_info);
-            std::process::exit(1);
-        }));
+        setup_panic_handler();
 
         let node_env = TestCoreEnvBuilder::new_with_mock_network()
             .set_provider_kind(ProviderKind::Local)
@@ -318,7 +561,7 @@ mod tests {
                 );
                 assert_eq!(Lsn::from(5), bifrost.get_trim_point(log_id).await?);
 
-                let mut read_stream = bifrost.create_reader(log_id, Lsn::OLDEST, Lsn::MAX).await?;
+                let mut read_stream = bifrost.create_reader(log_id, Lsn::OLDEST, Lsn::MAX)?;
 
                 let record = read_stream.next().await.unwrap()?;
                 assert_that!(
@@ -398,5 +641,311 @@ mod tests {
                 Ok(())
             })
             .await
+    }
+
+    // Note: This test doesn't validate read stream behaviour with zombie records at seal boundary.
+    #[tokio::test(start_paused = true)]
+    async fn test_readstream_simple_multi_loglet() -> anyhow::Result<()> {
+        setup_panic_handler();
+        const LOG_ID: LogId = LogId::new(0);
+
+        let node_env = TestCoreEnvBuilder::new_with_mock_network()
+            .set_provider_kind(ProviderKind::Local)
+            .build()
+            .await;
+
+        let tc = node_env.tc;
+        tc.run_in_scope("test", None, async {
+            let config = Live::from_value(Configuration::default());
+            RocksDbManager::init(Constant::new(CommonOptions::default()));
+
+            // enable both in-memory and local loglet types
+            let svc = BifrostService::new(task_center(), metadata())
+                .enable_local_loglet(&config)
+                .enable_in_memory_loglet();
+            let bifrost = svc.handle();
+            svc.start().await.expect("loglet must start");
+
+            // create the reader and put it on the side.
+            let mut reader = bifrost.create_reader(LOG_ID, Lsn::OLDEST, Lsn::MAX)?;
+            // We should be at tail, any attempt to read will yield `pending`.
+            assert_that!(
+                futures::poll!(std::pin::pin!(reader.next())),
+                pat!(Poll::Pending)
+            );
+
+            let tail = bifrost
+                .find_tail(LOG_ID, FindTailAttributes::default())
+                .await?;
+            // no records have been written
+            assert!(!tail.is_sealed());
+            assert_eq!(Lsn::OLDEST, tail.offset());
+            assert_eq!(Lsn::OLDEST, reader.read_pointer());
+
+            // Nothing is trimmed
+            assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
+
+            // append 10 records [1..10]
+            for i in 1..=10 {
+                let lsn = bifrost
+                    .append(LOG_ID, Payload::new(format!("segment-1-{}", i)))
+                    .await?;
+                assert_eq!(Lsn::from(i), lsn);
+            }
+
+            // read 5 records.
+            for i in 1..=5 {
+                let record = reader.next().await.expect("to stay alive")?;
+                assert_eq!(Lsn::from(i), record.offset);
+                assert_eq!(reader.read_pointer(), record.offset.next());
+                assert_eq!(
+                    Payload::new(format!("segment-1-{}", i)).body(),
+                    record.record.into_payload_unchecked().body()
+                );
+            }
+
+            // manually seal the loglet, create a new in-memory loglet at base_lsn=11
+            let raw_loglet = bifrost
+                .inner()
+                .find_loglet_for_lsn(LOG_ID, Lsn::new(5))
+                .await?;
+            raw_loglet.seal().await?;
+            // In fact, reader is allowed to go as far as the last known unsealed tail which
+            // in our case could be the real tail since we didn't have in-flight appends at seal
+            // time. It's legal for loglets to have lagging indicator of the unsealed pointer but
+            // we know that local loglet won't do this.
+            //
+            // read 5 more records.
+            println!("reading records at sealed loglet");
+            for i in 6..=10 {
+                let record = reader.next().await.expect("to stay alive")?;
+                assert_eq!(Lsn::from(i), record.offset);
+                assert_eq!(reader.read_pointer(), record.offset.next());
+                assert_eq!(
+                    Payload::new(format!("segment-1-{}", i)).body(),
+                    record.record.into_payload_unchecked().body()
+                );
+            }
+
+            // reads should yield pending since we are at the last known unsealed tail
+            // loglet.
+            assert_that!(
+                futures::poll!(std::pin::pin!(reader.next())),
+                pat!(Poll::Pending)
+            );
+            // again.
+            assert_that!(
+                futures::poll!(std::pin::pin!(reader.next())),
+                pat!(Poll::Pending)
+            );
+
+            let tail = bifrost
+                .find_tail(LOG_ID, FindTailAttributes::default())
+                .await?;
+
+            assert!(tail.is_sealed());
+            assert_eq!(Lsn::from(11), tail.offset());
+            // perform manual reconfiguration (can be replaced with bifrost reconfiguration API
+            // when it's implemented)
+            let old_version = bifrost.inner().metadata.logs_version();
+            let mut builder = bifrost.inner().metadata.logs().clone().into_builder();
+            let mut chain_builder = builder.chain(&LOG_ID).unwrap();
+            assert_eq!(1, chain_builder.num_segments());
+            let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);
+            chain_builder.append_segment(
+                Lsn::new(11),
+                ProviderKind::InMemory,
+                new_segment_params,
+            )?;
+
+            let new_metadata = builder.build();
+            let new_version = new_metadata.version();
+            assert_eq!(new_version, old_version.next());
+            node_env
+                .metadata_store_client
+                .put(
+                    BIFROST_CONFIG_KEY.clone(),
+                    new_metadata,
+                    restate_metadata_store::Precondition::MatchesVersion(old_version),
+                )
+                .await?;
+
+            // make sure we have updated metadata.
+            bifrost
+                .inner()
+                .metadata
+                .sync(MetadataKind::Logs, TargetVersion::Latest)
+                .await?;
+
+            // append 5 more records into the new loglet.
+            for i in 11..=15 {
+                let lsn = bifrost
+                    .append(LOG_ID, Payload::new(format!("segment-2-{}", i)))
+                    .await?;
+                println!("appended record={}", lsn);
+                assert_eq!(Lsn::from(i), lsn);
+            }
+
+            // read stream should jump across segments.
+            for i in 11..=15 {
+                let record = reader.next().await.expect("to stay alive")?;
+                assert_eq!(Lsn::from(i), record.offset);
+                assert_eq!(reader.read_pointer(), record.offset.next());
+                assert_eq!(
+                    Payload::new(format!("segment-2-{}", i)).body(),
+                    record.record.into_payload_unchecked().body()
+                );
+            }
+            // We are at tail. validate.
+            assert_that!(
+                futures::poll!(std::pin::pin!(reader.next())),
+                pat!(Poll::Pending)
+            );
+
+            assert_eq!(
+                Lsn::from(16),
+                bifrost
+                    .append(LOG_ID, Payload::new("segment-2-1000"))
+                    .await?
+            );
+
+            let record = reader.next().await.expect("to stay alive")?;
+            assert_eq!(Lsn::from(16), record.offset);
+            assert_eq!(
+                Payload::new("segment-2-1000").body(),
+                record.record.into_payload_unchecked().body()
+            );
+
+            anyhow::Ok(())
+        })
+        .await?;
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_readstream_sealed_multi_loglet() -> anyhow::Result<()> {
+        setup_panic_handler();
+        const LOG_ID: LogId = LogId::new(0);
+
+        let node_env = TestCoreEnvBuilder::new_with_mock_network()
+            .set_provider_kind(ProviderKind::Local)
+            .build()
+            .await;
+
+        let tc = node_env.tc;
+        tc.run_in_scope("test", None, async {
+            let config = Live::from_value(Configuration::default());
+            RocksDbManager::init(Constant::new(CommonOptions::default()));
+
+            // enable both in-memory and local loglet types
+            let svc = BifrostService::new(task_center(), metadata())
+                .enable_local_loglet(&config)
+                .enable_in_memory_loglet();
+            let bifrost = svc.handle();
+            svc.start().await.expect("loglet must start");
+
+            let tail = bifrost
+                .find_tail(LOG_ID, FindTailAttributes::default())
+                .await?;
+            // no records have been written
+            assert!(!tail.is_sealed());
+            assert_eq!(Lsn::OLDEST, tail.offset());
+
+            // append 10 records [1..10]
+            for i in 1..=10 {
+                let lsn = bifrost
+                    .append(LOG_ID, Payload::new(format!("segment-1-{}", i)))
+                    .await?;
+                assert_eq!(Lsn::from(i), lsn);
+            }
+
+            // manually seal the loglet, create a new in-memory loglet at base_lsn=11
+            let raw_loglet = bifrost
+                .inner()
+                .find_loglet_for_lsn(LOG_ID, Lsn::new(5))
+                .await?;
+            raw_loglet.seal().await?;
+
+            let tail = bifrost
+                .find_tail(LOG_ID, FindTailAttributes::default())
+                .await?;
+
+            assert!(tail.is_sealed());
+            assert_eq!(Lsn::from(11), tail.offset());
+            // perform manual reconfiguration (can be replaced with bifrost reconfiguration API
+            // when it's implemented)
+            let old_version = bifrost.inner().metadata.logs_version();
+            let mut builder = bifrost.inner().metadata.logs().clone().into_builder();
+            let mut chain_builder = builder.chain(&LOG_ID).unwrap();
+            assert_eq!(1, chain_builder.num_segments());
+            let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);
+            chain_builder.append_segment(
+                Lsn::new(11),
+                ProviderKind::InMemory,
+                new_segment_params,
+            )?;
+            let new_metadata = builder.build();
+            let new_version = new_metadata.version();
+            assert_eq!(new_version, old_version.next());
+            node_env
+                .metadata_store_client
+                .put(
+                    BIFROST_CONFIG_KEY.clone(),
+                    new_metadata,
+                    restate_metadata_store::Precondition::MatchesVersion(old_version),
+                )
+                .await?;
+
+            // make sure we have updated metadata.
+            bifrost
+                .inner()
+                .metadata
+                .sync(MetadataKind::Logs, TargetVersion::Latest)
+                .await?;
+
+            // append 5 more records into the new loglet.
+            for i in 11..=15 {
+                let lsn = bifrost
+                    .append(LOG_ID, Payload::new(format!("segment-2-{}", i)))
+                    .await?;
+                info!(?lsn, "appended record");
+                assert_eq!(Lsn::from(i), lsn);
+            }
+
+            // start a reader (from 3) and read everything. [3..15]
+            let mut reader = bifrost.create_reader(LOG_ID, Lsn::new(3), Lsn::MAX)?;
+
+            // first segment records
+            for i in 3..=10 {
+                let record = reader.next().await.expect("to stay alive")?;
+                assert_eq!(Lsn::from(i), record.offset);
+                assert_eq!(reader.read_pointer(), record.offset.next());
+                assert_eq!(
+                    Payload::new(format!("segment-1-{}", i)).body(),
+                    record.record.into_payload_unchecked().body()
+                );
+            }
+
+            // first segment records
+            for i in 11..=15 {
+                let record = reader.next().await.expect("to stay alive")?;
+                assert_eq!(Lsn::from(i), record.offset);
+                assert_eq!(reader.read_pointer(), record.offset.next());
+                assert_eq!(
+                    Payload::new(format!("segment-2-{}", i)).body(),
+                    record.record.into_payload_unchecked().body()
+                );
+            }
+
+            // We are at tail. validate.
+            assert_that!(
+                futures::poll!(std::pin::pin!(reader.next())),
+                pat!(Poll::Pending)
+            );
+
+            anyhow::Ok(())
+        })
+        .await?;
+        Ok(())
     }
 }

--- a/crates/bifrost/src/types.rs
+++ b/crates/bifrost/src/types.rs
@@ -81,6 +81,48 @@ pub enum TailState<Offset = Lsn> {
 }
 
 impl<Offset: SequenceNumber> TailState<Offset> {
+    pub fn new(sealed: bool, offset: Offset) -> Self {
+        if sealed {
+            TailState::Sealed(offset)
+        } else {
+            TailState::Open(offset)
+        }
+    }
+
+    /// Combines two TailStates together
+    ///
+    /// Only applies updates to the value according to the following rules:
+    ///   - Offsets can only move forward.
+    ///   - Tail cannot be see unsealed after seal.
+    ///
+    /// Returns true if the state was updated
+    pub fn combine(&mut self, sealed: bool, offset: Offset) -> bool {
+        let old_offset = self.offset();
+        let is_already_sealed = self.is_sealed();
+
+        let new_offset = std::cmp::max(self.offset(), offset);
+        let new_sealed = self.is_sealed() || sealed;
+        if new_sealed != is_already_sealed || new_offset > old_offset {
+            *self = TailState::new(new_sealed, new_offset);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Applies a seal on the tail state without changing the tail offset
+    /// Returns true if the state was updated
+    pub fn seal(&mut self) -> bool {
+        if self.is_sealed() {
+            false
+        } else {
+            *self = TailState::new(true, self.offset());
+            true
+        }
+    }
+}
+
+impl<Offset: SequenceNumber> TailState<Offset> {
     pub fn map<F, T>(self, f: F) -> TailState<T>
     where
         F: FnOnce(Offset) -> T,
@@ -91,10 +133,12 @@ impl<Offset: SequenceNumber> TailState<Offset> {
         }
     }
 
+    #[inline(always)]
     pub fn is_sealed(&self) -> bool {
         matches!(self, TailState::Sealed(_))
     }
 
+    #[inline(always)]
     pub fn offset(&self) -> Offset {
         match self {
             TailState::Open(offset) | TailState::Sealed(offset) => *offset,

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -21,6 +21,25 @@ use super::builder::LogsBuilder;
 use crate::logs::{LogId, Lsn, SequenceNumber};
 use crate::{flexbuffers_storage_encode_decode, Version, Versioned};
 
+// Starts with 0 being the oldest loglet in the chain.
+#[derive(
+    Default,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Debug,
+    Hash,
+    Serialize,
+    Deserialize,
+    derive_more::From,
+)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct SegmentIndex(pub(crate) u32);
+
 /// Log metadata is the map of logs known to the system with the corresponding chain.
 /// Metadata updates are versioned and atomic.
 #[serde_as]
@@ -40,6 +59,7 @@ impl Default for Logs {
         }
     }
 }
+
 /// the chain is a list of segments in (from Lsn) order.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,11 +81,26 @@ pub struct Segment<'a> {
     pub config: &'a LogletConfig,
 }
 
+impl<'a> Segment<'a> {
+    pub fn index(&'a self) -> SegmentIndex {
+        self.config.index()
+    }
+}
+
 /// A segment in the chain of loglet instances.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogletConfig {
     pub kind: ProviderKind,
     pub params: LogletParams,
+    /// This is a cheap and collision-free way to identify loglets within the same log without
+    /// using random numbers. Globally, the tuple (log_id, index) is unqiue.
+    ///
+    // serde(default) to v1.0 compatibility. This can be removed once we are confident that all
+    // persisted metadata have this index set. For v1.0 multi-segment logs are not supported so we
+    // only expect logs with 1 segment. Therefore, a default of 0 matches what we create on new
+    // loglet chains already.
+    #[serde(default)]
+    index: SegmentIndex,
 }
 
 /// The configuration of a single loglet segment. This holds information needed
@@ -117,8 +152,16 @@ pub enum ProviderKind {
 }
 
 impl LogletConfig {
-    pub fn new(kind: ProviderKind, params: LogletParams) -> Self {
-        Self { kind, params }
+    pub(crate) fn new(index: SegmentIndex, kind: ProviderKind, params: LogletParams) -> Self {
+        Self {
+            kind,
+            params,
+            index,
+        }
+    }
+
+    pub fn index(&self) -> SegmentIndex {
+        self.index
     }
 }
 
@@ -186,7 +229,10 @@ impl Chain {
     /// Create a chain with `base_lsn` as its oldest Lsn.
     pub fn with_base_lsn(base_lsn: Lsn, kind: ProviderKind, config: LogletParams) -> Self {
         let mut chain = BTreeMap::new();
-        chain.insert(base_lsn, LogletConfig::new(kind, config));
+        chain.insert(
+            base_lsn,
+            LogletConfig::new(SegmentIndex::default(), kind, config),
+        );
         Self { chain }
     }
 
@@ -199,6 +245,14 @@ impl Chain {
                 tail_lsn: None,
                 config,
             })
+            .expect("Chain must have at least one segment")
+    }
+
+    #[track_caller]
+    pub fn tail_index(&self) -> SegmentIndex {
+        self.chain
+            .last_key_value()
+            .map(|(_, v)| v.index())
             .expect("Chain must have at least one segment")
     }
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -243,8 +243,7 @@ where
                 LogId::from(self.partition_id),
                 last_applied_lsn.next(),
                 Lsn::MAX,
-            )
-            .await?
+            )?
             .map_ok(|record| {
                 let LogRecord { record, offset } = record;
                 match record {

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -679,10 +679,11 @@ mod tests {
                 None,
                 shuffle_env.shuffle.run(),
             )?;
-            let reader = shuffle_env
-                .bifrost
-                .create_reader(LogId::from(partition_id), Lsn::OLDEST, Lsn::MAX)
-                .await?;
+            let reader = shuffle_env.bifrost.create_reader(
+                LogId::from(partition_id),
+                Lsn::OLDEST,
+                Lsn::MAX,
+            )?;
 
             let messages = collect_invoke_commands_until(reader, last_invocation_id).await?;
 
@@ -723,10 +724,11 @@ mod tests {
                 None,
                 shuffle_env.shuffle.run(),
             )?;
-            let reader = shuffle_env
-                .bifrost
-                .create_reader(LogId::from(partition_id), Lsn::OLDEST, Lsn::MAX)
-                .await?;
+            let reader = shuffle_env.bifrost.create_reader(
+                LogId::from(partition_id),
+                Lsn::OLDEST,
+                Lsn::MAX,
+            )?;
 
             let messages = collect_invoke_commands_until(reader, last_invocation_id).await?;
 
@@ -759,10 +761,11 @@ mod tests {
         let shuffle_task_id = tc
             .run_in_scope("test", None, async {
                 let partition_id = shuffle_env.shuffle.metadata.partition_id;
-                let reader = shuffle_env
-                    .bifrost
-                    .create_reader(LogId::from(partition_id), Lsn::INVALID, Lsn::MAX)
-                    .await?;
+                let reader = shuffle_env.bifrost.create_reader(
+                    LogId::from(partition_id),
+                    Lsn::INVALID,
+                    Lsn::MAX,
+                )?;
                 let total_restarts = Arc::clone(&total_restarts);
 
                 let shuffle_task =

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -41,7 +41,7 @@ pub async fn run(
         let bifrost = bifrost.clone();
         let clock = clock.clone();
         async move {
-            let mut read_stream = bifrost.create_reader(log_id, Lsn::OLDEST, Lsn::MAX).await?;
+            let mut read_stream = bifrost.create_reader(log_id, Lsn::OLDEST, Lsn::MAX)?;
             let mut counter = 0;
             let mut cancel = std::pin::pin!(cancellation_watcher());
             let mut lag_latencies = Histogram::<u64>::new(3)?;


### PR DESCRIPTION
[Bifrost] Introduces SegmentIndex to identify segments in the log chain

This allows correct handling of sealing empty loglets and support for future reconfiguration operations.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1747).
* #1757
* #1753
* __->__ #1747
* #1744
* #1743
* #1742