### PR TITLE
Show GetPromise in CLI, together with promise name

### DIFF
--- a/cli/src/ui/invocations.rs
+++ b/cli/src/ui/invocations.rs
@@ -320,6 +320,9 @@ pub fn format_entry_type_details(entry_type: &JournalEntryType) -> String {
         JournalEntryType::Awakeable(awakeable_id) => {
             format!("{}", style(awakeable_id.to_string()).cyan())
         }
+        JournalEntryType::GetPromise(Some(promise_name)) => {
+            format!("{}", style(promise_name).cyan())
+        }
         _ => String::new(),
     }
 }

--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -46,6 +46,9 @@ define_table!(sys_journal(
     /// If this entry represents a sleep, indicates wakeup time.
     sleep_wakeup_at: DataType::Date64,
 
+    /// If this entry is a promise related entry (GetPromise, PeekPromise, CompletePromise), indicates the promise name.
+    promise_name: DataType::LargeUtf8,
+
     /// Raw binary representation of the entry. Check the [service protocol](https://github.com/restatedev/service-protocol)
     /// for more details to decode it.
     raw: DataType::LargeBinary,


### PR DESCRIPTION
Fix #1918, show get promise similarly to how we show awakeables.

This is the output when using Restate 1.1:

```
!10908 ➜ just run -- invocations describe inv_1jmqQq8C3SKv5Qv9OMX5i3Icx9uIWrM7Nn                                                                       ~/projects/work/restate (issues/1918) ✗
cargo run  -- invocations describe inv_1jmqQq8C3SKv5Qv9OMX5i3Icx9uIWrM7Nn
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/restate invocations describe inv_1jmqQq8C3SKv5Qv9OMX5i3Icx9uIWrM7Nn`

📜 Invocation Information:
――――――――――――――――――――――――――
 Created at:   2024-09-03 14:29:54.322 +02:00 (2 minutes ago)                                                                  
 Target:       LoanWorkflow/my-loan/run                                                                                        
 Status:       suspended  (31 seconds and 517 ms. The key will not be released until this invocation is complete) 
 Deployment:   dp_17j1qwPko8kdNL9GZyhnEoV [required]                                                                     
 Modified at:  2024-09-03 14:30:55.481 +02:00                                                                                  

  💡   This invocation is bound to run on deployment 'dp_17j1qwPko8kdNL9GZyhnEoV'. To guarantee 
       safety and correctness, invocations that made progress on a deployment                   
       cannot move to newer deployments automatically.                                          

🚂 Invocation Progress:
―――――――――――――――――――――――
[Ingress]
 └──(this)─> LoanWorkflow/my-loan/run
     ▸
     ├──── ☑️  #3 SideEffect 
     ├──── ⏸️  #5 Promise humanApproval
     └────>> suspended

```

With Restate 1.0:

```
!10910 ➜ just run -- invocations describe inv_1jmqQq8C3SKv5Qv9OMX5i3Icx9uIWrM7Nn                                                                       ~/projects/work/restate (issues/1918) ✗
cargo run  -- invocations describe inv_1jmqQq8C3SKv5Qv9OMX5i3Icx9uIWrM7Nn
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/restate invocations describe inv_1jmqQq8C3SKv5Qv9OMX5i3Icx9uIWrM7Nn`

📜 Invocation Information:
――――――――――――――――――――――――――
 Created at:   2024-09-03 14:29:54.322 +02:00 (2 minutes ago)                                                                           
 Target:       LoanWorkflow/my-loan/run                                                                                                 
 Status:       suspended  (1 minute, 8 seconds and 580 ms. The key will not be released until this invocation is complete) 
 Deployment:   dp_17j1qwPko8kdNL9GZyhnEoV [required]                                                                              
 Modified at:  2024-09-03 14:30:55.481 +02:00                                                                                           

  💡   This invocation is bound to run on deployment 'dp_17j1qwPko8kdNL9GZyhnEoV'. To guarantee 
       safety and correctness, invocations that made progress on a deployment                   
       cannot move to newer deployments automatically.                                          

🚂 Invocation Progress:
―――――――――――――――――――――――
[Ingress]
 └──(this)─> LoanWorkflow/my-loan/run
     ▸
     ├──── ☑️  #3 SideEffect 
     ├──── ⏸️  #5 Promise 
     └────>> suspended

```