### PR TITLE
[Snapshots] Introduce a Snapshot Producer component

### DIFF
--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -63,7 +63,7 @@ pub enum TaskKind {
     /// Do not use. This is a special task kind that indicate that work is running within
     /// task_center but its lifecycle is not managed by it.
     InPlace,
-    /// Tasks used during system initialization. Short lived but will shutdown the node if they
+    /// Tasks used during system initialization. Short-lived but will shut down the node if they
     /// failed.
     #[strum(props(OnCancel = "abort"))]
     SystemBoot,
@@ -73,7 +73,7 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort", OnError = "log"))]
     RpcConnection,
     /// A type for ingress until we start enforcing timeouts for inflight requests. This enables us
-    /// to shutdown cleanly without waiting indefinitely.
+    /// to shut down cleanly without waiting indefinitely.
     #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     IngressServer,
     RoleRunner,
@@ -81,6 +81,10 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     Ingress,
     PartitionProcessor,
+    /// Longer-running, low-priority tasks that is responsible for the export, and potentially
+    /// upload to remote storage, of partition store snapshots.
+    #[strum(props(OnCancel = "abort", OnError = "log"))]
+    PartitionSnapshotProducer,
     #[strum(props(OnError = "log"))]
     ConnectionReactor,
     Shuffle,

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -17,7 +17,7 @@ pub enum SnapshotFormatVersion {
 
 /// A partition store snapshot.
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PartitionSnapshotMetadata {
     pub version: SnapshotFormatVersion,
 

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -163,7 +163,7 @@ impl RocksAccess for rocksdb::DB {
         let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
 
         let mut import_opts = ImportColumnFamilyOptions::default();
-        import_opts.set_move_files(true);
+        import_opts.set_move_files(false); // keep the snapshot files intact
 
         Ok(Self::create_column_family_with_import(
             self,

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -51,11 +51,10 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
+use super::live::{LiveLoad, Pinned};
 use crate::errors::GenericError;
 use crate::live::Live;
 use crate::nodes_config::Role;
-
-use super::live::{LiveLoad, Pinned};
 
 #[cfg(any(test, feature = "test-util"))]
 enum TempOrPath {

--- a/crates/worker/src/partition/snapshot_producer.rs
+++ b/crates/worker/src/partition/snapshot_producer.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2023 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use anyhow::bail;
+use tracing::{info, warn};
+
+use restate_partition_store::snapshots::{PartitionSnapshotMetadata, SnapshotFormatVersion};
+use restate_partition_store::PartitionStore;
+use restate_types::identifiers::SnapshotId;
+
+/// Encapsulates producing a Restate partition snapshot out of a partition store.
+pub struct SnapshotProducer {}
+
+pub struct SnapshotSource {
+    pub cluster_name: String,
+    pub node_name: String,
+}
+
+impl SnapshotProducer {
+    pub async fn create(
+        snapshot_source: SnapshotSource,
+        mut partition_store: PartitionStore,
+        partition_snapshots_path: PathBuf,
+    ) -> anyhow::Result<PartitionSnapshotMetadata> {
+        if let Err(e) = tokio::fs::create_dir_all(&partition_snapshots_path).await {
+            warn!(
+                path = ?partition_snapshots_path,
+                error = ?e,
+                "Failed to create partition snapshot directory"
+            );
+            bail!("Failed to create partition snapshot directory: {:?}", e);
+        }
+
+        let snapshot_id = SnapshotId::new();
+        let snapshot_path = partition_snapshots_path.join(snapshot_id.to_string());
+        let snapshot = partition_store
+            .create_snapshot(snapshot_path.clone())
+            .await?;
+
+        let snapshot_meta = PartitionSnapshotMetadata {
+            version: SnapshotFormatVersion::V1,
+            cluster_name: snapshot_source.cluster_name,
+            node_name: snapshot_source.node_name,
+            partition_id: partition_store.partition_id(),
+            created_at: humantime::Timestamp::from(SystemTime::now()),
+            snapshot_id,
+            key_range: partition_store.partition_key_range().clone(),
+            min_applied_lsn: snapshot.min_applied_lsn,
+            db_comparator_name: snapshot.db_comparator_name.clone(),
+            files: snapshot.files.clone(),
+        };
+        let metadata_json = serde_json::to_string_pretty(&snapshot_meta)?;
+
+        let metadata_path = snapshot_path.join("metadata.json");
+        tokio::fs::write(metadata_path.clone(), metadata_json).await?;
+        info!(
+            lsn = %snapshot.min_applied_lsn,
+            metadata = ?metadata_path,
+            "Partition snapshot written"
+        );
+
+        Ok(snapshot_meta)
+    }
+}


### PR DESCRIPTION
This component can create online partition snapshots at runtime, building on #1954.


1. https://github.com/restatedev/restate/pull/1954
2. **this PR** https://github.com/restatedev/restate/pull/1981
3. https://github.com/restatedev/restate/pull/1998
4. https://github.com/restatedev/restate/pull/1999

Closes: https://github.com/restatedev/restate/issues/1894