### PR TITLE
[Bifrost] GetDigest message in replicated loglets

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/mod.rs
@@ -186,13 +186,9 @@ impl<T: TransportConnect> Sequencer<T> {
             .await
             .unwrap();
 
-        // Why is this AclRel?
         // We are updating the next write offset and we want to make sure that after this call that
         // we observe if task_center()'s shutdown signal was set or not consistently across
         // threads.
-        //
-        // The situation we want to avoid is that we fail to spawn an appender due to shutdown but
-        // the subsequent fetch_add don't observe task-center's internal shutdown atomic.
         let offset = LogletOffset::new(
             self.sequencer_shared_state
                 .next_write_offset

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -40,6 +40,7 @@ pub struct LogletWorkerHandle {
     get_records_tx: mpsc::UnboundedSender<Incoming<GetRecords>>,
     trim_tx: mpsc::UnboundedSender<Incoming<Trim>>,
     wait_for_tail_tx: mpsc::UnboundedSender<Incoming<WaitForTail>>,
+    get_digest_tx: mpsc::UnboundedSender<Incoming<GetDigest>>,
     tc_handle: TaskHandle<()>,
 }
 
@@ -49,48 +50,45 @@ impl LogletWorkerHandle {
         self.tc_handle
     }
 
+    pub fn enqueue_get_digest(&self, msg: Incoming<GetDigest>) -> Result<(), Incoming<GetDigest>> {
+        self.get_digest_tx.send(msg).map_err(|e| e.0)
+    }
+
     pub fn enqueue_wait_for_tail(
         &self,
         msg: Incoming<WaitForTail>,
     ) -> Result<(), Incoming<WaitForTail>> {
-        self.wait_for_tail_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.wait_for_tail_tx.send(msg).map_err(|e| e.0)
     }
 
     pub fn enqueue_store(&self, msg: Incoming<Store>) -> Result<(), Incoming<Store>> {
-        self.store_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.store_tx.send(msg).map_err(|e| e.0)
     }
 
     pub fn enqueue_release(&self, msg: Incoming<Release>) -> Result<(), Incoming<Release>> {
-        self.release_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.release_tx.send(msg).map_err(|e| e.0)
     }
 
     pub fn enqueue_seal(&self, msg: Incoming<Seal>) -> Result<(), Incoming<Seal>> {
-        self.seal_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.seal_tx.send(msg).map_err(|e| e.0)
     }
 
     pub fn enqueue_get_loglet_info(
         &self,
         msg: Incoming<GetLogletInfo>,
     ) -> Result<(), Incoming<GetLogletInfo>> {
-        self.get_loglet_info_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.get_loglet_info_tx.send(msg).map_err(|e| e.0)
     }
 
     pub fn enqueue_get_records(
         &self,
         msg: Incoming<GetRecords>,
     ) -> Result<(), Incoming<GetRecords>> {
-        self.get_records_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.get_records_tx.send(msg).map_err(|e| e.0)
     }
 
     pub fn enqueue_trim(&self, msg: Incoming<Trim>) -> Result<(), Incoming<Trim>> {
-        self.trim_tx.send(msg).map_err(|e| e.0)?;
-        Ok(())
+        self.trim_tx.send(msg).map_err(|e| e.0)
     }
 }
 
@@ -122,6 +120,7 @@ impl<S: LogStore> LogletWorker<S> {
         let (get_records_tx, get_records_rx) = mpsc::unbounded_channel();
         let (trim_tx, trim_rx) = mpsc::unbounded_channel();
         let (wait_for_tail_tx, wait_for_tail_rx) = mpsc::unbounded_channel();
+        let (get_digest_tx, get_digest_rx) = mpsc::unbounded_channel();
         let tc_handle = task_center.spawn_unmanaged(
             TaskKind::LogletWriter,
             "loglet-worker",
@@ -134,6 +133,7 @@ impl<S: LogStore> LogletWorker<S> {
                 get_records_rx,
                 trim_rx,
                 wait_for_tail_rx,
+                get_digest_rx,
             ),
         )?;
         Ok(LogletWorkerHandle {
@@ -144,6 +144,7 @@ impl<S: LogStore> LogletWorker<S> {
             get_records_tx,
             trim_tx,
             wait_for_tail_tx,
+            get_digest_tx,
             tc_handle,
         })
     }
@@ -158,6 +159,7 @@ impl<S: LogStore> LogletWorker<S> {
         mut get_records_rx: mpsc::UnboundedReceiver<Incoming<GetRecords>>,
         mut trim_rx: mpsc::UnboundedReceiver<Incoming<Trim>>,
         mut wait_for_tail_rx: mpsc::UnboundedReceiver<Incoming<WaitForTail>>,
+        mut get_digest_rx: mpsc::UnboundedReceiver<Incoming<GetDigest>>,
     ) {
         // The worker is the sole writer to this loglet's local-tail so it's safe to maintain a moving
         // local tail view and serialize changes to logstore as long as we send them in the correct
@@ -181,6 +183,12 @@ impl<S: LogStore> LogletWorker<S> {
                     // handoff
                     debug!(loglet_id = %self.loglet_id, "Loglet writer shutting down");
                     return;
+                }
+                // GET_DIGEST
+                Some(msg) = get_digest_rx.recv() => {
+                    self.loglet_state.notify_known_global_tail(msg.body().header.known_global_tail);
+                    // digest responses are spawned as tasks
+                    self.process_get_digest(msg);
                 }
                 Some(_) = in_flight_stores.next() => {}
                 // The in-flight seal (if any)
@@ -457,6 +465,40 @@ impl<S: LogStore> LogletWorker<S> {
                 };
                 // ship the response to the original connection
                 let _ = reciprocal.prepare(records).send().await;
+                Ok(())
+            },
+        );
+    }
+
+    fn process_get_digest(&mut self, msg: Incoming<GetDigest>) {
+        let mut log_store = self.log_store.clone();
+        let loglet_state = self.loglet_state.clone();
+        // fails on shutdown, in this case, we ignore the request
+        let _ = self.task_center.spawn(
+            TaskKind::Disposable,
+            "logserver-get-digest",
+            None,
+            async move {
+                let (reciprocal, msg) = msg.split();
+                // validation. Note that to_offset is inclusive.
+                if msg.from_offset > msg.to_offset {
+                    let response =
+                        reciprocal.prepare(Digest::empty().with_status(Status::Malformed));
+                    // ship the response to the original connection
+                    let _ = response.send().await;
+                    return Ok(());
+                }
+                let digest = match log_store.get_records_digest(msg, &loglet_state).await {
+                    Ok(digest) => digest,
+                    Err(_) => Digest::new(
+                        loglet_state.local_tail(),
+                        loglet_state.known_global_tail(),
+                        Default::default(),
+                    )
+                    .with_status(Status::Disabled),
+                };
+                // ship the response to the original connection
+                let _ = reciprocal.prepare(digest).send().await;
                 Ok(())
             },
         );

--- a/crates/log-server/src/logstore.rs
+++ b/crates/log-server/src/logstore.rs
@@ -15,7 +15,7 @@ use tokio::sync::oneshot;
 
 use restate_bifrost::loglet::OperationError;
 use restate_core::ShutdownError;
-use restate_types::net::log_server::{GetRecords, Records, Seal, Store, Trim};
+use restate_types::net::log_server::{Digest, GetDigest, GetRecords, Records, Seal, Store, Trim};
 use restate_types::replicated_loglet::ReplicatedLogletId;
 
 use crate::metadata::{LogStoreMarker, LogletState};
@@ -56,6 +56,12 @@ pub trait LogStore: Clone + Send + 'static {
         get_records_message: GetRecords,
         loglet_state: &LogletState,
     ) -> impl Future<Output = Result<Records, OperationError>> + Send;
+
+    fn get_records_digest(
+        &mut self,
+        get_records_message: GetDigest,
+        loglet_state: &LogletState,
+    ) -> impl Future<Output = Result<Digest, OperationError>> + Send;
 }
 
 /// A future that resolves when a log-store operation is completed

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use rocksdb::{BoundColumnFamily, ReadOptions, WriteBatch, WriteOptions, DB};
@@ -19,7 +20,8 @@ use restate_types::config::LogServerOptions;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::net::log_server::{
-    Gap, GetRecords, LogServerResponseHeader, MaybeRecord, Records, Seal, Store, Trim,
+    Digest, DigestEntry, Gap, GetDigest, GetRecords, LogServerResponseHeader, MaybeRecord,
+    RecordStatus, Records, Seal, Store, Trim,
 };
 use restate_types::replicated_loglet::ReplicatedLogletId;
 use restate_types::GenerationalNodeId;
@@ -344,6 +346,138 @@ impl LogStore for RocksDbLogStore {
             records,
         })
     }
+
+    async fn get_records_digest(
+        &mut self,
+        msg: GetDigest,
+        loglet_state: &LogletState,
+    ) -> Result<Digest, OperationError> {
+        let data_cf = self.data_cf();
+        let loglet_id = msg.header.loglet_id;
+        // If we are reading beyond the tail, the first thing we do is to clip to the
+        // local_tail.
+        let local_tail = loglet_state.local_tail();
+        let trim_point = loglet_state.trim_point();
+
+        // inclusive
+        let read_from = msg.from_offset.max(trim_point.next());
+        let read_to = msg.to_offset.min(local_tail.offset().prev());
+
+        // allocate for near-worst-case.
+        let mut entries = Vec::with_capacity(
+            usize::try_from(read_to.saturating_sub(*read_from)).expect("no overflow") + 1,
+        );
+
+        // Issue a trim gap until the known head
+        if read_from > msg.from_offset {
+            entries.push(DigestEntry {
+                from_offset: msg.from_offset,
+                to_offset: read_from.prev(),
+                status: RecordStatus::Trimmed,
+            });
+        }
+
+        // setup the iterator
+        let mut readopts = rocksdb::ReadOptions::default();
+        let oldest_key = DataRecordKey::new(loglet_id, read_from);
+        // the iterator has an exclusive upper bound
+        let upper_bound_bytes = if read_to == LogletOffset::MAX {
+            DataRecordKey::exclusive_upper_bound(loglet_id)
+        } else {
+            DataRecordKey::new(loglet_id, read_to.next()).to_bytes()
+        };
+        readopts.set_tailing(false);
+        // In some cases, the underlying ForwardIterator will fail if it hits a `RangeDelete` tombstone.
+        // For our purposes, we can ignore these tombstones, meaning that we will return those records
+        // instead of a gap.
+        // In summary, if loglet reader started before a trim point and data is readable, we should
+        // continue reading them. It's the responsibility of the upper layer to decide on a sane
+        // value of _from_offset_.
+        readopts.set_ignore_range_deletions(true);
+        readopts.set_prefix_same_as_start(true);
+        readopts.set_total_order_seek(false);
+        readopts.set_async_io(true);
+        let oldest_key_bytes = oldest_key.to_bytes();
+        readopts.set_iterate_lower_bound(oldest_key_bytes.clone());
+        readopts.set_iterate_upper_bound(upper_bound_bytes);
+        let mut iterator = self
+            .rocksdb
+            .inner()
+            .as_raw_db()
+            .raw_iterator_cf_opt(&data_cf, readopts);
+
+        // read_pointer points to the next offset we should attempt to read (or expect to read)
+        let mut read_pointer = read_from;
+        iterator.seek(oldest_key_bytes);
+
+        let mut current_open_entry: Option<DigestEntry> = None;
+
+        while iterator.valid() && iterator.key().is_some() && read_pointer <= read_to {
+            let loaded_key = DataRecordKey::from_slice(iterator.key().expect("log record exists"));
+            let offset = loaded_key.offset();
+            match offset.cmp(&read_pointer) {
+                Ordering::Greater => {
+                    // We found a record but it's beyond what we expect as next (local gap)
+                    // close the entry if we had one
+                    if let Some(open) = current_open_entry.take() {
+                        entries.push(open);
+                    }
+                    if offset > read_to {
+                        // we are done.
+                        break;
+                    }
+
+                    // open a new entry
+                    current_open_entry = Some(DigestEntry {
+                        from_offset: offset,
+                        to_offset: offset,
+                        status: RecordStatus::Exists,
+                    });
+                    // reset the pointer
+                    read_pointer = offset.next();
+                }
+                Ordering::Equal => {
+                    if let Some(open) = current_open_entry.as_mut() {
+                        open.to_offset = read_pointer;
+                    } else {
+                        // open a new entry
+                        current_open_entry = Some(DigestEntry {
+                            from_offset: offset,
+                            to_offset: offset,
+                            status: RecordStatus::Exists,
+                        });
+                    }
+                    read_pointer = read_pointer.next();
+                }
+                Ordering::Less => {
+                    // offset < read_pointer?
+                    panic!("Bad logic, iterator is going backward!");
+                }
+            }
+            iterator.next();
+            // Allow other tasks on this thread to run, but only if we have exhausted the coop
+            // budget.
+            tokio::task::consume_budget().await;
+        }
+
+        // we reached the end due to an error
+        if read_pointer <= read_to {
+            if let Err(e) = iterator.status() {
+                // whoa, we have I/O errors, we should switch into failsafe mode (todo)
+                return Err(RocksDbLogStoreError::Rocksdb(e).into());
+            }
+        }
+
+        if let Some(last) = current_open_entry.take() {
+            // close the last entry
+            entries.push(last);
+        }
+
+        Ok(Digest {
+            header: LogServerResponseHeader::new(local_tail, loglet_state.known_global_tail()),
+            entries,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -356,7 +490,9 @@ mod tests {
     use restate_types::config::Configuration;
     use restate_types::live::Live;
     use restate_types::logs::{LogletOffset, Record, RecordCache, SequenceNumber};
-    use restate_types::net::log_server::{LogServerRequestHeader, Store, StoreFlags};
+    use restate_types::net::log_server::{
+        DigestEntry, GetDigest, LogServerRequestHeader, RecordStatus, Status, Store, StoreFlags,
+    };
     use restate_types::replicated_loglet::ReplicatedLogletId;
     use restate_types::{GenerationalNodeId, PlainNodeId};
 
@@ -496,6 +632,172 @@ mod tests {
         assert_that!(
             state.sequencer(),
             some(eq(&GenerationalNodeId::new(2, 212)))
+        );
+
+        tc.shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    #[test(tokio::test(start_paused = true))]
+    async fn test_digest() -> Result<()> {
+        let (tc, mut log_store) = setup().await?;
+        let loglet_id_1 = ReplicatedLogletId::new(88);
+        let loglet_id_2 = ReplicatedLogletId::new(89);
+        let sequencer_1 = GenerationalNodeId::new(5, 213);
+        let sequencer_2 = GenerationalNodeId::new(2, 212);
+
+        let mut state = log_store.load_loglet_state(loglet_id_1).await?;
+        assert!(!state.is_sealed());
+        assert_that!(state.local_tail().offset(), eq(LogletOffset::OLDEST));
+        assert_that!(state.trim_point(), eq(LogletOffset::INVALID));
+
+        // get digest for empty log.
+        let msg = GetDigest {
+            // global offset is ignored by the log-store, it's safe to set it to any value.
+            header: LogServerRequestHeader::new(loglet_id_1, LogletOffset::new(10)),
+            from_offset: LogletOffset::new(5),
+            to_offset: LogletOffset::new(200),
+        };
+        let digest = log_store.get_records_digest(msg, &state).await?;
+        assert_that!(digest.header.status, eq(Status::Ok));
+        assert_that!(digest.header.local_tail, eq(LogletOffset::OLDEST));
+        assert!(digest.entries.is_empty());
+
+        // store some records
+
+        // loglet_1 will have those offsets
+        // [5 7 10 11 12 13 18].
+        let payloads = vec![Record::from("a sample record".to_owned())];
+
+        for offset in [5, 7, 10, 11, 12, 13, 18] {
+            let offset = LogletOffset::new(offset);
+            let store_msg = Store {
+                // fake movement of global commit to allow this store
+                header: LogServerRequestHeader::new(loglet_id_1, offset),
+                timeout_at: None,
+                sequencer: sequencer_1,
+                known_archived: LogletOffset::INVALID,
+                first_offset: offset,
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
+            log_store
+                .enqueue_store(store_msg.clone(), true)
+                .await?
+                .await?;
+        }
+
+        // the store doesn't update local-state, so we update it manually here to 20
+        state
+            .get_local_tail_watch()
+            .notify_offset_update(LogletOffset::new(20));
+
+        assert!(!state.is_sealed());
+        assert_that!(state.local_tail().offset(), eq(LogletOffset::new(20)));
+        assert_that!(state.trim_point(), eq(LogletOffset::INVALID));
+        // add records to the adjacent log just to validate we are not spilling over.
+        let store_msg = Store {
+            header: LogServerRequestHeader::new(loglet_id_2, LogletOffset::OLDEST),
+            timeout_at: None,
+            first_offset: LogletOffset::OLDEST,
+            sequencer: sequencer_2,
+            known_archived: LogletOffset::INVALID,
+            flags: StoreFlags::empty(),
+            payloads,
+        };
+        log_store.enqueue_store(store_msg, true).await?.await?;
+        // the adjacent log is at 2
+        let state2 = log_store.load_loglet_state(loglet_id_2).await?;
+        assert!(!state2.is_sealed());
+        assert_that!(state2.local_tail().offset(), eq(LogletOffset::new(2)));
+        assert_that!(state2.trim_point(), eq(LogletOffset::INVALID));
+
+        // Get the digest of loglet_1
+        // Scenario 1. Reasonable request bounds
+        let msg = GetDigest {
+            // global offset is ignored by the log-store, it's safe to set it to any value.
+            header: LogServerRequestHeader::new(loglet_id_1, LogletOffset::new(200)),
+            from_offset: LogletOffset::new(1),
+            to_offset: LogletOffset::new(200),
+        };
+        let digest = log_store.get_records_digest(msg, &state).await?;
+        assert_that!(digest.header.status, eq(Status::Ok));
+        assert_that!(digest.header.local_tail, eq(LogletOffset::new(20)));
+        // we expect [5..5] X,[7..7] X, [10..13] X, [18..18] X
+        assert_that!(digest.entries.len(), eq(4));
+        // left intentionally to debug tests
+        println!("Scenario 1");
+        for entry in &digest.entries {
+            println!("{}", entry);
+        }
+
+        assert_that!(
+            digest.entries,
+            elements_are![
+                eq(DigestEntry {
+                    from_offset: 5.into(),
+                    to_offset: 5.into(),
+                    status: RecordStatus::Exists,
+                }),
+                eq(DigestEntry {
+                    from_offset: 7.into(),
+                    to_offset: 7.into(),
+                    status: RecordStatus::Exists,
+                }),
+                eq(DigestEntry {
+                    from_offset: 10.into(),
+                    to_offset: 13.into(),
+                    status: RecordStatus::Exists,
+                }),
+                eq(DigestEntry {
+                    from_offset: 18.into(),
+                    to_offset: 18.into(),
+                    status: RecordStatus::Exists,
+                }),
+            ]
+        );
+
+        // Scenario 2.
+        // Get the digest, with a trim gap that eats up offset 11.
+        state.update_trim_point(LogletOffset::new(11));
+        let msg = GetDigest {
+            // global offset is ignored by the log-store, it's safe to set it to any value.
+            header: LogServerRequestHeader::new(loglet_id_1, LogletOffset::new(200)),
+            // start from 5 this time
+            from_offset: LogletOffset::new(5),
+            to_offset: LogletOffset::new(200),
+        };
+        let digest = log_store.get_records_digest(msg, &state).await?;
+        assert_that!(digest.header.status, eq(Status::Ok));
+        assert_that!(digest.header.local_tail, eq(LogletOffset::new(20)));
+        // we expect [5..11] T, [12..13] X, [18..18] X
+        assert_that!(digest.entries.len(), eq(3));
+        // left intentionally to debug tests
+        println!("Scenario 2");
+        for entry in &digest.entries {
+            println!("{}", entry);
+        }
+
+        assert_that!(
+            digest.entries,
+            elements_are![
+                eq(DigestEntry {
+                    from_offset: 5.into(),
+                    to_offset: 11.into(),
+                    status: RecordStatus::Trimmed,
+                }),
+                eq(DigestEntry {
+                    from_offset: 12.into(),
+                    to_offset: 13.into(),
+                    status: RecordStatus::Exists,
+                }),
+                eq(DigestEntry {
+                    from_offset: 18.into(),
+                    to_offset: 18.into(),
+                    status: RecordStatus::Exists,
+                }),
+            ]
         );
 
         tc.shutdown_node("test completed", 0).await;

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -56,9 +56,10 @@ enum TargetName {
   LOG_SERVER_RECORDS = 19;
   LOG_SERVER_TRIM = 20;
   LOG_SERVER_TRIMMED = 21;
-
   LOG_SERVER_WAIT_FOR_TAIL = 22;
   LOG_SERVER_TAIL_UPDATED = 23;
+  LOG_SERVER_GET_DIGEST = 24;
+  LOG_SERVER_DIGEST = 25;
   // Reserving space for more log-server messages
   // ReplicatedLoglet
   REPLICATED_LOGLET_APPEND = 40;


### PR DESCRIPTION

Digest as a summary of offset-range presence on a certain node. A a new request message `GetDigest` is introduced to the log-server to allow an efficient scanning of a range of offsets to check which offsets reside on this server. This process will be used as part of the tail repair to determine (a) whether a record meets the replication requirements and (b) where to fetch a certain record if we need to re-replicate.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2042).
* #2046
* __->__ #2042