### PR TITLE
Externa metadata store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,6 +5938,7 @@ name = "restate-metadata-store"
 version = "1.1.0"
 dependencies = [
  "anyhow",
+ "assert2",
  "async-trait",
  "bytes",
  "bytestring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,6 +2694,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bde3ce50a626efeb1caa9ab1083972d178bebb55ca627639c8ded507dfcbde"
+dependencies = [
+ "http 1.1.0",
+ "prost 0.13.1",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.1",
+ "tonic-build",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,6 +5666,7 @@ dependencies = [
  "derive_more",
  "enum-map",
  "enumset",
+ "etcd-client",
  "futures",
  "googletest",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ dialoguer = { version = "0.11.0" }
 downcast-rs = { version = "1.2.1" }
 enum-map = { version = "2.7.3" }
 enumset = { version = "1.1.3" }
+etcd-client = { version = "0.14" }
 flexbuffers = { version = "2.0.0" }
 futures = "0.3.25"
 futures-sink = "0.3.25"
@@ -194,7 +195,6 @@ tracing-test = { version = "0.2.5" }
 ulid = { version = "1.1.0" }
 url = { version = "2.5" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
-etcd-client = { version = "0.14" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ datafusion-expr = { version = "40.0.0" }
 derive_builder = "0.20.0"
 derive_more = { version = "1", features = ["full"] }
 dialoguer = { version = "0.11.0" }
-downcast-rs = { version ="1.2.1" }
+downcast-rs = { version = "1.2.1" }
 enum-map = { version = "2.7.3" }
 enumset = { version = "1.1.3" }
 flexbuffers = { version = "2.0.0" }
@@ -194,6 +194,7 @@ tracing-test = { version = "0.2.5" }
 ulid = { version = "1.1.0" }
 url = { version = "2.5" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
+etcd-client = { version = "0.14" }
 
 [profile.release]
 opt-level = 3

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,9 +46,15 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tokio-util = { workspace = true, features = ["net"] }
-tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip"] }
+tonic = { workspace = true, features = [
+    "transport",
+    "codegen",
+    "prost",
+    "gzip",
+] }
 tower = { workspace = true }
 tracing = { workspace = true }
+etcd-client = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true }
 enumset = { workspace = true }
+etcd-client = { workspace = true }
 futures = { workspace = true }
 hostname = { workspace = true }
 http = { workspace = true }
@@ -54,7 +55,6 @@ tonic = { workspace = true, features = [
 ] }
 tower = { workspace = true }
 tracing = { workspace = true }
-etcd-client = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/core/src/metadata_store/mod.rs
+++ b/crates/core/src/metadata_store/mod.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub mod providers;
 mod test_util;
 
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -27,33 +27,33 @@ impl From<EtcdError> for WriteError {
 }
 
 trait ToVersion {
-    //todo: version of the kv is reset to 1 if the key was deleted then recrated.
-    // this means that a key can change (by means of deletion and recreation) and will
-    // always have version 1!
-    //
-    // The only way to detect this is to also track the "mod revision" of the store as part
-    // of the VersionValue.
-    //
-    // The problem is that the restate Version is only u32 while both etcd version and mod version
-    // are both i64.
-    //
-    // Changing the Version to have a u64 value also delays the problem for later since it will be a while before
-    // mod_revision or version hit the u32::MAX but that's totally dependent on how frequent the changes are
-    //
-    // The correct solution is of course to make Version u128.
-    //
-    // What is implemented instead in current code is to use the lower 32bit of the Etcd version. We return an error
-    // if this value exceeds the u32::MAX.
-    // Objects will be deleted normally (it means version will reset) so it's up to the user of the store to make sure
-    // to use a tombstone instead of relying on actual delete (if needed).
-    //
-    // This is done instead of implementing the tombstone mechanism directly into the the Etcd store implementation because
-    // delete is not used right now, and also because the Etcd implementation is a temporary solution.
     fn to_version(self) -> Result<Version, ReadError>;
 }
 
 impl ToVersion for &KeyValue {
     fn to_version(self) -> Result<Version, ReadError> {
+        //todo: version of the kv is reset to 1 if the key was deleted then recrated.
+        // this means that a key can change (by means of deletion and recreation) and will
+        // always have version 1!
+        //
+        // The only way to detect this is to also track the "mod revision" of the store as part
+        // of the VersionValue.
+        //
+        // The problem is that the restate Version is only u32 while both etcd version and mod version
+        // are both i64.
+        //
+        // Changing the Version to have a u64 value also delays the problem for later since it will be a while before
+        // mod_revision or version hit the u32::MAX but that's totally dependent on how frequent the changes are
+        //
+        // The correct solution is of course to make Version u128.
+        //
+        // What is implemented instead in current code is to use the lower 32bit of the Etcd version. We return an error
+        // if this value exceeds the u32::MAX.
+        // Objects will be deleted normally (it means version will reset) so it's up to the user of the store to make sure
+        // to use a tombstone instead of relying on actual delete (if needed).
+        //
+        // This is done instead of implementing the tombstone mechanism directly into the the Etcd store implementation because
+        // delete is not used right now, and also because the Etcd implementation is a temporary solution.
         let version = Version::from(u32::try_from(self.version()).map_err(|e| {
             ReadError::Internal(format!("[etcd] key version exceeds max u32: {}", e))
         })?);

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -1,0 +1,90 @@
+use crate::metadata_store::{
+    MetadataStore, Precondition, ReadError, Version, VersionedValue, WriteError,
+};
+use anyhow::Context;
+use bytestring::ByteString;
+use etcd_client::{Client, GetOptions};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+impl From<etcd_client::Error> for ReadError {
+    fn from(value: etcd_client::Error) -> Self {
+        Self::Network(value.into())
+    }
+}
+
+pub struct EtcdMetadataStore {
+    client: Arc<Mutex<Client>>,
+}
+
+impl EtcdMetadataStore {
+    pub async fn new<S: AsRef<[A]>, A: AsRef<str>>(addresses: S) -> anyhow::Result<Self> {
+        //todo: maybe expose some of the connection options to the node config
+        let client = Client::connect(addresses, None)
+            .await
+            .context("failed to connect to etcd cluster")?;
+
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl MetadataStore for EtcdMetadataStore {
+    /// Gets the value and its current version for the given key. If key-value pair is not present,
+    /// then return [`None`].
+    async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+        let mut client = self.client.lock().await;
+        let mut response = client.get(key.into_bytes(), None).await?;
+
+        for kv in response.take_kvs() {
+            // return first value because this suppose to be an exact match
+            // not a scan
+            let version = kv.version();
+            let (_, value) = kv.into_key_value();
+            return Ok(Some(VersionedValue::new(
+                // todo: do we expand the version type to i64/u64?
+                Version::from(version as u32),
+                value.into(),
+            )));
+        }
+
+        Ok(None)
+    }
+
+    /// Gets the current version for the given key. If key-value pair is not present, then return
+    /// [`None`].
+    async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+        let mut client = self.client.lock().await;
+        let response = client
+            .get(
+                key.into_bytes(),
+                Some(GetOptions::default().with_keys_only().with_limit(1)),
+            )
+            .await?;
+
+        for kv in response.kvs() {
+            return Ok(Some(Version::from(kv.version() as u32)));
+        }
+
+        return Ok(None);
+    }
+
+    /// Puts the versioned value under the given key following the provided precondition. If the
+    /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
+    async fn put(
+        &self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        unimplemented!()
+    }
+
+    /// Deletes the key-value pair for the given key following the provided precondition. If the
+    /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
+    async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
+        unimplemented!()
+    }
+}

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -16,7 +16,7 @@ impl From<etcd_client::Error> for ReadError {
 // always have version 1!
 // The only way to detect this is to also track the "mod revision" of the store as part
 // of the VersionValue.
-// The problem is that the restate Version is only u32 while both etcd version + mod version
+// The problem is that the restate Version is only u32 while both etcd version and mod version
 // are both i64.
 //
 // What this implementation tries to do is to fit both mod_revision and version in a u32.

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -2,10 +2,17 @@ use crate::metadata_store::{
     MetadataStore, Precondition, ReadError, Version, VersionedValue, WriteError,
 };
 use anyhow::Context;
+use bytes::Bytes;
 use bytestring::ByteString;
-use etcd_client::{Client, GetOptions, KeyValue};
+use etcd_client::{Client, Compare, CompareOp, KeyValue, KvClient, Txn, TxnOp, TxnOpResponse};
 
 impl From<etcd_client::Error> for ReadError {
+    fn from(value: etcd_client::Error) -> Self {
+        Self::Network(value.into())
+    }
+}
+
+impl From<etcd_client::Error> for WriteError {
     fn from(value: etcd_client::Error) -> Self {
         Self::Network(value.into())
     }
@@ -16,23 +23,29 @@ impl From<etcd_client::Error> for ReadError {
 // always have version 1!
 // The only way to detect this is to also track the "mod revision" of the store as part
 // of the VersionValue.
+//
 // The problem is that the restate Version is only u32 while both etcd version and mod version
 // are both i64.
-//
-// What this implementation tries to do is to fit both mod_revision and version in a u32.
-// This will work until any of the 2 values is actually bigger than u16::MAX which is not that much
 //
 // Changing the Version to have a u64 value also delays the problem for later since it will be a while before
 // mod_revision or version hit the u32::MAX but that's totally dependent on how frequent the changes are
 //
 // The correct solution is of course to make Version u128.
+// What we do here is ONLY relying on the "version" of the key combined with the fact that we never actually delete the key
+// but instead put a "tombstone" in place so version doesn't reset
 trait ToVersion {
-    fn to_version(&self) -> Version;
+    fn to_version(self) -> Result<Version, ReadError>;
 }
 
 impl ToVersion for &KeyValue {
-    fn to_version(&self) -> Version {
-        Version::from((self.mod_revision() as u32) << 16 | self.version() as u32)
+    fn to_version(self) -> Result<Version, ReadError> {
+        if self.version() > u32::MAX as i64 {
+            return Err(ReadError::Codec(
+                "[etcd] key version exceeds max u32".into(),
+            ));
+        }
+
+        Ok(Version::from(self.version() as u32))
     }
 }
 
@@ -49,6 +62,84 @@ impl EtcdMetadataStore {
 
         Ok(Self { client })
     }
+
+    // put updates the key if and only if the key does not exist
+    // and because we never actually delete the key there is a possibility
+    // that the key exists, but it's value is nilled (that still considered "does not exist").
+    // this is why we run this complex transaction where we
+    // - check if the key exists but empty (value is empty bytes)
+    // - otherwise, we run an (or_else) branch where itself is a transaction
+    //   where we check if the key actually does not exist at all!
+    // - Then do a PUT
+    pub async fn put_not_exist(
+        &self,
+        client: &mut KvClient,
+        key: Bytes,
+        value: Bytes,
+    ) -> Result<bool, WriteError> {
+        // an or_else branch is executed if the and_then branch of the
+        // root transaction was not executed (failed condition)
+        // this means that checked if the value exists but empty always
+        // done first. Otherwise we check if the value does not exist at all
+        let or_else = Txn::new()
+            .when(vec![Compare::version(key.clone(), CompareOp::Equal, 0)])
+            .and_then(vec![TxnOp::put(key.clone(), value.clone(), None)]);
+
+        let txn = Txn::new()
+            .when(vec![Compare::value(
+                key.clone(),
+                CompareOp::Equal,
+                Vec::default(),
+            )])
+            .and_then(vec![TxnOp::put(key, value, None)])
+            .or_else(vec![TxnOp::txn(or_else)]);
+        let response = client.txn(txn).await?;
+
+        // to check if the put operation has actually been "executed"
+        // we need to check the success of the individual branches.
+        // and we can't really rely on the response.success() output
+        // the reason is if the or_else branch was executed this is
+        // still considered a failure, while in our case that can still
+        // be a success, unless the or_else branch itself failed as well
+        if let Some(resp) = response.op_responses().into_iter().next() {
+            match resp {
+                TxnOpResponse::Txn(txn) => {
+                    // this means we had to enter the else branch
+                    // and had to run the or_else transaction
+                    return Ok(txn.succeeded());
+                }
+                TxnOpResponse::Put(_) => {
+                    return Ok(response.succeeded());
+                }
+                _ => {
+                    unreachable!()
+                }
+            }
+        }
+        Ok(response.succeeded())
+    }
+
+    // only update the key if has the exact given version
+    // otherwise returns false
+    pub async fn put_with_version(
+        &self,
+        client: &mut KvClient,
+        key: Bytes,
+        value: Bytes,
+        version: i64,
+    ) -> Result<bool, WriteError> {
+        let txn = Txn::new()
+            .when(vec![Compare::version(
+                key.clone(),
+                CompareOp::Equal,
+                version,
+            )])
+            .and_then(vec![TxnOp::put(key, value, None)]);
+
+        let response = client.txn(txn).await?;
+
+        Ok(response.succeeded())
+    }
 }
 
 #[async_trait::async_trait]
@@ -59,52 +150,137 @@ impl MetadataStore for EtcdMetadataStore {
         let mut client = self.client.kv_client();
         let mut response = client.get(key.into_bytes(), None).await?;
 
-        for kv in response.take_kvs() {
-            // return first value because this suppose to be an exact match
-            // not a scan
+        // return first value because this suppose to be an exact match
+        // not a scan
+        let kv = match response.take_kvs().into_iter().next() {
+            None => return Ok(None),
+            Some(kv) => kv,
+        };
 
-            // please read todo! on implementation of .to_version()
-            let version = (&kv).to_version();
-            let (_, value) = kv.into_key_value();
-            return Ok(Some(VersionedValue::new(version, value.into())));
+        // please read todo! on implementation of .to_version()
+        let version = (&kv).to_version()?;
+        let (_, value) = kv.into_key_value();
+
+        if value.is_empty() {
+            // we keep an empty value in place of
+            // deleted keys to work around the version limitation
+            return Ok(None);
         }
 
-        Ok(None)
+        Ok(Some(VersionedValue::new(version, value.into())))
     }
 
     /// Gets the current version for the given key. If key-value pair is not present, then return
     /// [`None`].
     async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
         let mut client = self.client.kv_client();
-        let response = client
-            .get(
-                key.into_bytes(),
-                Some(GetOptions::default().with_keys_only().with_limit(1)),
-            )
-            .await?;
+        let mut response = client.get(key.into_bytes(), None).await?;
 
-        for kv in response.kvs() {
-            return Ok(Some(kv.to_version()));
+        // return first value because this suppose to be an exact match
+        // not a scan
+        let kv = match response.take_kvs().into_iter().next() {
+            None => return Ok(None),
+            Some(kv) => kv,
+        };
+
+        // please read todo! on implementation of .to_version()
+        let version = (&kv).to_version()?;
+        let (_, value) = kv.into_key_value();
+
+        if value.is_empty() {
+            // we keep an empty value in place of deleted
+            // keys to work around the version limitation
+            return Ok(None);
         }
 
-        return Ok(None);
+        Ok(Some(version))
     }
 
     /// Puts the versioned value under the given key following the provided precondition. If the
     /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
+    ///
+    /// NOTE: this implementation disregard that version attached on the value and depends only on the
+    /// auto version provided by etcd
+    ///
+    /// it's up to the caller of this function to make sure that both versions are in sync.
     async fn put(
         &self,
         key: ByteString,
         value: VersionedValue,
         precondition: Precondition,
     ) -> Result<(), WriteError> {
-        // let txt = Txn::new().when(compares)
-        unimplemented!()
+        let mut client = self.client.kv_client();
+        match precondition {
+            Precondition::None => {
+                client.put(key.into_bytes(), value.value, None).await?;
+            }
+            Precondition::DoesNotExist => {
+                if !self
+                    .put_not_exist(&mut client, key.into_bytes(), value.value)
+                    .await?
+                {
+                    // pre condition failed.
+                    return Err(WriteError::FailedPrecondition(
+                        "key-value pair exists".into(),
+                    ));
+                };
+            }
+            Precondition::MatchesVersion(version) => {
+                if !self
+                    .put_with_version(
+                        &mut client,
+                        key.into_bytes(),
+                        value.value,
+                        u32::from(version) as i64,
+                    )
+                    .await?
+                {
+                    return Err(WriteError::FailedPrecondition(
+                        "key version mismatch".into(),
+                    ));
+                };
+            }
+        }
+
+        Ok(())
     }
 
     /// Deletes the key-value pair for the given key following the provided precondition. If the
     /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
     async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
-        unimplemented!()
+        let mut client = self.client.kv_client();
+        match precondition {
+            Precondition::None => {
+                client.delete(key.into_bytes(), None).await?;
+            }
+            Precondition::DoesNotExist => {
+                if !self
+                    .put_not_exist(&mut client, key.into_bytes(), Vec::default().into())
+                    .await?
+                {
+                    // pre condition failed.
+                    return Err(WriteError::FailedPrecondition(
+                        "key-value pair exists".into(),
+                    ));
+                };
+            }
+            Precondition::MatchesVersion(version) => {
+                if !self
+                    .put_with_version(
+                        &mut client,
+                        key.into_bytes(),
+                        Vec::default().into(),
+                        u32::from(version) as i64,
+                    )
+                    .await?
+                {
+                    return Err(WriteError::FailedPrecondition(
+                        "key version mismatch".into(),
+                    ));
+                };
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -4,8 +4,6 @@ use crate::metadata_store::{
 use anyhow::Context;
 use bytestring::ByteString;
 use etcd_client::{Client, GetOptions};
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
 impl From<etcd_client::Error> for ReadError {
     fn from(value: etcd_client::Error) -> Self {

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -127,7 +127,7 @@ impl MetadataStore for EtcdMetadataStore {
         let mut client = self.client.kv_client();
         let mut response = client.get(key.into_bytes(), None).await?;
 
-        // return first value because this suppose to be an exact match
+        // return first value because this is supposed to be an exact match
         // not a scan
         let kv = match response.take_kvs().into_iter().next() {
             None => return Ok(None),

--- a/crates/core/src/metadata_store/providers/mod.rs
+++ b/crates/core/src/metadata_store/providers/mod.rs
@@ -1,0 +1,3 @@
+mod etcd;
+
+pub use etcd::EtcdMetadataStore;

--- a/crates/metadata-store/Cargo.toml
+++ b/crates/metadata-store/Cargo.toml
@@ -41,7 +41,7 @@ tonic = { workspace = true, features = ["transport", "codegen", "prost"] }
 tonic-reflection = { workspace = true }
 tonic-health = { workspace = true }
 tower = { workspace = true }
-tower-http = { workspace =  true, features = ["trace"] }
+tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -49,6 +49,7 @@ restate-core = { workspace = true, features = ["test-util"] }
 restate-rocksdb = { workspace = true, features = ["test-util"] }
 
 anyhow = { workspace = true }
+assert2 = { workspace = true }
 flexbuffers = { workspace = true }
 googletest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -14,7 +14,7 @@ mod store;
 mod service;
 
 use restate_core::metadata_store::MetadataStoreClient;
-use restate_types::config::MetadataStoreClientOptions;
+use restate_types::config::{self, MetadataStoreClientOptions};
 pub use service::LocalMetadataStoreService;
 
 use crate::local::grpc::client::LocalMetadataStoreClient;
@@ -23,8 +23,13 @@ use crate::local::grpc::client::LocalMetadataStoreClient;
 pub fn create_client(
     metadata_store_client_options: MetadataStoreClientOptions,
 ) -> MetadataStoreClient {
+    let metadata_store = match metadata_store_client_options.metadata_store {
+        config::MetadataStore::Grpc { address } => LocalMetadataStoreClient::new(address),
+        _ => unimplemented!(),
+    };
+
     MetadataStoreClient::new(
-        LocalMetadataStoreClient::new(metadata_store_client_options.metadata_store_address),
+        metadata_store,
         Some(metadata_store_client_options.metadata_store_client_backoff_policy),
     )
 }

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -23,8 +23,8 @@ use crate::local::grpc::client::LocalMetadataStoreClient;
 pub fn create_client(
     metadata_store_client_options: MetadataStoreClientOptions,
 ) -> MetadataStoreClient {
-    let metadata_store = match metadata_store_client_options.metadata_store {
-        config::MetadataStore::Grpc { address } => LocalMetadataStoreClient::new(address),
+    let metadata_store = match metadata_store_client_options.metadata_store_client {
+        config::MetadataStore::Embedded { address } => LocalMetadataStoreClient::new(address),
         _ => unimplemented!(),
     };
 

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -15,7 +15,7 @@ mod service;
 
 use restate_core::metadata_store::{providers::EtcdMetadataStore, MetadataStoreClient};
 use restate_types::{
-    config::{MetadataStore, MetadataStoreClientOptions},
+    config::{MetadataStoreClient as MetadataStoreClientConfig, MetadataStoreClientOptions},
     errors::GenericError,
 };
 pub use service::LocalMetadataStoreService;
@@ -29,11 +29,11 @@ pub async fn create_client(
     let backoff_policy = Some(metadata_store_client_options.metadata_store_client_backoff_policy);
 
     let client = match metadata_store_client_options.metadata_store_client {
-        MetadataStore::Embedded { address } => {
+        MetadataStoreClientConfig::Embedded { address } => {
             let store = LocalMetadataStoreClient::new(address);
             MetadataStoreClient::new(store, backoff_policy)
         }
-        MetadataStore::Etcd { addresses } => {
+        MetadataStoreClientConfig::Etcd { addresses } => {
             let store = EtcdMetadataStore::new(addresses).await?;
             MetadataStoreClient::new(store, backoff_policy)
         }

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -268,7 +268,7 @@ async fn durable_storage() -> anyhow::Result<()> {
     let uds_path = tempfile::tempdir()?.into_path().join("grpc-server");
     let bind_address = BindAddress::Uds(uds_path.clone());
     let metadata_store_client_opts = MetadataStoreClientOptionsBuilder::default()
-        .metadata_store(restate_types::config::MetadataStore::Grpc {
+        .metadata_store_client(restate_types::config::MetadataStore::Embedded {
             address: AdvertisedAddress::Uds(uds_path),
         })
         .build()
@@ -321,7 +321,7 @@ async fn create_test_environment(
     let advertised_address = AdvertisedAddress::Uds(uds_path);
     config.metadata_store = opts.clone();
     config.metadata_store.bind_address = bind_address;
-    config.common.metadata_store_client.metadata_store = config::MetadataStore::Grpc {
+    config.common.metadata_store_client.metadata_store_client = config::MetadataStore::Embedded {
         address: advertised_address.clone(),
     };
 
@@ -366,8 +366,8 @@ async fn start_metadata_store(
     )?;
 
     // await start-up of metadata store
-    let metadata_store_address = if let config::MetadataStore::Grpc { address } =
-        metadata_store_client_options.metadata_store
+    let metadata_store_address = if let config::MetadataStore::Embedded { address } =
+        metadata_store_client_options.metadata_store_client
     {
         address.clone()
     } else {

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -434,7 +434,7 @@ pub enum LogFormat {
 #[serde(rename_all = "kebab-case")]
 pub struct MetadataStoreClientOptions {
     /// Metadata store server to bootstrap the node from.
-    pub metadata_store_client: MetadataStore,
+    pub metadata_store_client: MetadataStoreClient,
 
     /// # Backoff policy used by the metadata store client
     ///
@@ -457,7 +457,7 @@ pub struct MetadataStoreClientOptions {
         description = "Definition of a bootstrap metadata store"
     )
 )]
-pub enum MetadataStore {
+pub enum MetadataStoreClient {
     /// Connects to an embedded metadata store that is run by nodes that run with the MetadataStore role.
     Embedded {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
@@ -474,7 +474,7 @@ pub enum MetadataStore {
 impl Default for MetadataStoreClientOptions {
     fn default() -> Self {
         Self {
-            metadata_store_client: MetadataStore::Embedded {
+            metadata_store_client: MetadataStoreClient::Embedded {
                 address: "http://127.0.0.1:5123"
                     .parse()
                     .expect("valid metadata store address"),

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -458,10 +458,14 @@ pub struct MetadataStoreClientOptions {
     )
 )]
 pub enum MetadataStore {
+    /// Connects to another node that is running Metadata Store
+    /// over gRPC.
+    /// The remote node must run with MetadataStore Role
     Grpc {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         address: AdvertisedAddress,
     },
+    /// Uses external etcd as metadata store.
     EtcD {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         addresses: Vec<AdvertisedAddress>,

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -437,7 +437,7 @@ pub enum LogFormat {
 #[serde(rename_all = "kebab-case")]
 pub struct MetadataStoreClientOptions {
     /// Metadata store server to bootstrap the node from.
-    pub metadata_store: MetadataStore,
+    pub metadata_store_client: MetadataStore,
 
     /// # Backoff policy used by the metadata store client
     ///
@@ -450,7 +450,7 @@ pub struct MetadataStoreClientOptions {
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
-    rename_all_fields = "kebab-case"
+    rename_all_fields = "kebab-case",
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(
@@ -464,12 +464,12 @@ pub enum MetadataStore {
     /// Connects to another node that is running Metadata Store
     /// over gRPC.
     /// The remote node must run with MetadataStore Role
-    Grpc {
+    Embedded {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         address: AdvertisedAddress,
     },
     /// Uses external etcd as metadata store.
-    EtcD {
+    Etcd {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         addresses: Vec<net::SocketAddr>,
     },
@@ -478,7 +478,7 @@ pub enum MetadataStore {
 impl Default for MetadataStoreClientOptions {
     fn default() -> Self {
         Self {
-            metadata_store: MetadataStore::Grpc {
+            metadata_store_client: MetadataStore::Embedded {
                 address: "http://127.0.0.1:5123"
                     .parse()
                     .expect("valid metadata store address"),

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -436,7 +436,7 @@ pub enum LogFormat {
 #[builder(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct MetadataStoreClientOptions {
-    /// Address of the metadata store server to bootstrap the node from.
+    /// Metadata store server to bootstrap the node from.
     pub metadata_store: MetadataStore,
 
     /// # Backoff policy used by the metadata store client

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use core::net;
 use enumset::EnumSet;
 use once_cell::sync::Lazy;
 use restate_serde_util::NonZeroByteCount;
@@ -23,6 +24,8 @@ use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::retries::RetryPolicy;
 use crate::PlainNodeId;
+
+use std::net::SocketAddr;
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 
@@ -468,7 +471,7 @@ pub enum MetadataStore {
     /// Uses external etcd as metadata store.
     EtcD {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-        addresses: Vec<AdvertisedAddress>,
+        addresses: Vec<net::SocketAddr>,
     },
 }
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -458,9 +458,7 @@ pub struct MetadataStoreClientOptions {
     )
 )]
 pub enum MetadataStore {
-    /// Connects to another node that is running Metadata Store
-    /// over gRPC.
-    /// The remote node must run with MetadataStore Role
+    /// Connects to an embedded metadata store that is run by nodes that run with the MetadataStore role.
     Embedded {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         address: AdvertisedAddress,

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use core::net;
 use enumset::EnumSet;
 use once_cell::sync::Lazy;
 use restate_serde_util::NonZeroByteCount;
@@ -24,8 +23,6 @@ use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::retries::RetryPolicy;
 use crate::PlainNodeId;
-
-use std::net::SocketAddr;
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -450,7 +450,7 @@ pub struct MetadataStoreClientOptions {
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
-    rename_all_fields = "kebab-case",
+    rename_all_fields = "kebab-case"
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(
@@ -469,9 +469,10 @@ pub enum MetadataStore {
         address: AdvertisedAddress,
     },
     /// Uses external etcd as metadata store.
+    /// The addresses are formatted as `host:port`
     Etcd {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-        addresses: Vec<net::SocketAddr>,
+        addresses: Vec<String>,
     },
 }
 


### PR DESCRIPTION
This PR adds support to external metadata store. Right now we only implement the etcd store. 

- [x] Support configuration for other metadata store types
- [x] Implement the etcd store
- [x] Testing
  - [ ] ~~Unit tests~~

Note: 
The Testing above is manual testing that involves an etcd cluster. The etcd nodes are randomly stopped or killed and looks like restate operations resumes normally with no issue. Unless the number of down etcd node is bigger than the quorum then of course it fails to write changes. This is restored once enough nodes are back

Fixes #1829