### PR TITLE
Replace OptimisticTransactionDB with DB and WriteBatchWithIndex 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.25.0+9.5.2"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=8b621f1b4fb15ed0ba4a4b9da239432159e40b01#8b621f1b4fb15ed0ba4a4b9da239432159e40b01"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=c6a279a40416cb47bbf576ffb190523d55818073#c6a279a40416cb47bbf576ffb190523d55818073"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "rust-rocksdb"
 version = "0.29.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=8b621f1b4fb15ed0ba4a4b9da239432159e40b01#8b621f1b4fb15ed0ba4a4b9da239432159e40b01"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=c6a279a40416cb47bbf576ffb190523d55818073#c6a279a40416cb47bbf576ffb190523d55818073"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8b621f1b4fb15ed0ba4a4b9da239432159e40b01" }
+rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "c6a279a40416cb47bbf576ffb190523d55818073" }
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -87,7 +87,8 @@ impl RocksDbLogStore {
             // it's also a small cf so it should be quick.
             .add_to_flush_on_shutdown(CfExactPattern::new(METADATA_CF))
             .ensure_column_families(cfs)
-            .build_as_db();
+            .build()
+            .expect("valid spec");
         let db_name = db_spec.name().clone();
         // todo: use the returned rocksdb object when open_db returns Arc<RocksDb>
         let _ = db_manager.open_db(updateable_options, db_spec).await?;

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -118,7 +118,8 @@ impl LocalMetadataStore {
                 cf_options(options.rocksdb_memory_budget()),
             )
             .ensure_column_families(cfs)
-            .build_as_db();
+            .build()
+            .expect("valid spec");
 
         let db = db_manager
             .open_db(updateable_rocksdb_options.clone(), db_spec)

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -68,7 +68,8 @@ impl PartitionStoreManager {
                 cf_options(per_partition_memory_budget),
             )
             .ensure_column_families(partition_ids_to_cfs(initial_partition_set))
-            .build_as_optimistic_db();
+            .build()
+            .expect("valid spec");
 
         let manager = RocksDbManager::get();
         let raw_db = manager.open_db(updateable_opts, db_spec).await?;

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -135,11 +135,11 @@ impl RocksDbManager {
         self.dbs.read().get(&name).cloned()
     }
 
-    pub async fn open_db<T: RocksAccess + Send + Sync + 'static>(
+    pub async fn open_db(
         &'static self,
         mut updateable_opts: BoxedLiveLoad<RocksDbOptions>,
-        mut db_spec: DbSpec<T>,
-    ) -> Result<Arc<T>, RocksError> {
+        mut db_spec: DbSpec,
+    ) -> Result<Arc<rocksdb::DB>, RocksError> {
         if self
             .shutting_down
             .load(std::sync::atomic::Ordering::Acquire)
@@ -154,7 +154,7 @@ impl RocksDbManager {
         self.amend_db_options(&mut db_spec.db_options, &options);
 
         // todo: move to bg thread pool
-        let db = Arc::new(RocksAccess::open_db(
+        let db = Arc::new(rocksdb::DB::open_db(
             &db_spec,
             self.default_cf_options(&options),
         )?);

--- a/crates/rocksdb/src/db_spec.rs
+++ b/crates/rocksdb/src/db_spec.rs
@@ -116,7 +116,7 @@ impl CfNameMatch for CfExactPattern {
 
 #[derive(Builder)]
 #[builder(pattern = "owned", build_fn(name = "build"))]
-pub struct DbSpec<T> {
+pub struct DbSpec {
     pub(crate) name: DbName,
     pub(crate) path: PathBuf,
     /// All column families that should be flushed on shutdown, no flush will be performed if empty
@@ -141,18 +141,16 @@ pub struct DbSpec<T> {
     /// a column family didn't match any, opening the database or the column family will fail with
     /// `UnknownColumnFamily` error
     pub(crate) cf_patterns: Vec<(BoxedCfMatcher, BoxedCfOptionUpdater)>,
-    #[builder(setter(skip))]
-    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T> DbSpec<T> {
+impl DbSpec {
     pub fn name(&self) -> &DbName {
         &self.name
     }
 }
 
-impl<T> DbSpecBuilder<T> {
-    pub fn new(name: DbName, path: PathBuf, db_options: rocksdb::Options) -> DbSpecBuilder<T> {
+impl DbSpecBuilder {
+    pub fn new(name: DbName, path: PathBuf, db_options: rocksdb::Options) -> DbSpecBuilder {
         Self {
             name: Some(name),
             path: Some(path),
@@ -180,17 +178,5 @@ impl<T> DbSpecBuilder<T> {
         cfs.push((Box::new(pattern), Box::new(options)));
         self.cf_patterns = Some(cfs);
         self
-    }
-}
-
-impl DbSpecBuilder<rocksdb::DB> {
-    pub fn build_as_db(self) -> DbSpec<rocksdb::DB> {
-        self.build().unwrap()
-    }
-}
-
-impl DbSpecBuilder<rocksdb::OptimisticTransactionDB> {
-    pub fn build_as_optimistic_db(self) -> DbSpec<rocksdb::OptimisticTransactionDB> {
-        self.build().unwrap()
     }
 }


### PR DESCRIPTION
This commit replaces the OptimisticTransactionDB with the normal DB
and using WriteBatchWithIndex instead of `Transactions`.

This fixes https://github.com/restatedev/restate/issues/1428.

This PR is based on #1886.

What did not come true is that the performance of Restate would improve with this change. Even though, we should be doing less work when it comes to writing the `WriteBatchWithIndex` and the same when reading, I observed a slight regression in throughput with this change on my machine (might be related to variance). @AhmedSoliman it would be great if you could double check this with your benchmark setup. I cannot really explain why this change (which on the paper removes work) ends up reducing throughput.