### PR TITLE
Fix: restatectl dump cluster renders status for all live nodes

### DIFF
--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -16,7 +16,6 @@ use restate_cli_util::CliContext;
 use restate_cli_util::CommonOpts;
 use restate_types::net::AdvertisedAddress;
 
-use crate::commands::dump::Dump;
 use crate::commands::log::Log;
 use crate::commands::metadata::Metadata;
 use crate::commands::node::Node;
@@ -44,9 +43,6 @@ pub struct ConnectionInfo {
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Command {
-    /// Dump various metadata from the cluster controller
-    #[clap(subcommand)]
-    Dump(Dump),
     /// Cluster distributed log operations
     #[clap(subcommand)]
     Logs(Log),

--- a/tools/restatectl/src/commands/dump/mod.rs
+++ b/tools/restatectl/src/commands/dump/mod.rs
@@ -8,12 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod cluster_state;
-
 use cling::prelude::*;
 
-#[derive(Run, Subcommand, Clone)]
-pub enum Dump {
-    /// Dump the latest cluster state
-    ClusterState(cluster_state::ClusterStateOpts),
-}
+#[derive(Subcommand, Clone)]
+pub enum Dump {}

--- a/tools/restatectl/src/commands/partitions/mod.rs
+++ b/tools/restatectl/src/commands/partitions/mod.rs
@@ -9,11 +9,14 @@
 // by the Apache License, Version 2.0.
 
 mod gen_metadata;
+mod status;
 
 use cling::prelude::*;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Partitions {
+    /// Print the partitions and their respective processors' status
+    Status(status::PartitionStatusOpts),
     /// Prints a generated partition table in JSON format
     GenerateMetadata(gen_metadata::GeneratePartitionTableOpts),
 }

--- a/tools/restatectl/src/commands/partitions/status.rs
+++ b/tools/restatectl/src/commands/partitions/status.rs
@@ -12,37 +12,36 @@ use std::collections::BTreeMap;
 
 use anyhow::Context;
 use cling::prelude::*;
+use tonic::codec::CompressionEncoding;
+
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_admin::cluster_controller::protobuf::ClusterStateRequest;
 use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
+use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::ui::Tense;
 use restate_types::logs::Lsn;
-
-use restate_cli_util::{c_println, c_title};
 use restate_types::protobuf::cluster::{
     node_state, DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode,
 };
-use restate_types::{GenerationalNodeId, PlainNodeId};
-use tonic::codec::CompressionEncoding;
+use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
 use crate::app::ConnectionInfo;
 use crate::commands::display_util::render_as_duration;
 use crate::util::grpc_connect;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
-#[clap(visible_alias = "cluster")]
-#[cling(run = "dump_cluster_state")]
-pub struct ClusterStateOpts {}
+#[cling(run = "list_partitions_status")]
+pub struct PartitionStatusOpts {}
 
 struct PartitionDetails {
     host_node: GenerationalNodeId,
     status: PartitionProcessorStatus,
 }
 
-async fn dump_cluster_state(
+async fn list_partitions_status(
     connection: &ConnectionInfo,
-    _opts: &ClusterStateOpts,
+    _opts: &PartitionStatusOpts,
 ) -> anyhow::Result<()> {
     let channel = grpc_connect(connection.cluster_controller.clone())
         .await
@@ -89,13 +88,13 @@ async fn dump_cluster_state(
     partitions_table.set_styled_header(vec![
         "P-ID",
         "NODE",
-        "RUN MODE",
+        "RUN-MODE",
         "REPLAY",
-        "APPLIED LSN",
-        "PERSISTED LSN",
-        "OBSERVED LEADER",
-        "# SKIPS",
-        "LAST REFRESH",
+        "APPLIED-LSN",
+        "PERSISTED-LSN",
+        "OBSERVED-LEADER",
+        "#-SKIPS",
+        "LAST-SEEN",
     ]);
     for (partition_id, processors) in partitions {
         for details in processors {
@@ -142,13 +141,24 @@ async fn dump_cluster_state(
             ]);
         }
     }
-    c_title!("🔄️", "ALIVE PARTITION PROCESSORS");
+    c_println!(
+        "Alive partition processors (nodes config {:#}, partition table {:#})",
+        state
+            .nodes_config_version
+            .map(Version::from)
+            .unwrap_or(Version::INVALID),
+        state
+            .partition_table_version
+            .map(Version::from)
+            .unwrap_or(Version::INVALID)
+    );
     c_println!("{}", partitions_table);
 
     if !dead_nodes.is_empty() {
-        c_title!("☠️", "DEAD NODES");
+        c_println!();
+        c_println!("☠️ Dead nodes");
         let mut dead_nodes_table = Table::new_styled();
-        dead_nodes_table.set_styled_header(vec!["NODE", "LAST SEEN ALIVE"]);
+        dead_nodes_table.set_styled_header(vec!["NODE", "LAST-SEEN"]);
         for (node_id, dead_node) in dead_nodes {
             dead_nodes_table.add_row(vec![
                 Cell::new(node_id),


### PR DESCRIPTION
This change fixes a trivial issue in the dump cluster sub-command where it would only print the partition processor status for one node rather than all nodes scheduler to run a given partition.

It also renames the tool from its original `dump cluster-status` subcommand to `partitions status`, which reflects much better what it's doing.

The server-side change is purely a cosmetic refactoring replacing an early if/continue with a two-arm match.

Example from a local three-worker / 4 partitions cluster:

```
> restatectl partitions status --cluster-controller $RESTATE_CLUSTER_CONTROLLER_ADDRESS
Alive partition processors (nodes config v7, partition table v1)
 P-ID  NODE  RUN-MODE          REPLAY  APPLIED-LSN  PERSISTED-LSN  OBSERVED-LEADER  #-SKIPS  LAST-SEEN
 0     N2:1  Leader            Active  2            ??             N2:1 - e2        0        1 second and 288 ms ago
 0     N4:1  Follower          Active  2            ??             N2:1 - e2        0        1 second and 381 ms ago
 1     N2:1  Leader            Active  1            ??             N2:1 - e1        0        1 second and 181 ms ago
 1     N4:1  Follower          Active  0            ??             ?? - ??          0        995 ms ago
 2     N2:1  Leader            Active  1            ??             N2:1 - e1        0        890 ms ago
 2     N4:1  Follower          Active  0            ??             ?? - ??          0        1 second and 425 ms ago
 3     N2:1  Follower          Active  1            ??             N3:1 - e1        0        1 second and 197 ms ago
 3     N4:1  Follower->Leader  Active  1            ??             N3:1 - e1        0        979 ms ago

☠️ Dead nodes
 NODE  LAST-SEEN
 N3    7 minutes, 5 seconds and 222 ms ago```
```

I'm keeping the `Dump` command around as it will be useful very shortly, I'll add the ability to do a raw dump of nodes / partition table / logs config there in addition to the friendlier tools we now have.