### PR TITLE
Expose peer metdata version through incoming messagtes

### DIFF
--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -339,6 +339,7 @@ pub mod test_util {
     use crate::network::MessageHandler;
     use crate::network::MessageRouterBuilder;
     use crate::network::NetworkError;
+    use crate::network::PeerMetadataVersion;
     use crate::network::ProtocolError;
     use crate::network::TransportConnect;
     use crate::TaskCenter;
@@ -735,6 +736,7 @@ pub mod test_util {
                                 self.connection.downgrade(),
                                 header.msg_id,
                                 header.in_response_to,
+                                PeerMetadataVersion::from(header),
                             ),
                             self.connection.protocol_version,
                         )

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -39,7 +39,7 @@ use super::transport_connector::TransportConnect;
 use super::{Handler, MessageRouter};
 use crate::metadata::Urgency;
 use crate::network::handshake::{negotiate_protocol_version, wait_for_hello};
-use crate::network::Incoming;
+use crate::network::{Incoming, PeerMetadataVersion};
 use crate::Metadata;
 use crate::{cancellation_watcher, current_task_id, task_center, TaskId, TaskKind};
 
@@ -592,6 +592,7 @@ where
                             connection.downgrade(),
                             header.msg_id,
                             header.in_response_to,
+                            PeerMetadataVersion::from(header),
                         ),
                         connection.protocol_version,
                     )
@@ -641,6 +642,7 @@ where
                             WeakConnection::new_closed(peer_node_id),
                             header.msg_id,
                             header.in_response_to,
+                            PeerMetadataVersion::from(header),
                         ),
                         protocol_version,
                     )

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -370,7 +370,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::network::WeakConnection;
+    use crate::network::{PeerMetadataVersion, WeakConnection};
 
     use super::*;
     use futures::future::join_all;
@@ -438,6 +438,7 @@ mod test {
                 WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
                 1,
                 Some(42),
+                PeerMetadataVersion::default(),
             ))
             .await;
 
@@ -450,6 +451,7 @@ mod test {
             WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
             1,
             Some(42),
+            PeerMetadataVersion::default(),
         ));
         assert!(maybe_msg.is_some());
 
@@ -464,6 +466,7 @@ mod test {
                 WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
                 1,
                 Some(1),
+                PeerMetadataVersion::default(),
             ))
             .await;
 
@@ -505,6 +508,7 @@ mod test {
                     WeakConnection::new_closed(GenerationalNodeId::new(0, 0)),
                     1,
                     Some(idx),
+                    PeerMetadataVersion::default(),
                 ));
             });
 


### PR DESCRIPTION
Expose peer metdata version through incoming messagtes

Summary:
This allows incoming messages to expose metadata of remote peer

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2061).
* #2062
* __->__ #2061