### PR TITLE
[Bifrost] Introduce KeyFilter to the read API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ async-channel = "2.1.1"
 async-trait = "0.1.73"
 axum = { version = "0.7.5", default-features = false }
 base64 = "0.22"
-bytes = { version = "1.3", features = ["serde"] }
+bytes = { version = "1.7", features = ["serde"] }
 bytes-utils = "0.1.3"
 bytestring = { version = "1.2", features = ["serde"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -19,7 +19,7 @@ use restate_rocksdb::{DbName, RocksDbManager};
 use restate_types::config::{
     BifrostOptionsBuilder, CommonOptionsBuilder, ConfigurationBuilder, LocalLogletOptionsBuilder,
 };
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 mod util;
@@ -31,7 +31,9 @@ async fn append_records_multi_log(bifrost: Bifrost, log_id_range: Range<u64>, co
             let bifrost = bifrost.clone();
             appends.push(async move {
                 let _ = bifrost
-                    .append(LogId::from(log_id), Payload::default())
+                    .create_appender(LogId::new(log_id))
+                    .expect("log exists")
+                    .append_raw("")
                     .await
                     .unwrap();
             })
@@ -44,15 +46,23 @@ async fn append_records_concurrent_single_log(bifrost: Bifrost, log_id: LogId, c
     let mut appends = FuturesOrdered::new();
     for _ in 0..count_per_log {
         let bifrost = bifrost.clone();
-        appends.push_back(async move { bifrost.append(log_id, Payload::default()).await.unwrap() })
+        appends.push_back(async move {
+            bifrost
+                .create_appender(log_id)
+                .expect("log exists")
+                .append_raw("")
+                .await
+                .unwrap()
+        })
     }
     while appends.next().await.is_some() {}
 }
 
 async fn append_seq(bifrost: Bifrost, log_id: LogId, count: u64) {
+    let mut appender = bifrost.create_appender(log_id).expect("log exists");
     for _ in 1..=count {
-        let _ = bifrost
-            .append(log_id, Payload::default())
+        let _ = appender
+            .append_raw("")
             .await
             .expect("bifrost accept record");
     }

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -34,7 +34,7 @@ const INITIAL_SERDE_BUFFER_SIZE: usize = 16_000; // Initial capacity 16KB
 #[derive(Clone)]
 pub struct Appender {
     log_id: LogId,
-    config: Live<Configuration>,
+    pub(super) config: Live<Configuration>,
     pub(super) serde_buffer: BytesMut,
     loglet_cache: Option<LogletWrapper>,
     bifrost_inner: Arc<BifrostInner>,
@@ -181,7 +181,6 @@ impl Appender {
         &mut self,
         bodies_with_keys: &[(Bytes, Keys)],
     ) -> Result<Lsn> {
-        self.bifrost_inner.fail_if_shutting_down()?;
         let mut retry_iter = self
             .config
             .live_load()
@@ -225,6 +224,7 @@ impl Appender {
         }
     }
 
+    #[cfg(any(test, feature = "test-util"))]
     pub async fn append_raw_batch(
         &mut self,
         batch: impl IntoIterator<Item = impl Into<Bytes>>,

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -17,13 +17,14 @@ use tracing::{debug, info, instrument, Span};
 use restate_types::config::Configuration;
 use restate_types::live::Live;
 use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{HasRecordKeys, Keys, LogId, Lsn, Payload};
+use restate_types::logs::{HasRecordKeys, Keys, LogId, Lsn};
 use restate_types::retries::RetryIter;
 use restate_types::storage::{StorageCodec, StorageEncode};
 
 use crate::bifrost::BifrostInner;
 use crate::loglet::{AppendError, LogletBase};
 use crate::loglet_wrapper::LogletWrapper;
+use crate::payload::Payload;
 use crate::{Error, Result};
 
 // Arbitrarily chosen size for the record size hint. Practically, we should estimate

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -1,0 +1,315 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::{Bytes, BytesMut};
+use tracing::{debug, info, instrument, Span};
+
+use restate_types::config::Configuration;
+use restate_types::live::Live;
+use restate_types::logs::metadata::SegmentIndex;
+use restate_types::logs::{HasRecordKeys, Keys, LogId, Lsn, Payload};
+use restate_types::retries::RetryIter;
+use restate_types::storage::{StorageCodec, StorageEncode};
+
+use crate::bifrost::BifrostInner;
+use crate::loglet::{AppendError, LogletBase};
+use crate::loglet_wrapper::LogletWrapper;
+use crate::{Error, Result};
+
+// Arbitrarily chosen size for the record size hint. Practically, we should estimate
+// the size from the payload, or use anecdotal data as guidance.
+pub(crate) const RECORD_SIZE_HINT: usize = 4_000; // 4KB per record
+const INITIAL_SERDE_BUFFER_SIZE: usize = 16_000; // Initial capacity 16KB
+
+#[derive(Clone)]
+pub struct Appender {
+    log_id: LogId,
+    config: Live<Configuration>,
+    pub(super) serde_buffer: BytesMut,
+    loglet_cache: Option<LogletWrapper>,
+    bifrost_inner: Arc<BifrostInner>,
+}
+
+impl std::fmt::Debug for Appender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Appender")
+            .field("log_id", &self.log_id)
+            .field("loglet_cache", &self.loglet_cache)
+            .finish()
+    }
+}
+
+impl Appender {
+    pub(crate) fn new(log_id: LogId, bifrost_inner: Arc<BifrostInner>) -> Self {
+        Self::with_buffer_size(log_id, bifrost_inner, INITIAL_SERDE_BUFFER_SIZE)
+    }
+
+    pub(crate) fn with_buffer_size(
+        log_id: LogId,
+        bifrost_inner: Arc<BifrostInner>,
+        serde_buffer_size: usize,
+    ) -> Self {
+        Self::with_serde_buffer(
+            log_id,
+            bifrost_inner,
+            BytesMut::with_capacity(serde_buffer_size),
+        )
+    }
+
+    pub(crate) fn with_serde_buffer(
+        log_id: LogId,
+        bifrost_inner: Arc<BifrostInner>,
+        serde_buffer: BytesMut,
+    ) -> Self {
+        let config = Configuration::updateable();
+
+        Self {
+            log_id,
+            config,
+            serde_buffer,
+            loglet_cache: Default::default(),
+            bifrost_inner,
+        }
+    }
+
+    /// Use only in tests.
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn append_raw(&mut self, raw_bytes: impl Into<Bytes>) -> Result<Lsn> {
+        self.append_raw_with_keys(raw_bytes, Keys::None).await
+    }
+
+    pub(crate) async fn append_raw_with_keys(
+        &mut self,
+        raw_bytes: impl Into<Bytes>,
+        keys: Keys,
+    ) -> Result<Lsn> {
+        self.bifrost_inner.fail_if_shutting_down()?;
+
+        let raw_bytes = raw_bytes.into();
+        // 50 bytes is an over-estimation of the size needed for Header. This is a temporary
+        // solution.
+        // todo: Move header serialization down to loglets and send payloads as &dyn StorageEncode
+        // instead.
+        self.serde_buffer.reserve(50 + raw_bytes.len());
+        let payload = Payload::new(raw_bytes);
+        StorageCodec::encode(payload, &mut self.serde_buffer).expect("record serde is infallible");
+        let raw_bytes = self.serde_buffer.split().freeze();
+
+        let mut retry_iter = self
+            .config
+            .live_load()
+            .bifrost
+            .append_retry_policy()
+            .into_iter();
+        let mut attempt = 0;
+
+        loop {
+            attempt += 1;
+            let loglet = match self.loglet_cache.as_mut() {
+                None => self
+                    .loglet_cache
+                    .insert(self.bifrost_inner.writeable_loglet(self.log_id).await?),
+                Some(wrapper) => wrapper,
+            };
+
+            Span::current().record(
+                "segment_index",
+                tracing::field::display(loglet.segment_index()),
+            );
+            match loglet.append(&raw_bytes, &keys).await {
+                Ok(lsn) => return Ok(lsn),
+                Err(AppendError::Sealed) => {
+                    info!(
+                        attempt = attempt,
+                        "Append will be retried (loglet being sealed), waiting for tail to be determined"
+                    );
+                    let new_loglet = Self::wait_next_unsealed_loglet(
+                        self.log_id,
+                        &self.bifrost_inner,
+                        loglet.segment_index(),
+                        &mut retry_iter,
+                    )
+                    .await?;
+                    self.loglet_cache = Some(new_loglet);
+                }
+                Err(AppendError::Shutdown(e)) => return Err(Error::Shutdown(e)),
+                Err(AppendError::Other(e)) => return Err(Error::LogletError(e)),
+            }
+        }
+    }
+
+    /// Appends a single record to the log.
+    #[instrument(
+        level = "debug",
+        skip(self, body),
+        err,
+        fields(
+            log_id = %self.log_id,
+            segment_index = tracing::field::Empty
+        )
+    )]
+    pub async fn append<T>(&mut self, body: T) -> Result<Lsn>
+    where
+        T: HasRecordKeys + StorageEncode,
+    {
+        let keys = body.record_keys();
+        StorageCodec::encode(&body, &mut self.serde_buffer).expect("record serde is infallible");
+        let raw_bytes = self.serde_buffer.split().freeze();
+        self.append_raw_with_keys(raw_bytes, keys).await
+    }
+
+    #[instrument(
+        level = "debug",
+        skip(self, bodies_with_keys)
+        err,
+        fields(
+            log_id = %self.log_id,
+            segment_index = tracing::field::Empty,
+        )
+    )]
+    pub(crate) async fn append_raw_batch_with_keys(
+        &mut self,
+        bodies_with_keys: &[(Bytes, Keys)],
+    ) -> Result<Lsn> {
+        self.bifrost_inner.fail_if_shutting_down()?;
+        let mut retry_iter = self
+            .config
+            .live_load()
+            .bifrost
+            .append_retry_policy()
+            .into_iter();
+
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let loglet = match self.loglet_cache.as_mut() {
+                None => self
+                    .loglet_cache
+                    .insert(self.bifrost_inner.writeable_loglet(self.log_id).await?),
+                Some(wrapper) => wrapper,
+            };
+            Span::current().record(
+                "segment_index",
+                tracing::field::display(loglet.segment_index()),
+            );
+            match loglet.append_batch(bodies_with_keys).await {
+                Ok(lsn) => return Ok(lsn),
+                Err(AppendError::Sealed) => {
+                    info!(
+                        attempt = attempt,
+                        "Append batch will be retried (loglet being sealed), waiting for tail to be determined"
+                    );
+                    let new_loglet = Self::wait_next_unsealed_loglet(
+                        self.log_id,
+                        &self.bifrost_inner,
+                        loglet.segment_index(),
+                        &mut retry_iter,
+                    )
+                    .await?;
+
+                    self.loglet_cache = Some(new_loglet);
+                }
+                Err(AppendError::Shutdown(e)) => return Err(Error::Shutdown(e)),
+                Err(AppendError::Other(e)) => return Err(Error::LogletError(e)),
+            }
+        }
+    }
+
+    pub async fn append_raw_batch(
+        &mut self,
+        batch: impl IntoIterator<Item = impl Into<Bytes>>,
+    ) -> Result<Lsn> {
+        let bodies_with_keys: Vec<_> = batch
+            .into_iter()
+            .map(|record| {
+                let raw_bytes: Bytes = record.into();
+                let keys = Keys::None;
+                // 50 bytes is an over-estimation of the size needed for Header. This is a temporary
+                // solution.
+                // todo: Move header serialization down to loglets and send payloads as &dyn StorageEncode
+                // instead.
+                self.serde_buffer.reserve(50 + raw_bytes.len());
+                let payload = Payload::new(raw_bytes);
+                StorageCodec::encode(payload, &mut self.serde_buffer)
+                    .expect("record serde is infallible");
+                (self.serde_buffer.split().freeze(), keys)
+            })
+            .collect();
+
+        self.append_raw_batch_with_keys(&bodies_with_keys).await
+    }
+
+    /// Appends a batch of records to the log.
+    ///
+    /// The returned Lsn is the Lsn of the first record committed in this batch .
+    /// This will only return after all records have been stored.
+    #[instrument(
+        level = "debug",
+        skip(self, batch),
+        err,
+        fields(
+            log_id = %self.log_id,
+            count = batch.len(),
+            segment_index = tracing::field::Empty
+        )
+    )]
+    pub async fn append_batch<T>(&mut self, batch: &[T]) -> Result<Lsn>
+    where
+        T: HasRecordKeys + StorageEncode,
+    {
+        // Attempt to reserve enough bytes for the payloads
+        self.serde_buffer.reserve(batch.len() * RECORD_SIZE_HINT);
+
+        let bodies_with_keys: Vec<_> = batch
+            .iter()
+            .map(|record| {
+                // todo (estimate size to reserve)
+                let keys = record.record_keys();
+                StorageCodec::encode(record, &mut self.serde_buffer)
+                    .expect("record serde is infallible");
+                let payload = Payload::new(self.serde_buffer.split().freeze());
+                StorageCodec::encode(payload, &mut self.serde_buffer)
+                    .expect("record serde is infallible");
+                (self.serde_buffer.split().freeze(), keys)
+            })
+            .collect();
+
+        self.append_raw_batch_with_keys(&bodies_with_keys).await
+    }
+
+    async fn wait_next_unsealed_loglet(
+        log_id: LogId,
+        bifrost_inner: &Arc<BifrostInner>,
+        sealed_segment: SegmentIndex,
+        retry_iter: &mut RetryIter<'_>,
+    ) -> Result<LogletWrapper> {
+        let start = Instant::now();
+        for sleep_dur in retry_iter.by_ref() {
+            bifrost_inner.fail_if_shutting_down()?;
+            tokio::time::sleep(sleep_dur).await;
+            let loglet = bifrost_inner.writeable_loglet(log_id).await?;
+            // Do we think that the last tail loglet is different and unsealed?
+            if loglet.tail_lsn.is_none() && loglet.segment_index() > sealed_segment {
+                let total_dur = start.elapsed();
+                debug!(
+                    "Found an unsealed segment {} after {:?}",
+                    loglet.segment_index(),
+                    total_dur
+                );
+                return Ok(loglet);
+            }
+        }
+
+        Err(Error::LogSealed(log_id))
+    }
+}

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -19,11 +19,12 @@ use tracing::{info, trace, warn};
 
 use restate_core::{task_center, ShutdownError, TaskCenter, TaskId};
 use restate_types::identifiers::PartitionId;
-use restate_types::logs::{HasRecordKeys, Keys, Payload};
+use restate_types::logs::{HasRecordKeys, Keys};
 use restate_types::storage::{StorageCodec, StorageEncode};
 
 use crate::appender::RECORD_SIZE_HINT;
 use crate::error::EnqueueError;
+use crate::payload::Payload;
 use crate::{Appender, Result};
 
 /// Performs appends in the background concurrently while maintaining the order of records

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -1,0 +1,403 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::FutureExt;
+use pin_project::pin_project;
+use tokio::sync::{mpsc, oneshot, Notify};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, trace, warn};
+
+use restate_core::{task_center, ShutdownError, TaskCenter, TaskId};
+use restate_types::identifiers::PartitionId;
+use restate_types::logs::{HasRecordKeys, Keys, Payload};
+use restate_types::storage::{StorageCodec, StorageEncode};
+
+use crate::appender::RECORD_SIZE_HINT;
+use crate::error::EnqueueError;
+use crate::{Appender, Result};
+
+/// Performs appends in the background concurrently while maintaining the order of records
+/// produced from the same producer. It runs as a background task and batches records whenever
+/// possible to reduce round-trips to the loglet.
+#[pin_project]
+pub struct BackgroundAppender<T> {
+    appender: Appender,
+    /// The number of records that can be buffered in the append queue
+    queue_capacity: usize,
+    /// The number of records that can get batched together before appending to the log
+    max_batch_size: usize,
+    /// Reusable vector for buffering recv() operations
+    recv_buffer: Vec<AppendOperation<T>>,
+    /// Reusable vector for callbacks of enqueue_with_notification calls
+    notif_buffer: Vec<oneshot::Sender<()>>,
+    /// Reusable serialized payloads vector
+    batch_buffer: Vec<(Bytes, Keys)>,
+}
+
+impl<T> BackgroundAppender<T>
+where
+    T: HasRecordKeys + StorageEncode + 'static,
+{
+    pub fn new(appender: Appender, queue_capacity: usize, max_batch_size: usize) -> Self {
+        Self {
+            appender,
+            queue_capacity,
+            max_batch_size,
+            batch_buffer: Vec::with_capacity(max_batch_size),
+            recv_buffer: Vec::with_capacity(max_batch_size),
+            notif_buffer: Vec::with_capacity(max_batch_size),
+        }
+    }
+
+    /// Start the background appender as a TaskCenter background task. Note that the task will not
+    /// autmatically react to TaskCenter's shutdown signal, it gives control over the shutdown
+    /// behaviour to the the owner of [`AppenderHandle`] to drain or drop when appropriate.
+    pub fn start(
+        self,
+        task_center: TaskCenter,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+    ) -> Result<AppenderHandle<T>, ShutdownError> {
+        let (tx, rx) = tokio::sync::mpsc::channel(self.queue_capacity);
+        let drain_token = CancellationToken::new();
+
+        // todo: move to `spawn_detached()` when implemented
+        let task_id = task_center.spawn_child(
+            restate_core::TaskKind::BifrostAppender,
+            name,
+            partition_id,
+            {
+                let drain_token = drain_token.clone();
+                async move { self.run(rx, drain_token).await }
+            },
+        )?;
+
+        Ok(AppenderHandle {
+            sender: Some(LogSender { tx }),
+            drain_token,
+            task_id,
+        })
+    }
+
+    async fn run(
+        self,
+        mut rx: mpsc::Receiver<AppendOperation<T>>,
+        drain_handle: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let Self {
+            mut appender,
+            max_batch_size,
+            mut notif_buffer,
+            mut batch_buffer,
+            mut recv_buffer,
+            ..
+        } = self;
+
+        // fused to avoid a busy loop while draining.
+        let mut drain_fut = std::pin::pin!(drain_handle.cancelled().fuse());
+        loop {
+            tokio::select! {
+                _ = &mut drain_fut => {
+                    trace!("Draining the background appender");
+                    // stop accepting messages and drain the queue
+                    rx.close();
+                }
+                received = rx.recv_many(&mut recv_buffer, max_batch_size) => {
+                    if received == 0 {
+                        // channel is closed, appender is drained
+                        break;
+                    }
+
+                    // The background appender stops if a batch write failed. All enqueued messages
+                    // will be dropped and senders will receive [`EnqueueError::Closed`]
+                    //
+                    // All buffers get reset within `process_appends()`
+                    Self::process_appends(
+                        &mut appender,
+                        &mut recv_buffer,
+                        &mut notif_buffer,
+                        &mut batch_buffer,
+                    ).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn process_appends(
+        appender: &mut Appender,
+        buffered_records: &mut Vec<AppendOperation<T>>,
+        notif_buffer: &mut Vec<oneshot::Sender<()>>,
+        batch_buffer: &mut Vec<(Bytes, Keys)>,
+    ) -> Result<()> {
+        batch_buffer.reserve(buffered_records.len());
+
+        // Attempt to reserve enough bytes for the payloads
+        appender
+            .serde_buffer
+            .reserve(buffered_records.len() * RECORD_SIZE_HINT);
+        for record in buffered_records.drain(..) {
+            match record {
+                AppendOperation::Enqueue(record) => {
+                    let keys = record.record_keys();
+                    StorageCodec::encode(&record, &mut appender.serde_buffer)
+                        .expect("record serde is infallible");
+                    // todo, optimize to avoid copying the payload bytes again
+                    let payload = Payload::new(appender.serde_buffer.split().freeze());
+                    StorageCodec::encode(payload, &mut appender.serde_buffer)
+                        .expect("record serde is infallible");
+                    info!("payload size ={}", appender.serde_buffer.len());
+                    batch_buffer.push((appender.serde_buffer.split().freeze(), keys));
+                }
+                AppendOperation::EnqueueWithNotification(record, tx) => {
+                    let keys = record.record_keys();
+                    StorageCodec::encode(&record, &mut appender.serde_buffer)
+                        .expect("record serde is infallible");
+                    // todo, optimize to avoid copying the payload bytes again
+                    let payload = Payload::new(appender.serde_buffer.split().freeze());
+                    StorageCodec::encode(payload, &mut appender.serde_buffer)
+                        .expect("record serde is infallible");
+                    batch_buffer.push((appender.serde_buffer.split().freeze(), keys));
+                    notif_buffer.push(tx);
+                }
+                AppendOperation::Canary(notify) => {
+                    notify.notify_one();
+                }
+            }
+        }
+
+        // Failure to append will stop the whole task
+        appender.append_raw_batch_with_keys(batch_buffer).await?;
+
+        // Notify those who asked for a commit notification
+        notif_buffer.drain(..).for_each(|tx| {
+            let _ = tx.send(());
+        });
+        // Clear buffers
+        batch_buffer.clear();
+        notif_buffer.clear();
+        Ok(())
+    }
+}
+
+/// Handle of the background appender.
+///
+/// Dropping this handle will async-request a graceful drain of the background task with no guarantee
+/// on whether pending appends have completed or not. The safest way to drain this
+/// handle before dropping is to call [`Self::drain()`] to wait for all enqueued appends
+/// to complete and to reject new enqueues.
+pub struct AppenderHandle<T> {
+    // This is always Some(). This is only set to None on detach().
+    sender: Option<LogSender<T>>,
+    // triggered on Drop
+    drain_token: CancellationToken,
+    task_id: TaskId,
+}
+
+impl<T> Drop for AppenderHandle<T> {
+    fn drop(&mut self) {
+        // trigger drain on drop but don't block.
+        self.drain_token.cancel();
+    }
+}
+
+impl<T> AppenderHandle<T> {
+    /// Detaches the handle from the background task. When detached, the background task will
+    /// automatically be drained and stopped after all LogSender instances are dropped.
+    pub fn detach(mut self) -> LogSender<T> {
+        let sender = std::mem::take(&mut self.sender);
+        // do not run the destructor because we don't want to drain. If the last sender (perhaps
+        // the one we are just returning below) is dropped, the background task will stop.
+        std::mem::forget(self);
+        sender.unwrap()
+    }
+
+    pub async fn drain(self) -> Result<(), ShutdownError> {
+        self.drain_token.cancel();
+        // wait for the receiver to drop (appender terminates)
+        self.sender.as_ref().unwrap().tx.closed().await;
+        // todo: This is temporary until spawn_detached is implemented in TaskCenter
+        // which returns an owned join handle
+        let Some(task) = task_center().take_task(self.task_id) else {
+            // task already completed
+            return Ok(());
+        };
+        // What to do if task panics!
+        if let Err(err) = task.await {
+            warn!(
+                ?err,
+                "Appender task might have been cancelled or panicked while draining",
+            );
+        }
+        Ok(())
+    }
+
+    /// If you need an owned LogSender, clone this.
+    pub fn sender(&self) -> &LogSender<T> {
+        self.sender.as_ref().unwrap()
+    }
+}
+
+#[derive(Clone)]
+pub struct LogSender<T> {
+    tx: tokio::sync::mpsc::Sender<AppendOperation<T>>,
+}
+
+impl<T> LogSender<T>
+where
+    T: HasRecordKeys + StorageEncode + 'static,
+{
+    /// Attempt to enqueue a record to the appender. Returns immediately if the
+    /// appender is pushing back or if the appender is draining or drained.
+    pub fn try_enqueue(&self, record: T) -> Result<(), EnqueueError<T>> {
+        let permit = match self.tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                return Err(EnqueueError::WouldBlock(record))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(record)),
+        };
+
+        permit.send(AppendOperation::Enqueue(record));
+        Ok(())
+    }
+
+    /// Enqueues an append and returns a commit token
+    pub fn try_enqueue_with_notification(&self, record: T) -> Result<CommitToken, EnqueueError<T>> {
+        let permit = match self.tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                return Err(EnqueueError::WouldBlock(record))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(record)),
+        };
+
+        let (tx, rx) = oneshot::channel();
+        permit.send(AppendOperation::EnqueueWithNotification(record, tx));
+        Ok(CommitToken { rx })
+    }
+
+    /// Waits for capacity on the channel and returns an error if the appender is
+    /// draining or drained.
+    pub async fn enqueue(&self, record: T) -> Result<(), EnqueueError<T>> {
+        let Ok(permit) = self.tx.reserve().await else {
+            return Err(EnqueueError::Closed(record));
+        };
+        permit.send(AppendOperation::Enqueue(record));
+
+        Ok(())
+    }
+
+    /// Attempt to enqueue a record to the appender. Returns immediately if the
+    /// appender is pushing back or if the appender is draining or drained.
+    ///
+    /// Attempts to enqueue all records in the iterator. This will immediately return if there is
+    /// no capacity in the channel to enqueue _all_ records.
+    pub fn try_enqueue_many<I>(&self, records: I) -> Result<(), EnqueueError<I>>
+    where
+        I: Iterator<Item = T> + ExactSizeIterator,
+    {
+        let permits = match self.tx.try_reserve_many(records.len()) {
+            Ok(permit) => permit,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                return Err(EnqueueError::WouldBlock(records))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(records)),
+        };
+
+        for (permit, record) in std::iter::zip(permits, records) {
+            permit.send(AppendOperation::Enqueue(record));
+        }
+        Ok(())
+    }
+
+    /// Attempts to enqueue all records in the iterator. This function waits until there is enough
+    /// capacity in the channel to enqueue _all_ records to avoid partial enqueues.
+    ///
+    /// The method is cancel safe in the sense that if enqueue_many is used in a `tokio::select!`,
+    /// no records are enqueued if another branch completed.
+    pub async fn enqueue_many<I>(&self, records: I) -> Result<(), EnqueueError<I>>
+    where
+        I: Iterator<Item = T> + ExactSizeIterator,
+    {
+        let Ok(permits) = self.tx.reserve_many(records.len()).await else {
+            return Err(EnqueueError::Closed(records));
+        };
+
+        for (permit, record) in std::iter::zip(permits, records) {
+            permit.send(AppendOperation::Enqueue(record));
+        }
+
+        Ok(())
+    }
+
+    /// Enqueues a record and returns a [`CommitToken`] future that's resolved when the record is
+    /// committed.
+    pub async fn enqueue_with_notification(
+        &self,
+        record: T,
+    ) -> Result<CommitToken, EnqueueError<T>> {
+        let Ok(permit) = self.tx.reserve().await else {
+            return Err(EnqueueError::Closed(record));
+        };
+
+        let (tx, rx) = oneshot::channel();
+        permit.send(AppendOperation::EnqueueWithNotification(record, tx));
+
+        Ok(CommitToken { rx })
+    }
+
+    /// Wait for previously enqueued records to be committed
+    ///
+    /// Not cancellation safe. Every call will attempt to acquire capacity on the channel and send
+    /// a new message to the appender.
+    pub async fn notify_committed(&self) -> Result<(), EnqueueError<()>> {
+        let Ok(permit) = self.tx.reserve().await else {
+            // channel is closed, this should happen the appender is draining or has been darained
+            // already
+            return Err(EnqueueError::Closed(()));
+        };
+
+        let notify = Arc::new(Notify::new());
+        let canary = AppendOperation::Canary(notify.clone());
+        permit.send(canary);
+
+        notify.notified().await;
+        Ok(())
+    }
+}
+
+/// A future that resolves when a record is committed by the background appender.
+pub struct CommitToken {
+    rx: oneshot::Receiver<()>,
+}
+
+impl std::future::Future for CommitToken {
+    type Output = Result<(), oneshot::error::RecvError>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.rx.poll_unpin(cx)
+    }
+}
+
+enum AppendOperation<T> {
+    Enqueue(T),
+    EnqueueWithNotification(T, oneshot::Sender<()>),
+    // A message denoting a request to be notified when it's processed by the appender.
+    // It's used to check if previously enqueued appends have been committed or not
+    Canary(Arc<Notify>),
+}

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 
 use bytes::BytesMut;
 use enum_map::EnumMap;
-use tracing::{info, instrument};
+use tracing::info;
 
 use restate_core::{Metadata, MetadataKind, TargetVersion};
 use restate_types::config::Configuration;
@@ -24,6 +24,7 @@ use restate_types::storage::StorageEncode;
 use restate_types::Version;
 
 use crate::appender::Appender;
+use crate::background_appender::BackgroundAppender;
 use crate::loglet::{LogletBase, LogletProvider};
 use crate::loglet_wrapper::LogletWrapper;
 use crate::watchdog::WatchdogSender;
@@ -92,18 +93,8 @@ impl Bifrost {
     /// Appends a single record to a log. The log id must exist, otherwise the
     /// operation fails with [`Error::UnknownLogId`]
     ///
-    /// It's recommended to use the [`Appender`] interface instead of this one. Use
-    /// [`Self::create_appender`] and reuse this appender to create a sequential write stream to
-    /// the virtual log.
-    #[instrument(
-        level = "debug",
-        skip(self, body),
-        err,
-        fields(
-            log_id = %log_id,
-            segment_index = tracing::field::Empty
-        )
-    )]
+    /// It's recommended to use the [`Appender`] interface. Use [`Self::create_appender`]
+    /// and reuse this appender to create a sequential write stream to the virtual log.
     pub async fn append<T>(&self, log_id: LogId, body: T) -> Result<Lsn>
     where
         T: HasRecordKeys + StorageEncode,
@@ -170,6 +161,22 @@ impl Bifrost {
         self.inner.fail_if_shutting_down()?;
         self.inner.check_log_id(log_id)?;
         Ok(Appender::new(log_id, self.inner.clone()))
+    }
+
+    pub fn create_background_appender<T>(
+        &self,
+        log_id: LogId,
+        queue_capacity: usize,
+        max_batch_size: usize,
+    ) -> Result<BackgroundAppender<T>>
+    where
+        T: HasRecordKeys + StorageEncode + 'static,
+    {
+        Ok(BackgroundAppender::new(
+            self.create_appender(log_id)?,
+            queue_capacity,
+            max_batch_size,
+        ))
     }
 
     /// Like [`Self::create_appender()`] except that it uses the supplied buffer space for

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -63,6 +63,7 @@ impl<'a> BifrostAdmin<'a> {
     /// trim all records of the log.
     #[instrument(level = "debug", skip(self), err)]
     pub async fn trim(&self, log_id: LogId, trim_point: Lsn) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         self.bifrost.inner.trim(log_id, trim_point).await
     }
 
@@ -83,6 +84,7 @@ impl<'a> BifrostAdmin<'a> {
         provider: ProviderKind,
         params: LogletParams,
     ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         let _ = self
             .bifrost
             .inner
@@ -115,6 +117,7 @@ impl<'a> BifrostAdmin<'a> {
         log_id: LogId,
         segment_index: SegmentIndex,
     ) -> Result<TailState> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         // first find the tail segment for this log.
         let loglet = self.bifrost.inner.writeable_loglet(log_id).await?;
 
@@ -165,6 +168,7 @@ impl<'a> BifrostAdmin<'a> {
         provider: ProviderKind,
         params: LogletParams,
     ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
         let logs = self
             .metadata_store_client
             .read_modify_write(BIFROST_CONFIG_KEY.clone(), move |logs: Option<Logs>| {

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -36,8 +36,6 @@ pub enum Error {
     /// Provider is unknown or disabled
     #[error("bifrost provider '{0}' is disabled or unrecognized")]
     Disabled(String),
-    #[error("read() at {0} failed waiting on reconfiguration of log {1}")]
-    ReadFailureDuringReconfiguration(LogId, Lsn),
     #[error(transparent)]
     AdminError(#[from] AdminError),
     #[error(transparent)]

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -44,6 +44,14 @@ pub enum Error {
     MetadataStoreError(#[from] restate_core::metadata_store::ReadWriteError),
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum EnqueueError<T> {
+    #[error("the operation rejected due to backpressure")]
+    WouldBlock(T),
+    #[error("appender is draining, closed, or crashed")]
+    Closed(T),
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AdminError {
     #[error("segment conflicts with existing segment with base_lsn={0}")]

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod appender;
+mod background_appender;
 mod bifrost;
 mod bifrost_admin;
 mod error;
@@ -22,6 +23,7 @@ mod types;
 mod watchdog;
 
 pub use appender::Appender;
+pub use background_appender::{AppenderHandle, BackgroundAppender, CommitToken, LogSender};
 pub use bifrost::Bifrost;
 pub use bifrost_admin::BifrostAdmin;
 pub use error::{Error, Result};

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -15,6 +15,7 @@ mod bifrost_admin;
 mod error;
 pub mod loglet;
 mod loglet_wrapper;
+mod payload;
 pub mod providers;
 mod read_stream;
 mod record;

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod appender;
 mod bifrost;
 mod bifrost_admin;
 mod error;
@@ -20,6 +21,7 @@ mod service;
 mod types;
 mod watchdog;
 
+pub use appender::Appender;
 pub use bifrost::Bifrost;
 pub use bifrost_admin::BifrostAdmin;
 pub use error::{Error, Result};

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -20,7 +20,7 @@ use tokio::sync::Barrier;
 use tokio::task::{JoinHandle, JoinSet};
 
 use restate_test_util::let_assert;
-use restate_types::logs::{Keys, Lsn, SequenceNumber};
+use restate_types::logs::{KeyFilter, Keys, Lsn, SequenceNumber};
 use tokio_stream::StreamExt;
 use tracing::info;
 
@@ -208,7 +208,7 @@ pub async fn single_loglet_readstream(loglet: Arc<dyn Loglet>) -> googletest::Re
     let read_from_offset = Lsn::new(6);
     let mut reader = loglet
         .clone()
-        .create_wrapped_read_stream(read_from_offset)
+        .create_wrapped_read_stream(KeyFilter::Any, read_from_offset)
         .await?;
 
     {
@@ -307,7 +307,7 @@ pub async fn single_loglet_readstream_with_trims(
 
     let mut read_stream = loglet
         .clone()
-        .create_wrapped_read_stream(Lsn::OLDEST)
+        .create_wrapped_read_stream(KeyFilter::Any, Lsn::OLDEST)
         .await?;
 
     let record = read_stream.next().await.unwrap()?;
@@ -558,7 +558,7 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
 
     let reader = loglet
         .clone()
-        .create_read_stream_with_tail(Lsn::OLDEST, Some(tail.offset()))
+        .create_read_stream_with_tail(KeyFilter::Any, Lsn::OLDEST, Some(tail.offset()))
         .await?;
 
     let records: BTreeSet<Lsn> = reader

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
-use restate_types::logs::{Lsn, SequenceNumber};
+use restate_types::logs::{Keys, Lsn, SequenceNumber};
 
 use crate::LogRecord;
 use crate::{Result, TailState};
@@ -122,7 +122,7 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     ) -> Result<SendableLogletReadStream<Self::Offset>>;
 
     /// Append a record to the loglet.
-    async fn append(&self, data: Bytes) -> Result<Self::Offset, AppendError>;
+    async fn append(&self, data: &Bytes, keys: &Keys) -> Result<Self::Offset, AppendError>;
 
     /// An optional optimization that loglets can implement. Offsets returned by this call **MUST**
     /// be offsets that were observed before a sealing point. For instance, the maximum acknowleged
@@ -147,9 +147,9 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     /// beyond it to a higher tail while remaining unsealed.
     fn watch_tail(&self) -> BoxStream<'static, TailState<Self::Offset>>;
 
-    /// Append a batch of records to the loglet. The returned offset (on success) if the offset of
+    /// Append a batch of records to the loglet. The returned offset (on success) is the offset of
     /// the first record in the batch)
-    async fn append_batch(&self, payloads: &[Bytes]) -> Result<Self::Offset, AppendError>;
+    async fn append_batch(&self, payloads: &[(Bytes, Keys)]) -> Result<Self::Offset, AppendError>;
 
     /// The tail is *the first unwritten position* in the loglet.
     ///

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 
-use restate_types::logs::{Keys, Lsn, SequenceNumber};
+use restate_types::logs::{KeyFilter, Keys, Lsn, SequenceNumber};
 
 use crate::LogRecord;
 use crate::{Result, TailState};
@@ -117,6 +117,7 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     /// stream is an open-ended tailing read stream.
     async fn create_read_stream(
         self: Arc<Self>,
+        filter: KeyFilter,
         from: Self::Offset,
         to: Option<Self::Offset>,
     ) -> Result<SendableLogletReadStream<Self::Offset>, OperationError>;

--- a/crates/bifrost/src/loglet/util.rs
+++ b/crates/bifrost/src/loglet/util.rs
@@ -11,11 +11,8 @@
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 
-use restate_core::ShutdownError;
-
-use crate::TailState;
-
 use super::LogletOffset;
+use crate::TailState;
 
 #[derive(Debug)]
 pub struct TailOffsetWatch {
@@ -36,16 +33,6 @@ impl TailOffsetWatch {
 
     pub fn notify_seal(&self) {
         self.sender.send_if_modified(|v| v.seal());
-    }
-
-    /// Blocks until the tail is beyond the given offset.
-    pub async fn wait_for(&self, offset: LogletOffset) -> Result<(), ShutdownError> {
-        self.receiver
-            .clone()
-            .wait_for(|v| v.offset() > offset)
-            .await
-            .map_err(|_| ShutdownError)?;
-        Ok(())
     }
 
     pub fn to_stream(&self) -> WatchStream<TailState<LogletOffset>> {

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -22,7 +22,8 @@ use restate_types::logs::metadata::SegmentIndex;
 use restate_types::logs::{Keys, Lsn, SequenceNumber};
 
 use crate::loglet::{
-    AppendError, Loglet, LogletBase, LogletOffset, OperationError, SendableLogletReadStream,
+    AppendError, Loglet, LogletBase, LogletOffset, LogletReadStream, OperationError,
+    SendableLogletReadStream,
 };
 use crate::{LogRecord, LsnExt};
 use crate::{Result, TailState};
@@ -75,7 +76,16 @@ impl LogletWrapper {
     pub async fn create_wrapped_read_stream(
         self,
         start_lsn: Lsn,
-    ) -> Result<LogletReadStreamWrapper> {
+    ) -> Result<LogletReadStreamWrapper, OperationError> {
+        let tail_lsn = self.tail_lsn;
+        self.create_read_stream_with_tail(start_lsn, tail_lsn).await
+    }
+
+    pub async fn create_read_stream_with_tail(
+        self,
+        start_lsn: Lsn,
+        tail_lsn: Option<Lsn>,
+    ) -> Result<LogletReadStreamWrapper, OperationError> {
         // Translates LSN to loglet offset
         Ok(LogletReadStreamWrapper::new(
             self.clone(),
@@ -84,12 +94,45 @@ impl LogletWrapper {
                     start_lsn.into_offset(self.base_lsn),
                     // We go back one LSN because `to` is inclusive and `tail_lsn` is exclusive.
                     // transposed to loglet offset (if set)
-                    self.tail_lsn
-                        .map(|tail| tail.prev().into_offset(self.base_lsn)),
+                    tail_lsn.map(|tail| tail.prev().into_offset(self.base_lsn)),
                 )
                 .await?,
             self.base_lsn,
         ))
+    }
+
+    /// Read or wait for the record at `from` offset, or the next available record if `from` isn't
+    /// defined for the loglet.
+    #[allow(unused)]
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn read(&self, from: Lsn) -> Result<LogRecord<Lsn, Bytes>, OperationError> {
+        let mut stream = self.clone().create_wrapped_read_stream(from).await?;
+        stream.next().await.unwrap_or_else(|| {
+            // We are trying to read past the the last record.
+            Err(OperationError::terminal(
+                LogletWrapperError::OutOfBoundsRead {
+                    attempt_lsn: from,
+                    tail_lsn: self.tail_lsn.unwrap_or(Lsn::INVALID),
+                },
+            ))
+        })
+    }
+
+    #[allow(unused)]
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn read_opt(
+        &self,
+        from: Lsn,
+    ) -> Result<Option<LogRecord<Lsn, Bytes>>, OperationError> {
+        let tail_lsn = match self.tail_lsn {
+            Some(tail) => tail,
+            None => self.find_tail().await?.offset(),
+        };
+        let mut stream = self
+            .clone()
+            .create_read_stream_with_tail(from, Some(tail_lsn))
+            .await?;
+        stream.next().await.transpose()
     }
 }
 
@@ -108,7 +151,7 @@ impl LogletBase for LogletWrapper {
         self: Arc<Self>,
         _after: Self::Offset,
         _to: Option<Self::Offset>,
-    ) -> Result<SendableLogletReadStream<Self::Offset>> {
+    ) -> Result<SendableLogletReadStream<Self::Offset>, OperationError> {
         unreachable!("create_read_stream on LogletWrapper should never be used directly")
     }
 
@@ -175,46 +218,6 @@ impl LogletBase for LogletWrapper {
 
         self.loglet.seal().await
     }
-
-    async fn read(&self, from: Lsn) -> Result<LogRecord<Lsn, Bytes>, OperationError> {
-        if self.tail_lsn.is_some_and(|tail| from >= tail) {
-            // We are trying to read past the the last record. Upper layers should fence against
-            // this case, therefore, we throw an OperationError.
-            return Err(OperationError::terminal(
-                LogletWrapperError::OutOfBoundsRead {
-                    attempt_lsn: from,
-                    tail_lsn: self.tail_lsn.unwrap(),
-                },
-            ));
-        }
-        // convert LSN to loglet offset
-        let offset = from.into_offset(self.base_lsn);
-        self.loglet
-            .read(offset)
-            .await
-            .map(|record| record.with_base_lsn(self.base_lsn))
-    }
-
-    async fn read_opt(
-        &self,
-        from: Self::Offset,
-    ) -> Result<Option<LogRecord<Self::Offset, Bytes>>, OperationError> {
-        if self.tail_lsn.is_some_and(|tail| from >= tail) {
-            // We are trying to read past the the last record. Upper layers should fence against
-            // this case, therefore, we throw an OperationError.
-            return Err(OperationError::terminal(
-                LogletWrapperError::OutOfBoundsRead {
-                    attempt_lsn: from,
-                    tail_lsn: self.tail_lsn.unwrap(),
-                },
-            ));
-        }
-        let offset = from.into_offset(self.base_lsn);
-        self.loglet
-            .read_opt(offset)
-            .await
-            .map(|maybe_record| maybe_record.map(|record| record.with_base_lsn(self.base_lsn)))
-    }
 }
 
 /// Wraps loglet read streams with the base LSN of the segment
@@ -251,6 +254,17 @@ impl LogletReadStreamWrapper {
     #[inline(always)]
     pub fn loglet(&self) -> &LogletWrapper {
         &self.loglet
+    }
+}
+
+impl LogletReadStream<Lsn> for LogletReadStreamWrapper {
+    fn read_pointer(&self) -> Lsn {
+        self.base_lsn
+            .offset_by(self.inner_read_stream.read_pointer())
+    }
+
+    fn is_terminated(&self) -> bool {
+        self.inner_read_stream.is_terminated()
     }
 }
 

--- a/crates/bifrost/src/payload.rs
+++ b/crates/bifrost/src/payload.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use restate_types::flexbuffers_storage_encode_decode;
+use restate_types::time::NanosSinceEpoch;
+
+/// Owned payload.
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Payload {
+    header: Header,
+    body: Bytes,
+}
+
+impl Payload {
+    pub fn new(body: impl Into<Bytes>) -> Self {
+        Self {
+            header: Header::default(),
+            body: body.into(),
+        }
+    }
+
+    pub fn body(&self) -> &Bytes {
+        &self.body
+    }
+
+    pub fn split(self) -> (Header, Bytes) {
+        (self.header, self.body)
+    }
+
+    pub fn into_body(self) -> Bytes {
+        self.body
+    }
+
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    pub fn into_header(self) -> Header {
+        self.header
+    }
+
+    pub fn body_size(&self) -> usize {
+        self.body.len()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Header {
+    pub created_at: NanosSinceEpoch,
+}
+
+impl Default for Header {
+    fn default() -> Self {
+        Self {
+            created_at: NanosSinceEpoch::now(),
+        }
+    }
+}
+
+flexbuffers_storage_encode_decode!(Payload);

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -23,7 +23,7 @@ pub use log_store::LogStoreError;
 use metrics::{counter, histogram, Histogram};
 pub use provider::Factory;
 use restate_core::ShutdownError;
-use restate_types::logs::{Keys, SequenceNumber};
+use restate_types::logs::{KeyFilter, Keys, SequenceNumber};
 use tokio::sync::Mutex;
 use tracing::{debug, trace, warn};
 
@@ -131,11 +131,12 @@ impl LogletBase for LocalLoglet {
 
     async fn create_read_stream(
         self: Arc<Self>,
+        filter: KeyFilter,
         from: Self::Offset,
         to: Option<Self::Offset>,
     ) -> Result<SendableLogletReadStream<Self::Offset>, OperationError> {
         Ok(Box::pin(
-            LocalLogletReadStream::create(self, from, to).await?,
+            LocalLogletReadStream::create(self, filter, from, to).await?,
         ))
     }
 

--- a/crates/bifrost/src/providers/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/providers/local_loglet/read_stream.rs
@@ -62,7 +62,7 @@ impl LocalLogletReadStream {
         loglet: Arc<LocalLoglet>,
         from_offset: LogletOffset,
         to: Option<LogletOffset>,
-    ) -> Result<Self> {
+    ) -> Result<Self, OperationError> {
         // Reading from INVALID resets to OLDEST.
         let from_offset = from_offset.max(LogletOffset::OLDEST);
         // We seek to next key on every iteration, we need to setup the iterator to be

--- a/crates/bifrost/src/providers/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/providers/local_loglet/read_stream.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, warn};
 
 use restate_core::ShutdownError;
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{KeyFilter, SequenceNumber};
 
 use crate::loglet::{LogletBase, LogletOffset, LogletReadStream, OperationError};
 use crate::providers::local_loglet::LogStoreError;
@@ -60,6 +60,7 @@ unsafe fn ignore_iterator_lifetime<'a>(
 impl LocalLogletReadStream {
     pub(crate) async fn create(
         loglet: Arc<LocalLoglet>,
+        _filter: KeyFilter,
         from_offset: LogletOffset,
         to: Option<LogletOffset>,
     ) -> Result<Self, OperationError> {

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -424,6 +424,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
 
     use crate::loglet::LogletBase;
+    use crate::payload::Payload;
     use crate::{
         setup_panic_handler, BifrostAdmin, BifrostService, FindTailAttributes, Record, TrimGap,
     };
@@ -445,7 +446,7 @@ mod tests {
     use tracing::info;
     use tracing_test::traced_test;
 
-    use restate_types::logs::{Payload, SequenceNumber};
+    use restate_types::logs::SequenceNumber;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[traced_test]

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -9,9 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use bytes::Bytes;
-use restate_types::logs::{Lsn, Payload, SequenceNumber};
+
+use restate_types::logs::{Lsn, SequenceNumber};
 use restate_types::storage::{StorageCodec, StorageDecodeError};
 
+use crate::payload::Payload;
 use crate::LsnExt;
 
 /// A single entry in the log.

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -80,6 +80,10 @@ pub enum TaskKind {
     /// A background task that the system needs for its operation. The task requires a system
     /// shutdown on errors and the system will wait for its graceful cancellation on shutdown.
     BifrostBackgroundHighPriority,
+    /// A background appender. The task will log on errors but the system will wait for its
+    /// graceful cancellation on shutdown.
+    #[strum(props(OnCancel = "wait", OnError = "log"))]
+    BifrostAppender,
     #[strum(props(OnCancel = "abort", OnError = "log"))]
     Disposable,
     LogletProvider,

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -10,12 +10,9 @@
 
 use std::ops::RangeInclusive;
 
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
-use crate::flexbuffers_storage_encode_decode;
 use crate::identifiers::PartitionId;
-use crate::time::NanosSinceEpoch;
 
 pub mod builder;
 pub mod metadata;
@@ -216,59 +213,6 @@ impl From<RangeInclusive<u64>> for KeyFilter {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Header {
-    pub created_at: NanosSinceEpoch,
-}
-
-impl Default for Header {
-    fn default() -> Self {
-        Self {
-            created_at: NanosSinceEpoch::now(),
-        }
-    }
-}
-
-/// Owned payload.
-#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Payload {
-    header: Header,
-    body: Bytes,
-}
-
-impl Payload {
-    pub fn new(body: impl Into<Bytes>) -> Self {
-        Self {
-            header: Header::default(),
-            body: body.into(),
-        }
-    }
-
-    pub fn body(&self) -> &Bytes {
-        &self.body
-    }
-
-    pub fn split(self) -> (Header, Bytes) {
-        (self.header, self.body)
-    }
-
-    pub fn into_body(self) -> Bytes {
-        self.body
-    }
-
-    pub fn header(&self) -> &Header {
-        &self.header
-    }
-
-    pub fn into_header(self) -> Header {
-        self.header
-    }
-
-    pub fn body_size(&self) -> usize {
-        self.body.len()
-    }
-}
-
 pub trait HasRecordKeys: Send + Sync {
     /// Keys of the record. Keys are used to filter the log when reading.
     fn record_keys(&self) -> Keys;
@@ -284,8 +228,6 @@ impl<T: HasRecordKeys> HasRecordKeys for &T {
         HasRecordKeys::record_keys(*self)
     }
 }
-
-flexbuffers_storage_encode_decode!(Payload);
 
 #[cfg(test)]
 mod tests {

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -99,7 +99,7 @@ impl StorageCodec {
 ///
 /// # Important
 /// The [`Self::encode`] implementation should use the codec specified by [`Self::DEFAULT_CODEC`].
-pub trait StorageEncode {
+pub trait StorageEncode: Sized {
     /// Codec which is used when encode new values.
     const DEFAULT_CODEC: StorageCodecKind;
 

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -8,10 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::leadership::ActionEffect;
-use futures::stream::FuturesUnordered;
+use std::collections::{btree_map, BTreeMap};
+use std::ops::RangeInclusive;
+use std::time::SystemTime;
+
 use restate_bifrost::Bifrost;
-use restate_core::Metadata;
+use restate_core::{task_center, Metadata};
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
 use restate_types::logs::LogId;
@@ -20,10 +22,13 @@ use restate_types::time::MillisSinceEpoch;
 use restate_types::Version;
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
-use std::collections::BTreeMap;
-use std::ops::RangeInclusive;
-use std::time::SystemTime;
-use tokio_stream::StreamExt;
+
+use super::leadership::ActionEffect;
+
+// Constants since it's very unlikely that we can derive a meaningful configuration
+// that the user can reason about.
+const BIFROST_QUEUE_SIZE: usize = 1000;
+const MAX_BIFROST_APPEND_BATCH: usize = 100;
 
 /// Responsible for proposing [ActionEffect].
 pub(super) struct ActionEffectHandler {
@@ -31,6 +36,7 @@ pub(super) struct ActionEffectHandler {
     epoch_sequence_number: EpochSequenceNumber,
     partition_key_range: RangeInclusive<PartitionKey>,
     bifrost: Bifrost,
+    bifrost_appenders: BTreeMap<LogId, restate_bifrost::AppenderHandle<Envelope>>,
     metadata: Metadata,
 }
 
@@ -47,6 +53,7 @@ impl ActionEffectHandler {
             epoch_sequence_number,
             partition_key_range,
             bifrost,
+            bifrost_appenders: Default::default(),
             metadata,
         }
     }
@@ -55,9 +62,6 @@ impl ActionEffectHandler {
         &mut self,
         effects: impl IntoIterator<Item = ActionEffect>,
     ) -> anyhow::Result<()> {
-        // groups envelopes write to Bifrost in batches
-        let mut buffer: BTreeMap<LogId, Vec<Envelope>> = Default::default();
-
         for actuator_output in effects {
             let envelope = match actuator_output {
                 ActionEffect::Invoker(invoker_output) => {
@@ -94,21 +98,24 @@ impl ActionEffectHandler {
                 LogId::from(partition_table.find_partition_id(envelope.partition_key())?)
             };
 
-            buffer.entry(log_id).or_default().push(envelope);
+            let sender = match self.bifrost_appenders.entry(log_id) {
+                btree_map::Entry::Vacant(entry) => {
+                    let appender = self
+                        .bifrost
+                        .create_background_appender(
+                            log_id,
+                            BIFROST_QUEUE_SIZE,
+                            MAX_BIFROST_APPEND_BATCH,
+                        )?
+                        .start(task_center(), "effect-appender", Some(self.partition_id))?;
+                    entry.insert(appender).sender()
+                }
+                btree_map::Entry::Occupied(sender) => sender.into_mut().sender(),
+            };
+            // Only blocks if background append is pushing back (queue full)
+            sender.enqueue(envelope).await?;
         }
 
-        let mut batches = FuturesUnordered::new();
-
-        // Attempt to write batches to different log ids concurrently
-        for (log_id, envelopes) in &buffer {
-            batches.push(self.bifrost.append_batch(*log_id, envelopes));
-        }
-        while let Some(o) = batches.next().await {
-            // fail if any write fails. This is not the best approach to handle write errors,
-            // however this is how it was.
-            // todo: we should implement a better error handling mechanism
-            let _ = o?;
-        }
         Ok(())
     }
 

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -10,17 +10,16 @@
 
 use super::leadership::ActionEffect;
 use futures::stream::FuturesUnordered;
-use restate_bifrost::{Bifrost, SMALL_BATCH_THRESHOLD_COUNT};
+use restate_bifrost::Bifrost;
 use restate_core::Metadata;
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 use restate_types::partition_table::FindPartition;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::Version;
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
-use smallvec::SmallVec;
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::time::SystemTime;
@@ -57,8 +56,7 @@ impl ActionEffectHandler {
         effects: impl IntoIterator<Item = ActionEffect>,
     ) -> anyhow::Result<()> {
         // groups envelopes write to Bifrost in batches
-        let mut buffer: BTreeMap<LogId, SmallVec<[Payload; SMALL_BATCH_THRESHOLD_COUNT]>> =
-            Default::default();
+        let mut buffer: BTreeMap<LogId, Vec<Envelope>> = Default::default();
 
         for actuator_output in effects {
             let envelope = match actuator_output {
@@ -96,17 +94,14 @@ impl ActionEffectHandler {
                 LogId::from(partition_table.find_partition_id(envelope.partition_key())?)
             };
 
-            buffer
-                .entry(log_id)
-                .or_default()
-                .push(Payload::new(envelope.to_bytes()?));
+            buffer.entry(log_id).or_default().push(envelope);
         }
 
         let mut batches = FuturesUnordered::new();
 
         // Attempt to write batches to different log ids concurrently
-        for (log_id, payloads) in &buffer {
-            batches.push(self.bifrost.append_batch(*log_id, payloads));
+        for (log_id, envelopes) in &buffer {
+            batches.push(self.bifrost.append_batch(*log_id, envelopes));
         }
         while let Some(o) = batches.next().await {
             // fail if any write fails. This is not the best approach to handle write errors,

--- a/crates/worker/src/partition/leadership.rs
+++ b/crates/worker/src/partition/leadership.rs
@@ -34,7 +34,7 @@ use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNu
 use restate_timer::TokioClock;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 use restate_types::net::ingress;
 use restate_types::storage::StorageEncodeError;
 use restate_types::GenerationalNodeId;
@@ -221,12 +221,11 @@ where
                 leader_epoch,
             }),
         );
-        let payload = Payload::new(envelope.to_bytes()?);
 
         self.bifrost
             .append(
                 LogId::from(self.partition_processor_metadata.partition_id),
-                payload,
+                envelope,
             )
             .await?;
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -31,7 +31,7 @@ use restate_storage_api::StorageError;
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
 use restate_types::journal::raw::RawEntryCodec;
-use restate_types::logs::{LogId, Lsn, SequenceNumber};
+use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::GenerationalNodeId;
 use restate_wal_protocol::control::AnnounceLeader;
@@ -246,6 +246,7 @@ where
             .bifrost
             .create_reader(
                 LogId::from(self.partition_id),
+                KeyFilter::Within(self.partition_key_range.clone()),
                 last_applied_lsn.next(),
                 Lsn::MAX,
             )?

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -227,7 +227,7 @@ where
         let state_machine = StateMachine::new(
             metadata,
             outbox_reader,
-            |msg| {
+            move |msg| {
                 let bifrost = bifrost.clone();
                 async move {
                     append_envelope_to_bifrost(&bifrost, msg).await?;

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -449,7 +449,7 @@ mod tests {
     use restate_storage_api::StorageError;
     use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionId};
     use restate_types::invocation::ServiceInvocation;
-    use restate_types::logs::{LogId, Lsn, SequenceNumber};
+    use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
     use restate_types::message::MessageIndex;
     use restate_types::partition_table::PartitionTable;
     use restate_types::storage::StorageCodec;
@@ -684,6 +684,7 @@ mod tests {
             )?;
             let reader = shuffle_env.bifrost.create_reader(
                 LogId::from(partition_id),
+                KeyFilter::Any,
                 Lsn::OLDEST,
                 Lsn::MAX,
             )?;
@@ -729,6 +730,7 @@ mod tests {
             )?;
             let reader = shuffle_env.bifrost.create_reader(
                 LogId::from(partition_id),
+                KeyFilter::Any,
                 Lsn::OLDEST,
                 Lsn::MAX,
             )?;
@@ -766,6 +768,7 @@ mod tests {
                 let partition_id = shuffle_env.shuffle.metadata.partition_id;
                 let reader = shuffle_env.bifrost.create_reader(
                     LogId::from(partition_id),
+                    KeyFilter::Any,
                     Lsn::INVALID,
                     Lsn::MAX,
                 )?;

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -16,7 +16,7 @@ use tracing::info;
 
 use restate_bifrost::Bifrost;
 use restate_core::TaskCenter;
-use restate_types::logs::{LogId, Payload};
+use restate_types::logs::LogId;
 
 use crate::util::print_latencies;
 use crate::Arguments;
@@ -37,16 +37,17 @@ pub async fn run(
     let mut bytes = BytesMut::default();
     let raw_data = [1u8; 1024];
     bytes.put_slice(&raw_data);
+    let bytes = bytes.freeze();
     let mut append_latencies = Histogram::<u64>::new(3)?;
     let mut counter = 0;
+    let mut appender = bifrost.create_appender(log_id)?;
     loop {
         if counter >= opts.num_records {
             break;
         }
         counter += 1;
         let start = Instant::now();
-        let payload = Payload::new(bytes.clone());
-        let _ = bifrost.append(log_id, payload).await?;
+        let _ = appender.append_raw(bytes.clone()).await?;
         append_latencies.record(start.elapsed().as_nanos() as u64)?;
         if counter % 1000 == 0 {
             info!("Appended {} records", counter);

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -18,7 +18,7 @@ use tracing::info;
 use restate_bifrost::{Bifrost, Error as BifrostError};
 use restate_bifrost::{LogRecord, Record};
 use restate_core::{cancellation_watcher, TaskCenter, TaskKind};
-use restate_types::logs::{LogId, Lsn, SequenceNumber};
+use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
 
 use crate::util::print_latencies;
 use crate::Arguments;
@@ -41,7 +41,8 @@ pub async fn run(
         let bifrost = bifrost.clone();
         let clock = clock.clone();
         async move {
-            let mut read_stream = bifrost.create_reader(log_id, Lsn::OLDEST, Lsn::MAX)?;
+            let mut read_stream =
+                bifrost.create_reader(log_id, KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)?;
             let mut counter = 0;
             let mut cancel = std::pin::pin!(cancellation_watcher());
             let mut lag_latencies = Histogram::<u64>::new(3)?;


### PR DESCRIPTION
[Bifrost] Introduce KeyFilter to the read API

Initial plumbing to pass down `KeyFilter` starting from the readstream API of bifrost and down to the loglet API. No filtering takes place yet, this is just the API change.

The partition state machine reader will also use the correct filter spanning its own partition key-range.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1798).
* #1809
* #1808
* __->__ #1798
* #1797
* #1794
* #1792
* #1789
* #1788