### PR TITLE
Fix for RUSTSEC-2024-0376 by upgrading tonic to 0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
  "futures-core",
  "prost 0.13.1",
  "prost-types 0.13.1",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing-core",
 ]
 
@@ -1774,7 +1774,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2706,7 +2706,7 @@ dependencies = [
  "prost 0.13.1",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tower",
  "tower-service",
@@ -4491,7 +4491,7 @@ dependencies = [
  "prost 0.13.1",
  "thiserror",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -4503,7 +4503,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.13.1",
- "tonic 0.12.1",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -5448,7 +5448,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tower",
  "tracing",
@@ -5680,7 +5680,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tower",
  "tracing",
@@ -5950,7 +5950,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-build",
  "tonic-health",
  "tonic-reflection",
@@ -6014,7 +6014,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic 0.11.0",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-reflection",
  "tower",
  "tower-http 0.5.2",
@@ -6383,7 +6383,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -6574,7 +6574,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
  "tonic-health",
  "tower",
  "tracing",
@@ -7642,9 +7642,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7739,9 +7739,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7770,41 +7770,42 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types 0.13.1",
  "quote",
  "syn 2.0.65",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e10e6a96ee08b6ce443487d4368442d328d0e746f3681f81127f7dc41b4955"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
  "prost 0.13.1",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
 ]
 
 [[package]]
 name = "tonic-reflection"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b742c83ad673e9ab5b4ce0981f7b9e8932be9d60e8682cbf9120494764dbc173"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
  "prost 0.13.1",
  "prost-types 0.13.1",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -8608,7 +8609,7 @@ dependencies = [
  "schemars",
  "serde_json",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,10 +181,10 @@ tokio = { version = "1.40.0", default-features = false, features = [
 ] }
 tokio-stream = "0.1.15"
 tokio-util = { version = "0.7.11" }
-tonic = { version = "0.12.1", default-features = false }
-tonic-reflection = { version = "0.12.1" }
-tonic-health = { version = "0.12.1" }
-tonic-build = { version = "0.12.1" }
+tonic = { version = "0.12.3", default-features = false }
+tonic-reflection = { version = "0.12.3" }
+tonic-health = { version = "0.12.3" }
+tonic-build = { version = "0.12.3" }
 tonic-0-11 = { package = "tonic", version = "0.11.0", default-features = false }
 tower = "0.4"
 tower-http = { version = "0.5.2", default-features = false }

--- a/crates/admin/build.rs
+++ b/crates/admin/build.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
         .extern_path(".restate.cluster", "::restate_types::protobuf::cluster")
-        .compile(
+        .compile_protos(
             &["./protobuf/cluster_ctrl_svc.proto"],
             &["protobuf", "../types/protobuf"],
         )?;

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.node", "::restate_types::protobuf::node")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
-        .compile(
+        .compile_protos(
             &["./protobuf/node_svc.proto"],
             &["protobuf", "../types/protobuf"],
         )?;

--- a/crates/metadata-store/build.rs
+++ b/crates/metadata-store/build.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .file_descriptor_set_path(out_dir.join("metadata_store_svc.bin"))
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile(&["./proto/metadata_store_svc.proto"], &["proto"])?;
+        .compile_protos(&["./proto/metadata_store_svc.proto"], &["proto"])?;
 
     Ok(())
 }

--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -89,7 +89,7 @@ impl LocalMetadataStoreService {
             .add_service(MetadataStoreSvcServer::new(LocalMetadataStoreHandler::new(
                 store.request_sender(),
             )))
-            .add_service(reflection_service_builder.build()?);
+            .add_service(reflection_service_builder.build_v1()?);
 
         let service = TowerToHyperService::new(
             server_builder

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -110,7 +110,7 @@ impl NetworkServer {
                 .send_compressed(CompressionEncoding::Gzip),
             )
             .add_optional_service(cluster_controller_service)
-            .add_service(reflection_service_builder.build()?);
+            .add_service(reflection_service_builder.build_v1()?);
 
         // Multiplex both grpc and http based on content-type
         let service = TowerToHyperService::new(


### PR DESCRIPTION

Summary: Fixes the RUSTSEC-2024-0376 vulnerability by upgrading tonic to 0.12.3

Test Plan: CI
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2020).
* #2019
* __->__ #2020