### PR TITLE
[Bifrost] smoke testing single-node append path for replicated loglet

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -156,7 +156,7 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
                 );
 
                 // Create loglet
-                let loglet = ReplicatedLoglet::start(
+                let loglet = ReplicatedLoglet::new(
                     log_id,
                     segment_index,
                     params,

--- a/crates/types/src/live.rs
+++ b/crates/types/src/live.rs
@@ -152,6 +152,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Pinned<T> {
     guard: arc_swap::Guard<Arc<T>, arc_swap::DefaultStrategy>,
 }

--- a/crates/types/src/logs/tail.rs
+++ b/crates/types/src/logs/tail.rs
@@ -10,7 +10,7 @@
 /// Represents the state of the tail of the loglet.
 use super::{Lsn, SequenceNumber};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TailState<Offset = Lsn> {
     /// Loglet is open for appends
     Open(Offset),


### PR DESCRIPTION

The test runs a log-server and a replicated loglet on the same node, sets up replication to 1 and performs a couple of appends.

This also fixes a bug in offset calculation in sequencer
