### PR TITLE
Remove `CodedErrorResultExt`

### DIFF
--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -18,7 +18,7 @@ use axum::response::IntoResponse;
 use axum::Json;
 use okapi_operation::*;
 use restate_admin_rest_model::deployments::*;
-use restate_errors::fmt::CodedErrorResultExt;
+use restate_errors::warn_it;
 use restate_service_client::Endpoint;
 use restate_service_protocol::discovery::DiscoverEndpoint;
 use restate_types::identifiers::{DeploymentId, InvalidLambdaARN};
@@ -99,7 +99,7 @@ pub async fn create_deployment<V>(
         .schema_registry
         .register_deployment(discover_endpoint, force, apply_mode)
         .await
-        .warn_it()?;
+        .inspect_err(|e| warn_it!(e))?;
 
     let response_body = RegisterDeploymentResponse { id, services };
 
@@ -220,7 +220,7 @@ pub async fn delete_deployment<V>(
             .schema_registry
             .delete_deployment(deployment_id)
             .await
-            .warn_it()?;
+            .inspect_err(|e| warn_it!(e))?;
         Ok(StatusCode::ACCEPTED)
     } else {
         Ok(StatusCode::NOT_IMPLEMENTED)

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -20,7 +20,7 @@ use http::StatusCode;
 use okapi_operation::*;
 use restate_admin_rest_model::services::ListServicesResponse;
 use restate_admin_rest_model::services::*;
-use restate_errors::fmt::CodedErrorResultExt;
+use restate_errors::warn_it;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
 use restate_types::schema::service::ServiceMetadata;
 use restate_types::state_mut::ExternalStateMutation;
@@ -110,7 +110,7 @@ pub async fn modify_service<V>(
         .schema_registry
         .modify_service(service_name, modify_request)
         .await
-        .warn_it()?;
+        .inspect_err(|e| warn_it!(e))?;
 
     Ok(response.into())
 }

--- a/crates/admin/src/rest_api/subscriptions.rs
+++ b/crates/admin/src/rest_api/subscriptions.rs
@@ -19,7 +19,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::{http, Json};
 use okapi_operation::*;
-use restate_errors::fmt::CodedErrorResultExt;
+use restate_errors::warn_it;
 use restate_types::identifiers::SubscriptionId;
 
 /// Create subscription.
@@ -46,7 +46,7 @@ pub async fn create_subscription<V: SubscriptionValidator>(
         .schema_registry
         .create_subscription(payload.source, payload.sink, payload.options)
         .await
-        .warn_it()?;
+        .inspect_err(|e| warn_it!(e))?;
 
     Ok((
         StatusCode::CREATED,
@@ -163,6 +163,6 @@ pub async fn delete_subscription<V>(
         .schema_registry
         .delete_subscription(subscription_id)
         .await
-        .warn_it()?;
+        .inspect_err(|e| warn_it!(e))?;
     Ok(StatusCode::ACCEPTED)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
         Err(e) => {
             // We cannot use tracing here as it's not configured yet
             eprintln!("{}", e.decorate());
-            eprintln!("{:#?}", RestateCode::from(&e));
+            eprintln!("{:#?}", RestateCode::from_code(e.code()));
             std::process::exit(EXIT_CODE_FAILURE);
         }
     };

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> anyhow::Result<()> {
         Err(e) => {
             // We cannot use tracing here as it's not configured yet
             eprintln!("{}", e.decorate());
-            eprintln!("{:#?}", RestateCode::from(&e));
+            eprintln!("{:#?}", RestateCode::from_code(e.code()));
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
By using this trait, we got log statements with wrong module path.
Massaged a bit the warn_it/info_it/error_it macros to accept both refs or owned errors.

Before this PR:

```
2024-08-27T11:20:37.070703Z WARN restate_errors::fmt
    error: [META0003] client error: client error (Connect)
    restate.error.code: META0003
```

With this PR:

```
2024-08-27T13:31:26.723094Z WARN restate_admin::rest_api::deployments
    error: [META0003] client error: client error (Connect)
    restate.error.code: META0003
```