### PR TITLE
Hide the `--wipe` flag

### DIFF
--- a/crates/errors/src/error_codes/META0010.md
+++ b/crates/errors/src/error_codes/META0010.md
@@ -6,5 +6,5 @@ Suggestions:
 
 * Up/Downgrade your Restate server to the requested version.
 * Migrate your data to the requested version by running the migration scripts.
-* Wipe your meta storage directory to start afresh via `--wipe=meta`.
+* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/${HOST}/local-metadata-store`.
 * Configure a different meta storage directory via `meta.storage_path`.

--- a/crates/errors/src/error_codes/META0010.md
+++ b/crates/errors/src/error_codes/META0010.md
@@ -6,5 +6,5 @@ Suggestions:
 
 * Up/Downgrade your Restate server to the requested version.
 * Migrate your data to the requested version by running the migration scripts.
-* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/${HOST}/local-metadata-store`.
+* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/<NODE_NAME>/local-metadata-store`.
 * Configure a different meta storage directory via `meta.storage_path`.

--- a/crates/errors/src/error_codes/META0011.md
+++ b/crates/errors/src/error_codes/META0011.md
@@ -4,6 +4,6 @@ Non-empty meta storage directory, configured via `meta.storage_path`, is missing
 
 Suggestions:
 
-* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/${HOST}/local-metadata-store`.
+* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/<NODE_NAME>/local-metadata-store`.
 * Configure a different meta storage directory via `meta.storage_path`.
 * Downgrade your Restate server to {'<='} 0.7.

--- a/crates/errors/src/error_codes/META0011.md
+++ b/crates/errors/src/error_codes/META0011.md
@@ -4,6 +4,6 @@ Non-empty meta storage directory, configured via `meta.storage_path`, is missing
 
 Suggestions:
 
-* Wipe your meta storage directory to start afresh via `--wipe=meta`.
+* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/${HOST}/local-metadata-store`.
 * Configure a different meta storage directory via `meta.storage_path`.
 * Downgrade your Restate server to {'<='} 0.7.

--- a/crates/errors/src/error_codes/RT0009.md
+++ b/crates/errors/src/error_codes/RT0009.md
@@ -4,6 +4,6 @@ Trying to open worker storage directory, configured via `worker.storage_rocksdb.
 
 Suggestions:
 
-* Wipe your worker storage directory to start afresh via `--wipe=worker`.
+* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/${HOST}/db`.
 * Configure a different worker storage directory via `worker.storage_rocksdb.path`.
 * Downgrade your Restate server to < 0.8.

--- a/crates/errors/src/error_codes/RT0009.md
+++ b/crates/errors/src/error_codes/RT0009.md
@@ -4,6 +4,6 @@ Trying to open worker storage directory, configured via `worker.storage_rocksdb.
 
 Suggestions:
 
-* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/${HOST}/db`.
+* Wipe your meta storage directory to start afresh via `rm -rf <BASE_DIR>/<NODE_NAME>/db`.
 * Configure a different worker storage directory via `worker.storage_rocksdb.path`.
 * Downgrade your Restate server to < 0.8.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,7 +64,7 @@ struct RestateArguments {
     /// Wipes the configured data before starting Restate.
     ///
     /// **WARNING** all the wiped data will be lost permanently!
-    #[arg(value_enum, long = "destroy-persisted-data", hide = true)]
+    #[arg(value_enum, long = "wipe", hide = true)]
     wipe: Option<WipeMode>,
 
     #[clap(flatten)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,7 +64,7 @@ struct RestateArguments {
     /// Wipes the configured data before starting Restate.
     ///
     /// **WARNING** all the wiped data will be lost permanently!
-    #[arg(value_enum, long = "wipe")]
+    #[arg(value_enum, long = "wipe", hide=true)]
     wipe: Option<WipeMode>,
 
     #[clap(flatten)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,7 +64,7 @@ struct RestateArguments {
     /// Wipes the configured data before starting Restate.
     ///
     /// **WARNING** all the wiped data will be lost permanently!
-    #[arg(value_enum, long = "wipe", hide = true)]
+    #[arg(value_enum, long = "destroy-persisted-data", hide = true)]
     wipe: Option<WipeMode>,
 
     #[clap(flatten)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,7 +64,7 @@ struct RestateArguments {
     /// Wipes the configured data before starting Restate.
     ///
     /// **WARNING** all the wiped data will be lost permanently!
-    #[arg(value_enum, long = "wipe", hide=true)]
+    #[arg(value_enum, long = "wipe", hide = true)]
     wipe: Option<WipeMode>,
 
     #[clap(flatten)]


### PR DESCRIPTION
Fixes #1650

I think hiding the flag is better than completely removing the code. This this way the user can still does a wipe without the need to actually remote data directories manually which can be error prone (for example removing the wrong files or directories)