### PR TITLE
Allow state to be deleted from non-existent services

### DIFF
--- a/cli/src/commands/state/edit.rs
+++ b/cli/src/commands/state/edit.rs
@@ -45,7 +45,7 @@ pub async fn run_edit(State(env): State<CliEnv>, opts: &Edit) -> Result<()> {
 }
 
 async fn edit(env: &CliEnv, opts: &Edit) -> Result<()> {
-    let current_state = get_current_state(env, &opts.service, &opts.key).await?;
+    let current_state = get_current_state(env, &opts.service, &opts.key, false).await?;
     let current_version = compute_version(&current_state);
 
     let tempdir = tempdir().context("unable to create a temporary directory")?;

--- a/cli/src/commands/state/get.rs
+++ b/cli/src/commands/state/get.rs
@@ -45,7 +45,7 @@ pub async fn run_get(State(env): State<CliEnv>, opts: &Get) -> Result<()> {
 }
 
 async fn get(env: &CliEnv, opts: &Get) -> Result<()> {
-    let current_state = get_current_state(env, &opts.service, &opts.key).await?;
+    let current_state = get_current_state(env, &opts.service, &opts.key, true).await?;
     let current_state_json = as_json(current_state, opts.binary)?;
 
     if opts.plain {


### PR DESCRIPTION
This will allow the `state clear` CLI command to work even for services that don't yet exist. We change the state modification API to allow services that don't exist when the request is to remove state (and not insert anything else). This means that it would be a no-op for truly non-existent services, and a useful op for ex-services.