### PR TITLE
Fix networking deadlock caused by hanging mutable reference

### DIFF
--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -28,10 +28,8 @@ use tracing::{debug, info, instrument, Span};
 use restate_types::errors::GenericError;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 
-pub fn create_tonic_channel_from_advertised_address(
-    address: AdvertisedAddress,
-) -> Result<Channel, http::Error> {
-    let channel = match address {
+pub fn create_tonic_channel_from_advertised_address(address: AdvertisedAddress) -> Channel {
+    match address {
         AdvertisedAddress::Uds(uds_path) => {
             // dummy endpoint required to specify an uds connector, it is not used anywhere
             Endpoint::try_from("http://127.0.0.1")
@@ -51,8 +49,7 @@ pub fn create_tonic_channel_from_advertised_address(
                 .http2_adaptive_window(true)
                 .connect_lazy()
         }
-    };
-    Ok(channel)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/metadata-store/src/local/grpc/client.rs
+++ b/crates/metadata-store/src/local/grpc/client.rs
@@ -31,8 +31,7 @@ pub struct LocalMetadataStoreClient {
 }
 impl LocalMetadataStoreClient {
     pub fn new(metadata_store_address: AdvertisedAddress) -> Self {
-        let channel = create_tonic_channel_from_advertised_address(metadata_store_address)
-            .expect("should not fail");
+        let channel = create_tonic_channel_from_advertised_address(metadata_store_address);
 
         Self {
             svc_client: MetadataStoreSvcClient::new(channel),

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -376,7 +376,7 @@ async fn start_metadata_store(
 
     let health_client = HealthClient::new(create_tonic_channel_from_advertised_address(
         address.clone(),
-    )?);
+    ));
     let retry_policy = RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, None);
 
     retry_policy

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -241,7 +241,7 @@ async fn start_metadata_store(
 
     let health_client = HealthClient::new(create_tonic_channel_from_advertised_address(
         address.clone(),
-    )?);
+    ));
     let retry_policy = RetryPolicy::exponential(Duration::from_millis(10), 2.0, None, None);
 
     retry_policy


### PR DESCRIPTION
When the entry is occupied, we were trying to read with a mutable reference held. I've also changed it slightly such that in the case where the channel already exists, we only take a read reference, and only fall back to a write lock when its not present.