### PR TITLE
[Bifrost] Test for sealing empty replicated loglet on single node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "log",
  "once_cell",
  "parking_lot",
  "quanta",
@@ -5372,6 +5373,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -27,7 +27,7 @@ derive_more = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 metrics = { workspace = true }
-moka = { workspace = true, features = ["sync"] }
+moka = { workspace = true, features = ["sync", "logging"] }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
@@ -41,6 +41,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -19,6 +19,7 @@ use tokio::task::{JoinHandle, JoinSet};
 use tokio_stream::StreamExt;
 use tracing::info;
 
+use restate_core::{task_center, TaskHandle, TaskKind};
 use restate_test_util::let_assert;
 use restate_types::logs::metadata::SegmentIndex;
 use restate_types::logs::{KeyFilter, Lsn, SequenceNumber, TailState};
@@ -117,37 +118,39 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
     // read from the future returns None
     assert!(loglet.read_opt(Lsn::new(end)).await?.is_none());
 
-    let handle1: JoinHandle<googletest::Result<()>> = tokio::spawn({
-        let loglet = loglet.clone();
-        async move {
-            // read future record 4
-            let record = loglet.read(Lsn::new(4)).await?;
-            assert_that!(record.sequence_number(), eq(Lsn::new(4)));
-            assert!(record.is_data_record());
-            assert_that!(
-                record.decode_unchecked::<String>(),
-                eq("record4".to_owned())
-            );
-            Ok(())
-        }
-    });
+    let handle1: TaskHandle<googletest::Result<()>> =
+        task_center().spawn_unmanaged(TaskKind::TestRunner, "read", None, {
+            let loglet = loglet.clone();
+            async move {
+                // read future record 4
+                let record = loglet.read(Lsn::new(4)).await?;
+                assert_that!(record.sequence_number(), eq(Lsn::new(4)));
+                assert!(record.is_data_record());
+                assert_that!(
+                    record.decode_unchecked::<String>(),
+                    eq("record4".to_owned())
+                );
+                Ok(())
+            }
+        })?;
 
     // Waiting for 10
-    let handle2: JoinHandle<googletest::Result<()>> = tokio::spawn({
-        let loglet = loglet.clone();
-        async move {
-            // read future record 10
-            let record = loglet.read(Lsn::new(10)).await?;
-            assert_that!(record.sequence_number(), eq(Lsn::new(10)));
-            assert!(record.is_data_record());
-            assert_that!(
-                record.decode_unchecked::<String>(),
-                eq("record10".to_owned())
-            );
+    let handle2: TaskHandle<googletest::Result<()>> =
+        task_center().spawn_unmanaged(TaskKind::TestRunner, "read", None, {
+            let loglet = loglet.clone();
+            async move {
+                // read future record 10
+                let record = loglet.read(Lsn::new(10)).await?;
+                assert_that!(record.sequence_number(), eq(Lsn::new(10)));
+                assert!(record.is_data_record());
+                assert_that!(
+                    record.decode_unchecked::<String>(),
+                    eq("record10".to_owned())
+                );
 
-            Ok(())
-        }
-    });
+                Ok(())
+            }
+        })?;
 
     // Giving a chance to other tasks to work.
     tokio::task::yield_now().await;
@@ -437,41 +440,51 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
+
     // +1 for the main task waiting on all concurrent appenders
     let append_barrier = Arc::new(Barrier::new(CONCURRENT_APPENDERS + 1));
 
     let mut appenders: JoinSet<googletest::Result<_>> = JoinSet::new();
+    let tc = task_center();
     for appender_id in 0..CONCURRENT_APPENDERS {
         appenders.spawn({
             let loglet = loglet.clone();
             let append_barrier = append_barrier.clone();
+            let tc = tc.clone();
             async move {
-                let mut i = 1;
-                let mut committed = Vec::new();
-                let mut warmup = true;
-                loop {
-                    let res = loglet
-                        .append(format!("appender-{}-record{}", appender_id, i).into())
-                        .await;
-                    i += 1;
-                    if i > WARMUP_APPENDS && warmup {
-                        println!("appender({}) - warmup complete....", appender_id);
-                        append_barrier.wait().await;
-                        warmup = false;
-                    }
-                    match res {
-                        Ok(offset) => {
-                            committed.push(offset);
+                tc.run_in_scope("append", None, async move {
+                    let mut i = 1;
+                    let mut committed = Vec::new();
+                    let mut warmup = true;
+                    loop {
+                        let res = loglet
+                            .append(format!("appender-{}-record{}", appender_id, i).into())
+                            .await;
+                        i += 1;
+                        if i > WARMUP_APPENDS && warmup {
+                            println!("appender({}) - warmup complete....", appender_id);
+                            append_barrier.wait().await;
+                            warmup = false;
                         }
-                        Err(AppendError::Sealed) => {
-                            break;
+                        match res {
+                            Ok(offset) => {
+                                committed.push(offset);
+                            }
+                            Err(AppendError::Sealed) => {
+                                println!("append failed({}) => SEALED", i);
+                                break;
+                            }
+                            Err(AppendError::Shutdown(_)) => {
+                                break;
+                            }
+                            Err(e) => fail!("unexpected error: {}", e)?,
                         }
-                        Err(e) => fail!("unexpected error: {}", e)?,
+                        // give a chance to other tasks to work
+                        tokio::task::yield_now().await;
                     }
-                    // give a chance to other tasks to work
-                    tokio::task::yield_now().await;
-                }
-                Ok(committed)
+                    Ok(committed)
+                })
+                .await
             }
         });
     }

--- a/crates/bifrost/src/loglet/util.rs
+++ b/crates/bifrost/src/loglet/util.rs
@@ -95,6 +95,12 @@ impl TailOffsetWatch {
             .map_err(|_| ShutdownError)
     }
 
+    pub fn subscribe(&self) -> watch::Receiver<TailState<LogletOffset>> {
+        let mut receiver = self.sender.subscribe();
+        receiver.mark_changed();
+        receiver
+    }
+
     /// The first yielded value is the latest known tail
     pub fn to_stream(&self) -> WatchStream<TailState<LogletOffset>> {
         let mut receiver = self.sender.subscribe();

--- a/crates/bifrost/src/providers/replicated_loglet/log_server_manager.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/log_server_manager.rs
@@ -93,7 +93,7 @@ impl RemoteLogServerManager {
             return Ok(current.clone());
         }
 
-        let connection = networking.node_connection(id.into()).await?;
+        let connection = networking.node_connection(id).await?;
         let server = RemoteLogServer {
             loglet_id: self.loglet_id,
             node_id: id,
@@ -142,7 +142,7 @@ impl RemoteLogServerManager {
             return Ok(());
         }
 
-        let connection = networking.node_connection(server.node_id.into()).await?;
+        let connection = networking.node_connection(server.node_id).await?;
         inner.connection = connection.clone();
         server.connection = connection.clone();
 

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -447,4 +447,20 @@ mod tests {
         })
         .await
     }
+
+    #[test(tokio::test(start_paused = true))]
+    async fn replicated_loglet_single_seal_empty() -> Result<()> {
+        let loglet_id = ReplicatedLogletId::new(122);
+        let params = ReplicatedLogletParams {
+            loglet_id,
+            sequencer: GenerationalNodeId::new(1, 1),
+            replication: ReplicationProperty::new(NonZeroU8::new(1).unwrap()),
+            nodeset: NodeSet::from_single(PlainNodeId::new(1)),
+            write_set: None,
+        };
+        run_in_test_env(params, |env| {
+            crate::loglet::loglet_tests::seal_empty(env.loglet)
+        })
+        .await
+    }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/metric_definitions.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/metric_definitions.rs
@@ -13,11 +13,35 @@
 use metrics::{describe_counter, Unit};
 
 pub(crate) const BIFROST_REPLICATED_APPEND: &str = "restate.bifrost.replicatedloglet.appends.total";
+pub(crate) const BIFROST_REPLICATED_READ_CACHE_HIT: &str =
+    "restate.bifrost.replicatedloglet.read_record_cache_hit.total";
+pub(crate) const BIFROST_REPLICATED_READ_CACHE_FILTERED: &str =
+    "restate.bifrost.replicatedloglet.read_record_cache_filtered.total";
+pub(crate) const BIFROST_REPLICATED_READ_TOTAL: &str =
+    "restate.bifrost.replicatedloglet.read_record.total";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(
         BIFROST_REPLICATED_APPEND,
         Unit::Count,
         "Number of append requests to bifrost's replicated loglet"
+    );
+
+    describe_counter!(
+        BIFROST_REPLICATED_READ_CACHE_HIT,
+        Unit::Count,
+        "Number of records read from RecordCache"
+    );
+
+    describe_counter!(
+        BIFROST_REPLICATED_READ_CACHE_FILTERED,
+        Unit::Count,
+        "Number of records filtered out while reading from RecordCache"
+    );
+
+    describe_counter!(
+        BIFROST_REPLICATED_READ_TOTAL,
+        Unit::Count,
+        "Number of records read"
     );
 }

--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -14,6 +14,7 @@ mod loglet;
 pub(crate) mod metric_definitions;
 mod network;
 mod provider;
+mod read_path;
 #[allow(dead_code)]
 mod record_cache;
 #[allow(dead_code)]

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod read_stream;
+mod read_stream_task;
+
+pub(super) use read_stream::*;
+pub(super) use read_stream_task::*;

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::task::{ready, Poll};
+
+use futures::{FutureExt, Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use restate_core::TaskHandle;
+use restate_types::logs::LogletOffset;
+
+use crate::loglet::{LogletReadStream, OperationError};
+use crate::LogEntry;
+
+pub(crate) struct ReplicatedLogletReadStream {
+    // the next record this stream will attempt to return when polled
+    pub(super) read_pointer: LogletOffset,
+    pub(super) rx_stream: ReceiverStream<Result<LogEntry<LogletOffset>, OperationError>>,
+    pub(super) reader_task: TaskHandle<Result<(), OperationError>>,
+    pub(super) terminated: bool,
+}
+
+impl Drop for ReplicatedLogletReadStream {
+    fn drop(&mut self) {
+        // make sure we abort the reader task if the read stream is disposed
+        self.reader_task.abort();
+    }
+}
+
+impl ReplicatedLogletReadStream {
+    pub fn new(
+        from_offset: LogletOffset,
+        rx_stream: mpsc::Receiver<Result<LogEntry<LogletOffset>, OperationError>>,
+        reader_task: TaskHandle<Result<(), OperationError>>,
+    ) -> Self {
+        Self {
+            read_pointer: from_offset,
+            rx_stream: ReceiverStream::new(rx_stream),
+            reader_task,
+            terminated: false,
+        }
+    }
+}
+
+impl LogletReadStream for ReplicatedLogletReadStream {
+    /// Current read pointer. This points to the next offset to be read.
+    fn read_pointer(&self) -> LogletOffset {
+        self.read_pointer
+    }
+    /// Returns true if the stream is terminated.
+    fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+}
+
+impl Stream for ReplicatedLogletReadStream {
+    type Item = Result<LogEntry<LogletOffset>, OperationError>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.terminated {
+            Poll::Ready(None)
+        } else {
+            match ready!(self.rx_stream.poll_next_unpin(cx)) {
+                Some(maybe_record) => match maybe_record {
+                    Ok(record) => {
+                        self.read_pointer = record.next_sequence_number();
+                        Poll::Ready(Some(Ok(record)))
+                    }
+                    Err(err) => {
+                        self.terminated = true;
+                        self.rx_stream.close();
+                        self.reader_task.abort();
+                        Poll::Ready(Some(Err(err)))
+                    }
+                },
+                None => {
+                    // stream terminated, but did the task fail?
+                    let task_err = ready!(self.reader_task.poll_unpin(cx));
+                    self.terminated = true;
+                    self.rx_stream.close();
+                    match task_err {
+                        Ok(Ok(_)) => Poll::Ready(None),
+                        Ok(Err(e)) => Poll::Ready(Some(Err(e))),
+                        Err(shutdown_err) => Poll::Ready(Some(Err(shutdown_err.into()))),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -1,0 +1,517 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use metrics::{counter, Counter};
+use rand::seq::SliceRandom;
+use restate_types::config::Configuration;
+use tokio::sync::mpsc;
+use tracing::{info, trace};
+
+use restate_core::network::{NetworkError, Networking, TransportConnect};
+use restate_core::{task_center, ShutdownError, TaskHandle, TaskKind};
+use restate_types::logs::{KeyFilter, LogletOffset, MatchKeyQuery, SequenceNumber};
+use restate_types::net::log_server::{GetRecords, LogServerRequestHeader, MaybeRecord};
+use restate_types::replicated_loglet::{EffectiveNodeSet, NodeSet, ReplicatedLogletParams};
+use restate_types::PlainNodeId;
+
+use crate::loglet::util::TailOffsetWatch;
+use crate::loglet::OperationError;
+use crate::providers::replicated_loglet::metric_definitions::{
+    BIFROST_REPLICATED_READ_CACHE_FILTERED, BIFROST_REPLICATED_READ_CACHE_HIT,
+    BIFROST_REPLICATED_READ_TOTAL,
+};
+use crate::providers::replicated_loglet::record_cache::RecordCache;
+use crate::providers::replicated_loglet::rpc_routers::LogServersRpc;
+use crate::LogEntry;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Impossible to read from nodeset {0:?}, all nodes are disabled")]
+struct ImpossibleNodeSetError(NodeSet);
+
+struct Stats {
+    cache_filtered: Counter,
+    cache_hits: Counter,
+    records_read: Counter,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        let cache_filtered = counter!(BIFROST_REPLICATED_READ_CACHE_FILTERED);
+        let cache_hits = counter!(BIFROST_REPLICATED_READ_CACHE_HIT);
+        let records_read = counter!(BIFROST_REPLICATED_READ_TOTAL);
+        Self {
+            cache_filtered,
+            cache_hits,
+            records_read,
+        }
+    }
+}
+
+pub struct ReadStreamTask {
+    my_params: ReplicatedLogletParams,
+    logservers_rpc: LogServersRpc,
+    filter: KeyFilter,
+    global_tail_watch: TailOffsetWatch,
+    last_known_tail: LogletOffset,
+    /// The offset of the batch to read next. This might be ahead of the actual read_pointer in the
+    /// handle because of how we perform read-ahead. So, this is what we should read next from
+    /// servers and _not_ what the consumer will read next from the stream.
+    read_pointer: LogletOffset,
+    /// Last offset to read before terminating the stream. None means "tailing" reader.
+    /// *Inclusive*
+    read_to: Option<LogletOffset>,
+    tx: mpsc::Sender<Result<LogEntry<LogletOffset>, OperationError>>,
+    record_cache: RecordCache,
+    stats: Stats,
+}
+
+impl ReadStreamTask {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start<T: TransportConnect>(
+        my_params: ReplicatedLogletParams,
+        networking: Networking<T>,
+        logservers_rpc: LogServersRpc,
+        filter: KeyFilter,
+        from_offset: LogletOffset,
+        read_to: Option<LogletOffset>,
+        known_global_tail: TailOffsetWatch,
+        record_cache: RecordCache,
+    ) -> Result<
+        (
+            mpsc::Receiver<Result<LogEntry<LogletOffset>, OperationError>>,
+            TaskHandle<Result<(), OperationError>>,
+        ),
+        OperationError,
+    > {
+        // todo(asoli): configuration
+        let (tx, rx) = mpsc::channel(100);
+        // Reading from INVALID resets to OLDEST.
+        let from_offset = from_offset.max(LogletOffset::OLDEST);
+
+        let task = Self {
+            my_params,
+            logservers_rpc,
+            filter,
+            read_pointer: from_offset,
+            read_to,
+            global_tail_watch: known_global_tail,
+            last_known_tail: LogletOffset::OLDEST,
+            tx,
+            record_cache,
+            stats: Stats::default(),
+        };
+        let handle = task_center().spawn_unmanaged(
+            TaskKind::ReplicatedLogletReadStream,
+            "replicatedloglet-read-stream",
+            None,
+            task.run(networking),
+        )?;
+
+        Ok((rx, handle))
+    }
+
+    async fn run<T: TransportConnect>(
+        mut self,
+        networking: Networking<T>,
+    ) -> Result<(), OperationError> {
+        let mut nodes_config = networking.metadata().updateable_nodes_config();
+        let my_node_id = networking.my_node_id();
+        let records_rpc_timeout = Configuration::pinned()
+            .bifrost
+            .replicated_loglet
+            .log_server_rpc_timeout;
+        // Channel size. This is the largest number of records we will try to readahead, if we can
+        // acquire the capacity for it.
+        //
+        // clamped to the channel capacity, ideally, the same value should be used to configure the
+        let readahead_max = 100.min(self.tx.max_capacity());
+        debug_assert!(readahead_max <= u16::MAX.into());
+        // This is automatically capped. This is the minimum number of slots that needs to be
+        // available in order to trigger fetching a new batch.
+        let readahead_trigger = 50;
+        debug_assert!(readahead_trigger >= 1 && readahead_trigger <= self.tx.max_capacity());
+
+        let mut tail_subscriber = self.global_tail_watch.subscribe();
+        // resolves immediately as it's pre-marked as changed.
+        tail_subscriber
+            .changed()
+            .await
+            .map_err(|_| OperationError::Shutdown(ShutdownError))?;
+        self.last_known_tail = tail_subscriber.borrow_and_update().offset();
+        // todo(asoli): [important] Need to fire up a FindTail task in the background? It depends on whether we
+        // are on the sequencer node or not. We might ask Bifrost's watchdog instead to dedupe
+        // FindTails and time-throttle them.
+        'main: loop {
+            // Read and ship records to the tx channel if there is capacity. We do not attempt to
+            // read records if we cannot reserve capacity to avoid wasting resources.
+            //
+            // Once we secure enough capacity, we get the records from whatever source and write
+            // them to the secured permits. The channel size limits how much read-ahead we can do
+            // from log-servers but when reading from cache, we only read when we need.
+            //
+            // Note 1: In loglet implementations, it's safe to return records even if loglet is sealed
+            // as long as we only return records before the global tail.
+            //
+            // Note 2: We have capacity-management impedance mismatch. We size channels by the number of
+            // records, but we use number of bytes (memory) to limit our total memory consumption.
+            // This can be improved in the future by using a semaphore representing the memory
+            // budget and unbounded channel instead.
+            //
+            //
+            // The server we read from will return up to its local tail if we are reading beyond
+            // the global tail. So, we can effectively cache those records and use them only when
+            // the global tail advances (basic read-ahead)
+            //
+            // If we received all records needed, we'll write to the tx all records that are both
+            // below the global_tail and under our target to (the latter is assumed implicitly
+            // given that we request from log-servers up to this value anyway).
+            //
+            // How readahead watermarks work?
+            // - Capacity is 100 (`readahead_trigger=50`)
+            // - We fetch 100, capacity is 0 (`readahead_max` is 100)
+            // - reader reads 1
+            // - Capacity is 1
+            // - reader reads 10
+            // - Capacity is 11
+            // - reader reads 40
+            // - Capacity is 51
+            // - readahead_trigger exceeded. We try to fetch 49. Capacity => 0.
+            // - Reader reads 1 (capacity is 1)
+            //
+            // What controls this read stream:
+            // 1. Did we arrive to the target `read_to` already?
+            // 2. Capacity is released, can we await on this? On certain triggers only. If capacity
+            //    is zero, we'll try to acquire capacity of `readahead_trigger`
+            // 3. Did we receive response from log-server, or failure, or timeout.
+            // 4. Is there a trim-gap?
+            // 5. Did the global tail advance?
+
+            // Are we there yet?
+            if self.should_terminate() {
+                // Terminate by dropping ourselves. In this case, the sender is dropped (we are the only sender holder)
+                trace!(
+                    "ReadStreamTask: Terminating read stream as we have reached the target offset"
+                );
+                return Ok(());
+            }
+
+            // Are we reading after last_known_tail offset?
+            // We are at tail. We need to wait until new records have been released.
+            if !self.can_advance() {
+                // HODL.
+                // todo(asoli): Measure tail-change wait time in histogram
+                // todo(asoli): (who's going to change this? - background FindTail?)
+                tail_subscriber
+                    .changed()
+                    .await
+                    .map_err(|_| OperationError::Shutdown(ShutdownError))?;
+                self.last_known_tail = tail_subscriber.borrow_and_update().offset();
+                // perhaps last_known_tail is updated because we have been sealed but the tail
+                // didn't change. Let's revisit from the top and see if we land here again.
+                continue 'main;
+            }
+            // We are only here because we should attempt to read something
+            debug_assert!(self.last_known_tail > self.read_pointer);
+            // todo(asoli): do we need to check for trim point?
+
+            // Do we have capacity for the next read?
+            // - capacity is 100, watermark is 50; we reserve 100; but if readahead_max is 80, we
+            // request 80;
+            // - capacity is 5, readahead_trigger is 50; we wait until 50 is available.
+            let mut permits = self
+                .tx
+                .reserve_many(self.tx.capacity().max(readahead_trigger).min(readahead_max))
+                // fails if receiver is dropped (no more read stream)
+                .await
+                .map_err(OperationError::terminal)?;
+
+            // Read from logservers
+            let effective_nodeset =
+                EffectiveNodeSet::new(&self.my_params.nodeset, nodes_config.live_load());
+            // order the nodeset such that our node is the first one to attempt
+            let mut mutable_effective_nodeset =
+                shuffle_nodeset_for_reads(&effective_nodeset, my_node_id.as_plain());
+
+            if mutable_effective_nodeset.is_empty() {
+                // if nodeset is all disabled, no readable nodes. impossible situation to resolve,
+                if self
+                    .my_params
+                    .nodeset
+                    .all_disabled(nodes_config.live_load())
+                {
+                    return Err(OperationError::terminal(ImpossibleNodeSetError(
+                        self.my_params.nodeset.clone(),
+                    )));
+                } else {
+                    // Some nodes might be provisioning, wait and try again after a cool off
+                    // period.
+                    // todo: make this configurable.
+                    info!(
+                        loglet_id = %self.my_params.loglet_id,
+                        offset = %self.read_pointer,
+                        "All nodes in the nodeset are unreadable. Retrying in 2 seconds.."
+                    );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue 'main;
+                }
+            }
+
+            'attempt_from_servers: loop {
+                // Read from _somewhere_ until we reach the tail, target, or the available permits.
+                // Start by reading from record cache as much as we can
+                'attempt_from_cache: loop {
+                    match self.send_next_from_cache(&mut permits) {
+                        // fast-forward
+                        CacheReadResult::Filtered | CacheReadResult::Sent => {
+                            self.read_pointer = self.read_pointer.next();
+                            continue 'attempt_from_cache;
+                        }
+                        CacheReadResult::Miss => {
+                            // Once a record is not in cache, we fallback to reading from log-servers until
+                            // we exhaust remaining permits.
+                            break 'attempt_from_cache;
+                        }
+                        CacheReadResult::Stop => {
+                            continue 'main;
+                        }
+                    }
+                }
+
+                let to_offset = self.calculate_read_ahead_to_offset(permits.len());
+                // If we are in the nodeset, we'll be the first to try
+                let Some(server) = mutable_effective_nodeset.pop() else {
+                    // no more servers to try. Going back and retrying the main loop to start over.
+                    info!(
+                        loglet_id = %self.my_params.loglet_id,
+                        from_offset = %self.read_pointer,
+                        %to_offset,
+                        "Could not request record batch, exhausted all servers in the nodeset. Retrying.."
+                    );
+                    continue 'main;
+                };
+
+                let ServerReadResult::Records(records) = self
+                    .readahead_from_server(server, to_offset, &networking, records_rpc_timeout)
+                    .await?
+                else {
+                    // move to the next server
+                    continue 'attempt_from_servers;
+                };
+
+                // Note that returned records can have gaps
+                for (offset, maybe_record) in records {
+                    // if offset is smaller, we just ignore.
+                    if offset >= self.last_known_tail || offset > self.read_pointer {
+                        // we have reached the tail, we have a record but we shouldn't ship it.
+                        // Let's cache it to assist future reads instead.
+                        self.add_to_cache(offset, maybe_record);
+                    } else if offset == self.read_pointer {
+                        match maybe_record {
+                            MaybeRecord::TrimGap(gap) => {
+                                let permit = permits.next().expect("must have at least one permit");
+                                trace!(
+                                    loglet_id = %self.my_params.loglet_id,
+                                    offset = %self.read_pointer,
+                                    "Shipping a trim gap from node {} to offset {}",
+                                    server,
+                                    gap.to
+                                );
+                                permit.send(Ok(LogEntry::new_trim_gap(self.read_pointer, gap.to)));
+                                // fast-forward
+                                self.read_pointer = gap.to.next();
+                            }
+                            MaybeRecord::ArchivalGap(_) => {
+                                todo!("We don't support reading from object-store yet")
+                            }
+                            MaybeRecord::FilteredGap(gap) => {
+                                // records didn't match the filter.
+                                // There is a risk that this gap goes beyond the global_tail, so we
+                                // clamp it to our known_tail to avoid drifting outside the
+                                // committed window.
+                                self.read_pointer = self.last_known_tail.min(gap.to.next());
+                            }
+                            MaybeRecord::Data(record) => {
+                                let permit = permits.next().expect("must have at least one permit");
+                                trace!(
+                                    loglet_id = %self.my_params.loglet_id,
+                                    offset = %self.read_pointer,
+                                    "Shipping a data record acquired from node {}",
+                                    server,
+                                );
+                                // We do not cache this record since it's rare that we go back and
+                                // read the same records that we shipped. If this assumption
+                                // changes in the future, we can cache at this point.
+                                self.stats.records_read.increment(1);
+                                permit.send(Ok(LogEntry::new_data(self.read_pointer, record)));
+                                self.read_pointer = self.read_pointer.next();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_to_cache(&self, offset: LogletOffset, maybe_record: MaybeRecord) {
+        if let MaybeRecord::Data(record) = maybe_record {
+            self.record_cache
+                .add(self.my_params.loglet_id, offset, record);
+        }
+    }
+
+    fn calculate_read_ahead_to_offset(&self, available_permits: usize) -> LogletOffset {
+        // estimate to-offset. Only limit it if this is a finite stream. Otherwise, it's okay
+        // to overshoot and populate the record cache with records if the log-server's local
+        // tail is beyond the global tail.
+        let to_offset = LogletOffset::new(
+            self.read_pointer.saturating_add(
+                available_permits
+                    .try_into()
+                    .expect("max permits fit into u32"),
+            ),
+        )
+        .prev();
+
+        if let Some(read_to) = self.read_to {
+            return to_offset.min(read_to);
+        }
+        to_offset
+    }
+
+    fn can_advance(&self) -> bool {
+        self.read_pointer < self.last_known_tail
+            && self.read_pointer <= self.read_to.unwrap_or(LogletOffset::MAX)
+    }
+
+    fn should_terminate(&self) -> bool {
+        self.read_to
+            .is_some_and(|read_to| self.read_pointer > read_to)
+    }
+
+    /// Only consumes a permit iff a record is found in cache
+    ///
+    /// Panics if permits is empty
+    fn send_next_from_cache(
+        &self,
+        permits: &mut mpsc::PermitIterator<Result<LogEntry<LogletOffset>, OperationError>>,
+    ) -> CacheReadResult {
+        if !self.can_advance() || permits.len() == 0 {
+            return CacheReadResult::Stop;
+        }
+
+        if let Some(record) = self
+            .record_cache
+            .get(self.my_params.loglet_id, self.read_pointer)
+        {
+            if !record.matches_key_query(&self.filter) {
+                // fast-forward this record
+                self.stats.cache_filtered.increment(1);
+                return CacheReadResult::Filtered;
+            }
+
+            let permit = permits.next().expect("must have at least one permit");
+            trace!(
+                loglet_id = %self.my_params.loglet_id,
+                offset = %self.read_pointer,
+                "Shipping record from record cache",
+            );
+            self.stats.cache_hits.increment(1);
+            self.stats.records_read.increment(1);
+            permit.send(Ok(LogEntry::new_data(self.read_pointer, record)));
+            CacheReadResult::Sent
+        } else {
+            CacheReadResult::Miss
+        }
+    }
+
+    async fn readahead_from_server<T: TransportConnect>(
+        &self,
+        server: PlainNodeId,
+        to_offset: LogletOffset,
+        networking: &Networking<T>,
+        timeout: Duration,
+    ) -> Result<ServerReadResult, OperationError> {
+        let request = GetRecords {
+            header: LogServerRequestHeader::new(self.my_params.loglet_id, self.last_known_tail),
+            total_limit_in_bytes: None,
+            filter: self.filter.clone(),
+            from_offset: self.read_pointer,
+            to_offset,
+        };
+        trace!(
+            loglet_id = %self.my_params.loglet_id,
+            from_offset = %self.read_pointer,
+            %to_offset,
+            "Attempting to read records from {}",
+            server
+        );
+
+        let maybe_records = self
+            .logservers_rpc
+            .get_records
+            .call_timeout(networking, server, request, timeout)
+            .await;
+
+        match maybe_records {
+            Ok(records) => {
+                self.global_tail_watch
+                    .notify_offset_update(records.body().known_global_tail);
+                Ok(ServerReadResult::Records(records.into_body().records))
+            }
+            Err(NetworkError::Shutdown(e)) => Err(OperationError::Shutdown(e)),
+            Err(e) => {
+                trace!(
+                    loglet_id = %self.my_params.loglet_id,
+                    from_offset = %self.read_pointer,
+                    %to_offset,
+                    ?e,
+                    "Could not request record batch from node {}", server
+                );
+                Ok(ServerReadResult::Skip)
+            }
+        }
+    }
+}
+
+enum CacheReadResult {
+    /// Record was found but didn't match filter, read_pointer advanced
+    Filtered,
+    /// Record was found and sent
+    Sent,
+    /// Not in cache, read_pointer not advanced
+    Miss,
+    /// We should not read the next record (out of permits, or will exceed the last_known_tail)
+    Stop,
+}
+
+enum ServerReadResult {
+    /// Maybe got some records for you
+    Records(Vec<(LogletOffset, MaybeRecord)>),
+    /// Unreachable or failing node, skip and try another
+    Skip,
+}
+
+fn shuffle_nodeset_for_reads(nodeset: &NodeSet, my_node_id: PlainNodeId) -> Vec<PlainNodeId> {
+    let mut new_nodeset: Vec<_> = nodeset.iter().cloned().collect();
+    // Shuffle nodes
+    new_nodeset.shuffle(&mut rand::thread_rng());
+
+    let has_my_node_idx = nodeset.iter().position(|&x| x == my_node_id);
+
+    // put my node at the end if it's there
+    if let Some(idx) = has_my_node_idx {
+        let len = new_nodeset.len();
+        new_nodeset.swap(idx, len - 1);
+    }
+
+    new_nodeset
+}

--- a/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
@@ -169,7 +169,7 @@ where
 
         let connection = self
             .networking
-            .node_connection(self.params.sequencer.into())
+            .node_connection(self.params.sequencer)
             .await?;
         let connection =
             RemoteSequencerConnection::start(self.known_global_tail.clone(), connection)?;
@@ -195,7 +195,7 @@ where
 
         let connection = self
             .networking
-            .node_connection(self.params.sequencer.into())
+            .node_connection(self.params.sequencer)
             .await?;
 
         let connection =

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -12,8 +12,8 @@ use core::str;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use restate_types::logs::LogletOffset;
 use restate_types::logs::{BodyWithKeys, HasRecordKeys, Keys, Lsn, Record};
+use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::storage::{PolyBytes, StorageDecode, StorageDecodeError, StorageEncode};
 use restate_types::time::NanosSinceEpoch;
 
@@ -72,6 +72,17 @@ impl<S: Copy> LogEntry<S> {
     #[inline]
     pub fn sequence_number(&self) -> S {
         self.offset
+    }
+
+    #[inline]
+    pub fn next_sequence_number(&self) -> S
+    where
+        S: SequenceNumber,
+    {
+        match &self.record {
+            MaybeRecord::TrimGap(gap) => gap.to.next(),
+            _ => self.offset.next(),
+        }
     }
 
     #[inline]

--- a/crates/core/src/network/networking.rs
+++ b/crates/core/src/network/networking.rs
@@ -19,7 +19,7 @@ use restate_types::{GenerationalNodeId, NodeId};
 
 use super::{
     ConnectionManager, HasConnection, NetworkError, NetworkSendError, NetworkSender, NoConnection,
-    Outgoing, WeakConnection,
+    Outgoing, OwnedConnection, WeakConnection,
 };
 use super::{GrpcConnector, TransportConnect};
 use crate::Metadata;
@@ -82,7 +82,11 @@ impl<T: TransportConnect> Networking<T> {
 
     /// A connection sender is pinned to a single stream, thus guaranteeing ordered delivery of
     /// messages.
-    pub async fn node_connection(&self, node: NodeId) -> Result<WeakConnection, NetworkError> {
+    pub async fn node_connection(
+        &self,
+        node: impl Into<NodeId>,
+    ) -> Result<WeakConnection, NetworkError> {
+        let node = node.into();
         // find latest generation if this is not generational node id
         let node = match node.as_generational() {
             Some(node) => node,
@@ -95,6 +99,27 @@ impl<T: TransportConnect> Networking<T> {
         };
 
         Ok(self.connections.get_or_connect(node).await?.downgrade())
+    }
+
+    /// A connection sender is pinned to a single stream, thus guaranteeing ordered delivery of
+    /// messages.
+    pub async fn node_owned_connection(
+        &self,
+        node: impl Into<NodeId>,
+    ) -> Result<Arc<OwnedConnection>, NetworkError> {
+        let node = node.into();
+        // find latest generation if this is not generational node id
+        let node = match node.as_generational() {
+            Some(node) => node,
+            None => {
+                self.metadata
+                    .nodes_config_ref()
+                    .find_node_by_id(node)?
+                    .current_generation
+            }
+        };
+
+        self.connections.get_or_connect(node).await
     }
 }
 

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
@@ -16,14 +17,15 @@ use futures::stream::BoxStream;
 use futures::StreamExt;
 use restate_types::NodeId;
 use tokio::sync::oneshot;
+use tokio::time::Instant;
 use tracing::{error, warn};
 
 use restate_types::net::codec::{Targeted, WireDecode, WireEncode};
 use restate_types::net::RpcRequest;
 
 use super::{
-    HasConnection, Incoming, MessageHandler, MessageRouterBuilder, NetworkSendError, NetworkSender,
-    Outgoing,
+    HasConnection, Incoming, MessageHandler, MessageRouterBuilder, NetworkError, NetworkSendError,
+    NetworkSender, Networking, Outgoing, TransportConnect,
 };
 use crate::{cancellation_watcher, ShutdownError};
 
@@ -83,6 +85,26 @@ where
             .map_err(|_| RpcError::Shutdown(ShutdownError))
     }
 
+    /// Does not perform retries
+    pub async fn call_timeout<X: TransportConnect>(
+        &self,
+        networking: &Networking<X>,
+        peer: impl Into<NodeId>,
+        msg: T,
+        timeout: Duration,
+    ) -> Result<Incoming<T::ResponseMessage>, NetworkError> {
+        let start = Instant::now();
+        let peer = peer.into();
+        let connection = tokio::time::timeout(timeout, networking.node_connection(peer))
+            .await
+            .map_err(|_| {
+                NetworkError::Timeout("deadline exceeded while waiting to establish connection")
+            })??;
+        let outgoing = Outgoing::new(peer, msg).assign_connection(connection);
+        self.call_outgoing_timeout(outgoing, timeout - start.elapsed())
+            .await
+    }
+
     /// Use this method when you have a connection associated with the outgoing request
     pub async fn call_on_connection(
         &self,
@@ -98,6 +120,30 @@ where
             .recv()
             .await
             .map_err(|_| RpcError::Shutdown(ShutdownError))
+    }
+
+    /// Use this method when you have a connection associated with the outgoing request
+    ///
+    /// Timeout encompasses the time it takes to send the request and the time it takes to receive
+    /// the response.
+    pub async fn call_outgoing_timeout(
+        &self,
+        outgoing: Outgoing<T, HasConnection>,
+        timeout: Duration,
+    ) -> Result<Incoming<T::ResponseMessage>, NetworkError> {
+        let token = self
+            .response_tracker
+            .register(&outgoing)
+            .expect("msg-id is registered once");
+
+        let start = Instant::now();
+        outgoing.send_timeout(timeout).await.map_err(|e| e.source)?;
+        let remaining = timeout - start.elapsed();
+        tokio::time::timeout(remaining, token.recv())
+            .await
+            .map_err(|_| NetworkError::Timeout("deadline exceeded while waiting for rpc response"))?
+            // We only fail here if the response tracker was dropped.
+            .map_err(NetworkError::Shutdown)
     }
 
     pub async fn send_on_connection(

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -106,6 +106,7 @@ pub enum TaskKind {
     NetworkMessageHandler,
     // Replicated loglet tasks
     ReplicatedLogletAppender,
+    ReplicatedLogletReadStream,
     #[strum(props(OnCancel = "abort"))]
     /// Log-server tasks
     LogletWriter,

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -61,16 +61,7 @@ impl LogServerService {
         })
     }
 
-    pub async fn start(self, metadata_writer: MetadataWriter) -> anyhow::Result<()> {
-        let tc = self.task_center.clone();
-        tc.spawn(TaskKind::SystemService, "log-server", None, async {
-            self.run(metadata_writer).await
-        })?;
-
-        Ok(())
-    }
-
-    async fn run(self, mut metadata_writer: MetadataWriter) -> anyhow::Result<()> {
+    pub async fn start(self, mut metadata_writer: MetadataWriter) -> anyhow::Result<()> {
         let LogServerService {
             updateable_config,
             task_center,
@@ -103,8 +94,8 @@ impl LogServerService {
         .await?;
 
         task_center.spawn_child(
-            TaskKind::NetworkMessageHandler,
-            "log-server-req-pump",
+            TaskKind::SystemService,
+            "log-server",
             None,
             request_pump.run(log_store, storage_state),
         )?;

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -109,8 +109,18 @@ impl NodeSet {
         self.0.insert(node);
     }
 
-    pub fn remove(&mut self, node: &PlainNodeId) {
-        self.0.remove(node);
+    /// Returns true if all nodes in the nodeset are disabled
+    pub fn all_disabled(&self, nodes_config: &NodesConfiguration) -> bool {
+        self.is_empty()
+            || self
+                .0
+                .iter()
+                .map(|node_id| nodes_config.get_log_server_storage_state(node_id))
+                .all(|storage_state| storage_state.is_disabled())
+    }
+
+    pub fn remove(&mut self, node: &PlainNodeId) -> bool {
+        self.0.remove(node)
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION

This also modifies the log-server startup to ensure provisioning happens before other components start.

Test Plan:
Uses the existing test in loglet_tests.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2039).
* __->__ #2039
* #2028