### PR TITLE
Make backoff policy in metadata store client configurable

### DIFF
--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -424,7 +424,7 @@ impl BifrostInner {
         &self,
         log_id: LogId,
         sealed_segment: SegmentIndex,
-        retry_iter: &mut RetryIter,
+        retry_iter: &mut RetryIter<'_>,
     ) -> Result<LogletWrapper> {
         let start = Instant::now();
         for sleep_dur in retry_iter.by_ref() {

--- a/crates/core/src/metadata_store/mod.rs
+++ b/crates/core/src/metadata_store/mod.rs
@@ -16,11 +16,10 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use bytestring::ByteString;
 use restate_types::errors::GenericError;
-use restate_types::retries::{RetryIter, RetryPolicy};
+use restate_types::retries::RetryPolicy;
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
 use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
@@ -101,21 +100,26 @@ pub trait MetadataStore {
 pub struct MetadataStoreClient {
     // premature optimization? Maybe introduce trait object once we have multiple implementations?
     inner: Arc<dyn MetadataStore + Send + Sync>,
+    backoff_policy: Option<RetryPolicy>,
 }
 
 impl MetadataStoreClient {
-    pub fn new<S>(metadata_store: S) -> Self
+    pub fn new<S>(metadata_store: S, backoff_policy: Option<RetryPolicy>) -> Self
     where
         S: MetadataStore + Send + Sync + 'static,
     {
         Self {
             inner: Arc::new(metadata_store),
+            backoff_policy,
         }
     }
 
     #[cfg(any(test, feature = "test-util"))]
     pub fn new_in_memory() -> Self {
-        MetadataStoreClient::new(InMemoryMetadataStore::default())
+        MetadataStoreClient::new(
+            InMemoryMetadataStore::default(),
+            None, // not needed since no concurrent modifications happening
+        )
     }
 
     /// Gets the value and its current version for the given key. If key-value pair is not present,
@@ -196,8 +200,7 @@ impl MetadataStoreClient {
         T: Versioned + Clone + StorageEncode + StorageDecode,
         F: FnMut() -> T,
     {
-        let max_backoff = Duration::from_millis(100);
-        let mut backoff_policy = Self::exponential_retry_policy(max_backoff);
+        let mut backoff_policy = self.backoff_policy.as_ref().map(|p| p.iter());
 
         loop {
             let value = self.get::<T>(key.clone()).await?;
@@ -214,22 +217,20 @@ impl MetadataStoreClient {
                 {
                     Ok(()) => return Ok(init_value),
                     Err(WriteError::FailedPrecondition(msg)) => {
-                        let backoff = backoff_policy.next().unwrap_or(max_backoff);
-                        debug!(
-                            "concurrent value update: {msg}; retrying in '{}'",
-                            humantime::format_duration(backoff)
-                        );
-                        tokio::time::sleep(backoff).await;
+                        if let Some(backoff) = backoff_policy.as_mut().and_then(|p| p.next()) {
+                            debug!(
+                                "Concurrent value update: {msg}; retrying in '{}'",
+                                humantime::format_duration(backoff)
+                            );
+                            tokio::time::sleep(backoff).await;
+                        } else {
+                            return Err(ReadWriteError::RetriesExhausted(key));
+                        }
                     }
                     Err(err) => return Err(err.into()),
                 }
             }
         }
-    }
-
-    fn exponential_retry_policy(max_backoff: Duration) -> RetryIter<'static> {
-        RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, Some(max_backoff))
-            .into_iter()
     }
 
     /// Reads the value under the given key from the metadata store, then modifies it and writes
@@ -245,8 +246,7 @@ impl MetadataStoreClient {
         T: Versioned + Clone + StorageEncode + StorageDecode,
         F: FnMut(Option<T>) -> Result<T, E>,
     {
-        let max_backoff = Duration::from_millis(100);
-        let mut backoff_policy = Self::exponential_retry_policy(max_backoff);
+        let mut backoff_policy = self.backoff_policy.as_ref().map(|p| p.iter());
 
         loop {
             let old_value = self
@@ -266,12 +266,15 @@ impl MetadataStoreClient {
                     match self.put(key.clone(), new_value.clone(), precondition).await {
                         Ok(()) => return Ok(new_value),
                         Err(WriteError::FailedPrecondition(msg)) => {
-                            let backoff = backoff_policy.next().unwrap_or(max_backoff);
-                            debug!(
-                                "concurrent value update: {msg}; retrying in '{}'",
-                                humantime::format_duration(backoff)
-                            );
-                            tokio::time::sleep(backoff).await;
+                            if let Some(backoff) = backoff_policy.as_mut().and_then(|p| p.next()) {
+                                debug!(
+                                    "Concurrent value update: {msg}; retrying in '{}'",
+                                    humantime::format_duration(backoff)
+                                );
+                                tokio::time::sleep(backoff).await;
+                            } else {
+                                return Err(ReadWriteError::RetriesExhausted(key).into());
+                            }
                         }
                         Err(err) => return Err(ReadModifyWriteError::ReadWrite(err.into())),
                     }
@@ -290,6 +293,8 @@ pub enum ReadWriteError {
     Internal(String),
     #[error("codec error: {0}")]
     Codec(GenericError),
+    #[error("retries for operation on key '{0}' exhausted")]
+    RetriesExhausted(ByteString),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -354,6 +359,7 @@ impl MetadataStoreClientError for ReadWriteError {
             ReadWriteError::Network(_) => true,
             ReadWriteError::Internal(_) => false,
             ReadWriteError::Codec(_) => false,
+            ReadWriteError::RetriesExhausted(_) => false,
         }
     }
 }

--- a/crates/core/src/metadata_store/mod.rs
+++ b/crates/core/src/metadata_store/mod.rs
@@ -227,7 +227,7 @@ impl MetadataStoreClient {
         }
     }
 
-    fn exponential_retry_policy(max_backoff: Duration) -> RetryIter {
+    fn exponential_retry_policy(max_backoff: Duration) -> RetryIter<'static> {
         RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, Some(max_backoff))
             .into_iter()
     }

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -188,7 +188,7 @@ mod task_orchestrator {
         // We use this to restart the consumer task in case of a failure
         consumer_task_clone: consumer_task::ConsumerTask,
         task_state_inner: TaskStateInner,
-        retry_iter: RetryIter,
+        retry_iter: RetryIter<'static>,
     }
 
     enum TaskStateInner {

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -22,7 +22,7 @@ use tokio::task::AbortHandle;
 pub(super) struct InvocationStateMachine {
     pub(super) invocation_target: InvocationTarget,
     invocation_state: InvocationState,
-    retry_iter: retries::RetryIter,
+    retry_iter: retries::RetryIter<'static>,
 }
 
 /// This struct tracks which entries the invocation task generates,

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -14,14 +14,19 @@ mod store;
 mod service;
 
 use restate_core::metadata_store::MetadataStoreClient;
-use restate_types::net::AdvertisedAddress;
+use restate_types::config::MetadataStoreClientOptions;
 pub use service::LocalMetadataStoreService;
 
 use crate::local::grpc::client::LocalMetadataStoreClient;
 
 /// Creates a [`MetadataStoreClient`] for the [`LocalMetadataStoreService`].
-pub fn create_client(advertised_address: AdvertisedAddress) -> MetadataStoreClient {
-    MetadataStoreClient::new(LocalMetadataStoreClient::new(advertised_address))
+pub fn create_client(
+    metadata_store_client_options: MetadataStoreClientOptions,
+) -> MetadataStoreClient {
+    MetadataStoreClient::new(
+        LocalMetadataStoreClient::new(metadata_store_client_options.metadata_store_address),
+        Some(metadata_store_client_options.metadata_store_client_backoff_policy),
+    )
 }
 
 #[cfg(test)]

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -142,7 +142,7 @@ impl Node {
         };
 
         let metadata_store_client = restate_metadata_store::local::create_client(
-            config.common.metadata_store_address.clone(),
+            config.common.metadata_store_client.clone(),
         );
 
         let mut router_builder = MessageRouterBuilder::default();
@@ -231,7 +231,7 @@ impl Node {
                 AdminDependencies::new(
                     cluster_controller.cluster_controller_handle(),
                     restate_metadata_store::local::create_client(
-                        config.common.metadata_store_address.clone(),
+                        config.common.metadata_store_client.clone(),
                     ),
                 )
             }),
@@ -275,7 +275,7 @@ impl Node {
         }
 
         let metadata_store_client = restate_metadata_store::local::create_client(
-            config.common.metadata_store_address.clone(),
+            config.common.metadata_store_client.clone(),
         );
 
         let metadata_writer = self.metadata_manager.writer();

--- a/crates/service-protocol/src/discovery.rs
+++ b/crates/service-protocol/src/discovery.rs
@@ -200,7 +200,7 @@ impl ServiceDiscovery {
         &self,
         endpoint: &DiscoverEndpoint,
     ) -> Result<DiscoveredMetadata, DiscoveryError> {
-        let retry_policy = self.retry_policy.clone().into_iter();
+        let retry_policy = self.retry_policy.iter();
         let (mut parts, body) = Self::invoke_discovery_endpoint(
             &self.client,
             endpoint.address(),
@@ -347,7 +347,7 @@ impl ServiceDiscovery {
         client: &ServiceClient,
         address: impl Display,
         build_request: impl Fn() -> Request<Empty<Bytes>>,
-        mut retry_iter: RetryIter,
+        mut retry_iter: RetryIter<'_>,
     ) -> Result<(ResponseParts, Bytes), DiscoveryError> {
         loop {
             let response_fut = client.call(build_request());

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -10,19 +10,19 @@
 
 use enumset::EnumSet;
 use once_cell::sync::Lazy;
+use restate_serde_util::NonZeroByteCount;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::str::FromStr;
-
-use restate_serde_util::NonZeroByteCount;
-
-use crate::net::{AdvertisedAddress, BindAddress};
-use crate::nodes_config::Role;
-use crate::PlainNodeId;
+use std::time::Duration;
 
 use super::{AwsOptions, HttpOptions, PerfStatsLevel, RocksDbOptions};
+use crate::net::{AdvertisedAddress, BindAddress};
+use crate::nodes_config::Role;
+use crate::retries::RetryPolicy;
+use crate::PlainNodeId;
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 
@@ -61,9 +61,8 @@ pub struct CommonOptions {
     #[builder(setter(strip_option))]
     base_dir: Option<PathBuf>,
 
-    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-    /// Address of the metadata store server to bootstrap the node from.
-    pub metadata_store_address: AdvertisedAddress,
+    #[serde(flatten)]
+    pub metadata_store_client: MetadataStoreClientOptions,
 
     /// Address to bind for the Node server. Default is `0.0.0.0:5122`
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
@@ -332,9 +331,7 @@ impl Default for CommonOptions {
             // compatible and easy for users.
             allow_bootstrap: true,
             base_dir: None,
-            metadata_store_address: "http://127.0.0.1:5123"
-                .parse()
-                .expect("valid metadata store address"),
+            metadata_store_client: MetadataStoreClientOptions::default(),
             bind_address: "0.0.0.0:5122".parse().unwrap(),
             advertised_address: AdvertisedAddress::from_str("http://127.0.0.1:5122/").unwrap(),
             bootstrap_num_partitions: NonZeroU64::new(24).unwrap(),
@@ -412,4 +409,42 @@ pub enum LogFormat {
     ///
     /// Enables json logging. You can use a json log collector to ingest these logs and further process them.
     Json,
+}
+
+/// # Service Client options
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schemars",
+    schemars(rename = "MetadataStoreClientOptions", default)
+)]
+#[builder(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct MetadataStoreClientOptions {
+    /// Address of the metadata store server to bootstrap the node from.
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub metadata_store_address: AdvertisedAddress,
+
+    /// # Backoff policy used by the metadata store client
+    ///
+    /// Backoff policy used by the metadata store client when it encounters concurrent
+    /// modifications.
+    pub metadata_store_client_backoff_policy: RetryPolicy,
+}
+
+impl Default for MetadataStoreClientOptions {
+    fn default() -> Self {
+        Self {
+            metadata_store_address: "http://127.0.0.1:5123"
+                .parse()
+                .expect("valid metadata store address"),
+            metadata_store_client_backoff_policy: RetryPolicy::exponential(
+                Duration::from_millis(10),
+                2.0,
+                None,
+                Some(Duration::from_millis(100)),
+            ),
+        }
+    }
 }

--- a/crates/types/src/retries.rs
+++ b/crates/types/src/retries.rs
@@ -10,6 +10,7 @@
 
 //! A core aspect of Restate it's the ability to retry invocations. This module contains the types defining retries.
 
+use std::borrow::Cow;
 use std::cmp;
 use std::future::Future;
 use std::num::NonZeroUsize;
@@ -195,15 +196,24 @@ impl RetryPolicy {
             }
         }
     }
+
+    pub fn iter(&self) -> RetryIter<'_> {
+        let policy = Cow::Borrowed(self);
+        RetryIter {
+            policy,
+            attempts: 0,
+            last_retry: None,
+        }
+    }
 }
 
 impl IntoIterator for RetryPolicy {
     type Item = Duration;
-    type IntoIter = RetryIter;
+    type IntoIter = RetryIter<'static>;
 
     fn into_iter(self) -> Self::IntoIter {
         RetryIter {
-            policy: self,
+            policy: Cow::Owned(self),
             attempts: 0,
             last_retry: None,
         }
@@ -211,19 +221,19 @@ impl IntoIterator for RetryPolicy {
 }
 
 #[derive(Debug)]
-pub struct RetryIter {
-    policy: RetryPolicy,
+pub struct RetryIter<'a> {
+    policy: Cow<'a, RetryPolicy>,
     attempts: usize,
     last_retry: Option<Duration>,
 }
 
-impl Iterator for RetryIter {
+impl<'a> Iterator for RetryIter<'a> {
     type Item = Duration;
 
     /// adds up to 1/3 target duration as jitter
     fn next(&mut self) -> Option<Self::Item> {
         self.attempts += 1;
-        match self.policy {
+        match self.policy.as_ref() {
             RetryPolicy::None => None,
             RetryPolicy::FixedDelay {
                 interval,
@@ -232,7 +242,7 @@ impl Iterator for RetryIter {
                 if max_attempts.is_some_and(|limit| self.attempts > limit.into()) {
                     None
                 } else {
-                    Some(with_jitter(interval.into(), DEFAULT_JITTER_MULTIPLIER))
+                    Some(with_jitter((*interval).into(), DEFAULT_JITTER_MULTIPLIER))
                 }
             }
             RetryPolicy::Exponential {
@@ -245,21 +255,24 @@ impl Iterator for RetryIter {
                     None
                 } else if self.last_retry.is_some() {
                     let new_retry = cmp::min(
-                        self.last_retry.unwrap().mul_f32(factor),
+                        self.last_retry.unwrap().mul_f32(*factor),
                         max_interval.map(Into::into).unwrap_or(Duration::MAX),
                     );
                     self.last_retry = Some(new_retry);
                     return Some(with_jitter(new_retry, DEFAULT_JITTER_MULTIPLIER));
                 } else {
-                    self.last_retry = Some(*initial_interval);
-                    return Some(with_jitter(*initial_interval, DEFAULT_JITTER_MULTIPLIER));
+                    self.last_retry = Some((*initial_interval).into());
+                    return Some(with_jitter(
+                        (*initial_interval).into(),
+                        DEFAULT_JITTER_MULTIPLIER,
+                    ));
                 }
             }
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let max_attempts = match self.policy {
+        let max_attempts = match self.policy.as_ref() {
             RetryPolicy::None => return (0, Some(0)),
             RetryPolicy::FixedDelay { max_attempts, .. } => max_attempts,
             RetryPolicy::Exponential { max_attempts, .. } => max_attempts,
@@ -289,7 +302,7 @@ pub fn with_jitter(duration: Duration, max_multiplier: f32) -> Duration {
     }
 }
 
-impl ExactSizeIterator for RetryIter {}
+impl<'a> ExactSizeIterator for RetryIter<'a> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This commit makes the backoff policy in the metadata store client
configurable via the configuration.

This fixes https://github.com/restatedev/restate/issues/1752.