### PR TITLE
restatectl command to generate partition table

### DIFF
--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -20,6 +20,7 @@ use crate::commands::dump::Dump;
 use crate::commands::log::Log;
 use crate::commands::metadata::Metadata;
 use crate::commands::node::Node;
+use crate::commands::partitions::Partitions;
 
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]
@@ -51,6 +52,9 @@ pub enum Command {
     /// Cluster node status
     #[clap(subcommand)]
     Nodes(Node),
+    /// Manage partition table
+    #[clap(subcommand)]
+    Partitions(Partitions),
     /// Cluster metadata
     #[clap(subcommand)]
     Metadata(Metadata),

--- a/tools/restatectl/src/commands/partitions/gen_metadata.rs
+++ b/tools/restatectl/src/commands/partitions/gen_metadata.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::num::NonZeroU32;
+
+use cling::prelude::*;
+
+use restate_types::partition_table::PartitionTable;
+use restate_types::Version;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap()]
+#[cling(run = "generate_partition_table")]
+pub struct GeneratePartitionTableOpts {
+    #[clap(long, default_value = "2")]
+    version: NonZeroU32,
+    /// The number of logs
+    #[clap(long, short)]
+    num_partition: u16,
+    /// Pretty json?
+    #[clap(long)]
+    pretty: bool,
+}
+
+async fn generate_partition_table(opts: &GeneratePartitionTableOpts) -> anyhow::Result<()> {
+    let table = PartitionTable::with_equally_sized_partitions(
+        Version::from(u32::from(opts.version)),
+        opts.num_partition,
+    );
+
+    let output = if opts.pretty {
+        serde_json::to_string_pretty(&table)?
+    } else {
+        serde_json::to_string(&table)?
+    };
+    println!("{}", output);
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partitions/mod.rs
+++ b/tools/restatectl/src/commands/partitions/mod.rs
@@ -8,9 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod display_util;
-pub mod dump;
-pub mod log;
-pub mod metadata;
-pub mod node;
-pub mod partitions;
+mod gen_metadata;
+
+use cling::prelude::*;
+
+#[derive(Run, Subcommand, Clone)]
+pub enum Partitions {
+    /// Prints a generated partition table in JSON format
+    GenerateMetadata(gen_metadata::GeneratePartitionTableOpts),
+}


### PR DESCRIPTION

Generates partition table metadata (version 2 by default)

```console
cargo run --bin restatectl -- partitions generate-metadata -n 5 --pretty
```

```
{
  "version": 2,
  "num_partitions": 5,
  "partitions": [
    [
      0,
      {
        "key_range": {
          "start": 0,
          "end": 3689348814741910323
        }
      }
    ],
    [
      1,
      {
        "key_range": {
          "start": 3689348814741910324,
          "end": 7378697629483820646
        }
      }
    ],
    [
      2,
      {
        "key_range": {
          "start": 7378697629483820647,
          "end": 11068046444225730969
        }
      }
    ],
    [
      3,
      {
        "key_range": {
          "start": 11068046444225730970,
          "end": 14757395258967641292
        }
      }
    ],
    [
      4,
      {
        "key_range": {
          "start": 14757395258967641293,
          "end": 18446744073709551615
        }
      }
    ]
  ]
}
```
