### PR TITLE
Instantiate one RocksDB instance per PartitionStore

### DIFF
--- a/crates/rocksdb/src/db_spec.rs
+++ b/crates/rocksdb/src/db_spec.rs
@@ -35,6 +35,10 @@ impl DbName {
     pub fn new(name: &str) -> Self {
         Self(name.into())
     }
+
+    pub fn from_string(name: String) -> Self {
+        Self(SmartString::from(name))
+    }
 }
 
 #[derive(

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -78,7 +78,7 @@ pub fn node_dir() -> PathBuf {
 }
 
 #[cfg(not(any(test, feature = "test-util")))]
-fn data_dir(dir: &str) -> PathBuf {
+pub fn data_dir(dir: &str) -> PathBuf {
     node_dir().join(dir)
 }
 


### PR DESCRIPTION
Small experiment for measuring the (non)-impact of lock contention within RocksDB by giving every `PartitionStore` its own `RocksDB` instance.