### PR TITLE
[Bifrost] Move Record to restate-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ tracing-test = { version = "0.2.5" }
 ulid = { version = "1.1.0" }
 url = { version = "2.5" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [profile.release]
 opt-level = 3

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -17,13 +17,12 @@ use tracing::{debug, info, instrument};
 use restate_types::config::Configuration;
 use restate_types::live::Live;
 use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{LogId, Lsn};
+use restate_types::logs::{LogId, Lsn, Record};
 use restate_types::retries::RetryIter;
 
 use crate::bifrost::BifrostInner;
 use crate::loglet::AppendError;
 use crate::loglet_wrapper::LogletWrapper;
-use crate::record::Record;
 use crate::{Error, InputRecord, Result};
 
 #[derive(Clone, derive_more::Debug)]

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 use pin_project::pin_project;
+use restate_types::logs::Record;
 use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{trace, warn};
 
@@ -20,7 +21,6 @@ use restate_types::identifiers::PartitionId;
 use restate_types::storage::StorageEncode;
 
 use crate::error::EnqueueError;
-use crate::record::Record;
 use crate::{Appender, InputRecord, Result};
 
 /// Performs appends in the background concurrently while maintaining the order of records

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -28,7 +28,7 @@ pub use bifrost::Bifrost;
 pub use bifrost_admin::BifrostAdmin;
 pub use error::{Error, Result};
 pub use read_stream::LogReadStream;
-pub use record::{Header, InputRecord, LogEntry, Record};
+pub use record::{InputRecord, LogEntry};
 pub use service::BifrostService;
 pub use types::*;
 

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -28,9 +28,8 @@ use std::task::{ready, Poll};
 use async_trait::async_trait;
 use futures::{FutureExt, Stream};
 
-use restate_types::logs::{KeyFilter, LogletOffset};
+use restate_types::logs::{KeyFilter, LogletOffset, Record};
 
-use crate::record::Record;
 use crate::LogEntry;
 use crate::{Result, TailState};
 

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -18,10 +18,10 @@ use tracing::instrument;
 
 use restate_core::ShutdownError;
 use restate_types::logs::metadata::SegmentIndex;
+use restate_types::logs::Record;
 use restate_types::logs::{KeyFilter, LogletOffset, Lsn, SequenceNumber};
 
 use crate::loglet::{AppendError, Loglet, OperationError, SendableLogletReadStream};
-use crate::record::Record;
 use crate::{Commit, LogEntry, LsnExt};
 use crate::{Result, TailState};
 

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -14,13 +14,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::{Stream, StreamExt};
+use tracing::instrument;
 
 use restate_core::ShutdownError;
 use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
-use tracing::instrument;
+use restate_types::logs::{KeyFilter, LogletOffset, Lsn, SequenceNumber};
 
-use crate::loglet::{AppendError, Loglet, LogletOffset, OperationError, SendableLogletReadStream};
+use crate::loglet::{AppendError, Loglet, OperationError, SendableLogletReadStream};
 use crate::record::Record;
 use crate::{Commit, LogEntry, LsnExt};
 use crate::{Result, TailState};

--- a/crates/bifrost/src/providers/local_loglet/keys.rs
+++ b/crates/bifrost/src/providers/local_loglet/keys.rs
@@ -12,9 +12,7 @@ use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use restate_types::logs::SequenceNumber;
-
-use crate::loglet::LogletOffset;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 
 pub(crate) const DATA_KEY_PREFIX_LENGTH: usize = size_of::<u8>() + size_of::<u64>();
 
@@ -124,11 +122,10 @@ impl MetadataKey {
 mod tests {
     // test RecordKey
     use super::*;
-    use crate::loglet::LogletOffset;
 
     #[test]
     fn test_record_key() {
-        let key = RecordKey::new(1, LogletOffset(2));
+        let key = RecordKey::new(1, LogletOffset::new(2));
         let mut buf = BytesMut::new();
         let bytes = key.encode_and_split(&mut buf);
         let key2 = RecordKey::from_slice(&bytes);

--- a/crates/bifrost/src/providers/local_loglet/log_state.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_state.rs
@@ -15,10 +15,10 @@ use smallvec::SmallVec;
 use tracing::{error, trace, warn};
 
 use restate_types::flexbuffers_storage_encode_decode;
+use restate_types::logs::LogletOffset;
 use restate_types::storage::StorageCodec;
 
 use super::keys::{MetadataKey, MetadataKind};
-use crate::loglet::LogletOffset;
 
 use super::LogStoreError;
 

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -24,7 +24,7 @@ use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LocalLogletOptions;
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::logs::{LogletOffset, Record, SequenceNumber};
 
 use super::keys::{MetadataKey, MetadataKind, RecordKey};
 use super::log_state::LogStateUpdates;
@@ -34,7 +34,6 @@ use super::metric_definitions::{
 };
 use super::record_format::{encode_record_and_split, FORMAT_FOR_NEW_APPENDS};
 use crate::loglet::OperationError;
-use crate::record::Record;
 
 type Ack = oneshot::Sender<Result<(), OperationError>>;
 type AckRecv = oneshot::Receiver<Result<(), OperationError>>;

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -24,7 +24,7 @@ use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LocalLogletOptions;
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 
 use super::keys::{MetadataKey, MetadataKind, RecordKey};
 use super::log_state::LogStateUpdates;
@@ -33,7 +33,7 @@ use super::metric_definitions::{
     BIFROST_LOCAL_WRITE_BATCH_COUNT, BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES,
 };
 use super::record_format::{encode_record_and_split, FORMAT_FOR_NEW_APPENDS};
-use crate::loglet::{LogletOffset, OperationError};
+use crate::loglet::OperationError;
 use crate::record::Record;
 
 type Ack = oneshot::Sender<Result<(), OperationError>>;

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -29,7 +29,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
 use restate_core::ShutdownError;
-use restate_types::logs::{KeyFilter, LogletOffset, SequenceNumber};
+use restate_types::logs::{KeyFilter, LogletOffset, Record, SequenceNumber};
 
 use self::log_store::LogStoreError;
 use self::log_store::RocksDbLogStore;
@@ -41,7 +41,6 @@ use crate::loglet::{Loglet, LogletCommit, OperationError, SendableLogletReadStre
 use crate::providers::local_loglet::metric_definitions::{
     BIFROST_LOCAL_TRIM, BIFROST_LOCAL_TRIM_LENGTH,
 };
-use crate::record::Record;
 use crate::{Result, TailState};
 
 #[derive(derive_more::Debug)]
@@ -273,11 +272,9 @@ mod tests {
     use futures::TryStreamExt;
     use googletest::prelude::eq;
     use googletest::{assert_that, elements_are};
-    use restate_types::storage::PolyBytes;
     use test_log::test;
 
     use crate::loglet::Loglet;
-    use crate::Header;
     use restate_core::TestCoreEnvBuilder;
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
@@ -428,15 +425,5 @@ mod tests {
             Ok(())
         })
         .await
-    }
-
-    impl From<(&str, Keys)> for Record {
-        fn from((value, keys): (&str, Keys)) -> Self {
-            Record::from_parts(
-                Header::default(),
-                keys,
-                PolyBytes::Typed(Arc::new(value.to_owned())),
-            )
-        }
     }
 }

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -23,14 +23,13 @@ use tracing::{debug, info};
 
 use restate_core::ShutdownError;
 use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::{KeyFilter, LogId, LogletOffset, MatchKeyQuery, SequenceNumber};
+use restate_types::logs::{KeyFilter, LogId, LogletOffset, MatchKeyQuery, Record, SequenceNumber};
 
 use crate::loglet::util::TailOffsetWatch;
 use crate::loglet::{
     Loglet, LogletCommit, LogletProvider, LogletProviderFactory, LogletReadStream, OperationError,
     SendableLogletReadStream,
 };
-use crate::Record;
 use crate::Result;
 use crate::{LogEntry, TailState};
 

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -25,7 +25,7 @@ use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
 use restate_types::logs::LogId;
 
 use super::metric_definitions;
-use crate::loglet::{Loglet, LogletOffset, LogletProvider, LogletProviderFactory, OperationError};
+use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::Error;
 
 pub struct Factory {

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -14,15 +14,13 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use restate_types::logs::{KeyFilter, MatchKeyQuery};
-
 use restate_types::logs::{BodyWithKeys, HasRecordKeys, Keys, Lsn};
+use restate_types::logs::{KeyFilter, LogletOffset, MatchKeyQuery};
 use restate_types::storage::{
     PolyBytes, StorageCodec, StorageDecode, StorageDecodeError, StorageEncode,
 };
 use restate_types::time::NanosSinceEpoch;
 
-use crate::loglet::LogletOffset;
 use crate::LsnExt;
 
 /// An entry in the log.

--- a/crates/bifrost/src/types.rs
+++ b/crates/bifrost/src/types.rs
@@ -12,9 +12,9 @@ use std::task::{ready, Poll};
 
 use futures::FutureExt;
 
-use restate_types::logs::{Lsn, SequenceNumber};
+use restate_types::logs::{LogletOffset, Lsn, SequenceNumber};
 
-use crate::loglet::{AppendError, LogletOffset};
+use crate::loglet::AppendError;
 
 // Only implemented for LSNs
 pub(crate) trait LsnExt
@@ -204,9 +204,8 @@ impl std::future::Future for Commit {
 
 #[cfg(test)]
 mod tests {
-    use crate::loglet::LogletOffset;
     use crate::types::LsnExt;
-    use restate_types::logs::{Lsn, SequenceNumber};
+    use restate_types::logs::{LogletOffset, Lsn, SequenceNumber};
 
     #[test]
     fn lsn_to_offset() {

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -11,8 +11,7 @@
 // todo: remove after scaffolding is complete
 #![allow(unused)]
 
-use restate_bifrost::loglet::LogletOffset;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::PlainNodeId;
 

--- a/crates/log-server/src/rocksdb_logstore/keys.rs
+++ b/crates/log-server/src/rocksdb_logstore/keys.rs
@@ -15,8 +15,7 @@ use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-use restate_bifrost::loglet::LogletOffset;
-use restate_types::logs::SequenceNumber;
+use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::replicated_loglet::ReplicatedLogletId;
 
 const DATA_KEY_PREFIX: u8 = b'd';

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -63,7 +63,7 @@ toml = { version = "0.8.12" }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 ulid = { workspace = true }
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 restate-test-util = { workspace = true }

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -18,6 +18,8 @@ use crate::storage::StorageEncode;
 
 pub mod builder;
 pub mod metadata;
+mod record;
+pub use record::Record;
 
 #[derive(
     Debug,

--- a/crates/types/src/logs/record.rs
+++ b/crates/types/src/logs/record.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use crate::storage::{PolyBytes, StorageCodec, StorageDecode, StorageDecodeError, StorageEncode};
+use crate::time::NanosSinceEpoch;
+
+use super::{KeyFilter, Keys, MatchKeyQuery};
+
+#[derive(Debug, Clone)]
+pub struct Record {
+    created_at: NanosSinceEpoch,
+    body: PolyBytes,
+    keys: Keys,
+}
+
+impl Record {
+    pub fn from_parts(created_at: NanosSinceEpoch, keys: Keys, body: PolyBytes) -> Self {
+        Self {
+            created_at,
+            keys,
+            body,
+        }
+    }
+
+    pub fn created_at(&self) -> NanosSinceEpoch {
+        self.created_at
+    }
+
+    pub fn keys(&self) -> &Keys {
+        &self.keys
+    }
+
+    pub fn body(&self) -> &PolyBytes {
+        &self.body
+    }
+
+    pub fn dissolve(self) -> (NanosSinceEpoch, PolyBytes, Keys) {
+        (self.created_at, self.body, self.keys)
+    }
+
+    /// Decode the record body into an owned value T.
+    ///
+    /// Internally, this will clone the inner value if it's already in record cache, or will move
+    /// the value from the underlying Arc delivered from the loglet. Use this approach if you need
+    /// to mutate the value in-place and the cost of cloning sections is high. It's generally
+    /// recommended to use `decode_arc` whenever possible for large payloads.
+    pub fn decode<T: StorageDecode + StorageEncode + Clone>(self) -> Result<T, StorageDecodeError> {
+        let decoded = match self.body {
+            PolyBytes::Bytes(slice) => {
+                let mut buf = std::io::Cursor::new(slice);
+                StorageCodec::decode(&mut buf)?
+            }
+            PolyBytes::Typed(value) => {
+                let target_arc: Arc<T> = value.downcast_arc().map_err(|_| {
+                StorageDecodeError::DecodeValue(
+                    anyhow::anyhow!(
+                        "Type mismatch. Original value in PolyBytes::Typed does not match requested type"
+                    )
+                    .into(),
+                )})?;
+                // Attempts to move the inner value (T) if this Arc has exactly one strong
+                // reference. Otherwise, it clones the inner value.
+                match Arc::try_unwrap(target_arc) {
+                    Ok(value) => value,
+                    Err(value) => value.as_ref().clone(),
+                }
+            }
+        };
+        Ok(decoded)
+    }
+
+    /// Decode the record body into an Arc<T>. This is the most efficient way to access the entry
+    /// if you need read-only access or if it's acceptable to selectively clone inner sections. If
+    /// the record is in record cache, this will avoid cloning or deserialization of the value.
+    pub fn decode_arc<T: StorageDecode + StorageEncode>(
+        self,
+    ) -> Result<Arc<T>, StorageDecodeError> {
+        let decoded = match self.body {
+            PolyBytes::Bytes(slice) => {
+                let mut buf = std::io::Cursor::new(slice);
+                Arc::new(StorageCodec::decode(&mut buf)?)
+            }
+            PolyBytes::Typed(value) => {
+                value.downcast_arc().map_err(|_| {
+                StorageDecodeError::DecodeValue(
+                    anyhow::anyhow!(
+                        "Type mismatch. Original value in PolyBytes::Typed does not match requested type"
+                    )
+                    .into(),
+                )})?
+            },
+        };
+        Ok(decoded)
+    }
+}
+
+impl MatchKeyQuery for Record {
+    fn matches_key_query(&self, query: &KeyFilter) -> bool {
+        self.keys.matches_key_query(query)
+    }
+}
+
+impl From<String> for Record {
+    fn from(value: String) -> Self {
+        Record {
+            created_at: NanosSinceEpoch::now(),
+            keys: Keys::None,
+            body: PolyBytes::Typed(Arc::new(value)),
+        }
+    }
+}
+
+impl From<&str> for Record {
+    fn from(value: &str) -> Self {
+        Record {
+            created_at: NanosSinceEpoch::now(),
+            keys: Keys::None,
+            body: PolyBytes::Typed(Arc::new(value.to_owned())),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl From<(&str, Keys)> for Record {
+    fn from((value, keys): (&str, Keys)) -> Self {
+        Record::from_parts(
+            NanosSinceEpoch::now(),
+            keys,
+            PolyBytes::Typed(Arc::new(value.to_owned())),
+        )
+    }
+}

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -1,0 +1,174 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bitflags::bitflags;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use super::TargetName;
+use crate::logs::{Keys, LogletOffset};
+use crate::net::define_rpc;
+use crate::replicated_loglet::ReplicatedLogletId;
+use crate::time::{MillisSinceEpoch, NanosSinceEpoch};
+use crate::GenerationalNodeId;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Status {
+    /// Operation was successful
+    Ok = 0,
+    /// The node's storage system is disabled and cannot accept operations at the moment.
+    Disabled,
+    /// If the operation expired or not completed due to load shedding. The operation can be
+    /// retried by the client. It's guaranteed that this store has not been persisted by the node.
+    Dropped,
+    /// Operation rejected due to an ongoing or completed seal
+    Sealed,
+    /// Operation has been rejected. Operation requires that the sender is the authoritative
+    /// sequencer.
+    SequencerMismatch,
+    /// This indicates that the operation cannot be accepted due to the offset being out of bounds.
+    /// For instance, if a store is sent to a log-server that with a lagging local commit offset.
+    OutOfBounds,
+    /// The record is malformed, this could be because it has too many records or any other reason
+    /// that leads the server to reject processing it.
+    Malformed,
+}
+
+// Store
+define_rpc! {
+    @request = Store,
+    @response = Stored,
+    @request_target = TargetName::LogServerStore,
+    @response_target = TargetName::LogServerStored,
+}
+
+// Release
+define_rpc! {
+    @request = Release,
+    @response = Released,
+    @request_target = TargetName::LogServerRelease,
+    @response_target = TargetName::LogServerReleased,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordHeader {
+    pub created_at: NanosSinceEpoch,
+}
+
+#[derive(derive_more::Debug, Clone, Serialize, Deserialize)]
+pub struct RecordPayload {
+    pub created_at: NanosSinceEpoch,
+    #[debug("Bytes({} bytes)", body.len())]
+    pub body: Bytes,
+    pub keys: Keys,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppendFlags(u32);
+
+// ------- Node to Bifrost ------ //
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Append {
+    pub loglet_id: ReplicatedLogletId,
+    pub flags: AppendFlags,
+    /// The receiver should skip handling this message if it hasn't started to act on it
+    /// before timeout expires. 0 means no timeout
+    pub timeout_at: MillisSinceEpoch,
+    pub payloads: Vec<RecordPayload>,
+}
+
+impl Append {
+    /// The message's timeout has passed, we should discard if possible.
+    pub fn expired(&self) -> bool {
+        MillisSinceEpoch::now() >= self.timeout_at
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Appended {
+    known_global_tail: LogletOffset,
+    status: Status,
+    // INVALID if Status indicates that the append failed
+    first_offset: LogletOffset,
+}
+
+// ------- Bifrost to LogServer ------ //
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoreFlags(u32);
+bitflags! {
+    impl StoreFlags: u32 {
+        const IgnoreSeal = 0b000_00001;
+    }
+}
+
+/// Store one or more records on a log-server
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Store {
+    // The receiver should skip handling this message if it hasn't started to act on it
+    // before timeout expires. 0 means no timeout
+    pub timeout_at: MillisSinceEpoch,
+    pub known_global_tail: LogletOffset,
+    pub flags: StoreFlags,
+    pub loglet_id: ReplicatedLogletId,
+    /// Offset of the first record in the batch of payloads. Payloads in the batch get a gap-less
+    /// range of offsets that starts with (includes) the value of `first_offset`.
+    pub first_offset: LogletOffset,
+    /// This is the sequencer identifier for this log. This should be set even for repair store messages.
+    pub sequencer: GenerationalNodeId,
+    /// Denotes the last record that has been safely uploaded to an archiving data store.
+    pub known_archived: LogletOffset,
+    pub payloads: Vec<RecordPayload>,
+}
+
+impl Store {
+    /// The message's timeout has passed, we should discard if possible.
+    pub fn expired(&self) -> bool {
+        MillisSinceEpoch::now() >= self.timeout_at
+    }
+
+    // returns None on overflow
+    pub fn last_offset(&self) -> Option<LogletOffset> {
+        let len: u32 = self.payloads.len().try_into().ok()?;
+        self.first_offset.checked_add(len - 1).map(Into::into)
+    }
+}
+
+/// Response to a `Store` request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Stored {
+    pub local_tail: LogletOffset,
+    pub status: Status,
+}
+
+impl Stored {
+    pub fn new(local_tail: LogletOffset) -> Self {
+        Self {
+            local_tail,
+            status: Status::Ok,
+        }
+    }
+
+    pub fn status(mut self, status: Status) -> Self {
+        self.status = status;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+    pub loglet_id: ReplicatedLogletId,
+    pub known_global_tail: LogletOffset,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Released {
+    pub known_global_tail: LogletOffset,
+}


### PR DESCRIPTION
[Bifrost] Move Record to restate-types

Another mechanical change to make this type available to log-server in future PRs

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1929).
* #1935
* #1933
* __->__ #1929
* #1928
* #1927