### PR TITLE
[Bifrost] Backward-friendly log-server role

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -435,7 +435,7 @@ mod tests {
     use restate_types::metadata_store::keys::SCHEDULING_PLAN_KEY;
     use restate_types::net::partition_processor_manager::{ControlProcessors, ProcessorCommand};
     use restate_types::net::AdvertisedAddress;
-    use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
+    use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
     use restate_types::partition_table::PartitionTable;
     use restate_types::time::MillisSinceEpoch;
     use restate_types::{GenerationalNodeId, PlainNodeId, Version};
@@ -718,6 +718,7 @@ mod tests {
                 *node_id,
                 AdvertisedAddress::Http(Uri::default()),
                 Role::Worker.into(),
+                LogServerConfig::default(),
             );
             nodes_config.upsert_node(node_config);
         }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -437,7 +437,7 @@ mod tests {
         ControlProcessors, GetProcessorsState, ProcessorsStateResponse,
     };
     use restate_types::net::{AdvertisedAddress, MessageEnvelope};
-    use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
+    use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
     use restate_types::{GenerationalNodeId, Version};
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -744,12 +744,14 @@ mod tests {
             GenerationalNodeId::new(1, 1),
             AdvertisedAddress::Uds("foobar".into()),
             Role::Worker.into(),
+            LogServerConfig::default(),
         ));
         nodes_config.upsert_node(NodeConfig::new(
             "node-2".to_owned(),
             GenerationalNodeId::new(2, 2),
             AdvertisedAddress::Uds("bar".into()),
             Role::Worker.into(),
+            LogServerConfig::default(),
         ));
         let builder = modify_builder(builder.with_nodes_config(nodes_config));
 

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -573,7 +573,7 @@ mod tests {
 
     use restate_test_util::assert_eq;
     use restate_types::net::AdvertisedAddress;
-    use restate_types::nodes_config::{NodeConfig, Role};
+    use restate_types::nodes_config::{LogServerConfig, NodeConfig, Role};
     use restate_types::{GenerationalNodeId, Version};
 
     use crate::metadata::spawn_metadata_manager;
@@ -742,7 +742,13 @@ mod tests {
         let address = AdvertisedAddress::from_str("http://127.0.0.1:5122/").unwrap();
         let node_id = GenerationalNodeId::new(1, 1);
         let roles = Role::Admin | Role::Worker;
-        let my_node = NodeConfig::new("MyNode-1".to_owned(), node_id, address, roles);
+        let my_node = NodeConfig::new(
+            "MyNode-1".to_owned(),
+            node_id,
+            address,
+            roles,
+            LogServerConfig::default(),
+        );
         nodes_config.upsert_node(my_node);
         nodes_config
     }

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -707,7 +707,7 @@ mod tests {
     use restate_types::net::{
         ProtocolVersion, RequestId, CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION,
     };
-    use restate_types::nodes_config::{NodeConfig, NodesConfigError, Role};
+    use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfigError, Role};
     use restate_types::protobuf::node::message;
     use restate_types::protobuf::node::message::Body;
     use restate_types::Version;
@@ -913,6 +913,7 @@ mod tests {
             node_id,
             AdvertisedAddress::Uds("foobar1".into()),
             Role::Worker.into(),
+            LogServerConfig::default(),
         );
         nodes_config.upsert_node(node_config);
 

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -35,7 +35,7 @@ use restate_types::net::codec::{
 use restate_types::net::metadata::MetadataKind;
 use restate_types::net::CURRENT_PROTOCOL_VERSION;
 use restate_types::net::{AdvertisedAddress, MessageEnvelope};
-use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
+use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
 use restate_types::partition_table::PartitionTable;
 use restate_types::protobuf::node::{Header, Message};
 use restate_types::{GenerationalNodeId, NodeId, Version};
@@ -395,7 +395,13 @@ pub fn create_mock_nodes_config(node_id: u32, generation: u32) -> NodesConfigura
     let address = AdvertisedAddress::from_str("http://127.0.0.1:5122/").unwrap();
     let node_id = GenerationalNodeId::new(node_id, generation);
     let roles = Role::Admin | Role::Worker;
-    let my_node = NodeConfig::new(format!("MyNode-{}", node_id), node_id, address, roles);
+    let my_node = NodeConfig::new(
+        format!("MyNode-{}", node_id),
+        node_id,
+        address,
+        roles,
+        LogServerConfig::default(),
+    );
     nodes_config.upsert_node(my_node);
     nodes_config
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -39,7 +39,7 @@ use restate_types::logs::metadata::{bootstrap_logs_metadata, Logs};
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY, SCHEDULING_PLAN_KEY,
 };
-use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
+use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
 use restate_types::partition_table::PartitionTable;
 use restate_types::retries::RetryPolicy;
 use restate_types::Version;
@@ -591,6 +591,7 @@ impl Node {
                         my_node_id,
                         common_opts.advertised_address.clone(),
                         common_opts.roles,
+                        LogServerConfig::default(),
                     )
                 };
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -304,7 +304,13 @@ impl CommonOptions {
 impl Default for CommonOptions {
     fn default() -> Self {
         Self {
-            roles: EnumSet::all(),
+            // todo (asoli): Remove this when:
+            //   a. The safe rollback version supports log-server (at least supports parsing the
+            //   config with the log-server role)
+            //   b. When log-server becomes enabled by default.
+            //
+            //   see "roles_compat_test" test below.
+            roles: EnumSet::all() - Role::LogServer,
             node_name: None,
             force_node_id: None,
             cluster_name: "localcluster".to_owned(),
@@ -514,5 +520,20 @@ impl Default for TracingOptions {
             tracing_filter: "info".to_owned(),
             tracing_headers: SerdeableHeaderHashMap::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::nodes_config::Role;
+
+    use super::CommonOptions;
+
+    #[test]
+    fn roles_compat_test() {
+        let opts = CommonOptions::default();
+        // make sure we don't add log-server by default until previous version can parse nodes
+        // configuration with this role.
+        assert!(!opts.roles.contains(Role::LogServer));
     }
 }

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -339,8 +339,7 @@ pub fn new_single_node_loglet_params(default_provider: ProviderKind) -> LogletPa
         ProviderKind::InMemory => LogletParams::from(loglet_id),
         #[cfg(feature = "replicated-loglet")]
         ProviderKind::Replicated => panic!(
-            "replicated-loglet cannot be used as default-provider in a single-node setup.\
-            To use replicated loglet, the node must be running in cluster-mode"
+            "replicated-loglet is still in development and cannot be used as default-provider in this version. Pleae use 'local' instead."
         ),
     }
 }


### PR DESCRIPTION
[Bifrost] Backward-friendly log-server role

- Allow the server to parse the role "log-server" but it doesn't enable this as a default role when generating config. This allows next version to rollback without requiring manual nodes_config edits.
- Adds new (backward-compatible) LogServerConfig stanza in nodes configuration with default `Provisioning` if unset.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1895).
* #1896
* __->__ #1895