### PR TITLE
Add metadata get/patch subcommands to restatectl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6433,6 +6433,7 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_json",
+ "strum 0.26.2",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3418,6 +3418,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonptr"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6410,15 +6422,19 @@ name = "restatectl"
 version = "1.1.3"
 dependencies = [
  "anyhow",
+ "bytes",
+ "bytestring",
  "chrono",
  "clap",
  "clap-verbosity-flag",
  "cling",
  "crossterm 0.27.0",
  "ctrlc",
+ "derive_more",
  "futures-util",
  "hyper-util",
  "itertools 0.13.0",
+ "json-patch",
  "prost-types",
  "restate-admin",
  "restate-bifrost",

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -22,7 +22,7 @@ pub use service::{Error, LocalMetadataStoreService};
 
 use crate::local::grpc::client::LocalMetadataStoreClient;
 
-/// Creates a [`MetadataStoreClient`] for the [`LocalMetadataStoreService`].
+/// Creates a [`MetadataStoreClient`].
 pub async fn create_client(
     metadata_store_client_options: MetadataStoreClientOptions,
 ) -> Result<MetadataStoreClient, GenericError> {

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -37,6 +37,7 @@ prost-types = { workspace = true }
 rlimit = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -20,15 +20,19 @@ restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
 
 anyhow = { workspace = true }
+bytes = { workspace = true }
+bytestring = { workspace = true }
 chrono = { workspace = true }
 clap = { version = "4.1", features = ["derive", "env", "wrap_help", "color"] }
 clap-verbosity-flag = { version = "2.0.1" }
 cling = { version = "0.1.0", default-features = false, features = ["derive"] }
 crossterm = { version = "0.27.0" }
 ctrlc = { version = "3.4" }
+derive_more = { workspace = true }
 futures-util = { workspace = true }
 hyper-util = { workspace = true }
 itertools = { workspace = true }
+json-patch = "2.0.0"
 prost-types = { workspace = true }
 rlimit = { workspace = true }
 serde = { workspace = true }

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -29,8 +29,6 @@ pub struct CliApp {
     pub common_opts: CommonOpts,
     #[clap(flatten)]
     pub connection: ConnectionInfo,
-    #[clap(flatten)]
-    pub metadata_store: MetadataStoreOpts,
     #[clap(subcommand)]
     pub cmd: Command,
 }
@@ -38,25 +36,8 @@ pub struct CliApp {
 #[derive(Parser, Collect, Debug, Clone)]
 pub struct ConnectionInfo {
     /// Cluster Controller host:port (e.g. http://localhost:5122/)
-    #[clap(long, value_hint= clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(), global = true)]
+    #[clap(long, value_hint = clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(), global = true)]
     pub cluster_controller: AdvertisedAddress,
-}
-
-#[derive(Parser, Collect, Debug, Clone)]
-pub struct MetadataStoreOpts {
-    /// Metadata store host:port (e.g. http://localhost:5123/)
-    #[clap(long, value_hint= clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5123/").unwrap(), global = true)]
-    pub address: AdvertisedAddress,
-    #[clap(long, default_value_t = MetadataStoreType::Embedded, global = true)]
-    /// Metadata store type
-    pub store: MetadataStoreType,
-}
-
-#[derive(Parser, Collect, Debug, Clone, derive_more::Display, derive_more::FromStr)]
-pub enum MetadataStoreType {
-    Local,
-    Embedded,
-    Etcd,
 }
 
 #[derive(Run, Subcommand, Clone)]

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -18,6 +18,7 @@ use restate_types::net::AdvertisedAddress;
 
 use crate::commands::dump::Dump;
 use crate::commands::log::Log;
+use crate::commands::metadata::Metadata;
 use crate::commands::node::Node;
 
 #[derive(Run, Parser, Clone)]
@@ -28,6 +29,8 @@ pub struct CliApp {
     pub common_opts: CommonOpts,
     #[clap(flatten)]
     pub connection: ConnectionInfo,
+    #[clap(flatten)]
+    pub metadata_store: MetadataStoreOpts,
     #[clap(subcommand)]
     pub cmd: Command,
 }
@@ -37,6 +40,23 @@ pub struct ConnectionInfo {
     /// Cluster Controller host:port (e.g. http://localhost:5122/)
     #[clap(long, value_hint= clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(), global = true)]
     pub cluster_controller: AdvertisedAddress,
+}
+
+#[derive(Parser, Collect, Debug, Clone)]
+pub struct MetadataStoreOpts {
+    /// Metadata store host:port (e.g. http://localhost:5123/)
+    #[clap(long, value_hint= clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5123/").unwrap(), global = true)]
+    pub address: AdvertisedAddress,
+    #[clap(long, default_value_t = MetadataStoreType::Embedded, global = true)]
+    /// Metadata store type
+    pub store: MetadataStoreType,
+}
+
+#[derive(Parser, Collect, Debug, Clone, derive_more::Display, derive_more::FromStr)]
+pub enum MetadataStoreType {
+    Local,
+    Embedded,
+    Etcd,
 }
 
 #[derive(Run, Subcommand, Clone)]
@@ -50,6 +70,9 @@ pub enum Command {
     /// Cluster node status
     #[clap(subcommand)]
     Nodes(Node),
+    /// Cluster metadata
+    #[clap(subcommand)]
+    Metadata(Metadata),
 }
 
 fn init(common_opts: &CommonOpts) {

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -11,10 +11,10 @@
 use std::str::FromStr;
 
 use cling::prelude::*;
-use restate_types::net::AdvertisedAddress;
 
 use restate_cli_util::CliContext;
 use restate_cli_util::CommonOpts;
+use restate_types::net::AdvertisedAddress;
 
 use crate::commands::dump::Dump;
 use crate::commands::log::Log;

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -8,33 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp::max;
 use std::path::PathBuf;
-use std::time::Duration;
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use cling::prelude::*;
-
 use futures_util::StreamExt;
-use restate_bifrost::{BifrostService, FindTailAttributes};
-use restate_core::network::net_util::create_tonic_channel_from_advertised_address;
-use restate_core::network::{MessageRouterBuilder, Networking};
-use restate_core::{MetadataBuilder, MetadataManager, TaskCenter, TaskCenterBuilder, TaskKind};
-use restate_metadata_store::local::LocalMetadataStoreService;
-use restate_metadata_store::MetadataStoreClient;
-use restate_rocksdb::RocksDbManager;
-use restate_server::config_loader::ConfigLoaderBuilder;
-use restate_types::config::{
-    Configuration, MetadataStoreClientOptions, MetadataStoreOptions, RocksDbOptions,
-};
-use restate_types::live::{BoxedLiveLoad, Live};
-use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
-use restate_types::retries::RetryPolicy;
-use restate_wal_protocol::Envelope;
-use tonic_health::pb::health_client::HealthClient;
-use tonic_health::pb::HealthCheckRequest;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
-use crate::build_info;
+use restate_bifrost::{BifrostService, FindTailAttributes};
+use restate_core::network::{MessageRouterBuilder, Networking};
+use restate_core::{MetadataBuilder, MetadataManager, TaskKind};
+use restate_rocksdb::RocksDbManager;
+use restate_types::config::Configuration;
+use restate_types::live::Live;
+use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
+use restate_wal_protocol::Envelope;
+
+use crate::environment::metadata_store;
+use crate::environment::task_center::run_in_task_center;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]
@@ -49,11 +41,12 @@ pub struct DumpLogOpts {
         value_name = "FILE"
     )]
     config_file: Option<PathBuf>,
+
     /// Specifies the log_id to dump.
     #[arg(short, long)]
     log_id: u32,
 
-    /// Start LSN, if unset it'll read from oldest record in the log.
+    /// Start LSN, if unset it'll read from the oldest record in the log.
     #[arg(long)]
     from_lsn: Option<u64>,
 }
@@ -66,198 +59,108 @@ struct DecodedLogRecord {
 }
 
 async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
-    let config_path = opts
-        .config_file
-        .as_ref()
-        .map(|p| std::fs::canonicalize(p).expect("config-file path is valid"));
-    // Initial configuration loading
-    let config_loader = ConfigLoaderBuilder::default()
-        .load_env(true)
-        .path(config_path.clone())
-        .build()
-        .unwrap();
-
-    let config = match config_loader.load_once() {
-        Ok(c) => c,
-        Err(e) => {
-            // We cannot use tracing here as it's not configured yet
-            eprintln!("{:?}", e);
-            std::process::exit(1);
+    run_in_task_center(opts.config_file.as_ref(), |config, tc| async move {
+        if !config.bifrost.local.data_dir().exists() {
+            bail!(
+                "The specified path '{}' does not contain a local-loglet directory.",
+                config.bifrost.local.data_dir().display()
+            );
         }
-    };
 
-    // Setting initial configuration as global current
-    restate_types::config::set_current_config(config);
-    if rlimit::increase_nofile_limit(u64::MAX).is_err() {
-        warn!("Failed to increase the number of open file descriptors limit.");
-    }
+        let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+        debug!("RocksDB Initialized");
 
-    let config = Configuration::pinned();
+        let metadata_builder = MetadataBuilder::default();
+        let metadata = metadata_builder.to_metadata();
+        tc.try_set_global_metadata(metadata.clone());
 
-    if !config.bifrost.local.data_dir().exists() {
-        eprintln!(
-            "The specified path '{}' does not contain a local-loglet directory.",
-            config.bifrost.local.data_dir().display()
+        let metadata_store_client = metadata_store::start_metadata_store(
+            config.common.metadata_store_client.clone(),
+            Live::from_value(config.metadata_store.clone()).boxed(),
+            Live::from_value(config.metadata_store.clone())
+                .map(|c| &c.rocksdb)
+                .boxed(),
+            &tc,
+        )
+        .await?;
+        debug!("Metadata store client created");
+
+        let networking = Networking::new(metadata_builder.to_metadata(), config.networking.clone());
+        let metadata_manager = MetadataManager::new(
+            metadata_builder,
+            networking.clone(),
+            metadata_store_client.clone(),
         );
-        std::process::exit(1);
-    }
+        let mut router_builder = MessageRouterBuilder::default();
+        metadata_manager.register_in_message_router(&mut router_builder);
 
-    let task_center = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .ingress_runtime_handle(tokio::runtime::Handle::current())
-        .options(config.common.clone())
-        .build()
-        .expect("task_center builds");
+        tc.spawn(
+            TaskKind::SystemService,
+            "metadata-manager",
+            None,
+            metadata_manager.run(),
+        )?;
 
-    let tc = task_center.clone();
-    task_center
-        .run_in_scope("main", None, async move {
-            let config_source = if let Some(config_file) = &opts.config_file {
-                config_file.display().to_string()
-            } else {
-                "[default]".to_owned()
-            };
-            info!(
-                node_name = Configuration::pinned().node_name(),
-                config_source = %config_source,
-                base_dir = %restate_types::config::node_filepath("").display(),
-                "restatectl {}",
-                build_info::build_info()
-            );
+        let bifrost_svc = BifrostService::new(tc.clone(), metadata.clone())
+            .enable_local_loglet(&Configuration::updateable());
 
-            // Initialize rocksdb manager
-            let rocksdb_manager =
-                RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+        let bifrost = bifrost_svc.handle();
+        // Ensures bifrost has initial metadata synced up before starting the worker.
+        // Need to run start in new tc scope to have access to metadata()
+        bifrost_svc.start().await?;
 
-            debug!("Rocksdb Initialized");
-
-            let metadata_builder = MetadataBuilder::default();
-            let metadata = metadata_builder.to_metadata();
-            tc.try_set_global_metadata(metadata.clone());
-
-            let metadata_store_client = start_metadata_store(
-                config.common.metadata_store_client.clone(),
-                Live::from_value(config.metadata_store.clone()).boxed(),
-                Live::from_value(config.metadata_store.clone())
-                    .map(|c| &c.rocksdb)
-                    .boxed(),
-                &tc,
-            )
+        let log_id = LogId::from(opts.log_id);
+        debug!("Finding log tail");
+        let tail = bifrost
+            .find_tail(log_id, FindTailAttributes::default())
             .await?;
-            debug!("Metadata store client created");
+        debug!("Log tail is {:?}", tail);
+        let trim_point = bifrost.get_trim_point(log_id).await?;
+        debug!("Trim point is {:?}", trim_point);
+        let from_lsn: Lsn = opts
+            .from_lsn
+            .map(Into::into)
+            .unwrap_or_else(|| max(trim_point.next(), Lsn::OLDEST));
+        debug!(
+            ?log_id,
+            ?from_lsn,
+            to_lsn = ?tail.offset().prev(),
+            "Creating Bifrost log reader",
+        );
+        let mut reader =
+            bifrost.create_reader(log_id, KeyFilter::Any, from_lsn, tail.offset().prev())?;
 
-            let networking =
-                Networking::new(metadata_builder.to_metadata(), config.networking.clone());
-            let metadata_manager = MetadataManager::new(
-                metadata_builder,
-                networking.clone(),
-                metadata_store_client.clone(),
-            );
-            let mut router_builder = MessageRouterBuilder::default();
-            metadata_manager.register_in_message_router(&mut router_builder);
+        while let Some(record) = reader.next().await {
+            debug!("Got record: {:?}", record);
 
-            tc.spawn(
-                TaskKind::SystemService,
-                "metadata-manager",
-                None,
-                metadata_manager.run(),
-            )?;
-
-            let bifrost_svc = BifrostService::new(tc.clone(), metadata.clone())
-                .enable_local_loglet(&Configuration::updateable());
-
-            let bifrost = bifrost_svc.handle();
-            // Ensures bifrost has initial metadata synced up before starting the worker.
-            // Need to run start in new tc scope to have access to metadata()
-            bifrost_svc.start().await?;
-
-            let log_id = LogId::from(opts.log_id);
-            debug!("Finding log tail");
-            let tail = bifrost
-                .find_tail(log_id, FindTailAttributes::default())
-                .await?;
-            debug!("log tail is {:?}", tail);
-            let from_lsn: Lsn = opts.from_lsn.map(Into::into).unwrap_or(Lsn::OLDEST);
-            let mut reader =
-                bifrost.create_reader(log_id, KeyFilter::Any, from_lsn, tail.offset().prev())?;
-
-            while let Some(record) = reader.next().await {
-                let record = record?;
-                if record.is_trim_gap() {
-                    info!(
-                        "Trim gap found, skipping until {}",
-                        record.trim_gap_to_sequence_number().unwrap()
-                    );
-                    continue;
-                }
-
-                let lsn = record.sequence_number();
-                let envelope = record.try_decode::<Envelope>().unwrap().with_context(|| {
-                    format!(
-                        "Error decoding record at lsn={} from log_id={}",
-                        lsn, log_id
-                    )
-                })?;
-
-                let decoded_log_record = DecodedLogRecord {
-                    log_id,
-                    lsn,
-                    envelope,
-                };
-                println!("{}", serde_json::to_string(&decoded_log_record)?);
+            let record = record?;
+            if record.is_trim_gap() {
+                info!(
+                    "Trim gap found, skipping until after {}",
+                    record.trim_gap_to_sequence_number().unwrap()
+                );
+                continue;
             }
 
-            tc.shutdown_node("finished", 0).await;
-            rocksdb_manager.shutdown().await;
-            anyhow::Ok(())
-        })
-        .await?;
+            let lsn = record.sequence_number();
+            let envelope = record.try_decode::<Envelope>().unwrap().with_context(|| {
+                format!(
+                    "Error decoding record at lsn={} from log_id={}",
+                    lsn, log_id
+                )
+            })?;
+
+            let decoded_log_record = DecodedLogRecord {
+                log_id,
+                lsn,
+                envelope,
+            };
+            println!("{}", serde_json::to_string(&decoded_log_record)?);
+        }
+
+        rocksdb_manager.shutdown().await;
+        anyhow::Ok(())
+    })
+    .await?;
     Ok(())
-}
-
-async fn start_metadata_store(
-    metadata_store_client_options: MetadataStoreClientOptions,
-    opts: BoxedLiveLoad<MetadataStoreOptions>,
-    updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
-    task_center: &TaskCenter,
-) -> anyhow::Result<MetadataStoreClient> {
-    let service = LocalMetadataStoreService::from_options(opts, updateables_rocksdb_options);
-    let grpc_service_name = service.grpc_service_name().to_owned();
-
-    task_center.spawn(
-        TaskKind::MetadataStore,
-        "local-metadata-store",
-        None,
-        async move {
-            service.run().await?;
-            Ok(())
-        },
-    )?;
-
-    let address = match &metadata_store_client_options.metadata_store_client {
-        restate_types::config::MetadataStoreClient::Embedded { address } => address.clone(),
-        _ => panic!("unsupported metadata store type"),
-    };
-
-    let health_client = HealthClient::new(create_tonic_channel_from_advertised_address(
-        address.clone(),
-    ));
-    let retry_policy = RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, None);
-
-    retry_policy
-        .retry(|| async {
-            health_client
-                .clone()
-                .check(HealthCheckRequest {
-                    service: grpc_service_name.clone(),
-                })
-                .await
-        })
-        .await?;
-
-    let client = restate_metadata_store::local::create_client(metadata_store_client_options)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))?;
-
-    Ok(client)
 }

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+
+use bytestring::ByteString;
+use clap::Parser;
+use cling::{Collect, Run};
+use tracing::debug;
+
+use restate_rocksdb::RocksDbManager;
+use restate_types::config::Configuration;
+use restate_types::live::Live;
+
+use crate::commands::metadata::GenericMetadataValue;
+use crate::environment::metadata_store;
+use crate::environment::task_center::run_in_task_center;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap()]
+#[cling(run = "get_value")]
+pub struct GetValueOpts {
+    /// Restate configuration file
+    #[arg(
+        short,
+        long = "config-file",
+        env = "RESTATE_CONFIG",
+        value_name = "FILE"
+    )]
+    config_file: Option<PathBuf>,
+
+    /// The key to get
+    #[arg(short, long)]
+    key: String,
+}
+
+async fn get_value(opts: &GetValueOpts) -> anyhow::Result<()> {
+    let value = run_in_task_center(
+        opts.config_file.as_ref(),
+        |config, task_center| async move {
+            let rocksdb_manager =
+                RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+            debug!("RocksDB Initialized");
+
+            let metadata_store_client = metadata_store::start_metadata_store(
+                config.common.metadata_store_client.clone(),
+                Live::from_value(config.metadata_store.clone()).boxed(),
+                Live::from_value(config.metadata_store.clone())
+                    .map(|c| &c.rocksdb)
+                    .boxed(),
+                &task_center,
+            )
+            .await?;
+            debug!("Metadata store client created");
+
+            let value: Option<GenericMetadataValue> = metadata_store_client
+                .get(ByteString::from(opts.key.as_str()))
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))?;
+
+            rocksdb_manager.shutdown().await;
+            anyhow::Ok(value)
+        },
+    )
+    .await?;
+
+    let value = serde_json::to_string_pretty(&value).map_err(|e| anyhow::anyhow!(e))?;
+    println!("{}", value);
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod get;
+mod patch;
+
+use cling::prelude::*;
+use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
+
+#[derive(Run, Subcommand, Clone)]
+pub enum Metadata {
+    /// Get a single key's value from the metadata store
+    Get(get::GetValueOpts),
+    /// Patch a value stored in the metadata store
+    Patch(patch::PatchValueOpts),
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GenericMetadataValue {
+    // We assume that the concrete serialized type's encoded version field is called "version".
+    version: Version,
+
+    #[serde(flatten)]
+    data: serde_json::Map<String, serde_json::Value>,
+}
+
+flexbuffers_storage_encode_decode!(GenericMetadataValue);
+
+impl GenericMetadataValue {
+    pub fn to_json_value(&self) -> serde_json::Value {
+        serde_json::Value::Object(self.data.clone())
+    }
+}
+
+impl Versioned for GenericMetadataValue {
+    fn version(&self) -> Version {
+        self.version
+    }
+}

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -8,11 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod get;
-mod patch;
+use std::path::PathBuf;
+use std::str::FromStr;
 
 use cling::prelude::*;
+
+use restate_core::metadata_store::MetadataStoreClient;
+use restate_metadata_store::local::create_client;
+use restate_types::config::MetadataStoreClientOptions;
+use restate_types::net::AdvertisedAddress;
 use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
+
+mod get;
+mod patch;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Metadata {
@@ -20,6 +28,49 @@ pub enum Metadata {
     Get(get::GetValueOpts),
     /// Patch a value stored in the metadata store
     Patch(patch::PatchValueOpts),
+}
+
+#[derive(Args, Clone, Debug)]
+#[clap()]
+pub struct MetadataCommonOpts {
+    /// Metadata store server address; for Etcd addresses use comma-separated list
+    #[arg(short, long = "address", default_value = "http://127.0.0.1:5123")]
+    address: String,
+
+    /// Metadata store access mode
+    #[arg(long, default_value_t)]
+    access_mode: MetadataAccessMode,
+
+    /// Service type for access mode = "remote"
+    #[arg(long, default_value_t)]
+    remote_service_type: RemoteServiceType,
+
+    /// Restate configuration file for access mode = "direct"
+    #[arg(
+        short,
+        long = "config-file",
+        env = "RESTATE_CONFIG",
+        value_name = "FILE"
+    )]
+    config_file: Option<PathBuf>,
+}
+
+#[derive(clap::ValueEnum, Clone, Default, Debug, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
+enum MetadataAccessMode {
+    /// Connect to a remote metadata server at the specified address
+    #[default]
+    Remote,
+    /// Open a local metadata store database directory directly
+    Direct,
+}
+
+#[derive(clap::ValueEnum, Clone, Default, Debug, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
+enum RemoteServiceType {
+    #[default]
+    Restate,
+    Etcd,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -43,4 +94,31 @@ impl Versioned for GenericMetadataValue {
     fn version(&self) -> Version {
         self.version
     }
+}
+
+pub async fn create_metadata_store_client(
+    opts: &MetadataCommonOpts,
+) -> anyhow::Result<MetadataStoreClient> {
+    let client = match opts.remote_service_type {
+        RemoteServiceType::Restate => restate_types::config::MetadataStoreClient::Embedded {
+            address: AdvertisedAddress::from_str(opts.address.as_str())
+                .map_err(|e| anyhow::anyhow!("Failed to parse address: {}", e))?,
+        },
+        RemoteServiceType::Etcd => restate_types::config::MetadataStoreClient::Etcd {
+            addresses: opts
+                .address
+                .split(',')
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>(),
+        },
+    };
+
+    let metadata_store_client_options = MetadataStoreClientOptions {
+        metadata_store_client: client,
+        ..MetadataStoreClientOptions::default()
+    };
+
+    create_client(metadata_store_client_options)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))
 }

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -1,0 +1,138 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+
+use bytestring::ByteString;
+use clap::Parser;
+use cling::{Collect, Run};
+use tracing::debug;
+
+use restate_core::metadata_store::Precondition;
+use restate_rocksdb::RocksDbManager;
+use restate_types::config::Configuration;
+use restate_types::live::Live;
+use restate_types::Version;
+
+use crate::commands::metadata::GenericMetadataValue;
+use crate::environment::metadata_store;
+use crate::environment::task_center::run_in_task_center;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap()]
+#[cling(run = "patch_value")]
+pub struct PatchValueOpts {
+    /// Set a configuration file to use for Restate.
+    /// For more details, check the documentation.
+    #[arg(
+        short,
+        long = "config-file",
+        env = "RESTATE_CONFIG",
+        value_name = "FILE"
+    )]
+    config_file: Option<PathBuf>,
+
+    /// The key to patch
+    #[arg(short, long)]
+    key: String,
+
+    /// The JSON patch to apply to value
+    #[arg(short, long)]
+    patch: String,
+
+    /// Expected version for conditional update
+    #[arg(short = 'e', long)]
+    version: Option<u32>,
+
+    /// Preview the change without applying it
+    #[arg(short = 'n', long, default_value_t = false)]
+    dry_run: bool,
+}
+
+async fn patch_value(opts: &PatchValueOpts) -> anyhow::Result<()> {
+    let patch: json_patch::Patch = serde_json::from_str(opts.patch.as_str())
+        .map_err(|e| anyhow::anyhow!("Parsing JSON patch: {}", e))?;
+
+    let value = run_in_task_center(
+        opts.config_file.as_ref(),
+        |config, task_center| async move {
+            let rocksdb_manager =
+                RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+            debug!("RocksDB Initialized");
+
+            let metadata_store_client = metadata_store::start_metadata_store(
+                config.common.metadata_store_client.clone(),
+                Live::from_value(config.metadata_store.clone()).boxed(),
+                Live::from_value(config.metadata_store.clone())
+                    .map(|c| &c.rocksdb)
+                    .boxed(),
+                &task_center,
+            )
+            .await?;
+            debug!("Metadata store client created");
+
+            let value: GenericMetadataValue = metadata_store_client
+                .get(ByteString::from(opts.key.as_str()))
+                .await?
+                .ok_or(anyhow::anyhow!("Key not found: '{}'", opts.key))?;
+
+            if let Some(expected_version) = opts.version {
+                if value.version != Version::from(expected_version) {
+                    anyhow::bail!(
+                        "Version mismatch: expected v{}, got {:#} from store",
+                        expected_version,
+                        value.version
+                    );
+                }
+            }
+
+            let mut document = value.to_json_value();
+            let result = match json_patch::patch(&mut document, &patch) {
+                Ok(_) => {
+                    let new_value = GenericMetadataValue {
+                        version: value.version.next(),
+                        data: serde_json::from_value(document.clone())
+                            .map_err(|e| anyhow::anyhow!(e))?,
+                    };
+
+                    if !opts.dry_run {
+                        debug!(
+                            "Updating metadata key '{}' with expected {:?} version to {:?}",
+                            opts.key, value.version, new_value.version
+                        );
+
+                        metadata_store_client
+                            .put(
+                                ByteString::from(opts.key.as_str()),
+                                &new_value,
+                                Precondition::MatchesVersion(value.version),
+                            )
+                            .await
+                            .map_err(|e| anyhow::anyhow!("Store update failed: {}", e))?
+                    } else {
+                        println!("Dry run - updated value:\n");
+                    }
+
+                    Ok(new_value)
+                }
+                Err(e) => Err(anyhow::anyhow!("Patch failed: {}", e)),
+            };
+
+            rocksdb_manager.shutdown().await;
+            result
+        },
+    )
+    .await?;
+
+    let value = serde_json::to_string_pretty(&value).map_err(|e| anyhow::anyhow!(e))?;
+    println!("{}", value);
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/mod.rs
+++ b/tools/restatectl/src/commands/mod.rs
@@ -11,4 +11,5 @@
 mod display_util;
 pub mod dump;
 pub mod log;
+pub mod metadata;
 pub mod node;

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+use restate_core::metadata_store::MetadataStoreClient;
+use restate_core::network::net_util::create_tonic_channel_from_advertised_address;
+use restate_core::{TaskCenter, TaskKind};
+use restate_metadata_store::local::LocalMetadataStoreService;
+use restate_types::config::{MetadataStoreClientOptions, MetadataStoreOptions, RocksDbOptions};
+use restate_types::live::BoxedLiveLoad;
+use restate_types::retries::RetryPolicy;
+
+pub async fn start_metadata_store(
+    metadata_store_client_options: MetadataStoreClientOptions,
+    opts: BoxedLiveLoad<MetadataStoreOptions>,
+    updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+    task_center: &TaskCenter,
+) -> anyhow::Result<MetadataStoreClient> {
+    let service = LocalMetadataStoreService::from_options(opts, updateables_rocksdb_options);
+    let grpc_service_name = service.grpc_service_name().to_owned();
+
+    task_center.spawn(
+        TaskKind::MetadataStore,
+        "local-metadata-store",
+        None,
+        async move {
+            service.run().await?;
+            Ok(())
+        },
+    )?;
+
+    let address = match &metadata_store_client_options.metadata_store_client {
+        restate_types::config::MetadataStoreClient::Embedded { address } => address.clone(),
+        _ => panic!("unsupported metadata store type"),
+    };
+
+    let health_client = HealthClient::new(create_tonic_channel_from_advertised_address(
+        address.clone(),
+    ));
+    let retry_policy = RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, None);
+
+    retry_policy
+        .retry(|| async {
+            health_client
+                .clone()
+                .check(HealthCheckRequest {
+                    service: grpc_service_name.clone(),
+                })
+                .await
+        })
+        .await?;
+
+    let client = restate_metadata_store::local::create_client(metadata_store_client_options)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))?;
+
+    Ok(client)
+}

--- a/tools/restatectl/src/environment/mod.rs
+++ b/tools/restatectl/src/environment/mod.rs
@@ -8,9 +8,5 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod app;
-pub(crate) mod commands;
-pub(crate) mod util;
-pub use app::CliApp;
-mod build_info;
-pub(crate) mod environment;
+pub mod metadata_store;
+pub mod task_center;

--- a/tools/restatectl/src/environment/task_center.rs
+++ b/tools/restatectl/src/environment/task_center.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::future::Future;
+use std::path::PathBuf;
+
+use tracing::warn;
+
+use restate_core::{TaskCenter, TaskCenterBuilder};
+use restate_server::config_loader::ConfigLoaderBuilder;
+use restate_types::config::Configuration;
+use restate_types::live::Pinned;
+
+/// Loads configuration, creates a task center, executes the supplied function body in scope of TC, and shuts down.
+pub async fn run_in_task_center<F, O>(config_file: Option<&PathBuf>, fn_body: F) -> O::Output
+where
+    F: FnOnce(Pinned<Configuration>, TaskCenter) -> O,
+    O: Future,
+{
+    let config_path = config_file
+        .as_ref()
+        .map(|p| std::fs::canonicalize(p).expect("config-file path is valid"));
+
+    let config_loader = ConfigLoaderBuilder::default()
+        .load_env(true)
+        .path(config_path.clone())
+        .build()
+        .unwrap();
+
+    let config = match config_loader.load_once() {
+        Ok(c) => c,
+        Err(e) => {
+            // We cannot use tracing here as it's not configured yet
+            eprintln!("{:?}", e);
+            std::process::exit(1);
+        }
+    };
+
+    restate_types::config::set_current_config(config);
+    if rlimit::increase_nofile_limit(u64::MAX).is_err() {
+        warn!("Failed to increase the number of open file descriptors limit.");
+    }
+
+    let config = Configuration::pinned();
+
+    let task_center = TaskCenterBuilder::default()
+        .default_runtime_handle(tokio::runtime::Handle::current())
+        .ingress_runtime_handle(tokio::runtime::Handle::current())
+        .options(config.common.clone())
+        .build()
+        .expect("task_center builds");
+
+    let result = task_center
+        .run_in_scope("main", None, fn_body(config, task_center.clone()))
+        .await;
+
+    task_center.shutdown_node("finished", 0).await;
+    result
+}


### PR DESCRIPTION
This PR introduces a new `metadata` subcommand with options to retrieve and update values in both "direct" mode working on a `local-metadata-store` or remotely against both the Restate-native metadata service and Etcd.

The FlexBuffers-encoded values are rendered to the user as JSON. This allows us to use JSON Patch to succinctly express modifications.

Here is how it looks in action:

```
# connects to the default metadata service on localhost
> restatectl metadata get -k "schema_registry"
{
  "version": 9,
  "deployments": [
    [
      "dp_11Oa6uG2mNPjTYcD03AFgnn",
      {
        "metadata": {
          "created_at": 1727447806006,
          "delivery_options": {
            "additional_headers": {}
          },
          "supported_protocol_versions": {
            "end": 2,
            "start": 1
          },
          ...

# opens the metadata DB directly, suitable for offline use e.g. to repair a crashed server
> restatectl metadata patch --access-mode direct --config-file config.toml --key "schema_registry" \
  --patch '[{"op": "replace", "path": "/deployments/0/1/metadata/supported_protocol_versions/end", "value": 1}]' --version 7 --dry-run
Error: Version mismatch: expected v7, got v9 from store

> restatectl metadata patch -c config.toml -k "schema_registry" -
  -p '[{"op": "replace", "path": "/deployments/0/1/metadata/supported_protocol_versions/end", "value": 1}]' -e 9
{
  "version": 10,
  "deployments": [
    [
      "dp_11Oa6uG2mNPjTYcD03AFgnn",
      {
        "metadata": {
          "created_at": 1727447806006,
          "delivery_options": {
            "additional_headers": {}
          },
          "supported_protocol_versions": {
            "end": 1,
            "start": 1
          },
          ...
```
