### PR TITLE
Use net_util::run_hyper_server to run admin http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,6 +5416,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper-util",
  "okapi-operation",
  "prost 0.13.1",
  "prost-dto",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,6 +39,7 @@ futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
+hyper-util = { workspace = true }
 okapi-operation = { version = "0.3.0-rc2", features = ["axum-integration"] }
 prost = { workspace = true }
 prost-dto = { workspace = true }

--- a/crates/admin/src/rest_api/handlers.rs
+++ b/crates/admin/src/rest_api/handlers.rs
@@ -33,11 +33,7 @@ pub async fn list_service_handlers<V>(
     State(state): State<AdminServiceState<V>>,
     Path(service_name): Path<String>,
 ) -> Result<Json<ListServiceHandlersResponse>, MetaApiError> {
-    match state
-        .task_center
-        .run_in_scope_sync("list-service-handlers", None, || {
-            state.schema_registry.list_service_handlers(&service_name)
-        }) {
+    match state.schema_registry.list_service_handlers(&service_name) {
         Some(handlers) => Ok(ListServiceHandlersResponse { handlers }.into()),
         None => Err(MetaApiError::ServiceNotFound(service_name)),
     }
@@ -67,12 +63,9 @@ pub async fn get_service_handler<V>(
     Path((service_name, handler_name)): Path<(String, String)>,
 ) -> Result<Json<HandlerMetadata>, MetaApiError> {
     match state
-        .task_center
-        .run_in_scope_sync("get-service-handler", None, || {
-            state
-                .schema_registry
-                .get_service_handler(&service_name, &handler_name)
-        }) {
+        .schema_registry
+        .get_service_handler(&service_name, &handler_name)
+    {
         Some(metadata) => Ok(metadata.into()),
         _ => Err(MetaApiError::HandlerNotFound {
             service_name,

--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -93,17 +93,11 @@ pub async fn delete_invocation<V>(
 
     let partition_key = invocation_id.partition_key();
 
-    let result = state
-        .task_center
-        .run_in_scope(
-            "delete_invocation",
-            None,
-            append_envelope_to_bifrost(
-                &state.bifrost,
-                Envelope::new(create_envelope_header(partition_key), cmd),
-            ),
-        )
-        .await;
+    let result = append_envelope_to_bifrost(
+        &state.bifrost,
+        Envelope::new(create_envelope_header(partition_key), cmd),
+    )
+    .await;
 
     if let Err(err) = result {
         warn!("Could not append invocation termination command to Bifrost: {err}");

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -19,10 +19,8 @@ mod services;
 mod subscriptions;
 mod version;
 
-use codederror::CodedError;
 use okapi_operation::axum_integration::{delete, get, patch, post};
 use okapi_operation::*;
-use restate_errors::warn_it;
 use restate_types::identifiers::PartitionKey;
 use restate_types::schema::subscriptions::SubscriptionValidator;
 use restate_wal_protocol::{Destination, Header, Source};
@@ -107,12 +105,4 @@ fn create_envelope_header(partition_key: PartitionKey) -> Header {
             dedup: None,
         },
     }
-}
-
-#[inline]
-fn log_error<T, E: CodedError>(result: Result<T, E>) -> Result<T, E> {
-    result.map_err(|err| {
-        warn_it!(err);
-        err
-    })
 }

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -8,8 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use super::create_envelope_header;
 use super::error::*;
-use super::{create_envelope_header, log_error};
 use crate::schema_registry::ModifyServiceChange;
 use crate::state::AdminServiceState;
 
@@ -20,6 +20,7 @@ use http::StatusCode;
 use okapi_operation::*;
 use restate_admin_rest_model::services::ListServicesResponse;
 use restate_admin_rest_model::services::*;
+use restate_errors::fmt::CodedErrorResultExt;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
 use restate_types::schema::service::ServiceMetadata;
 use restate_types::state_mut::ExternalStateMutation;
@@ -105,12 +106,11 @@ pub async fn modify_service<V>(
         return get_service(State(state), Path(service_name)).await;
     }
 
-    let response = log_error(
-        state
-            .schema_registry
-            .modify_service(service_name, modify_request)
-            .await,
-    )?;
+    let response = state
+        .schema_registry
+        .modify_service(service_name, modify_request)
+        .await
+        .warn_it()?;
 
     Ok(response.into())
 }

--- a/crates/admin/src/rest_api/subscriptions.rs
+++ b/crates/admin/src/rest_api/subscriptions.rs
@@ -76,10 +76,8 @@ pub async fn get_subscription<V>(
     Path(subscription_id): Path<SubscriptionId>,
 ) -> Result<Json<SubscriptionResponse>, MetaApiError> {
     let subscription = state
-        .task_center
-        .run_in_scope_sync("get-subscription", None, || {
-            state.schema_registry.get_subscription(subscription_id)
-        })
+        .schema_registry
+        .get_subscription(subscription_id)
         .ok_or_else(|| MetaApiError::SubscriptionNotFound(subscription_id))?;
 
     Ok(SubscriptionResponse::from(subscription).into())
@@ -126,11 +124,7 @@ pub async fn list_subscriptions<V>(
         _ => vec![],
     };
 
-    let subscriptions = state
-        .task_center
-        .run_in_scope_sync("list-subscriptions", None, || {
-            state.schema_registry.list_subscriptions(&filters)
-        });
+    let subscriptions = state.schema_registry.list_subscriptions(&filters);
 
     ListSubscriptionsResponse {
         subscriptions: subscriptions

--- a/crates/admin/src/rest_api/subscriptions.rs
+++ b/crates/admin/src/rest_api/subscriptions.rs
@@ -14,12 +14,12 @@ use crate::state::AdminServiceState;
 use restate_admin_rest_model::subscriptions::*;
 use restate_types::schema::subscriptions::{ListSubscriptionFilter, SubscriptionValidator};
 
-use crate::rest_api::log_error;
 use axum::extract::Query;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::{http, Json};
 use okapi_operation::*;
+use restate_errors::fmt::CodedErrorResultExt;
 use restate_types::identifiers::SubscriptionId;
 
 /// Create subscription.
@@ -42,12 +42,11 @@ pub async fn create_subscription<V: SubscriptionValidator>(
     State(state): State<AdminServiceState<V>>,
     #[request_body(required = true)] Json(payload): Json<CreateSubscriptionRequest>,
 ) -> Result<impl axum::response::IntoResponse, MetaApiError> {
-    let subscription = log_error(
-        state
-            .schema_registry
-            .create_subscription(payload.source, payload.sink, payload.options)
-            .await,
-    )?;
+    let subscription = state
+        .schema_registry
+        .create_subscription(payload.source, payload.sink, payload.options)
+        .await
+        .warn_it()?;
 
     Ok((
         StatusCode::CREATED,
@@ -160,11 +159,10 @@ pub async fn delete_subscription<V>(
     State(state): State<AdminServiceState<V>>,
     Path(subscription_id): Path<SubscriptionId>,
 ) -> Result<StatusCode, MetaApiError> {
-    log_error(
-        state
-            .schema_registry
-            .delete_subscription(subscription_id)
-            .await,
-    )?;
+    state
+        .schema_registry
+        .delete_subscription(subscription_id)
+        .await
+        .warn_it()?;
     Ok(StatusCode::ACCEPTED)
 }

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -17,16 +17,16 @@ use restate_types::config::AdminOptions;
 use restate_types::live::LiveLoad;
 use tonic::transport::Channel;
 use tower::ServiceBuilder;
-use tracing::info;
 
 use restate_core::metadata_store::MetadataStoreClient;
+use restate_core::network::net_util;
 use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::{cancellation_token, task_center, MetadataWriter};
+use restate_core::{task_center, MetadataWriter};
 use restate_service_protocol::discovery::ServiceDiscovery;
+use restate_types::net::BindAddress;
 use restate_types::schema::subscriptions::SubscriptionValidator;
 
 use crate::schema_registry::SchemaRegistry;
-use crate::Error;
 use crate::{rest_api, state, storage_query};
 
 #[derive(Debug, thiserror::Error)]
@@ -85,28 +85,14 @@ where
                     )),
             );
 
-        // run our app with hyper
-        let listener = tokio::net::TcpListener::bind(&opts.bind_address)
-            .await
-            .map_err(|err| Error::Binding {
-                address: opts.bind_address,
-                source: Box::new(err),
-            })?;
+        let service = hyper_util::service::TowerToHyperService::new(router.into_service());
 
-        let local_addr = listener.local_addr().map_err(|err| Error::Binding {
-            address: opts.bind_address,
-            source: Box::new(err),
-        })?;
-        info!(
-            net.host.addr = %local_addr.ip(),
-            net.host.port = %local_addr.port(),
-            "Admin API listening"
-        );
-
-        let cancellation_token = cancellation_token();
-        Ok(axum::serve(listener, router)
-            .with_graceful_shutdown(async move { cancellation_token.cancelled().await })
-            .await
-            .map_err(|e| Error::Running(Box::new(e)))?)
+        net_util::run_hyper_server(
+            &BindAddress::Socket(opts.bind_address),
+            service,
+            "admin-api-server",
+        )
+        .await
+        .map_err(Into::into)
     }
 }

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -21,7 +21,7 @@ use tower::ServiceBuilder;
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::network::net_util;
 use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::{task_center, MetadataWriter};
+use restate_core::MetadataWriter;
 use restate_service_protocol::discovery::ServiceDiscovery;
 use restate_types::net::BindAddress;
 use restate_types::schema::subscriptions::SubscriptionValidator;
@@ -65,8 +65,7 @@ where
     ) -> anyhow::Result<()> {
         let opts = updateable_config.live_load();
 
-        let rest_state =
-            state::AdminServiceState::new(self.schema_registry, bifrost, task_center());
+        let rest_state = state::AdminServiceState::new(self.schema_registry, bifrost);
 
         let query_state = Arc::new(state::QueryServiceState { node_svc_client });
         let router = axum::Router::new().merge(storage_query::create_router(query_state));

--- a/crates/admin/src/state.rs
+++ b/crates/admin/src/state.rs
@@ -12,14 +12,12 @@
 use crate::schema_registry::SchemaRegistry;
 use restate_bifrost::Bifrost;
 use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::TaskCenter;
 use tonic::transport::Channel;
 
 #[derive(Clone, derive_builder::Builder)]
 pub struct AdminServiceState<V> {
     pub schema_registry: SchemaRegistry<V>,
     pub bifrost: Bifrost,
-    pub task_center: TaskCenter,
 }
 
 #[derive(Clone)]
@@ -28,15 +26,10 @@ pub struct QueryServiceState {
 }
 
 impl<V> AdminServiceState<V> {
-    pub fn new(
-        schema_registry: SchemaRegistry<V>,
-        bifrost: Bifrost,
-        task_center: TaskCenter,
-    ) -> Self {
+    pub fn new(schema_registry: SchemaRegistry<V>, bifrost: Bifrost) -> Self {
         Self {
             schema_registry,
             bifrost,
-            task_center,
         }
     }
 }

--- a/crates/errors/src/fmt.rs
+++ b/crates/errors/src/fmt.rs
@@ -116,6 +116,44 @@ impl fmt::Debug for RestateCode {
     }
 }
 
+/// Extension trait which extends [`Result<T, impl CodedError>`] with some formatting functions.
+pub trait CodedErrorResultExt {
+    /// Log on info level if error and return self.
+    fn info_it(self) -> Self;
+
+    /// Log on warn level if error and return self.
+    fn warn_it(self) -> Self;
+
+    /// Log on error level if error and return self.
+    fn error_it(self) -> Self;
+}
+
+impl<T, E: CodedError> CodedErrorResultExt for Result<T, E> {
+    #[inline]
+    fn info_it(self) -> Self {
+        if let Err(err) = &self {
+            info_it!(*err);
+        }
+        self
+    }
+
+    #[inline]
+    fn warn_it(self) -> Self {
+        if let Err(err) = &self {
+            warn_it!(*err);
+        }
+        self
+    }
+
+    #[inline]
+    fn error_it(self) -> Self {
+        if let Err(err) = &self {
+            error_it!(*err);
+        }
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
#### Use net_util::run_hyper_server to run admin http server.

#### Remove TaskCenter from AdminServiceState

Since we are spawning the connection handling of the Admin HTTP server
in the TaskCenter, we no longer need to spawn TaskCenter tasks from
within the REST handlers.