### PR TITLE
[Bifrost] Add RPC routers for bifrost to logserver communication

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -13,6 +13,7 @@ mod loglet;
 pub(crate) mod metric_definitions;
 mod provider;
 pub mod replication;
+mod rpc_routers;
 #[allow(dead_code)]
 pub mod sequencer;
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// todo(asoli): remove once this is used
+#![allow(dead_code)]
+
+use restate_core::network::rpc_router::RpcRouter;
+use restate_core::network::MessageRouterBuilder;
+use restate_types::net::log_server::{GetLogletInfo, GetRecords, Release, Seal, Store, Trim};
+
+/// Used by replicated loglets to send requests and receive responses from log-servers
+/// Cloning this is cheap and all clones will share the same internal trackers.
+#[derive(Clone)]
+pub struct LogServersRpc {
+    pub store: RpcRouter<Store>,
+    pub release: RpcRouter<Release>,
+    pub trim: RpcRouter<Trim>,
+    pub seal: RpcRouter<Seal>,
+    pub get_loglet_info: RpcRouter<GetLogletInfo>,
+    pub get_records: RpcRouter<GetRecords>,
+}
+
+impl LogServersRpc {
+    /// Registers all routers into the supplied message router. This ensures that
+    /// responses are routed correctly.
+    pub fn new(router_builder: &mut MessageRouterBuilder) -> Self {
+        let store = RpcRouter::new(router_builder);
+        let release = RpcRouter::new(router_builder);
+        let trim = RpcRouter::new(router_builder);
+        let seal = RpcRouter::new(router_builder);
+        let get_loglet_info = RpcRouter::new(router_builder);
+        let get_records = RpcRouter::new(router_builder);
+
+        Self {
+            store,
+            release,
+            trim,
+            seal,
+            get_loglet_info,
+            get_records,
+        }
+    }
+}


### PR DESCRIPTION

The new structure `LogServersRpc` is passed down to all loglets to facilitate sending and receiving network messages to logservers.
