### PR TITLE
[restatectl] Support metadata Put

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-stdin"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471df7896633bfc1e7d3da5b598422891e4cb8931210168ec63ea586e285803f"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "clap-verbosity-flag"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6426,6 +6435,7 @@ dependencies = [
  "bytestring",
  "chrono",
  "clap",
+ "clap-stdin",
  "clap-verbosity-flag",
  "cling",
  "crossterm 0.27.0",

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -25,6 +25,7 @@ bytestring = { workspace = true }
 chrono = { workspace = true }
 clap = { version = "4.1", features = ["derive", "env", "wrap_help", "color"] }
 clap-verbosity-flag = { version = "2.0.1" }
+clap-stdin = "0.5.1"
 cling = { version = "0.1.0", default-features = false, features = ["derive"] }
 crossterm = { version = "0.27.0" }
 ctrlc = { version = "3.4" }

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -21,6 +21,7 @@ use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
 
 mod get;
 mod patch;
+mod put;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Metadata {
@@ -28,6 +29,8 @@ pub enum Metadata {
     Get(get::GetValueOpts),
     /// Patch a value stored in the metadata store
     Patch(patch::PatchValueOpts),
+    /// Replace a single key's value from the metastore
+    Put(put::PutValueOpts),
 }
 
 #[derive(Args, Clone, Debug)]

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -31,26 +31,26 @@ use crate::environment::task_center::run_in_task_center;
 #[cling(run = "patch_value")]
 pub struct PatchValueOpts {
     #[clap(flatten)]
-    metadata: MetadataCommonOpts,
+    pub metadata: MetadataCommonOpts,
 
     /// The key to patch
     #[arg(short, long)]
-    key: String,
+    pub key: String,
 
-    /// The JSON patch to apply to value
+    /// The JSON document to put
     #[arg(short, long)]
-    patch: String,
+    pub patch: String,
 
     /// Expected version for conditional update
     #[arg(short = 'e', long)]
-    version: Option<u32>,
+    pub version: Option<u32>,
 
     /// Preview the change without applying it
     #[arg(short = 'n', long, default_value_t = false)]
-    dry_run: bool,
+    pub dry_run: bool,
 }
 
-async fn patch_value(opts: &PatchValueOpts) -> anyhow::Result<()> {
+pub(crate) async fn patch_value(opts: &PatchValueOpts) -> anyhow::Result<()> {
     let patch = serde_json::from_str(opts.patch.as_str())
         .map_err(|e| anyhow::anyhow!("Parsing JSON patch: {}", e))?;
 

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -10,7 +10,6 @@
 
 use std::collections::HashMap;
 
-use anyhow::anyhow;
 use clap::Parser;
 use clap_stdin::FileOrStdin;
 use cling::{Collect, Run};
@@ -45,10 +44,9 @@ pub struct PutValueOpts {
 async fn put_value(opts: &PutValueOpts) -> anyhow::Result<()> {
     let opts = opts.clone();
 
-    let doc_body = opts.doc.contents().map_err(|e| anyhow!(e))?;
+    let doc_body = opts.doc.contents()?;
 
-    let mut doc: Value = serde_json::from_str(&doc_body)
-        .map_err(|e| anyhow::anyhow!("Parsing JSON value: {}", e))?;
+    let mut doc: Value = serde_json::from_str(&doc_body)?;
 
     if let Some(obj) = doc.as_object_mut() {
         // make sure that the value does not contain the version field.
@@ -61,7 +59,7 @@ async fn put_value(opts: &PutValueOpts) -> anyhow::Result<()> {
     patch_command.insert("value", doc);
 
     let patch = vec![patch_command];
-    let patch_as_str = serde_json::to_string_pretty(&patch).map_err(|e| anyhow::anyhow!(e))?;
+    let patch_as_str = serde_json::to_string_pretty(&patch)?;
 
     let patch_opts = PatchValueOpts {
         metadata: opts.metadata,

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -29,8 +29,7 @@ pub struct PutValueOpts {
     key: String,
 
     /// The JSON document to store, can be read from stdin or a file path
-    #[arg(short, long)]
-    content: FileOrStdin,
+    doc: FileOrStdin,
 
     /// Expected version for conditional update
     #[arg(short = 'e', long)]
@@ -44,7 +43,7 @@ pub struct PutValueOpts {
 async fn put_value(opts: &PutValueOpts) -> anyhow::Result<()> {
     let opts = opts.clone();
 
-    let doc_body = opts.content.contents().map_err(|e| anyhow!(e))?;
+    let doc_body = opts.doc.contents().map_err(|e| anyhow!(e))?;
 
     let mut doc: Value = serde_json::from_str(&doc_body)
         .map_err(|e| anyhow::anyhow!("Parsing JSON value: {}", e))?;

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::commands::metadata::patch::{patch_value, PatchValueOpts};
-use crate::commands::metadata::MetadataCommonOpts;
+use std::collections::HashMap;
+
 use anyhow::anyhow;
 use clap::Parser;
 use clap_stdin::FileOrStdin;
 use cling::{Collect, Run};
 use serde_json::Value;
-use std::collections::HashMap;
+
+use crate::commands::metadata::patch::{patch_value, PatchValueOpts};
+use crate::commands::metadata::MetadataCommonOpts;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::commands::metadata::patch::{patch_value, PatchValueOpts};
+use crate::commands::metadata::MetadataCommonOpts;
+use clap::Parser;
+use cling::{Collect, Run};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap()]
+#[cling(run = "put_value")]
+pub struct PutValueOpts {
+    #[clap(flatten)]
+    metadata: MetadataCommonOpts,
+
+    /// The key to patch
+    #[arg(short, long)]
+    key: String,
+
+    /// The JSON document to store
+    #[arg(short, long)]
+    doc: Option<String>,
+
+    /// The local path to the JSON document to store
+    #[arg(short, long)]
+    path: Option<String>,
+
+    /// Expected version for conditional update
+    #[arg(short = 'e', long)]
+    version: Option<u32>,
+
+    /// Preview the change without applying it
+    #[arg(short = 'n', long, default_value_t = false)]
+    dry_run: bool,
+}
+
+async fn put_value(opts: &PutValueOpts) -> anyhow::Result<()> {
+    let opts = opts.clone();
+
+    let doc_body = if let Some(doc) = opts.doc {
+        doc
+    } else if let Some(path) = opts.path {
+        fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("Unable to read the document: {}", e))?
+    } else {
+        anyhow::bail!("Please specify either doc or path");
+    };
+
+    let mut doc: Value = serde_json::from_str(&doc_body)
+        .map_err(|e| anyhow::anyhow!("Parsing JSON value: {}", e))?;
+
+    if let Some(obj) = doc.as_object_mut() {
+        // make sure that the value does not contain the version field.
+        obj.remove("version");
+    }
+
+    let mut patch_command = HashMap::<&'static str, Value>::new();
+    patch_command.insert("op", "replace".into());
+    patch_command.insert("path", "".into());
+    patch_command.insert("value", doc);
+
+    let patch = vec![patch_command];
+    let patch_as_str = serde_json::to_string_pretty(&patch).map_err(|e| anyhow::anyhow!(e))?;
+
+    let patch_opts = PatchValueOpts {
+        metadata: opts.metadata,
+        key: opts.key,
+        patch: patch_as_str,
+        version: opts.version,
+        dry_run: opts.dry_run,
+    };
+
+    patch_value(&patch_opts).await
+}


### PR DESCRIPTION
This commit adds support for put operations for metadata It is just a convenience around patch.

```
 ./target/debug/restatectl metadata get --key "partition_table" > foo.json
```

Either:

```
restatectl metadata put --key "partition_table" foo.json
```

Or:

```
cat foo.json | restatectl metadata put --key "partition_table" --path foo.json -
```