### PR TITLE
[Bifrost] New Appender with Keys support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ async-channel = "2.1.1"
 async-trait = "0.1.73"
 axum = { version = "0.7.5", default-features = false }
 base64 = "0.22"
-bytes = { version = "1.3", features = ["serde"] }
+bytes = { version = "1.7", features = ["serde"] }
 bytes-utils = "0.1.3"
 bytestring = { version = "1.2", features = ["serde"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -19,7 +19,7 @@ use restate_rocksdb::{DbName, RocksDbManager};
 use restate_types::config::{
     BifrostOptionsBuilder, CommonOptionsBuilder, ConfigurationBuilder, LocalLogletOptionsBuilder,
 };
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 mod util;
@@ -31,7 +31,9 @@ async fn append_records_multi_log(bifrost: Bifrost, log_id_range: Range<u64>, co
             let bifrost = bifrost.clone();
             appends.push(async move {
                 let _ = bifrost
-                    .append(LogId::from(log_id), Payload::default())
+                    .create_appender(LogId::new(log_id))
+                    .expect("log exists")
+                    .append_raw("")
                     .await
                     .unwrap();
             })
@@ -44,15 +46,23 @@ async fn append_records_concurrent_single_log(bifrost: Bifrost, log_id: LogId, c
     let mut appends = FuturesOrdered::new();
     for _ in 0..count_per_log {
         let bifrost = bifrost.clone();
-        appends.push_back(async move { bifrost.append(log_id, Payload::default()).await.unwrap() })
+        appends.push_back(async move {
+            bifrost
+                .create_appender(log_id)
+                .expect("log exists")
+                .append_raw("")
+                .await
+                .unwrap()
+        })
     }
     while appends.next().await.is_some() {}
 }
 
 async fn append_seq(bifrost: Bifrost, log_id: LogId, count: u64) {
+    let mut appender = bifrost.create_appender(log_id).expect("log exists");
     for _ in 1..=count {
-        let _ = bifrost
-            .append(log_id, Payload::default())
+        let _ = appender
+            .append_raw("")
             .await
             .expect("bifrost accept record");
     }

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -1,0 +1,315 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::{Bytes, BytesMut};
+use tracing::{debug, info, instrument, Span};
+
+use restate_types::config::Configuration;
+use restate_types::live::Live;
+use restate_types::logs::metadata::SegmentIndex;
+use restate_types::logs::{HasRecordKeys, Keys, LogId, Lsn, Payload};
+use restate_types::retries::RetryIter;
+use restate_types::storage::{StorageCodec, StorageEncode};
+
+use crate::bifrost::BifrostInner;
+use crate::loglet::{AppendError, LogletBase};
+use crate::loglet_wrapper::LogletWrapper;
+use crate::{Error, Result};
+
+// Arbitrarily chosen size for the record size hint. Practically, we should estimate
+// the size from the payload, or use anecdotal data as guidance.
+pub(crate) const RECORD_SIZE_HINT: usize = 4_000; // 4KB per record
+const INITIAL_SERDE_BUFFER_SIZE: usize = 16_000; // Initial capacity 16KB
+
+#[derive(Clone)]
+pub struct Appender {
+    log_id: LogId,
+    config: Live<Configuration>,
+    pub(super) serde_buffer: BytesMut,
+    loglet_cache: Option<LogletWrapper>,
+    bifrost_inner: Arc<BifrostInner>,
+}
+
+impl std::fmt::Debug for Appender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Appender")
+            .field("log_id", &self.log_id)
+            .field("loglet_cache", &self.loglet_cache)
+            .finish()
+    }
+}
+
+impl Appender {
+    pub(crate) fn new(log_id: LogId, bifrost_inner: Arc<BifrostInner>) -> Self {
+        Self::with_buffer_size(log_id, bifrost_inner, INITIAL_SERDE_BUFFER_SIZE)
+    }
+
+    pub(crate) fn with_buffer_size(
+        log_id: LogId,
+        bifrost_inner: Arc<BifrostInner>,
+        serde_buffer_size: usize,
+    ) -> Self {
+        Self::with_serde_buffer(
+            log_id,
+            bifrost_inner,
+            BytesMut::with_capacity(serde_buffer_size),
+        )
+    }
+
+    pub(crate) fn with_serde_buffer(
+        log_id: LogId,
+        bifrost_inner: Arc<BifrostInner>,
+        serde_buffer: BytesMut,
+    ) -> Self {
+        let config = Configuration::updateable();
+
+        Self {
+            log_id,
+            config,
+            serde_buffer,
+            loglet_cache: Default::default(),
+            bifrost_inner,
+        }
+    }
+
+    /// Use only in tests.
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn append_raw(&mut self, raw_bytes: impl Into<Bytes>) -> Result<Lsn> {
+        self.append_raw_with_keys(raw_bytes, Keys::None).await
+    }
+
+    pub(crate) async fn append_raw_with_keys(
+        &mut self,
+        raw_bytes: impl Into<Bytes>,
+        keys: Keys,
+    ) -> Result<Lsn> {
+        self.bifrost_inner.fail_if_shutting_down()?;
+
+        let raw_bytes = raw_bytes.into();
+        // 50 bytes is an over-estimation of the size needed for Header. This is a temporary
+        // solution.
+        // todo: Move header serialization down to loglets and send payloads as &dyn StorageEncode
+        // instead.
+        self.serde_buffer.reserve(50 + raw_bytes.len());
+        let payload = Payload::new(raw_bytes);
+        StorageCodec::encode(payload, &mut self.serde_buffer).expect("record serde is infallible");
+        let raw_bytes = self.serde_buffer.split().freeze();
+
+        let mut retry_iter = self
+            .config
+            .live_load()
+            .bifrost
+            .append_retry_policy()
+            .into_iter();
+        let mut attempt = 0;
+
+        loop {
+            attempt += 1;
+            let loglet = match self.loglet_cache.as_mut() {
+                None => self
+                    .loglet_cache
+                    .insert(self.bifrost_inner.writeable_loglet(self.log_id).await?),
+                Some(wrapper) => wrapper,
+            };
+
+            Span::current().record(
+                "segment_index",
+                tracing::field::display(loglet.segment_index()),
+            );
+            match loglet.append(&raw_bytes, &keys).await {
+                Ok(lsn) => return Ok(lsn),
+                Err(AppendError::Sealed) => {
+                    info!(
+                        attempt = attempt,
+                        "Append will be retried (loglet being sealed), waiting for tail to be determined"
+                    );
+                    let new_loglet = Self::wait_next_unsealed_loglet(
+                        self.log_id,
+                        &self.bifrost_inner,
+                        loglet.segment_index(),
+                        &mut retry_iter,
+                    )
+                    .await?;
+                    self.loglet_cache = Some(new_loglet);
+                }
+                Err(AppendError::Shutdown(e)) => return Err(Error::Shutdown(e)),
+                Err(AppendError::Other(e)) => return Err(Error::LogletError(e)),
+            }
+        }
+    }
+
+    /// Appends a single record to the log.
+    #[instrument(
+        level = "debug",
+        skip(self, body),
+        err,
+        fields(
+            log_id = %self.log_id,
+            segment_index = tracing::field::Empty
+        )
+    )]
+    pub async fn append<T>(&mut self, body: T) -> Result<Lsn>
+    where
+        T: HasRecordKeys + StorageEncode,
+    {
+        let keys = body.record_keys();
+        StorageCodec::encode(&body, &mut self.serde_buffer).expect("record serde is infallible");
+        let raw_bytes = self.serde_buffer.split().freeze();
+        self.append_raw_with_keys(raw_bytes, keys).await
+    }
+
+    #[instrument(
+        level = "debug",
+        skip(self, bodies_with_keys)
+        err,
+        fields(
+            log_id = %self.log_id,
+            segment_index = tracing::field::Empty,
+        )
+    )]
+    pub(crate) async fn append_raw_batch_with_keys(
+        &mut self,
+        bodies_with_keys: &[(Bytes, Keys)],
+    ) -> Result<Lsn> {
+        self.bifrost_inner.fail_if_shutting_down()?;
+        let mut retry_iter = self
+            .config
+            .live_load()
+            .bifrost
+            .append_retry_policy()
+            .into_iter();
+
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let loglet = match self.loglet_cache.as_mut() {
+                None => self
+                    .loglet_cache
+                    .insert(self.bifrost_inner.writeable_loglet(self.log_id).await?),
+                Some(wrapper) => wrapper,
+            };
+            Span::current().record(
+                "segment_index",
+                tracing::field::display(loglet.segment_index()),
+            );
+            match loglet.append_batch(bodies_with_keys).await {
+                Ok(lsn) => return Ok(lsn),
+                Err(AppendError::Sealed) => {
+                    info!(
+                        attempt = attempt,
+                        "Append batch will be retried (loglet being sealed), waiting for tail to be determined"
+                    );
+                    let new_loglet = Self::wait_next_unsealed_loglet(
+                        self.log_id,
+                        &self.bifrost_inner,
+                        loglet.segment_index(),
+                        &mut retry_iter,
+                    )
+                    .await?;
+
+                    self.loglet_cache = Some(new_loglet);
+                }
+                Err(AppendError::Shutdown(e)) => return Err(Error::Shutdown(e)),
+                Err(AppendError::Other(e)) => return Err(Error::LogletError(e)),
+            }
+        }
+    }
+
+    pub async fn append_raw_batch(
+        &mut self,
+        batch: impl IntoIterator<Item = impl Into<Bytes>>,
+    ) -> Result<Lsn> {
+        let bodies_with_keys: Vec<_> = batch
+            .into_iter()
+            .map(|record| {
+                let raw_bytes: Bytes = record.into();
+                let keys = Keys::None;
+                // 50 bytes is an over-estimation of the size needed for Header. This is a temporary
+                // solution.
+                // todo: Move header serialization down to loglets and send payloads as &dyn StorageEncode
+                // instead.
+                self.serde_buffer.reserve(50 + raw_bytes.len());
+                let payload = Payload::new(raw_bytes);
+                StorageCodec::encode(payload, &mut self.serde_buffer)
+                    .expect("record serde is infallible");
+                (self.serde_buffer.split().freeze(), keys)
+            })
+            .collect();
+
+        self.append_raw_batch_with_keys(&bodies_with_keys).await
+    }
+
+    /// Appends a batch of records to the log.
+    ///
+    /// The returned Lsn is the Lsn of the first record committed in this batch .
+    /// This will only return after all records have been stored.
+    #[instrument(
+        level = "debug",
+        skip(self, batch),
+        err,
+        fields(
+            log_id = %self.log_id,
+            count = batch.len(),
+            segment_index = tracing::field::Empty
+        )
+    )]
+    pub async fn append_batch<T>(&mut self, batch: &[T]) -> Result<Lsn>
+    where
+        T: HasRecordKeys + StorageEncode,
+    {
+        // Attempt to reserve enough bytes for the payloads
+        self.serde_buffer.reserve(batch.len() * RECORD_SIZE_HINT);
+
+        let bodies_with_keys: Vec<_> = batch
+            .iter()
+            .map(|record| {
+                // todo (estimate size to reserve)
+                let keys = record.record_keys();
+                StorageCodec::encode(record, &mut self.serde_buffer)
+                    .expect("record serde is infallible");
+                let payload = Payload::new(self.serde_buffer.split().freeze());
+                StorageCodec::encode(payload, &mut self.serde_buffer)
+                    .expect("record serde is infallible");
+                (self.serde_buffer.split().freeze(), keys)
+            })
+            .collect();
+
+        self.append_raw_batch_with_keys(&bodies_with_keys).await
+    }
+
+    async fn wait_next_unsealed_loglet(
+        log_id: LogId,
+        bifrost_inner: &Arc<BifrostInner>,
+        sealed_segment: SegmentIndex,
+        retry_iter: &mut RetryIter<'_>,
+    ) -> Result<LogletWrapper> {
+        let start = Instant::now();
+        for sleep_dur in retry_iter.by_ref() {
+            bifrost_inner.fail_if_shutting_down()?;
+            tokio::time::sleep(sleep_dur).await;
+            let loglet = bifrost_inner.writeable_loglet(log_id).await?;
+            // Do we think that the last tail loglet is different and unsealed?
+            if loglet.tail_lsn.is_none() && loglet.segment_index() > sealed_segment {
+                let total_dur = start.elapsed();
+                debug!(
+                    "Found an unsealed segment {} after {:?}",
+                    loglet.segment_index(),
+                    total_dur
+                );
+                return Ok(loglet);
+            }
+        }
+
+        Err(Error::LogSealed(log_id))
+    }
+}

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -63,6 +63,7 @@ impl<'a> BifrostAdmin<'a> {
     /// trim all records of the log.
     #[instrument(level = "debug", skip(self), err)]
     pub async fn trim(&self, log_id: LogId, trim_point: Lsn) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         self.bifrost.inner.trim(log_id, trim_point).await
     }
 
@@ -83,6 +84,7 @@ impl<'a> BifrostAdmin<'a> {
         provider: ProviderKind,
         params: LogletParams,
     ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         let _ = self
             .bifrost
             .inner
@@ -115,6 +117,7 @@ impl<'a> BifrostAdmin<'a> {
         log_id: LogId,
         segment_index: SegmentIndex,
     ) -> Result<TailState> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         // first find the tail segment for this log.
         let loglet = self.bifrost.inner.writeable_loglet(log_id).await?;
 
@@ -165,6 +168,7 @@ impl<'a> BifrostAdmin<'a> {
         provider: ProviderKind,
         params: LogletParams,
     ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         let logs = self
             .metadata_store_client
             .read_modify_write(BIFROST_CONFIG_KEY.clone(), move |logs: Option<Logs>| {

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod appender;
 mod bifrost;
 mod bifrost_admin;
 mod error;
@@ -20,6 +21,7 @@ mod service;
 mod types;
 mod watchdog;
 
+pub use appender::Appender;
 pub use bifrost::Bifrost;
 pub use bifrost_admin::BifrostAdmin;
 pub use error::{Error, Result};

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
-use restate_types::logs::{Lsn, SequenceNumber};
+use restate_types::logs::{Keys, Lsn, SequenceNumber};
 
 use crate::LogRecord;
 use crate::{Result, TailState};
@@ -122,7 +122,7 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     ) -> Result<SendableLogletReadStream<Self::Offset>>;
 
     /// Append a record to the loglet.
-    async fn append(&self, data: Bytes) -> Result<Self::Offset, AppendError>;
+    async fn append(&self, data: &Bytes, keys: &Keys) -> Result<Self::Offset, AppendError>;
 
     /// An optional optimization that loglets can implement. Offsets returned by this call **MUST**
     /// be offsets that were observed before a sealing point. For instance, the maximum acknowleged
@@ -147,9 +147,9 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     /// beyond it to a higher tail while remaining unsealed.
     fn watch_tail(&self) -> BoxStream<'static, TailState<Self::Offset>>;
 
-    /// Append a batch of records to the loglet. The returned offset (on success) if the offset of
+    /// Append a batch of records to the loglet. The returned offset (on success) is the offset of
     /// the first record in the batch)
-    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Self::Offset, AppendError>;
+    async fn append_batch(&self, payloads: &[(Bytes, Keys)]) -> Result<Self::Offset, AppendError>;
 
     /// The tail is *the first unwritten position* in the loglet.
     ///

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -99,7 +99,7 @@ impl StorageCodec {
 ///
 /// # Important
 /// The [`Self::encode`] implementation should use the codec specified by [`Self::DEFAULT_CODEC`].
-pub trait StorageEncode {
+pub trait StorageEncode: Sized {
     /// Codec which is used when encode new values.
     const DEFAULT_CODEC: StorageCodecKind;
 

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -10,17 +10,16 @@
 
 use super::leadership::ActionEffect;
 use futures::stream::FuturesUnordered;
-use restate_bifrost::{Bifrost, SMALL_BATCH_THRESHOLD_COUNT};
+use restate_bifrost::Bifrost;
 use restate_core::Metadata;
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 use restate_types::partition_table::FindPartition;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::Version;
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
-use smallvec::SmallVec;
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::time::SystemTime;
@@ -57,8 +56,7 @@ impl ActionEffectHandler {
         effects: impl IntoIterator<Item = ActionEffect>,
     ) -> anyhow::Result<()> {
         // groups envelopes write to Bifrost in batches
-        let mut buffer: BTreeMap<LogId, SmallVec<[Payload; SMALL_BATCH_THRESHOLD_COUNT]>> =
-            Default::default();
+        let mut buffer: BTreeMap<LogId, Vec<Envelope>> = Default::default();
 
         for actuator_output in effects {
             let envelope = match actuator_output {
@@ -96,17 +94,14 @@ impl ActionEffectHandler {
                 LogId::from(partition_table.find_partition_id(envelope.partition_key())?)
             };
 
-            buffer
-                .entry(log_id)
-                .or_default()
-                .push(Payload::new(envelope.to_bytes()?));
+            buffer.entry(log_id).or_default().push(envelope);
         }
 
         let mut batches = FuturesUnordered::new();
 
         // Attempt to write batches to different log ids concurrently
-        for (log_id, payloads) in &buffer {
-            batches.push(self.bifrost.append_batch(*log_id, payloads));
+        for (log_id, envelopes) in &buffer {
+            batches.push(self.bifrost.append_batch(*log_id, envelopes));
         }
         while let Some(o) = batches.next().await {
             // fail if any write fails. This is not the best approach to handle write errors,

--- a/crates/worker/src/partition/leadership.rs
+++ b/crates/worker/src/partition/leadership.rs
@@ -34,7 +34,7 @@ use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNu
 use restate_timer::TokioClock;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 use restate_types::net::ingress;
 use restate_types::storage::StorageEncodeError;
 use restate_types::GenerationalNodeId;
@@ -221,12 +221,11 @@ where
                 leader_epoch,
             }),
         );
-        let payload = Payload::new(envelope.to_bytes()?);
 
         self.bifrost
             .append(
                 LogId::from(self.partition_processor_metadata.partition_id),
-                payload,
+                envelope,
             )
             .await?;
 

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -227,7 +227,7 @@ where
         let state_machine = StateMachine::new(
             metadata,
             outbox_reader,
-            |msg| {
+            move |msg| {
                 let bifrost = bifrost.clone();
                 async move {
                     append_envelope_to_bifrost(&bifrost, msg).await?;

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -16,7 +16,7 @@ use tracing::info;
 
 use restate_bifrost::Bifrost;
 use restate_core::TaskCenter;
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 
 use crate::util::print_latencies;
 use crate::Arguments;
@@ -37,16 +37,17 @@ pub async fn run(
     let mut bytes = BytesMut::default();
     let raw_data = [1u8; 1024];
     bytes.put_slice(&raw_data);
+    let bytes = bytes.freeze();
     let mut append_latencies = Histogram::<u64>::new(3)?;
     let mut counter = 0;
+    let mut appender = bifrost.create_appender(log_id)?;
     loop {
         if counter >= opts.num_records {
             break;
         }
         counter += 1;
         let start = Instant::now();
-        let payload = Payload::new(bytes.clone());
-        let _ = bifrost.append(log_id, payload).await?;
+        let _ = appender.append_raw(bytes.clone()).await?;
         append_latencies.record(start.elapsed().as_nanos() as u64)?;
         if counter % 1000 == 0 {
             info!("Appended {} records", counter);


### PR DESCRIPTION
[Bifrost] New Appender with Keys support


Envelope implements a new trait `HasRecordKeys` to support future matching of records based on a `KeyMatcher`. The new appender is the canonical way to write to a single log. It tries to recycle the write buffer (although it doesn't use freelist which would be a potential future improvement) and it defers serialization to unlock the potential for better serialization write buffer management.

Appender is created by `bifrost.create_appender(log_id)?` and it's the core abstraction that `BackgroundAppender` builds upon (next PR)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1788).
* #1809
* #1808
* #1798
* #1797
* #1794
* #1792
* #1789
* __->__ #1788