### PR TITLE
[Bifrost] RepairTail task for replicated loglet

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -170,6 +170,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
             to,
             known_global_tail,
             cache,
+            false,
         )
         .await?;
         let read_stream = ReplicatedLogletReadStream::new(from, rx_stream, reader_task);
@@ -209,6 +210,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
                     self.networking.clone(),
                     self.logservers_rpc.clone(),
                     self.known_global_tail.clone(),
+                    self.record_cache.clone(),
                 );
                 let tail_status = task.run().await;
                 match tail_status {

--- a/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
@@ -110,6 +110,26 @@ impl<'a, Attribute> NodeSetChecker<'a, Attribute> {
         self.node_attribute.is_empty()
     }
 
+    /// resets all attributes for all nodes to this value
+    pub fn reset_with(&mut self, attribute: Attribute)
+    where
+        Attribute: Clone,
+    {
+        for (_, v) in self.node_attribute.iter_mut() {
+            *v = attribute.clone();
+        }
+    }
+
+    /// resets all attributes for all nodes with the default value of Attribute
+    pub fn reset_with_default(&mut self)
+    where
+        Attribute: Default,
+    {
+        for (_, v) in self.node_attribute.iter_mut() {
+            *v = Default::default();
+        }
+    }
+
     /// Set the attribute value of a node. Note that a node can only be
     /// associated with one attribute value at a time, so if the node has an
     /// existing attribute value, the value will be cleared.
@@ -128,8 +148,12 @@ impl<'a, Attribute> NodeSetChecker<'a, Attribute> {
         }
     }
 
-    pub fn set_attribute_on_each(&mut self, nodes: &[PlainNodeId], f: impl Fn() -> Attribute) {
-        for node in nodes {
+    pub fn set_attribute_on_each<'b>(
+        &mut self,
+        nodes: impl IntoIterator<Item = &'b PlainNodeId>,
+        f: impl Fn() -> Attribute,
+    ) {
+        for node in nodes.into_iter() {
             // ignore if the node is not in the original nodeset
             if self.storage_states.contains_key(node) {
                 self.node_attribute.insert(*node, f());

--- a/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
@@ -14,7 +14,7 @@
 use restate_core::network::rpc_router::RpcRouter;
 use restate_core::network::MessageRouterBuilder;
 use restate_types::net::log_server::{
-    GetLogletInfo, GetRecords, Release, Seal, Store, Trim, WaitForTail,
+    GetDigest, GetLogletInfo, GetRecords, Release, Seal, Store, Trim, WaitForTail,
 };
 use restate_types::net::replicated_loglet::Append;
 
@@ -28,6 +28,7 @@ pub struct LogServersRpc {
     pub seal: RpcRouter<Seal>,
     pub get_loglet_info: RpcRouter<GetLogletInfo>,
     pub get_records: RpcRouter<GetRecords>,
+    pub get_digest: RpcRouter<GetDigest>,
     pub wait_for_tail: RpcRouter<WaitForTail>,
 }
 
@@ -41,6 +42,7 @@ impl LogServersRpc {
         let seal = RpcRouter::new(router_builder);
         let get_loglet_info = RpcRouter::new(router_builder);
         let get_records = RpcRouter::new(router_builder);
+        let get_digest = RpcRouter::new(router_builder);
         let wait_for_tail = RpcRouter::new(router_builder);
 
         Self {
@@ -50,6 +52,7 @@ impl LogServersRpc {
             seal,
             get_loglet_info,
             get_records,
+            get_digest,
             wait_for_tail,
         }
     }

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/digests.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/digests.rs
@@ -1,0 +1,358 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use rand::thread_rng;
+use tokio::task::JoinSet;
+use tracing::{debug, trace, warn};
+
+use restate_core::network::rpc_router::{RpcError, RpcRouter};
+use restate_core::network::{Networking, TransportConnect};
+use restate_core::{cancellation_watcher, task_center, ShutdownError};
+use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::net::log_server::{
+    Digest, LogServerRequestHeader, RecordStatus, Status, Store, StoreFlags,
+};
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicatedLogletParams};
+use restate_types::{GenerationalNodeId, PlainNodeId};
+
+use crate::loglet::util::TailOffsetWatch;
+use crate::loglet::OperationError;
+use crate::providers::replicated_loglet::replication::spread_selector::{
+    SelectorStrategy, SpreadSelector,
+};
+use crate::providers::replicated_loglet::replication::NodeSetChecker;
+use crate::LogEntry;
+
+#[derive(Debug, thiserror::Error)]
+#[error("could not replicate record, exhausted all store attempts")]
+struct ReplicationFailed;
+
+/// Tracks digest responses and record repairs to achieve a consistent and durable
+/// state of the loglet tail.
+pub struct Digests {
+    loglet_id: ReplicatedLogletId,
+    // inclusive. The first record we need to repair.
+    start_offset: LogletOffset,
+    // exclusive (this should be the durable global_tail after finishing)
+    target_tail: LogletOffset,
+    // all offsets `[start_offset..target_tail)`
+    offsets_under_repair: BTreeMap<LogletOffset, NodeSet>,
+    known_nodes: NodeSet,
+    spread_selector: SpreadSelector,
+}
+
+impl Digests {
+    pub fn new(
+        my_params: &ReplicatedLogletParams,
+        start_offset: LogletOffset,
+        target_tail: LogletOffset,
+    ) -> Self {
+        let offsets = if start_offset >= target_tail {
+            // already finished
+            Default::default()
+        } else {
+            BTreeMap::from_iter(
+                (*start_offset..*target_tail).map(|o| (LogletOffset::new(o), Default::default())),
+            )
+        };
+
+        let spread_selector = SpreadSelector::new(
+            my_params.nodeset.clone(),
+            // todo: should be from the same configuration source as what the sequencer uses.
+            SelectorStrategy::Flood,
+            my_params.replication.clone(),
+        );
+
+        Digests {
+            loglet_id: my_params.loglet_id,
+            start_offset,
+            target_tail,
+            known_nodes: Default::default(),
+            offsets_under_repair: offsets,
+            spread_selector,
+        }
+    }
+
+    /// The start of the range currently under repair
+    pub fn start_offset(&self) -> LogletOffset {
+        self.start_offset
+    }
+
+    /// The target tail we are repairing to
+    pub fn target_tail(&self) -> LogletOffset {
+        self.target_tail
+    }
+
+    /// If true, no repairs are needed
+    pub fn is_finished(&self) -> bool {
+        self.start_offset >= self.target_tail
+    }
+
+    /// Processes an incoming digest message from a node. Entries outside the current range under
+    /// repair are ignored.
+    ///
+    /// This will also update the known_global_tail from digest message headers as expected
+    pub fn on_digest_message(
+        &mut self,
+        peer_node: PlainNodeId,
+        msg: Digest,
+        known_global_tail: &TailOffsetWatch,
+    ) {
+        known_global_tail.notify_offset_update(msg.header.known_global_tail);
+        self.update_start_offset(known_global_tail.latest_offset());
+
+        if self.is_finished() {
+            return;
+        }
+
+        if msg.header.status != Status::Ok {
+            return;
+        }
+
+        if !self.known_nodes.insert(peer_node) {
+            warn!(
+                loglet_id = %self.loglet_id,
+                node_id = %peer_node,
+                "We have received a successful digest from this node already!"
+            );
+            return;
+        }
+
+        for entry in msg.entries {
+            // todo: consider handling Archived and Trimmed responses.
+            if entry.status == RecordStatus::Exists {
+                for (_, copies) in self
+                    .offsets_under_repair
+                    .range_mut(entry.from_offset..=entry.to_offset)
+                {
+                    copies.insert(peer_node);
+                }
+            }
+        }
+    }
+
+    /// Attempts to copy the given entry to satisfy its replication property if needed.
+    ///
+    /// This returns when the record is sufficiently replicated.
+    pub async fn replicate_record_and_advance<T: TransportConnect>(
+        &mut self,
+        entry: LogEntry<LogletOffset>,
+        sequencer: GenerationalNodeId,
+        networking: &Networking<T>,
+        store_rpc: &RpcRouter<Store>,
+    ) -> Result<(), OperationError> {
+        let offset = entry.sequence_number();
+        if offset < self.start_offset {
+            // Ignore this record. We have already moved past this offset.
+            return Ok(());
+        }
+        // If we see a trim gap, we always assume that the trim-gap is up to a previously known
+        // global tail value so we fast forward until the end of the gap.
+        if entry.is_trim_gap() {
+            debug!(
+                loglet_id = %self.loglet_id,
+                "Observed a trim gap from offset {} to {} while repairing the tail of the loglet, \
+                 those offsets will be considered repaired",
+                offset,
+                entry.trim_gap_to_sequence_number().unwrap(),
+            );
+            self.update_start_offset(entry.next_sequence_number());
+            return Ok(());
+        }
+
+        let known_copies = self
+            .offsets_under_repair
+            .get(&offset)
+            .expect("repairing an offset that we have not truncated");
+
+        // See how many copies do we need to do to achieve write quorum.
+        let fixup_nodes = self
+            .spread_selector
+            .select_fixups(
+                known_copies,
+                &mut thread_rng(),
+                &networking.metadata().nodes_config_ref(),
+                &NodeSet::empty(),
+            )
+            // what do we do if we can't generate a spread? nodes are in data-loss or readonly, or
+            // whatever state.
+            // We definitely cannot proceed but should we retry? let's only do that when we need to,
+            // for now, we bail.
+            .map_err(OperationError::retryable)?;
+
+        trace!(
+            loglet_id = %self.loglet_id,
+            %offset,
+            "Repairing record, existing copies on {} and fixup nodes are {}",
+            known_copies,
+            fixup_nodes,
+        );
+
+        // We handled trim gaps before this point.
+        let record = entry.into_record().expect("must be a data record");
+
+        let mut replication_checker = NodeSetChecker::new(
+            self.spread_selector.nodeset(),
+            &networking.metadata().nodes_config_ref(),
+            self.spread_selector.replication_property(),
+        );
+        // record is already replicated on those nodes
+        replication_checker.set_attribute_on_each(known_copies, || true);
+
+        let payloads = vec![record].into();
+
+        let msg = Store {
+            // As we send store messages, we consider the start_offset a reliable source of
+            // `global_known_tail`. This allows log-servers to accept those writes if they were still
+            // behind.
+            header: LogServerRequestHeader::new(self.loglet_id, self.start_offset),
+            timeout_at: None,
+            // Must be set to bypass the seal
+            flags: StoreFlags::IgnoreSeal,
+            first_offset: offset,
+            sequencer,
+            known_archived: LogletOffset::INVALID,
+            payloads,
+        };
+        // We run stores as tasks because we'll wait only for the necessary write-quorum but the
+        // rest of the stores can continue in the background as best-effort replication (if the
+        // spread selector strategy picked extra nodes)
+        let mut inflight_stores = JoinSet::new();
+        for node in fixup_nodes {
+            inflight_stores.spawn({
+                let networking = networking.clone();
+                let msg = msg.clone();
+                let store_rpc = store_rpc.clone();
+                let tc = task_center();
+                async move {
+                    tc.run_in_scope("repair-store", None, async move {
+                        (node, store_rpc.call(&networking, node, msg).await)
+                    })
+                    .await
+                }
+            });
+        }
+        let mut cancel = std::pin::pin!(cancellation_watcher());
+
+        loop {
+            if replication_checker.check_write_quorum(|attr| *attr) {
+                trace!(
+                    loglet_id = %self.loglet_id,
+                    %offset,
+                    "Record has been repaired"
+                );
+                // record has been fully replicated.
+                self.update_start_offset(offset);
+                return Ok(());
+            }
+
+            if inflight_stores.is_empty() {
+                // No more store attempts left. We couldn't replicate this record.
+                return Err(OperationError::retryable(ReplicationFailed));
+            }
+
+            let stored_on_peer = tokio::select! {
+                _ = &mut cancel => {
+                    return Err(OperationError::Shutdown(ShutdownError));
+                }
+                Some(Ok((peer, maybe_stored))) = inflight_stores.join_next() => {
+                    // maybe_stored is err if we can't send the store (or shutdown)
+                    match maybe_stored {
+                        Ok(stored) if stored.body().header.status == Status::Ok =>  {
+                            Some(peer)
+                        }
+                        Ok(stored) => {
+                            // Store failed with some non-ok status
+                            debug!(
+                                loglet_id = %self.loglet_id,
+                                peer = %stored.peer(),
+                                %offset,
+                                "Could not store record on node as part of the tail repair procedure. Log server responded with status={:?}",
+                                stored.body().header.status
+                            );
+                            None
+                        }
+                        Err(RpcError::Shutdown(e)) => return Err(OperationError::Shutdown(e)),
+                        // give up on this store.
+                        Err(e) => {
+                            debug!(
+                                loglet_id = %self.loglet_id,
+                                %peer,
+                                %offset,
+                                %e,
+                                "Could not store record on node as part of the tail repair procedure. Network error",
+                            );
+                            None
+                        }
+                    }
+                }
+            };
+
+            if let Some(stored_on_peer) = stored_on_peer {
+                replication_checker.set_attribute(stored_on_peer, true);
+            }
+        }
+    }
+
+    pub fn can_repair(&self, nodes_config: &NodesConfiguration) -> bool {
+        // only do that if known_nodes can satisfy write-quorum.
+        let mut checker = NodeSetChecker::new(
+            self.spread_selector.nodeset(),
+            nodes_config,
+            self.spread_selector.replication_property(),
+        );
+        checker.set_attribute_on_each(&self.known_nodes, || true);
+        checker.check_write_quorum(|known| *known)
+    }
+
+    // returns true if we can advance to repair
+    pub fn advance(&mut self, nodes_config: &NodesConfiguration) -> bool {
+        if !self.can_repair(nodes_config) {
+            // we don't have write-quorum of nodes yet, we can't advance start_offset.
+            return false;
+        }
+        let mut range = self.offsets_under_repair.range(..);
+        let mut checker = NodeSetChecker::new(
+            self.spread_selector.nodeset(),
+            nodes_config,
+            self.spread_selector.replication_property(),
+        );
+        // walk backwards
+        while let Some((offset, nodes)) = range.next_back() {
+            checker.reset_with_default();
+            checker.set_attribute_on_each(nodes, || true);
+            if checker.check_write_quorum(|known| *known) {
+                // this offset is good, advance to the next one
+                self.update_start_offset(offset.next());
+                return true;
+            }
+        }
+        false
+    }
+
+    fn update_start_offset(&mut self, new_start_offset: LogletOffset) {
+        let original = self.start_offset;
+        self.start_offset = self.start_offset.max(new_start_offset);
+        if self.start_offset != original {
+            self.truncate_range();
+        }
+    }
+
+    fn truncate_range(&mut self) {
+        if self.is_finished() {
+            self.offsets_under_repair.clear();
+        } else {
+            self.offsets_under_repair = self.offsets_under_repair.split_off(&self.start_offset);
+        }
+    }
+}

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
@@ -8,8 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod digests;
 mod find_tail;
+mod repair_tail;
 mod seal;
 
 pub use find_tail::*;
+pub use repair_tail::*;
 pub use seal::*;

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
@@ -1,0 +1,274 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use restate_core::network::{Networking, TransportConnect};
+use restate_core::{ShutdownError, TaskCenter};
+use restate_types::logs::{KeyFilter, LogletOffset, RecordCache, SequenceNumber};
+use restate_types::net::log_server::{GetDigest, LogServerRequestHeader};
+use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams};
+use tokio::task::JoinSet;
+use tracing::{trace, warn};
+
+use crate::loglet::util::TailOffsetWatch;
+use crate::providers::replicated_loglet::read_path::ReadStreamTask;
+use crate::providers::replicated_loglet::rpc_routers::LogServersRpc;
+
+use super::digests::Digests;
+
+/// # Overview
+///
+/// The primary reason for why we need such a procedure is because the sequencer node marks the record as
+/// released _before_ it sends out a Release message to log-servers. In other words, we don't require a
+/// quorum of nodes to acknowledge the `Release` message to consider a record committed. This is an important
+/// design optimization to reduce latency of the write path. The sequencer needs 1-RTT (store wave) to commit
+/// a record rather than 2-RTT (store+release).
+///
+/// The tradeoff is the speed at which we can determine the last global committed tail if the sequencer is not
+/// available. There is a number of optimizations that can be added to improve the efficiency of this operation,
+/// those include but are not limited to:
+/// 1. Log-servers persisting the last known_global_tail periodically/async and using this value as known_global_tail on startup.
+/// 2. Sequencer-driven seal. If the sequencer is alive, it can send a special value with the seal message to
+///    indicate what is the ultimate known-global-tail that nodes should repair to instead of relying on the observed max-tail.
+/// 3. Limit `from_offset` to repair from to max(min(local_tails), max(known_global_tails), known_archived, trim_point)
+/// 4. Archiving records to the external object-store instead of re-replication, although, this
+///    doesn't improve the efficiency of the repair operation itself.
+///
+/// The repair process must be reentrant, fault-tolerant, and yields correct immutable state of the
+/// tail even with concurrent runs.
+///
+/// # Details
+///
+/// ## Digest Phase (where are my records?)
+/// Given the input range [max(known_global_tails)..max-local-tail], determine the biggest offset at which we can
+/// find evidence of a write-quorum of a record, including unauthoritative nodes (`StorageState::DataLoss`).
+/// Let's call this `max_known_durable_offset`. We narrow down the repair range to [max_known_durable_offset+1..max-local-tail).
+/// If len()=0, we have no work to do. max-local-tail is fully replicated.
+///
+/// Ask nodes to send a digest first before reading the records? Who has what.
+/// - For a digest request [start_offset, max-tail-requested]
+/// - Node sends a list that looks like this:
+///   FROM           TO  -> STATUS
+///   [start_offset..t1] -> A (Archived)                      Good to know. (A = Archived)
+///   [t2..t10]          -> X (Exists)                        len = t10-t1 = 9 records exists on this node
+///   [t11..t11]         -> X
+///   this implies [t12..max-tail-requested-1) has no records.
+///
+/// ## Replication Phase (restore replication)
+///
+/// Starting from the beginning of the range, we create a special read-stream to read records up to
+/// the target tail.
+/// Then we send a store wave to fixup the replication of this record while ignoring the seal flag to achieve write-quorum.
+/// We use knowledge obtained from digests to decide which nodes to replicate to, if insufficient nodes are writeable.
+/// [Future] Batch the set of records and upload to object-store. Update the archived pointer a write-quorum of nodes after upload.
+/// The write-quorum is not strictly required in the case where the object-store allows a cheap query to ask if an offset is archived or not.
+///
+/// Update the known_global_tail to allow nodes to move their local-tail during repair. This also allows them to persist this value.
+///
+/// ## todo: Completion Phase (try to avoid same-range repair in future runs)
+/// Once max-tail is reached. Send a Release message with special flag (repair) to update log-servers with the newly agreed-upon
+/// known_global_tail. This is a best-effort phase and it should not block the completion of the repair task.
+pub struct RepairTail<T> {
+    my_params: ReplicatedLogletParams,
+    task_center: TaskCenter,
+    networking: Networking<T>,
+    logservers_rpc: LogServersRpc,
+    record_cache: RecordCache,
+    known_global_tail: TailOffsetWatch,
+    digests: Digests,
+}
+
+pub enum RepairTailResult {
+    Completed,
+    DigestFailed,
+    ReplicationFailed,
+    // Due to system shutdown
+    Shutdown(ShutdownError),
+}
+
+impl<T: TransportConnect> RepairTail<T> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        my_params: ReplicatedLogletParams,
+        task_center: TaskCenter,
+        networking: Networking<T>,
+        logservers_rpc: LogServersRpc,
+        record_cache: RecordCache,
+        known_global_tail: TailOffsetWatch,
+        start_offset: LogletOffset,
+        target_tail: LogletOffset,
+    ) -> Self {
+        let digests = Digests::new(&my_params, start_offset, target_tail);
+        RepairTail {
+            my_params,
+            task_center,
+            networking,
+            logservers_rpc,
+            record_cache,
+            known_global_tail,
+            digests,
+        }
+    }
+
+    pub async fn run(mut self) -> RepairTailResult {
+        if self.digests.is_finished() {
+            return RepairTailResult::Completed;
+        }
+        let mut get_digest_requests = JoinSet::new();
+        let effective_nodeset = EffectiveNodeSet::new(
+            &self.my_params.nodeset,
+            &self.networking.metadata().nodes_config_ref(),
+        );
+
+        // Dispatch GetDigest to all readable nodes
+        for node in effective_nodeset.iter() {
+            let msg = GetDigest {
+                header: LogServerRequestHeader::new(
+                    self.my_params.loglet_id,
+                    self.known_global_tail.latest_offset(),
+                ),
+                from_offset: self.digests.start_offset(),
+                to_offset: self.digests.target_tail().prev(),
+            };
+            get_digest_requests.spawn({
+                let tc = self.task_center.clone();
+                let networking = self.networking.clone();
+                let logservers_rpc = self.logservers_rpc.clone();
+                let peer = *node;
+                async move {
+                    tc.run_in_scope("get-digest-from-node", None, async move {
+                        loop {
+                            // todo: handle retries with exponential backoff...
+                            let Ok(incoming) = logservers_rpc
+                                .get_digest
+                                .call(&networking, peer, msg.clone())
+                                .await
+                            else {
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                continue;
+                            };
+                            return incoming;
+                        }
+                    })
+                    .await
+                }
+            });
+        }
+
+        // # Digest Phase
+        while let Some(Ok(digest_message)) = get_digest_requests.join_next().await {
+            let peer_node = digest_message.peer().as_plain();
+            self.digests.on_digest_message(
+                peer_node,
+                digest_message.into_body(),
+                &self.known_global_tail,
+            );
+            if self
+                .digests
+                .advance(&self.networking.metadata().nodes_config_ref())
+            {
+                trace!(
+                    loglet_id = %self.my_params.loglet_id,
+                    node_id = %peer_node,
+                    "Digest phase completed."
+                );
+                break;
+            }
+            // can we start repair, but continue to accept digest responses as repair is on-going.
+        }
+
+        if self.digests.is_finished() {
+            return RepairTailResult::Completed;
+        }
+
+        // No enough nodes responded to be able to repair
+        if !self
+            .digests
+            .can_repair(&self.networking.metadata().nodes_config_ref())
+        {
+            return RepairTailResult::DigestFailed;
+        }
+
+        // Keep reading responses from digest requests since it can assist moving the start_offset
+        // during repair. In this case, we'll fast-forward and ignore replication for the updated
+        // range, this might lead to some over-replication and that's fine.
+        // For every record between start_offset->target_tail.prev() we need to replicate enough
+        // copies to satisfy the write-quorum.
+        //
+        // Replication goes in the direction of "start_offset" towards the tail, one record at a
+        // a time.
+        let Ok((mut rx, read_stream_task)) = ReadStreamTask::start(
+            self.my_params.clone(),
+            self.networking.clone(),
+            self.logservers_rpc.clone(),
+            KeyFilter::Any,
+            self.digests.start_offset(),
+            Some(self.digests.target_tail().prev()),
+            self.known_global_tail.clone(),
+            self.record_cache.clone(),
+            /* move-beyond-global-tail = */ true,
+        )
+        .await
+        else {
+            return RepairTailResult::Shutdown(ShutdownError);
+        };
+
+        'replication_phase: loop {
+            if self.digests.is_finished() {
+                break;
+            }
+            tokio::select! {
+                // we fail the readstream during shutdown only, in that case, there is not much
+                // we can do but to stop.
+                Some(Ok(entry)) = rx.recv()  => {
+                    // we received a record. Should we replicate it?
+                    if let Err(e) = self.digests.replicate_record_and_advance(
+                        entry,
+                        self.my_params.sequencer,
+                        &self.networking,
+                        &self.logservers_rpc.store,
+                    ).await {
+                        warn!(error=%e, "Failed to replicate record while repairing the tail");
+                        break 'replication_phase;
+                    }
+                }
+                Some(Ok(digest_message)) = get_digest_requests.join_next() => {
+                    let peer_node = digest_message.peer().as_plain();
+                    self.digests.on_digest_message(
+                        peer_node,
+                        digest_message.into_body(),
+                        &self.known_global_tail,
+                    );
+                    self.digests.advance(&self.networking.metadata().nodes_config_ref());
+
+                }
+                    // we have no more work to do. We'll likely fail.
+                else => {}
+            }
+        }
+
+        read_stream_task.abort();
+        get_digest_requests.abort_all();
+
+        // Are we complete?
+        if self.digests.is_finished() {
+            return RepairTailResult::Completed;
+        }
+
+        warn!(
+            loglet_id = %self.my_params.loglet_id,
+            "Failed to repair the tail. The unrepaired region is from {} to {}",
+            self.digests.start_offset(),
+            self.digests.target_tail().prev()
+        );
+        RepairTailResult::ReplicationFailed
+    }
+}

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -80,6 +80,7 @@ impl ReplicatedLogletId {
     serde::Deserialize,
     Debug,
     Clone,
+    Default,
     Eq,
     PartialEq,
     derive_more::IntoIterator,
@@ -119,8 +120,9 @@ impl NodeSet {
         self.0.contains(node)
     }
 
-    pub fn insert(&mut self, node: PlainNodeId) {
-        self.0.insert(node);
+    /// returns true if this node didn't already exist in the nodeset
+    pub fn insert(&mut self, node: PlainNodeId) -> bool {
+        self.0.insert(node)
     }
 
     /// Returns true if all nodes in the nodeset are disabled
@@ -148,6 +150,16 @@ impl NodeSet {
     /// Filters out nodes that are not part of the effective nodeset (empty nodes)
     pub fn to_effective(&self, nodes_config: &NodesConfiguration) -> EffectiveNodeSet {
         EffectiveNodeSet::new(self, nodes_config)
+    }
+}
+
+impl<'a> IntoIterator for &'a NodeSet {
+    type Item = &'a PlainNodeId;
+
+    type IntoIter = <&'a HashSet<PlainNodeId> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
 }
 

--- a/crates/types/src/replicated_loglet/spread.rs
+++ b/crates/types/src/replicated_loglet/spread.rs
@@ -62,3 +62,13 @@ impl<const N: usize> From<[u32; N]> for Spread {
         Self(value.into_iter().map(PlainNodeId::from).collect())
     }
 }
+
+impl<'a> IntoIterator for &'a Spread {
+    type Item = &'a PlainNodeId;
+
+    type IntoIter = <&'a Box<[PlainNodeId]> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}


### PR DESCRIPTION

This puts together the design and implementation of the tail repair procedure that's required when FindTail cannot establish a consistent durable tail from log-servers. The details are described as comments in code.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2046).
* #2064
* #2056
* __->__ #2046