### PR TITLE
[Bifrost] Make LogServerManager shared across components in replicated loglet

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod error;
+mod log_server_manager;
 mod loglet;
 pub(crate) mod metric_definitions;
 mod network;

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -100,6 +100,9 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     Watchdog,
     NetworkMessageHandler,
+    // Replicated loglet tasks
+    ReplicatedLogletAppender,
+    #[strum(props(OnCancel = "abort"))]
     /// Log-server tasks
     LogletWriter,
 }


### PR DESCRIPTION

- Makes LogServerManager shared across components in replicated loglet, not just sequencer.
- Networking is passed in when needed to unnecessary clones, and fewer generic types
- StoreTask now holds references instead of clones
