### PR TITLE
Replace rocksdb with rust-rocksdb dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
  "restate-tracing-instrumentation",
  "restate-types",
  "rlimit",
- "rocksdb",
+ "rust-rocksdb",
  "serde",
  "serde_json",
  "serde_with",
@@ -3781,22 +3781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.17.0+9.0.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c7ccbbcd261bdec011c4976c441676512a1a4841#c7ccbbcd261bdec011c4976c441676512a1a4841"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "glob",
- "libc",
- "libz-sys",
- "lz4-sys",
- "pkg-config",
- "zstd-sys",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
 dependencies = [
  "cc",
  "libc",
@@ -5541,7 +5525,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "rlimit",
- "rocksdb",
+ "rust-rocksdb",
  "serde",
  "smallvec",
  "static_assertions",
@@ -5907,7 +5891,7 @@ dependencies = [
  "restate-rocksdb",
  "restate-test-util",
  "restate-types",
- "rocksdb",
+ "rust-rocksdb",
  "schemars",
  "serde",
  "serde_json",
@@ -5948,7 +5932,7 @@ dependencies = [
  "restate-core",
  "restate-rocksdb",
  "restate-types",
- "rocksdb",
+ "rust-rocksdb",
  "schemars",
  "serde",
  "static_assertions",
@@ -6009,7 +5993,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "restate-worker",
- "rocksdb",
+ "rust-rocksdb",
  "schemars",
  "semver",
  "serde",
@@ -6056,7 +6040,7 @@ dependencies = [
  "restate-storage-api",
  "restate-test-util",
  "restate-types",
- "rocksdb",
+ "rust-rocksdb",
  "schemars",
  "serde",
  "static_assertions",
@@ -6102,7 +6086,7 @@ dependencies = [
  "restate-serde-util",
  "restate-test-util",
  "restate-types",
- "rocksdb",
+ "rust-rocksdb",
  "smartstring",
  "static_assertions",
  "strum 0.26.2",
@@ -6155,7 +6139,7 @@ dependencies = [
  "restate-types",
  "restate-worker",
  "rlimit",
- "rocksdb",
+ "rust-rocksdb",
  "schemars",
  "serde",
  "serde_with",
@@ -6605,13 +6589,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.22.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c7ccbbcd261bdec011c4976c441676512a1a4841#c7ccbbcd261bdec011c4976c441676512a1a4841"
+name = "rust-librocksdb-sys"
+version = "0.25.0+9.5.2"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=8b621f1b4fb15ed0ba4a4b9da239432159e40b01#8b621f1b4fb15ed0ba4a4b9da239432159e40b01"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "pkg-config",
+ "zstd-sys",
+]
+
+[[package]]
+name = "rust-rocksdb"
+version = "0.29.0"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=8b621f1b4fb15ed0ba4a4b9da239432159e40b01#8b621f1b4fb15ed0ba4a4b9da239432159e40b01"
 dependencies = [
  "libc",
- "librocksdb-sys",
  "parking_lot",
+ "rust-librocksdb-sys",
  "smartstring",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,9 +151,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.22.0", features = [
-    "multi-threaded-cf",
-], git = "https://github.com/restatedev/rust-rocksdb", rev = "c7ccbbcd261bdec011c4976c441676512a1a4841" }
+rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8b621f1b4fb15ed0ba4a4b9da239432159e40b01" }
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -280,7 +280,10 @@ impl RocksDbManager {
         // no need to retain 1000 log files by default.
         //
         db_options.set_keep_log_file_num(2);
-        db_options.set_recycle_log_file_num(4);
+        if !opts.rocksdb_disable_wal() {
+            // RocksDB does not support recycling wal log files if wal is disabled when writing
+            db_options.set_recycle_log_file_num(4);
+        }
         // Disable WAL archiving.
         // the following two options has to be both 0 to disable WAL log archive.
         db_options.set_wal_size_limit_mb(0);


### PR DESCRIPTION
The [rust-rocksdb](https://crates.io/crates/rust-rocksdb) crate is a fork of rocksdb which is actively maintained. For example, it depends on the latest RocksDB version 9.5.2 whereas rocksdb depended on RocksDB 9.0.0.

RocksDB 9.5.2 no longer allows to disable the WAL and have `set_recycle_log_file_num` set to > 0. Therefore, we set `set_recycle_log_file_num = 0` if WAL is disabled. This, however, will prevent a dynamic switch between enabling/disabling of the WAL.

The PR picks `rust-rocksdb` from https://github.com/restatedev/rust-rocksdb/tree/next-0.29 which has the additional fixes from https://github.com/restatedev/rust-rocksdb/tree/next ported to https://github.com/zaidoon1/rust-rocksdb/tree/v0.29.0. Once we merge this PR we can remove https://github.com/restatedev/rust-rocksdb/tree/next.

This fixes #1885.