### PR TITLE
[Bifrost] WaitForTail message implementation

### DIFF
--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -39,6 +39,7 @@ pub struct LogletWorkerHandle {
     get_loglet_info_tx: mpsc::UnboundedSender<Incoming<GetLogletInfo>>,
     get_records_tx: mpsc::UnboundedSender<Incoming<GetRecords>>,
     trim_tx: mpsc::UnboundedSender<Incoming<Trim>>,
+    wait_for_tail_tx: mpsc::UnboundedSender<Incoming<WaitForTail>>,
     tc_handle: TaskHandle<()>,
 }
 
@@ -46,6 +47,14 @@ impl LogletWorkerHandle {
     pub fn cancel(self) -> TaskHandle<()> {
         self.tc_handle.cancel();
         self.tc_handle
+    }
+
+    pub fn enqueue_wait_for_tail(
+        &self,
+        msg: Incoming<WaitForTail>,
+    ) -> Result<(), Incoming<WaitForTail>> {
+        self.wait_for_tail_tx.send(msg).map_err(|e| e.0)?;
+        Ok(())
     }
 
     pub fn enqueue_store(&self, msg: Incoming<Store>) -> Result<(), Incoming<Store>> {
@@ -112,6 +121,7 @@ impl<S: LogStore> LogletWorker<S> {
         let (get_loglet_info_tx, get_loglet_info_rx) = mpsc::unbounded_channel();
         let (get_records_tx, get_records_rx) = mpsc::unbounded_channel();
         let (trim_tx, trim_rx) = mpsc::unbounded_channel();
+        let (wait_for_tail_tx, wait_for_tail_rx) = mpsc::unbounded_channel();
         let tc_handle = task_center.spawn_unmanaged(
             TaskKind::LogletWriter,
             "loglet-worker",
@@ -123,6 +133,7 @@ impl<S: LogStore> LogletWorker<S> {
                 get_loglet_info_rx,
                 get_records_rx,
                 trim_rx,
+                wait_for_tail_rx,
             ),
         )?;
         Ok(LogletWorkerHandle {
@@ -132,10 +143,12 @@ impl<S: LogStore> LogletWorker<S> {
             get_loglet_info_tx,
             get_records_tx,
             trim_tx,
+            wait_for_tail_tx,
             tc_handle,
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run(
         mut self,
         mut store_rx: mpsc::UnboundedReceiver<Incoming<Store>>,
@@ -144,6 +157,7 @@ impl<S: LogStore> LogletWorker<S> {
         mut get_loglet_info_rx: mpsc::UnboundedReceiver<Incoming<GetLogletInfo>>,
         mut get_records_rx: mpsc::UnboundedReceiver<Incoming<GetRecords>>,
         mut trim_rx: mpsc::UnboundedReceiver<Incoming<Trim>>,
+        mut wait_for_tail_rx: mpsc::UnboundedReceiver<Incoming<WaitForTail>>,
     ) {
         // The worker is the sole writer to this loglet's local-tail so it's safe to maintain a moving
         // local tail view and serialize changes to logstore as long as we send them in the correct
@@ -158,6 +172,8 @@ impl<S: LogStore> LogletWorker<S> {
 
         loop {
             tokio::select! {
+                // todo(asoli): Benchmark on diverse workload to determine if biased causes
+                // starvation.
                 biased;
                 _ = &mut shutdown => {
                     // todo: consider a draining shutdown if needed
@@ -178,6 +194,12 @@ impl<S: LogStore> LogletWorker<S> {
                 Some(_) = waiting_for_seal.next() => {}
                 // The set of network sends waiting to complete
                 Some(_) = in_flight_network_sends.next() => {}
+                // WAIT_FOR_TAIL
+                Some(msg) = wait_for_tail_rx.recv() => {
+                    self.loglet_state.notify_known_global_tail(msg.body().header.known_global_tail);
+                    // responses are spawned as disposable tasks
+                    self.process_wait_for_tail(msg);
+                }
                 // RELEASE
                 Some(msg) = release_rx.recv() => {
                     self.loglet_state.notify_known_global_tail(msg.body().header.known_global_tail);
@@ -218,7 +240,7 @@ impl<S: LogStore> LogletWorker<S> {
                 Some(msg) = get_records_rx.recv() => {
                     self.loglet_state.notify_known_global_tail(msg.body().header.known_global_tail);
                     // read responses are spawned as disposable tasks
-                    self.process_get_records(msg).await;
+                    self.process_get_records(msg);
                 }
                 // TRIM
                 Some(msg) = trim_rx.recv() => {
@@ -364,7 +386,48 @@ impl<S: LogStore> LogletWorker<S> {
         }
     }
 
-    async fn process_get_records(&mut self, msg: Incoming<GetRecords>) {
+    fn process_wait_for_tail(&mut self, msg: Incoming<WaitForTail>) {
+        let loglet_state = self.loglet_state.clone();
+        // fails on shutdown, in this case, we ignore the request
+        let _ = self.task_center.spawn(
+            TaskKind::Disposable,
+            "loglet-tail-monitor",
+            None,
+            async move {
+                let (reciprocal, msg) = msg.split();
+                let local_tail_watch = loglet_state.get_local_tail_watch();
+                // If shutdown happened, this task will be disposed of and we won't send
+                // the response.
+                match msg.query {
+                    TailUpdateQuery::LocalTail(target_offset) => {
+                        local_tail_watch.wait_for_offset_or_seal(target_offset).await?;
+                    }
+                    TailUpdateQuery::GlobalTail(target_global_tail) => {
+                        let global_tail_tracker = loglet_state.get_global_tail_tracker();
+                        tokio::select! {
+                            res = global_tail_tracker.wait_for_offset(target_global_tail) => { res.map(|_|()) },
+                            // Are we locally sealed?
+                            res = local_tail_watch.wait_for_seal() => { res },
+                        }?;
+                    }
+                    TailUpdateQuery::LocalOrGlobal(target_offset) => {
+                        let global_tail_tracker = loglet_state.get_global_tail_tracker();
+                        tokio::select! {
+                            res = global_tail_tracker.wait_for_offset(target_offset) => { res.map(|_|()) },
+                            res = local_tail_watch.wait_for_offset_or_seal(target_offset) => { res.map(|_|()) },
+                        }?;
+                    }
+                };
+
+                let update =
+                    TailUpdated::new(loglet_state.local_tail(), loglet_state.known_global_tail());
+                let _ = reciprocal.prepare(update).send().await;
+                Ok(())
+            },
+        );
+    }
+
+    fn process_get_records(&mut self, msg: Incoming<GetRecords>) {
         let mut log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -207,7 +207,6 @@ impl GlobalTailTracker {
         });
     }
 
-    #[allow(dead_code)]
     pub async fn wait_for_offset(
         &self,
         offset: LogletOffset,

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
 use chrono::Utc;
-use dashmap::DashMap;
 use tokio::sync::watch;
 use xxhash_rust::xxh3::Xxh3Builder;
 
 use restate_bifrost::loglet::util::TailOffsetWatch;
 use restate_bifrost::loglet::OperationError;
+use restate_core::ShutdownError;
 use restate_types::logs::{LogletOffset, SequenceNumber, TailState};
 use restate_types::replicated_loglet::ReplicatedLogletId;
 use restate_types::{GenerationalNodeId, PlainNodeId};
@@ -98,6 +98,7 @@ pub struct LogletState {
     sequencer: Arc<OnceLock<GenerationalNodeId>>,
     local_tail: TailOffsetWatch,
     trim_point: watch::Sender<LogletOffset>,
+    known_global_tail: GlobalTailTracker,
 }
 
 impl LogletState {
@@ -106,10 +107,12 @@ impl LogletState {
         local_tail: LogletOffset,
         sealed: bool,
         trim_point: LogletOffset,
+        known_global_tail: LogletOffset,
     ) -> Self {
         let local_tail = TailOffsetWatch::new(TailState::new(sealed, local_tail));
         let trim_point = watch::Sender::new(trim_point);
         let sequencer = Arc::new(OnceLock::new());
+        let known_global_tail = GlobalTailTracker::new(known_global_tail);
         if let Some(sequencer_node) = sequencer_node {
             let _ = sequencer.set(sequencer_node);
         }
@@ -117,6 +120,7 @@ impl LogletState {
             sequencer,
             local_tail,
             trim_point,
+            known_global_tail,
         }
     }
 
@@ -129,8 +133,12 @@ impl LogletState {
         self.sequencer.set(sequencer).is_ok()
     }
 
-    pub fn get_tail_watch(&self) -> TailOffsetWatch {
+    pub fn get_local_tail_watch(&self) -> TailOffsetWatch {
         self.local_tail.clone()
+    }
+
+    pub fn get_global_tail_tracker(&self) -> GlobalTailTracker {
+        self.known_global_tail.clone()
     }
 
     pub fn is_sealed(&self) -> bool {
@@ -139,6 +147,14 @@ impl LogletState {
 
     pub fn local_tail(&self) -> TailState<LogletOffset> {
         *self.local_tail.get()
+    }
+
+    pub fn known_global_tail(&self) -> LogletOffset {
+        self.known_global_tail.get()
+    }
+
+    pub fn notify_known_global_tail(&self, known_global_tail: LogletOffset) {
+        self.known_global_tail.notify(known_global_tail)
     }
 
     pub fn trim_point(&self) -> LogletOffset {
@@ -171,18 +187,17 @@ impl Default for GlobalTailTracker {
 }
 
 impl GlobalTailTracker {
-    pub fn subscribe(&self) -> watch::Receiver<LogletOffset> {
-        let mut receiver = self.watch_tx.subscribe();
-        receiver.mark_changed();
-        receiver
+    pub fn new(initial_offset: LogletOffset) -> Self {
+        Self {
+            watch_tx: watch::Sender::new(initial_offset),
+        }
     }
 
-    #[allow(unused)]
-    pub fn known_global_tail(&self) -> LogletOffset {
+    pub fn get(&self) -> LogletOffset {
         *self.watch_tx.borrow()
     }
 
-    pub fn maybe_update(&self, potential_global_tail: LogletOffset) {
+    pub fn notify(&self, potential_global_tail: LogletOffset) {
         self.watch_tx.send_if_modified(|known_global_tail| {
             if potential_global_tail > *known_global_tail {
                 *known_global_tail = potential_global_tail;
@@ -191,25 +206,18 @@ impl GlobalTailTracker {
             false
         });
     }
-}
 
-/// Tracks known global tail for all loglets
-#[derive(Default, Clone)]
-pub struct GlobalTailTrackerMap {
-    inner: Arc<DashMap<ReplicatedLogletId, GlobalTailTracker, Xxh3Builder>>,
-}
-
-impl GlobalTailTrackerMap {
-    #[allow(unused)]
-    pub fn known_global_tail(&self, loglet_id: ReplicatedLogletId) -> LogletOffset {
-        self.inner
-            .entry(loglet_id)
-            .or_default()
-            .value()
-            .known_global_tail()
-    }
-
-    pub fn get_tracker(&self, loglet_id: ReplicatedLogletId) -> GlobalTailTracker {
-        self.inner.entry(loglet_id).or_default().value().clone()
+    #[allow(dead_code)]
+    pub async fn wait_for_offset(
+        &self,
+        offset: LogletOffset,
+    ) -> Result<LogletOffset, ShutdownError> {
+        let mut receiver = self.watch_tx.subscribe();
+        receiver.mark_changed();
+        receiver
+            .wait_for(|current| *current >= offset)
+            .await
+            .map(|m| *m)
+            .map_err(|_| ShutdownError)
     }
 }

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -57,10 +57,12 @@ enum TargetName {
   LOG_SERVER_TRIM = 20;
   LOG_SERVER_TRIMMED = 21;
 
+  LOG_SERVER_WAIT_FOR_TAIL = 22;
+  LOG_SERVER_TAIL_UPDATED = 23;
+  // Reserving space for more log-server messages
   // ReplicatedLoglet
-  REPLICATED_LOGLET_APPEND = 22;
-  REPLICATED_LOGLET_APPENDED = 23;
-
+  REPLICATED_LOGLET_APPEND = 40;
+  REPLICATED_LOGLET_APPENDED = 41;
 }
 
 enum NodeStatus {


### PR DESCRIPTION
A new message that allows Bifrost to wait for a logserver to catch up to a certain local/global tail, or for the node to be sealed.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2012).
* #2019
* __->__ #2012
* #2008