### PR TITLE
Fix bug when filling StartMessage.duration_since_last_stored_entry

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -37,7 +37,6 @@ use restate_types::schema::deployment::{
     Deployment, DeploymentMetadata, DeploymentType, ProtocolType,
 };
 use restate_types::service_protocol::ServiceProtocolVersion;
-use restate_types::time::MillisSinceEpoch;
 use std::collections::HashSet;
 use std::future::poll_fn;
 use std::time::Duration;
@@ -159,7 +158,7 @@ where
                 journal_size,
                 state_iter,
                 self.invocation_task.retry_count_since_last_stored_entry,
-                journal_metadata.last_modification_date
+                journal_metadata.last_modification_date.elapsed()
             )
             .await
         );
@@ -409,7 +408,7 @@ where
         journal_size: u32,
         state_entries: EagerState<I>,
         retry_count_since_last_stored_entry: u32,
-        duration_since_last_stored_entry: MillisSinceEpoch,
+        duration_since_last_stored_entry: Duration,
     ) -> Result<(), InvocationTaskError> {
         let is_partial = state_entries.is_partial();
 

--- a/crates/service-protocol/src/message/encoding.rs
+++ b/crates/service-protocol/src/message/encoding.rs
@@ -361,7 +361,6 @@ mod tests {
     use crate::codec::ProtobufRawEntryCodec;
     use restate_test_util::{assert, assert_eq, let_assert};
     use restate_types::journal::raw::RawEntryCodec;
-    use std::time::SystemTime;
 
     #[test]
     fn fill_decoder_with_several_messages() {
@@ -376,7 +375,7 @@ mod tests {
             true,
             vec![],
             10,
-            SystemTime::now().into(),
+            Duration::ZERO,
         );
 
         let expected_msg_1: ProtocolMessage = ProtobufRawEntryCodec::serialize_as_input_entry(

--- a/crates/service-protocol/src/message/mod.rs
+++ b/crates/service-protocol/src/message/mod.rs
@@ -16,14 +16,14 @@ use prost::Message;
 use restate_types::journal::raw::PlainRawEntry;
 use restate_types::journal::CompletionResult;
 use restate_types::journal::{Completion, EntryIndex};
+use restate_types::service_protocol;
+use std::time::Duration;
 
 mod encoding;
 mod header;
 
 pub use encoding::{Decoder, Encoder, EncodingError};
 pub use header::{MessageHeader, MessageKind, MessageType};
-use restate_types::service_protocol;
-use restate_types::time::MillisSinceEpoch;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProtocolMessage {
@@ -49,7 +49,7 @@ impl ProtocolMessage {
         partial_state: bool,
         state_map_entries: impl IntoIterator<Item = (Bytes, Bytes)>,
         retry_count_since_last_stored_entry: u32,
-        duration_since_last_stored_entry: MillisSinceEpoch,
+        duration_since_last_stored_entry: Duration,
     ) -> Self {
         Self::Start(service_protocol::StartMessage {
             id,
@@ -64,7 +64,7 @@ impl ProtocolMessage {
                 .and_then(|b| String::from_utf8(b.to_vec()).ok())
                 .unwrap_or_default(),
             retry_count_since_last_stored_entry,
-            duration_since_last_stored_entry: duration_since_last_stored_entry.as_u64(),
+            duration_since_last_stored_entry: duration_since_last_stored_entry.as_millis() as u64,
         })
     }
 


### PR DESCRIPTION
What happened here is that in the original design this was not a relative duration, but an absolute duration from the UNIX_EPOCH... When I switched that I forgot to change this line of code filling the field :)