### PR TITLE
Fixs SIGSEGV due to missing rocksdb shutdown in leader stepdown test

### DIFF
--- a/crates/worker/src/partition/leadership.rs
+++ b/crates/worker/src/partition/leadership.rs
@@ -767,8 +767,12 @@ mod tests {
 
             assert!(matches!(state.state, State::Follower));
 
-            Ok(())
+            googletest::Result::Ok(())
         })
-        .await
+        .await?;
+
+        tc.shutdown_node("test_completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixs SIGSEGV due to missing rocksdb shutdown in leader stepdown test

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1774).
* #1772
* __->__ #1774