### PR TITLE
Kafka perf improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5775,6 +5775,7 @@ dependencies = [
  "base64 0.22.0",
  "bytes",
  "derive_builder",
+ "metrics",
  "opentelemetry",
  "rdkafka",
  "restate-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5217,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053adfa02fab06e86c01d586cc68aa47ee0ff4489a59469081dc12cbcde578bf"
+checksum = "f16c17f411935214a5870e40aff9291f8b40a73e97bf8de29e5959c473d5ef33"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 derive_builder = { workspace = true }
+metrics = { workspace = true }
 opentelemetry = { workspace = true }
 rdkafka = { version = "0.35", features = ["libz-static", "cmake-build"] }
 schemars = { workspace = true, optional = true }

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -23,7 +23,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 derive_builder = { workspace = true }
 opentelemetry = { workspace = true }
-rdkafka = { version = "0.34", features = ["libz-static", "cmake-build"] }
+rdkafka = { version = "0.35", features = ["libz-static", "cmake-build"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ingress-kafka/src/metric_definitions.rs
+++ b/crates/ingress-kafka/src/metric_definitions.rs
@@ -8,13 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod consumer_task;
-mod metric_definitions;
-mod subscription_controller;
+use metrics::{describe_counter, Unit};
 
-use tokio::sync::mpsc;
+pub const KAFKA_INGRESS_REQUESTS: &str = "restate.kafka_ingress.requests.total";
 
-pub use subscription_controller::{Command, Error, Service};
-
-pub type SubscriptionCommandSender = mpsc::Sender<Command>;
-pub type SubscriptionCommandReceiver = mpsc::Receiver<Command>;
+pub(crate) fn describe_metrics() {
+    describe_counter!(
+        KAFKA_INGRESS_REQUESTS,
+        Unit::Count,
+        "Number of Kafka ingress requests"
+    );
+}

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -48,6 +48,7 @@ pub struct Service {
 
 impl Service {
     pub fn new(dispatcher: IngressDispatcher) -> Service {
+        metric_definitions::describe_metrics();
         let (commands_tx, commands_rx) = mpsc::channel(10);
 
         Service {

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 
 use crate::subscription_controller::task_orchestrator::TaskOrchestrator;
 use rdkafka::error::KafkaError;
-use restate_core::cancellation_watcher;
+use restate_core::{cancellation_watcher, task_center};
 use restate_ingress_dispatcher::IngressDispatcher;
 use restate_types::config::IngressOptions;
 use restate_types::identifiers::SubscriptionId;
@@ -133,6 +133,7 @@ impl Service {
 
         // Create the consumer task
         let consumer_task = consumer_task::ConsumerTask::new(
+            task_center(),
             client_config,
             vec![topic.to_string()],
             MessageSender::new(subscription, self.dispatcher.clone()),


### PR DESCRIPTION
This is the result of investigating the Kafka ingress performance.

Before:

![Screenshot 2024-09-16 at 17-35-03 View panel - New dashboard - Dashboards - Grafana](https://github.com/user-attachments/assets/72e60db4-fe6a-402f-a9a3-e587a0903a23)

After:

![Screenshot 2024-09-16 at 17-35-53 View panel - New dashboard - Dashboards - Grafana](https://github.com/user-attachments/assets/3cabc046-fca9-44e1-a8c0-90f926a86ec4)

Red line is _Bifrost append_ thpt, green line is _PP Invoke command_ thpt. The kafka load tool generates as much load as possible (around 25k/s records on my machine).

In both situations the initial slow section seems to be caused by the load tool, which takes a good amount of my cpu. After it finishes producing, restate takes all the CPU.  

In the after case, the kafka container OOMs before finishing (probably caused by the high load generated by the consumer), so I cut the section afterwards.

I ran this test using Rust SDK and a virtual object as target, and the following subscription:

```
http localhost:9070/subscriptions source="kafka://my-cluster/test-topic" sink="service://Greeter/greet" \
  options["fetch.queue.backoff.ms"]="500" \
  options["queued.max.messages.kbytes"]="131072" \
  options["reconnect.backoff.max.ms"]="1000"
```

The Kafka topic has **24 partitions** (same number of Restate's partitions). The thpt improvement in this PR is greatly affected by the Kafka topic partition number, meaning higher number of Kafka partitions equals to higher throughput.

Tuning the knobs though has **irrelevant impact** most of the times (at least on my machine). I tried to tune `fetch.wait.max.ms` too, just increases CPU usage. 