### PR TITLE
Make it easier to debug failing local cluster runner tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,11 +5726,13 @@ dependencies = [
  "enumset",
  "futures",
  "http 1.1.0",
+ "itertools 0.13.0",
  "nix 0.29.0",
  "regex",
  "reqwest",
  "restate-metadata-store",
  "restate-types",
+ "rev_lines",
  "rlimit",
  "serde",
  "tempfile",
@@ -6461,6 +6463,15 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "vergen",
+]
+
+[[package]]
+name = "rev_lines"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed62916ac7a5ccbf13fa5e1d303029ff015600fee841756dfc134a1ac62bf05f"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/local-cluster-runner/Cargo.toml
+++ b/crates/local-cluster-runner/Cargo.toml
@@ -21,9 +21,11 @@ clap-verbosity-flag = { workspace = true }
 futures = { workspace = true }
 enumset = { workspace = true }
 http = { workspace = true }
+itertools = { workspace = true }
 nix = { version = "0.29.0", features = ["signal"] }
 regex = "1.1"
 reqwest = { workspace = true }
+rev_lines = "0.3.0"
 rlimit = { workspace = true }
 serde = { workspace =  true }
 tempfile = { workspace = true }

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -7,11 +7,12 @@ use restate_local_cluster_runner::{
     node::{BinarySource, Node},
 };
 use restate_types::{config::Configuration, nodes_config::Role, PlainNodeId};
+use test_log::test;
 
 mod common;
 
-#[tokio::test]
-async fn node_id_mismatch() {
+#[test(tokio::test)]
+async fn node_id_mismatch() -> googletest::Result<()> {
     let base_config = Configuration::default();
 
     let nodes = Node::new_test_nodes_with_metadata(
@@ -26,15 +27,13 @@ async fn node_id_mismatch() {
         .nodes(nodes)
         .build()
         .start()
-        .await
-        .unwrap();
+        .await?;
 
-    assert!(cluster.wait_healthy(Duration::from_secs(30)).await);
+    cluster.wait_healthy(Duration::from_secs(30)).await?;
 
     cluster.nodes[1]
         .graceful_shutdown(Duration::from_secs(2))
-        .await
-        .unwrap();
+        .await?;
 
     let mismatch_node = Node::builder()
         .binary_source(BinarySource::CargoTest)
@@ -47,19 +46,21 @@ async fn node_id_mismatch() {
         .with_roles(enum_set!(Role::Admin | Role::Worker))
         .build();
 
-    cluster.push_node(mismatch_node).await.unwrap();
+    cluster.push_node(mismatch_node).await?;
 
     assert!(cluster.nodes[2]
-        .lines("Node ID mismatch".parse().unwrap())
+        .lines("Node ID mismatch".parse()?)
         .next()
         .await
         .is_some());
 
-    assert_eq!(Some(1), cluster.nodes[2].status().await.unwrap().code());
+    assert_eq!(Some(1), cluster.nodes[2].status().await?.code());
+
+    Ok(())
 }
 
-#[tokio::test]
-async fn cluster_name_mismatch() {
+#[test(tokio::test)]
+async fn cluster_name_mismatch() -> googletest::Result<()> {
     let base_config = Configuration::default();
 
     let nodes = Node::new_test_nodes_with_metadata(
@@ -75,10 +76,9 @@ async fn cluster_name_mismatch() {
         .nodes(nodes)
         .build()
         .start()
-        .await
-        .unwrap();
+        .await?;
 
-    assert!(cluster.wait_healthy(Duration::from_secs(30)).await);
+    cluster.wait_healthy(Duration::from_secs(30)).await?;
 
     let mismatch_node = Node::new_test_node(
         "mismatch",
@@ -89,14 +89,15 @@ async fn cluster_name_mismatch() {
 
     let mut mismatch_node = mismatch_node
         .start_clustered(cluster.base_dir(), "cluster-2")
-        .await
-        .unwrap();
+        .await?;
 
     assert!(mismatch_node
-        .lines("Cluster name mismatch".parse().unwrap())
+        .lines("Cluster name mismatch".parse()?)
         .next()
         .await
         .is_some());
 
-    assert_eq!(Some(1), mismatch_node.status().await.unwrap().code())
+    assert_eq!(Some(1), mismatch_node.status().await?.code());
+
+    Ok(())
 }

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -139,7 +139,7 @@ where
             .start()
             .await?;
 
-        assert!(cluster.wait_healthy(Duration::from_secs(30)).await);
+        cluster.wait_healthy(Duration::from_secs(30)).await?;
 
         // join a new node to the cluster solely to act as a bifrost client
         // it will have node id log_server_count+2


### PR DESCRIPTION
We have seen at least one flake  where the cluster wasn't ready in time. This could be some subtle race condition. To help find it we will print out logs from the node that isn't up. Also some tests just didn't have logging enabled.