### PR TITLE
[Bifrost] Make StorageEncode object safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6432,6 +6432,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "static_assertions",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "syn 2.0.65",

--- a/crates/bifrost/src/providers/local_loglet/log_state.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_state.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use restate_types::flexbuffers_storage_encode_decode;
 use restate_types::storage::StorageCodec;
 use rocksdb::MergeOperands;
@@ -110,7 +110,7 @@ impl LogStateUpdates {
         Ok(buf.freeze())
     }
 
-    pub fn encode<B: BufMut>(&self, buf: &mut B) -> Result<(), LogStoreError> {
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<(), LogStoreError> {
         Ok(StorageCodec::encode(self, buf)?)
     }
 

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::{BufMut, BytesMut};
+use bytes::BytesMut;
 use bytestring::ByteString;
 use restate_core::cancellation_watcher;
 use restate_core::metadata_store::{Precondition, VersionedValue};
@@ -323,7 +323,7 @@ impl LocalMetadataStore {
             .map_err(Into::into)
     }
 
-    fn encode<T: StorageEncode, B: BufMut>(value: T, buf: &mut B) -> Result<()> {
+    fn encode<T: StorageEncode>(value: T, buf: &mut BytesMut) -> Result<()> {
         StorageCodec::encode(value, buf)?;
         Ok(())
     }

--- a/crates/storage-api/src/storage.rs
+++ b/crates/storage-api/src/storage.rs
@@ -19,12 +19,13 @@ macro_rules! protobuf_storage_encode_decode {
     };
     ($ty:ident, $protobuf_ty:path) => {
         impl restate_types::storage::StorageEncode for $ty {
-            const DEFAULT_CODEC: restate_types::storage::StorageCodecKind =
-                restate_types::storage::StorageCodecKind::Protobuf;
+            fn default_codec(&self) -> restate_types::storage::StorageCodecKind {
+                restate_types::storage::StorageCodecKind::Protobuf
+            }
 
-            fn encode<B: bytes::BufMut>(
+            fn encode(
                 &self,
-                buf: &mut B,
+                buf: &mut ::bytes::BytesMut,
             ) -> std::result::Result<(), restate_types::storage::StorageEncodeError> {
                 <$protobuf_ty as prost::Message>::encode(&self.clone().into(), buf).map_err(|err| {
                     restate_types::storage::StorageEncodeError::EncodeValue(err.into())

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -49,6 +49,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
+static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 sync_wrapper = { workspace = true }

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -10,10 +10,11 @@
 
 use std::ops::RangeInclusive;
 
+use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 
 use crate::identifiers::PartitionId;
-use crate::storage::StorageEncode;
+use crate::storage::{StorageCodecKind, StorageEncode};
 
 pub mod builder;
 pub mod metadata;
@@ -279,12 +280,11 @@ impl<T> StorageEncode for BodyWithKeys<T>
 where
     T: StorageEncode,
 {
-    const DEFAULT_CODEC: crate::storage::StorageCodecKind = T::DEFAULT_CODEC;
+    fn default_codec(&self) -> StorageCodecKind {
+        StorageEncode::default_codec(&self.inner)
+    }
 
-    fn encode<B: bytes::BufMut>(
-        &self,
-        buf: &mut B,
-    ) -> Result<(), crate::storage::StorageEncodeError> {
+    fn encode(&self, buf: &mut BytesMut) -> Result<(), crate::storage::StorageEncodeError> {
         T::encode(&self.inner, buf)
     }
 }


### PR DESCRIPTION
[Bifrost] Make StorageEncode object safe

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1809).
* #1816
* #1813
* __->__ #1809
* #1808