### PR TITLE
Configurable network error retry policy

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -445,7 +445,7 @@ impl Node {
         metadata_store_client: &MetadataStoreClient,
         config: &Configuration,
     ) -> Result<FixedPartitionTable, Error> {
-        Self::retry_on_network_error(config.common.network_error_retry_policy(), || {
+        Self::retry_on_network_error(config.common.network_error_retry_policy.clone(), || {
             metadata_store_client.get_or_insert(PARTITION_TABLE_KEY.clone(), || {
                 FixedPartitionTable::new(Version::MIN, config.common.bootstrap_num_partitions())
             })
@@ -459,7 +459,7 @@ impl Node {
         config: &Configuration,
         num_partitions: u64,
     ) -> Result<Logs, Error> {
-        Self::retry_on_network_error(config.common.network_error_retry_policy(), || {
+        Self::retry_on_network_error(config.common.network_error_retry_policy.clone(), || {
             metadata_store_client.get_or_insert(BIFROST_CONFIG_KEY.clone(), || {
                 bootstrap_logs_metadata(config.bifrost.default_provider, num_partitions)
             })
@@ -472,7 +472,7 @@ impl Node {
         metadata_store_client: &MetadataStoreClient,
         common_opts: &CommonOptions,
     ) -> Result<NodesConfiguration, Error> {
-        Self::retry_on_network_error(common_opts.network_error_retry_policy(), || {
+        Self::retry_on_network_error(common_opts.network_error_retry_policy.clone(), || {
             let mut previous_node_generation = None;
             metadata_store_client.read_modify_write(NODES_CONFIG_KEY.clone(), move |nodes_config| {
                 let mut nodes_config = if common_opts.allow_bootstrap {

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -233,6 +233,11 @@ pub struct CommonOptions {
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub metadata_update_interval: humantime::Duration,
+
+    /// # Network error retry policy
+    ///
+    /// The retry policy for node network error
+    network_error_retry_policy: Option<RetryPolicy>,
 }
 
 static HOSTNAME: Lazy<String> = Lazy::new(|| {
@@ -317,6 +322,10 @@ impl CommonOptions {
                 .expect("number of cpu cores fits in u32"),
         )
     }
+
+    pub fn network_error_retry_policy(&self) -> RetryPolicy {
+        self.network_error_retry_policy.clone().unwrap_or_default()
+    }
 }
 
 impl Default for CommonOptions {
@@ -357,6 +366,12 @@ impl Default for CommonOptions {
             rocksdb_perf_level: PerfStatsLevel::EnableCount,
             rocksdb: Default::default(),
             metadata_update_interval: std::time::Duration::from_secs(3).into(),
+            network_error_retry_policy: Some(RetryPolicy::exponential(
+                Duration::from_millis(10),
+                2.0,
+                Some(15),
+                Some(Duration::from_secs(5)),
+            )),
         }
     }
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -324,7 +324,14 @@ impl CommonOptions {
     }
 
     pub fn network_error_retry_policy(&self) -> RetryPolicy {
-        self.network_error_retry_policy.clone().unwrap_or_default()
+        self.network_error_retry_policy.clone().unwrap_or_else(|| {
+            RetryPolicy::exponential(
+                Duration::from_millis(10),
+                2.0,
+                Some(15),
+                Some(Duration::from_secs(5)),
+            )
+        })
     }
 }
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -237,7 +237,7 @@ pub struct CommonOptions {
     /// # Network error retry policy
     ///
     /// The retry policy for node network error
-    network_error_retry_policy: Option<RetryPolicy>,
+    pub network_error_retry_policy: RetryPolicy,
 }
 
 static HOSTNAME: Lazy<String> = Lazy::new(|| {
@@ -322,17 +322,6 @@ impl CommonOptions {
                 .expect("number of cpu cores fits in u32"),
         )
     }
-
-    pub fn network_error_retry_policy(&self) -> RetryPolicy {
-        self.network_error_retry_policy.clone().unwrap_or_else(|| {
-            RetryPolicy::exponential(
-                Duration::from_millis(10),
-                2.0,
-                Some(15),
-                Some(Duration::from_secs(5)),
-            )
-        })
-    }
 }
 
 impl Default for CommonOptions {
@@ -373,12 +362,12 @@ impl Default for CommonOptions {
             rocksdb_perf_level: PerfStatsLevel::EnableCount,
             rocksdb: Default::default(),
             metadata_update_interval: std::time::Duration::from_secs(3).into(),
-            network_error_retry_policy: Some(RetryPolicy::exponential(
+            network_error_retry_policy: RetryPolicy::exponential(
                 Duration::from_millis(10),
                 2.0,
                 Some(15),
                 Some(Duration::from_secs(5)),
-            )),
+            ),
         }
     }
 }


### PR DESCRIPTION
Fixes #1769

This makes the network error retry policy configurable for the node