### PR TITLE
[Bifrost] Bifrost appends will wait for reconfiguration

### DIFF
--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -73,7 +73,7 @@ pub struct DeleteInvocationParams {
     )
 )]
 pub async fn delete_invocation<V>(
-    State(mut state): State<AdminServiceState<V>>,
+    State(state): State<AdminServiceState<V>>,
     Path(invocation_id): Path<String>,
     Query(DeleteInvocationParams { mode }): Query<DeleteInvocationParams>,
 ) -> Result<StatusCode, MetaApiError> {
@@ -99,7 +99,7 @@ pub async fn delete_invocation<V>(
             "delete_invocation",
             None,
             append_envelope_to_bifrost(
-                &mut state.bifrost,
+                &state.bifrost,
                 Envelope::new(create_envelope_header(partition_key), cmd),
             ),
         )

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -148,7 +148,7 @@ pub async fn modify_service<V>(
     )
 )]
 pub async fn modify_service_state<V>(
-    State(mut state): State<AdminServiceState<V>>,
+    State(state): State<AdminServiceState<V>>,
     Path(service_name): Path<String>,
     #[request_body(required = true)] Json(ModifyServiceStateRequest {
         version,
@@ -186,7 +186,7 @@ pub async fn modify_service_state<V>(
             "modify_service_state",
             None,
             append_envelope_to_bifrost(
-                &mut state.bifrost,
+                &state.bifrost,
                 Envelope::new(
                     create_envelope_header(partition_key),
                     Command::PatchState(patch_state),

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -14,12 +14,14 @@ use std::sync::OnceLock;
 
 use bytes::BytesMut;
 use enum_map::EnumMap;
+use restate_types::retries::{RetryIter, RetryPolicy};
 use smallvec::SmallVec;
-use tracing::{info, instrument};
+use tokio::time::Instant;
+use tracing::{debug, info, instrument, Span};
 
 use restate_core::{Metadata, MetadataKind, TargetVersion};
 use restate_types::config::Configuration;
-use restate_types::logs::metadata::{MaybeSegment, ProviderKind, Segment};
+use restate_types::logs::metadata::{MaybeSegment, ProviderKind, Segment, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, Payload, SequenceNumber};
 use restate_types::storage::StorageCodec;
 use restate_types::Version;
@@ -94,17 +96,42 @@ impl Bifrost {
 
     /// Appends a single record to a log. The log id must exist, otherwise the
     /// operation fails with [`Error::UnknownLogId`]
-    #[instrument(level = "debug", skip(self, payload), err)]
+    #[instrument(
+        level = "debug",
+        skip(self, payload),
+        err,
+        fields(
+            log_id = %log_id,
+            size_in_bytes = payload.body_size(),
+            segment_index = tracing::field::Empty
+        )
+    )]
     pub async fn append(&self, log_id: LogId, payload: Payload) -> Result<Lsn> {
-        self.inner.append(log_id, payload).await
+        // asoli (todo: use RetryIter<'a> when it's merged)
+        let retry_policy = Configuration::pinned().bifrost.append_retry_policy.clone();
+        self.inner.append(log_id, payload, retry_policy).await
     }
 
     /// Appends a batch of records to a log. The log id must exist, otherwise the
     /// operation fails with [`Error::UnknownLogId`]. The returned Lsn is the Lsn of the first
     /// record in this batch. This will only return after all records have been stored.
-    #[instrument(level = "debug", skip(self, payloads), err)]
+    #[instrument(
+        level = "debug",
+        skip(self, payloads),
+        err,
+        fields(
+            log_id = %log_id,
+            count = payloads.len(),
+            size_in_bytes = payloads.iter().fold(0, |acc, payload| acc + payload.body_size()),
+            segment_index = tracing::field::Empty
+        )
+    )]
     pub async fn append_batch(&self, log_id: LogId, payloads: &[Payload]) -> Result<Lsn> {
-        self.inner.append_batch(log_id, payloads).await
+        // asoli (todo: use RetryIter<'a> when it's merged)
+        let retry_policy = Configuration::pinned().bifrost.append_retry_policy.clone();
+        self.inner
+            .append_batch(log_id, payloads, retry_policy)
+            .await
     }
 
     /// Read the next record from the LSN provided. The `from` indicates the LSN where we will
@@ -232,23 +259,50 @@ impl BifrostInner {
 
     /// Appends a single record to a log. The log id must exist, otherwise the
     /// operation fails with [`Error::UnknownLogId`]
-    pub async fn append(&self, log_id: LogId, payload: Payload) -> Result<Lsn> {
+    pub async fn append(
+        &self,
+        log_id: LogId,
+        payload: Payload,
+        retry_policy: RetryPolicy,
+    ) -> Result<Lsn> {
         self.fail_if_shutting_down()?;
-        let loglet = self.writeable_loglet(log_id).await?;
         let mut buf = BytesMut::default();
         StorageCodec::encode(payload, &mut buf).expect("serialization to bifrost is infallible");
+        let buf = buf.freeze();
 
-        let res = loglet.append(buf.freeze()).await;
-        // todo: Handle retries, segment seals and other recoverable errors.
-        res.map_err(|e| match e {
-            AppendError::Sealed => todo!(),
-            AppendError::Shutdown(e) => Error::Shutdown(e),
-            AppendError::Other(e) => Error::LogletError(e),
-        })
+        let mut retry_iter = retry_policy.into_iter();
+        let mut attempt = 0;
+        let mut loglet = self.writeable_loglet(log_id).await?;
+        loop {
+            attempt += 1;
+            Span::current().record(
+                "segment_index",
+                tracing::field::display(loglet.segment_index()),
+            );
+            match loglet.append(buf.clone()).await {
+                Ok(lsn) => return Ok(lsn),
+                Err(AppendError::Sealed) => {
+                    info!(
+                        attempt = attempt,
+                        "Append will be retried (loglet being sealed), waiting for tail to be determined"
+                    );
+                    loglet = self
+                        .wait_next_unsealed_loglet(log_id, loglet.segment_index(), &mut retry_iter)
+                        .await?;
+                }
+                Err(AppendError::Shutdown(e)) => return Err(Error::Shutdown(e)),
+                Err(AppendError::Other(e)) => return Err(Error::LogletError(e)),
+            }
+        }
     }
 
-    pub async fn append_batch(&self, log_id: LogId, payloads: &[Payload]) -> Result<Lsn> {
-        let loglet = self.writeable_loglet(log_id).await?;
+    pub async fn append_batch(
+        &self,
+        log_id: LogId,
+        payloads: &[Payload],
+        retry_policy: RetryPolicy,
+    ) -> Result<Lsn> {
+        let mut loglet = self.writeable_loglet(log_id).await?;
         let raw_payloads: SmallVec<[_; SMALL_BATCH_THRESHOLD_COUNT]> = payloads
             .iter()
             .map(|payload| {
@@ -258,13 +312,29 @@ impl BifrostInner {
                 buf.freeze()
             })
             .collect();
-        let res = loglet.append_batch(&raw_payloads).await;
-        // todo: Handle retries, segment seals and other recoverable errors.
-        res.map_err(|e| match e {
-            AppendError::Sealed => todo!(),
-            AppendError::Shutdown(e) => Error::Shutdown(e),
-            AppendError::Other(e) => Error::LogletError(e),
-        })
+        let mut retry_iter = retry_policy.into_iter();
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            Span::current().record(
+                "segment_index",
+                tracing::field::display(loglet.segment_index()),
+            );
+            match loglet.append_batch(&raw_payloads).await {
+                Ok(lsn) => return Ok(lsn),
+                Err(AppendError::Sealed) => {
+                    info!(
+                        attempt = attempt,
+                        "Append batch will be retried (loglet being sealed), waiting for tail to be determined"
+                    );
+                    loglet = self
+                        .wait_next_unsealed_loglet(log_id, loglet.segment_index(), &mut retry_iter)
+                        .await?;
+                }
+                Err(AppendError::Shutdown(e)) => return Err(Error::Shutdown(e)),
+                Err(AppendError::Other(e)) => return Err(Error::LogletError(e)),
+            }
+        }
     }
 
     pub async fn read(&self, log_id: LogId, from: Lsn) -> Result<Option<LogRecord>> {
@@ -345,6 +415,32 @@ impl BifrostInner {
         let loglet = self.writeable_loglet(log_id).await?;
         let tail = loglet.find_tail().await?;
         Ok((loglet, tail))
+    }
+
+    async fn wait_next_unsealed_loglet(
+        &self,
+        log_id: LogId,
+        sealed_segment: SegmentIndex,
+        retry_iter: &mut RetryIter,
+    ) -> Result<LogletWrapper> {
+        let start = Instant::now();
+        for sleep_dur in retry_iter.by_ref() {
+            self.fail_if_shutting_down()?;
+            tokio::time::sleep(sleep_dur).await;
+            let loglet = self.writeable_loglet(log_id).await?;
+            // Do we think that the last tail loglet is different and unsealed?
+            if loglet.tail_lsn.is_none() && loglet.segment_index() > sealed_segment {
+                let total_dur = start.elapsed();
+                debug!(
+                    "Found an unsealed segment {} after {:?}",
+                    loglet.segment_index(),
+                    total_dur
+                );
+                return Ok(loglet);
+            }
+        }
+
+        Err(Error::LogSealed(log_id))
     }
 
     async fn get_trim_point(&self, log_id: LogId) -> Result<Lsn, Error> {
@@ -473,6 +569,8 @@ impl BifrostInner {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+
     use tokio::time::Duration;
 
     use super::*;
@@ -485,7 +583,7 @@ mod tests {
     use restate_types::Versioned;
 
     use crate::{BifrostAdmin, Record, TrimGap};
-    use restate_core::{metadata, TestCoreEnv};
+    use restate_core::{metadata, TaskKind, TestCoreEnv};
     use restate_core::{task_center, TestCoreEnvBuilder};
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::CommonOptions;
@@ -894,5 +992,130 @@ mod tests {
             Ok(())
         })
         .await
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn test_appends_correctly_handle_reconfiguration() -> googletest::Result<()> {
+        const LOG_ID: LogId = LogId::new(0);
+        let node_env = TestCoreEnvBuilder::new_with_mock_network()
+            .with_partition_table(FixedPartitionTable::new(Version::MIN, 1))
+            .set_provider_kind(ProviderKind::Local)
+            .build()
+            .await;
+        let tc = node_env.tc;
+        tc.run_in_scope("test", None, async {
+            RocksDbManager::init(Constant::new(CommonOptions::default()));
+            let bifrost = Bifrost::init_local(metadata()).await;
+            let bifrost_admin = BifrostAdmin::new(
+                &bifrost,
+                &node_env.metadata_writer,
+                &node_env.metadata_store_client,
+            );
+
+            // create an appender
+            let stop_signal = Arc::new(AtomicBool::default());
+            let append_counter = Arc::new(AtomicUsize::new(0));
+            let _ = tc.spawn(TaskKind::TestRunner, "append-records", None, {
+                let append_counter = append_counter.clone();
+                let stop_signal = stop_signal.clone();
+                let bifrost = bifrost.clone();
+                async move {
+                    let mut i = 0;
+                    while !stop_signal.load(Ordering::Relaxed) {
+                        i += 1;
+                        if i % 2 == 0 {
+                            // append individual record
+                            let lsn = bifrost
+                                .append(LOG_ID, Payload::new(format!("record{}", i)))
+                                .await?;
+                            println!("Appended {}", lsn);
+                        } else {
+                            // append batch
+                            let mut payloads = Vec::with_capacity(10);
+                            for j in 1..=10 {
+                                payloads.push(Payload::new(format!("record-in-batch{}-{}", i, j)));
+                            }
+                            let lsn = bifrost.append_batch(LOG_ID, &payloads).await?;
+                            println!("Appended batch {}", lsn);
+                        }
+                        append_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                    }
+                    println!("Appender terminated");
+                    Ok(())
+                }
+            })?;
+
+            let mut append_counter_before_seal;
+            loop {
+                append_counter_before_seal = append_counter.load(Ordering::Relaxed);
+                if append_counter_before_seal < 100 {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                } else {
+                    break;
+                }
+            }
+
+            // seal and don't extend the chain.
+            let _ = bifrost_admin.seal(LOG_ID, SegmentIndex::from(0)).await?;
+
+            // appends should stall!
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let append_counter_during_seal = append_counter.load(Ordering::Relaxed);
+            for _ in 0..5 {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                let counter_now = append_counter.load(Ordering::Relaxed);
+                assert_that!(counter_now, eq(append_counter_during_seal));
+                println!("Appends are stalling, counter={}", counter_now);
+            }
+
+            for i in 1..=5 {
+                let last_segment = bifrost
+                    .inner
+                    .writeable_loglet(LOG_ID)
+                    .await?
+                    .segment_index();
+                // allow appender to run a little.
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                // seal the loglet and extend with an in-memory one
+                let new_segment_params = new_single_node_loglet_params(ProviderKind::Local);
+                bifrost_admin
+                    .seal_and_extend_chain(
+                        LOG_ID,
+                        None,
+                        Version::MIN,
+                        ProviderKind::Local,
+                        new_segment_params,
+                    )
+                    .await?;
+                println!("Seal {}", i);
+                assert_that!(
+                    bifrost
+                        .inner
+                        .writeable_loglet(LOG_ID)
+                        .await?
+                        .segment_index(),
+                    gt(last_segment)
+                );
+            }
+
+            // make sure that appends are still happening.
+            let mut append_counter_after_seal = append_counter.load(Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            assert_that!(append_counter_after_seal, gt(append_counter_before_seal));
+            for _ in 0..5 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                let counter_now = append_counter.load(Ordering::Relaxed);
+                assert_that!(counter_now, gt(append_counter_after_seal));
+                append_counter_after_seal = counter_now;
+            }
+
+            googletest::Result::Ok(())
+        })
+        .await?;
+        tc.shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
     }
 }

--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -92,7 +92,6 @@ impl DispatchIngressRequest for IngressDispatcher {
         &self,
         ingress_request: IngressDispatcherRequest,
     ) -> Result<(), IngressDispatchError> {
-        let mut bifrost = self.bifrost.clone();
         let IngressDispatcherRequest {
             inner,
             request_mode,
@@ -133,7 +132,7 @@ impl DispatchIngressRequest for IngressDispatcher {
             dedup_source,
             msg_index,
         );
-        let (log_id, lsn) = append_envelope_to_bifrost(&mut bifrost, envelope).await?;
+        let (log_id, lsn) = append_envelope_to_bifrost(&self.bifrost, envelope).await?;
 
         debug!(
             log_id = %log_id,

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -44,7 +44,7 @@ pub struct BifrostOptions {
     /// Configuration of replicated loglet provider
     pub replicated_loglet: ReplicatedLogletOptions,
 
-    /// # Retry policy
+    /// # Read retry policy
     ///
     /// Retry policy to use when bifrost waits for reconfiguration to complete during
     /// read operations
@@ -56,6 +56,14 @@ pub struct BifrostOptions {
     #[serde_as(as = "serde_with::DisplayFromStr")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub seal_retry_interval: humantime::Duration,
+
+    /// # Append retry policy
+    ///
+    /// Retry policy to use when bifrost waits for reconfiguration to complete during
+    /// append operations.
+    ///
+    /// Note that appends will be retried forever by default.
+    pub append_retry_policy: RetryPolicy,
 }
 
 impl BifrostOptions {
@@ -76,6 +84,12 @@ impl Default for BifrostOptions {
                 Duration::from_millis(50),
                 2.0,
                 Some(50),
+                Some(Duration::from_secs(1)),
+            ),
+            append_retry_policy: RetryPolicy::exponential(
+                Duration::from_millis(10),
+                2.0,
+                None,
                 Some(Duration::from_secs(1)),
             ),
             seal_retry_interval: Duration::from_secs(2).into(),

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -190,6 +190,10 @@ impl Payload {
     pub fn into_header(self) -> Header {
         self.header
     }
+
+    pub fn body_size(&self) -> usize {
+        self.body.len()
+    }
 }
 
 flexbuffers_storage_encode_decode!(Payload);

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -178,7 +178,7 @@ pub enum Error {
 /// Important: This method must only be called in the context of a [`TaskCenter`] task because
 /// it needs access to [`metadata()`].
 pub async fn append_envelope_to_bifrost(
-    bifrost: &mut Bifrost,
+    bifrost: &Bifrost,
     envelope: Envelope,
 ) -> Result<(LogId, Lsn), Error> {
     let partition_table = metadata().wait_for_partition_table(Version::MIN).await?;

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -100,18 +100,14 @@ impl ActionEffectHandler {
         let mut batches = FuturesUnordered::new();
 
         // Attempt to write batches to different log ids concurrently
-        for (log_id, payloads) in buffer {
-            let bifrost = self.bifrost.clone();
-            batches.push(async move {
-                bifrost.append_batch(log_id, &payloads).await?;
-                anyhow::Ok(())
-            });
+        for (log_id, payloads) in &buffer {
+            batches.push(self.bifrost.append_batch(*log_id, payloads));
         }
         while let Some(o) = batches.next().await {
             // fail if any write fails. This is not the best approach to handle write errors,
             // however this is how it was.
             // todo: we should implement a better error handling mechanism
-            o?
+            let _ = o?;
         }
         Ok(())
     }

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -228,9 +228,9 @@ where
             metadata,
             outbox_reader,
             |msg| {
-                let mut bifrost = bifrost.clone();
+                let bifrost = bifrost.clone();
                 async move {
-                    append_envelope_to_bifrost(&mut bifrost, msg).await?;
+                    append_envelope_to_bifrost(&bifrost, msg).await?;
                     Ok(())
                 }
             },


### PR DESCRIPTION
[Bifrost] Bifrost appends will wait for reconfiguration

Bifrost appends will wait for reconfiguration to complete. Additionally, log metadata will now handle empty segments correctly. An empty segment will be removed from the chain and replaced with the newly created one but with a higher segment index.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1772).
* #1776
* #1775
* __->__ #1772