### PR TITLE
Deterministic invocation ID part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,23 @@ jobs:
         RESTATE_WORKER__EXPERIMENTAL_FEATURE_NEW_INVOCATION_STATUS_TABLE=true
       testArtifactOutput: sdk-java-neo-invocation-status-integration-test-report
 
+  sdk-java-disable-idempotency-table:
+    name: Run SDK-Java integration tests with DisableIdempotencyTable
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+      actions: read
+    secrets: inherit
+    needs: docker
+    uses: restatedev/sdk-java/.github/workflows/integration.yaml@main
+    with:
+      restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
+      envVars: |
+        RESTATE_WORKER__EXPERIMENTAL_FEATURE_DISABLE_IDEMPOTENCY_TABLE=true
+      testArtifactOutput: sdk-java-disable-idempotency-table-integration-test-report
+
   sdk-python:
     name: Run SDK-Python integration tests
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -442,7 +442,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -501,7 +501,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -512,7 +512,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1054,7 +1054,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1132,7 +1132,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
  "syn_derive",
 ]
 
@@ -1464,7 +1464,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2013,7 +2013,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2272,7 +2272,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "paste",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2420,7 +2420,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2462,7 +2462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2483,7 +2483,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
  "unicode-xid",
 ]
 
@@ -2546,7 +2546,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2609,7 +2609,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2631,7 +2631,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2891,7 +2891,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2905,6 +2905,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2979,7 +2985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005e4cb962c56efd249bdeeb4ac232b11e1c45a2e49793bba2b2982dcc3f2e9d"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3653,7 +3659,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4052,7 +4058,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4686,7 +4692,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4794,7 +4800,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4931,7 +4937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5007,14 +5013,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5027,7 +5033,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -5059,7 +5065,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.85",
  "tempfile",
 ]
 
@@ -5073,7 +5079,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5096,7 +5102,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5107,7 +5113,7 @@ checksum = "4feef623adf0ea256c19bdc3fbcad12060be6b3fb5f29bd471b1eeb02b3d33f6"
 dependencies = [
  "proc-macro2",
  "prost-dto-core",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5213,9 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -5348,14 +5354,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5369,13 +5375,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5392,9 +5398,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
@@ -5415,6 +5421,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "memchr",
 ]
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rend"
@@ -6551,7 +6563,7 @@ dependencies = [
  "sha2",
  "static_assertions",
  "strum 0.26.2",
- "syn 2.0.65",
+ "syn 2.0.85",
  "sync_wrapper 1.0.1",
  "tempfile",
  "test-log",
@@ -6651,6 +6663,7 @@ dependencies = [
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-wal-protocol",
+ "rstest",
  "schemars",
  "serde",
  "serde_json",
@@ -6786,6 +6799,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.85",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-librocksdb-sys"
 version = "0.25.0+9.5.2"
 source = "git+https://github.com/restatedev/rust-rocksdb?rev=8f832b7e742e0d826fb9fed05a62e4bd747969bf#8f832b7e742e0d826fb9fed05a62e4bd747969bf"
@@ -6849,9 +6892,9 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -7021,7 +7064,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7104,7 +7147,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7115,7 +7158,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7157,7 +7200,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7199,7 +7242,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7399,7 +7442,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7436,7 +7479,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7511,7 +7554,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7524,7 +7567,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7569,9 +7612,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7587,7 +7630,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7694,7 +7737,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7720,7 +7763,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7873,7 +7916,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8011,7 +8054,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8130,7 +8173,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8231,7 +8274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8273,7 +8316,7 @@ checksum = "560b82d656506509d43abe30e0ba64c56b1953ab3d4fe7ba5902747a7a3cedd5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8307,7 +8350,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.65",
+ "syn 2.0.85",
  "thiserror",
  "unicode-ident",
 ]
@@ -8325,7 +8368,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.65",
+ "syn 2.0.85",
  "typify-impl",
 ]
 
@@ -8366,9 +8409,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
@@ -8522,7 +8565,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -8556,7 +8599,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8926,7 +8969,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8946,7 +8989,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
 ] }
 rlimit = { version = "0.10.1" }
 rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8f832b7e742e0d826fb9fed05a62e4bd747969bf" }
+rstest = "0.23.0"
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -51,6 +51,9 @@ pub struct WorkerOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     experimental_feature_new_invocation_status_table: bool,
 
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    experimental_feature_disable_idempotency_table: bool,
+
     pub storage: StorageOptions,
 
     pub invoker: InvokerOptions,
@@ -85,6 +88,10 @@ impl WorkerOptions {
     pub fn experimental_feature_new_invocation_status_table(&self) -> bool {
         self.experimental_feature_new_invocation_status_table
     }
+
+    pub fn experimental_feature_disable_idempotency_table(&self) -> bool {
+        self.experimental_feature_disable_idempotency_table
+    }
 }
 
 impl Default for WorkerOptions {
@@ -94,6 +101,7 @@ impl Default for WorkerOptions {
             num_timers_in_memory_limit: None,
             cleanup_interval: Duration::from_secs(60 * 60).into(),
             experimental_feature_new_invocation_status_table: false,
+            experimental_feature_disable_idempotency_table: false,
             storage: StorageOptions::default(),
             invoker: Default::default(),
             max_command_batch_size: NonZeroUsize::new(4).expect("Non zero number"),

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -785,7 +785,9 @@ pub enum InvocationQuery {
 }
 
 impl InvocationQuery {
-    pub fn as_invocation_id(&self) -> InvocationId {
+    pub fn to_invocation_id(&self) -> InvocationId {
+        // The business logic of this function is based on the deterministic invocation id generation.
+        // For more info, please look at InvocationUuid::generate where the magic stuff happens.
         match self {
             InvocationQuery::Invocation(iid) => *iid,
             InvocationQuery::Workflow(wfid) => InvocationId::generate(

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -82,6 +82,7 @@ restate-test-util = { workspace = true, features = ["prost"] }
 restate-types = { workspace = true, features = ["test-util"] }
 prost = { workspace = true }
 
+rstest = "0.23.0"
 googletest = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -82,7 +82,7 @@ restate-test-util = { workspace = true, features = ["prost"] }
 restate-types = { workspace = true, features = ["test-util"] }
 prost = { workspace = true }
 
-rstest = "0.23.0"
+rstest = { workspace = true }
 googletest = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }

--- a/crates/worker/src/ingress_integration.rs
+++ b/crates/worker/src/ingress_integration.rs
@@ -56,22 +56,28 @@ impl InvocationStorageReader for InvocationStorageReaderImpl {
             })?;
 
         let invocation_id = match query {
-            InvocationQuery::Invocation(iid) => iid,
-            ref q @ InvocationQuery::Workflow(ref sid) => {
-                match partition_storage.get_virtual_object_status(sid).await? {
+            InvocationQuery::Invocation(invocation_id) => invocation_id,
+            ref q @ InvocationQuery::Workflow(ref service_id) => {
+                match partition_storage
+                    .get_virtual_object_status(service_id)
+                    .await?
+                {
                     VirtualObjectStatus::Locked(iid) => iid,
                     VirtualObjectStatus::Unlocked => {
                         // Try the deterministic id
-                        q.as_invocation_id()
+                        q.to_invocation_id()
                     }
                 }
             }
-            ref q @ InvocationQuery::IdempotencyId(ref iid) => {
-                match partition_storage.get_idempotency_metadata(iid).await? {
+            ref q @ InvocationQuery::IdempotencyId(ref idempotency_id) => {
+                match partition_storage
+                    .get_idempotency_metadata(idempotency_id)
+                    .await?
+                {
                     Some(idempotency_metadata) => idempotency_metadata.invocation_id,
                     None => {
                         // Try the deterministic id
-                        q.as_invocation_id()
+                        q.to_invocation_id()
                     }
                 }
             }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -78,6 +78,7 @@ pub(super) struct PartitionProcessorBuilder<InvokerInputSender> {
 
     num_timers_in_memory_limit: Option<usize>,
     enable_new_invocation_status_table: bool,
+    disable_idempotency_table: bool,
     cleanup_interval: Duration,
     channel_size: usize,
     max_command_batch_size: usize,
@@ -112,6 +113,7 @@ where
             num_timers_in_memory_limit: options.num_timers_in_memory_limit(),
             enable_new_invocation_status_table: options
                 .experimental_feature_new_invocation_status_table(),
+            disable_idempotency_table: options.experimental_feature_disable_idempotency_table(),
             cleanup_interval: options.cleanup_interval(),
             channel_size: options.internal_queue_length(),
             max_command_batch_size: options.max_command_batch_size(),
@@ -134,6 +136,7 @@ where
             num_timers_in_memory_limit,
             cleanup_interval,
             enable_new_invocation_status_table,
+            disable_idempotency_table,
             channel_size,
             max_command_batch_size,
             invoker_tx,
@@ -147,6 +150,7 @@ where
             &mut partition_store,
             partition_key_range.clone(),
             enable_new_invocation_status_table,
+            disable_idempotency_table,
         )
         .await?;
 
@@ -196,6 +200,7 @@ where
         partition_store: &mut PartitionStore,
         partition_key_range: RangeInclusive<PartitionKey>,
         enable_new_invocation_status_table: bool,
+        disable_idempotency_table: bool,
     ) -> Result<StateMachine<Codec>, StorageError>
     where
         Codec: RawEntryCodec + Default + Debug,
@@ -214,6 +219,7 @@ where
             } else {
                 invocation_status_table::SourceTable::Old
             },
+            disable_idempotency_table,
         );
 
         Ok(state_machine)

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -49,8 +49,8 @@ use restate_tracing_instrumentation as instrumentation;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::errors::{
     InvocationError, InvocationErrorCode, ALREADY_COMPLETED_INVOCATION_ERROR,
-    ATTACH_NOT_SUPPORTED_INVOCATION_ERROR, CANCELED_INVOCATION_ERROR, GONE_INVOCATION_ERROR,
-    KILLED_INVOCATION_ERROR, NOT_FOUND_INVOCATION_ERROR, WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR,
+    ATTACH_NOT_SUPPORTED_INVOCATION_ERROR, CANCELED_INVOCATION_ERROR, KILLED_INVOCATION_ERROR,
+    NOT_FOUND_INVOCATION_ERROR, WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR,
 };
 use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey, ServiceId};
 use restate_types::identifiers::{
@@ -84,7 +84,6 @@ use restate_wal_protocol::Command;
 use std::collections::HashSet;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::iter;
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 use std::time::Duration;
@@ -105,6 +104,9 @@ pub struct StateMachine<Codec> {
     /// This is used to establish whether for new invocations we should use the NeoInvocationStatus or not.
     /// The neo table is enabled via [restate_types::config::WorkerOptions::experimental_feature_new_invocation_status_table].
     default_invocation_status_source_table: SourceTable,
+    /// This is used to establish whether we should use the idempotency new invocations we should use the NeoInvocationStatus or not.
+    /// The neo table is enabled via [restate_types::config::WorkerOptions::experimental_feature_new_invocation_status_table].
+    disable_idempotency_table: bool,
 
     _codec: PhantomData<Codec>,
 }
@@ -163,6 +165,7 @@ impl<Codec> StateMachine<Codec> {
         outbox_head_seq_number: Option<MessageIndex>,
         partition_key_range: RangeInclusive<PartitionKey>,
         default_invocation_status_source_table: invocation_status_table::SourceTable,
+        disable_idempotency_table: bool,
     ) -> Self {
         let latency =
             histogram!(crate::metric_definitions::PARTITION_HANDLE_INVOKER_EFFECT_COMMAND);
@@ -173,6 +176,7 @@ impl<Codec> StateMachine<Codec> {
             partition_key_range,
             latency,
             default_invocation_status_source_table,
+            disable_idempotency_table,
             _codec: PhantomData,
         }
     }
@@ -337,24 +341,13 @@ impl<Codec: RawEntryCodec> StateMachine<Codec> {
         Span::current().record_invocation_target(&service_invocation.invocation_target);
         // Phases of an invocation
         // 1. Try deduplicate it first
-        // 1.1. Deduplicate using idempotency id
-        // 1.2. Deduplicate for "run once" workflow semantics (only for workflow handlers of workflows services)
         // 2. Check if we need to schedule it
         // 3. Check if we need to inbox it (only for exclusive handlers of virtual objects services)
         // 4. Execute it
 
-        // 1.1. Handle deduplication for idempotency id
-        let Some(service_invocation) = self
-            .handle_service_invocation_idempotency_id(ctx, service_invocation)
-            .await?
-        else {
-            // Invocation was deduplicated, nothing else to do here
-            return Ok(());
-        };
-
-        // 1.2. Handle deduplication for workflows
+        // 1. Try deduplicate it first
         let Some(mut service_invocation) = self
-            .handle_service_invocation_workflow_run(ctx, service_invocation)
+            .handle_duplicated_requests(ctx, service_invocation)
             .await?
         else {
             // Invocation was deduplicated, nothing else to do here
@@ -430,148 +423,177 @@ impl<Codec: RawEntryCodec> StateMachine<Codec> {
     }
 
     /// Returns the invocation in case the invocation is not a duplicate
-    async fn handle_service_invocation_idempotency_id<
-        State: IdempotencyTable + InvocationStatusTable + OutboxTable + FsmTable,
-    >(
-        &mut self,
-        ctx: &mut StateMachineApplyContext<'_, State>,
-        service_invocation: ServiceInvocation,
-    ) -> Result<Option<ServiceInvocation>, Error> {
-        if let Some(idempotency_id) = service_invocation.compute_idempotency_id() {
-            if service_invocation.invocation_target.invocation_target_ty()
-                == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow)
-            {
-                warn!("The idempotency key for workflow methods is ignored!");
-            } else {
-                if self
-                    .try_resolve_idempotent_request(
-                        ctx,
-                        &idempotency_id,
-                        &service_invocation.invocation_id,
-                        service_invocation.response_sink.as_ref(),
-                    )
-                    .await?
-                    .is_some()
-                {
-                    Self::send_submit_notification_if_needed(
-                        ctx,
-                        service_invocation.invocation_id,
-                        false,
-                        service_invocation.submit_notification_sink,
-                    );
-                    debug_if_leader!(
-                        ctx.is_leader,
-                        restate.idempotency.id = ?idempotency_id,
-                        "Invocation is a duplicate"
-                    );
-
-                    // Invocation was either resolved, or the sink was enqueued. Nothing else to do here.
-                    return Ok(None);
-                }
-
-                debug_if_leader!(
-                        ctx.is_leader,
-                        restate.idempotency.id = ?idempotency_id,
-                        "First time we see this idempotency id, invocation will be processed");
-
-                // Idempotent invocation needs to be processed for the first time, let's roll!
-                Self::do_store_idempotency_id(
-                    ctx,
-                    idempotency_id,
-                    service_invocation.invocation_id,
-                )
-                .await?;
-            }
-        }
-        Ok(Some(service_invocation))
-    }
-
-    /// Returns the invocation in case the invocation is not a duplicate
-    async fn handle_service_invocation_workflow_run<
-        State: VirtualObjectStatusTable + OutboxTable + FsmTable,
+    async fn handle_duplicated_requests<
+        State: IdempotencyTable
+            + InvocationStatusTable
+            + VirtualObjectStatusTable
+            + OutboxTable
+            + FsmTable,
     >(
         &mut self,
         ctx: &mut StateMachineApplyContext<'_, State>,
         mut service_invocation: ServiceInvocation,
     ) -> Result<Option<ServiceInvocation>, Error> {
-        if service_invocation.invocation_target.invocation_target_ty()
-            == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow)
-        {
-            let keyed_service_id = service_invocation
-                .invocation_target
-                .as_keyed_service_id()
-                .expect("When the handler type is Workflow, the invocation target must have a key");
+        let invocation_id = service_invocation.invocation_id;
+        let is_workflow_run = service_invocation.invocation_target.invocation_target_ty()
+            == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow);
+        let mut has_idempotency_key = service_invocation.idempotency_key.is_some();
 
-            let service_status = ctx
-                .storage
-                .get_virtual_object_status(&keyed_service_id)
+        if !is_workflow_run && !has_idempotency_key {
+            // No duplicate id should exist
+            debug_assert!(
+                ctx.get_invocation_status(&invocation_id)
+                    .await
+                    .is_ok_and(|status| status == InvocationStatus::Free),
+                "There shouldn't be a duplicate for invocation id {}",
+                invocation_id
+            );
+            return Ok(Some(service_invocation));
+        }
+
+        if is_workflow_run && has_idempotency_key {
+            warn!("The idempotency key for workflow methods is ignored!");
+            has_idempotency_key = false;
+        }
+
+        let previous_invocation_status = async {
+            let mut is = ctx.get_invocation_status(&invocation_id).await?;
+            if is != InvocationStatus::Free {
+                // Deduplicated invocation with the new deterministic invocation id
+              Ok::<_, Error>(is)
+            } else {
+                // We might still need to deduplicate based on the idempotency table for old invocation ids
+                if has_idempotency_key {
+                    let idempotency_id = service_invocation
+                        .compute_idempotency_id()
+                        .expect("Idempotency key must be present");
+
+                    if let Some(idempotency_metadata) = ctx.storage.get_idempotency_metadata(&idempotency_id).await? {
+                        is = ctx.get_invocation_status(&idempotency_metadata.invocation_id).await?;
+                    }
+                }
+                // Or on lock status for workflow runs with old invocation ids
+                if is_workflow_run {
+                    let keyed_service_id = service_invocation
+                        .invocation_target
+                        .as_keyed_service_id()
+                        .expect("When the handler type is Workflow, the invocation target must have a key");
+
+                    if let VirtualObjectStatus::Locked(locked_invocation_id) = ctx
+                        .storage
+                        .get_virtual_object_status(&keyed_service_id)
+                        .await? {
+                        is = ctx.get_invocation_status(&locked_invocation_id).await?;
+                    }
+                }
+                Ok(is)
+            }
+
+        }.await?;
+
+        if previous_invocation_status == InvocationStatus::Free {
+            // --- New invocation
+            debug_if_leader!(
+                ctx.is_leader,
+                "First time we see this invocation id, invocation will be processed"
+            );
+
+            // Store the invocation id mapping if we have to and continue the processing
+            if is_workflow_run && !self.disable_idempotency_table {
+                ctx.storage
+                        .put_virtual_object_status(
+                            &service_invocation
+                                .invocation_target
+                                .as_keyed_service_id()
+                                .expect("When the handler type is Workflow, the invocation target must have a key"),
+                            &VirtualObjectStatus::Locked(invocation_id),
+                        )
+                        .await;
+            }
+            if has_idempotency_key && !self.disable_idempotency_table {
+                Self::do_store_idempotency_id(
+                    ctx,
+                    service_invocation
+                        .compute_idempotency_id()
+                        .expect("Idempotency key must be present"),
+                    service_invocation.invocation_id,
+                )
                 .await?;
+            }
+            return Ok(Some(service_invocation));
+        }
 
-            // If locked, then we check the original invocation
-            if let VirtualObjectStatus::Locked(original_invocation_id) = service_status {
-                if let Some(response_sink) = service_invocation.response_sink {
-                    // --- ATTACH business logic below, this is currently disabled due to the pending discussion about equality check.
-                    //     We instead simply fail the invocation with CONFLICT status code
-                    //
-                    // let invocation_status =
-                    //     ctx.storage.get_invocation_status(&original_invocation_id).await?;
-                    //
-                    // match invocation_status {
-                    //     InvocationStatus::Completed(
-                    //         CompletedInvocation { response_result, .. }) => {
-                    //         self.send_response_to_sinks(
-                    //             effects,
-                    //             iter::once(response_sink),
-                    //             response_result,
-                    //             Some(service_invocation.invocation_id),
-                    //             Some(&service_invocation.invocation_target),
-                    //         );
-                    //     }
-                    //     InvocationStatus::Free => panic!("Unexpected state, the InvocationStatus cannot be Free for invocation {} given it's in locked status", original_invocation_id),
-                    //     is => Self::do_append_response_sink(ctx,
-                    //         original_invocation_id,
-                    //         is,
-                    //         response_sink
-                    //     )
-                    // }
+        // --- Invocation already exists
 
+        // Send submit notification
+        Self::send_submit_notification_if_needed(
+            ctx,
+            service_invocation.invocation_id,
+            false,
+            service_invocation.submit_notification_sink,
+        );
+
+        // For idempotency_key requests, append the response sink or return back the original result
+        if has_idempotency_key {
+            debug_if_leader!(
+                ctx.is_leader,
+                restate.idempotency.key = ?service_invocation.idempotency_key.unwrap(),
+                "Invocation with idempotency key is a duplicate"
+            );
+            match previous_invocation_status {
+                is @ InvocationStatus::Invoked { .. }
+                | is @ InvocationStatus::Suspended { .. }
+                | is @ InvocationStatus::Inboxed { .. }
+                | is @ InvocationStatus::Scheduled { .. } => {
+                    if let Some(ref response_sink) = service_invocation.response_sink {
+                        if !is
+                            .get_response_sinks()
+                            .expect("response sink must be present")
+                            .contains(response_sink)
+                        {
+                            Self::do_append_response_sink(
+                                ctx,
+                                invocation_id,
+                                is,
+                                response_sink.clone(),
+                            )
+                            .await?
+                        }
+                    }
+                }
+                InvocationStatus::Completed(completed) => {
                     self.send_response_to_sinks(
                         ctx,
-                        iter::once(response_sink),
-                        ResponseResult::Failure(WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR),
-                        Some(original_invocation_id),
-                        Some(&service_invocation.invocation_target),
+                        service_invocation.response_sink.take().into_iter(),
+                        completed.response_result,
+                        Some(invocation_id),
+                        Some(&completed.invocation_target),
                     )
                     .await?;
                 }
-
-                Self::send_submit_notification_if_needed(
-                    ctx,
-                    service_invocation.invocation_id,
-                    false,
-                    service_invocation.submit_notification_sink.take(),
-                );
-
-                debug_if_leader!(
-                    ctx.is_leader,
-                    "Invocation to workflow method is a duplicate"
-                );
-
-                return Ok(None);
+                InvocationStatus::Free => {
+                    unreachable!("This was checked before!")
+                }
             }
+            return Ok(None);
+        }
+        // For workflow run, we don't append the response sink, but we send a failure instead.
+        if is_workflow_run {
             debug_if_leader!(
                 ctx.is_leader,
-                "First time we see this workflow id, invocation will be processed"
+                "Invocation to workflow method is a duplicate"
             );
-
-            ctx.storage
-                .put_virtual_object_status(
-                    &keyed_service_id,
-                    &VirtualObjectStatus::Locked(service_invocation.invocation_id),
-                )
-                .await;
+            self.send_response_to_sinks(
+                ctx,
+                service_invocation.response_sink.take().into_iter(),
+                ResponseResult::Failure(WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR),
+                Some(invocation_id),
+                Some(&service_invocation.invocation_target),
+            )
+            .await?;
         }
-        Ok(Some(service_invocation))
+
+        Ok(None)
     }
 
     /// Returns the invocation in case the invocation should run immediately
@@ -804,71 +826,6 @@ impl<Codec: RawEntryCodec> StateMachine<Codec> {
         ctx.storage.put_inbox_seq_number(seq_number + 1).await;
         self.inbox_seq_number += 1;
         Ok(seq_number)
-    }
-
-    /// If an invocation id is returned, the request has been resolved and no further processing is needed
-    async fn try_resolve_idempotent_request<
-        State: ReadOnlyIdempotencyTable + InvocationStatusTable + OutboxTable + FsmTable,
-    >(
-        &mut self,
-        ctx: &mut StateMachineApplyContext<'_, State>,
-        idempotency_id: &IdempotencyId,
-        caller_id: &InvocationId,
-        response_sink: Option<&ServiceInvocationResponseSink>,
-    ) -> Result<Option<InvocationId>, Error> {
-        if let Some(idempotency_meta) = ctx.storage.get_idempotency_metadata(idempotency_id).await?
-        {
-            let original_invocation_id = idempotency_meta.invocation_id;
-            match ctx
-                .storage
-                .get_invocation_status(&original_invocation_id)
-                .await?
-            {
-                is @ InvocationStatus::Invoked { .. }
-                | is @ InvocationStatus::Suspended { .. }
-                | is @ InvocationStatus::Inboxed { .. }
-                | is @ InvocationStatus::Scheduled { .. } => {
-                    if let Some(response_sink) = response_sink {
-                        if !is
-                            .get_response_sinks()
-                            .expect("response sink must be present")
-                            .contains(response_sink)
-                        {
-                            Self::do_append_response_sink(
-                                ctx,
-                                original_invocation_id,
-                                is,
-                                response_sink.clone(),
-                            )
-                            .await?
-                        }
-                    }
-                }
-                InvocationStatus::Completed(completed) => {
-                    self.send_response_to_sinks(
-                        ctx,
-                        response_sink.cloned(),
-                        completed.response_result,
-                        Some(original_invocation_id),
-                        Some(&completed.invocation_target),
-                    )
-                    .await?;
-                }
-                InvocationStatus::Free => {
-                    self.send_response_to_sinks(
-                        ctx,
-                        response_sink.cloned(),
-                        GONE_INVOCATION_ERROR,
-                        Some(*caller_id),
-                        None,
-                    )
-                    .await?
-                }
-            }
-            Ok(Some(original_invocation_id))
-        } else {
-            Ok(None)
-        }
     }
 
     async fn handle_external_state_mutation<
@@ -2687,35 +2644,21 @@ impl<Codec: RawEntryCodec> StateMachine<Codec> {
 
         let invocation_id = match attach_invocation_request.invocation_query {
             InvocationQuery::Invocation(iid) => iid,
-            InvocationQuery::Workflow(sid) => {
-                match ctx.storage.get_virtual_object_status(&sid).await? {
+            ref q @ InvocationQuery::Workflow(ref sid) => {
+                match ctx.storage.get_virtual_object_status(sid).await? {
                     VirtualObjectStatus::Locked(iid) => iid,
                     VirtualObjectStatus::Unlocked => {
-                        self.send_response_to_sinks(
-                            ctx,
-                            vec![attach_invocation_request.response_sink],
-                            NOT_FOUND_INVOCATION_ERROR,
-                            None,
-                            None,
-                        )
-                        .await?;
-                        return Ok(());
+                        // Try the deterministic id
+                        q.as_invocation_id()
                     }
                 }
             }
-            InvocationQuery::IdempotencyId(iid) => {
-                match ctx.storage.get_idempotency_metadata(&iid).await? {
+            ref q @ InvocationQuery::IdempotencyId(ref iid) => {
+                match ctx.storage.get_idempotency_metadata(iid).await? {
                     Some(idempotency_metadata) => idempotency_metadata.invocation_id,
                     None => {
-                        self.send_response_to_sinks(
-                            ctx,
-                            vec![attach_invocation_request.response_sink],
-                            NOT_FOUND_INVOCATION_ERROR,
-                            None,
-                            None,
-                        )
-                        .await?;
-                        return Ok(());
+                        // Try the deterministic id
+                        q.as_invocation_id()
                     }
                 }
             }


### PR DESCRIPTION
* Re-implement the deduplication code path for idempotent requests/workflow requests, by using the new deterministic id
* Handle deterministic ID for attach/get output
* Add disable_idempotency_table experimental feature, such that on Restate 1.2 we'll still write the idempotency table and the virtual object lock table (for workflow runs), but we'll stop using it in restate 1.3
* Added rstest for matrix testing the unit tests with the different features enabled/disabled.

Fix https://github.com/restatedev/restate/issues/1989