### PR TITLE
[Bifrost] LogletOffset is now u32

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -11,7 +11,7 @@
 #![allow(clippy::async_yields_async)]
 
 //! Utilities for benchmarking the Restate runtime
-use std::num::NonZeroU64;
+use std::num::NonZeroU16;
 use std::time::Duration;
 
 use futures_util::{future, TryFutureExt};
@@ -127,7 +127,7 @@ pub fn flamegraph_options<'a>() -> Options<'a> {
 pub fn restate_configuration() -> Configuration {
     let common_options = CommonOptionsBuilder::default()
         .base_dir(tempfile::tempdir().expect("tempdir failed").into_path())
-        .bootstrap_num_partitions(NonZeroU64::new(10).unwrap())
+        .bootstrap_num_partitions(NonZeroU16::new(10).unwrap())
         .build()
         .expect("building common options should work");
 

--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -47,7 +47,7 @@ enum TailState {
 }
 
 message DescribeLogRequest {
-  uint64 log_id = 1;
+  uint32 log_id = 1;
 }
 
 message DescribeLogResponse {
@@ -65,6 +65,6 @@ message ListNodesResponse {
 }
 
 message TrimLogRequest {
-  uint64 log_id = 1;
+  uint32 log_id = 1;
   uint64 trim_point = 2;
 }

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -900,7 +900,7 @@ mod tests {
 
     fn random_cluster_state(
         node_ids: &Vec<GenerationalNodeId>,
-        num_partitions: u64,
+        num_partitions: u16,
     ) -> ClusterState {
         let nodes = random_nodes_state(node_ids, num_partitions);
 
@@ -915,7 +915,7 @@ mod tests {
 
     fn random_nodes_state(
         node_ids: &Vec<GenerationalNodeId>,
-        num_partitions: u64,
+        num_partitions: u16,
     ) -> BTreeMap<PlainNodeId, NodeState> {
         let mut result = BTreeMap::default();
         let mut rng = rand::thread_rng();
@@ -949,7 +949,7 @@ mod tests {
     fn random_alive_node(
         rng: &mut ThreadRng,
         node_id: GenerationalNodeId,
-        num_partitions: u64,
+        num_partitions: u16,
     ) -> AliveNode {
         let partitions = random_partition_status(rng, num_partitions);
         AliveNode {
@@ -961,7 +961,7 @@ mod tests {
 
     fn random_partition_status(
         rng: &mut ThreadRng,
-        num_partitions: u64,
+        num_partitions: u16,
     ) -> BTreeMap<PartitionId, PartitionProcessorStatus> {
         let mut result = BTreeMap::default();
 

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 
 pub async fn spawn_environment(
     config: Configuration,
-    num_logs: u64,
+    num_logs: u16,
     provider: ProviderKind,
 ) -> TaskCenter {
     if rlimit::increase_nofile_limit(u64::MAX).is_err() {

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -558,7 +558,7 @@ mod tests {
 
             // Ensure original clone writes to the same underlying loglet.
             let lsn = clean_bifrost_clone
-                .create_appender(LogId::from(0))?
+                .create_appender(LogId::new(0))?
                 .append("")
                 .await?;
             assert_eq!(max_lsn + Lsn::from(1), lsn);
@@ -573,7 +573,7 @@ mod tests {
             max_lsn = lsn;
 
             let tail = bifrost
-                .find_tail(LogId::from(0), FindTailAttributes::default())
+                .find_tail(LogId::new(0), FindTailAttributes::default())
                 .await?;
             assert_eq!(max_lsn.next(), tail.offset());
 
@@ -602,7 +602,7 @@ mod tests {
             let bifrost = Bifrost::init_with_factory(metadata(), factory).await;
 
             let start = tokio::time::Instant::now();
-            let lsn = bifrost.create_appender(LogId::from(0))?.append("").await?;
+            let lsn = bifrost.create_appender(LogId::new(0))?.append("").await?;
             assert_eq!(Lsn::from(1), lsn);
             // The append was properly delayed
             assert_eq!(delay, start.elapsed());

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -24,7 +24,7 @@ use tokio_stream::StreamExt;
 use tracing::info;
 
 use super::{Loglet, LogletOffset};
-use crate::loglet::{AppendError, LogletReadStream};
+use crate::loglet::AppendError;
 use crate::loglet_wrapper::LogletWrapper;
 use crate::{setup_panic_handler, TailState};
 

--- a/crates/bifrost/src/providers/local_loglet/keys.rs
+++ b/crates/bifrost/src/providers/local_loglet/keys.rs
@@ -49,6 +49,8 @@ impl RecordKey {
         buf.reserve(Self::serialized_size());
         buf.put_u8(b'd');
         buf.put_u64(self.loglet_id);
+        // despite offset being 32bit, for backward compatibility and future-proofing, we keep the
+        // storage layer as u64 but we assert that the actual value fits u32 on read.
         buf.put_u64(self.offset.into());
     }
 
@@ -57,7 +59,8 @@ impl RecordKey {
         let c = data.get_u8();
         debug_assert_eq!(c, b'd');
         let loglet_id = data.get_u64();
-        let offset = LogletOffset::from(data.get_u64());
+        let offset =
+            LogletOffset::new(u32::try_from(data.get_u64()).expect("offset must fit within u32"));
         Self { loglet_id, offset }
     }
 }

--- a/crates/bifrost/src/providers/local_loglet/log_state.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_state.rs
@@ -35,8 +35,8 @@ pub struct LogStateUpdates {
 /// Represents a single update to the log state.
 #[derive(Debug, Serialize, Deserialize)]
 enum LogStateUpdate {
-    ReleasePointer(u64),
-    TrimPoint(u64),
+    ReleasePointer(u32),
+    TrimPoint(u32),
     Seal,
 }
 
@@ -131,8 +131,8 @@ flexbuffers_storage_encode_decode!(LogStateUpdates);
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct LogState {
-    pub release_pointer: u64,
-    pub trim_point: u64,
+    pub release_pointer: u32,
+    pub trim_point: u32,
     pub seal: bool,
 }
 

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -325,7 +325,9 @@ impl RocksDbLogWriterHandle {
         payloads: Arc<[ErasedInputRecord]>,
     ) -> Result<AckRecv, ShutdownError> {
         let (ack, receiver) = oneshot::channel();
-        let last_offset_in_batch = (start_offset + payloads.len()).prev();
+        // Do not allow more than 65k records in a single batch!
+        assert!(payloads.len() <= u16::MAX as usize);
+        let last_offset_in_batch = (start_offset + payloads.len() as u32).prev();
         let data_update = DataUpdate::PutRecords {
             first_offset: start_offset,
             payloads,

--- a/crates/bifrost/src/providers/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/providers/local_loglet/read_stream.rs
@@ -31,7 +31,7 @@ use super::keys::RecordKey;
 use super::LocalLoglet;
 
 pub(crate) struct LocalLogletReadStream {
-    log_id: u64,
+    loglet_id: u64,
     filter: KeyFilter,
     /// Buffer for serialization
     serde_buffer: BytesMut,
@@ -113,7 +113,7 @@ impl LocalLogletReadStream {
         };
 
         Ok(Self {
-            log_id: loglet.loglet_id,
+            loglet_id: loglet.loglet_id,
             filter,
             serde_buffer,
             loglet,
@@ -127,7 +127,7 @@ impl LocalLogletReadStream {
     }
 }
 
-impl LogletReadStream<LogletOffset> for LocalLogletReadStream {
+impl LogletReadStream for LocalLogletReadStream {
     /// Current read pointer. This points to the next offset to be read.
     fn read_pointer(&self) -> LogletOffset {
         self.read_pointer
@@ -200,14 +200,14 @@ impl Stream for LocalLogletReadStream {
                 let trim_gap = LogEntry::new_trim_gap(self.read_pointer, trim_point);
                 // next record should be beyond at the head
                 self.read_pointer = head_offset;
-                let key = RecordKey::new(self.log_id, trim_point);
+                let key = RecordKey::new(self.loglet_id, trim_point);
                 // park the iterator at the trim point, next iteration will seek it forward.
                 let key_bytes = key.encode_and_split(&mut self.serde_buffer);
                 self.iterator.seek(key_bytes);
                 return Poll::Ready(Some(Ok(trim_gap)));
             }
 
-            let key = RecordKey::new(self.log_id, self.read_pointer);
+            let key = RecordKey::new(self.loglet_id, self.read_pointer);
             if self.iterator.valid() {
                 // can move to next.
                 self.iterator.next();
@@ -232,7 +232,7 @@ impl Stream for LocalLogletReadStream {
                 // We have a bug! we shouldn't be in this location where the record
                 // doesn't exist but we expect it to!
                 error!(
-                    log_id = self.log_id,
+                    loglet_id = self.loglet_id,
                     read_pointer = %self.read_pointer,
                     trim_point = %potentially_different_trim_point,
                     last_known_tail = %self.last_known_tail,
@@ -246,9 +246,9 @@ impl Stream for LocalLogletReadStream {
             debug_assert_eq!(loaded_key.offset, key.offset);
 
             // Defensive, the upper_bound set on the iterator should prevent this.
-            if loaded_key.loglet_id != self.log_id {
+            if loaded_key.loglet_id != self.loglet_id {
                 warn!(
-                    log_id = self.log_id,
+                    log_id = self.loglet_id,
                     "read_after moved to the adjacent log {}, that should not happen.\
                     This is harmless but needs to be investigated!",
                     key.loglet_id,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -449,9 +449,7 @@ impl Node {
         .await?;
 
         // sanity check
-        if partition_table.num_partitions()
-            != u64::try_from(logs.num_logs()).expect("usize fits into u64")
-        {
+        if usize::from(partition_table.num_partitions()) != logs.num_logs() {
             return Err(Error::SafetyCheck(format!("The partition table (number partitions: {}) and logs configuration (number logs: {}) don't match. Please make sure that they are aligned.", partition_table.num_partitions(), logs.num_logs())))?;
         }
 
@@ -510,7 +508,7 @@ impl Node {
     async fn fetch_or_insert_logs_configuration(
         metadata_store_client: &MetadataStoreClient,
         config: &Configuration,
-        num_partitions: u64,
+        num_partitions: u16,
     ) -> Result<Logs, Error> {
         Self::retry_on_network_error(config.common.network_error_retry_policy.clone(), || {
             metadata_store_client.get_or_insert(BIFROST_CONFIG_KEY.clone(), || {

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -15,7 +15,7 @@ options_schema = ["dep:schemars"]
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-rocksdb = { workspace = true }
-restate-storage-api = { workspace = true, features = ["serde"] }
+restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -28,7 +28,7 @@ async fn writing_to_rocksdb(mut rocksdb: PartitionStore) {
     // write
     //
     let mut txn = rocksdb.transaction();
-    for j in 0..100000 {
+    for j in 0..u16::MAX {
         txn.put_dedup_seq_number(
             ProducerId::Partition(PartitionId::from(j)),
             &DedupSequenceNumber::Sn(0),

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -8,20 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{define_table_key, KeyKind};
-use crate::TableKind::PartitionStateMachine;
-use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess};
+use std::future;
+use std::future::Future;
+
 use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
 use restate_storage_api::Result;
 use restate_types::identifiers::PartitionId;
 use restate_types::storage::{StorageDecode, StorageEncode};
-use std::future;
-use std::future::Future;
+
+use crate::keys::{define_table_key, KeyKind};
+use crate::TableKind::PartitionStateMachine;
+use crate::{PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess};
 
 define_table_key!(
     PartitionStateMachine,
     KeyKind::Fsm,
-    PartitionStateMachineKey(partition_id: PartitionId, state_id: u64)
+    PartitionStateMachineKey(partition_id: PaddedPartitionId, state_id: u64)
 );
 
 fn get<T: StorageDecode, S: StorageAccess>(
@@ -30,7 +32,7 @@ fn get<T: StorageDecode, S: StorageAccess>(
     state_id: u64,
 ) -> Result<Option<T>> {
     let key = PartitionStateMachineKey::default()
-        .partition_id(partition_id)
+        .partition_id(partition_id.into())
         .state_id(state_id);
     storage.get_value(key)
 }
@@ -42,14 +44,14 @@ fn put<S: StorageAccess>(
     state_value: &impl StorageEncode,
 ) {
     let key = PartitionStateMachineKey::default()
-        .partition_id(partition_id)
+        .partition_id(partition_id.into())
         .state_id(state_id);
     storage.put_kv(key, state_value);
 }
 
 fn clear<S: StorageAccess>(storage: &mut S, partition_id: PartitionId, state_id: u64) {
     let key = PartitionStateMachineKey::default()
-        .partition_id(partition_id)
+        .partition_id(partition_id.into())
         .state_id(state_id);
     storage.delete_key(&key);
 }

--- a/crates/partition-store/src/scan.rs
+++ b/crates/partition-store/src/scan.rs
@@ -13,7 +13,7 @@ use crate::scan::TableScan::{
     FullScanPartitionKeyRange, KeyRangeInclusiveInSinglePartition, SinglePartition,
     SinglePartitionKeyPrefix,
 };
-use crate::{ScanMode, TableKind};
+use crate::{PaddedPartitionId, ScanMode, TableKind};
 use bytes::BytesMut;
 use restate_types::identifiers::{PartitionId, PartitionKey};
 use std::ops::RangeInclusive;
@@ -65,6 +65,7 @@ impl<K: TableKey> From<TableScan<K>> for PhysicalScan {
                 }
             }
             SinglePartition(partition_id) => {
+                let partition_id = PaddedPartitionId::from(partition_id);
                 let mut prefix_start = BytesMut::with_capacity(
                     partition_id.serialized_length() + KeyKind::SERIALIZED_LENGTH,
                 );

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [features]
 test-util = []
-serde = ["dep:serde"]
 
 [dependencies]
 restate-types = { workspace = true }
@@ -22,7 +21,7 @@ futures-util = { workspace = true }
 opentelemetry = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/storage-api/src/timer_table/mod.rs
+++ b/crates/storage-api/src/timer_table/mod.rs
@@ -175,8 +175,7 @@ impl restate_types::timer::TimerKey for TimerKey {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Timer {
     // TODO remove this variant when removing the old invocation status table
     Invoke(ServiceInvocation),

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -35,7 +35,8 @@ message NodeState {
 message AliveNode {
   restate.common.NodeId generational_node_id = 1;
   google.protobuf.Timestamp last_heartbeat_at = 2;
-  map<uint64, PartitionProcessorStatus> partitions = 3;
+  // partition id is u16 but protobuf doesn't support u16. This must be a value that's safe to convert to u16
+  map<uint32, PartitionProcessorStatus> partitions = 3;
 }
 
 message DeadNode { google.protobuf.Timestamp last_seen_alive = 1; }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -13,7 +13,7 @@ use once_cell::sync::Lazy;
 use restate_serde_util::NonZeroByteCount;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -80,8 +80,8 @@ pub struct CommonOptions {
     /// NOTE: This config entry only impacts the initial number of partitions, the
     /// value of this entry is ignored for bootstrapped nodes/clusters.
     ///
-    /// Cannot be higher than `4611686018427387903` (You should almost never need as many partitions anyway)
-    pub(crate) bootstrap_num_partitions: NonZeroU64,
+    /// Cannot be higher than `65535` (You should almost never need as many partitions anyway)
+    pub(crate) bootstrap_num_partitions: NonZeroU16,
 
     /// # Shutdown grace timeout
     ///
@@ -261,7 +261,7 @@ impl CommonOptions {
         &self.cluster_name
     }
 
-    pub fn bootstrap_num_partitions(&self) -> u64 {
+    pub fn bootstrap_num_partitions(&self) -> u16 {
         self.bootstrap_num_partitions.into()
     }
 
@@ -339,7 +339,7 @@ impl Default for CommonOptions {
             metadata_store_client: MetadataStoreClientOptions::default(),
             bind_address: "0.0.0.0:5122".parse().unwrap(),
             advertised_address: AdvertisedAddress::from_str("http://127.0.0.1:5122/").unwrap(),
-            bootstrap_num_partitions: NonZeroU64::new(24).unwrap(),
+            bootstrap_num_partitions: NonZeroU16::new(24).unwrap(),
             histogram_inactivity_timeout: None,
             disable_prometheus: false,
             service_client: Default::default(),

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroU16, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 use tracing::warn;
@@ -235,7 +235,7 @@ pub struct StorageOptions {
     /// By default this uses the value defined in `bootstrap-num-partitions` in the common section of
     /// the config.
     #[serde(skip_serializing_if = "Option::is_none")]
-    num_partitions_to_share_memory_budget: Option<NonZeroU64>,
+    num_partitions_to_share_memory_budget: Option<NonZeroU16>,
 
     /// The memory budget for rocksdb memtables in bytes
     ///
@@ -307,11 +307,11 @@ impl StorageOptions {
             .get()
     }
 
-    pub fn num_partitions_to_share_memory_budget(&self) -> u64 {
+    pub fn num_partitions_to_share_memory_budget(&self) -> u16 {
         self.num_partitions_to_share_memory_budget
             .unwrap_or_else(|| {
                 warn!("num-partitions-to-share-memory-budget is not set, defaulting to 10");
-                NonZeroU64::new(10).unwrap()
+                NonZeroU16::new(10).unwrap()
             })
             .get()
     }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -94,18 +94,23 @@ impl From<LeaderEpoch> for crate::protobuf::common::LeaderEpoch {
 )]
 #[repr(transparent)]
 #[serde(transparent)]
-pub struct PartitionId(u64);
+pub struct PartitionId(u16);
+
+impl From<PartitionId> for u32 {
+    fn from(value: PartitionId) -> Self {
+        u32::from(value.0)
+    }
+}
 
 impl PartitionId {
     /// It's your responsibility to ensure the value is within the valid range.
-    pub const fn new_unchecked(v: u64) -> Self {
+    pub const fn new_unchecked(v: u16) -> Self {
         Self(v)
     }
 
-    pub const MIN: Self = Self(u64::MIN);
-    // LogIds (bifrost) are capped at 62bits to allow for internal logs, the largest
-    // partition ID cannot exceed this value.
-    pub const MAX: Self = Self((1 << 62) - 1);
+    pub const MIN: Self = Self(u16::MIN);
+    // 65535 partitions.
+    pub const MAX: Self = Self(u16::MAX);
 
     #[inline]
     pub fn next(self) -> Self {

--- a/crates/types/src/logs/builder.rs
+++ b/crates/types/src/logs/builder.rs
@@ -152,7 +152,7 @@ mod tests {
         // a builder with 2 logs
         let mut builder = LogsBuilder::default();
         let chain = builder.add_log(
-            LogId::from(1),
+            LogId::new(1),
             Chain::new(ProviderKind::InMemory, LogletParams::from("test1")),
         )?;
 
@@ -188,15 +188,15 @@ mod tests {
         // fails.
         assert_that!(
             builder.add_log(
-                LogId::from(1),
+                LogId::new(1),
                 Chain::new(ProviderKind::InMemory, LogletParams::from("test1"),)
             ),
-            err(pat!(BuilderError::LogAlreadyExists(eq(LogId::from(1)))))
+            err(pat!(BuilderError::LogAlreadyExists(eq(LogId::new(1)))))
         );
 
         builder
             .add_log(
-                LogId::from(2),
+                LogId::new(2),
                 Chain::new(ProviderKind::InMemory, LogletParams::from("test2")),
             )
             .unwrap();
@@ -206,7 +206,7 @@ mod tests {
 
         assert_eq!(
             Lsn::OLDEST,
-            logs.chain(&LogId::from(1)).unwrap().tail().base_lsn
+            logs.chain(&LogId::new(1)).unwrap().tail().base_lsn
         );
 
         Ok(())
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_add_segments() -> googletest::Result<()> {
-        let log_id = LogId::from(1);
+        let log_id = LogId::new(1);
         let mut builder = LogsBuilder::default();
         let mut chain = builder.add_log(
             log_id,
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_find_segments() -> googletest::Result<()> {
-        let log_id = LogId::from(1);
+        let log_id = LogId::new(1);
         let mut builder = LogsBuilder::default();
         let mut chain = builder.add_log(
             log_id,
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_trim_log_single_segment() -> googletest::Result<()> {
-        let log_id = LogId::from(1);
+        let log_id = LogId::new(1);
         let mut builder = LogsBuilder::default();
         builder.add_log(
             log_id,
@@ -440,7 +440,7 @@ mod tests {
 
     #[test]
     fn test_trim_log_multi_segment() -> googletest::Result<()> {
-        let log_id = LogId::from(1);
+        let log_id = LogId::new(1);
         let mut builder = LogsBuilder::default();
         let mut chain = builder.add_log(
             log_id,

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -347,7 +347,7 @@ pub fn new_single_node_loglet_params(default_provider: ProviderKind) -> LogletPa
 
 /// Initializes the bifrost metadata with static log metadata, it creates a log for every partition
 /// with a chain of the default loglet provider kind.
-pub fn bootstrap_logs_metadata(default_provider: ProviderKind, num_partitions: u64) -> Logs {
+pub fn bootstrap_logs_metadata(default_provider: ProviderKind, num_partitions: u16) -> Logs {
     // Get metadata from somewhere
     let mut builder = LogsBuilder::default();
     #[allow(clippy::mutable_key_type)]

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -33,24 +33,28 @@ pub mod metadata;
     Serialize,
     Deserialize,
 )]
-pub struct LogId(u64);
+pub struct LogId(u32);
 
 impl LogId {
-    // Allows us to use the first 62 bits for log ids, while reserving space for
-    // internal logs as needed. Partitions cannot be larger than 2^62.
-    pub const MAX_PARTITION_LOG: LogId = LogId((1 << 62) - 1);
+    pub const MAX: LogId = LogId(u32::MAX);
     pub const MIN: LogId = LogId(0);
 }
 
 impl LogId {
-    pub const fn new(value: u64) -> Self {
+    pub const fn new(value: u32) -> Self {
         Self(value)
     }
 }
 
 impl From<PartitionId> for LogId {
     fn from(value: PartitionId) -> Self {
-        LogId(*value)
+        LogId(u32::from(*value))
+    }
+}
+
+impl From<u16> for LogId {
+    fn from(value: u16) -> Self {
+        LogId(u32::from(value))
     }
 }
 

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -122,8 +122,7 @@ impl SequenceNumber for Lsn {
 
 pub trait SequenceNumber
 where
-    Self:
-        Copy + std::fmt::Debug + Sized + Into<u64> + From<u64> + Eq + PartialEq + Ord + PartialOrd,
+    Self: Copy + std::fmt::Debug + Sized + Into<u64> + Eq + PartialEq + Ord + PartialOrd,
 {
     /// The maximum possible sequence number, this is useful when creating a read stream
     const MAX: Self;

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde", "restate-storage-api/serde"]
+serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde"]
 options_schema = ["dep:schemars"]
 
 [dependencies]

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -142,7 +142,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn spawn_environment(config: Live<Configuration>, num_logs: u64) -> (TaskCenter, Bifrost) {
+fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (TaskCenter, Bifrost) {
     let tc = TaskCenterBuilder::default()
         .options(config.pinned().common.clone())
         .build()

--- a/tools/restatectl/src/commands/dump/cluster_state.rs
+++ b/tools/restatectl/src/commands/dump/cluster_state.rs
@@ -63,7 +63,7 @@ async fn dump_cluster_state(
         .cluster_state
         .ok_or_else(|| anyhow::anyhow!("no cluster state returned"))?;
 
-    let mut processors: BTreeMap<u64, PartitionDetails> = BTreeMap::new();
+    let mut processors: BTreeMap<u32, PartitionDetails> = BTreeMap::new();
     let mut dead_nodes: BTreeMap<PlainNodeId, DeadNode> = BTreeMap::new();
     for (node_id, node_state) in state.nodes {
         match node_state.state.expect("node state is set") {

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -31,7 +31,7 @@ use crate::util::grpc_connect;
 pub struct DescribeLogIdOpts {
     #[arg(short, long)]
     /// The log id to describe
-    log_id: u64,
+    log_id: u32,
 }
 
 async fn describe_log(connection: &ConnectionInfo, opts: &DescribeLogIdOpts) -> anyhow::Result<()> {


### PR DESCRIPTION
[Bifrost] LogletOffset is now u32

This type fits better the model of the virtual log where the entire LSN address space is u64.

Bonus: I noticed an occasional segfault in partition tests due to improper rocksdb shutdown, so I fixed it.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1880).
* #1883
* __->__ #1880
* #1879