### PR TITLE
[TaskCenter] Cleanup of task-center and introduces unmanaged tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,6 +5668,7 @@ dependencies = [
  "hyper-util",
  "metrics",
  "once_cell",
+ "parking_lot",
  "pin-project",
  "prost 0.13.1",
  "prost-types 0.13.1",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 metrics = { workspace = true }
 once_cell = { workspace = true }
+parking_lot = { workspace = true }
 pin-project = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#[derive(Debug, thiserror::Error)]
+#[error("system is shutting down")]
+pub(crate) struct ShutdownSourceErr;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ShutdownError;
+impl std::fmt::Display for ShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("system is shutting down")
+    }
+}
+
+impl std::error::Error for ShutdownError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&ShutdownSourceErr)
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod error;
 mod metadata;
 pub mod metadata_store;
 mod metric_definitions;
@@ -15,6 +16,7 @@ pub mod network;
 mod task_center;
 mod task_center_types;
 pub mod worker_api;
+pub use error::*;
 
 pub use metadata::{
     spawn_metadata_manager, Metadata, MetadataBuilder, MetadataKind, MetadataManager,

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -9,47 +9,44 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
-use std::fmt::Display;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use futures::{Future, FutureExt};
-use metrics::counter;
-use restate_types::config::CommonOptions;
-use restate_types::GenerationalNodeId;
+use metrics::{counter, gauge};
+use parking_lot::Mutex;
 use tokio::runtime::RuntimeMetrics;
-use tokio::task::JoinHandle;
 use tokio::task_local;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 use tracing::{debug, error, info, instrument, trace, warn};
 
+use restate_types::config::CommonOptions;
 use restate_types::identifiers::PartitionId;
+use restate_types::GenerationalNodeId;
 
 use crate::metric_definitions::{TC_FINISHED, TC_SPAWN, TC_STATUS_COMPLETED, TC_STATUS_FAILED};
-use crate::{metric_definitions, Metadata, TaskId, TaskKind};
+use crate::{
+    metric_definitions, Metadata, ShutdownError, ShutdownSourceErr, TaskHandle, TaskId, TaskKind,
+};
 
-static WORKER_ID: AtomicUsize = AtomicUsize::new(0);
-static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(0);
+static WORKER_ID: AtomicUsize = const { AtomicUsize::new(0) };
+static NEXT_TASK_ID: AtomicU64 = const { AtomicU64::new(0) };
 const EXIT_CODE_FAILURE: i32 = 1;
 
-#[derive(Debug, thiserror::Error)]
-#[error("system is shutting down")]
-struct ShutdownSourceErr;
-
-#[derive(Debug, Clone, Copy)]
-pub struct ShutdownError;
-impl Display for ShutdownError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("system is shutting down")
-    }
-}
-
-impl std::error::Error for ShutdownError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&ShutdownSourceErr)
-    }
+#[derive(Clone)]
+pub struct TaskContext {
+    /// It's nice to have a unique ID for each task.
+    id: TaskId,
+    name: &'static str,
+    kind: TaskKind,
+    /// cancel this token to request cancelling this task.
+    cancellation_token: CancellationToken,
+    /// Tasks associated with a specific partition ID will have this set. This allows
+    /// for cancellation of tasks associated with that partition.
+    partition_id: Option<PartitionId>,
+    metadata: Option<Metadata>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -144,7 +141,7 @@ impl TaskCenterBuilder {
                 global_cancel_token: CancellationToken::new(),
                 shutdown_requested: AtomicBool::new(false),
                 current_exit_code: AtomicI32::new(0),
-                tasks: Mutex::new(HashMap::new()),
+                managed_tasks: Mutex::new(HashMap::new()),
                 global_metadata: OnceLock::new(),
                 pp_runtimes: Mutex::new(HashMap::with_capacity(64)),
             }),
@@ -198,8 +195,20 @@ impl TaskCenter {
     }
 
     pub fn partition_processors_runtime_metrics(&self) -> Vec<(&'static str, RuntimeMetrics)> {
-        let guard = self.inner.pp_runtimes.lock().unwrap();
+        let guard = self.inner.pp_runtimes.lock();
         guard.iter().map(|(k, v)| (*k, v.metrics())).collect()
+    }
+
+    /// Submit telemetry for all runtimes to metrics recorder
+    pub fn submit_metrics(&self) {
+        Self::submit_runtime_metrics("default", self.default_runtime_metrics());
+        Self::submit_runtime_metrics("ingress", self.ingress_runtime_metrics());
+
+        // Partition processor runtimes
+        let processor_runtimes = self.partition_processors_runtime_metrics();
+        for (task_name, metrics) in processor_runtimes {
+            Self::submit_runtime_metrics(task_name, metrics);
+        }
     }
 
     /// Use to monitor an on-going shutdown when requested
@@ -217,14 +226,51 @@ impl TaskCenter {
         self.inner.current_exit_code.load(Ordering::Relaxed)
     }
 
-    #[inline]
-    fn runtime_for_kind(&self, kind: TaskKind) -> &tokio::runtime::Handle {
-        match kind.runtime() {
-            crate::AsyncRuntime::Default => &self.inner.default_runtime_handle,
-            crate::AsyncRuntime::Ingress => &self.inner.ingress_runtime_handle,
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.inner.global_metadata.get()
+    }
+
+    fn submit_runtime_metrics(runtime: &'static str, stats: RuntimeMetrics) {
+        gauge!("restate.tokio.num_workers", "runtime" => runtime).set(stats.num_workers() as f64);
+        gauge!("restate.tokio.blocking_threads", "runtime" => runtime)
+            .set(stats.num_blocking_threads() as f64);
+        gauge!("restate.tokio.blocking_queue_depth", "runtime" => runtime)
+            .set(stats.blocking_queue_depth() as f64);
+        gauge!("restate.tokio.num_alive_tasks", "runtime" => runtime)
+            .set(stats.num_alive_tasks() as f64);
+        gauge!("restate.tokio.io_driver_ready_count", "runtime" => runtime)
+            .set(stats.io_driver_ready_count() as f64);
+        gauge!("restate.tokio.remote_schedule_count", "runtime" => runtime)
+            .set(stats.remote_schedule_count() as f64);
+        // per worker stats
+        for idx in 0..stats.num_workers() {
+            gauge!("restate.tokio.worker_overflow_count", "runtime" => runtime, "worker" =>
+            idx.to_string())
+            .set(stats.worker_overflow_count(idx) as f64);
+            gauge!("restate.tokio.worker_poll_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_poll_count(idx) as f64);
+            gauge!("restate.tokio.worker_park_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_park_count(idx) as f64);
+            gauge!("restate.tokio.worker_noop_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_noop_count(idx) as f64);
+            gauge!("restate.tokio.worker_steal_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_steal_count(idx) as f64);
+            gauge!("restate.tokio.worker_total_busy_duration_seconds", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_total_busy_duration(idx).as_secs_f64());
+            gauge!("restate.tokio.worker_mean_poll_time", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_mean_poll_time(idx).as_secs_f64());
         }
     }
 
+    /// Clone the currently set METADATA (and if Some()). Otherwise falls back to global metadata.
+    #[track_caller]
+    fn clone_metadata(&self) -> Option<Metadata> {
+        CONTEXT
+            .try_with(|m| m.metadata.clone())
+            .ok()
+            .flatten()
+            .or_else(|| self.inner.global_metadata.get().cloned())
+    }
     /// Triggers a shutdown of the system. All running tasks will be asked gracefully
     /// to cancel but we will only wait for tasks with a TaskKind that has the property
     /// "OnCancel" set to "wait".
@@ -273,63 +319,74 @@ impl TaskCenter {
     {
         let inner = self.inner.clone();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
-        let task = Arc::new(Task {
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
             id,
             name,
             kind,
             partition_id,
-            cancel: cancel.clone(),
-            join_handle: Mutex::new(None),
+            cancellation_token: cancel.clone(),
+            metadata,
+        };
+        let task = Arc::new(Task {
+            context: context.clone(),
+            handle: Mutex::new(None),
         });
 
-        inner.tasks.lock().unwrap().insert(id, Arc::clone(&task));
-        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
-        let metadata = METADATA
-            .try_with(|m| m.clone())
-            .ok()
-            .flatten()
-            .or_else(|| inner.global_metadata.get().cloned());
+        inner.managed_tasks.lock().insert(id, Arc::clone(&task));
 
-        let mut handle_mut = task.join_handle.lock().unwrap();
+        let mut handle_mut = task.handle.lock();
 
-        let task_cloned = Arc::clone(&task);
-        let tokio_task = tokio::task::Builder::new().name(name);
-        let fut = wrapper(
-            self.clone(),
-            id,
-            kind,
-            task_cloned,
-            cancel,
-            metadata,
-            future,
-        );
-
-        let kind_str: &'static str = kind.into();
-        let join_handle = {
-            if matches!(kind, TaskKind::PartitionProcessor) {
-                let mut guard = self.inner.pp_runtimes.lock().unwrap();
-                // special case.
-                let runtime = guard
-                    .entry(name)
-                    .or_insert_with(|| tokio_pp_builder(name).build().unwrap())
-                    .handle();
-
-                counter!(TC_SPAWN, "kind" => kind_str, "runtime" => name).increment(1);
-                tokio_task
-                    .spawn_on(fut, runtime)
-                    .expect("pp dedicated runtime can be spawned")
-            } else {
-                let runtime_name: &'static str = kind.runtime().into();
-                counter!(TC_SPAWN, "kind" => kind_str, "runtime" => runtime_name).increment(1);
-                tokio_task
-                    .spawn_on(fut, self.runtime_for_kind(kind))
-                    .expect("runtime can spawn tasks")
-            }
-        };
-        *handle_mut = Some(join_handle);
+        let fut = wrapper(self.clone(), context, future);
+        *handle_mut = Some(self.spawn_on_runtime(kind, name, cancel, fut));
+        // drop the lock
         drop(handle_mut);
         // Task is ready
         id
+    }
+
+    fn spawn_on_runtime<F, T>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        cancellation_token: CancellationToken,
+        fut: F,
+    ) -> TaskHandle<T>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let kind_str: &'static str = kind.into();
+        let tokio_task = tokio::task::Builder::new().name(name);
+        let inner_handle = if matches!(kind, TaskKind::PartitionProcessor) {
+            let mut guard = self.inner.pp_runtimes.lock();
+            // special case.
+            let runtime = guard
+                .entry(name)
+                .or_insert_with(|| tokio_pp_builder(name).build().unwrap())
+                .handle();
+
+            counter!(TC_SPAWN, "kind" => kind_str, "runtime" => name).increment(1);
+            tokio_task
+                .spawn_on(fut, runtime)
+                .expect("pp dedicated runtime can be spawned")
+        } else {
+            let runtime_name: &'static str = kind.runtime().into();
+            counter!(TC_SPAWN, "kind" => kind_str, "runtime" => runtime_name).increment(1);
+            let runtime = match kind.runtime() {
+                crate::AsyncRuntime::Inherit => &tokio::runtime::Handle::current(),
+                crate::AsyncRuntime::Default => &self.inner.default_runtime_handle,
+                crate::AsyncRuntime::Ingress => &self.inner.ingress_runtime_handle,
+            };
+            tokio_task
+                .spawn_on(fut, runtime)
+                .expect("runtime can spawn tasks")
+        };
+
+        TaskHandle {
+            cancellation_token,
+            inner_handle,
+        }
     }
 
     /// Launch a new task
@@ -344,11 +401,43 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let inner = self.inner.clone();
-        if inner.shutdown_requested.load(Ordering::Relaxed) {
+        if self.inner.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
         Ok(self.spawn_unchecked(kind, name, partition_id, future))
+    }
+
+    #[track_caller]
+    pub fn spawn_unmanaged<F, T>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> Result<TaskHandle<T>, ShutdownError>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        if self.inner.shutdown_requested.load(Ordering::Relaxed) {
+            return Err(ShutdownError);
+        }
+
+        let cancel = CancellationToken::new();
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
+            id,
+            name,
+            kind,
+            partition_id,
+            cancellation_token: cancel.clone(),
+            metadata,
+        };
+
+        let fut = unmanaged_wrapper(self.clone(), context, future);
+
+        Ok(self.spawn_on_runtime(kind, name, cancel, fut))
     }
 
     // Allows for spawning a new task without checking if the system is shutting down. This means
@@ -382,20 +471,21 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let inner = self.inner.clone();
-        if inner.shutdown_requested.load(Ordering::Relaxed) {
+        if self.inner.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
 
         let parent_id =
             current_task_id().expect("spawn_child called outside of a task-center task");
-        let parent_kind =
-            current_task_kind().expect("spawn_child called outside of a task-center task");
-        let parent_name = CURRENT_TASK
-            .try_with(|ct| ct.name)
-            .expect("spawn_child called outside of a task-center task");
+        // From this point onwards, we unwrap() directly with the assumption that we are in task-center
+        // context and that the previous (expect) guards against reaching this point if we are
+        // outside task-center.
+        let parent_kind = current_task_kind().unwrap();
+        let parent_name = CONTEXT.try_with(|ctx| ctx.name).unwrap();
 
-        let cancel = cancellation_token().child_token();
+        let cancel = CONTEXT
+            .try_with(|ctx| ctx.cancellation_token.child_token())
+            .unwrap();
         let result = self.spawn_inner(kind, name, partition_id, cancel, future);
 
         trace!(
@@ -421,7 +511,9 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let cancel = cancellation_token().child_token();
+        let cancel = CONTEXT
+            .try_with(|ctx| ctx.cancellation_token.child_token())
+            .expect("spawning inside task-center context");
         self.spawn_inner(kind, name, partition_id, cancel, future)
     }
 
@@ -442,38 +534,38 @@ impl TaskCenter {
         let mut victims = Vec::new();
 
         {
-            let tasks = inner.tasks.lock().unwrap();
+            let tasks = inner.managed_tasks.lock();
             for task in tasks.values() {
-                if (kind.is_none() || Some(task.kind) == kind)
-                    && (partition_id.is_none() || task.partition_id == partition_id)
+                if (kind.is_none() || Some(task.context.kind) == kind)
+                    && (partition_id.is_none() || task.context.partition_id == partition_id)
                 {
-                    task.cancel.cancel();
-                    victims.push((Arc::clone(task), task.kind, task.partition_id));
+                    task.context.cancellation_token.cancel();
+                    victims.push((Arc::clone(task), task.kind(), task.partition_id()));
                 }
             }
         }
 
         for (task, task_kind, partition_id) in victims {
-            let join_handle = {
-                let mut task_mut = task.join_handle.lock().unwrap();
+            let handle = {
+                let mut task_mut = task.handle.lock();
                 // Task is not running anymore or another cancel is waiting for it.
                 task_mut.take()
             };
-            if let Some(mut join_handle) = join_handle {
+            if let Some(mut handle) = handle {
                 if task_kind.should_abort_on_cancel() {
                     // We should not wait, instead, just abort the tokio task.
-                    debug!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "task {} aborted!", task.id);
-                    join_handle.abort();
+                    debug!(kind = ?task_kind, name = ?task.name(), partition_id = ?partition_id, "task {} aborted!", task.id());
+                    handle.abort();
                 } else if task_kind.should_wait_on_cancel() {
                     // Give the task a chance to finish before logging.
-                    if tokio::time::timeout(Duration::from_secs(2), &mut join_handle)
+                    if tokio::time::timeout(Duration::from_secs(2), &mut handle)
                         .await
                         .is_err()
                     {
-                        info!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "waiting for task {} to shutdown", task.id);
+                        info!(kind = ?task_kind, name = ?task.name(), partition_id = ?partition_id, "waiting for task {} to shutdown", task.id());
                         // Ignore join errors on cancel. on_finish already takes care
-                        let _ = join_handle.await;
-                        info!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "task {} completed", task.id);
+                        let _ = handle.await;
+                        info!(kind = ?task_kind, name = ?task.name(), partition_id = ?partition_id, "task {} completed", task.id());
                     }
                 } else {
                     // Ignore the task. the task will be dropped on tokio runtime drop.
@@ -513,30 +605,20 @@ impl TaskCenter {
     where
         F: Future<Output = O>,
     {
-        let cancel_token = CancellationToken::new();
+        let cancel = CancellationToken::new();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
-        let task = Arc::new(Task {
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
             id,
             name,
             kind: TaskKind::InPlace,
+            cancellation_token: cancel.clone(),
             partition_id,
-            cancel: cancel_token.clone(),
-            join_handle: Mutex::new(None),
-        });
-        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
-        let metadata = METADATA
-            .try_with(|m| m.clone())
-            .ok()
-            .flatten()
-            .or_else(|| self.inner.global_metadata.get().cloned());
-        METADATA
-            .scope(
-                metadata,
-                CURRENT_TASK_CENTER.scope(
-                    self.clone(),
-                    CANCEL_TOKEN.scope(cancel_token, CURRENT_TASK.scope(task, future)),
-                ),
-            )
+            metadata,
+        };
+
+        CURRENT_TASK_CENTER
+            .scope(self.clone(), CONTEXT.scope(context, future))
             .await
     }
 
@@ -551,40 +633,31 @@ impl TaskCenter {
     where
         F: FnOnce() -> O,
     {
-        let cancel_token = CancellationToken::new();
+        let cancel = CancellationToken::new();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
-        let task = Arc::new(Task {
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
             id,
             name,
             kind: TaskKind::InPlace,
             partition_id,
-            cancel: cancel_token.clone(),
-            join_handle: Mutex::new(None),
-        });
-        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
-        let metadata = METADATA
-            .try_with(|m| m.clone())
-            .ok()
-            .flatten()
-            .or_else(|| self.inner.global_metadata.get().cloned());
-        METADATA.sync_scope(metadata, || {
-            CURRENT_TASK_CENTER.sync_scope(self.clone(), || {
-                CANCEL_TOKEN.sync_scope(cancel_token, || CURRENT_TASK.sync_scope(task, f))
-            })
-        })
+            cancellation_token: cancel.clone(),
+            metadata,
+        };
+        CURRENT_TASK_CENTER.sync_scope(self.clone(), || CONTEXT.sync_scope(context, f))
     }
 
     /// Take control over the running task from task-center. This returns None if the task was not
     /// found, completed, or has been cancelled.
-    pub fn take_task(&self, task_id: TaskId) -> Option<JoinHandle<()>> {
+    pub fn take_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {
         let inner = self.inner.clone();
         let task = {
             // find the task
-            let mut tasks = inner.tasks.lock().unwrap();
+            let mut tasks = inner.managed_tasks.lock();
             tasks.remove(&task_id)?
         };
 
-        let mut task_mut = task.join_handle.lock().unwrap();
+        let mut task_mut = task.handle.lock();
         // Task is not running anymore or a cancellation is already in progress.
         task_mut.take()
     }
@@ -592,45 +665,44 @@ impl TaskCenter {
     /// Request cancellation of a task. This returns the join handle if the task was found and was
     /// not already cancelled or completed. The returned task will not be awaited by task-center on
     /// shutdown, and it's the responsibility of the caller to join or abort.
-    pub fn cancel_task(&self, task_id: TaskId) -> Option<JoinHandle<()>> {
+    pub fn cancel_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {
         let inner = self.inner.clone();
         let task = {
             // find the task
-            let tasks = inner.tasks.lock().unwrap();
+            let tasks = inner.managed_tasks.lock();
             let task = tasks.get(&task_id)?;
             // request cancellation
-            task.cancel.cancel();
+            task.cancel();
             Arc::clone(task)
         };
 
-        let mut task_mut = task.join_handle.lock().unwrap();
+        let mut task_mut = task.handle.lock();
         // Task is not running anymore or a cancellation is already in progress.
         task_mut.take()
     }
 
     async fn on_finish(
         &self,
+        task_id: TaskId,
         result: std::result::Result<
             anyhow::Result<()>,
             std::boxed::Box<dyn std::any::Any + std::marker::Send>,
         >,
-        kind: TaskKind,
-        task_id: TaskId,
     ) {
-        let kind_str: &'static str = kind.into();
         let inner = self.inner.clone();
         // Remove our entry from the tasks map.
-        let Some(task) = inner.tasks.lock().unwrap().remove(&task_id) else {
+        let Some(task) = inner.managed_tasks.lock().remove(&task_id) else {
             // This can happen if the task ownership was taken by calling take_task(id);
             return;
         };
+        let kind_str: &'static str = task.kind().into();
 
-        let should_shutdown_on_error = kind.should_shutdown_on_error();
+        let should_shutdown_on_error = task.kind().should_shutdown_on_error();
         let mut request_node_shutdown = false;
         {
             match result {
                 Ok(Ok(())) => {
-                    trace!(kind = ?kind, name = ?task.name, "Task {} exited normally", task_id);
+                    trace!(kind = ?task.kind(), name = ?task.name(), "Task {} exited normally", task_id);
                     counter!(TC_FINISHED, "kind" => kind_str, "status" => TC_STATUS_COMPLETED)
                         .increment(1);
                 }
@@ -642,17 +714,17 @@ impl TaskCenter {
                     {
                         // The task failed to spawn other tasks because the system
                         // is already shutting down, we ignore those errors.
-                        tracing::debug!(kind = ?kind, name = ?task.name, "[Shutdown] Task {} stopped due to shutdown", task_id);
+                        tracing::debug!(kind = ?task.kind(), name = ?task.name(), "[Shutdown] Task {} stopped due to shutdown", task_id);
                         return;
                     }
                     if should_shutdown_on_error {
-                        error!(kind = ?kind, name = ?task.name,
+                        error!(kind = ?task.kind(), name = ?task.name(),
                             "Shutting down: task {} failed with: {:?}",
                             task_id, err
                         );
                         request_node_shutdown = true;
                     } else {
-                        error!(kind = ?kind, name = ?task.name, "Task {} failed with: {:?}", task_id, err);
+                        error!(kind = ?task.kind(), name = ?task.name(), "Task {} failed with: {:?}", task_id, err);
                     }
                     counter!(TC_FINISHED, "kind" => kind_str, "status" => TC_STATUS_FAILED)
                         .increment(1);
@@ -661,10 +733,10 @@ impl TaskCenter {
                     counter!(TC_FINISHED, "kind" => kind_str, "status" => TC_STATUS_FAILED)
                         .increment(1);
                     if should_shutdown_on_error {
-                        error!(kind = ?kind, name = ?task.name, "Shutting down: task {} panicked: {:?}", task_id, err);
+                        error!(kind = ?task.kind(), name = ?task.name(), "Shutting down: task {} panicked: {:?}", task_id, err);
                         request_node_shutdown = true;
                     } else {
-                        error!(kind = ?kind, name = ?task.name, "Task {} panicked: {:?}", task_id, err);
+                        error!(kind = ?task.kind(), name = ?task.name(), "Task {} panicked: {:?}", task_id, err);
                     }
                 }
             }
@@ -674,7 +746,7 @@ impl TaskCenter {
             // Note that the task itself has been already removed from the task map, so shutdown
             // will not wait for its completion.
             self.shutdown_node(
-                &format!("task {} failed and requested a shutdown", task.name),
+                &format!("task {} failed and requested a shutdown", task.name()),
                 EXIT_CODE_FAILURE,
             )
             .await;
@@ -696,90 +768,97 @@ struct TaskCenterInner {
     global_cancel_token: CancellationToken,
     shutdown_requested: AtomicBool,
     current_exit_code: AtomicI32,
-    tasks: Mutex<HashMap<TaskId, Arc<Task>>>,
+    managed_tasks: Mutex<HashMap<TaskId, Arc<Task>>>,
     global_metadata: OnceLock<Metadata>,
 }
 
-pub struct Task {
-    /// It's nice to have a unique ID for each task.
-    id: TaskId,
-    name: &'static str,
-    kind: TaskKind,
-    /// cancel this token to request cancelling this task.
-    cancel: CancellationToken,
+pub struct Task<R = ()> {
+    context: TaskContext,
+    handle: Mutex<Option<TaskHandle<R>>>,
+}
 
-    /// Tasks associated with a specific partition ID will have this set. This allows
-    /// for cancellation of tasks associated with that partition.
-    partition_id: Option<PartitionId>,
-    join_handle: Mutex<Option<JoinHandle<()>>>,
+impl<R> Task<R> {
+    fn id(&self) -> TaskId {
+        self.context.id
+    }
+
+    fn name(&self) -> &'static str {
+        self.context.name
+    }
+
+    fn kind(&self) -> TaskKind {
+        self.context.kind
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.context.partition_id
+    }
+
+    fn cancel(&self) {
+        self.context.cancellation_token.cancel()
+    }
 }
 
 task_local! {
-    // This is a cancellation token which will be cancelled when a task needs to shut down.
-    static CANCEL_TOKEN: CancellationToken;
-
-    // Tasks have self-reference.
-    static CURRENT_TASK: Arc<Task>;
+    // Tasks provide access to their context
+    static CONTEXT: TaskContext;
 
     // Current task center
     static CURRENT_TASK_CENTER: TaskCenter;
-
-    // Metadata handle
-    static METADATA: Option<Metadata>;
 }
 
 /// This wrapper function runs in a newly-spawned task. It initializes the
 /// task-local variables and calls the payload function.
-async fn wrapper<F>(
-    task_center: TaskCenter,
-    task_id: TaskId,
-    kind: TaskKind,
-    task: Arc<Task>,
-    cancel_token: CancellationToken,
-    metadata: Option<Metadata>,
-    future: F,
-) where
+async fn wrapper<F>(task_center: TaskCenter, context: TaskContext, future: F)
+where
     F: Future<Output = anyhow::Result<()>> + Send + 'static,
 {
-    trace!(kind = ?kind, name = ?task.name, "Starting task {}", task_id);
+    let id = context.id;
+    trace!(kind = ?context.kind, name = ?context.name, "Starting task {}", context.id);
 
     let result = CURRENT_TASK_CENTER
         .scope(
             task_center.clone(),
-            CANCEL_TOKEN.scope(
-                cancel_token,
-                CURRENT_TASK.scope(
-                    task,
-                    METADATA.scope(metadata, {
-                        // We use AssertUnwindSafe here so that the wrapped function
-                        // doesn't need to be UnwindSafe. We should not do anything after
-                        // unwinding that'd risk us being in unwind-unsafe behavior.
-                        AssertUnwindSafe(future).catch_unwind()
-                    }),
-                ),
-            ),
+            CONTEXT.scope(context, {
+                // We use AssertUnwindSafe here so that the wrapped function
+                // doesn't need to be UnwindSafe. We should not do anything after
+                // unwinding that'd risk us being in unwind-unsafe behavior.
+                AssertUnwindSafe(future).catch_unwind()
+            }),
         )
         .await;
-    task_center.on_finish(result, kind, task_id).await;
+    task_center.on_finish(id, result).await;
+}
+
+/// Like wrapper but doesn't call on_finish nor it catches panics
+async fn unmanaged_wrapper<F, T>(task_center: TaskCenter, context: TaskContext, future: F) -> T
+where
+    F: Future<Output = T> + Send + 'static,
+{
+    trace!(kind = ?context.kind, name = ?context.name, "Starting task {}", context.id);
+
+    CURRENT_TASK_CENTER
+        .scope(task_center.clone(), CONTEXT.scope(context, future))
+        .await
 }
 
 /// The current task-center task kind. This returns None if we are not in the scope
 /// of a task-center task.
 pub fn current_task_kind() -> Option<TaskKind> {
-    CURRENT_TASK.try_with(|ct| ct.kind).ok()
+    CONTEXT.try_with(|ctx| ctx.kind).ok()
 }
 
 /// The current task-center task Id. This returns None if we are not in the scope
 /// of a task-center task.
 pub fn current_task_id() -> Option<TaskId> {
-    CURRENT_TASK.try_with(|ct| ct.id).ok()
+    CONTEXT.try_with(|ctx| ctx.id).ok()
 }
 
 /// Access to global metadata handle. This is available in task-center tasks only!
 #[track_caller]
 pub fn metadata() -> Metadata {
-    METADATA
-        .try_with(|m| m.clone())
+    CONTEXT
+        .try_with(|ctx| ctx.metadata.clone())
         .expect("metadata() called outside task-center scope")
         .expect("metadata() called before global metadata was set")
 }
@@ -787,15 +866,15 @@ pub fn metadata() -> Metadata {
 /// Access to this node id. This is available in task-center tasks only!
 #[track_caller]
 pub fn my_node_id() -> GenerationalNodeId {
-    METADATA
-        .try_with(|m| m.as_ref().map(|m| m.my_node_id()))
+    CONTEXT
+        .try_with(|ctx| ctx.metadata.as_ref().map(|m| m.my_node_id()))
         .expect("my_node_id() called outside task-center scope")
         .expect("my_node_id() called before global metadata was set")
 }
 
 /// The current partition Id associated to the running task-center task.
 pub fn current_task_partition_id() -> Option<PartitionId> {
-    CURRENT_TASK.try_with(|ct| ct.partition_id).ok().flatten()
+    CONTEXT.try_with(|ctx| ctx.partition_id).ok().flatten()
 }
 
 /// Get the current task center. Use this to spawn tasks on the current task center.
@@ -819,7 +898,7 @@ pub async fn cancellation_watcher() {
 /// cancel_task() call, or if it's a child and the parent is being cancelled by a
 /// cancel_task() call, this cancellation token will be set to cancelled.
 pub fn cancellation_token() -> CancellationToken {
-    let res = CANCEL_TOKEN.try_with(|t| t.clone());
+    let res = CONTEXT.try_with(|ctx| ctx.cancellation_token.clone());
 
     if cfg!(any(test, feature = "test-util")) {
         // allow in tests to call from non-task-center tasks.
@@ -831,14 +910,14 @@ pub fn cancellation_token() -> CancellationToken {
 
 /// Has the current task been requested to cancel?
 pub fn is_cancellation_requested() -> bool {
-    if let Ok(cancel) = CANCEL_TOKEN.try_with(|t| t.clone()) {
-        cancel.is_cancelled()
-    } else {
-        if cfg!(any(test, feature = "test-util")) {
-            warn!("is_cancellation_requested() called in task-center task");
-        }
-        false
-    }
+    CONTEXT
+        .try_with(|ctx| ctx.cancellation_token.is_cancelled())
+        .unwrap_or_else(|_| {
+            if cfg!(any(test, feature = "test-util")) {
+                warn!("is_cancellation_requested() called outside task-center context");
+            }
+            false
+        })
 }
 
 #[cfg(test)]

--- a/crates/node/src/network_server/handler/mod.rs
+++ b/crates/node/src/network_server/handler/mod.rs
@@ -25,8 +25,6 @@ use crate::network_server::prometheus_helpers::{
 };
 use crate::network_server::state::NodeCtrlHandlerState;
 
-use super::prometheus_helpers::submit_tokio_metrics;
-
 const ROCKSDB_TICKERS: &[Ticker] = &[
     Ticker::BlockCacheBytesRead,
     Ticker::BlockCacheBytesWrite,
@@ -183,14 +181,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
     let mut out = String::new();
 
     // Default tokio runtime metrics
-    submit_tokio_metrics("default", state.task_center.default_runtime_metrics());
-    submit_tokio_metrics("ingress", state.task_center.ingress_runtime_metrics());
-
-    // Partition processor runtimes
-    let processor_runtimes = state.task_center.partition_processors_runtime_metrics();
-    for (task_name, metrics) in processor_runtimes {
-        submit_tokio_metrics(task_name, metrics);
-    }
+    state.task_center.submit_metrics();
 
     // Response content type is plain/text and that's expected.
     if let Some(prometheus_handle) = state.prometheus_handle {

--- a/crates/node/src/network_server/prometheus_helpers.rs
+++ b/crates/node/src/network_server/prometheus_helpers.rs
@@ -10,11 +10,9 @@
 
 use std::fmt::Write;
 
-use metrics::gauge;
 use metrics_exporter_prometheus::formatting;
 use restate_rocksdb::RocksDb;
 use rocksdb::statistics::{HistogramData, Ticker};
-use tokio::runtime::RuntimeMetrics;
 
 static PREFIX: &str = "restate";
 
@@ -168,36 +166,4 @@ pub fn format_rocksdb_histogram_for_prometheus(
         data.count(),
     );
     let _ = writeln!(out);
-}
-
-pub fn submit_tokio_metrics(runtime: &'static str, stats: RuntimeMetrics) {
-    gauge!("restate.tokio.num_workers", "runtime" => runtime).set(stats.num_workers() as f64);
-    gauge!("restate.tokio.blocking_threads", "runtime" => runtime)
-        .set(stats.num_blocking_threads() as f64);
-    gauge!("restate.tokio.blocking_queue_depth", "runtime" => runtime)
-        .set(stats.blocking_queue_depth() as f64);
-    gauge!("restate.tokio.num_alive_tasks", "runtime" => runtime)
-        .set(stats.num_alive_tasks() as f64);
-    gauge!("restate.tokio.io_driver_ready_count", "runtime" => runtime)
-        .set(stats.io_driver_ready_count() as f64);
-    gauge!("restate.tokio.remote_schedule_count", "runtime" => runtime)
-        .set(stats.remote_schedule_count() as f64);
-    // per worker stats
-    for idx in 0..stats.num_workers() {
-        gauge!("restate.tokio.worker_overflow_count", "runtime" => runtime, "worker" =>
-            idx.to_string())
-        .set(stats.worker_overflow_count(idx) as f64);
-        gauge!("restate.tokio.worker_poll_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_poll_count(idx) as f64);
-        gauge!("restate.tokio.worker_park_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_park_count(idx) as f64);
-        gauge!("restate.tokio.worker_noop_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_noop_count(idx) as f64);
-        gauge!("restate.tokio.worker_steal_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_steal_count(idx) as f64);
-        gauge!("restate.tokio.worker_total_busy_duration_seconds", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_total_busy_duration(idx).as_secs_f64());
-        gauge!("restate.tokio.worker_mean_poll_time", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_mean_poll_time(idx).as_secs_f64());
-    }
 }


### PR DESCRIPTION
[TaskCenter] Cleanup of task-center and introduces unmanaged tasks

Cleanup and simplifying the code a litte, removes a few unnecessary clones. And most importantl, introduces `spawn_unmanaged()` that returns a runtime-agnostic TaskHandle<T>.

Unmanaged tasks:
- Created with an automatic cancellation token, code running in the task would still use the cancellation watcher as per usual
- Tasks that return a value
- Owner of TaskHandle can decide to cancel gracefully or abort.
- Choice of runtime is still encapsulated within TaskCenter

Other changes:
- Important: Scheduling now works differently. Spawned tasks by default "inherit"s the parent's runtime. This reduces remote tokio scheduling and scopes partition processor workloads more accurately to their respective runtimes.
- Direct and fast access to metadata() from `tc.metadata()` is now available.
- Simplified task locals under one struct `TaskContext`
- Moved telemetry submittion within task-center itself (used in subsequent PRs)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1850).
* #1868
* #1867
* #1864
* #1863
* #1862
* #1861
* #1856
* #1855
* __->__ #1850