### PR TITLE
[ReplicatedLoglet] ReplicationProperty is failure-domain-aware

### DIFF
--- a/crates/core/src/network/message_router.rs
+++ b/crates/core/src/network/message_router.rs
@@ -97,6 +97,20 @@ impl MessageRouterBuilder {
         }
     }
 
+    /// Attach a handler that receives all messages targeting a certain [`TargetName`].
+    #[track_caller]
+    pub fn add_raw_handler<H>(
+        &mut self,
+        target: TargetName,
+        handler: Box<dyn Handler<Error = CodecError> + Send + Sync>,
+    ) where
+        H: Handler + Send + Sync + 'static,
+    {
+        if self.handlers.insert(target, handler).is_some() {
+            panic!("Handler for target {} has been registered already!", target);
+        }
+    }
+
     /// Subscribe to a stream of messages for a specific target. This enables consumers of messages
     /// to use async stream API to process messages of a given target as an alternative to the
     /// message callback-style API as in `add_message_handler`.

--- a/crates/types/src/replicated_loglet/mod.rs
+++ b/crates/types/src/replicated_loglet/mod.rs
@@ -9,5 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod params;
+mod replication_property;
 
 pub use params::*;
+pub use replication_property::*;

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -8,15 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// todo: remove when fleshed out
-#![allow(unused)]
-
 use std::collections::HashSet;
-use std::num::NonZeroU8;
 
-use serde_with::{DisplayFromStr, VecSkipError};
+use serde_with::DisplayFromStr;
 
 use crate::{GenerationalNodeId, PlainNodeId};
+
+use super::ReplicationProperty;
 
 /// Configuration parameters of a replicated loglet segment
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
@@ -27,7 +25,7 @@ pub struct ReplicatedLogletParams {
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     sequencer: GenerationalNodeId,
     /// Replication properties of this loglet
-    replication: Replication,
+    replication: ReplicationProperty,
     nodeset: NodeSet,
     /// The set of nodes the sequencer has been considering for writes after the last
     /// known_global_tail advance.
@@ -71,25 +69,6 @@ pub struct ReplicatedLogletId(u64);
 impl ReplicatedLogletId {
     pub const fn new(id: u64) -> Self {
         Self(id)
-    }
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
-pub struct Replication {
-    /// The write-quorum for appends
-    replication_factor: NonZeroU8,
-    /// The number of extra copies (best effort) to be replicated in addition to the
-    /// replication_factor.
-    ///
-    /// default is 0
-    #[serde(default)]
-    extra_copies: u8,
-}
-
-impl Replication {
-    pub fn read_quorum_size(&self, nodeset: &NodeSet) -> u8 {
-        // N - replication_factor + 1
-        nodeset.len() - self.replication_factor.get() + 1
     }
 }
 

--- a/crates/types/src/replicated_loglet/replication_property.rs
+++ b/crates/types/src/replicated_loglet/replication_property.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{btree_map, BTreeMap};
+use std::num::NonZeroU8;
+
+use enum_map::Enum;
+
+/// Defines the scope of location for replication. This enum is ordered where the greatest
+/// scope is at the bottom of the enum. i.e. Region > Zone > Node.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Hash,
+    Enum,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    strum::EnumIter,
+    strum::Display,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum LocationScope {
+    Node,
+    Zone,
+    Region,
+}
+
+impl LocationScope {
+    pub const MAX: Self = Self::Region;
+    pub const MIN: Self = Self::Node;
+
+    pub fn next_greater_scope(self) -> Option<LocationScope> {
+        let next = self.into_usize() + 1;
+        (next < LocationScope::LENGTH).then(|| LocationScope::from_usize(next))
+    }
+
+    pub fn next_smaller_scope(self) -> Option<LocationScope> {
+        let current = self.into_usize();
+        (current != 0).then(|| LocationScope::from_usize(current - 1))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct ReplicationPropertyError(String);
+
+/// The replication policy for appends
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct ReplicationProperty(BTreeMap<LocationScope, u8>);
+
+impl ReplicationProperty {
+    pub fn new(replication_factor: NonZeroU8) -> Self {
+        let mut map = BTreeMap::default();
+        map.insert(LocationScope::Node, replication_factor.into());
+        Self(map)
+    }
+
+    pub fn with_scope(scope: LocationScope, replication_factor: NonZeroU8) -> Self {
+        let mut map = BTreeMap::default();
+        map.insert(scope, replication_factor.into());
+        Self(map)
+    }
+
+    pub fn iter(&self) -> btree_map::Iter<'_, LocationScope, u8> {
+        self.0.iter()
+    }
+
+    pub fn set_scope(
+        &mut self,
+        scope: LocationScope,
+        replication_factor: NonZeroU8,
+    ) -> Result<&mut Self, ReplicationPropertyError> {
+        // Replication factor for a scope cannot be higher lower scopes or lower than higher
+        // scopes, and if it's equal, it will be ignored.
+
+        for (s, r) in &self.0 {
+            if *s < scope && *r < replication_factor.into() {
+                return Err(ReplicationPropertyError(format!(
+                    "Cannot set {{\"{}\": {}}} as it conflicts with {{\"{}\": {}}}",
+                    scope, replication_factor, s, r
+                )));
+            }
+
+            if *s > scope && *r > replication_factor.into() {
+                return Err(ReplicationPropertyError(format!(
+                    "Cannot set {{\"{}\": {}}} as it conflicts with {{\"{}\": {}}}",
+                    scope, replication_factor, s, r
+                )));
+            }
+        }
+        self.0.insert(scope, replication_factor.into());
+        Ok(self)
+    }
+
+    pub fn num_copies(&self) -> u8 {
+        *self
+            .0
+            .first_key_value()
+            .expect("must have at least one scope")
+            .1
+    }
+
+    pub fn at_scope_or_greater(&self, scope: LocationScope) -> Option<(&LocationScope, &u8)> {
+        self.0.range(scope..).next()
+    }
+
+    pub fn at_smallest_scope(&self) -> (&LocationScope, &u8) {
+        self.0
+            .first_key_value()
+            .expect("must have at least one scope")
+    }
+
+    pub fn at_greatest_scope(&self) -> (&LocationScope, &u8) {
+        self.0
+            .last_key_value()
+            .expect("must have at least one scope")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[test]
+    fn test_location_scope() {
+        assert_that!(LocationScope::Zone, gt(LocationScope::Node));
+        assert_that!(LocationScope::Region, gt(LocationScope::Zone));
+        assert_that!(
+            LocationScope::Node.next_greater_scope(),
+            some(eq(LocationScope::Zone))
+        );
+
+        assert_that!(LocationScope::Region.next_greater_scope(), none());
+
+        assert_that!(LocationScope::Node.next_smaller_scope(), none());
+        assert_that!(
+            LocationScope::Region.next_smaller_scope(),
+            some(eq(LocationScope::Zone))
+        );
+    }
+
+    #[test]
+    fn test_replication_property() -> Result<()> {
+        let mut r = ReplicationProperty::new(NonZeroU8::new(4).unwrap());
+        assert_that!(r.num_copies(), eq(4));
+        assert_that!(r.at_greatest_scope(), eq((&LocationScope::Node, &4)));
+        assert_that!(
+            r.at_scope_or_greater(LocationScope::Node),
+            some(eq((&LocationScope::Node, &4)))
+        );
+
+        r.set_scope(LocationScope::Region, NonZeroU8::new(2).unwrap())?;
+        assert_that!(r.num_copies(), eq(4));
+        assert_that!(
+            r.at_scope_or_greater(LocationScope::Zone),
+            some(eq((&LocationScope::Region, &2)))
+        );
+
+        r.set_scope(LocationScope::Zone, NonZeroU8::new(2).unwrap())?;
+        assert_that!(r.num_copies(), eq(4));
+        assert_that!(
+            r.at_scope_or_greater(LocationScope::Zone),
+            some(eq((&LocationScope::Zone, &2)))
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
[ReplicatedLoglet] ReplicationProperty is failure-domain-aware

Defines a `ReplicationProperty` struct that represents the failure-domain-aware replication property

Example:
```json
{
  "region": 3,
  "node": 5,
}
```
Which means that the data is replicated across 5 nodes distributed across 3 regions

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/1959).
* __->__ #1959
* #1957