### PR TITLE
Add single node Raft metadata store with memory storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2586,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2958,6 +2979,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,6 +3008,18 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5099,6 +5141,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
+name = "protobuf-build"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
+dependencies = [
+ "bitflags 1.3.2",
+ "protobuf",
+ "protobuf-codegen",
+ "regex",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5186,6 +5258,36 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
+]
+
+[[package]]
+name = "raft"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12688b23a649902762d4c11d854d73c49c9b93138f2de16403ef9f571ad5bae"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "getset",
+ "protobuf",
+ "raft-proto",
+ "rand",
+ "slog",
+ "slog-envlogger",
+ "slog-stdlog",
+ "slog-term",
+ "thiserror",
+]
+
+[[package]]
+name = "raft-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
+dependencies = [
+ "bytes",
+ "protobuf",
+ "protobuf-build",
 ]
 
 [[package]]
@@ -5939,12 +6041,15 @@ dependencies = [
  "hyper-util",
  "prost 0.13.1",
  "prost-types 0.13.1",
+ "protobuf",
+ "raft",
  "restate-core",
  "restate-rocksdb",
  "restate-types",
  "rocksdb",
  "schemars",
  "serde",
+ "slog",
  "static_assertions",
  "tempfile",
  "test-log",
@@ -5959,7 +6064,9 @@ dependencies = [
  "tower",
  "tower-http 0.5.2",
  "tracing",
+ "tracing-slog",
  "tracing-subscriber",
+ "ulid",
 ]
 
 [[package]]
@@ -7092,6 +7199,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-async"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-envlogger"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
+dependencies = [
+ "log",
+ "regex",
+ "slog",
+ "slog-async",
+ "slog-scope",
+ "slog-stdlog",
+ "slog-term",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
+name = "slog-stdlog"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
+dependencies = [
+ "log",
+ "slog",
+ "slog-scope",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e022d0b998abfe5c3782c1f03551a596269450ccd677ea51c56f8b214610e8"
+dependencies = [
+ "is-terminal",
+ "slog",
+ "term",
+ "thread_local",
+ "time",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7332,6 +7507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7341,6 +7522,17 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -7911,6 +8103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-slog"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9306d2ca06aa9dfc8aa729ff884e9dca181f588a298cc5c59d4fdd91372570bf"
+dependencies = [
+ "once_cell",
+ "slog",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8029,6 +8232,7 @@ checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
  "web-time",
 ]
 

--- a/crates/metadata-store/Cargo.toml
+++ b/crates/metadata-store/Cargo.toml
@@ -18,6 +18,7 @@ restate-rocksdb = { workspace = true }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }
+assert2 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
@@ -29,9 +30,12 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+protobuf = "2.28.0"
+raft = { version = "0.7.0" }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+slog = { version = "2.7.0" }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -43,6 +47,8 @@ tonic-health = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
+tracing-slog = { version = "0.3.0" }
+ulid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }

--- a/crates/metadata-store/src/grpc/client.rs
+++ b/crates/metadata-store/src/grpc/client.rs
@@ -20,16 +20,16 @@ use restate_core::network::net_util::create_tonic_channel_from_advertised_addres
 use restate_types::net::AdvertisedAddress;
 use restate_types::Version;
 
+use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc_svc::metadata_store_svc_client::MetadataStoreSvcClient;
 use crate::grpc_svc::{DeleteRequest, GetRequest, PutRequest};
-use crate::local::grpc::pb_conversions::ConversionError;
 
-/// Client end to interact with the [`LocalMetadataStore`].
+/// Client end to interact with the metadata store.
 #[derive(Debug, Clone)]
-pub struct LocalMetadataStoreClient {
+pub struct GrpcMetadataStoreClient {
     svc_client: MetadataStoreSvcClient<Channel>,
 }
-impl LocalMetadataStoreClient {
+impl GrpcMetadataStoreClient {
     pub fn new(metadata_store_address: AdvertisedAddress) -> Self {
         let channel = create_tonic_channel_from_advertised_address(metadata_store_address)
             .expect("should not fail");
@@ -41,7 +41,7 @@ impl LocalMetadataStoreClient {
 }
 
 #[async_trait]
-impl MetadataStore for LocalMetadataStoreClient {
+impl MetadataStore for GrpcMetadataStoreClient {
     async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
         let response = self
             .svc_client

--- a/crates/metadata-store/src/grpc/handler.rs
+++ b/crates/metadata-store/src/grpc/handler.rs
@@ -132,7 +132,7 @@ impl MetadataStoreSvc for MetadataStoreHandler {
 impl From<RequestError> for Status {
     fn from(err: RequestError) -> Self {
         match err {
-            RequestError::FailedPrecondition(msg) => Status::failed_precondition(msg),
+            RequestError::FailedPrecondition(msg) => Status::failed_precondition(msg.to_string()),
             err => Status::internal(err.to_string()),
         }
     }

--- a/crates/metadata-store/src/grpc/handler.rs
+++ b/crates/metadata-store/src/grpc/handler.rs
@@ -11,7 +11,7 @@
 use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvc;
 use crate::grpc_svc::{DeleteRequest, GetRequest, GetResponse, GetVersionResponse, PutRequest};
-use crate::{Error, MetadataStoreRequest, RequestSender};
+use crate::{MetadataStoreRequest, RequestError, RequestSender};
 use async_trait::async_trait;
 use tokio::sync::oneshot;
 use tonic::{Request, Response, Status};
@@ -129,10 +129,10 @@ impl MetadataStoreSvc for MetadataStoreHandler {
     }
 }
 
-impl From<Error> for Status {
-    fn from(err: Error) -> Self {
+impl From<RequestError> for Status {
+    fn from(err: RequestError) -> Self {
         match err {
-            Error::FailedPrecondition(msg) => Status::failed_precondition(msg),
+            RequestError::FailedPrecondition(msg) => Status::failed_precondition(msg),
             err => Status::internal(err.to_string()),
         }
     }

--- a/crates/metadata-store/src/grpc/handler.rs
+++ b/crates/metadata-store/src/grpc/handler.rs
@@ -132,7 +132,8 @@ impl MetadataStoreSvc for MetadataStoreHandler {
 impl From<RequestError> for Status {
     fn from(err: RequestError) -> Self {
         match err {
-            RequestError::FailedPrecondition(msg) => Status::failed_precondition(msg.to_string()),
+            RequestError::FailedPrecondition(err) => Status::failed_precondition(err.to_string()),
+            RequestError::Unavailable(err) => Status::unavailable(err.to_string()),
             err => Status::internal(err.to_string()),
         }
     }

--- a/crates/metadata-store/src/grpc/handler.rs
+++ b/crates/metadata-store/src/grpc/handler.rs
@@ -8,28 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvc;
 use crate::grpc_svc::{DeleteRequest, GetRequest, GetResponse, GetVersionResponse, PutRequest};
-use crate::local::grpc::pb_conversions::ConversionError;
-use crate::local::store::{Error, MetadataStoreRequest, RequestSender};
+use crate::{Error, MetadataStoreRequest, RequestSender};
 use async_trait::async_trait;
 use tokio::sync::oneshot;
 use tonic::{Request, Response, Status};
 
-/// Grpc svc handler for the [`LocalMetadataStore`].
+/// Grpc svc handler for the metadata store.
 #[derive(Debug)]
-pub struct LocalMetadataStoreHandler {
+pub struct MetadataStoreHandler {
     request_tx: RequestSender,
 }
 
-impl LocalMetadataStoreHandler {
+impl MetadataStoreHandler {
     pub fn new(request_tx: RequestSender) -> Self {
         Self { request_tx }
     }
 }
 
 #[async_trait]
-impl MetadataStoreSvc for LocalMetadataStoreHandler {
+impl MetadataStoreSvc for MetadataStoreHandler {
     async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
         let (result_tx, result_rx) = oneshot::channel();
 

--- a/crates/metadata-store/src/grpc/mod.rs
+++ b/crates/metadata-store/src/grpc/mod.rs
@@ -10,6 +10,8 @@
 
 pub mod client;
 pub mod handler;
+pub mod server;
+pub mod service_builder;
 
 pub mod pb_conversions {
     use crate::grpc_svc;

--- a/crates/metadata-store/src/grpc/server.rs
+++ b/crates/metadata-store/src/grpc/server.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::Request;
+use hyper::body::Incoming;
+use hyper_util::service::TowerToHyperService;
+use restate_core::network::net_util;
+use restate_core::ShutdownError;
+use restate_types::net::BindAddress;
+use tonic::body::boxed;
+use tonic::service::Routes;
+use tower::ServiceExt;
+
+pub struct GrpcServer {
+    bind_address: BindAddress,
+    routes: Routes,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed running grpc server: {0}")]
+    GrpcServer(#[from] net_util::Error),
+    #[error("system is shutting down")]
+    Shutdown(#[from] ShutdownError),
+}
+
+impl GrpcServer {
+    pub fn new(bind_address: BindAddress, routes: Routes) -> Self {
+        Self {
+            bind_address,
+            routes,
+        }
+    }
+
+    pub async fn run(self) -> Result<(), Error> {
+        // Trace layer
+        let span_factory = tower_http::trace::DefaultMakeSpan::new()
+            .include_headers(true)
+            .level(tracing::Level::ERROR);
+
+        let server_builder = tonic::transport::Server::builder()
+            .layer(tower_http::trace::TraceLayer::new_for_grpc().make_span_with(span_factory))
+            .add_routes(self.routes);
+
+        let service = TowerToHyperService::new(
+            server_builder
+                .into_service()
+                .map_request(|req: Request<Incoming>| req.map(boxed)),
+        );
+
+        net_util::run_hyper_server(&self.bind_address, service, "metadata-store-grpc").await?;
+
+        Ok(())
+    }
+}

--- a/crates/metadata-store/src/grpc/service_builder.rs
+++ b/crates/metadata-store/src/grpc/service_builder.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::{Request, Response};
+use std::convert::Infallible;
+use tonic::body::BoxBody;
+use tonic::server::NamedService;
+use tonic::service::{Routes, RoutesBuilder};
+use tonic_health::ServingStatus;
+use tower::Service;
+
+#[derive(Debug)]
+pub struct GrpcServiceBuilder<'a> {
+    reflection_service_builder: Option<tonic_reflection::server::Builder<'a>>,
+    routes_builder: RoutesBuilder,
+    svc_names: Vec<&'static str>,
+}
+
+impl<'a> Default for GrpcServiceBuilder<'a> {
+    fn default() -> Self {
+        let routes_builder = RoutesBuilder::default();
+
+        Self {
+            reflection_service_builder: Some(tonic_reflection::server::Builder::configure()),
+            routes_builder,
+            svc_names: Vec::default(),
+        }
+    }
+}
+
+impl<'a> GrpcServiceBuilder<'a> {
+    pub fn add_service<S>(&mut self, svc: S)
+    where
+        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        self.svc_names.push(S::NAME);
+        self.routes_builder.add_service(svc);
+    }
+
+    pub fn register_file_descriptor_set_for_reflection<'b: 'a>(
+        &mut self,
+        encoded_file_descriptor_set: &'b [u8],
+    ) {
+        self.reflection_service_builder = Some(
+            self.reflection_service_builder
+                .take()
+                .expect("be present")
+                .register_encoded_file_descriptor_set(encoded_file_descriptor_set),
+        );
+    }
+
+    pub async fn build(mut self) -> Result<Routes, tonic_reflection::server::Error> {
+        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+
+        for svc_name in self.svc_names {
+            health_reporter
+                .set_service_status(svc_name, ServingStatus::Serving)
+                .await;
+        }
+
+        self.routes_builder.add_service(health_service);
+        self.routes_builder.add_service(
+            self.reflection_service_builder
+                .expect("be present")
+                .build()?,
+        );
+        Ok(self.routes_builder.routes())
+    }
+}

--- a/crates/metadata-store/src/lib.rs
+++ b/crates/metadata-store/src/lib.rs
@@ -8,9 +8,71 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod grpc;
 mod grpc_svc;
 pub mod local;
 
+use bytestring::ByteString;
+use restate_core::metadata_store::VersionedValue;
 pub use restate_core::metadata_store::{
     MetadataStoreClient, Precondition, ReadError, ReadModifyWriteError, WriteError,
 };
+use restate_types::errors::GenericError;
+use restate_types::storage::{StorageDecodeError, StorageEncodeError};
+use restate_types::Version;
+use tokio::sync::{mpsc, oneshot};
+
+pub type RequestSender = mpsc::Sender<MetadataStoreRequest>;
+pub type RequestReceiver = mpsc::Receiver<MetadataStoreRequest>;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub enum MetadataStoreRequest {
+    Get {
+        key: ByteString,
+        result_tx: oneshot::Sender<Result<Option<VersionedValue>>>,
+    },
+    GetVersion {
+        key: ByteString,
+        result_tx: oneshot::Sender<Result<Option<Version>>>,
+    },
+    Put {
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+        result_tx: oneshot::Sender<Result<()>>,
+    },
+    Delete {
+        key: ByteString,
+        precondition: Precondition,
+        result_tx: oneshot::Sender<Result<()>>,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("storage error: {0}")]
+    Storage(#[from] GenericError),
+    #[error("failed precondition: {0}")]
+    FailedPrecondition(String),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("encode error: {0}")]
+    Encode(#[from] StorageEncodeError),
+    #[error("decode error: {0}")]
+    Decode(#[from] StorageDecodeError),
+}
+
+impl Error {
+    fn kv_pair_exists() -> Self {
+        Error::FailedPrecondition("key-value pair already exists".to_owned())
+    }
+
+    fn version_mismatch(expected: Version, actual: Option<Version>) -> Self {
+        Error::FailedPrecondition(format!(
+            "Expected version '{}' but found version '{:?}'",
+            expected, actual
+        ))
+    }
+}

--- a/crates/metadata-store/src/lib.rs
+++ b/crates/metadata-store/src/lib.rs
@@ -32,7 +32,9 @@ pub type RequestReceiver = mpsc::Receiver<MetadataStoreRequest>;
 #[derive(Debug, thiserror::Error)]
 pub enum RequestError {
     #[error("internal error: {0}")]
-    Internal(#[from] GenericError),
+    Internal(GenericError),
+    #[error("service currently unavailable: {0}")]
+    Unavailable(GenericError),
     #[error("failed precondition: {0}")]
     FailedPrecondition(#[from] PreconditionViolation),
     #[error("invalid argument: {0}")]

--- a/crates/metadata-store/src/lib.rs
+++ b/crates/metadata-store/src/lib.rs
@@ -17,41 +17,19 @@ use restate_core::metadata_store::VersionedValue;
 pub use restate_core::metadata_store::{
     MetadataStoreClient, Precondition, ReadError, ReadModifyWriteError, WriteError,
 };
+use restate_core::ShutdownError;
 use restate_types::errors::GenericError;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use restate_types::Version;
 use tokio::sync::{mpsc, oneshot};
 
+pub type BoxedMetadataStoreService = Box<dyn MetadataStoreService>;
+
 pub type RequestSender = mpsc::Sender<MetadataStoreRequest>;
 pub type RequestReceiver = mpsc::Receiver<MetadataStoreRequest>;
 
-type Result<T, E = Error> = std::result::Result<T, E>;
-
-#[derive(Debug)]
-pub enum MetadataStoreRequest {
-    Get {
-        key: ByteString,
-        result_tx: oneshot::Sender<Result<Option<VersionedValue>>>,
-    },
-    GetVersion {
-        key: ByteString,
-        result_tx: oneshot::Sender<Result<Option<Version>>>,
-    },
-    Put {
-        key: ByteString,
-        value: VersionedValue,
-        precondition: Precondition,
-        result_tx: oneshot::Sender<Result<()>>,
-    },
-    Delete {
-        key: ByteString,
-        precondition: Precondition,
-        result_tx: oneshot::Sender<Result<()>>,
-    },
-}
-
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum RequestError {
     #[error("storage error: {0}")]
     Storage(#[from] GenericError),
     #[error("failed precondition: {0}")]
@@ -64,13 +42,77 @@ pub enum Error {
     Decode(#[from] StorageDecodeError),
 }
 
-impl Error {
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("error while running server grpc reflection service: {0}")]
+    GrpcReflection(#[from] tonic_reflection::server::Error),
+    #[error("system is shutting down")]
+    Shutdown(#[from] ShutdownError),
+    #[error(transparent)]
+    Generic(#[from] GenericError),
+}
+
+#[async_trait::async_trait]
+pub trait MetadataStoreServiceBoxed {
+    async fn run_boxed(self: Box<Self>) -> Result<(), Error>;
+}
+
+#[async_trait::async_trait]
+impl<T: MetadataStoreService> MetadataStoreServiceBoxed for T {
+    async fn run_boxed(self: Box<Self>) -> Result<(), Error> {
+        (*self).run().await
+    }
+}
+
+#[async_trait::async_trait]
+pub trait MetadataStoreService: MetadataStoreServiceBoxed + Send {
+    async fn run(self) -> Result<(), Error>;
+
+    fn boxed(self) -> BoxedMetadataStoreService
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: MetadataStoreService + ?Sized> MetadataStoreService for Box<T> {
+    async fn run(self) -> Result<(), Error> {
+        self.run_boxed().await
+    }
+}
+
+#[derive(Debug)]
+pub enum MetadataStoreRequest {
+    Get {
+        key: ByteString,
+        result_tx: oneshot::Sender<Result<Option<VersionedValue>, RequestError>>,
+    },
+    GetVersion {
+        key: ByteString,
+        result_tx: oneshot::Sender<Result<Option<Version>, RequestError>>,
+    },
+    Put {
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+        result_tx: oneshot::Sender<Result<(), RequestError>>,
+    },
+    Delete {
+        key: ByteString,
+        precondition: Precondition,
+        result_tx: oneshot::Sender<Result<(), RequestError>>,
+    },
+}
+
+impl RequestError {
     fn kv_pair_exists() -> Self {
-        Error::FailedPrecondition("key-value pair already exists".to_owned())
+        RequestError::FailedPrecondition("key-value pair already exists".to_owned())
     }
 
     fn version_mismatch(expected: Version, actual: Option<Version>) -> Self {
-        Error::FailedPrecondition(format!(
+        RequestError::FailedPrecondition(format!(
             "Expected version '{}' but found version '{:?}'",
             expected, actual
         ))

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod grpc;
 mod store;
 
 mod service;
@@ -20,9 +19,9 @@ use restate_types::{
 };
 pub use service::LocalMetadataStoreService;
 
-use crate::local::grpc::client::LocalMetadataStoreClient;
+use crate::grpc::client::GrpcMetadataStoreClient;
 
-/// Creates a [`MetadataStoreClient`] for the [`LocalMetadataStoreService`].
+/// Creates a [`MetadataStoreClient`] for the [`GrpcMetadataStoreClient`].
 pub async fn create_client(
     metadata_store_client_options: MetadataStoreClientOptions,
 ) -> Result<MetadataStoreClient, GenericError> {
@@ -30,7 +29,7 @@ pub async fn create_client(
 
     let client = match metadata_store_client_options.metadata_store_client {
         MetadataStoreClientConfig::Embedded { address } => {
-            let store = LocalMetadataStoreClient::new(address);
+            let store = GrpcMetadataStoreClient::new(address);
             MetadataStoreClient::new(store, backoff_policy)
         }
         MetadataStoreClientConfig::Etcd { addresses } => {

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -8,7 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{MetadataStoreRequest, RequestError, RequestReceiver, RequestSender};
+use crate::{
+    MetadataStoreRequest, PreconditionViolation, RequestError, RequestReceiver, RequestSender,
+};
 use bytes::BytesMut;
 use bytestring::ByteString;
 use restate_core::cancellation_watcher;
@@ -162,7 +164,7 @@ impl LocalMetadataStore {
         let slice = self
             .db
             .get_pinned_cf(&cf_handle, key)
-            .map_err(|err| RequestError::Storage(err.into()))?;
+            .map_err(|err| RequestError::Internal(err.into()))?;
 
         if let Some(bytes) = slice {
             Ok(Some(Self::decode(bytes)?))
@@ -176,7 +178,7 @@ impl LocalMetadataStore {
         let slice = self
             .db
             .get_pinned_cf(&cf_handle, key)
-            .map_err(|err| RequestError::Storage(err.into()))?;
+            .map_err(|err| RequestError::Internal(err.into()))?;
 
         if let Some(bytes) = slice {
             // todo only deserialize the version part
@@ -200,7 +202,7 @@ impl LocalMetadataStore {
                 if current_version.is_none() {
                     Ok(self.write_versioned_kv_pair(key, value).await?)
                 } else {
-                    Err(RequestError::kv_pair_exists())
+                    Err(PreconditionViolation::kv_pair_exists())?
                 }
             }
             Precondition::MatchesVersion(version) => {
@@ -208,7 +210,10 @@ impl LocalMetadataStore {
                 if current_version == Some(version) {
                     Ok(self.write_versioned_kv_pair(key, value).await?)
                 } else {
-                    Err(RequestError::version_mismatch(version, current_version))
+                    Err(PreconditionViolation::version_mismatch(
+                        version,
+                        current_version,
+                    ))?
                 }
             }
         }
@@ -235,7 +240,7 @@ impl LocalMetadataStore {
                 wb,
             )
             .await
-            .map_err(|err| RequestError::Storage(err.into()))
+            .map_err(|err| RequestError::Internal(err.into()))
     }
 
     fn delete(&mut self, key: &ByteString, precondition: Precondition) -> Result<(), RequestError> {
@@ -249,7 +254,7 @@ impl LocalMetadataStore {
                     // nothing to do
                     Ok(())
                 } else {
-                    Err(RequestError::kv_pair_exists())
+                    Err(PreconditionViolation::kv_pair_exists())?
                 }
             }
             Precondition::MatchesVersion(version) => {
@@ -258,7 +263,10 @@ impl LocalMetadataStore {
                 if current_version == Some(version) {
                     self.delete_kv_pair(key)
                 } else {
-                    Err(RequestError::version_mismatch(version, current_version))
+                    Err(PreconditionViolation::version_mismatch(
+                        version,
+                        current_version,
+                    ))?
                 }
             }
         }
@@ -268,7 +276,7 @@ impl LocalMetadataStore {
         let write_options = self.write_options();
         self.db
             .delete_cf_opt(&self.kv_cf_handle(), key, &write_options)
-            .map_err(|err| RequestError::Storage(err.into()))
+            .map_err(|err| RequestError::Internal(err.into()))
     }
 
     fn encode<T: StorageEncode>(value: &T, buf: &mut BytesMut) -> Result<(), RequestError> {

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -30,7 +30,7 @@ use restate_types::net::{AdvertisedAddress, BindAddress};
 use restate_types::retries::RetryPolicy;
 use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
 
-use crate::local::grpc::client::LocalMetadataStoreClient;
+use crate::grpc::client::GrpcMetadataStoreClient;
 use crate::local::service::LocalMetadataStoreService;
 use crate::{MetadataStoreClient, Precondition, WriteError};
 
@@ -309,7 +309,7 @@ async fn durable_storage() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Creates a test environment with the [`RocksDBMetadataStore`] and a [`MetadataStoreClient`]
+/// Creates a test environment with the [`RocksDBMetadataStore`] and a [`GrpcMetadataStoreClient`]
 /// connected to it.
 async fn create_test_environment(
     opts: &MetadataStoreOptions,
@@ -354,7 +354,7 @@ async fn start_metadata_store(
     task_center: &TaskCenter,
 ) -> anyhow::Result<MetadataStoreClient> {
     let service = LocalMetadataStoreService::from_options(opts, updateables_rocksdb_options);
-    let grpc_service_name = service.grpc_service_name().to_owned();
+    let grpc_service_name = LocalMetadataStoreService::grpc_service_name().to_owned();
 
     task_center.spawn(
         TaskKind::MetadataStore,
@@ -387,9 +387,9 @@ async fn start_metadata_store(
         })
         .await?;
 
-    let rocksdb_client = LocalMetadataStoreClient::new(address);
+    let grpc_client = GrpcMetadataStoreClient::new(address);
     let client = MetadataStoreClient::new(
-        rocksdb_client,
+        grpc_client,
         Some(metadata_store_client_options.metadata_store_client_backoff_policy),
     );
 

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -32,7 +32,7 @@ use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
 
 use crate::grpc::client::GrpcMetadataStoreClient;
 use crate::local::service::LocalMetadataStoreService;
-use crate::{MetadataStoreClient, Precondition, WriteError};
+use crate::{MetadataStoreClient, MetadataStoreService, Precondition, WriteError};
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Serialize, Deserialize)]
 struct Value {

--- a/crates/metadata-store/src/raft/mod.rs
+++ b/crates/metadata-store/src/raft/mod.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod service;
+mod store;

--- a/crates/metadata-store/src/raft/service.rs
+++ b/crates/metadata-store/src/raft/service.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::grpc::handler::MetadataStoreHandler;
+use crate::grpc::server::GrpcServer;
+use crate::grpc::service_builder::GrpcServiceBuilder;
+use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvcServer;
+use crate::raft::store::RaftMetadataStore;
+use crate::{grpc_svc, Error, MetadataStoreService};
+use futures::TryFutureExt;
+use restate_core::{task_center, TaskKind};
+use restate_types::config::MetadataStoreOptions;
+use restate_types::live::BoxedLiveLoad;
+
+pub struct RaftMetadataStoreService {
+    options: BoxedLiveLoad<MetadataStoreOptions>,
+}
+
+impl RaftMetadataStoreService {
+    pub fn new(options: BoxedLiveLoad<MetadataStoreOptions>) -> Self {
+        Self { options }
+    }
+}
+
+#[async_trait::async_trait]
+impl MetadataStoreService for RaftMetadataStoreService {
+    async fn run(mut self) -> Result<(), Error> {
+        let store_options = self.options.live_load();
+        let store = RaftMetadataStore::new().map_err(Error::generic)?;
+
+        let mut builder = GrpcServiceBuilder::default();
+
+        builder.register_file_descriptor_set_for_reflection(grpc_svc::FILE_DESCRIPTOR_SET);
+        builder.add_service(MetadataStoreSvcServer::new(MetadataStoreHandler::new(
+            store.request_sender(),
+        )));
+
+        let grpc_server =
+            GrpcServer::new(store_options.bind_address.clone(), builder.build().await?);
+
+        task_center().spawn_child(
+            TaskKind::RpcServer,
+            "metadata-store-grpc",
+            None,
+            grpc_server.run().map_err(Into::into),
+        )?;
+
+        store.run().await.map_err(Error::generic)?;
+
+        Ok(())
+    }
+}

--- a/crates/metadata-store/src/raft/store.rs
+++ b/crates/metadata-store/src/raft/store.rs
@@ -1,0 +1,530 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::{
+    MetadataStoreRequest, PreconditionViolation, RequestError, RequestReceiver, RequestSender,
+};
+use assert2::let_assert;
+use bytes::{Bytes, BytesMut};
+use bytestring::ByteString;
+use protobuf::{Message as ProtobufMessage, ProtobufError};
+use raft::prelude::{ConfChange, ConfChangeV2, ConfState, Entry, EntryType, Message};
+use raft::storage::MemStorage;
+use raft::{Config, RawNode};
+use restate_core::cancellation_watcher;
+use restate_core::metadata_store::{Precondition, VersionedValue};
+use restate_types::storage::{StorageCodec, StorageDecodeError, StorageEncodeError};
+use restate_types::{flexbuffers_storage_encode_decode, Version};
+use slog::o;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time;
+use tokio::time::MissedTickBehavior;
+use tracing::{debug, info, warn};
+use tracing_slog::TracingSlogDrain;
+use ulid::Ulid;
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed creating raft node: {0}")]
+pub struct BuildError(#[from] raft::Error);
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed appending entries: {0}")]
+    Append(#[from] raft::Error),
+    #[error("failed deserializing raft serialized requests: {0}")]
+    DecodeRequest(StorageDecodeError),
+    #[error("failed deserializing conf change: {0}")]
+    DecodeConf(ProtobufError),
+    #[error("failed applying conf change: {0}")]
+    ApplyConfChange(raft::Error),
+}
+
+pub struct RaftMetadataStore {
+    _logger: slog::Logger,
+    raw_node: RawNode<MemStorage>,
+    tick_interval: time::Interval,
+
+    callbacks: HashMap<Ulid, Callback>,
+    kv_entries: HashMap<ByteString, VersionedValue>,
+
+    request_tx: RequestSender,
+    request_rx: RequestReceiver,
+}
+
+impl RaftMetadataStore {
+    pub fn new() -> Result<Self, BuildError> {
+        let (request_tx, request_rx) = mpsc::channel(2);
+
+        let config = Config {
+            id: 1,
+            ..Default::default()
+        };
+
+        let store = MemStorage::new_with_conf_state(ConfState::from((vec![1], vec![])));
+        let drain = TracingSlogDrain;
+        let logger = slog::Logger::root(drain, o!());
+
+        let raw_node = RawNode::new(&config, store, &logger)?;
+
+        let mut tick_interval = time::interval(Duration::from_millis(100));
+        tick_interval.set_missed_tick_behavior(MissedTickBehavior::Burst);
+
+        Ok(Self {
+            // we only need to keep it alive
+            _logger: logger,
+            raw_node,
+            tick_interval,
+            callbacks: HashMap::default(),
+            kv_entries: HashMap::default(),
+            request_rx,
+            request_tx,
+        })
+    }
+
+    pub fn request_sender(&self) -> RequestSender {
+        self.request_tx.clone()
+    }
+
+    pub async fn run(mut self) -> Result<(), Error> {
+        let mut cancellation = std::pin::pin!(cancellation_watcher());
+
+        loop {
+            tokio::select! {
+                _ = &mut cancellation => {
+                    break;
+                }
+                Some(request) = self.request_rx.recv() => {
+                    // todo: Unclear whether every replica should be allowed to propose. Maybe
+                    //  only the leader should propose and respond to clients.
+                    let (callback, request) = Self::split_request(request);
+
+                    if let Err(err) = request
+                        .encode_to_vec()
+                        .map_err(Into::into)
+                        .and_then(|request| self.raw_node
+                            .propose(vec![], request)
+                            .map_err(|err| RequestError::Internal(err.into()))) {
+                        info!("Failed processing request: {err}");
+                        callback.fail(err);
+                        continue;
+                    }
+
+                    self.register_callback(callback);
+                }
+                _ = self.tick_interval.tick() => {
+                    self.raw_node.tick();
+                }
+            }
+
+            self.on_ready()?;
+        }
+
+        debug!("Stop running RaftMetadataStore.");
+
+        Ok(())
+    }
+
+    fn on_ready(&mut self) -> Result<(), Error> {
+        if !self.raw_node.has_ready() {
+            return Ok(());
+        }
+
+        let mut ready = self.raw_node.ready();
+
+        // first need to send outgoing messages
+        if !ready.messages().is_empty() {
+            self.send_messages(ready.take_messages());
+        }
+
+        // apply snapshot if one was sent
+        if !ready.snapshot().is_empty() {
+            if let Err(err) = self
+                .raw_node
+                .store()
+                .wl()
+                .apply_snapshot(ready.snapshot().clone())
+            {
+                warn!("failed applying snapshot: {err}");
+            }
+        }
+
+        // then handle committed entries
+        self.handle_committed_entries(ready.take_committed_entries())?;
+
+        // append new Raft entries to storage
+        self.raw_node.store().wl().append(ready.entries())?;
+
+        // update the hard state if an update was produced (e.g. vote has happened)
+        if let Some(hs) = ready.hs() {
+            self.raw_node.store().wl().set_hardstate(hs.clone());
+        }
+
+        // send persisted messages (after entries were appended and hard state was updated)
+        if !ready.persisted_messages().is_empty() {
+            self.send_messages(ready.take_persisted_messages());
+        }
+
+        // advance the raft node
+        let mut light_ready = self.raw_node.advance(ready);
+
+        // update the commit index if it changed
+        if let Some(commit) = light_ready.commit_index() {
+            self.raw_node
+                .store()
+                .wl()
+                .mut_hard_state()
+                .set_commit(commit);
+        }
+
+        // send outgoing messages
+        if !light_ready.messages().is_empty() {
+            self.send_messages(light_ready.take_messages());
+        }
+
+        // handle committed entries
+        if !light_ready.committed_entries().is_empty() {
+            self.handle_committed_entries(light_ready.take_committed_entries())?;
+        }
+
+        self.raw_node.advance_apply();
+
+        Ok(())
+    }
+
+    fn register_callback(&mut self, callback: Callback) {
+        self.callbacks.insert(callback.request_id, callback);
+    }
+
+    fn send_messages(&self, _messages: Vec<Message>) {
+        // todo: Send messages to other peers
+    }
+
+    fn handle_committed_entries(&mut self, committed_entries: Vec<Entry>) -> Result<(), Error> {
+        for entry in committed_entries {
+            if entry.data.is_empty() {
+                // new leader was elected
+                continue;
+            }
+
+            match entry.get_entry_type() {
+                EntryType::EntryNormal => self.handle_normal_entry(entry)?,
+                EntryType::EntryConfChange => self.handle_conf_change(entry)?,
+                EntryType::EntryConfChangeV2 => self.handle_conf_change_v2(entry)?,
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_normal_entry(&mut self, entry: Entry) -> Result<(), Error> {
+        let request = Request::decode_from_bytes(entry.data).map_err(Error::DecodeRequest)?;
+        self.handle_request(request);
+
+        Ok(())
+    }
+
+    fn handle_request(&mut self, request: Request) {
+        match request.kind {
+            RequestKind::Get { key } => {
+                let result = self.get(key);
+                if let Some(callback) = self.callbacks.remove(&request.request_id) {
+                    callback.complete_get(result);
+                }
+            }
+            RequestKind::GetVersion { key } => {
+                let result = self.get_version(key);
+                if let Some(callback) = self.callbacks.remove(&request.request_id) {
+                    callback.complete_get_version(result);
+                }
+            }
+            RequestKind::Put {
+                key,
+                value,
+                precondition,
+            } => {
+                let result = self.put(key, value, precondition);
+                if let Some(callback) = self.callbacks.remove(&request.request_id) {
+                    callback.complete_put(result.map_err(Into::into));
+                }
+            }
+            RequestKind::Delete { key, precondition } => {
+                let result = self.delete(key, precondition);
+                if let Some(callback) = self.callbacks.remove(&request.request_id) {
+                    callback.complete_delete(result.map_err(Into::into));
+                }
+            }
+        }
+    }
+
+    fn get(&self, key: ByteString) -> Option<VersionedValue> {
+        self.kv_entries.get(&key).cloned()
+    }
+
+    fn get_version(&self, key: ByteString) -> Option<Version> {
+        self.kv_entries.get(&key).map(|entry| entry.version)
+    }
+
+    fn put(
+        &mut self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), PreconditionViolation> {
+        match precondition {
+            Precondition::None => {
+                self.kv_entries.insert(key, value);
+            }
+            Precondition::DoesNotExist => {
+                if self.kv_entries.contains_key(&key) {
+                    return Err(PreconditionViolation::kv_pair_exists());
+                }
+
+                self.kv_entries.insert(key, value);
+            }
+            Precondition::MatchesVersion(expected_version) => {
+                let actual_version = self.kv_entries.get(&key).map(|entry| entry.version);
+
+                if actual_version == Some(expected_version) {
+                    self.kv_entries.insert(key, value);
+                } else {
+                    return Err(PreconditionViolation::version_mismatch(
+                        expected_version,
+                        actual_version,
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn delete(
+        &mut self,
+        key: ByteString,
+        precondition: Precondition,
+    ) -> Result<(), PreconditionViolation> {
+        match precondition {
+            Precondition::None => {
+                self.kv_entries.remove(&key);
+            }
+            Precondition::DoesNotExist => {
+                if self.kv_entries.contains_key(&key) {
+                    return Err(PreconditionViolation::kv_pair_exists());
+                }
+            }
+            Precondition::MatchesVersion(expected_version) => {
+                let actual_version = self.kv_entries.get(&key).map(|entry| entry.version);
+
+                if actual_version == Some(expected_version) {
+                    self.kv_entries.remove(&key);
+                } else {
+                    return Err(PreconditionViolation::version_mismatch(
+                        expected_version,
+                        actual_version,
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_conf_change(&mut self, entry: Entry) -> Result<(), Error> {
+        let mut cc = ConfChange::default();
+        cc.merge_from_bytes(&entry.data)
+            .map_err(Error::DecodeConf)?;
+        let cs = self
+            .raw_node
+            .apply_conf_change(&cc)
+            .map_err(Error::ApplyConfChange)?;
+        self.raw_node.store().wl().set_conf_state(cs);
+        Ok(())
+    }
+
+    fn handle_conf_change_v2(&mut self, entry: Entry) -> Result<(), Error> {
+        let mut cc = ConfChangeV2::default();
+        cc.merge_from_bytes(&entry.data)
+            .map_err(Error::DecodeConf)?;
+        let cs = self
+            .raw_node
+            .apply_conf_change(&cc)
+            .map_err(Error::ApplyConfChange)?;
+        self.raw_node.store().wl().set_conf_state(cs);
+        Ok(())
+    }
+
+    fn split_request(request: MetadataStoreRequest) -> (Callback, Request) {
+        let (request_kind, callback_kind) = match request {
+            MetadataStoreRequest::Get { key, result_tx } => {
+                (RequestKind::Get { key }, CallbackKind::Get { result_tx })
+            }
+            MetadataStoreRequest::GetVersion { key, result_tx } => (
+                RequestKind::GetVersion { key },
+                CallbackKind::GetVersion { result_tx },
+            ),
+            MetadataStoreRequest::Put {
+                key,
+                value,
+                precondition,
+                result_tx,
+            } => (
+                RequestKind::Put {
+                    key,
+                    value,
+                    precondition,
+                },
+                CallbackKind::Put { result_tx },
+            ),
+            MetadataStoreRequest::Delete {
+                key,
+                precondition,
+                result_tx,
+            } => (
+                RequestKind::Delete { key, precondition },
+                CallbackKind::Delete { result_tx },
+            ),
+        };
+
+        let request_id = Ulid::new();
+
+        let callback = Callback {
+            request_id,
+            kind: callback_kind,
+        };
+
+        let request = Request {
+            request_id,
+            kind: request_kind,
+        };
+
+        (callback, request)
+    }
+}
+
+struct Callback {
+    request_id: Ulid,
+    kind: CallbackKind,
+}
+
+impl Callback {
+    fn fail(self, err: impl Into<RequestError>) {
+        match self.kind {
+            CallbackKind::Get { result_tx } => {
+                // err only if the oneshot receiver has gone away
+                let _ = result_tx.send(Err(err.into()));
+            }
+            CallbackKind::GetVersion { result_tx } => {
+                // err only if the oneshot receiver has gone away
+                let _ = result_tx.send(Err(err.into()));
+            }
+            CallbackKind::Put { result_tx } => {
+                // err only if the oneshot receiver has gone away
+                let _ = result_tx.send(Err(err.into()));
+            }
+            CallbackKind::Delete { result_tx } => {
+                // err only if the oneshot receiver has gone away
+                let _ = result_tx.send(Err(err.into()));
+            }
+        };
+    }
+
+    fn complete_get(self, result: Option<VersionedValue>) {
+        let_assert!(
+            CallbackKind::Get { result_tx } = self.kind,
+            "expected 'Get' callback"
+        );
+        // err if caller has gone
+        let _ = result_tx.send(Ok(result));
+    }
+
+    fn complete_get_version(self, result: Option<Version>) {
+        let_assert!(
+            CallbackKind::GetVersion { result_tx } = self.kind,
+            "expected 'GetVersion' callback"
+        );
+        // err if caller has gone
+        let _ = result_tx.send(Ok(result));
+    }
+
+    fn complete_put(self, result: Result<(), RequestError>) {
+        let_assert!(
+            CallbackKind::Put { result_tx } = self.kind,
+            "expected 'Put' callback"
+        );
+        // err if caller has gone
+        let _ = result_tx.send(result);
+    }
+
+    fn complete_delete(self, result: Result<(), RequestError>) {
+        let_assert!(
+            CallbackKind::Delete { result_tx } = self.kind,
+            "expected 'Delete' callback"
+        );
+        // err if caller has gone
+        let _ = result_tx.send(result);
+    }
+}
+
+enum CallbackKind {
+    Get {
+        result_tx: oneshot::Sender<Result<Option<VersionedValue>, RequestError>>,
+    },
+    GetVersion {
+        result_tx: oneshot::Sender<Result<Option<Version>, RequestError>>,
+    },
+    Put {
+        result_tx: oneshot::Sender<Result<(), RequestError>>,
+    },
+    Delete {
+        result_tx: oneshot::Sender<Result<(), RequestError>>,
+    },
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct Request {
+    request_id: Ulid,
+    kind: RequestKind,
+}
+
+flexbuffers_storage_encode_decode!(Request);
+
+impl Request {
+    fn encode_to_vec(&self) -> Result<Vec<u8>, StorageEncodeError> {
+        let mut buffer = BytesMut::new();
+        // todo: Removing support for BufMut requires an extra copy from BytesMut to Vec :-(
+        StorageCodec::encode(self, &mut buffer)?;
+        Ok(buffer.to_vec())
+    }
+
+    fn decode_from_bytes(mut bytes: Bytes) -> Result<Self, StorageDecodeError> {
+        StorageCodec::decode::<Request, _>(&mut bytes)
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+enum RequestKind {
+    Get {
+        key: ByteString,
+    },
+    GetVersion {
+        key: ByteString,
+    },
+    Put {
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    },
+    Delete {
+        key: ByteString,
+        precondition: Precondition,
+    },
+}

--- a/crates/metadata-store/src/raft/store.rs
+++ b/crates/metadata-store/src/raft/store.rs
@@ -112,7 +112,7 @@ impl RaftMetadataStore {
                         .map_err(Into::into)
                         .and_then(|request| self.raw_node
                             .propose(vec![], request)
-                            .map_err(|err| RequestError::Internal(err.into()))) {
+                            .map_err(RequestError::from)) {
                         info!("Failed processing request: {err}");
                         callback.fail(err);
                         continue;
@@ -527,4 +527,13 @@ enum RequestKind {
         key: ByteString,
         precondition: Precondition,
     },
+}
+
+impl From<raft::Error> for RequestError {
+    fn from(value: raft::Error) -> Self {
+        match value {
+            err @ raft::Error::ProposalDropped => RequestError::Unavailable(err.into()),
+            err => RequestError::Internal(err.into()),
+        }
+    }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -31,6 +31,7 @@ use restate_core::{task_center, TaskKind};
 #[cfg(feature = "replicated-loglet")]
 use restate_log_server::LogServerService;
 use restate_metadata_store::local::LocalMetadataStoreService;
+use restate_metadata_store::raft::service::RaftMetadataStoreService;
 use restate_metadata_store::{
     BoxedMetadataStoreService, MetadataStoreClient, MetadataStoreService,
 };
@@ -280,9 +281,10 @@ impl Node {
                     .boxed(),
             )
             .boxed(),
-            Kind::Raft => {
-                unimplemented!("not yet supported")
-            }
+            Kind::Raft => RaftMetadataStoreService::new(
+                updateable_config.clone().map(|c| &c.metadata_store).boxed(),
+            )
+            .boxed(),
         }
     }
 

--- a/crates/types/src/config/metadata_store.rs
+++ b/crates/types/src/config/metadata_store.rs
@@ -60,6 +60,20 @@ pub struct MetadataStoreOptions {
     ///
     /// The RocksDB options which will be used to configure the metadata store's RocksDB instance.
     pub rocksdb: RocksDbOptions,
+
+    /// # Type of metadata store to start
+    ///
+    /// The type of metadata store to start when running the metadata store role.
+    pub kind: Kind,
+}
+
+#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum Kind {
+    #[default]
+    Local,
+    Raft,
 }
 
 impl MetadataStoreOptions {
@@ -112,6 +126,7 @@ impl Default for MetadataStoreOptions {
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.01,
             rocksdb,
+            kind: Kind::default(),
         }
     }
 }


### PR DESCRIPTION
This commit adds the skeleton of the Raft metadata store. At the moment
only a single node with memory storage is supported.

This fixes https://github.com/restatedev/restate/issues/1785.