### PR TITLE
Fix marking the SchedulingPlan wrongly as modified if no leadership change happened

### DIFF
--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -57,6 +57,17 @@ impl ClusterState {
             NodeState::Dead(_) => Some(node_id),
         })
     }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn empty() -> Self {
+        ClusterState {
+            last_refreshed: None,
+            nodes_config_version: Version::INVALID,
+            partition_table_version: Version::INVALID,
+            logs_metadata_version: Version::INVALID,
+            nodes: BTreeMap::default(),
+        }
+    }
 }
 
 fn instant_to_proto(t: Instant) -> prost_types::Duration {

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -247,6 +247,7 @@ pub struct ReplicatedLogletOptions {
     pub record_cache_memory_size: ByteCount,
 }
 
+#[cfg(feature = "replicated-loglet")]
 impl Default for ReplicatedLogletOptions {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
Fix marking the SchedulingPlan wrongly as modified if no leadership change happened.