### PR TITLE
[Snapshots] 1: Introduce partition store snapshotting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6016,6 +6016,7 @@ dependencies = [
  "futures",
  "futures-util",
  "googletest",
+ "humantime",
  "num-bigint",
  "once_cell",
  "paste",
@@ -6030,6 +6031,8 @@ dependencies = [
  "rust-rocksdb",
  "schemars",
  "serde",
+ "serde_json",
+ "serde_with",
  "static_assertions",
  "strum 0.26.2",
  "sync_wrapper 1.0.1",
@@ -6596,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.25.0+9.5.2"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c6a279a40416cb47bbf576ffb190523d55818073#c6a279a40416cb47bbf576ffb190523d55818073"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=8f832b7e742e0d826fb9fed05a62e4bd747969bf#8f832b7e742e0d826fb9fed05a62e4bd747969bf"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6612,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "rust-rocksdb"
 version = "0.29.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c6a279a40416cb47bbf576ffb190523d55818073#c6a279a40416cb47bbf576ffb190523d55818073"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=8f832b7e742e0d826fb9fed05a62e4bd747969bf#8f832b7e742e0d826fb9fed05a62e4bd747969bf"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "c6a279a40416cb47bbf576ffb190523d55818073" }
+rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8f832b7e742e0d826fb9fed05a62e4bd747969bf" }
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -12,12 +12,6 @@ default = []
 options_schema = ["dep:schemars"]
 
 [dependencies]
-restate-core = { workspace = true }
-restate-errors = { workspace = true }
-restate-rocksdb = { workspace = true }
-restate-storage-api = { workspace = true }
-restate-types = { workspace = true }
-
 anyhow = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
@@ -27,12 +21,20 @@ derive_more = { workspace = true }
 enum-map = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
+humantime = { workspace = true }
 once_cell = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true }
+restate-core = { workspace = true }
+restate-errors = { workspace = true }
+restate-rocksdb = { workspace = true }
+restate-storage-api = { workspace = true }
+restate-types = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["hex"] }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }
@@ -51,6 +53,7 @@ criterion = { workspace = true, features = ["async_tokio"] }
 googletest = { workspace = true }
 num-bigint = "0.4"
 rand = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -22,6 +22,7 @@ mod partition_store_manager;
 pub mod promise_table;
 pub mod scan;
 pub mod service_status_table;
+pub mod snapshots;
 pub mod state_table;
 pub mod timer_table;
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::ops::RangeInclusive;
+use std::path::PathBuf;
 use std::slice;
 use std::sync::Arc;
 
@@ -18,6 +19,7 @@ use codederror::CodedError;
 use restate_rocksdb::CfName;
 use restate_rocksdb::IoMode;
 use restate_rocksdb::Priority;
+use restate_storage_api::fsm_table::ReadOnlyFsmTable;
 use restate_types::config::Configuration;
 use rocksdb::DBCompressionType;
 use rocksdb::DBPinnableSlice;
@@ -39,6 +41,7 @@ use crate::keys::KeyKind;
 use crate::keys::TableKey;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
+use crate::snapshots::LocalPartitionSnapshot;
 
 pub type DB = rocksdb::DB;
 
@@ -416,6 +419,38 @@ impl PartitionStore {
             .await
             .map_err(|err| StorageError::Generic(err.into()))?;
         Ok(())
+    }
+
+    /// Creates a snapshot of the partition in the given directory, which must not exist prior to
+    /// the export. The snapshot is atomic and contains, at a minimum, the reported applied LSN.
+    /// Additional log records may have been applied between when the LSN was read, and when the
+    /// snapshot was actually created. The actual snapshot applied LSN will always be equal to, or
+    /// greater than, the reported applied LSN.
+    ///
+    /// *NB:* Creating a snapshot causes an implicit flush of the column family!
+    ///
+    /// See [rocksdb::checkpoint::Checkpoint::export_column_family] for additional implementation details.
+    pub async fn create_snapshot(
+        &mut self,
+        snapshot_dir: PathBuf,
+    ) -> Result<LocalPartitionSnapshot> {
+        let applied_lsn = self
+            .get_applied_lsn()
+            .await?
+            .ok_or(StorageError::DataIntegrityError)?;
+
+        let metadata = self
+            .rocksdb
+            .export_cf(self.data_cf_name.clone(), snapshot_dir.clone())
+            .await
+            .map_err(|err| StorageError::Generic(err.into()))?;
+
+        Ok(LocalPartitionSnapshot {
+            base_dir: snapshot_dir,
+            files: metadata.get_files(),
+            db_comparator_name: metadata.get_db_comparator_name(),
+            min_applied_lsn: applied_lsn,
+        })
     }
 }
 

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -1,0 +1,101 @@
+use std::ops::RangeInclusive;
+use std::path::PathBuf;
+
+use rocksdb::LiveFile;
+use serde::{Deserialize, Serialize};
+use serde_with::hex::Hex;
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
+
+use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId};
+use restate_types::logs::Lsn;
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SnapshotFormatVersion {
+    #[default]
+    V1,
+}
+
+/// A partition store snapshot.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PartitionSnapshotMetadata {
+    pub version: SnapshotFormatVersion,
+
+    /// Restate cluster name which produced the snapshot.
+    pub cluster_name: String,
+
+    /// Restate partition id.
+    pub partition_id: PartitionId,
+
+    /// Node that produced this snapshot.
+    pub node_name: String,
+
+    /// Local node time when the snapshot was created.
+    #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+    pub created_at: humantime::Timestamp,
+
+    /// Snapshot id.
+    pub snapshot_id: SnapshotId,
+
+    /// The partition key range that the partition processor which generated this snapshot was
+    /// responsible for, at the time the snapshot was generated.
+    pub key_range: RangeInclusive<PartitionKey>,
+
+    /// The minimum LSN guaranteed to be applied in this snapshot. The actual
+    /// LSN may be >= [minimum_lsn].
+    pub min_applied_lsn: Lsn,
+
+    /// The RocksDB comparator name used by the partition processor which generated this snapshot.
+    pub db_comparator_name: String,
+
+    /// The RocksDB SST files comprising the snapshot.
+    #[serde_as(as = "Vec<SnapshotSstFile>")]
+    pub files: Vec<LiveFile>,
+}
+
+/// A locally-stored partition snapshot.
+#[derive(Debug)]
+pub struct LocalPartitionSnapshot {
+    pub base_dir: PathBuf,
+    pub min_applied_lsn: Lsn,
+    pub db_comparator_name: String,
+    pub files: Vec<LiveFile>,
+}
+
+/// RocksDB SST file that is part of a snapshot. Serialization wrapper around [LiveFile].
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "LiveFile")]
+pub struct SnapshotSstFile {
+    pub column_family_name: String,
+    pub name: String,
+    pub directory: String,
+    pub size: usize,
+    pub level: i32,
+    #[serde_as(as = "Option<Hex>")]
+    pub start_key: Option<Vec<u8>>,
+    #[serde_as(as = "Option<Hex>")]
+    pub end_key: Option<Vec<u8>>,
+    pub smallest_seqno: u64,
+    pub largest_seqno: u64,
+    pub num_entries: u64,
+    pub num_deletions: u64,
+}
+
+impl SerializeAs<LiveFile> for SnapshotSstFile {
+    fn serialize_as<S>(value: &LiveFile, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        SnapshotSstFile::serialize(value, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, LiveFile> for SnapshotSstFile {
+    fn deserialize_as<D>(deserializer: D) -> Result<LiveFile, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        SnapshotSstFile::deserialize(deserializer)
+    }
+}

--- a/crates/partition-store/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/tests/snapshots_test/mod.rs
@@ -1,0 +1,81 @@
+use std::ops::RangeInclusive;
+use std::time::SystemTime;
+use tempfile::tempdir;
+
+use restate_partition_store::snapshots::{
+    LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion,
+};
+use restate_partition_store::{PartitionStore, PartitionStoreManager};
+use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
+use restate_storage_api::Transaction;
+use restate_types::config::WorkerOptions;
+use restate_types::identifiers::{PartitionKey, SnapshotId};
+use restate_types::live::Live;
+use restate_types::logs::Lsn;
+use restate_types::time::MillisSinceEpoch;
+
+pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_store: PartitionStore) {
+    insert_test_data(&mut partition_store).await;
+
+    let snapshots_dir = tempdir().unwrap();
+
+    let partition_id = partition_store.partition_id();
+    let path_buf = snapshots_dir.path().to_path_buf().join("sn1");
+
+    let snapshot = partition_store.create_snapshot(path_buf).await.unwrap();
+
+    let snapshot_meta = PartitionSnapshotMetadata {
+        version: SnapshotFormatVersion::V1,
+        cluster_name: "cluster_name".to_string(),
+        partition_id,
+        node_name: "node".to_string(),
+        created_at: humantime::Timestamp::from(SystemTime::from(MillisSinceEpoch::new(0))),
+        snapshot_id: SnapshotId::from_parts(0, 0),
+        key_range: partition_store.partition_key_range().clone(),
+        min_applied_lsn: snapshot.min_applied_lsn,
+        db_comparator_name: snapshot.db_comparator_name.clone(),
+        files: snapshot.files.clone(),
+    };
+    let metadata_json = serde_json::to_string_pretty(&snapshot_meta).unwrap();
+
+    drop(partition_store);
+    drop(snapshot);
+
+    manager.drop_partition(partition_id).await;
+
+    let snapshot_meta: PartitionSnapshotMetadata = serde_json::from_str(&metadata_json).unwrap();
+
+    let snapshot = LocalPartitionSnapshot {
+        base_dir: snapshots_dir.path().into(),
+        min_applied_lsn: snapshot_meta.min_applied_lsn,
+        db_comparator_name: snapshot_meta.db_comparator_name.clone(),
+        files: snapshot_meta.files.clone(),
+    };
+
+    let worker_options = Live::from_value(WorkerOptions::default());
+
+    let mut new_partition_store = manager
+        .restore_partition_store_snapshot(
+            partition_id,
+            RangeInclusive::new(0, PartitionKey::MAX - 1),
+            snapshot,
+            &worker_options.pinned().storage.rocksdb,
+        )
+        .await
+        .unwrap();
+
+    verify_restored_data(&mut new_partition_store).await;
+}
+
+async fn insert_test_data(partition: &mut PartitionStore) {
+    let mut txn = partition.transaction();
+    txn.put_applied_lsn(Lsn::new(100)).await;
+    txn.commit().await.expect("commit succeeds");
+}
+
+async fn verify_restored_data(partition: &mut PartitionStore) {
+    assert_eq!(
+        Lsn::new(100),
+        partition.get_applied_lsn().await.unwrap().unwrap()
+    );
+}

--- a/crates/rocksdb/src/background.rs
+++ b/crates/rocksdb/src/background.rs
@@ -24,6 +24,8 @@ use crate::{Priority, OP_TYPE, PRIORITY, STORAGE_BG_TASK_IN_FLIGHT};
 pub enum StorageTaskKind {
     WriteBatch,
     OpenColumnFamily,
+    ImportColumnFamily,
+    ExportColumnFamily,
     FlushWal,
     FlushMemtables,
     Shutdown,

--- a/crates/rocksdb/src/error.rs
+++ b/crates/rocksdb/src/error.rs
@@ -27,6 +27,9 @@ pub enum RocksError {
     #[error("already open")]
     #[code(unknown)]
     AlreadyOpen,
+    #[error("already exists")]
+    #[code(unknown)]
+    ColumnFamilyExists,
     #[error(transparent)]
     #[code(unknown)]
     Other(#[from] rocksdb::Error),

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -12,7 +12,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use rocksdb::perf::MemoryUsageBuilder;
-use rocksdb::ColumnFamilyDescriptor;
+use rocksdb::ExportImportFilesMetaData;
+use rocksdb::{ColumnFamilyDescriptor, ImportColumnFamilyOptions};
 use tracing::trace;
 
 use crate::BoxedCfMatcher;
@@ -44,6 +45,13 @@ pub trait RocksAccess {
         name: CfName,
         default_cf_options: rocksdb::Options,
         cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+    ) -> Result<(), RocksError>;
+    fn import_cf(
+        &self,
+        name: CfName,
+        default_cf_options: rocksdb::Options,
+        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        metadata: ExportImportFilesMetaData,
     ) -> Result<(), RocksError>;
     fn cfs(&self) -> Vec<CfName>;
 
@@ -143,6 +151,27 @@ impl RocksAccess for rocksdb::DB {
     ) -> Result<(), RocksError> {
         let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
         Ok(Self::create_cf(self, name.as_str(), &options)?)
+    }
+
+    fn import_cf(
+        &self,
+        name: CfName,
+        default_cf_options: rocksdb::Options,
+        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        metadata: ExportImportFilesMetaData,
+    ) -> Result<(), RocksError> {
+        let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
+
+        let mut import_opts = ImportColumnFamilyOptions::default();
+        import_opts.set_move_files(true);
+
+        Ok(Self::create_column_family_with_import(
+            self,
+            &options,
+            name.as_str(),
+            &import_opts,
+            &metadata,
+        )?)
     }
 
     fn flush_memtables(&self, cfs: &[CfName], wait: bool) -> Result<(), RocksError> {

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -17,7 +17,7 @@ pub enum StorageError {
     Generic(#[from] anyhow::Error),
     #[error("failed to convert Rust objects to/from protobuf: {0}")]
     Conversion(anyhow::Error),
-    #[error("Integrity constrained is violated")]
+    #[error("Integrity constraint is violated")]
     DataIntegrityError,
     #[error("Operational error that can be caused during a graceful shutdown")]
     OperationalError,

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -45,6 +45,7 @@ prefixed_ids! {
         Deployment("dp"),
         Subscription("sub"),
         Awakeable("prom"),
+        Snapshot("snap"),
     }
 }
 


### PR DESCRIPTION
With this change we add the basic ability for the PartitionProcessor to export
its state into a snapshot, and later re-create this by importing the same
snapshot.


1. **this PR** https://github.com/restatedev/restate/pull/1954
2. https://github.com/restatedev/restate/pull/1981
3. https://github.com/restatedev/restate/pull/1991
4. https://github.com/restatedev/restate/pull/1992
