### PR TITLE
Correctly handle gateway errors

### DIFF
--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -138,6 +138,10 @@ pub(crate) enum InvocationTaskError {
     #[error("cannot resume invocation because it was created with an incompatible service protocol version '{}' and the server does not support upgrading versions yet", .0.as_repr())]
     #[code(restate_errors::RT0014)]
     UnsupportedServiceProtocolVersion(ServiceProtocolVersion),
+
+    #[error("service is temporary unavailable '{0}'")]
+    #[code(restate_errors::RT0010)]
+    ServiceUnavialable(http::StatusCode),
 }
 
 #[derive(Debug, Default)]

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -141,7 +141,7 @@ pub(crate) enum InvocationTaskError {
 
     #[error("service is temporary unavailable '{0}'")]
     #[code(restate_errors::RT0010)]
-    ServiceUnavialable(http::StatusCode),
+    ServiceUnavailable(http::StatusCode),
 }
 
 #[derive(Debug, Default)]

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -422,7 +422,7 @@ where
         // but we still get a response code from the gateway itself. In that
         // case we still need to return the proper error
         if GATEWAY_ERRORS_CODES.contains(&parts.status) {
-            return Err(InvocationTaskError::ServiceUnavialable(parts.status));
+            return Err(InvocationTaskError::ServiceUnavailable(parts.status));
         }
 
         // otherwise we return generic UnexpectedResponse


### PR DESCRIPTION
When a user service is running behind a gateway it is possible that the gateway returns an http error (like 503) when service is down. We need to handle this correctly in code and return proper error

Fixes #1548

I have tested this fix by running the go example app behind traefik. I first made sure that the setup is working as expected then I shutdown traefik to reproduce the issue.

The logs show the proper error message plus `restate.error.code: RT0010`