### PR TITLE
[Bifrost] CheckSeal task for replicated loglet

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use tracing::{info, trace};
+
+use restate_core::network::rpc_router::RpcRouter;
+use restate_core::network::{Networking, TransportConnect};
+use restate_core::{cancellation_watcher, ShutdownError};
+use restate_types::net::log_server::GetLogletInfo;
+use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams};
+
+use super::{FindTailOnNode, NodeTailStatus};
+use crate::loglet::util::TailOffsetWatch;
+use crate::providers::replicated_loglet::replication::NodeSetChecker;
+
+/// Attempts to detect if the loglet has been sealed or if there is a seal in progress by
+/// consulting nodes until it reaches f-majority, and it stops at the first sealed response
+/// from any log-server since this is a sufficient signal that a seal is on-going.
+///
+/// the goal of this operation to get a signal on sequencer node that a seal has happened (or
+/// ongoing) if we have not been receiving appends for some time.
+///
+/// This allows PeriodicFindTail to detect seal that was triggered externally to unblock read
+/// streams running locally that rely on the sequencer's view of known_global_tail.
+///
+///
+/// Note that this task can return Open if it cannot reach out to any node, so we should not use it
+/// for operations that rely on absolute correctness of the tail. For those, use FindTailTask
+/// instead.
+pub struct CheckSealTask {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CheckSealOutcome {
+    Sealing,
+    ProbablyOpen,
+}
+
+impl CheckSealTask {
+    pub async fn run<T: TransportConnect>(
+        my_params: &ReplicatedLogletParams,
+        get_loglet_info_rpc: &RpcRouter<GetLogletInfo>,
+        known_global_tail: &TailOffsetWatch,
+        networking: &Networking<T>,
+    ) -> Result<CheckSealOutcome, ShutdownError> {
+        // If all nodes in the nodeset is in "provisioning", we can confidently short-circuit
+        // the result to LogletOffset::Oldest and the loglet is definitely unsealed.
+        if my_params
+            .nodeset
+            .all_provisioning(&networking.metadata().nodes_config_ref())
+        {
+            return Ok(CheckSealOutcome::ProbablyOpen);
+        }
+        // todo: If effective nodeset is empty, should we consider that the loglet is implicitly
+        // sealed?
+
+        let effective_nodeset = EffectiveNodeSet::new(
+            &my_params.nodeset,
+            &networking.metadata().nodes_config_ref(),
+        );
+
+        let mut nodeset_checker = NodeSetChecker::<'_, NodeTailStatus>::new(
+            &effective_nodeset,
+            &networking.metadata().nodes_config_ref(),
+            &my_params.replication,
+        );
+
+        let mut nodes = effective_nodeset.shuffle_for_reads(networking.metadata().my_node_id());
+
+        let mut cancel = std::pin::pin!(cancellation_watcher());
+        trace!(
+            loglet_id = %my_params.loglet_id,
+            effective_nodeset = %effective_nodeset,
+            "Checking seal status for loglet",
+        );
+        loop {
+            if nodeset_checker
+                .check_fmajority(NodeTailStatus::is_known_unsealed)
+                .passed()
+            {
+                // once we reach f-majority of unsealed, we stop.
+                return Ok(CheckSealOutcome::ProbablyOpen);
+            }
+
+            let Some(next_node) = nodes.pop() else {
+                info!(
+                    loglet_id = %my_params.loglet_id,
+                    effective_nodeset = %effective_nodeset,
+                    "Insufficient nodes responded to GetLogletInfo requests, we cannot determine seal status, we'll assume it's unsealed for now",
+                );
+                return Ok(CheckSealOutcome::ProbablyOpen);
+            };
+
+            let task = FindTailOnNode {
+                node_id: next_node,
+                loglet_id: my_params.loglet_id,
+                get_loglet_info_rpc,
+                known_global_tail,
+            };
+            let tail_status = tokio::select! {
+                _ = &mut cancel => {
+                    return Err(ShutdownError);
+                }
+                (_, tail_status) = task.run(networking) => { tail_status },
+            };
+            if tail_status.is_known_sealed() {
+                // we only need to see a single node sealed to declare that we are probably sealing (or
+                // sealed)
+                return Ok(CheckSealOutcome::ProbablyOpen);
+            }
+            nodeset_checker.merge_attribute(next_node, tail_status);
+        }
+    }
+}

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
@@ -8,13 +8,75 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod check_seal;
 mod digests;
 mod find_tail;
 mod periodic_tail_checker;
 mod repair_tail;
 mod seal;
 
+pub use check_seal::*;
 pub use find_tail::*;
 pub use periodic_tail_checker::*;
 pub use repair_tail::*;
 pub use seal::*;
+
+use restate_types::logs::LogletOffset;
+
+use super::replication::Merge;
+
+#[derive(Debug, Default)]
+enum NodeTailStatus {
+    #[default]
+    Unknown,
+    Known {
+        local_tail: LogletOffset,
+        sealed: bool,
+    },
+}
+
+impl NodeTailStatus {
+    fn local_tail(&self) -> Option<LogletOffset> {
+        match self {
+            NodeTailStatus::Known { local_tail, .. } => Some(*local_tail),
+            _ => None,
+        }
+    }
+
+    fn is_known(&self) -> bool {
+        matches!(self, NodeTailStatus::Known { .. })
+    }
+
+    #[allow(dead_code)]
+    fn is_known_unsealed(&self) -> bool {
+        matches!(self, NodeTailStatus::Known { sealed, .. } if !*sealed)
+    }
+
+    fn is_known_sealed(&self) -> bool {
+        matches!(self, NodeTailStatus::Known { sealed, .. } if *sealed)
+    }
+}
+
+impl Merge for NodeTailStatus {
+    fn merge(&mut self, other: Self) {
+        match (self, other) {
+            (_, NodeTailStatus::Unknown) => {}
+            (this @ NodeTailStatus::Unknown, o) => {
+                *this = o;
+            }
+            (
+                NodeTailStatus::Known {
+                    local_tail: my_offset,
+                    sealed: my_seal,
+                },
+                NodeTailStatus::Known {
+                    local_tail: other_offset,
+                    sealed: other_seal,
+                },
+            ) => {
+                *my_offset = (*my_offset).max(other_offset);
+                *my_seal |= other_seal;
+            }
+        }
+    }
+}

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -1006,11 +1006,9 @@ pub fn with_metadata<F, R>(f: F) -> R
 where
     F: FnOnce(&Metadata) -> R,
 {
-    CONTEXT.with(|ctx| {
-        f(ctx
-            .metadata
-            .as_ref()
-            .expect("metadata() is set in this task. Is global metadata set?"))
+    CURRENT_TASK_CENTER.with(|tc| {
+        f(tc.metadata()
+            .expect("metadata must be set. Is global metadata set?"))
     })
 }
 

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -245,6 +245,12 @@ impl From<GenerationalNodeId> for crate::protobuf::common::NodeId {
     }
 }
 
+impl From<GenerationalNodeId> for PlainNodeId {
+    fn from(value: GenerationalNodeId) -> Self {
+        value.0
+    }
+}
+
 impl PlainNodeId {
     pub const fn new(id: u32) -> PlainNodeId {
         PlainNodeId(id)


### PR DESCRIPTION
This hunts for signals to tell us if there is an ongoing seal or not. It's not used as a source of truth for whether a loglet is sealed or not, but it's important to detect an externally started seal operation that the sequencer was not aware of.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2066).
* #2094
* #2076
* #2075
* __->__ #2066