### PR TITLE
Perform "just verify" on PRs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Check license headers
         run: ./tools/scripts/check-license-headers
 
-      - name: Rustfmt Check
-        uses: actions-rust-lang/rustfmt@v1
-
   build-and-test:
     name: Build and test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -79,11 +76,8 @@ jobs:
       - name: Check Cargo.lock file is updated
         run: cargo update -w --locked
 
-      - name: Clippy Check
-        run: just clippy
-
-      - name: Run tests
-        run: just test
+      - name: Run verify
+        run: just verify
 
   docker:
     name: Create docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,22 +9,6 @@ on:
       - main
 
 jobs:
-  rustfmt:
-    name: RustFmt Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt
-          rustflags: ""
-
-      - name: Check license headers
-        run: ./tools/scripts/check-license-headers
-
   build-and-test:
     name: Build and test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -136,7 +136,7 @@ impl Bifrost {
     ///
     /// ```no_run
     /// use restate_bifrost::{Bifrost, FindTailAttributes, LogReadStream};
-    /// use restate_types::logs::{LogId, SequenceNumber};
+    /// use restate_types::logs::{KeyFilter, LogId, SequenceNumber};
     ///
     /// async fn reader(bifrost: &Bifrost, log_id: LogId) -> LogReadStream {
     ///     bifrost.create_reader(

--- a/justfile
+++ b/justfile
@@ -138,7 +138,10 @@ generate-config-schema:
     cargo xtask generate-config-schema > restate_config_schema.json
 
 check-deny:
-    cargo deny --all-features check
+    # cargo-deny-action runs as a separate workflow in CI
+    if [[ -z "$CI" ]]; then
+        cargo deny --all-features check
+    fi
 
 flamegraph *flags:
     cargo flamegraph {{ _flamegraph_options }} {{ flags }}

--- a/justfile
+++ b/justfile
@@ -138,7 +138,8 @@ generate-config-schema:
     cargo xtask generate-config-schema > restate_config_schema.json
 
 check-deny:
-    # cargo-deny-action runs as a separate workflow in CI
+    #!/usr/bin/env bash
+    # cargo-deny-action runs as a standalone workflow in CI
     if [[ -z "$CI" ]]; then
         cargo deny --all-features check
     fi

--- a/tools/restatectl/src/commands/mod.rs
+++ b/tools/restatectl/src/commands/mod.rs
@@ -8,4 +8,5 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod dump;
+pub mod
+   dump;

--- a/tools/restatectl/src/commands/mod.rs
+++ b/tools/restatectl/src/commands/mod.rs
@@ -8,5 +8,4 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod
-   dump;
+pub mod dump;


### PR DESCRIPTION
Use "verify" as a single alias for all local verification (format check, linting, tests). My goal is to unify what I do as a developer before I push changes for PR, and what the CI build-and-test target does to validate them. I noticed that we are not running the `doctest` target as part of CI and a recent change got in that broke those.

This PR eliminates the standalone RustFmt CI job as this is already part of the `just verify` target. The `rustfmt` phase itself is very quick so we don't get much by executing this in parallel:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/4a1f2cb6-fe01-43e2-8678-424c366721af">

The `cargo deny` action is special-cased as the tool would have to be installed separately, and we have this running via `EmbarkStudios/cargo-deny-action` as part of `deps.yml`. We could do the same for `rustfmt` if preferred.