### PR TITLE
[Networking] Allow sending messages through Outgoing<M>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ tracing-test = { version = "0.2.5" }
 ulid = { version = "1.1.0" }
 url = { version = "2.5" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [profile.release]
 opt-level = 3

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -14,13 +14,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::{Stream, StreamExt};
+use tracing::instrument;
 
 use restate_core::ShutdownError;
 use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
-use tracing::instrument;
+use restate_types::logs::{KeyFilter, LogletOffset, Lsn, SequenceNumber};
 
-use crate::loglet::{AppendError, Loglet, LogletOffset, OperationError, SendableLogletReadStream};
+use crate::loglet::{AppendError, Loglet, OperationError, SendableLogletReadStream};
 use crate::record::Record;
 use crate::{Commit, LogEntry, LsnExt};
 use crate::{Result, TailState};

--- a/crates/bifrost/src/providers/local_loglet/keys.rs
+++ b/crates/bifrost/src/providers/local_loglet/keys.rs
@@ -12,9 +12,7 @@ use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use restate_types::logs::SequenceNumber;
-
-use crate::loglet::LogletOffset;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 
 pub(crate) const DATA_KEY_PREFIX_LENGTH: usize = size_of::<u8>() + size_of::<u64>();
 
@@ -124,11 +122,10 @@ impl MetadataKey {
 mod tests {
     // test RecordKey
     use super::*;
-    use crate::loglet::LogletOffset;
 
     #[test]
     fn test_record_key() {
-        let key = RecordKey::new(1, LogletOffset(2));
+        let key = RecordKey::new(1, LogletOffset::new(2));
         let mut buf = BytesMut::new();
         let bytes = key.encode_and_split(&mut buf);
         let key2 = RecordKey::from_slice(&bytes);

--- a/crates/bifrost/src/providers/local_loglet/log_state.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_state.rs
@@ -15,10 +15,10 @@ use smallvec::SmallVec;
 use tracing::{error, trace, warn};
 
 use restate_types::flexbuffers_storage_encode_decode;
+use restate_types::logs::LogletOffset;
 use restate_types::storage::StorageCodec;
 
 use super::keys::{MetadataKey, MetadataKind};
-use crate::loglet::LogletOffset;
 
 use super::LogStoreError;
 

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -24,7 +24,7 @@ use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LocalLogletOptions;
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 
 use super::keys::{MetadataKey, MetadataKind, RecordKey};
 use super::log_state::LogStateUpdates;
@@ -33,7 +33,7 @@ use super::metric_definitions::{
     BIFROST_LOCAL_WRITE_BATCH_COUNT, BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES,
 };
 use super::record_format::{encode_record_and_split, FORMAT_FOR_NEW_APPENDS};
-use crate::loglet::{LogletOffset, OperationError};
+use crate::loglet::OperationError;
 use crate::record::Record;
 
 type Ack = oneshot::Sender<Result<(), OperationError>>;

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -25,7 +25,7 @@ use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
 use restate_types::logs::LogId;
 
 use super::metric_definitions;
-use crate::loglet::{Loglet, LogletOffset, LogletProvider, LogletProviderFactory, OperationError};
+use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::Error;
 
 pub struct Factory {

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -14,15 +14,13 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use restate_types::logs::{KeyFilter, MatchKeyQuery};
-
 use restate_types::logs::{BodyWithKeys, HasRecordKeys, Keys, Lsn};
+use restate_types::logs::{KeyFilter, LogletOffset, MatchKeyQuery};
 use restate_types::storage::{
     PolyBytes, StorageCodec, StorageDecode, StorageDecodeError, StorageEncode,
 };
 use restate_types::time::NanosSinceEpoch;
 
-use crate::loglet::LogletOffset;
 use crate::LsnExt;
 
 /// An entry in the log.

--- a/crates/bifrost/src/types.rs
+++ b/crates/bifrost/src/types.rs
@@ -12,9 +12,9 @@ use std::task::{ready, Poll};
 
 use futures::FutureExt;
 
-use restate_types::logs::{Lsn, SequenceNumber};
+use restate_types::logs::{LogletOffset, Lsn, SequenceNumber};
 
-use crate::loglet::{AppendError, LogletOffset};
+use crate::loglet::AppendError;
 
 // Only implemented for LSNs
 pub(crate) trait LsnExt
@@ -204,9 +204,8 @@ impl std::future::Future for Commit {
 
 #[cfg(test)]
 mod tests {
-    use crate::loglet::LogletOffset;
     use crate::types::LsnExt;
-    use restate_types::logs::{Lsn, SequenceNumber};
+    use restate_types::logs::{LogletOffset, Lsn, SequenceNumber};
 
     #[test]
     fn lsn_to_offset() {

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -11,8 +11,7 @@
 // todo: remove after scaffolding is complete
 #![allow(unused)]
 
-use restate_bifrost::loglet::LogletOffset;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::PlainNodeId;
 

--- a/crates/log-server/src/rocksdb_logstore/keys.rs
+++ b/crates/log-server/src/rocksdb_logstore/keys.rs
@@ -15,8 +15,7 @@ use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use restate_bifrost::loglet::LogletOffset;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::replicated_loglet::ReplicatedLogletId;
 
 const DATA_KEY_PREFIX: u8 = b'd';

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -63,7 +63,7 @@ toml = { version = "0.8.12" }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 ulid = { workspace = true }
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 restate-test-util = { workspace = true }

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -1,0 +1,174 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bitflags::bitflags;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use super::TargetName;
+use crate::logs::{Keys, LogletOffset};
+use crate::net::define_rpc;
+use crate::replicated_loglet::ReplicatedLogletId;
+use crate::time::{MillisSinceEpoch, NanosSinceEpoch};
+use crate::GenerationalNodeId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Status {
+    /// Operation was successful
+    Ok = 0,
+    /// The node's storage system is disabled and cannot accept operations at the moment.
+    Disabled,
+    /// If the operation expired or not completed due to load shedding. The operation can be
+    /// retried by the client. It's guaranteed that this store has not been persisted by the node.
+    Dropped,
+    /// Operation rejected due to an ongoing or completed seal
+    Sealed,
+    /// Operation has been rejected. Operation requires that the sender is the authoritative
+    /// sequencer.
+    SequencerMismatch,
+    /// This indicates that the operation cannot be accepted due to the offset being out of bounds.
+    /// For instance, if a store is sent to a log-server that with a lagging local commit offset.
+    OutOfBounds,
+    /// The record is malformed, this could be because it has too many records or any other reason
+    /// that leads the server to reject processing it.
+    Malformed,
+}
+
+// Store
+define_rpc! {
+    @request = Store,
+    @response = Stored,
+    @request_target = TargetName::LogServerStore,
+    @response_target = TargetName::LogServerStored,
+}
+
+// Release
+define_rpc! {
+    @request = Release,
+    @response = Released,
+    @request_target = TargetName::LogServerRelease,
+    @response_target = TargetName::LogServerReleased,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordHeader {
+    pub created_at: NanosSinceEpoch,
+}
+
+#[derive(derive_more::Debug, Clone, Serialize, Deserialize)]
+pub struct RecordPayload {
+    pub created_at: NanosSinceEpoch,
+    #[debug("Bytes({} bytes)", body.len())]
+    pub body: Bytes,
+    pub keys: Keys,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppendFlags(u32);
+
+// ------- Node to Bifrost ------ //
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Append {
+    pub loglet_id: ReplicatedLogletId,
+    pub flags: AppendFlags,
+    /// The receiver should skip handling this message if it hasn't started to act on it
+    /// before timeout expires. 0 means no timeout
+    pub timeout_at: MillisSinceEpoch,
+    pub payloads: Vec<RecordPayload>,
+}
+
+impl Append {
+    /// The message's timeout has passed, we should discard if possible.
+    pub fn expired(&self) -> bool {
+        MillisSinceEpoch::now() >= self.timeout_at
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Appended {
+    known_global_tail: LogletOffset,
+    status: Status,
+    // INVALID if Status indicates that the append failed
+    first_offset: LogletOffset,
+}
+
+// ------- Bifrost to LogServer ------ //
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoreFlags(u32);
+bitflags! {
+    impl StoreFlags: u32 {
+        const IgnoreSeal = 0b000_00001;
+    }
+}
+
+/// Store one or more records on a log-server
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Store {
+    // The receiver should skip handling this message if it hasn't started to act on it
+    // before timeout expires. 0 means no timeout
+    pub timeout_at: MillisSinceEpoch,
+    pub known_global_tail: LogletOffset,
+    pub flags: StoreFlags,
+    pub loglet_id: ReplicatedLogletId,
+    /// Offset of the first record in the batch of payloads. Payloads in the batch get a gap-less
+    /// range of offsets that starts with (includes) the value of `first_offset`.
+    pub first_offset: LogletOffset,
+    /// This is the sequencer identifier for this log. This should be set even for repair store messages.
+    pub sequencer: GenerationalNodeId,
+    /// Denotes the last record that has been safely uploaded to an archiving data store.
+    pub known_archived: LogletOffset,
+    pub payloads: Vec<RecordPayload>,
+}
+
+impl Store {
+    /// The message's timeout has passed, we should discard if possible.
+    pub fn expired(&self) -> bool {
+        MillisSinceEpoch::now() >= self.timeout_at
+    }
+
+    // returns None on overflow
+    pub fn last_offset(&self) -> Option<LogletOffset> {
+        let len: u32 = self.payloads.len().try_into().ok()?;
+        self.first_offset.checked_add(len - 1).map(Into::into)
+    }
+}
+
+/// Response to a `Store` request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Stored {
+    pub local_tail: LogletOffset,
+    pub status: Status,
+}
+
+impl Stored {
+    pub fn new(local_tail: LogletOffset) -> Self {
+        Self {
+            local_tail,
+            status: Status::Ok,
+        }
+    }
+
+    pub fn status(mut self, status: Status) -> Self {
+        self.status = status;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+    pub loglet_id: ReplicatedLogletId,
+    pub known_global_tail: LogletOffset,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Released {
+    pub known_global_tail: LogletOffset,
+}


### PR DESCRIPTION
[Networking] Allow sending messages through Outgoing<M>

Allows Outgoing<M> values to be sent directly if they were reciprocal to Incoming.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1928).
* #1935
* #1933
* #1929
* __->__ #1928
* #1927