### PR TITLE
Use `Arc<[Record]>` instead of `Vec<Record>` for `Store` messages

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -420,7 +420,7 @@ struct LogServerStoreTask<'a, T> {
     networking: &'a Networking<T>,
     server: RemoteLogServer,
     first_offset: LogletOffset,
-    records: &'a [Record],
+    records: &'a Arc<[Record]>,
     rpc_router: &'a RpcRouter<Store>,
 }
 
@@ -521,7 +521,7 @@ impl<'a, T: TransportConnect> LogServerStoreTask<'a, T> {
             first_offset: self.first_offset,
             flags: StoreFlags::empty(),
             known_archived: LogletOffset::INVALID,
-            payloads: Vec::from_iter(self.records.iter().cloned()),
+            payloads: Arc::clone(self.records),
             sequencer: self.sequencer_shared_state.my_node_id,
             timeout_at: None,
         };

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -583,6 +583,8 @@ impl<S: LogStore> LogletWorker<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use googletest::prelude::*;
     use test_log::test;
@@ -640,10 +642,11 @@ mod tests {
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(tc.clone(), LOGLET, log_store, loglet_state)?;
 
-        let payloads = vec![
+        let payloads: Arc<[Record]> = vec![
             Record::from("a sample record"),
             Record::from("another record"),
-        ];
+        ]
+        .into();
 
         // offsets 1, 2
         let msg1 = Store {
@@ -716,10 +719,11 @@ mod tests {
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(tc.clone(), LOGLET, log_store, loglet_state)?;
 
-        let payloads = vec![
+        let payloads: Arc<[Record]> = vec![
             Record::from("a sample record"),
             Record::from("another record"),
-        ];
+        ]
+        .into();
 
         // offsets 1, 2
         let msg1 = Store {
@@ -889,7 +893,7 @@ mod tests {
                     known_archived: LogletOffset::INVALID,
                     first_offset: LogletOffset::new(2),
                     flags: StoreFlags::empty(),
-                    payloads: vec![Record::from("record2")],
+                    payloads: vec![Record::from("record2")].into(),
                 },
                 None,
             ))
@@ -906,7 +910,7 @@ mod tests {
                     known_archived: LogletOffset::INVALID,
                     first_offset: LogletOffset::new(5),
                     flags: StoreFlags::empty(),
-                    payloads: vec![Record::from(("record5", Keys::Single(11)))],
+                    payloads: vec![Record::from(("record5", Keys::Single(11)))].into(),
                 },
                 None,
             ))
@@ -923,7 +927,7 @@ mod tests {
                     known_archived: LogletOffset::INVALID,
                     first_offset: LogletOffset::new(10),
                     flags: StoreFlags::empty(),
-                    payloads: vec![Record::from("record10"), Record::from("record11")],
+                    payloads: vec![Record::from("record10"), Record::from("record11")].into(),
                 },
                 None,
             ))
@@ -1156,7 +1160,7 @@ mod tests {
                     known_archived: LogletOffset::INVALID,
                     first_offset: LogletOffset::new(5),
                     flags: StoreFlags::empty(),
-                    payloads: vec![Record::from("record5"), Record::from("record6")],
+                    payloads: vec![Record::from("record5"), Record::from("record6")].into(),
                 },
                 None,
             ))

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -571,7 +571,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::OLDEST,
             flags: StoreFlags::empty(),
-            payloads,
+            payloads: payloads.into(),
         };
         // add record at offset=1, no sequencer set.
         log_store
@@ -680,7 +680,7 @@ mod tests {
                 known_archived: LogletOffset::INVALID,
                 first_offset: offset,
                 flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
+                payloads: payloads.clone().into(),
             };
             log_store
                 .enqueue_store(store_msg.clone(), true)
@@ -704,7 +704,7 @@ mod tests {
             sequencer: sequencer_2,
             known_archived: LogletOffset::INVALID,
             flags: StoreFlags::empty(),
-            payloads,
+            payloads: payloads.into(),
         };
         log_store.enqueue_store(store_msg, true).await?.await?;
         // the adjacent log is at 2

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -202,7 +202,7 @@ impl LogStoreWriter {
     ) {
         buffer.reserve(store_message.estimated_encode_size());
         let mut offset = store_message.first_offset;
-        for payload in store_message.payloads {
+        for payload in store_message.payloads.iter() {
             let key_bytes =
                 DataRecordKey::new(store_message.header.loglet_id, offset).encode_and_split(buffer);
             record_cache.add(store_message.header.loglet_id, offset, payload.clone());

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -188,7 +189,7 @@ pub struct Store {
     /// Denotes the last record that has been safely uploaded to an archiving data store.
     pub known_archived: LogletOffset,
     // todo (asoli) serialize efficiently
-    pub payloads: Vec<Record>,
+    pub payloads: Arc<[Record]>,
 }
 
 impl Store {


### PR DESCRIPTION
Use `Arc<[Record]>` instead of `Vec<Record>` for `Store` messages

Summary:
Using `Arc` to avoid copying record batches when sending a store wave
to mutiple log server.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2049).
* #2050
* __->__ #2049