### PR TITLE
Free disk space action not needed any more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,6 @@ jobs:
     env:
       RUST_BACKTRACE: full
     steps:
-      - name: Clean up Github actions runner
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
-
       - name: Install liburing
         run: sudo apt-get install -y liburing-dev
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,17 +49,6 @@ jobs:
     timeout-minutes: ${{ inputs.debug && 140 || 70 }}
 
     steps:
-      - name: Clean up Github actions runner
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This takes about 40s, and we have a lot more storage space on warp than we did on github