### PR TITLE
Enable Dockerfile to build cli in separate stage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      buildCli:
+        description: 'build cli Docker image'
+        required: false
+        default: false
+        type: boolean
 
   workflow_dispatch:
     inputs:
@@ -107,8 +112,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build${{inputs.uploadImageAsTarball != true && ' and push ' || ' '}}Docker image
-        id: build
+      - name: Build${{inputs.uploadImageAsTarball != true && ' and push ' || ' '}}server Docker image
+        id: build-server
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -118,6 +123,28 @@ jobs:
           load: ${{ inputs.uploadImageAsTarball == true }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ inputs.platforms || 'linux/arm64,linux/amd64' }}
+          target: "server"
+          build-args: |
+            CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug }}
+            ACTIONS_CACHE_URL
+            ACTIONS_RUNTIME_TOKEN
+            SCCACHE_GHA_ENABLED=true
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}
+
+      - name: Build${{inputs.uploadImageAsTarball != true && ' and push ' || ' '}}cli Docker image
+        id: build-cli
+        if: ${{ inputs.buildCli }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: "docker/Dockerfile"
+          push: ${{ inputs.uploadImageAsTarball != true }}
+          tags: ${{ format('{0}-cli', steps.meta.outputs.tags) }}
+          load: ${{ inputs.uploadImageAsTarball == true }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ inputs.platforms || 'linux/arm64,linux/amd64' }}
+          target: "cli"
           build-args: |
             CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug }}
             ACTIONS_CACHE_URL
@@ -129,7 +156,7 @@ jobs:
       - name: Save docker image as tar
         if: ${{ inputs.uploadImageAsTarball }}
         run: |
-          docker save -o restate.tar ${{ steps.build.outputs.imageid }}
+          docker save -o restate.tar ${{ steps.build-server.outputs.imageid }}
 
       - name: Upload docker image tar as artifact
         if: ${{ inputs.uploadImageAsTarball }}
@@ -142,7 +169,7 @@ jobs:
 
       # Even if uploadImageAsTarball, push main images
       # This won't actually build again, it'll just use cache
-      - name: Push Docker image
+      - name: Push server Docker image
         if: ${{ inputs.uploadImageAsTarball && github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
@@ -152,6 +179,30 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           load: false
           labels: ${{ steps.meta.outputs.labels }}
+          target: "server"
+          # ignore inputs.platforms as we always need to push both arm64 and amd64 docker images
+          platforms: 'linux/arm64,linux/amd64'
+          build-args: |
+            CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug }}
+            ACTIONS_CACHE_URL
+            ACTIONS_RUNTIME_TOKEN
+            SCCACHE_GHA_ENABLED=true
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}
+
+      # Even if uploadImageAsTarball, push main images
+      # This won't actually build again, it'll just use cache
+      - name: Push cli Docker image
+        if: ${{ inputs.buildCli && inputs.uploadImageAsTarball && github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: "docker/Dockerfile"
+          push: true
+          tags: ${{ format('{0}-cli', steps.meta.outputs.tags) }}
+          load: false
+          labels: ${{ steps.meta.outputs.labels }}
+          target: "cli"
           # ignore inputs.platforms as we always need to push both arm64 and amd64 docker images
           platforms: 'linux/arm64,linux/amd64'
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     secrets: inherit
     with:
       pushToDockerHub: true
+      buildCli: true
 
   release-helm:
     name: Release helm chart

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,18 +35,34 @@ ARG SCCACHE_GHA_ENABLED=''
 ARG CARGO_PROFILE_RELEASE_DEBUG=false
 # Caching layer if nothing has changed
 # Only build restate binary to avoid compiling unneeded crates
-RUN just arch=$TARGETARCH libc=gnu chef-cook --release --bin restate-server
+RUN just arch=$TARGETARCH libc=gnu chef-cook --release --bin restate-server --bin restate
 COPY . .
+
+FROM builder as builder-cli
+RUN just arch=$TARGETARCH libc=gnu build --release --bin restate && \
+    just notice-file && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate
+
+FROM builder as builder-server
 RUN just arch=$TARGETARCH libc=gnu build --release --bin restate-server && \
     just notice-file && \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server
 
 # We do not need the Rust toolchain to run the server binary!
-FROM debian:bookworm-slim AS runtime
-COPY --from=builder /restate/target/restate-server /usr/local/bin
-COPY --from=builder /restate/NOTICE /NOTICE
-COPY --from=builder /restate/LICENSE /LICENSE
+FROM debian:bookworm-slim AS cli
+COPY --from=builder-cli /restate/target/restate /usr/local/bin
+COPY --from=builder-cli /restate/NOTICE /NOTICE
+COPY --from=builder-cli /restate/LICENSE /LICENSE
 # copy OS roots
-COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=builder-cli /etc/ssl /etc/ssl
+WORKDIR /
+ENTRYPOINT ["/usr/local/bin/restate"]
+
+FROM debian:bookworm-slim AS server
+COPY --from=builder-server /restate/target/restate-server /usr/local/bin
+COPY --from=builder-server /restate/NOTICE /NOTICE
+COPY --from=builder-server /restate/LICENSE /LICENSE
+# copy OS roots
+COPY --from=builder-server /etc/ssl /etc/ssl
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/restate-server"]

--- a/justfile
+++ b/justfile
@@ -124,9 +124,9 @@ test: (_target-installed target)
 # Runs lints and tests
 verify: lint test
 
-docker:
+docker *args:
     # podman builds do not work without --platform set, even though it claims to default to host arch
-    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --load
+    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --load {{ args }}
 
 notice-file:
     cargo license -d -a --avoid-build-deps --avoid-dev-deps {{ _features }} | (echo "Restate Runtime\nCopyright (c) 2024 Restate Software, Inc., Restate GmbH <code@restate.dev>\n" && cat) > NOTICE


### PR DESCRIPTION
This commit adds a separate stage which allows to build the cli. Moreover, it updates the docker.yml workflow to also build the cli Docker image if requested.

This fixes #1758.