### PR TITLE
Minor tweaks for perf purposes

### DIFF
--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -77,6 +77,7 @@ pub enum TaskKind {
     IngressServer,
     RoleRunner,
     SystemService,
+    #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     Ingress,
     PartitionProcessor,
     #[strum(props(OnError = "log"))]

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -28,8 +28,12 @@ use super::leadership::ActionEffect;
 
 // Constants since it's very unlikely that we can derive a meaningful configuration
 // that the user can reason about.
-const BIFROST_QUEUE_SIZE: usize = 1000;
-const MAX_BIFROST_APPEND_BATCH: usize = 100;
+//
+// The queue size is small to reduce the tail latency. This comes at the cost of throughput but
+// this runs within a single processor and the expected throughput is bound by the overall
+// throughput of the processor itself.
+const BIFROST_QUEUE_SIZE: usize = 20;
+const MAX_BIFROST_APPEND_BATCH: usize = 5000;
 
 /// Responsible for proposing [ActionEffect].
 pub(super) struct ActionEffectHandler {

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -399,6 +399,9 @@ where
                     self.leadership_state.handle_action_effect(action_effects).await?;
                 },
             }
+            // Allow other tasks on this thread to run, but only if we have exhausted the coop
+            // budget.
+            tokio::task::consume_budget().await;
         }
 
         debug!(restate.node = %metadata().my_node_id(), %self.partition_id, "Shutting partition processor down.");

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -78,6 +78,7 @@ pub async fn run(
                     if counter % 10000 == 0 {
                         info!("Read {} records", counter);
                     }
+                    tokio::task::consume_budget().await
                 }
                 let total_time = start.elapsed();
                 info!(
@@ -118,6 +119,7 @@ pub async fn run(
                     if counter % 10000 == 0 {
                         info!("Appended {} records", counter);
                     }
+                    tokio::task::consume_budget().await
                 }
                 info!("Appender waiting for drain");
                 appender_handle.drain().await?;


### PR DESCRIPTION
Minor tweaks for perf purposes

- Reduce background appender buffering window to limit tail latency
- Makes sure we run ingress requests on ingress runtime

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1863).
* #1875
* #1864
* __->__ #1863