### PR TITLE
[Bifrost] Let loglet API support pipelining natively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,6 +5668,7 @@ dependencies = [
  "hyper-util",
  "metrics",
  "once_cell",
+ "parking_lot",
  "pin-project",
  "prost 0.13.1",
  "prost-types 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "restate-test-util",
  "restate-tracing-instrumentation",
  "restate-types",
+ "rlimit",
  "rocksdb",
  "serde",
  "serde_json",
@@ -1741,22 +1742,22 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a257c22cd7e487dd4a13d413beabc512c5052f0bc048db0da6a84c3d8a6142fd"
+checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
 dependencies = [
  "futures-core",
- "prost 0.12.3",
- "prost-types 0.12.3",
- "tonic 0.11.0",
+ "prost 0.13.1",
+ "prost-types 0.13.1",
+ "tonic 0.12.1",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c4cc54bae66f7d9188996404abdf7fdfa23034ef8e43478c8810828abad758"
+checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -1764,14 +1765,15 @@ dependencies = [
  "futures-task",
  "hdrhistogram",
  "humantime",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "hyper-util",
+ "prost 0.13.1",
+ "prost-types 0.13.1",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
+ "tonic 0.12.1",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -21,7 +21,7 @@ use restate_types::logs::{LogId, Lsn};
 use restate_types::retries::RetryIter;
 
 use crate::bifrost::BifrostInner;
-use crate::loglet::{AppendError, LogletBase};
+use crate::loglet::AppendError;
 use crate::loglet_wrapper::LogletWrapper;
 use crate::record::ErasedInputRecord;
 use crate::{Error, InputRecord, Result};

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -230,9 +230,7 @@ impl<T: StorageEncode> LogSender<T> {
     {
         let permit = match self.tx.try_reserve() {
             Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                return Err(EnqueueError::WouldBlock(record))
-            }
+            Err(mpsc::error::TrySendError::Full(_)) => return Err(EnqueueError::Full(record)),
             Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(record)),
         };
 
@@ -251,9 +249,7 @@ impl<T: StorageEncode> LogSender<T> {
     {
         let permit = match self.tx.try_reserve() {
             Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                return Err(EnqueueError::WouldBlock(record))
-            }
+            Err(mpsc::error::TrySendError::Full(_)) => return Err(EnqueueError::Full(record)),
             Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(record)),
         };
 
@@ -290,9 +286,7 @@ impl<T: StorageEncode> LogSender<T> {
     {
         let permits = match self.tx.try_reserve_many(records.len()) {
             Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                return Err(EnqueueError::WouldBlock(records))
-            }
+            Err(mpsc::error::TrySendError::Full(_)) => return Err(EnqueueError::Full(records)),
             Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(records)),
         };
 

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -22,7 +22,7 @@ use restate_types::Version;
 
 use crate::appender::Appender;
 use crate::background_appender::BackgroundAppender;
-use crate::loglet::{LogletBase, LogletProvider};
+use crate::loglet::LogletProvider;
 use crate::loglet_wrapper::LogletWrapper;
 use crate::watchdog::WatchdogSender;
 use crate::{Error, FindTailAttributes, InputRecord, LogReadStream, Result, TailState};

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -22,7 +22,6 @@ use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::Version;
 
 use crate::error::AdminError;
-use crate::loglet::LogletBase;
 use crate::{Bifrost, Error, Result, TailState};
 
 /// Bifrost's Admin API

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
 #[derive(thiserror::Error, Debug)]
 pub enum EnqueueError<T> {
     #[error("the operation rejected due to backpressure")]
-    WouldBlock(T),
+    Full(T),
     #[error("appender is draining, closed, or crashed")]
     Closed(T),
 }

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -24,7 +24,7 @@ use tokio_stream::StreamExt;
 use tracing::info;
 
 use super::{Loglet, LogletOffset};
-use crate::loglet::{AppendError, LogletBase, LogletReadStream};
+use crate::loglet::{AppendError, LogletReadStream};
 use crate::loglet_wrapper::LogletWrapper;
 use crate::{setup_panic_handler, TailState};
 
@@ -223,7 +223,7 @@ pub async fn single_loglet_readstream(loglet: Arc<dyn Loglet>) -> googletest::Re
     let read_from_offset = Lsn::new(6);
     let mut reader = loglet
         .clone()
-        .create_wrapped_read_stream(KeyFilter::Any, read_from_offset)
+        .create_read_stream(KeyFilter::Any, read_from_offset)
         .await?;
 
     {
@@ -316,7 +316,7 @@ pub async fn single_loglet_readstream_with_trims(
 
     let mut read_stream = loglet
         .clone()
-        .create_wrapped_read_stream(KeyFilter::Any, Lsn::OLDEST)
+        .create_read_stream(KeyFilter::Any, Lsn::OLDEST)
         .await?;
 
     let record = read_stream.next().await.unwrap()?;

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -101,16 +101,12 @@ impl SequenceNumber for LogletOffset {
 ///                      ^ Last Committed
 ///                      ^  -- Last released (optional and internal)
 ///
-///       1 -> Offset::OLDEST
-///       0 -> Offset::INVALID
+///       1 -> LogletOffset::OLDEST
+///       0 -> LogletOffset::INVALID
 /// ```
-pub trait Loglet: LogletBase<Offset = LogletOffset> {}
-impl<T> Loglet for T where T: LogletBase<Offset = LogletOffset> {}
 
 #[async_trait]
-pub trait LogletBase: Send + Sync + std::fmt::Debug {
-    type Offset: SequenceNumber;
-
+pub trait Loglet: Send + Sync + std::fmt::Debug {
     /// Create a read stream that streams record from a single loglet instance.
     ///
     /// `to`: The offset of the last record to be read (inclusive). If `None`, the
@@ -118,12 +114,12 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     async fn create_read_stream(
         self: Arc<Self>,
         filter: KeyFilter,
-        from: Self::Offset,
-        to: Option<Self::Offset>,
-    ) -> Result<SendableLogletReadStream<Self::Offset>, OperationError>;
+        from: LogletOffset,
+        to: Option<LogletOffset>,
+    ) -> Result<SendableLogletReadStream<LogletOffset>, OperationError>;
 
     /// Append a record to the loglet.
-    async fn append(&self, record: ErasedInputRecord) -> Result<Self::Offset, AppendError> {
+    async fn append(&self, record: ErasedInputRecord) -> Result<LogletOffset, AppendError> {
         self.append_batch(Arc::new([record])).await
     }
 
@@ -138,14 +134,14 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     /// point at which readers should stop **before**, therefore, when reading, if the next offset
     /// to read == the tail, it means that you can only read this offset if the tail watch moves
     /// beyond it to a higher tail while remaining unsealed.
-    fn watch_tail(&self) -> BoxStream<'static, TailState<Self::Offset>>;
+    fn watch_tail(&self) -> BoxStream<'static, TailState<LogletOffset>>;
 
     /// Append a batch of records to the loglet. The returned offset (on success) is the offset of
     /// the last committed record in the batch)
     async fn append_batch(
         &self,
         payloads: Arc<[ErasedInputRecord]>,
-    ) -> Result<Self::Offset, AppendError>;
+    ) -> Result<LogletOffset, AppendError>;
 
     /// The tail is *the first unwritten position* in the loglet.
     ///
@@ -154,12 +150,12 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     /// after the next `append()` call.
     ///
     /// If the loglet is empty, the loglet should return TailState::Open(Offset::OLDEST).
-    async fn find_tail(&self) -> Result<TailState<Self::Offset>, OperationError>;
+    async fn find_tail(&self) -> Result<TailState<LogletOffset>, OperationError>;
 
     /// The offset of the slot **before** the first readable record (if it exists), or the offset
     /// before the next slot that will be written to. Must not return Self::INVALID. If the loglet
     /// is never trimmed, this must return `None`.
-    async fn get_trim_point(&self) -> Result<Option<Self::Offset>, OperationError>;
+    async fn get_trim_point(&self) -> Result<Option<LogletOffset>, OperationError>;
 
     /// Trim the loglet prefix up to and including the `trim_point`.
     /// If trim_point equal or higher than the loglet tail, the loglet trims its data until the tail.
@@ -169,7 +165,7 @@ pub trait LogletBase: Send + Sync + std::fmt::Debug {
     ///
     /// Passing `Offset::INVALID` is a no-op. (success)
     /// Passing `Offset::OLDEST` trims the first record in the loglet (if exists).
-    async fn trim(&self, trim_point: Self::Offset) -> Result<(), OperationError>;
+    async fn trim(&self, trim_point: LogletOffset) -> Result<(), OperationError>;
 
     /// Seal the loglet. This operation is idempotent.
     ///

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -18,13 +18,16 @@ pub(crate) mod util;
 pub use error::*;
 use futures::stream::BoxStream;
 pub use provider::{LogletProvider, LogletProviderFactory};
+use restate_core::ShutdownError;
+use tokio::sync::oneshot;
 
 use std::ops::Add;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{ready, Poll};
 
 use async_trait::async_trait;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 
 use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
 
@@ -118,11 +121,6 @@ pub trait Loglet: Send + Sync + std::fmt::Debug {
         to: Option<LogletOffset>,
     ) -> Result<SendableLogletReadStream<LogletOffset>, OperationError>;
 
-    /// Append a record to the loglet.
-    async fn append(&self, record: ErasedInputRecord) -> Result<LogletOffset, AppendError> {
-        self.append_batch(Arc::new([record])).await
-    }
-
     /// Create a stream watching the state of tail for this loglet
     ///
     /// The stream will return the last known TailState with seal notification semantics
@@ -136,12 +134,27 @@ pub trait Loglet: Send + Sync + std::fmt::Debug {
     /// beyond it to a higher tail while remaining unsealed.
     fn watch_tail(&self) -> BoxStream<'static, TailState<LogletOffset>>;
 
-    /// Append a batch of records to the loglet. The returned offset (on success) is the offset of
-    /// the last committed record in the batch)
-    async fn append_batch(
+    /// Enqueues a batch of records for the loglet to write. This function blocks when the loglet cannot
+    /// accept this batch as a form of back-pressure. Once the batch is accepted, it will be committed
+    /// in the background and the caller doesn't need to await for the commit status.
+    ///
+    /// That said, if commit confirmation is needed, use the returned future `LogletCommit` to wait
+    /// for commit completion and to acquire the **last offset** in that batch.
+    ///
+    /// Note: For pipelined writes. The order of records/batches is determined by the order of
+    /// calling this function from a single source. The user must wait for this function to return
+    /// before appending the next batch in a stream of ordered records.
+    ///
+    /// However, awaiting the returned `LogletCommit` is optional and can happen concurrently and in
+    /// any order. In the case of pipelined writes, loglets must acknowledge writes
+    /// only after all previously enqueued writes have been durably committed. The loglet should
+    /// retry failing appends indefinitely until the loglet is sealed. In that case, such commits
+    /// might still appear to future readers but without returning the commit acknowledgement to
+    /// the original writer.
+    async fn enqueue_batch(
         &self,
         payloads: Arc<[ErasedInputRecord]>,
-    ) -> Result<LogletOffset, AppendError>;
+    ) -> Result<LogletCommit, ShutdownError>;
 
     /// The tail is *the first unwritten position* in the loglet.
     ///
@@ -186,3 +199,35 @@ pub trait LogletReadStream<S: SequenceNumber>:
 }
 
 pub type SendableLogletReadStream<S = Lsn> = Pin<Box<dyn LogletReadStream<S> + Send>>;
+
+pub struct LogletCommit {
+    rx: oneshot::Receiver<Result<LogletOffset, AppendError>>,
+}
+
+impl LogletCommit {
+    pub(crate) fn sealed() -> Self {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(AppendError::Sealed));
+        Self { rx }
+    }
+
+    pub(crate) fn resolved(offset: LogletOffset) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Ok(offset));
+        Self { rx }
+    }
+}
+
+impl std::future::Future for LogletCommit {
+    type Output = Result<LogletOffset, AppendError>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        match ready!(self.rx.poll_unpin(cx)) {
+            Ok(res) => Poll::Ready(res),
+            Err(_) => Poll::Ready(Err(AppendError::Shutdown(ShutdownError))),
+        }
+    }
+}

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -23,7 +23,7 @@ use restate_types::logs::LogId;
 use super::log_store::RocksDbLogStore;
 use super::log_store_writer::RocksDbLogWriterHandle;
 use super::{metric_definitions, LocalLoglet};
-use crate::loglet::{Loglet, LogletOffset, LogletProvider, LogletProviderFactory, OperationError};
+use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::Error;
 
 pub struct Factory {
@@ -83,7 +83,7 @@ impl LogletProvider for LocalLogletProvider {
         log_id: LogId,
         segment_index: SegmentIndex,
         params: &LogletParams,
-    ) -> Result<Arc<dyn Loglet<Offset = LogletOffset>>, Error> {
+    ) -> Result<Arc<dyn Loglet>, Error> {
         let mut guard = self.active_loglets.lock();
         let loglet = match guard.entry((log_id, segment_index)) {
             hash_map::Entry::Vacant(entry) => {

--- a/crates/bifrost/src/providers/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/providers/local_loglet/read_stream.rs
@@ -22,7 +22,7 @@ use restate_core::ShutdownError;
 use restate_rocksdb::RocksDbPerfGuard;
 use restate_types::logs::{KeyFilter, SequenceNumber};
 
-use crate::loglet::{LogletBase, LogletOffset, LogletReadStream, OperationError};
+use crate::loglet::{Loglet, LogletOffset, LogletReadStream, OperationError};
 use crate::providers::local_loglet::record_format::decode_and_filter_record;
 use crate::providers::local_loglet::LogStoreError;
 use crate::{LogEntry, Result, TailState};

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -74,7 +74,7 @@ impl LogletProvider for ReplicatedLogletProvider {
         _log_id: LogId,
         _segment_index: SegmentIndex,
         _params: &LogletParams,
-    ) -> Result<Arc<dyn Loglet<Offset = LogletOffset>>, Error> {
+    ) -> Result<Arc<dyn Loglet>, Error> {
         todo!("Not implemented yet")
     }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 metrics = { workspace = true }
 once_cell = { workspace = true }
+parking_lot = { workspace = true }
 pin-project = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#[derive(Debug, thiserror::Error)]
+#[error("system is shutting down")]
+pub(crate) struct ShutdownSourceErr;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ShutdownError;
+impl std::fmt::Display for ShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("system is shutting down")
+    }
+}
+
+impl std::error::Error for ShutdownError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&ShutdownSourceErr)
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod error;
 mod metadata;
 pub mod metadata_store;
 mod metric_definitions;
@@ -15,6 +16,7 @@ pub mod network;
 mod task_center;
 mod task_center_types;
 pub mod worker_api;
+pub use error::*;
 
 pub use metadata::{
     spawn_metadata_manager, Metadata, MetadataBuilder, MetadataKind, MetadataManager,

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -9,47 +9,44 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
-use std::fmt::Display;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use futures::{Future, FutureExt};
-use metrics::counter;
-use restate_types::config::CommonOptions;
-use restate_types::GenerationalNodeId;
+use metrics::{counter, gauge};
+use parking_lot::Mutex;
 use tokio::runtime::RuntimeMetrics;
-use tokio::task::JoinHandle;
 use tokio::task_local;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 use tracing::{debug, error, info, instrument, trace, warn};
 
+use restate_types::config::CommonOptions;
 use restate_types::identifiers::PartitionId;
+use restate_types::GenerationalNodeId;
 
 use crate::metric_definitions::{TC_FINISHED, TC_SPAWN, TC_STATUS_COMPLETED, TC_STATUS_FAILED};
-use crate::{metric_definitions, Metadata, TaskId, TaskKind};
+use crate::{
+    metric_definitions, Metadata, ShutdownError, ShutdownSourceErr, TaskHandle, TaskId, TaskKind,
+};
 
-static WORKER_ID: AtomicUsize = AtomicUsize::new(0);
-static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(0);
+static WORKER_ID: AtomicUsize = const { AtomicUsize::new(0) };
+static NEXT_TASK_ID: AtomicU64 = const { AtomicU64::new(0) };
 const EXIT_CODE_FAILURE: i32 = 1;
 
-#[derive(Debug, thiserror::Error)]
-#[error("system is shutting down")]
-struct ShutdownSourceErr;
-
-#[derive(Debug, Clone, Copy)]
-pub struct ShutdownError;
-impl Display for ShutdownError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("system is shutting down")
-    }
-}
-
-impl std::error::Error for ShutdownError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&ShutdownSourceErr)
-    }
+#[derive(Clone)]
+pub struct TaskContext {
+    /// It's nice to have a unique ID for each task.
+    id: TaskId,
+    name: &'static str,
+    kind: TaskKind,
+    /// cancel this token to request cancelling this task.
+    cancellation_token: CancellationToken,
+    /// Tasks associated with a specific partition ID will have this set. This allows
+    /// for cancellation of tasks associated with that partition.
+    partition_id: Option<PartitionId>,
+    metadata: Option<Metadata>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -144,7 +141,7 @@ impl TaskCenterBuilder {
                 global_cancel_token: CancellationToken::new(),
                 shutdown_requested: AtomicBool::new(false),
                 current_exit_code: AtomicI32::new(0),
-                tasks: Mutex::new(HashMap::new()),
+                managed_tasks: Mutex::new(HashMap::new()),
                 global_metadata: OnceLock::new(),
                 pp_runtimes: Mutex::new(HashMap::with_capacity(64)),
             }),
@@ -198,8 +195,20 @@ impl TaskCenter {
     }
 
     pub fn partition_processors_runtime_metrics(&self) -> Vec<(&'static str, RuntimeMetrics)> {
-        let guard = self.inner.pp_runtimes.lock().unwrap();
+        let guard = self.inner.pp_runtimes.lock();
         guard.iter().map(|(k, v)| (*k, v.metrics())).collect()
+    }
+
+    /// Submit telemetry for all runtimes to metrics recorder
+    pub fn submit_metrics(&self) {
+        Self::submit_runtime_metrics("default", self.default_runtime_metrics());
+        Self::submit_runtime_metrics("ingress", self.ingress_runtime_metrics());
+
+        // Partition processor runtimes
+        let processor_runtimes = self.partition_processors_runtime_metrics();
+        for (task_name, metrics) in processor_runtimes {
+            Self::submit_runtime_metrics(task_name, metrics);
+        }
     }
 
     /// Use to monitor an on-going shutdown when requested
@@ -217,14 +226,51 @@ impl TaskCenter {
         self.inner.current_exit_code.load(Ordering::Relaxed)
     }
 
-    #[inline]
-    fn runtime_for_kind(&self, kind: TaskKind) -> &tokio::runtime::Handle {
-        match kind.runtime() {
-            crate::AsyncRuntime::Default => &self.inner.default_runtime_handle,
-            crate::AsyncRuntime::Ingress => &self.inner.ingress_runtime_handle,
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.inner.global_metadata.get()
+    }
+
+    fn submit_runtime_metrics(runtime: &'static str, stats: RuntimeMetrics) {
+        gauge!("restate.tokio.num_workers", "runtime" => runtime).set(stats.num_workers() as f64);
+        gauge!("restate.tokio.blocking_threads", "runtime" => runtime)
+            .set(stats.num_blocking_threads() as f64);
+        gauge!("restate.tokio.blocking_queue_depth", "runtime" => runtime)
+            .set(stats.blocking_queue_depth() as f64);
+        gauge!("restate.tokio.num_alive_tasks", "runtime" => runtime)
+            .set(stats.num_alive_tasks() as f64);
+        gauge!("restate.tokio.io_driver_ready_count", "runtime" => runtime)
+            .set(stats.io_driver_ready_count() as f64);
+        gauge!("restate.tokio.remote_schedule_count", "runtime" => runtime)
+            .set(stats.remote_schedule_count() as f64);
+        // per worker stats
+        for idx in 0..stats.num_workers() {
+            gauge!("restate.tokio.worker_overflow_count", "runtime" => runtime, "worker" =>
+            idx.to_string())
+            .set(stats.worker_overflow_count(idx) as f64);
+            gauge!("restate.tokio.worker_poll_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_poll_count(idx) as f64);
+            gauge!("restate.tokio.worker_park_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_park_count(idx) as f64);
+            gauge!("restate.tokio.worker_noop_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_noop_count(idx) as f64);
+            gauge!("restate.tokio.worker_steal_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_steal_count(idx) as f64);
+            gauge!("restate.tokio.worker_total_busy_duration_seconds", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_total_busy_duration(idx).as_secs_f64());
+            gauge!("restate.tokio.worker_mean_poll_time", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_mean_poll_time(idx).as_secs_f64());
         }
     }
 
+    /// Clone the currently set METADATA (and if Some()). Otherwise falls back to global metadata.
+    #[track_caller]
+    fn clone_metadata(&self) -> Option<Metadata> {
+        CONTEXT
+            .try_with(|m| m.metadata.clone())
+            .ok()
+            .flatten()
+            .or_else(|| self.inner.global_metadata.get().cloned())
+    }
     /// Triggers a shutdown of the system. All running tasks will be asked gracefully
     /// to cancel but we will only wait for tasks with a TaskKind that has the property
     /// "OnCancel" set to "wait".
@@ -273,63 +319,74 @@ impl TaskCenter {
     {
         let inner = self.inner.clone();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
-        let task = Arc::new(Task {
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
             id,
             name,
             kind,
             partition_id,
-            cancel: cancel.clone(),
-            join_handle: Mutex::new(None),
+            cancellation_token: cancel.clone(),
+            metadata,
+        };
+        let task = Arc::new(Task {
+            context: context.clone(),
+            handle: Mutex::new(None),
         });
 
-        inner.tasks.lock().unwrap().insert(id, Arc::clone(&task));
-        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
-        let metadata = METADATA
-            .try_with(|m| m.clone())
-            .ok()
-            .flatten()
-            .or_else(|| inner.global_metadata.get().cloned());
+        inner.managed_tasks.lock().insert(id, Arc::clone(&task));
 
-        let mut handle_mut = task.join_handle.lock().unwrap();
+        let mut handle_mut = task.handle.lock();
 
-        let task_cloned = Arc::clone(&task);
-        let tokio_task = tokio::task::Builder::new().name(name);
-        let fut = wrapper(
-            self.clone(),
-            id,
-            kind,
-            task_cloned,
-            cancel,
-            metadata,
-            future,
-        );
-
-        let kind_str: &'static str = kind.into();
-        let join_handle = {
-            if matches!(kind, TaskKind::PartitionProcessor) {
-                let mut guard = self.inner.pp_runtimes.lock().unwrap();
-                // special case.
-                let runtime = guard
-                    .entry(name)
-                    .or_insert_with(|| tokio_pp_builder(name).build().unwrap())
-                    .handle();
-
-                counter!(TC_SPAWN, "kind" => kind_str, "runtime" => name).increment(1);
-                tokio_task
-                    .spawn_on(fut, runtime)
-                    .expect("pp dedicated runtime can be spawned")
-            } else {
-                let runtime_name: &'static str = kind.runtime().into();
-                counter!(TC_SPAWN, "kind" => kind_str, "runtime" => runtime_name).increment(1);
-                tokio_task
-                    .spawn_on(fut, self.runtime_for_kind(kind))
-                    .expect("runtime can spawn tasks")
-            }
-        };
-        *handle_mut = Some(join_handle);
+        let fut = wrapper(self.clone(), context, future);
+        *handle_mut = Some(self.spawn_on_runtime(kind, name, cancel, fut));
+        // drop the lock
         drop(handle_mut);
         // Task is ready
         id
+    }
+
+    fn spawn_on_runtime<F, T>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        cancellation_token: CancellationToken,
+        fut: F,
+    ) -> TaskHandle<T>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let kind_str: &'static str = kind.into();
+        let tokio_task = tokio::task::Builder::new().name(name);
+        let inner_handle = if matches!(kind, TaskKind::PartitionProcessor) {
+            let mut guard = self.inner.pp_runtimes.lock();
+            // special case.
+            let runtime = guard
+                .entry(name)
+                .or_insert_with(|| tokio_pp_builder(name).build().unwrap())
+                .handle();
+
+            counter!(TC_SPAWN, "kind" => kind_str, "runtime" => name).increment(1);
+            tokio_task
+                .spawn_on(fut, runtime)
+                .expect("pp dedicated runtime can be spawned")
+        } else {
+            let runtime_name: &'static str = kind.runtime().into();
+            counter!(TC_SPAWN, "kind" => kind_str, "runtime" => runtime_name).increment(1);
+            let runtime = match kind.runtime() {
+                crate::AsyncRuntime::Inherit => &tokio::runtime::Handle::current(),
+                crate::AsyncRuntime::Default => &self.inner.default_runtime_handle,
+                crate::AsyncRuntime::Ingress => &self.inner.ingress_runtime_handle,
+            };
+            tokio_task
+                .spawn_on(fut, runtime)
+                .expect("runtime can spawn tasks")
+        };
+
+        TaskHandle {
+            cancellation_token,
+            inner_handle,
+        }
     }
 
     /// Launch a new task
@@ -344,11 +401,43 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let inner = self.inner.clone();
-        if inner.shutdown_requested.load(Ordering::Relaxed) {
+        if self.inner.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
         Ok(self.spawn_unchecked(kind, name, partition_id, future))
+    }
+
+    #[track_caller]
+    pub fn spawn_unmanaged<F, T>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        partition_id: Option<PartitionId>,
+        future: F,
+    ) -> Result<TaskHandle<T>, ShutdownError>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        if self.inner.shutdown_requested.load(Ordering::Relaxed) {
+            return Err(ShutdownError);
+        }
+
+        let cancel = CancellationToken::new();
+        let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
+            id,
+            name,
+            kind,
+            partition_id,
+            cancellation_token: cancel.clone(),
+            metadata,
+        };
+
+        let fut = unmanaged_wrapper(self.clone(), context, future);
+
+        Ok(self.spawn_on_runtime(kind, name, cancel, fut))
     }
 
     // Allows for spawning a new task without checking if the system is shutting down. This means
@@ -382,20 +471,21 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let inner = self.inner.clone();
-        if inner.shutdown_requested.load(Ordering::Relaxed) {
+        if self.inner.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
 
         let parent_id =
             current_task_id().expect("spawn_child called outside of a task-center task");
-        let parent_kind =
-            current_task_kind().expect("spawn_child called outside of a task-center task");
-        let parent_name = CURRENT_TASK
-            .try_with(|ct| ct.name)
-            .expect("spawn_child called outside of a task-center task");
+        // From this point onwards, we unwrap() directly with the assumption that we are in task-center
+        // context and that the previous (expect) guards against reaching this point if we are
+        // outside task-center.
+        let parent_kind = current_task_kind().unwrap();
+        let parent_name = CONTEXT.try_with(|ctx| ctx.name).unwrap();
 
-        let cancel = cancellation_token().child_token();
+        let cancel = CONTEXT
+            .try_with(|ctx| ctx.cancellation_token.child_token())
+            .unwrap();
         let result = self.spawn_inner(kind, name, partition_id, cancel, future);
 
         trace!(
@@ -421,7 +511,9 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let cancel = cancellation_token().child_token();
+        let cancel = CONTEXT
+            .try_with(|ctx| ctx.cancellation_token.child_token())
+            .expect("spawning inside task-center context");
         self.spawn_inner(kind, name, partition_id, cancel, future)
     }
 
@@ -442,38 +534,38 @@ impl TaskCenter {
         let mut victims = Vec::new();
 
         {
-            let tasks = inner.tasks.lock().unwrap();
+            let tasks = inner.managed_tasks.lock();
             for task in tasks.values() {
-                if (kind.is_none() || Some(task.kind) == kind)
-                    && (partition_id.is_none() || task.partition_id == partition_id)
+                if (kind.is_none() || Some(task.context.kind) == kind)
+                    && (partition_id.is_none() || task.context.partition_id == partition_id)
                 {
-                    task.cancel.cancel();
-                    victims.push((Arc::clone(task), task.kind, task.partition_id));
+                    task.context.cancellation_token.cancel();
+                    victims.push((Arc::clone(task), task.kind(), task.partition_id()));
                 }
             }
         }
 
         for (task, task_kind, partition_id) in victims {
-            let join_handle = {
-                let mut task_mut = task.join_handle.lock().unwrap();
+            let handle = {
+                let mut task_mut = task.handle.lock();
                 // Task is not running anymore or another cancel is waiting for it.
                 task_mut.take()
             };
-            if let Some(mut join_handle) = join_handle {
+            if let Some(mut handle) = handle {
                 if task_kind.should_abort_on_cancel() {
                     // We should not wait, instead, just abort the tokio task.
-                    debug!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "task {} aborted!", task.id);
-                    join_handle.abort();
+                    debug!(kind = ?task_kind, name = ?task.name(), partition_id = ?partition_id, "task {} aborted!", task.id());
+                    handle.abort();
                 } else if task_kind.should_wait_on_cancel() {
                     // Give the task a chance to finish before logging.
-                    if tokio::time::timeout(Duration::from_secs(2), &mut join_handle)
+                    if tokio::time::timeout(Duration::from_secs(2), &mut handle)
                         .await
                         .is_err()
                     {
-                        info!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "waiting for task {} to shutdown", task.id);
+                        info!(kind = ?task_kind, name = ?task.name(), partition_id = ?partition_id, "waiting for task {} to shutdown", task.id());
                         // Ignore join errors on cancel. on_finish already takes care
-                        let _ = join_handle.await;
-                        info!(kind = ?task_kind, name = ?task.name, partition_id = ?partition_id, "task {} completed", task.id);
+                        let _ = handle.await;
+                        info!(kind = ?task_kind, name = ?task.name(), partition_id = ?partition_id, "task {} completed", task.id());
                     }
                 } else {
                     // Ignore the task. the task will be dropped on tokio runtime drop.
@@ -513,30 +605,20 @@ impl TaskCenter {
     where
         F: Future<Output = O>,
     {
-        let cancel_token = CancellationToken::new();
+        let cancel = CancellationToken::new();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
-        let task = Arc::new(Task {
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
             id,
             name,
             kind: TaskKind::InPlace,
+            cancellation_token: cancel.clone(),
             partition_id,
-            cancel: cancel_token.clone(),
-            join_handle: Mutex::new(None),
-        });
-        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
-        let metadata = METADATA
-            .try_with(|m| m.clone())
-            .ok()
-            .flatten()
-            .or_else(|| self.inner.global_metadata.get().cloned());
-        METADATA
-            .scope(
-                metadata,
-                CURRENT_TASK_CENTER.scope(
-                    self.clone(),
-                    CANCEL_TOKEN.scope(cancel_token, CURRENT_TASK.scope(task, future)),
-                ),
-            )
+            metadata,
+        };
+
+        CURRENT_TASK_CENTER
+            .scope(self.clone(), CONTEXT.scope(context, future))
             .await
     }
 
@@ -551,40 +633,31 @@ impl TaskCenter {
     where
         F: FnOnce() -> O,
     {
-        let cancel_token = CancellationToken::new();
+        let cancel = CancellationToken::new();
         let id = TaskId::from(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed));
-        let task = Arc::new(Task {
+        let metadata = self.clone_metadata();
+        let context = TaskContext {
             id,
             name,
             kind: TaskKind::InPlace,
             partition_id,
-            cancel: cancel_token.clone(),
-            join_handle: Mutex::new(None),
-        });
-        // Clone the currently set METADATA (and is Some()), otherwise fallback to global metadata.
-        let metadata = METADATA
-            .try_with(|m| m.clone())
-            .ok()
-            .flatten()
-            .or_else(|| self.inner.global_metadata.get().cloned());
-        METADATA.sync_scope(metadata, || {
-            CURRENT_TASK_CENTER.sync_scope(self.clone(), || {
-                CANCEL_TOKEN.sync_scope(cancel_token, || CURRENT_TASK.sync_scope(task, f))
-            })
-        })
+            cancellation_token: cancel.clone(),
+            metadata,
+        };
+        CURRENT_TASK_CENTER.sync_scope(self.clone(), || CONTEXT.sync_scope(context, f))
     }
 
     /// Take control over the running task from task-center. This returns None if the task was not
     /// found, completed, or has been cancelled.
-    pub fn take_task(&self, task_id: TaskId) -> Option<JoinHandle<()>> {
+    pub fn take_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {
         let inner = self.inner.clone();
         let task = {
             // find the task
-            let mut tasks = inner.tasks.lock().unwrap();
+            let mut tasks = inner.managed_tasks.lock();
             tasks.remove(&task_id)?
         };
 
-        let mut task_mut = task.join_handle.lock().unwrap();
+        let mut task_mut = task.handle.lock();
         // Task is not running anymore or a cancellation is already in progress.
         task_mut.take()
     }
@@ -592,45 +665,44 @@ impl TaskCenter {
     /// Request cancellation of a task. This returns the join handle if the task was found and was
     /// not already cancelled or completed. The returned task will not be awaited by task-center on
     /// shutdown, and it's the responsibility of the caller to join or abort.
-    pub fn cancel_task(&self, task_id: TaskId) -> Option<JoinHandle<()>> {
+    pub fn cancel_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {
         let inner = self.inner.clone();
         let task = {
             // find the task
-            let tasks = inner.tasks.lock().unwrap();
+            let tasks = inner.managed_tasks.lock();
             let task = tasks.get(&task_id)?;
             // request cancellation
-            task.cancel.cancel();
+            task.cancel();
             Arc::clone(task)
         };
 
-        let mut task_mut = task.join_handle.lock().unwrap();
+        let mut task_mut = task.handle.lock();
         // Task is not running anymore or a cancellation is already in progress.
         task_mut.take()
     }
 
     async fn on_finish(
         &self,
+        task_id: TaskId,
         result: std::result::Result<
             anyhow::Result<()>,
             std::boxed::Box<dyn std::any::Any + std::marker::Send>,
         >,
-        kind: TaskKind,
-        task_id: TaskId,
     ) {
-        let kind_str: &'static str = kind.into();
         let inner = self.inner.clone();
         // Remove our entry from the tasks map.
-        let Some(task) = inner.tasks.lock().unwrap().remove(&task_id) else {
+        let Some(task) = inner.managed_tasks.lock().remove(&task_id) else {
             // This can happen if the task ownership was taken by calling take_task(id);
             return;
         };
+        let kind_str: &'static str = task.kind().into();
 
-        let should_shutdown_on_error = kind.should_shutdown_on_error();
+        let should_shutdown_on_error = task.kind().should_shutdown_on_error();
         let mut request_node_shutdown = false;
         {
             match result {
                 Ok(Ok(())) => {
-                    trace!(kind = ?kind, name = ?task.name, "Task {} exited normally", task_id);
+                    trace!(kind = ?task.kind(), name = ?task.name(), "Task {} exited normally", task_id);
                     counter!(TC_FINISHED, "kind" => kind_str, "status" => TC_STATUS_COMPLETED)
                         .increment(1);
                 }
@@ -642,17 +714,17 @@ impl TaskCenter {
                     {
                         // The task failed to spawn other tasks because the system
                         // is already shutting down, we ignore those errors.
-                        tracing::debug!(kind = ?kind, name = ?task.name, "[Shutdown] Task {} stopped due to shutdown", task_id);
+                        tracing::debug!(kind = ?task.kind(), name = ?task.name(), "[Shutdown] Task {} stopped due to shutdown", task_id);
                         return;
                     }
                     if should_shutdown_on_error {
-                        error!(kind = ?kind, name = ?task.name,
+                        error!(kind = ?task.kind(), name = ?task.name(),
                             "Shutting down: task {} failed with: {:?}",
                             task_id, err
                         );
                         request_node_shutdown = true;
                     } else {
-                        error!(kind = ?kind, name = ?task.name, "Task {} failed with: {:?}", task_id, err);
+                        error!(kind = ?task.kind(), name = ?task.name(), "Task {} failed with: {:?}", task_id, err);
                     }
                     counter!(TC_FINISHED, "kind" => kind_str, "status" => TC_STATUS_FAILED)
                         .increment(1);
@@ -661,10 +733,10 @@ impl TaskCenter {
                     counter!(TC_FINISHED, "kind" => kind_str, "status" => TC_STATUS_FAILED)
                         .increment(1);
                     if should_shutdown_on_error {
-                        error!(kind = ?kind, name = ?task.name, "Shutting down: task {} panicked: {:?}", task_id, err);
+                        error!(kind = ?task.kind(), name = ?task.name(), "Shutting down: task {} panicked: {:?}", task_id, err);
                         request_node_shutdown = true;
                     } else {
-                        error!(kind = ?kind, name = ?task.name, "Task {} panicked: {:?}", task_id, err);
+                        error!(kind = ?task.kind(), name = ?task.name(), "Task {} panicked: {:?}", task_id, err);
                     }
                 }
             }
@@ -674,7 +746,7 @@ impl TaskCenter {
             // Note that the task itself has been already removed from the task map, so shutdown
             // will not wait for its completion.
             self.shutdown_node(
-                &format!("task {} failed and requested a shutdown", task.name),
+                &format!("task {} failed and requested a shutdown", task.name()),
                 EXIT_CODE_FAILURE,
             )
             .await;
@@ -696,90 +768,97 @@ struct TaskCenterInner {
     global_cancel_token: CancellationToken,
     shutdown_requested: AtomicBool,
     current_exit_code: AtomicI32,
-    tasks: Mutex<HashMap<TaskId, Arc<Task>>>,
+    managed_tasks: Mutex<HashMap<TaskId, Arc<Task>>>,
     global_metadata: OnceLock<Metadata>,
 }
 
-pub struct Task {
-    /// It's nice to have a unique ID for each task.
-    id: TaskId,
-    name: &'static str,
-    kind: TaskKind,
-    /// cancel this token to request cancelling this task.
-    cancel: CancellationToken,
+pub struct Task<R = ()> {
+    context: TaskContext,
+    handle: Mutex<Option<TaskHandle<R>>>,
+}
 
-    /// Tasks associated with a specific partition ID will have this set. This allows
-    /// for cancellation of tasks associated with that partition.
-    partition_id: Option<PartitionId>,
-    join_handle: Mutex<Option<JoinHandle<()>>>,
+impl<R> Task<R> {
+    fn id(&self) -> TaskId {
+        self.context.id
+    }
+
+    fn name(&self) -> &'static str {
+        self.context.name
+    }
+
+    fn kind(&self) -> TaskKind {
+        self.context.kind
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.context.partition_id
+    }
+
+    fn cancel(&self) {
+        self.context.cancellation_token.cancel()
+    }
 }
 
 task_local! {
-    // This is a cancellation token which will be cancelled when a task needs to shut down.
-    static CANCEL_TOKEN: CancellationToken;
-
-    // Tasks have self-reference.
-    static CURRENT_TASK: Arc<Task>;
+    // Tasks provide access to their context
+    static CONTEXT: TaskContext;
 
     // Current task center
     static CURRENT_TASK_CENTER: TaskCenter;
-
-    // Metadata handle
-    static METADATA: Option<Metadata>;
 }
 
 /// This wrapper function runs in a newly-spawned task. It initializes the
 /// task-local variables and calls the payload function.
-async fn wrapper<F>(
-    task_center: TaskCenter,
-    task_id: TaskId,
-    kind: TaskKind,
-    task: Arc<Task>,
-    cancel_token: CancellationToken,
-    metadata: Option<Metadata>,
-    future: F,
-) where
+async fn wrapper<F>(task_center: TaskCenter, context: TaskContext, future: F)
+where
     F: Future<Output = anyhow::Result<()>> + Send + 'static,
 {
-    trace!(kind = ?kind, name = ?task.name, "Starting task {}", task_id);
+    let id = context.id;
+    trace!(kind = ?context.kind, name = ?context.name, "Starting task {}", context.id);
 
     let result = CURRENT_TASK_CENTER
         .scope(
             task_center.clone(),
-            CANCEL_TOKEN.scope(
-                cancel_token,
-                CURRENT_TASK.scope(
-                    task,
-                    METADATA.scope(metadata, {
-                        // We use AssertUnwindSafe here so that the wrapped function
-                        // doesn't need to be UnwindSafe. We should not do anything after
-                        // unwinding that'd risk us being in unwind-unsafe behavior.
-                        AssertUnwindSafe(future).catch_unwind()
-                    }),
-                ),
-            ),
+            CONTEXT.scope(context, {
+                // We use AssertUnwindSafe here so that the wrapped function
+                // doesn't need to be UnwindSafe. We should not do anything after
+                // unwinding that'd risk us being in unwind-unsafe behavior.
+                AssertUnwindSafe(future).catch_unwind()
+            }),
         )
         .await;
-    task_center.on_finish(result, kind, task_id).await;
+    task_center.on_finish(id, result).await;
+}
+
+/// Like wrapper but doesn't call on_finish nor it catches panics
+async fn unmanaged_wrapper<F, T>(task_center: TaskCenter, context: TaskContext, future: F) -> T
+where
+    F: Future<Output = T> + Send + 'static,
+{
+    trace!(kind = ?context.kind, name = ?context.name, "Starting task {}", context.id);
+
+    CURRENT_TASK_CENTER
+        .scope(task_center.clone(), CONTEXT.scope(context, future))
+        .await
 }
 
 /// The current task-center task kind. This returns None if we are not in the scope
 /// of a task-center task.
 pub fn current_task_kind() -> Option<TaskKind> {
-    CURRENT_TASK.try_with(|ct| ct.kind).ok()
+    CONTEXT.try_with(|ctx| ctx.kind).ok()
 }
 
 /// The current task-center task Id. This returns None if we are not in the scope
 /// of a task-center task.
 pub fn current_task_id() -> Option<TaskId> {
-    CURRENT_TASK.try_with(|ct| ct.id).ok()
+    CONTEXT.try_with(|ctx| ctx.id).ok()
 }
 
 /// Access to global metadata handle. This is available in task-center tasks only!
 #[track_caller]
 pub fn metadata() -> Metadata {
-    METADATA
-        .try_with(|m| m.clone())
+    CONTEXT
+        .try_with(|ctx| ctx.metadata.clone())
         .expect("metadata() called outside task-center scope")
         .expect("metadata() called before global metadata was set")
 }
@@ -787,15 +866,15 @@ pub fn metadata() -> Metadata {
 /// Access to this node id. This is available in task-center tasks only!
 #[track_caller]
 pub fn my_node_id() -> GenerationalNodeId {
-    METADATA
-        .try_with(|m| m.as_ref().map(|m| m.my_node_id()))
+    CONTEXT
+        .try_with(|ctx| ctx.metadata.as_ref().map(|m| m.my_node_id()))
         .expect("my_node_id() called outside task-center scope")
         .expect("my_node_id() called before global metadata was set")
 }
 
 /// The current partition Id associated to the running task-center task.
 pub fn current_task_partition_id() -> Option<PartitionId> {
-    CURRENT_TASK.try_with(|ct| ct.partition_id).ok().flatten()
+    CONTEXT.try_with(|ctx| ctx.partition_id).ok().flatten()
 }
 
 /// Get the current task center. Use this to spawn tasks on the current task center.
@@ -819,7 +898,7 @@ pub async fn cancellation_watcher() {
 /// cancel_task() call, or if it's a child and the parent is being cancelled by a
 /// cancel_task() call, this cancellation token will be set to cancelled.
 pub fn cancellation_token() -> CancellationToken {
-    let res = CANCEL_TOKEN.try_with(|t| t.clone());
+    let res = CONTEXT.try_with(|ctx| ctx.cancellation_token.clone());
 
     if cfg!(any(test, feature = "test-util")) {
         // allow in tests to call from non-task-center tasks.
@@ -831,14 +910,14 @@ pub fn cancellation_token() -> CancellationToken {
 
 /// Has the current task been requested to cancel?
 pub fn is_cancellation_requested() -> bool {
-    if let Ok(cancel) = CANCEL_TOKEN.try_with(|t| t.clone()) {
-        cancel.is_cancelled()
-    } else {
-        if cfg!(any(test, feature = "test-util")) {
-            warn!("is_cancellation_requested() called in task-center task");
-        }
-        false
-    }
+    CONTEXT
+        .try_with(|ctx| ctx.cancellation_token.is_cancelled())
+        .unwrap_or_else(|_| {
+            if cfg!(any(test, feature = "test-util")) {
+                warn!("is_cancellation_requested() called outside task-center context");
+            }
+            false
+        })
 }
 
 #[cfg(test)]

--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -9,13 +9,15 @@ publish = false
 
 [features]
 default = []
+# temporary. This feature should be default (or removed) once log-server is enabled by default.
+replicated-loglet = ["restate-types/replicated-loglet"]
 options_schema = ["dep:schemars"]
 test-util = []
 
 [dependencies]
 restate-core = { workspace = true }
 restate-rocksdb = { workspace = true }
-restate-types = { workspace = true, features = ["replicated-loglet"] }
+restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = []
-replicated-loglet = ["restate-bifrost/replicated-loglet", "restate-log-server"]
+replicated-loglet = ["restate-bifrost/replicated-loglet", "dep:restate-log-server"]
 options_schema = [
     "dep:schemars",
     "restate-admin/options_schema",

--- a/crates/node/src/network_server/handler/mod.rs
+++ b/crates/node/src/network_server/handler/mod.rs
@@ -25,8 +25,6 @@ use crate::network_server::prometheus_helpers::{
 };
 use crate::network_server::state::NodeCtrlHandlerState;
 
-use super::prometheus_helpers::submit_tokio_metrics;
-
 const ROCKSDB_TICKERS: &[Ticker] = &[
     Ticker::BlockCacheBytesRead,
     Ticker::BlockCacheBytesWrite,
@@ -183,14 +181,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
     let mut out = String::new();
 
     // Default tokio runtime metrics
-    submit_tokio_metrics("default", state.task_center.default_runtime_metrics());
-    submit_tokio_metrics("ingress", state.task_center.ingress_runtime_metrics());
-
-    // Partition processor runtimes
-    let processor_runtimes = state.task_center.partition_processors_runtime_metrics();
-    for (task_name, metrics) in processor_runtimes {
-        submit_tokio_metrics(task_name, metrics);
-    }
+    state.task_center.submit_metrics();
 
     // Response content type is plain/text and that's expected.
     if let Some(prometheus_handle) = state.prometheus_handle {

--- a/crates/node/src/network_server/prometheus_helpers.rs
+++ b/crates/node/src/network_server/prometheus_helpers.rs
@@ -10,11 +10,9 @@
 
 use std::fmt::Write;
 
-use metrics::gauge;
 use metrics_exporter_prometheus::formatting;
 use restate_rocksdb::RocksDb;
 use rocksdb::statistics::{HistogramData, Ticker};
-use tokio::runtime::RuntimeMetrics;
 
 static PREFIX: &str = "restate";
 
@@ -168,36 +166,4 @@ pub fn format_rocksdb_histogram_for_prometheus(
         data.count(),
     );
     let _ = writeln!(out);
-}
-
-pub fn submit_tokio_metrics(runtime: &'static str, stats: RuntimeMetrics) {
-    gauge!("restate.tokio.num_workers", "runtime" => runtime).set(stats.num_workers() as f64);
-    gauge!("restate.tokio.blocking_threads", "runtime" => runtime)
-        .set(stats.num_blocking_threads() as f64);
-    gauge!("restate.tokio.blocking_queue_depth", "runtime" => runtime)
-        .set(stats.blocking_queue_depth() as f64);
-    gauge!("restate.tokio.num_alive_tasks", "runtime" => runtime)
-        .set(stats.num_alive_tasks() as f64);
-    gauge!("restate.tokio.io_driver_ready_count", "runtime" => runtime)
-        .set(stats.io_driver_ready_count() as f64);
-    gauge!("restate.tokio.remote_schedule_count", "runtime" => runtime)
-        .set(stats.remote_schedule_count() as f64);
-    // per worker stats
-    for idx in 0..stats.num_workers() {
-        gauge!("restate.tokio.worker_overflow_count", "runtime" => runtime, "worker" =>
-            idx.to_string())
-        .set(stats.worker_overflow_count(idx) as f64);
-        gauge!("restate.tokio.worker_poll_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_poll_count(idx) as f64);
-        gauge!("restate.tokio.worker_park_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_park_count(idx) as f64);
-        gauge!("restate.tokio.worker_noop_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_noop_count(idx) as f64);
-        gauge!("restate.tokio.worker_steal_count", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_steal_count(idx) as f64);
-        gauge!("restate.tokio.worker_total_busy_duration_seconds", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_total_busy_duration(idx).as_secs_f64());
-        gauge!("restate.tokio.worker_mean_poll_time", "runtime" => runtime, "worker" => idx.to_string())
-            .set(stats.worker_mean_poll_time(idx).as_secs_f64());
-    }
 }

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -500,6 +500,7 @@ where
     R: Send + 'static,
 {
     let mut task = std::pin::pin!(manager.async_spawn(task));
+    let mut timeout = std::pin::pin!(tokio::time::sleep(manager.stall_detection_duration()));
     let mut stalled = false;
     let mut stalled_since = Instant::now();
     loop {
@@ -514,7 +515,7 @@ where
                 }
                 return result;
             }
-            _ = tokio::time::sleep(manager.stall_detection_duration()), if !stalled => {
+            _ = &mut timeout, if !stalled => {
                 stalled = true;
                 stalled_since = Instant::now();
                 gauge!(ROCKSDB_STALL_FLARE).increment(1);

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -17,7 +17,7 @@ rt-tokio = ["dep:tokio"]
 restate-types = { workspace = true }
 
 arc-swap = { workspace = true }
-console-subscriber = { version = "0.3.0", optional = true }
+console-subscriber = { version = "0.4.0", optional = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 nu-ansi-term = "0.46.0"

--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -30,45 +30,45 @@ use super::LogFormat;
 pub struct CommonOptionCliOverride {
     /// Defines the roles which this Restate node should run, by default the node
     /// starts with all roles.
-    #[clap(long, alias = "role")]
-    roles: Option<Vec<Role>>,
+    #[clap(long, alias = "role", global = true)]
+    pub roles: Option<Vec<Role>>,
 
     /// Unique name for this node in the cluster. The node must not change unless
     /// it's started with empty local store. It defaults to the node hostname.
-    #[clap(long, env = "RESTATE_NODE_NAME")]
-    node_name: Option<String>,
+    #[clap(long, env = "RESTATE_NODE_NAME", global = true)]
+    pub node_name: Option<String>,
 
     /// If set, the node insists on acquiring this node ID.
-    #[clap(long)]
-    force_node_id: Option<PlainNodeId>,
+    #[clap(long, global = true)]
+    pub force_node_id: Option<PlainNodeId>,
 
     /// A unique identifier for the cluster. All nodes in the same cluster should
     /// have the same.
-    #[clap(long, env = "RESTATE_CLUSTER_NAME")]
-    cluster_name: Option<String>,
+    #[clap(long, env = "RESTATE_CLUSTER_NAME", global = true)]
+    pub cluster_name: Option<String>,
 
     /// If true, then a new cluster is bootstrapped. This node *must* have an admin
     /// role and a new nodes configuration will be created that includes this node.
-    #[clap(long)]
-    allow_bootstrap: Option<bool>,
+    #[clap(long, global = true)]
+    pub allow_bootstrap: Option<bool>,
 
     /// The working directory which this Restate node should use for relative paths. The default is
     /// `restate-data` under the current working directory.
-    #[clap(long)]
-    base_dir: Option<PathBuf>,
+    #[clap(long, global = true)]
+    pub base_dir: Option<PathBuf>,
 
     /// Address of the metadata store server to bootstrap the node from.
-    #[clap(long)]
-    metadata_store_address: Option<AdvertisedAddress>,
+    #[clap(long, global = true)]
+    pub metadata_store_address: Option<AdvertisedAddress>,
 
     /// Address to bind for the Node server. e.g. `0.0.0.0:5122`
-    #[clap(long)]
-    bind_address: Option<BindAddress>,
+    #[clap(long, global = true)]
+    pub bind_address: Option<BindAddress>,
 
     /// Address that other nodes will use to connect to this node. Defaults to use bind_address if
     /// unset. e.g. `http://127.0.0.1:5122/`
-    #[clap(long)]
-    advertise_address: Option<AdvertisedAddress>,
+    #[clap(long, global = true)]
+    pub advertise_address: Option<AdvertisedAddress>,
 
     /// # Partitions
     ///
@@ -79,21 +79,21 @@ pub struct CommonOptionCliOverride {
     /// value of this entry is ignored for bootstrapped nodes/clusters.
     ///
     /// Cannot be higher than `4611686018427387903` (You should almost never need as many partitions anyway)
-    #[clap(long)]
-    bootstrap_num_partitions: Option<NonZeroU64>,
+    #[clap(long, global = true)]
+    pub bootstrap_num_partitions: Option<NonZeroU64>,
 
     /// This timeout is used when shutting down the various Restate components to drain all the internal queues.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    #[clap(long)]
-    shutdown_timeout: Option<Duration>,
+    #[clap(long, global = true)]
+    pub shutdown_timeout: Option<Duration>,
 
     /// # Tracing Endpoint
     ///
     /// Specify the tracing endpoint to send traces to.
     /// Traces will be exported using [OTLP gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc)
     /// through [opentelemetry_otlp](https://docs.rs/opentelemetry-otlp/0.12.0/opentelemetry_otlp/).
-    #[clap(long, env = "RESTATE_TRACING_ENDPOINT")]
-    tracing_endpoint: Option<String>,
+    #[clap(long, env = "RESTATE_TRACING_ENDPOINT", global = true)]
+    pub tracing_endpoint: Option<String>,
 
     /// # Distributed Tracing JSON Export Path
     ///
@@ -105,32 +105,32 @@ pub struct CommonOptionCliOverride {
     /// It can be used to export traces in a structured format without configuring a Jaeger agent.
     ///
     /// To inspect the traces, open the Jaeger UI and use the Upload JSON feature to load and inspect them.
-    #[clap(long)]
-    tracing_json_path: Option<PathBuf>,
+    #[clap(long, global = true)]
+    pub tracing_json_path: Option<PathBuf>,
 
     /// # Tracing Filter
     ///
     /// Distributed tracing exporter filter.
     /// Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
-    #[clap(long)]
-    tracing_filter: Option<String>,
+    #[clap(long, global = true)]
+    pub tracing_filter: Option<String>,
 
     /// # Logging Filter
     ///
     /// Log filter configuration. Can be overridden by the `RUST_LOG` environment variable.
     /// Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
-    #[clap(long)]
-    log_filter: Option<String>,
+    #[clap(long, global = true)]
+    pub log_filter: Option<String>,
 
     /// # Logging format
     ///
     /// Format to use when logging.
-    #[clap(long)]
-    log_format: Option<LogFormat>,
+    #[clap(long, global = true)]
+    pub log_format: Option<LogFormat>,
 
     /// # Disable ANSI in log output
     ///
     /// Disable ANSI terminal codes for logs. This is useful when the log collector doesn't support processing ANSI terminal codes.
-    #[clap(long)]
-    log_disable_ansi_codes: Option<bool>,
+    #[clap(long, global = true)]
+    pub log_disable_ansi_codes: Option<bool>,
 }

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -254,7 +254,7 @@ impl<T: StorageEncode> WithKeys for T {
 /// or without implementing [`restate_bifrost::HasRecordKeys`] on your message type.
 ///
 /// When reading these records, you must directly decode with the inner type T.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BodyWithKeys<T> {
     inner: T,
     keys: Keys,

--- a/tools/bifrost-benchpress/Cargo.toml
+++ b/tools/bifrost-benchpress/Cargo.toml
@@ -7,6 +7,17 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = []
+console = [
+    "tokio/full",
+    "tokio/tracing",
+    "restate-tracing-instrumentation/console-subscriber",
+]
+io-uring = [
+    "rocksdb/io-uring"
+]
+
 [dependencies]
 restate-bifrost = { workspace = true, features = ["test-util"] }
 restate-core = { workspace = true, features = ["test-util"] }
@@ -15,7 +26,7 @@ restate-metadata-store = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-server = { workspace = true }
 restate-test-util = { workspace = true }
-restate-tracing-instrumentation = { workspace = true, features = ["console-subscriber"] }
+restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
 restate-types = { workspace = true, features = ["test-util"] }
 
 anyhow = { workspace = true }
@@ -30,6 +41,7 @@ metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 once_cell = { workspace = true }
 quanta = { version = "0.12.3" }
+rlimit = { workspace = true }
 rocksdb = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/bifrost-benchpress/src/lib.rs
+++ b/tools/bifrost-benchpress/src/lib.rs
@@ -28,17 +28,18 @@ pub struct Arguments {
         short,
         long = "config-file",
         env = "RESTATE_CONFIG",
-        value_name = "FILE"
+        value_name = "FILE",
+        global = true
     )]
     pub config_file: Option<PathBuf>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub no_prometheus_stats: bool,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub no_rocksdb_stats: bool,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub retain_test_dir: bool,
 
     #[clap(flatten)]

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -27,7 +27,9 @@ use restate_metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
 use restate_server::config_loader::ConfigLoaderBuilder;
 use restate_tracing_instrumentation::init_tracing_and_logging;
-use restate_types::config::{reset_base_temp_dir, reset_base_temp_dir_and_retain, Configuration};
+use restate_types::config::{
+    reset_base_temp_dir, reset_base_temp_dir_and_retain, set_base_temp_dir, Configuration,
+};
 use restate_types::live::Live;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 
@@ -41,11 +43,19 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 fn main() -> anyhow::Result<()> {
     let cli_args = Arguments::parse();
-    let tmp_base = if cli_args.retain_test_dir {
+    // base-dir is set by CLI overrides, let's make sure we use it.
+    let base_dir = if let Some(base_dir) = &cli_args.opts_overrides.base_dir {
+        set_base_temp_dir(base_dir.clone());
+        base_dir.clone()
+    } else if cli_args.retain_test_dir {
         reset_base_temp_dir_and_retain()
     } else {
         reset_base_temp_dir()
     };
+
+    if rlimit::increase_nofile_limit(u64::MAX).is_err() {
+        eprintln!("WARN: Failed to increase the number of open file descriptors limit.");
+    }
 
     // We capture the absolute path of the config file on startup before we change the current
     // working directory (base-dir arg)
@@ -74,7 +84,7 @@ fn main() -> anyhow::Result<()> {
 
     // just in case anything reads directly the base dir and it's not set correctly for any random
     // reason.
-    config.common.set_base_dir(tmp_base.clone());
+    config.common.set_base_dir(base_dir.clone());
 
     restate_types::config::set_current_config(config.clone());
 
@@ -94,9 +104,13 @@ fn main() -> anyhow::Result<()> {
                 append_latency::run(&args, opts, task_center.clone(), bifrost).await?;
             }
         }
+        // record tokio's runtime metrics
+        task_center.submit_metrics();
+
         task_center.shutdown_node("completed", 0).await;
         // print prometheus if asked.
         if !args.no_prometheus_stats {
+            // submit tokio metris
             print_prometheus_stats(&recorder);
         }
 
@@ -119,10 +133,10 @@ fn main() -> anyhow::Result<()> {
         anyhow::Ok(())
     })?;
 
-    if cli_args.retain_test_dir {
-        println!("Keeping the base_dir in {}", tmp_base.display());
+    if cli_args.opts_overrides.base_dir.is_some() || cli_args.retain_test_dir {
+        println!("Keeping the base_dir in {}", base_dir.display());
     } else {
-        println!("Removing test dir at {}", tmp_base.display());
+        println!("Removing test dir at {}", base_dir.display());
     }
 
     Ok(())

--- a/tools/bifrost-benchpress/src/util.rs
+++ b/tools/bifrost-benchpress/src/util.rs
@@ -14,6 +14,15 @@ use std::time::Duration;
 use hdrhistogram::Histogram;
 use metrics_exporter_prometheus::PrometheusHandle;
 use restate_rocksdb::{DbName, RocksDbManager};
+use restate_types::flexbuffers_storage_encode_decode;
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct DummyPayload {
+    pub precise_ts: u64,
+    pub blob: bytes::Bytes,
+}
+
+flexbuffers_storage_encode_decode!(DummyPayload);
 
 pub fn print_latencies(title: &str, histogram: Histogram<u64>) {
     let mut stdout = std::io::stdout().lock();
@@ -37,6 +46,11 @@ pub fn print_latencies(title: &str, histogram: Histogram<u64>) {
         &mut stdout,
         "P999: {:?}",
         Duration::from_nanos(histogram.value_at_percentile(99.9))
+    );
+    let _ = writeln!(
+        &mut stdout,
+        "P9999: {:?}",
+        Duration::from_nanos(histogram.value_at_percentile(99.99))
     );
     let _ = writeln!(
         &mut stdout,

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -8,108 +8,142 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
+use anyhow::Result;
+use bytes::BytesMut;
 use futures::StreamExt;
 use hdrhistogram::Histogram;
 use tracing::info;
 
-use restate_bifrost::LogEntry;
-use restate_bifrost::{Bifrost, Error as BifrostError};
-use restate_core::{cancellation_watcher, TaskCenter, TaskKind};
+use restate_bifrost::Bifrost;
+use restate_core::{TaskCenter, TaskHandle, TaskKind};
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, WithKeys};
 
-use crate::util::print_latencies;
+use crate::util::{print_latencies, DummyPayload};
 use crate::Arguments;
 
+const LOG_ID: LogId = LogId::new(0);
+
 #[derive(Debug, Clone, clap::Parser)]
-pub struct WriteToReadOpts {}
+pub struct WriteToReadOpts {
+    /// Maximum number of records to be written to bifrost loglet on every append attempt.
+    #[clap(long, default_value = "2000")]
+    max_batch_size: usize,
+
+    /// Number of records that can be buffered in background appender before back-pressure kicks
+    /// in.
+    #[clap(long, default_value = "5000")]
+    write_buffer_size: usize,
+
+    /// The number of records to write during this test
+    #[clap(long, default_value = "400000")]
+    num_records: usize,
+
+    /// The payload size of each record in bytes. Default is 500 bytes
+    #[clap(long, default_value = "500")]
+    payload_size: usize,
+}
 
 pub async fn run(
     _common_args: &Arguments,
-    _args: &WriteToReadOpts,
+    args: &WriteToReadOpts,
     tc: TaskCenter,
     bifrost: Bifrost,
-) -> anyhow::Result<()> {
-    let log_id = LogId::from(0);
+) -> Result<()> {
     let clock = quanta::Clock::new();
     // Create two tasks, one that writes to the log continously and another one that reads from the
     // log and measures the latency. Collect latencies in a histogram and print the histogram
     // before the test ends.
-    let reader_task = tc.spawn(TaskKind::TestRunner, "test-log-reader", None, {
-        let bifrost = bifrost.clone();
-        let clock = clock.clone();
-        async move {
-            let mut read_stream =
-                bifrost.create_reader(log_id, KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)?;
-            let mut counter = 0;
-            let mut cancel = std::pin::pin!(cancellation_watcher());
-            let mut lag_latencies = Histogram::<u64>::new(3)?;
-            let mut on_record = |record: Result<LogEntry, BifrostError>| {
-                if let Ok(record) = record {
-                    let data = record.try_decode::<String>().expect("data record")?;
-                    let latency_raw: u64 = data.parse()?;
-                    let latency = clock.scaled(latency_raw).elapsed();
-                    lag_latencies.record(latency.as_nanos() as u64)?;
-                } else {
-                    panic!("Unexpected error");
-                }
-                anyhow::Ok(())
-            };
-            loop {
-                counter += 1;
-                tokio::select! {
-                    _ = &mut cancel =>  {
-                        // test is over. print histogram
-                        info!("Reader stopping");
-                        break;
-                    }
-                    record = read_stream.next() => {
-                        let record = record.expect("stream will not terminate");
-                        on_record(record)?;
-                    }
-                }
-                if counter % 1000 == 0 {
-                    info!("Read {} records", counter);
-                }
-            }
-
-            println!("Total records read: {}", counter);
-            print_latencies("read lag", lag_latencies);
-            Ok(())
-        }
-    })?;
-
-    let writer_task = tc.spawn(TaskKind::TestRunner, "test-log-appender", None, {
-        let bifrost = bifrost.clone();
-        let clock = clock.clone();
-        async move {
-            let mut append_latencies = Histogram::<u64>::new(3)?;
-            let mut counter = 0;
-            let mut appender = bifrost.create_appender(log_id)?;
-            loop {
-                counter += 1;
+    let reader_task: TaskHandle<Result<_>> =
+        tc.spawn_unmanaged(TaskKind::PartitionProcessor, "test-log-reader", None, {
+            let clock = clock.clone();
+            let args = args.clone();
+            let bifrost = bifrost.clone();
+            async move {
+                let mut read_stream =
+                    bifrost.create_reader(LOG_ID, KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)?;
+                let mut read_latency = Histogram::<u64>::new(3)?;
                 let start = Instant::now();
-                let data = clock.raw().to_string().with_no_keys();
-                if appender.append(data).await.is_err() {
-                    println!("Total records written: {}", counter);
-                    print_latencies("append latency", append_latencies);
-                    break;
-                };
+                for counter in 1..=args.num_records {
+                    let record = read_stream.next().await.expect("stream will not terminate");
+                    if let Ok(record) = record {
+                        let data = record.try_decode::<DummyPayload>().expect("data record")?;
+                        let latency = clock.scaled(data.precise_ts).elapsed();
+                        read_latency.record(latency.as_nanos() as u64)?;
+                    } else {
+                        panic!("Unexpected error");
+                    }
 
-                append_latencies.record(start.elapsed().as_nanos() as u64)?;
-                if counter % 1000 == 0 {
-                    info!("Appended {} records", counter);
+                    if counter % 10000 == 0 {
+                        info!("Read {} records", counter);
+                    }
                 }
+                let total_time = start.elapsed();
+                info!(
+                    "Reader stopped. Total time: {:?}. Read throughput: {} ops/s",
+                    total_time,
+                    args.num_records as f64 / total_time.as_secs_f64(),
+                );
+                Ok(read_latency)
             }
-            anyhow::Ok(())
-        }
-    })?;
+        })?;
 
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    let writer_task: TaskHandle<Result<_>> =
+        tc.spawn_unmanaged(TaskKind::PartitionProcessor, "test-log-appender", None, {
+            let clock = clock.clone();
+            let bifrost = bifrost.clone();
+            let tc = tc.clone();
+            let args = args.clone();
+            let blob = BytesMut::zeroed(args.payload_size).freeze();
+            async move {
+                let mut append_latency = Histogram::<u64>::new(3)?;
+                let appender_handle = bifrost
+                    .create_background_appender(
+                        LOG_ID,
+                        args.write_buffer_size,
+                        args.max_batch_size,
+                    )?
+                    .start(tc, "writer", None)?;
+                let sender = appender_handle.sender();
+                let start = Instant::now();
+                for counter in 1..=args.num_records {
+                    let start = Instant::now();
+                    let record = DummyPayload {
+                        precise_ts: clock.raw(),
+                        blob: blob.clone(),
+                    };
+                    sender.enqueue(record.with_no_keys()).await.unwrap();
+                    append_latency.record(start.elapsed().as_nanos() as u64)?;
+                    if counter % 10000 == 0 {
+                        info!("Appended {} records", counter);
+                    }
+                }
+                info!("Appender waiting for drain");
+                appender_handle.drain().await?;
 
-    tc.cancel_task(reader_task).unwrap().await?;
-    info!("Reader stopped");
-    let _ = tc.cancel_task(writer_task);
+                let total_time = start.elapsed();
+                println!(
+                    "Total records written: {}. Total time: {:?}, append throughput: {} ops/s",
+                    args.num_records,
+                    total_time,
+                    args.num_records as f64 / total_time.as_secs_f64(),
+                );
+                Ok(append_latency)
+            }
+        })?;
+
+    let (append_latency, read_latency) = tokio::join!(writer_task, reader_task);
+    let (append_latency, read_latency) = (append_latency??, read_latency??);
+
+    println!(
+        "Log Chain: {:#?}",
+        tc.metadata().unwrap().logs().chain(&LOG_ID).unwrap()
+    );
+    println!("Payload size per record: {} bytes", args.payload_size);
+    println!();
+    print_latencies("append latency", append_latency);
+    print_latencies("write-to-read latency", read_latency);
+    tc.shutdown_node("completed", 0).await;
     Ok(())
 }


### PR DESCRIPTION
[Bifrost] Let loglet API support pipelining natively

This refactors the loglet API to provide first-level pipelining facility. At this stage, this is not used to its full potential since all loglets will still block on every enqueue call before returning the new `Commit` future.

This also removes unnecessary implementation in Appender and proxies everything all the way down to this single loglet call (enqueue_batch)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1862).
* #1868
* #1867
* #1864
* #1863
* __->__ #1862
* #1861
* #1856
* #1855
* #1850