### PR TITLE
Classify Metadata Store failed precondition as successful

### DIFF
--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -23,6 +23,8 @@ use restate_types::live::BoxedLiveLoad;
 use tonic::body::boxed;
 use tonic::server::NamedService;
 use tower::ServiceExt;
+use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
+use tower_http::trace;
 
 pub struct LocalMetadataStoreService {
     opts: BoxedLiveLoad<MetadataStoreOptions>,
@@ -64,10 +66,13 @@ impl LocalMetadataStoreService {
         let options = opts.live_load();
         let bind_address = options.bind_address.clone();
         let store = LocalMetadataStore::create(options, rocksdb_options).await?;
-        // Trace layer
-        let span_factory = tower_http::trace::DefaultMakeSpan::new()
+
+        let trace_layer = trace::TraceLayer::new(SharedClassifier::new(
+            GrpcErrorsAsFailures::new().with_success(GrpcCode::FailedPrecondition),
+        ))
+        .make_span_with(tower_http::trace::DefaultMakeSpan::new()
             .include_headers(true)
-            .level(tracing::Level::ERROR);
+            .level(tracing::Level::ERROR));
 
         let reflection_service_builder = tonic_reflection::server::Builder::configure()
             .register_encoded_file_descriptor_set(grpc_svc::FILE_DESCRIPTOR_SET);
@@ -78,7 +83,7 @@ impl LocalMetadataStoreService {
             .await;
 
         let server_builder = tonic::transport::Server::builder()
-            .layer(tower_http::trace::TraceLayer::new_for_grpc().make_span_with(span_factory))
+            .layer(trace_layer)
             .add_service(health_service)
             .add_service(MetadataStoreSvcServer::new(LocalMetadataStoreHandler::new(
                 store.request_sender(),

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -19,9 +19,7 @@ use tokio::sync::oneshot;
 
 use codederror::CodedError;
 use restate_bifrost::BifrostService;
-use restate_core::metadata_store::{
-    MetadataStoreClientError, Precondition, ReadWriteError, WriteError,
-};
+use restate_core::metadata_store::{MetadataStoreClientError, ReadWriteError};
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::Networking;
 use restate_core::{


### PR DESCRIPTION
A rejected conditional operation is still a success from the server's point of view. This avoid unnecessary noise on startup, e.g. when the log or partition configuration is loaded.

Without this change, `restate-server` always prints the following error after the initial bootstrap startup:

```
2024-09-08T11:26:13.201071Z ERROR tower_http::trace::on_failure
  response failed
    classification: Code: 9
    latency: 0 ms
on rs:worker-7
  in tower_http::trace::make_span::request
    method: POST
    uri: http://127.0.0.1:5123/dev.restate.metadata_store_svc.MetadataStoreSvc/Put
    version: HTTP/2.0
    headers: {"te": "trailers", "content-type": "application/grpc", "user-agent": "tonic/0.12.1"}
```

This happens because we were leaning on metadata store preconditions and always attempting to insert a default scheduling plan on startup.

With this change:

- we make the Tower tracing layer not consider precondition errors as "failures" - however, we should probably do our own logging at e.g. debug level to aid conflict resolution
- not lean on preconditions, and try load the existing scheduling plan on startup; only if it doesn't exist attempt to put a default one; this brings the scheduling plan in line with the existing `fetch_or_insert_partition_table` and `fetch_or_insert_logs_configuration` methods ([code](https://github.com/restatedev/restate/blob/4149c0ea2cc8f3c332b1bd3defe6695a50f82da4/crates/node/src/lib.rs#L460-L474))

