### PR TITLE
restatectl describe log reports log trim point

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -51,10 +51,13 @@ message DescribeLogRequest {
 }
 
 message DescribeLogResponse {
+  uint32 log_id = 5;
+  uint32 logs_version = 6;
   // Serialized restate_types::logs::metadata::Chain
   bytes chain = 1;
   TailState tail_state = 2;
   uint64 tail_offset = 3;
+  uint64 trim_point = 4;
 }
 
 message ListNodesRequest { }


### PR DESCRIPTION
While testing snapshots, I realized we don't currently have a good way to query the trim position for a log.

This is what the tool output looks like now:

```
> restatectl logs list

📋 Logs:
――――――――
 Metadata version  v1

Logs
 LOG-ID  SEGMENTS  TAIL BASE LSN  KIND
 0       1         1              Local

> restatectl logs describe -l 0

📋 Log 0:
―――――――――
 Metadata version  v1
 Trim point        9640

Segments
 SEGMENT  STATE  BASE LSN  TAIL LSN  KIND
 0        OPEN   1         9642      Local
```