### PR TITLE
Let MultiplexedInvokerStatusReader share state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6469,6 +6469,7 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "opentelemetry",
+ "parking_lot",
  "pin-project",
  "prost 0.13.1",
  "rand",

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -56,6 +56,7 @@ humantime = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
+parking_lot = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
 schemars = { workspace = true, optional = true }


### PR DESCRIPTION
The MultiplexedInvokerStatusReader now shares the ChannelStatusReader via an Arc<Mutex<>>.

This fixes #1961.