### PR TITLE
Control memory-loglet with dedicated feature flag

### DIFF
--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -10,7 +10,8 @@ publish = false
 [features]
 default = []
 replicated-loglet = ["restate-types/replicated-loglet"]
-test-util = []
+memory-loglet = ["restate-types/memory-loglet"]
+test-util = ["memory-loglet"]
 
 [dependencies]
 restate-core = { workspace = true }

--- a/crates/bifrost/src/providers/mod.rs
+++ b/crates/bifrost/src/providers/mod.rs
@@ -10,7 +10,7 @@
 
 pub mod local_loglet;
 
-#[cfg(any(test, feature = "test-util"))]
+#[cfg(any(test, feature = "memory-loglet"))]
 pub mod memory_loglet;
 #[cfg(feature = "replicated-loglet")]
 pub mod replicated_loglet;

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -22,7 +22,7 @@ use restate_types::logs::metadata::ProviderKind;
 
 use crate::bifrost::BifrostInner;
 use crate::providers::local_loglet;
-#[cfg(any(test, feature = "test-util"))]
+#[cfg(any(test, feature = "memory-loglet"))]
 use crate::providers::memory_loglet;
 use crate::watchdog::{Watchdog, WatchdogCommand};
 use crate::{loglet::LogletProviderFactory, Bifrost};
@@ -60,7 +60,7 @@ impl BifrostService {
         self
     }
 
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "memory-loglet"))]
     pub fn enable_in_memory_loglet(mut self) -> Self {
         let factory = memory_loglet::Factory::default();
         self.factories.insert(factory.kind(), Box::new(factory));

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -77,6 +77,7 @@ pub enum TaskKind {
     IngressServer,
     RoleRunner,
     SystemService,
+    #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     Ingress,
     PartitionProcessor,
     #[strum(props(OnError = "log"))]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [features]
 default = []
 replicated-loglet = ["restate-bifrost/replicated-loglet", "dep:restate-log-server"]
+memory-loglet = ["restate-bifrost/memory-loglet"]
 options_schema = [
     "dep:schemars",
     "restate-admin/options_schema",

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -182,6 +182,10 @@ impl Node {
         );
         let bifrost_svc = BifrostService::new(tc.clone(), metadata.clone())
             .enable_local_loglet(&updateable_config);
+
+        #[cfg(feature = "memory-loglet")]
+        let bifrost_svc = bifrost_svc.enable_in_memory_loglet();
+
         #[cfg(feature = "replicated-loglet")]
         let bifrost_svc = bifrost_svc.with_factory(replicated_loglet_factory);
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -11,8 +11,9 @@ publish = false
 default = []
 
 replicated-loglet = []
+memory-loglet = []
 schemars = ["dep:schemars", "restate-serde-util/schema"]
-test-util = ["dep:tempfile", "dep:restate-test-util"]
+test-util = ["memory-loglet", "dep:tempfile", "dep:restate-test-util"]
 
 [dependencies]
 restate-base64-util = { workspace = true }

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -144,7 +144,7 @@ pub enum ProviderKind {
     /// A local rocksdb-backed loglet.
     Local,
     /// An in-memory loglet, primarily for testing.
-    #[cfg(any(test, feature = "test-util"))]
+    #[cfg(any(test, feature = "memory-loglet"))]
     InMemory,
     #[cfg(feature = "replicated-loglet")]
     /// [IN DEVELOPMENT]
@@ -335,7 +335,7 @@ pub fn new_single_node_loglet_params(default_provider: ProviderKind) -> LogletPa
     let loglet_id = rand::thread_rng().next_u64().to_string();
     match default_provider {
         ProviderKind::Local => LogletParams::from(loglet_id),
-        #[cfg(any(test, feature = "test-util"))]
+        #[cfg(any(test, feature = "memory-loglet"))]
         ProviderKind::InMemory => LogletParams::from(loglet_id),
         #[cfg(feature = "replicated-loglet")]
         ProviderKind::Replicated => panic!(

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -28,8 +28,12 @@ use super::leadership::ActionEffect;
 
 // Constants since it's very unlikely that we can derive a meaningful configuration
 // that the user can reason about.
-const BIFROST_QUEUE_SIZE: usize = 1000;
-const MAX_BIFROST_APPEND_BATCH: usize = 100;
+//
+// The queue size is small to reduce the tail latency. This comes at the cost of throughput but
+// this runs within a single processor and the expected throughput is bound by the overall
+// throughput of the processor itself.
+const BIFROST_QUEUE_SIZE: usize = 20;
+const MAX_BIFROST_APPEND_BATCH: usize = 5000;
 
 /// Responsible for proposing [ActionEffect].
 pub(super) struct ActionEffectHandler {

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -399,6 +399,9 @@ where
                     self.leadership_state.handle_action_effect(action_effects).await?;
                 },
             }
+            // Allow other tasks on this thread to run, but only if we have exhausted the coop
+            // budget.
+            tokio::task::consume_budget().await;
         }
 
         debug!(restate.node = %metadata().my_node_id(), %self.partition_id, "Shutting partition processor down.");

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,9 +26,8 @@ options_schema = [
     "restate-tracing-instrumentation/options_schema",
     "restate-types/schemars",
 ]
-replicated-loglet = [
-    "restate-node/replicated-loglet",
-]
+replicated-loglet =  ["restate-node/replicated-loglet"]
+memory-loglet = ["restate-node/memory-loglet"]
 
 [dependencies]
 restate-admin = { workspace = true }

--- a/tools/bifrost-benchpress/Cargo.toml
+++ b/tools/bifrost-benchpress/Cargo.toml
@@ -17,6 +17,7 @@ console = [
 io-uring = [
     "rocksdb/io-uring"
 ]
+memory-loglet = ["restate-bifrost/memory-loglet"]
 
 [dependencies]
 restate-bifrost = { workspace = true, features = ["test-util"] }

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -78,6 +78,7 @@ pub async fn run(
                     if counter % 10000 == 0 {
                         info!("Read {} records", counter);
                     }
+                    tokio::task::consume_budget().await
                 }
                 let total_time = start.elapsed();
                 info!(
@@ -118,6 +119,7 @@ pub async fn run(
                     if counter % 10000 == 0 {
                         info!("Appended {} records", counter);
                     }
+                    tokio::task::consume_budget().await
                 }
                 info!("Appender waiting for drain");
                 appender_handle.drain().await?;


### PR DESCRIPTION
Control memory-loglet with dedicated feature flag

This allows us to use memory-loglet in performance testing without enabling test mode

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1864).
* #1875
* __->__ #1864
* #1863