### PR TITLE
[Bifrost] Simplify sequencer and integrate with replicated loglet

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -15,16 +15,18 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use restate_types::logs::metadata::SegmentIndex;
 use tracing::debug;
 
 use restate_core::network::{Networking, TransportConnect};
-use restate_core::{Metadata, ShutdownError, TaskCenter};
+use restate_core::ShutdownError;
+use restate_types::logs::metadata::SegmentIndex;
 use restate_types::logs::{KeyFilter, LogId, LogletOffset, Record, SequenceNumber, TailState};
 use restate_types::replicated_loglet::ReplicatedLogletParams;
 
 use crate::loglet::util::TailOffsetWatch;
 use crate::loglet::{Loglet, LogletCommit, OperationError, SendableLogletReadStream};
+use crate::providers::replicated_loglet::replication::spread_selector::SelectorStrategy;
+use crate::providers::replicated_loglet::sequencer::Sequencer;
 
 use super::record_cache::RecordCache;
 use super::rpc_routers::{LogServersRpc, SequencersRpc};
@@ -39,10 +41,6 @@ pub(super) struct ReplicatedLoglet<T> {
     segment_index: SegmentIndex,
     my_params: ReplicatedLogletParams,
     #[debug(skip)]
-    task_center: TaskCenter,
-    #[debug(skip)]
-    metadata: Metadata,
-    #[debug(skip)]
     networking: Networking<T>,
     #[debug(skip)]
     logservers_rpc: LogServersRpc,
@@ -52,9 +50,9 @@ pub(super) struct ReplicatedLoglet<T> {
     /// Note that this comes with a few caveats:
     /// - On startup, this defaults to `Open(OLDEST)`
     /// - find_tail() should use this value iff we have a local sequencer for all other cases, we
-    /// should run a proper tail search.
+    ///   should run a proper tail search.
     known_global_tail: TailOffsetWatch,
-    sequencer: SequencerAccess,
+    sequencer: SequencerAccess<T>,
 }
 
 impl<T: TransportConnect> ReplicatedLoglet<T> {
@@ -62,52 +60,57 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
         log_id: LogId,
         segment_index: SegmentIndex,
         my_params: ReplicatedLogletParams,
-        task_center: TaskCenter,
-        metadata: Metadata,
         networking: Networking<T>,
         logservers_rpc: LogServersRpc,
         sequencers_rpc: &SequencersRpc,
         record_cache: RecordCache,
-    ) -> Self {
-        let sequencer = if metadata.my_node_id() == my_params.sequencer {
+    ) -> Result<Self, ShutdownError> {
+        let known_global_tail = TailOffsetWatch::new(TailState::Open(LogletOffset::OLDEST));
+
+        let sequencer = if networking.my_node_id() == my_params.sequencer {
             debug!(
                 loglet_id = %my_params.loglet_id,
                 "We are the sequencer node for this loglet"
             );
+            // todo(asoli): Potentially configurable or controllable in tests either in
+            // ReplicatedLogletParams or in the config file.
+            let selector_strategy = SelectorStrategy::Flood;
+
             SequencerAccess::Local {
-                // create the sequencer and store the handle
+                handle: Sequencer::new(
+                    my_params.clone(),
+                    selector_strategy,
+                    networking.clone(),
+                    logservers_rpc.store.clone(),
+                    known_global_tail.clone(),
+                ),
             }
         } else {
             SequencerAccess::Remote {
                 sequencers_rpc: sequencers_rpc.clone(),
             }
         };
-        Self {
+        Ok(Self {
             log_id,
             segment_index,
             my_params,
-            task_center,
-            metadata,
             networking,
             logservers_rpc,
             record_cache,
-            known_global_tail: TailOffsetWatch::new(TailState::Open(LogletOffset::OLDEST)),
+            known_global_tail,
             sequencer,
-        }
+        })
     }
 }
 
-// todo(asoli): This will hold a handle to access the local sequencer, or a swappable handle if
-// it's a remote sequencer.
 #[derive(derive_more::Debug, derive_more::IsVariant)]
-pub enum SequencerAccess {
+pub enum SequencerAccess<T> {
     /// The sequencer is remote (or retired/preempted)
     #[debug("Remote")]
     Remote { sequencers_rpc: SequencersRpc },
     /// We are the loglet leaders
     #[debug("Local")]
-    // todo (add handle)
-    Local {},
+    Local { handle: Sequencer<T> },
 }
 
 #[async_trait]
@@ -128,8 +131,13 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         Box::pin(self.known_global_tail.to_stream())
     }
 
-    async fn enqueue_batch(&self, _payloads: Arc<[Record]>) -> Result<LogletCommit, ShutdownError> {
-        todo!()
+    async fn enqueue_batch(&self, payloads: Arc<[Record]>) -> Result<LogletCommit, ShutdownError> {
+        match self.sequencer {
+            SequencerAccess::Local { ref handle } => handle.enqueue_batch(payloads).await,
+            SequencerAccess::Remote { .. } => {
+                todo!("Access to remote sequencers is not implemented yet")
+            }
+        }
     }
 
     async fn find_tail(&self) -> Result<TailState<LogletOffset>, OperationError> {

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -14,7 +14,7 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 
 use restate_core::network::{Incoming, MessageRouterBuilder, TransportConnect};
 use restate_core::{cancellation_watcher, Metadata};
@@ -48,7 +48,7 @@ impl RequestPump {
 
     /// Must run in task-center context
     pub async fn run<T: TransportConnect>(
-        self,
+        mut self,
         _provider: Arc<ReplicatedLogletProvider<T>>,
     ) -> anyhow::Result<()> {
         trace!("Starting replicated loglet request pump");
@@ -57,6 +57,8 @@ impl RequestPump {
             tokio::select! {
                 _ = &mut cancel => {
                     break;
+                }
+                Some(_append) = self.append_stream.next() => {
                 }
             }
         }

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/append.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/append.rs
@@ -400,7 +400,7 @@ impl<T: TransportConnect> LogServerStoreTask<T> {
             known_global_tail: self.sequencer_shared_state.committed_tail.latest_offset(),
             loglet_id: self.server.loglet_id(),
             payloads: Vec::from_iter(self.records.iter().cloned()),
-            sequencer: self.sequencer_shared_state.node_id,
+            sequencer: self.sequencer_shared_state.my_node_id,
             timeout_at: None,
         };
 

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/node.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/node.rs
@@ -54,7 +54,7 @@ impl RemoteLogServer {
 struct RemoteLogServerManagerInner<T> {
     loglet_id: ReplicatedLogletId,
     servers: BTreeMap<PlainNodeId, LogServerLock>,
-    node_set: NodeSet,
+    nodeset: NodeSet,
     networking: Networking<T>,
 }
 
@@ -77,20 +77,16 @@ impl<T> Clone for RemoteLogServerManager<T> {
 
 impl<T: TransportConnect> RemoteLogServerManager<T> {
     /// creates the node set and start the appenders
-    pub fn new(
-        loglet_id: ReplicatedLogletId,
-        networking: Networking<T>,
-        node_set: NodeSet,
-    ) -> Self {
+    pub fn new(loglet_id: ReplicatedLogletId, networking: Networking<T>, nodeset: NodeSet) -> Self {
         let mut servers = BTreeMap::default();
-        for node_id in node_set.iter() {
+        for node_id in nodeset.iter() {
             servers.insert(*node_id, LogServerLock::default());
         }
 
         let inner = RemoteLogServerManagerInner {
             loglet_id,
             servers,
-            node_set,
+            nodeset,
             networking,
         };
 

--- a/crates/core/src/network/networking.rs
+++ b/crates/core/src/network/networking.rs
@@ -15,7 +15,7 @@ use tracing::{info, instrument, trace};
 
 use restate_types::config::NetworkingOptions;
 use restate_types::net::codec::{Targeted, WireEncode};
-use restate_types::NodeId;
+use restate_types::{GenerationalNodeId, NodeId};
 
 use super::{
     ConnectionManager, HasConnection, NetworkError, NetworkSendError, NetworkSender, NoConnection,
@@ -70,6 +70,14 @@ impl<T: TransportConnect> Networking<T> {
 
     pub fn connection_manager(&self) -> &ConnectionManager<T> {
         &self.connections
+    }
+
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    pub fn my_node_id(&self) -> GenerationalNodeId {
+        self.metadata.my_node_id()
     }
 
     /// A connection sender is pinned to a single stream, thus guaranteeing ordered delivery of

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -100,6 +100,9 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     Watchdog,
     NetworkMessageHandler,
+    // Replicated loglet tasks
+    Sequencer,
+    /// Log-server tasks
     LogletWriter,
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -169,12 +169,7 @@ impl Node {
         #[cfg(feature = "replicated-loglet")]
         let replicated_loglet_factory = restate_bifrost::providers::replicated_loglet::Factory::new(
             tc.clone(),
-            updateable_config
-                .clone()
-                .map(|c| &c.bifrost.replicated_loglet)
-                .boxed(),
             metadata_store_client.clone(),
-            metadata.clone(),
             networking.clone(),
             &mut router_builder,
         );

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -214,11 +214,13 @@ impl Default for LocalLogletOptions {
 #[serde(rename_all = "kebab-case")]
 #[builder(default)]
 pub struct ReplicatedLogletOptions {
-    /// Maximum number of inflight batches before sequencer
+    /// Maximum number of inflight records sequencer can accept
     ///
     /// Once this maximum is hit, sequencer will induce back pressure
-    /// on clients
-    pub maximum_inflight_batches: NonZeroUsize,
+    /// on clients. This controls the total number of records regardless of how many batches.
+    ///
+    /// Note that this will be increased to fit the biggest batch of records being enqueued.
+    pub maximum_inflight_records: NonZeroUsize,
 
     /// Sequencer backoff strategy
     ///
@@ -235,7 +237,7 @@ pub struct ReplicatedLogletOptions {
 impl Default for ReplicatedLogletOptions {
     fn default() -> Self {
         Self {
-            maximum_inflight_batches: NonZeroUsize::new(128).unwrap(),
+            maximum_inflight_records: NonZeroUsize::new(1000).unwrap(),
 
             sequencer_backoff_strategy: RetryPolicy::exponential(
                 Duration::from_millis(100),


### PR DESCRIPTION

Most notable changes:
- Sequencer is not a task and avoids intermediate channels to enqueue
- Sequencer admission control is configured by the number of records, not the number of batches in flight since this easier to reason about from user configuration perspective
- reduce the number of inputs to types by reusing metadata's availability in Networking (also fewer copies)
