### PR TITLE
[Compat] Avoid the old seal logstate field

### DIFF
--- a/crates/bifrost/src/providers/local_loglet/log_state.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_state.rs
@@ -129,11 +129,21 @@ impl LogStateUpdates {
 
 flexbuffers_storage_encode_decode!(LogStateUpdates);
 
+/// DEPRECATED in v1.0
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+enum SealReason {
+    Resharding,
+    Other(String),
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct LogState {
     pub release_pointer: u32,
     pub trim_point: u32,
-    pub seal: bool,
+    // deprecated and unused. Kept for v1 compatibility.
+    #[serde(default)]
+    seal: Option<SealReason>,
+    pub sealed: bool,
 }
 
 impl LogState {
@@ -209,7 +219,7 @@ pub fn log_state_full_merge(
                     log_state.trim_point = log_state.trim_point.max(offset);
                 }
                 LogStateUpdate::Seal => {
-                    log_state.seal = true;
+                    log_state.sealed = true;
                 }
             }
         }

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -86,7 +86,7 @@ impl LocalLoglet {
         let next_write_offset_raw = log_state.release_pointer + 1;
         let next_write_offset = Mutex::new(LogletOffset::from(next_write_offset_raw));
         let release_pointer = LogletOffset::from(log_state.release_pointer);
-        let sealed = AtomicBool::new(log_state.seal);
+        let sealed = AtomicBool::new(log_state.sealed);
         let append_latency = histogram!(BIFROST_LOCAL_APPEND_DURATION);
         let loglet = Self {
             loglet_id,
@@ -98,7 +98,7 @@ impl LocalLoglet {
             last_committed_offset,
             sealed,
             tail_watch: TailOffsetWatch::new(TailState::new(
-                log_state.seal,
+                log_state.sealed,
                 release_pointer.next(),
             )),
             append_latency,


### PR DESCRIPTION
[Compat] Avoid the old seal logstate field

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1914).
* #1917
* __->__ #1914