### PR TITLE
Enhance the `restatectl describe log` command

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -60,6 +60,8 @@ message DescribeLogResponse {
   TailState tail_state = 2;
   uint64 tail_offset = 3;
   uint64 trim_point = 4;
+  // Serialized restate_types::nodes_config::NodesConfiguration
+  bytes nodes_configuration = 7;
 }
 
 message ListNodesRequest {}

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -90,16 +90,6 @@ impl ReplicatedLogletId {
 )]
 pub struct NodeSet(#[serde_as(as = "HashSet<DisplayFromStr>")] HashSet<PlainNodeId>);
 
-impl Display for NodeSet {
-    /// The alternate format displays a *sorted* list of short-form plain node ids, suitable for human-friendly output.
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match f.alternate() {
-            false => self.write_nodes(f),
-            true => self.write_nodes_sorted(f),
-        }
-    }
-}
-
 impl NodeSet {
     pub fn empty() -> Self {
         Self(HashSet::new())
@@ -181,30 +171,6 @@ impl NodeSet {
 
         new_nodeset
     }
-
-    fn write_nodes(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        let mut nodes = self.0.iter();
-        if let Some(node) = nodes.next() {
-            write!(f, "{}", node)?;
-            for node in nodes {
-                write!(f, ", {}", node)?;
-            }
-        }
-        write!(f, "]")
-    }
-
-    fn write_nodes_sorted(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        let mut nodes = self.0.iter().sorted();
-        if let Some(node) = nodes.next() {
-            write!(f, "{}", node)?;
-            for node in nodes {
-                write!(f, ", {}", node)?;
-            }
-        }
-        write!(f, "]")
-    }
 }
 
 impl<'a> IntoIterator for &'a NodeSet {
@@ -245,6 +211,40 @@ impl<A: Into<PlainNodeId>> FromIterator<A> for NodeSet {
     fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
         Self(HashSet::from_iter(iter.into_iter().map(Into::into)))
     }
+}
+
+impl Display for NodeSet {
+    /// The alternate format displays a *sorted* list of short-form plain node ids, suitable for human-friendly output.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match f.alternate() {
+            false => write_nodes(self, f),
+            true => write_nodes_sorted(self, f),
+        }
+    }
+}
+
+fn write_nodes(node_set: &NodeSet, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "[")?;
+    let mut nodes = node_set.0.iter();
+    if let Some(node) = nodes.next() {
+        write!(f, "{}", node)?;
+        for node in nodes {
+            write!(f, ", {}", node)?;
+        }
+    }
+    write!(f, "]")
+}
+
+fn write_nodes_sorted(node_set: &NodeSet, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "[")?;
+    let mut nodes = node_set.0.iter().sorted();
+    if let Some(node) = nodes.next() {
+        write!(f, "{}", node)?;
+        for node in nodes {
+            write!(f, ", {}", node)?;
+        }
+    }
+    write!(f, "]")
 }
 
 #[serde_with::serde_as]

--- a/crates/types/src/replicated_loglet/replication_property.rs
+++ b/crates/types/src/replicated_loglet/replication_property.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{btree_map, BTreeMap};
+use std::fmt::{Display, Formatter};
 use std::num::NonZeroU8;
 
 use enum_map::Enum;
@@ -126,6 +127,31 @@ impl ReplicationProperty {
         self.0
             .last_key_value()
             .expect("must have at least one scope")
+    }
+}
+
+impl Display for ReplicationProperty {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        let mut iter = self.0.iter();
+        if let Some((scope, replication_factor)) = iter.next() {
+            write!(
+                f,
+                "{}: {}",
+                format!("{:?}", scope).to_lowercase(),
+                replication_factor
+            )?;
+            for (scope, replication_factor) in iter {
+                write!(
+                    f,
+                    ", {}: {}",
+                    format!("{:?}", scope).to_lowercase(),
+                    replication_factor
+                )?;
+            }
+        }
+        write!(f, "}}")?;
+        Ok(())
     }
 }
 

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -36,8 +36,14 @@ pub struct CliApp {
 
 #[derive(Parser, Collect, Debug, Clone)]
 pub struct ConnectionInfo {
-    /// Cluster Controller host:port (e.g. http://localhost:5122/)
-    #[clap(long, value_hint = clap::ValueHint::Url, default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(), global = true)]
+    /// Cluster Controller address
+    #[clap(
+        long,
+        value_hint = clap::ValueHint::Url,
+        default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(),
+        env = "RESTATE_CLUSTER_CONTROLLER_ADDRESS",
+        global = true
+    )]
     pub cluster_controller: AdvertisedAddress,
 }
 

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -9,10 +9,8 @@
 // by the Apache License, Version 2.0.
 
 use std::str::FromStr;
-use std::string::ParseError;
 
 use anyhow::{anyhow, Context};
-use clap::builder::ValueRange;
 use cling::prelude::*;
 use itertools::Itertools;
 use tonic::codec::CompressionEncoding;
@@ -134,7 +132,7 @@ async fn describe_log(
     mut client: ClusterCtrlSvcClient<Channel>,
     opts: &DescribeLogIdOpts,
 ) -> anyhow::Result<()> {
-    let req = DescribeLogRequest { log_id: log_id };
+    let req = DescribeLogRequest { log_id };
     let mut response = client.describe_log(req).await?.into_inner();
 
     let mut buf = response.chain.clone();

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -62,7 +62,13 @@ async fn describe_log(connection: &ConnectionInfo, opts: &DescribeLogIdOpts) -> 
     c_println!("{}", table);
 
     let mut chain_table = Table::new_styled();
-    chain_table.set_styled_header(vec!["SEGMENT", "STATE", "BASE LSN", "TAIL LSN", "KIND"]);
+    chain_table.set_styled_header(vec![
+        "SEGMENT",
+        "STATE",
+        "SEGMENT START",
+        "SEGMENT TAIL",
+        "LOGLET KIND",
+    ]);
 
     let mut buf = response.chain.clone();
     let chain = StorageCodec::decode::<Chain, _>(&mut buf)?;

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -142,7 +142,7 @@ async fn describe_log(
     let mut buf = response.chain.clone();
     let chain = StorageCodec::decode::<Chain, _>(&mut buf)?;
 
-    c_println!("Log Id: {}: (v{})", log_id, response.logs_version);
+    c_println!("Log Id: {} (v{})", log_id, response.logs_version);
 
     let mut chain_table = Table::new_styled();
     chain_table.set_styled_header(vec![

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -88,8 +88,13 @@ async fn describe_log(connection: &ConnectionInfo, opts: &DescribeLogIdOpts) -> 
 
     if let Some(tail_segment) = tail_segment {
         c_title!("🔗", "TAIL SEGMENT");
-        let config = tail_segment.config.params.as_bytes().escape_ascii().to_string();
-        c_println!("Configuration:\n\n{}", config);
+        let raw_config = tail_segment
+            .config
+            .params
+            .as_bytes()
+            .escape_ascii()
+            .to_string();
+        c_println!("Configuration:\n\n{}", raw_config);
     }
 
     Ok(())

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -10,16 +10,17 @@
 
 use anyhow::Context;
 use cling::prelude::*;
+use itertools::Itertools;
 use tonic::codec::CompressionEncoding;
 
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::{
-    DescribeLogRequest, DescribeLogResponse, TailState,
-};
-use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
+use restate_admin::cluster_controller::protobuf::DescribeLogRequest;
+use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::{c_println, c_title};
-use restate_types::logs::metadata::{Chain, Segment};
+use restate_types::logs::metadata::{Chain, ProviderKind, Segment, SegmentIndex};
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::replicated_loglet::ReplicatedLogletParams;
 use restate_types::storage::StorageCodec;
 
 use crate::app::ConnectionInfo;
@@ -29,9 +30,33 @@ use crate::util::grpc_connect;
 #[clap()]
 #[cling(run = "describe_log")]
 pub struct DescribeLogIdOpts {
-    #[arg(short, long)]
     /// The log id to describe
+    #[arg(short, long)]
     log_id: u32,
+
+    /// The first segment id to display
+    #[arg(long)]
+    from_segment_id: Option<u32>,
+
+    /// Skip over the first N segments
+    #[arg(long, conflicts_with_all = ["from_segment_id"])]
+    skip: Option<usize>,
+
+    /// Print the last N segments
+    #[arg(long, default_value = "true", conflicts_with = "head")]
+    tail: bool,
+
+    /// Print the first N segments
+    #[arg(long)]
+    head: bool,
+
+    /// Display at most N segments
+    #[arg(long, default_value = "25")]
+    max_results: usize,
+
+    /// Display all available segments, ignoring max results
+    #[arg(long, conflicts_with_all = ["head", "tail", "max_results"])]
+    display_all: bool,
 }
 
 async fn describe_log(connection: &ConnectionInfo, opts: &DescribeLogIdOpts) -> anyhow::Result<()> {
@@ -49,95 +74,204 @@ async fn describe_log(connection: &ConnectionInfo, opts: &DescribeLogIdOpts) -> 
     let req = DescribeLogRequest {
         log_id: opts.log_id,
     };
-    let response = client.describe_log(req).await?.into_inner();
-
-    c_title!("📋", format!("LOG {}", response.log_id));
-
-    let mut table = Table::new_styled();
-    table.add_row(vec![
-        "Metadata version",
-        &format!("v{}", response.logs_version),
-    ]);
-    table.add_row(vec!["Trim point", &format!("{}", response.trim_point)]);
-    c_println!("{}", table);
-
-    let mut chain_table = Table::new_styled();
-    chain_table.set_styled_header(vec![
-        "SEGMENT",
-        "STATE",
-        "SEGMENT START",
-        "SEGMENT TAIL",
-        "LOGLET KIND",
-    ]);
+    let mut response = client.describe_log(req).await?.into_inner();
 
     let mut buf = response.chain.clone();
     let chain = StorageCodec::decode::<Chain, _>(&mut buf)?;
 
-    let mut tail_segment = None;
-    let tail_base_lsn = chain.tail().base_lsn;
-    for (idx, segment) in chain.iter().enumerate() {
-        let is_tail_segment = segment.base_lsn == tail_base_lsn;
-        chain_table.add_row(vec![
-            Cell::new(idx),
-            render_segment_state(is_tail_segment, &response),
-            render_base_lsn(is_tail_segment, &segment),
-            render_tail_lsn(is_tail_segment, &response),
-            Cell::new(format!("{:?}", segment.config.kind)),
-        ]);
-        if is_tail_segment {
-            tail_segment = Some(segment);
-        }
-    }
+    let mut header = Table::new_styled();
+    header.add_row(vec!["Log id", &format!("{}", response.log_id)]);
+    header.add_row(vec![
+        "Metadata version",
+        &format!("v{}", response.logs_version),
+    ]);
+    header.add_row(vec!["Trim point", &format!("{}", response.trim_point)]);
+    c_println!("{}", header);
     c_println!();
-    c_println!("Segments");
-    c_println!("{}", chain_table);
 
-    if let Some(tail_segment) = tail_segment {
-        c_title!("🔗", "TAIL SEGMENT");
-        let raw_config = tail_segment
-            .config
-            .params
-            .as_bytes()
-            .escape_ascii()
-            .to_string();
-        c_println!("Configuration:\n\n{}", raw_config);
+    let mut chain_table = Table::new_styled();
+    chain_table.set_styled_header(vec![
+        "", // tail segment marker
+        "IDX",
+        "KIND",
+        "LOGLET-ID",
+        "FROM-LSN",
+        "REPLICATION",
+        "SEQUENCER",
+        "EFF-NODESET",
+    ]);
+
+    let last_segment = chain
+        .iter()
+        .last()
+        .map(|s| s.index())
+        .unwrap_or(SegmentIndex::from(u32::MAX));
+
+    let mut first_segment_rendered = None;
+    let mut last_segment_rendered = None;
+
+    let segments: Box<dyn Iterator<Item = Segment>> = match (opts.skip, opts.from_segment_id) {
+        (Some(n), _) => Box::new(chain.iter().skip(n)),
+        (_, Some(from_segment_id)) => {
+            let starting_segment_id = SegmentIndex::from(from_segment_id);
+            Box::new(
+                chain
+                    .iter()
+                    .skip_while(move |s| s.index() < starting_segment_id),
+            )
+        }
+        _ => Box::new(chain.iter()),
+    };
+
+    let segments: Box<dyn Iterator<Item = Segment>> = if opts.display_all {
+        Box::new(segments)
+    } else if opts.head {
+        Box::new(segments.take(opts.max_results))
+    } else {
+        Box::new(segments.tail(opts.max_results))
+    };
+
+    for segment in segments {
+        if first_segment_rendered.is_none() {
+            first_segment_rendered = Some(segment.index());
+        }
+
+        // For the purpose of this display, "is-tail" boils down to simply "is this the last known segment?"
+        let is_tail_segment = segment.index() == last_segment;
+
+        match segment.config.kind {
+            ProviderKind::Replicated => {
+                let nodes_configuration = StorageCodec::decode::<NodesConfiguration, _>(
+                    &mut response.nodes_configuration,
+                )?;
+                let replicated_log_params = get_replicated_log_params(&segment);
+                match replicated_log_params {
+                    Some(params) => {
+                        chain_table.add_row(vec![
+                            render_tail_segment_marker(is_tail_segment),
+                            Cell::new(format!("{}", segment.index())),
+                            Cell::new(format!("{:?}", segment.config.kind)),
+                            Cell::new(format!("{}", params.loglet_id)),
+                            Cell::new(format!("{}", segment.base_lsn)),
+                            Cell::new(format!("{:#}", params.replication)),
+                            render_sequencer(is_tail_segment, &params, &nodes_configuration),
+                            render_effective_nodeset(
+                                is_tail_segment,
+                                &params,
+                                &nodes_configuration,
+                            ),
+                        ]);
+                    }
+                    None => {
+                        chain_table.add_row(vec![
+                            render_tail_segment_marker(is_tail_segment),
+                            Cell::new(format!("{}", segment.index())),
+                            Cell::new(format!("{:?}", segment.config.kind)),
+                            Cell::new("N/A"),
+                            Cell::new(format!("{}", segment.base_lsn)),
+                            Cell::new("N/A"),
+                            Cell::new("N/A"),
+                            Cell::new("N/A"),
+                        ]);
+                    }
+                }
+            }
+            _ => {
+                chain_table.add_row(vec![
+                    render_tail_segment_marker(is_tail_segment),
+                    Cell::new(format!("{}", segment.index())),
+                    Cell::new(format!("{:?}", segment.config.kind)),
+                    Cell::new(""),
+                    Cell::new(format!("{}", segment.base_lsn)),
+                    Cell::new(""),
+                    Cell::new(""),
+                    Cell::new(""),
+                ]);
+            }
+        }
+
+        last_segment_rendered = Some(segment.index());
     }
+
+    let column = chain_table.column_mut(0).unwrap();
+    column.set_padding((0, 0));
+
+    if last_segment_rendered.is_none() {
+        c_println!("No segments to display.");
+        return Ok(());
+    }
+
+    c_title!(
+        "🔗",
+        format!(
+            "LOG SEGMENTS [{}..{}]",
+            first_segment_rendered.unwrap(),
+            last_segment_rendered.unwrap()
+        )
+    );
+    c_println!("{}", chain_table);
 
     Ok(())
 }
 
-fn render_segment_state(is_tail: bool, response: &DescribeLogResponse) -> Cell {
+fn render_tail_segment_marker(is_tail: bool) -> Cell {
     if is_tail {
-        render_tail_state(response)
-    } else {
-        // Assuming anything that isn't the tail is sealed
-        Cell::new(TailState::Sealed.as_str_name()).fg(Color::DarkGrey)
-    }
-}
-
-fn render_tail_state(response: &DescribeLogResponse) -> Cell {
-    let tail_state = TailState::try_from(response.tail_state).unwrap();
-    Cell::new(tail_state.as_str_name())
-        .fg(Color::Green)
-        .add_attribute(Attribute::Bold)
-}
-
-fn render_tail_lsn(is_tail_segment: bool, response: &DescribeLogResponse) -> Cell {
-    if is_tail_segment {
-        Cell::new(format!("{}", response.tail_offset))
-            .fg(Color::Green)
-            .add_attribute(Attribute::Bold)
+        Cell::new("▶︎").fg(Color::Green)
     } else {
         Cell::new("")
     }
 }
 
-fn render_base_lsn(is_tail_segment: bool, segment: &Segment) -> Cell {
-    if is_tail_segment {
-        Cell::new(format!("{}", segment.base_lsn))
-            .fg(Color::Green)
-            .add_attribute(Attribute::Bold)
+fn get_replicated_log_params(segment: &Segment) -> Option<ReplicatedLogletParams> {
+    match segment.config.kind {
+        ProviderKind::Replicated => Some(
+            ReplicatedLogletParams::deserialize_from(segment.config.params.as_bytes()).unwrap(),
+        ),
+        _ => None,
+    }
+}
+
+fn render_effective_nodeset(
+    is_tail: bool,
+    params: &ReplicatedLogletParams,
+    nodes_configuration: &NodesConfiguration,
+) -> Cell {
+    let effective_node_set = params.nodeset.to_effective(nodes_configuration);
+
+    let color = match (is_tail, effective_node_set.len()) {
+        (false, _) => Color::DarkGrey,
+        (_, n) => {
+            // todo: update crude replication health color-coding to use majority check
+            if n >= params.replication.num_copies() as usize {
+                Color::Green
+            } else if n == 0 {
+                Color::Red
+            } else {
+                Color::DarkYellow
+            }
+        }
+    };
+
+    Cell::new(format!("{:#}", effective_node_set)).fg(color)
+}
+
+fn render_sequencer(
+    is_tail: bool,
+    params: &ReplicatedLogletParams,
+    nodes_configuration: &NodesConfiguration,
+) -> Cell {
+    if is_tail {
+        let sequencer_generational =
+            nodes_configuration.find_node_by_id(params.sequencer.as_plain());
+        let color = if sequencer_generational
+            .is_ok_and(|node| node.current_generation.generation() == params.sequencer.generation())
+        {
+            Color::Green
+        } else {
+            Color::Red
+        };
+        Cell::new(format!("{:#}", params.sequencer)).fg(color)
     } else {
-        Cell::new(format!("{}", segment.base_lsn))
+        Cell::new("")
     }
 }

--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -60,14 +60,14 @@ async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> anyhow:
         logs_table.add_row(vec![
             Cell::new(log_id),
             Cell::new(chain.num_segments()).fg(Color::DarkGrey),
+            Cell::new(format!("{:?}", chain.tail().config.kind)),
             Cell::new(format!("{}", &chain.tail().base_lsn))
                 .fg(Color::Green)
                 .add_attribute(Attribute::Bold),
-            Cell::new(format!("{:?}", chain.tail().config.kind)),
         ]);
     }
 
-    logs_table.set_styled_header(vec!["LOG-ID", "SEGMENTS", "TAIL BASE LSN", "KIND"]);
+    logs_table.set_styled_header(vec!["LOG-ID", "SEGMENTS", "TAIL-SEGMENT-KIND", "FROM-LSN"]);
     c_println!("{}", logs_table);
 
     Ok(())

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -37,7 +37,12 @@ pub enum Metadata {
 #[clap()]
 pub struct MetadataCommonOpts {
     /// Metadata store server address; for Etcd addresses use comma-separated list
-    #[arg(short, long = "address", default_value = "http://127.0.0.1:5123")]
+    #[arg(
+        short,
+        long = "address",
+        default_value = "http://127.0.0.1:5123",
+        env = "RESTATE_METADATA_ADDRESS"
+    )]
     address: String,
 
     /// Metadata store access mode


### PR DESCRIPTION
Example with a 4-partition replicated loglet.

- we now support multiple logs including ranges of ids
- support head/tail/all to control the displayed segments per log (tail -25 by default)

```
> restatectl logs describe 0-3 --extra --tail 1
Log Id: 0 (v11)
  IDX  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  EFF-NODESET   PARAMS
▶︎ 6    142       Replicated  6          {node: 2}    N2:1       [N2, N3, N4]  {"loglet_id":6,"sequencer":"N2:1","replication":{"node":2},"nodeset":["N3","N2","N4"]}
---
1/5 segments shown.

Log Id: 1 (v11)
  IDX  FROM-LSN  KIND        LOGLET-ID             REPLICATION  SEQUENCER  EFF-NODESET   PARAMS
▶︎ 3    66        Replicated  14232785765231168648  {node: 2}    N2:1       [N2, N3, N4]  {"loglet_id":14232785765231168648,"sequencer":"N2:1","replication":{"node":2},"nodeset":["N4","N3","N2"]}
---
1/3 segments shown.

Log Id: 2 (v11)
  IDX  FROM-LSN  KIND        LOGLET-ID   REPLICATION  SEQUENCER  EFF-NODESET   PARAMS
▶︎ 2    34        Replicated  8589934594  {node: 2}    N2:1       [N2, N3, N4]  {"loglet_id":8589934594,"sequencer":"N2:1","replication":{"node":2},"nodeset":["N3","N2","N4"]}
---
1/3 segments shown.

Log Id: 3 (v11)
  IDX  FROM-LSN  KIND        LOGLET-ID           REPLICATION  SEQUENCER  EFF-NODESET   PARAMS
▶︎ 3    59        Replicated  899374228732567819  {node: 2}    N3:4       [N2, N3, N4]  {"loglet_id":899374228732567819,"sequencer":"N3:4","replication":{"node":2},"nodeset":["N3","N4","N2"]}
---
1/4 segments shown.

> restatectl logs describe -h
Get the details of a specific log

Usage: restatectl logs describe [OPTIONS] <LOG_ID>...

Arguments:
  <LOG_ID>...  The log id(s) to describe

Options:
      --from-segment-id <FROM_SEGMENT_ID>        The first segment id to display
  -v, --verbose...                               Increase logging verbosity
  -q, --quiet...                                 Decrease logging verbosity
      --skip <SKIP>                              Skip over the first N segments
      --table-style <TABLE_STYLE>                Which table output style to use [default: compact] [possible values: compact, borders]
      --tail <TAIL>                              Print the last N log segments [default: 25]
      --head <HEAD>                              Print the first N log segments
      --time-format <TIME_FORMAT>                [default: human] [possible values: human, iso8601, rfc2822]
      --all                                      Display all available segments, ignoring max results
  -y, --yes                                      Auto answer "yes" to confirmation prompts
      --connect-timeout <CONNECT_TIMEOUT>        Connection timeout for network calls, in milliseconds [default: 5000]
      --extra                                    Display additional information such as replicated loglet config
      --request-timeout <REQUEST_TIMEOUT>        Overall request timeout for network calls, in milliseconds [default: 13000]
      --cluster-controller <CLUSTER_CONTROLLER>  Cluster Controller address [env: RESTATE_CLUSTER_CONTROLLER_ADDRESS=unix:/Users/pavel/restate/restate/restate-data/metadata-node/node.sock] [default: http://localhost:5122/]
  -h, --help                                     Print help (see more with '--help')
```