### PR TITLE
Introduce partition store snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6022,6 +6022,8 @@ dependencies = [
  "rust-rocksdb",
  "schemars",
  "serde",
+ "serde_json",
+ "serde_with",
  "static_assertions",
  "strum 0.26.2",
  "sync_wrapper 1.0.1",
@@ -6587,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.25.0+9.5.2"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c6a279a40416cb47bbf576ffb190523d55818073#c6a279a40416cb47bbf576ffb190523d55818073"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=1fbf824be1e0b49e0c85a38c46d9e96e8bc0dcfc#1fbf824be1e0b49e0c85a38c46d9e96e8bc0dcfc"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6603,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "rust-rocksdb"
 version = "0.29.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c6a279a40416cb47bbf576ffb190523d55818073#c6a279a40416cb47bbf576ffb190523d55818073"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=1fbf824be1e0b49e0c85a38c46d9e96e8bc0dcfc#1fbf824be1e0b49e0c85a38c46d9e96e8bc0dcfc"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "c6a279a40416cb47bbf576ffb190523d55818073" }
+rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "1fbf824be1e0b49e0c85a38c46d9e96e8bc0dcfc" }
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -33,6 +33,7 @@ prost = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+serde_with = { workspace = true, features = ["hex"] }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }
@@ -51,6 +52,7 @@ criterion = { workspace = true, features = ["async_tokio"] }
 googletest = { workspace = true }
 num-bigint = "0.4"
 rand = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -22,6 +22,7 @@ mod partition_store_manager;
 pub mod promise_table;
 pub mod scan;
 pub mod service_status_table;
+pub mod snapshots;
 pub mod state_table;
 pub mod timer_table;
 

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -8,13 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_types::live::BoxedLiveLoad;
+use rocksdb::ExportImportFilesMetaData;
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
-
-use restate_types::live::BoxedLiveLoad;
 use tokio::sync::Mutex;
-use tracing::debug;
+use tracing::{debug, error, info, warn};
 
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
@@ -26,6 +26,7 @@ use restate_types::identifiers::PartitionKey;
 use restate_types::live::LiveLoad;
 
 use crate::cf_options;
+use crate::snapshots::LocalPartitionSnapshot;
 use crate::PartitionStore;
 use crate::DB;
 
@@ -56,7 +57,7 @@ impl PartitionStoreManager {
         mut storage_opts: impl LiveLoad<StorageOptions> + Send + 'static,
         updateable_opts: BoxedLiveLoad<RocksDbOptions>,
         initial_partition_set: &[(PartitionId, RangeInclusive<PartitionKey>)],
-    ) -> std::result::Result<Self, RocksError> {
+    ) -> Result<Self, RocksError> {
         let options = storage_opts.live_load();
 
         let per_partition_memory_budget = options.rocksdb_memory_budget()
@@ -102,7 +103,7 @@ impl PartitionStoreManager {
         partition_key_range: RangeInclusive<PartitionKey>,
         open_mode: OpenMode,
         opts: &RocksDbOptions,
-    ) -> std::result::Result<PartitionStore, RocksError> {
+    ) -> Result<PartitionStore, RocksError> {
         let mut guard = self.lookup.lock().await;
         if let Some(store) = guard.live.get(&partition_id) {
             return Ok(store.clone());
@@ -129,6 +130,63 @@ impl PartitionStoreManager {
         guard.live.insert(partition_id, partition_store.clone());
 
         Ok(partition_store)
+    }
+
+    pub async fn create_partition_store_from_snapshot(
+        &self,
+        partition_id: PartitionId,
+        partition_key_range: RangeInclusive<PartitionKey>,
+        snapshot: LocalPartitionSnapshot,
+        opts: &RocksDbOptions,
+    ) -> Result<PartitionStore, RocksError> {
+        let mut guard = self.lookup.lock().await;
+        if let Some(store) = guard.live.get(&partition_id) {
+            return Ok(store.clone());
+        }
+        let cf_name = cf_for_partition(partition_id);
+        let already_exists = self.rocksdb.inner().cf_handle(&cf_name).is_some();
+        if already_exists {
+            warn!(?partition_id, "already exists, refusing to import snapshot");
+            return Err(RocksError::AlreadyOpen);
+        }
+
+        let mut import_metadata = ExportImportFilesMetaData::default();
+        import_metadata.set_db_comparator_name(snapshot.db_comparator_name.as_str());
+        import_metadata.set_files(&snapshot.files);
+
+        info!(?partition_id, ?snapshot.min_applied_lsn, "initializing partition store from snapshot");
+        let result = self
+            .rocksdb
+            .import_cf(cf_name.clone(), opts, import_metadata)
+            .await;
+
+        if result.is_err() {
+            error!(?partition_id, "failed to import snapshot");
+            return Err(result.unwrap_err());
+        }
+
+        assert!(self.rocksdb.inner().cf_handle(&cf_name).is_some());
+
+        let partition_store = PartitionStore::new(
+            self.raw_db.clone(),
+            self.rocksdb.clone(),
+            cf_name,
+            partition_id,
+            partition_key_range,
+        );
+        guard.live.insert(partition_id, partition_store.clone());
+
+        Ok(partition_store)
+    }
+
+    // todo(pavel): make this conditional work!
+    // #[cfg(test)]
+    pub async fn drop_partition(&self, partition_id: PartitionId) {
+        let mut guard = self.lookup.lock().await;
+        self.raw_db
+            .drop_cf(&cf_for_partition(partition_id))
+            .unwrap();
+        guard.live.remove(&partition_id);
     }
 }
 

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -1,0 +1,78 @@
+use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::logs::Lsn;
+use rocksdb::LiveFile;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
+use std::ops::RangeInclusive;
+use std::path::PathBuf;
+
+/// Partition snapshot description.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PartitionSnapshotMetadata {
+    /// Restate cluster name which produced the snapshot.
+    pub cluster_name: String,
+
+    // todo(pavel): the partition table version may be useful for sanity check on restore
+    /// Restate partition id.
+    pub partition_id: PartitionId,
+
+    /// The partition key range that the partition processor which generated this snapshot was
+    /// responsible for, at the time the snapshot was generated.
+    pub key_range: RangeInclusive<PartitionKey>,
+
+    /// The minimum LSN guaranteed to be applied in this snapshot. The actual
+    /// LSN may be >= [minimum_lsn].
+    pub min_applied_lsn: Lsn,
+
+    /// The RocksDB SST files comprising the snapshot.
+    #[serde_as(as = "Vec<SnapshotSstFile>")]
+    pub files: Vec<LiveFile>,
+}
+
+/// A locally-stored partition snapshot.
+#[derive(Debug)]
+pub struct LocalPartitionSnapshot {
+    pub base_dir: PathBuf,
+    pub min_applied_lsn: Lsn,
+    pub db_comparator_name: String,
+    pub files: Vec<LiveFile>,
+}
+
+/// RocksDB SST file that is part of a snapshot. Serialization wrapper around [LiveFile].
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "LiveFile")]
+pub struct SnapshotSstFile {
+    pub column_family_name: String,
+    pub name: String,
+    pub directory: String,
+    pub size: usize,
+    pub level: i32,
+    #[serde_as(as = "Option<serde_with::hex::Hex>")]
+    pub start_key: Option<Vec<u8>>,
+    #[serde_as(as = "Option<serde_with::hex::Hex>")]
+    pub end_key: Option<Vec<u8>>,
+    pub smallest_seqno: u64,
+    pub largest_seqno: u64,
+    pub num_entries: u64,
+    pub num_deletions: u64,
+}
+
+impl SerializeAs<LiveFile> for SnapshotSstFile {
+    fn serialize_as<S>(value: &LiveFile, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        SnapshotSstFile::serialize(value, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, LiveFile> for SnapshotSstFile {
+    fn deserialize_as<D>(deserializer: D) -> Result<LiveFile, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        SnapshotSstFile::deserialize(deserializer)
+    }
+}

--- a/crates/partition-store/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/tests/snapshots_test/mod.rs
@@ -1,0 +1,73 @@
+use restate_partition_store::snapshots::{LocalPartitionSnapshot, PartitionSnapshotMetadata};
+use restate_partition_store::{PartitionStore, PartitionStoreManager};
+use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
+use restate_storage_api::Transaction;
+use restate_types::config::WorkerOptions;
+use restate_types::identifiers::PartitionKey;
+use restate_types::live::Live;
+use restate_types::logs::Lsn;
+use std::ops::RangeInclusive;
+use tempfile::tempdir;
+use tracing::instrument;
+
+#[instrument(skip_all, level = "warn")]
+pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_store: PartitionStore) {
+    insert_test_data(&mut partition_store).await;
+
+    let snapshots_dir = tempdir().unwrap();
+
+    let partition_id = partition_store.partition_id();
+    let path_buf = snapshots_dir.path().to_path_buf().join("sn1");
+
+    let snapshot = partition_store.create_snapshot(path_buf).await.unwrap();
+
+    let snapshot_meta = PartitionSnapshotMetadata {
+        cluster_name: "cluster_name".to_string(),
+        partition_id,
+        key_range: partition_store.partition_key_range().clone(),
+        min_applied_lsn: snapshot.min_applied_lsn,
+        files: snapshot.files.clone(),
+    };
+    let metadata_json = serde_json::to_string_pretty(&snapshot_meta).unwrap();
+    let db_comparator_name = snapshot.db_comparator_name.clone();
+
+    drop(partition_store);
+    drop(snapshot);
+    manager.drop_partition(partition_id).await;
+
+    let snapshot_meta: PartitionSnapshotMetadata =
+        serde_json::from_str(metadata_json.as_str()).unwrap();
+    let snapshot = LocalPartitionSnapshot {
+        base_dir: snapshots_dir.path().into(),
+        db_comparator_name,
+        min_applied_lsn: snapshot_meta.min_applied_lsn,
+        files: snapshot_meta.files.clone(),
+    };
+
+    let worker_options = Live::from_value(WorkerOptions::default());
+
+    let mut new_partition_store = manager
+        .create_partition_store_from_snapshot(
+            partition_id,
+            RangeInclusive::new(0, PartitionKey::MAX - 1),
+            snapshot,
+            &worker_options.pinned().storage.rocksdb,
+        )
+        .await
+        .unwrap();
+
+    verify_restored_data(&mut new_partition_store).await;
+}
+
+async fn insert_test_data(partition: &mut PartitionStore) {
+    let mut txn = partition.transaction();
+    txn.put_applied_lsn(Lsn::new(100)).await;
+    txn.commit().await.expect("commit succeeds");
+}
+
+async fn verify_restored_data(partition: &mut PartitionStore) {
+    assert_eq!(
+        Lsn::new(100),
+        partition.get_applied_lsn().await.unwrap().unwrap()
+    );
+}

--- a/crates/rocksdb/src/background.rs
+++ b/crates/rocksdb/src/background.rs
@@ -24,6 +24,8 @@ use crate::{Priority, OP_TYPE, PRIORITY, STORAGE_BG_TASK_IN_FLIGHT};
 pub enum StorageTaskKind {
     WriteBatch,
     OpenColumnFamily,
+    ImportColumnFamily,
+    ExportColumnFamily,
     FlushWal,
     FlushMemtables,
     Shutdown,

--- a/crates/rocksdb/src/error.rs
+++ b/crates/rocksdb/src/error.rs
@@ -29,6 +29,9 @@ pub enum RocksError {
     AlreadyOpen,
     #[error(transparent)]
     #[code(unknown)]
+    ExportColumnFamily(rocksdb::Error),
+    #[error(transparent)]
+    #[code(unknown)]
     Other(#[from] rocksdb::Error),
 }
 

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -12,7 +12,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use rocksdb::perf::MemoryUsageBuilder;
-use rocksdb::ColumnFamilyDescriptor;
+use rocksdb::ExportImportFilesMetaData;
+use rocksdb::{ColumnFamilyDescriptor, ImportColumnFamilyOptions};
 use tracing::trace;
 
 use crate::BoxedCfMatcher;
@@ -44,6 +45,13 @@ pub trait RocksAccess {
         name: CfName,
         default_cf_options: rocksdb::Options,
         cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+    ) -> Result<(), RocksError>;
+    fn import_cf(
+        &self,
+        name: CfName,
+        default_cf_options: rocksdb::Options,
+        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        metadata: ExportImportFilesMetaData,
     ) -> Result<(), RocksError>;
     fn cfs(&self) -> Vec<CfName>;
 
@@ -143,6 +151,27 @@ impl RocksAccess for rocksdb::DB {
     ) -> Result<(), RocksError> {
         let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
         Ok(Self::create_cf(self, name.as_str(), &options)?)
+    }
+
+    fn import_cf(
+        &self,
+        name: CfName,
+        default_cf_options: rocksdb::Options,
+        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        metadata: ExportImportFilesMetaData,
+    ) -> Result<(), RocksError> {
+        let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
+
+        let mut import_opts = ImportColumnFamilyOptions::default();
+        import_opts.set_move_files(true);
+
+        Ok(Self::create_column_family_with_import(
+            self,
+            &options,
+            name.as_str(),
+            &import_opts,
+            &metadata,
+        )?)
     }
 
     fn flush_memtables(&self, cfs: &[CfName], wait: bool) -> Result<(), RocksError> {

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -17,7 +17,7 @@ pub enum StorageError {
     Generic(#[from] anyhow::Error),
     #[error("failed to convert Rust objects to/from protobuf: {0}")]
     Conversion(anyhow::Error),
-    #[error("Integrity constrained is violated")]
+    #[error("Integrity constraint is violated")]
     DataIntegrityError,
     #[error("Operational error that can be caused during a graceful shutdown")]
     OperationalError,


### PR DESCRIPTION

With this change we add the basic ability for the PartitionProcessor to export
its state into a snapshot, and later re-create this by importing the same
snapshot.
