### PR TITLE
[Bifrost] restatectl logs generate-metadata command

### DIFF
--- a/crates/types/src/logs/builder.rs
+++ b/crates/types/src/logs/builder.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroU32;
 use std::ops::Deref;
 
 use super::metadata::{
     Chain, LogletConfig, LogletParams, Logs, MaybeSegment, ProviderKind, SegmentIndex,
 };
 use super::{LogId, Lsn};
+use crate::Version;
 
 #[derive(Debug, Default, Clone)]
 pub struct LogsBuilder {
@@ -53,6 +55,12 @@ impl LogsBuilder {
             version: self.inner.version.next(),
             logs: self.inner.logs,
         }
+    }
+
+    pub fn set_version(&mut self, version: NonZeroU32) {
+        // because we increment this value on build() so we assume that the input is the intended
+        // outcome of the build() call.
+        self.inner.version = Version::from(u32::from(version) - 1);
     }
 }
 

--- a/tools/restatectl/src/commands/log/gen_metadata.rs
+++ b/tools/restatectl/src/commands/log/gen_metadata.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::num::{NonZeroU32, NonZeroU8};
+
+use cling::prelude::*;
+
+use restate_types::logs::builder::LogsBuilder;
+use restate_types::logs::metadata::{Chain, LogletParams, ProviderKind};
+use restate_types::logs::LogId;
+use restate_types::replicated_loglet::{
+    NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty,
+};
+use restate_types::{GenerationalNodeId, PlainNodeId};
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap()]
+#[cling(run = "generate_log_metadata")]
+pub struct GenerateLogMetadataOpts {
+    #[clap(long, default_value = "2")]
+    version: NonZeroU32,
+    /// Replication property
+    #[clap(long, short)]
+    replication_factor: NonZeroU8,
+    /// A comma-separated list of the nodes in the nodeset. e.g. N1,N2,N4 or 1,2,3
+    #[clap(long, required = true, value_delimiter=',', num_args = 1..)]
+    nodeset: Vec<PlainNodeId>,
+    /// The generational node id of the sequencer node, e.g. N1:1
+    #[clap(long, short)]
+    sequencer: GenerationalNodeId,
+    /// The number of logs
+    #[clap(long, short)]
+    num_logs: u32,
+    /// Pretty json?
+    #[clap(long)]
+    pretty: bool,
+}
+
+async fn generate_log_metadata(opts: &GenerateLogMetadataOpts) -> anyhow::Result<()> {
+    let mut builder = LogsBuilder::default();
+    for log_id in 0..opts.num_logs {
+        let minor = 1;
+        // format is, log_id in the higher order u32, and 1 in the lower.
+        let loglet_id: u64 = (u64::from(log_id) << (size_of::<LogId>() * 8)) + minor;
+        let loglet_params = ReplicatedLogletParams {
+            loglet_id: ReplicatedLogletId::new(loglet_id),
+            sequencer: opts.sequencer,
+            replication: ReplicationProperty::new(opts.replication_factor),
+            nodeset: NodeSet::from_iter(opts.nodeset.clone()),
+            write_set: None,
+        };
+        let params = LogletParams::from(loglet_params.serialize()?);
+        builder
+            .add_log(
+                LogId::from(log_id),
+                Chain::new(ProviderKind::Replicated, params),
+            )
+            .unwrap();
+    }
+
+    builder.set_version(opts.version);
+
+    let logs = builder.build();
+    let output = if opts.pretty {
+        serde_json::to_string_pretty(&logs)?
+    } else {
+        serde_json::to_string(&logs)?
+    };
+    println!("{}", output);
+    Ok(())
+}

--- a/tools/restatectl/src/commands/log/mod.rs
+++ b/tools/restatectl/src/commands/log/mod.rs
@@ -10,6 +10,7 @@
 
 mod describe_log;
 mod dump_log;
+mod gen_metadata;
 mod list_logs;
 mod trim_log;
 
@@ -19,6 +20,8 @@ use cling::prelude::*;
 pub enum Log {
     /// List the logs by partition
     List(list_logs::ListLogsOpts),
+    /// Prints a generated log-metadata in JSON format
+    GenerateMetadata(gen_metadata::GenerateLogMetadataOpts),
     /// Get the details of a specific log
     Describe(describe_log::DescribeLogIdOpts),
     /// Dump the contents of a bifrost log


### PR DESCRIPTION

Generates a JSON formatted log metadata for replicated-loglet.


## Example Usage:
```console
cargo run --bin restatectl -- logs generate-metadata -r 2 -n 2 -s N1:2 --nodeset N1,N2,N3 --pretty
```

```
{
  "version": 2,
  "logs": [
    [
      0,
      {
        "chain": [
          [
            1,
            {
              "kind": "replicated",
              "params": "{\"loglet_id\":1,\"sequencer\":\"N1:2\",\"replication\":{\"node\":2},\"nodeset\":[\"N1\",\"N2\",\"N3\"]}",
              "index": 0
            }
          ]
        ]
      }
    ],
    [
      1,
      {
        "chain": [
          [
            1,
            {
              "kind": "replicated",
              "params": "{\"loglet_id\":4294967297,\"sequencer\":\"N1:2\",\"replication\":{\"node\":2},\"nodeset\":[\"N3\",\"N1\",\"N2\"]}",
              "index": 0
            }
          ]
        ]
      }
    ]
  ]
}

```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2051).
* #2052
* __->__ #2051