### PR TITLE
Disable log-server role by default to fix v1.0.x compatibility

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [features]
 default = []
 memory-loglet = ["restate-bifrost/memory-loglet"]
+replicated-loglet = ["restate-bifrost/replicated-loglet"]
 options_schema = [
     "dep:schemars",
     "restate-admin/options_schema",
@@ -18,7 +19,7 @@ options_schema = [
 
 [dependencies]
 restate-admin = { workspace = true, features = ["servers"] }
-restate-bifrost = { workspace = true, features = ["replicated-loglet"] }
+restate-bifrost = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-log-server = { workspace = true }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -304,7 +304,13 @@ impl CommonOptions {
 impl Default for CommonOptions {
     fn default() -> Self {
         Self {
-            roles: EnumSet::all(),
+            // todo (asoli): Remove this when:
+            //   a. The safe rollback version supports log-server (at least supports parsing the
+            //   config with the log-server role)
+            //   b. When log-server becomes enabled by default.
+            //
+            //   see "roles_compat_test" test below.
+            roles: EnumSet::all() - Role::LogServer,
             node_name: None,
             force_node_id: None,
             cluster_name: "localcluster".to_owned(),
@@ -540,5 +546,19 @@ impl Default for TracingOptions {
             tracing_filter: "info".to_owned(),
             tracing_headers: SerdeableHeaderHashMap::default(),
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use crate::nodes_config::Role;
+
+    use super::CommonOptions;
+
+    #[test]
+    fn roles_compat_test() {
+        let opts = CommonOptions::default();
+        // make sure we don't add log-server by default until previous version can parse nodes
+        // configuration with this role.
+        assert!(!opts.roles.contains(Role::LogServer));
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,7 @@ options_schema = [
     "restate-types/schemars",
 ]
 memory-loglet = ["restate-node/memory-loglet"]
+replicated-loglet = ["restate-node/replicated-loglet"]
 
 [dependencies]
 restate-admin = { workspace = true }


### PR DESCRIPTION

This change disables the log-server role by default to avoid breaking. Additionally, if log-server role is enabled, log-server will not start unless the binary is built with `-F replicated-loglet` to protect the public release from starting the server. This change is necessary to maintain compatibility with v1.0.x.

This change also attempts to detect the presence of log-store and asks the user to remove it manually. We don't remove it automatically to avoid accidental data wipes if accidental rollbacks took place from future versions back to this.
