### PR TITLE
Auto provision

### DIFF
--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -82,6 +82,13 @@ pub struct CommonOptionCliOverride {
     #[clap(long, global = true)]
     pub bootstrap_num_partitions: Option<NonZeroU64>,
 
+    /// # Automatically provision number of configured partitions
+    ///
+    /// If this option is set to `false`, then one needs to manually write a partition table to
+    /// the metadata store. Without a partition table, the cluster will not start.
+    #[clap(long, global = true)]
+    pub auto_provision_partitions: Option<bool>,
+
     /// This timeout is used when shutting down the various Restate components to drain all the internal queues.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     #[clap(long, global = true)]

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -215,6 +215,12 @@ pub struct CommonOptions {
     ///
     /// The retry policy for node network error
     pub network_error_retry_policy: RetryPolicy,
+
+    /// # Automatically provision number of configured partitions
+    ///
+    /// If this option is set to `false`, then one needs to manually write a partition table to
+    /// the metadata store. Without a partition table, the cluster will not start.
+    pub auto_provision_partitions: bool,
 }
 
 static HOSTNAME: Lazy<String> = Lazy::new(|| {
@@ -359,6 +365,7 @@ impl Default for CommonOptions {
                 Some(15),
                 Some(Duration::from_secs(5)),
             ),
+            auto_provision_partitions: true,
         }
     }
 }


### PR DESCRIPTION
Adds a feature to disable the auto-provisioning of partitions by the cluster controller. To disable the auto-provisioning, you can set the `auto-provision-partitions = false` in the configuration or on the CLI via `--auto-provision-partitions=false`.

This PR is based on #2053 