### PR TITLE
Bump datafusion dependency to 35.0.0-object-store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,8 +2146,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4328f5467f76d890fe3f924362dbc3a838c6a733f762b32d87f9e0b7bef5fb49"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "ahash",
  "arrow 50.0.0",
@@ -2187,8 +2186,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29a7752143b446db4a2cccd9a6517293c6b97e8c39e520ca43ccd07135a4f7e"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "ahash",
  "arrow 50.0.0",
@@ -2206,8 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d447650af16e138c31237f53ddaef6dd4f92f0e2d3f2f35d190e16c214ca496"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "arrow 50.0.0",
  "chrono",
@@ -2227,8 +2224,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d19598e48a498850fb79f97a9719b1f95e7deb64a7a06f93f313e8fa1d524b"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "ahash",
  "arrow 50.0.0",
@@ -2243,8 +2239,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7feb0391f1fc75575acb95b74bfd276903dc37a5409fcebe160bc7ddff2010"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "arrow 50.0.0",
  "async-trait",
@@ -2261,8 +2256,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e911bca609c89a54e8f014777449d8290327414d3e10c57a3e3c2122e38878d0"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "ahash",
  "arrow 50.0.0",
@@ -2295,8 +2289,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b546b8a02e9c2ab35ac6420d511f12a4701950c1eb2e568c122b4fefb0be3"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "ahash",
  "arrow 50.0.0",
@@ -2326,8 +2319,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d18d36f260bbbd63aafdb55339213a23d540d3419810575850ef0a798a6b768"
+source = "git+https://github.com/restatedev/datafusion.git?tag=35.0.0-object-store#14e99626c51b839642a44b8c43b1a3bfa7ff3490"
 dependencies = [
  "arrow 50.0.0",
  "arrow-schema 50.0.0",
@@ -4217,16 +4209,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
+checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "parking_lot",
  "percent-encoding",
  "snafu",
@@ -6186,7 +6178,6 @@ dependencies = [
  "chrono",
  "codederror",
  "datafusion",
- "datafusion-expr",
  "derive_builder",
  "futures",
  "googletest",
@@ -6218,7 +6209,6 @@ dependencies = [
  "chrono",
  "codederror",
  "datafusion",
- "datafusion-expr",
  "derive_builder",
  "futures",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,7 @@ cling = { version = "0.1", default-features = false, features = ["derive"] }
 criterion = "0.5"
 crossterm = { version = "0.27.0" }
 dashmap = { version = "5.5.3" }
-datafusion = { version = "35.0.0", default-features = false, features = ["crypto_expressions", "encoding_expressions", "regex_expressions", "unicode_expressions"] }
-datafusion-expr = { version = "35.0.0" }
+datafusion = { git = "https://github.com/restatedev/datafusion.git", tag = "35.0.0-object-store", default-features = false, features = ["crypto_expressions", "encoding_expressions", "regex_expressions", "unicode_expressions"] }
 derive-getters = {  version = "0.4.0" }
 derive_builder = "0.20.0"
 derive_more = { version = "0.99.17" }

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -27,7 +27,6 @@ bytestring = { workspace = true }
 chrono = { version = "0.4.26", default-features = false, features = ["clock"] }
 codederror = { workspace = true }
 datafusion = { workspace = true }
-datafusion-expr = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 paste = { workspace = true }

--- a/crates/storage-query-datafusion/src/analyzer.rs
+++ b/crates/storage-query-datafusion/src/analyzer.rs
@@ -10,8 +10,8 @@
 
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{col, Join, LogicalPlan};
 use datafusion::optimizer::analyzer::AnalyzerRule;
-use datafusion_expr::{col, Join, LogicalPlan};
 
 pub(crate) struct UseSymmetricHashJoinWhenPartitionKeyIsPresent;
 

--- a/crates/storage-query-postgres/Cargo.toml
+++ b/crates/storage-query-postgres/Cargo.toml
@@ -27,7 +27,6 @@ bytestring = { workspace = true }
 chrono = { workspace = true }
 codederror = { workspace = true }
 datafusion = { workspace = true }
-datafusion-expr = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 paste = { workspace = true}


### PR DESCRIPTION
Datafusion 35.0.0-object-store is a forked 35.0.0 version which swapped object_store 0.9 with object_store 0.10.2 at the cost of Parquet support.

This fixes #1749.

This temporary fix should no longer be necessary once #1673 gets merged.