### PR TITLE
Fix trace HTTP header injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4474,18 +4474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
-dependencies = [
- "async-trait",
- "bytes",
- "http 1.1.0",
- "opentelemetry",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5846,8 +5834,6 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "opentelemetry",
- "opentelemetry-http",
- "opentelemetry_sdk",
  "prost 0.13.1",
  "restate-core",
  "restate-errors",
@@ -5870,7 +5856,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -38,15 +38,12 @@ tokio-stream = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
-opentelemetry-http = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -227,7 +227,11 @@ where
             (INVOCATION_ID_HEADER_NAME, invocation_id_header_value),
         ]);
 
-        // Inject OpenTelemetry context
+        // Inject OpenTelemetry context into the headers
+        // The parent span as seen by the SDK will be the service invocation span context
+        // which is emitted at INFO level representing the invocation, *not* the DEBUG level
+        // `invoker_invocation_task` which wraps this code. This is so that headers will be sent
+        // when in INFO level, not just in DEBUG level.
         {
             let span_context = parent_span_context.span_context();
             if span_context.is_valid() {


### PR DESCRIPTION
This was currently broken due to use of Span::current() which will at this stage have no useful trace or span id. Instead we should use the parent span context which is durably stored with the invocation.