### PR TITLE
Create restate-web-ui crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,6 +6369,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-web-ui"
+version = "1.1.3"
+
+[[package]]
 name = "restate-worker"
 version = "1.1.3"
 dependencies = [

--- a/crates/web-ui/Cargo.toml
+++ b/crates/web-ui/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "restate-web-ui"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]

--- a/crates/web-ui/src/lib.rs
+++ b/crates/web-ui/src/lib.rs
@@ -1,0 +1,1 @@
+pub const UI_ASSETS: &'static [u8] = include_bytes!("../assets/ui-v0.0.0.zip");


### PR DESCRIPTION
- This PR sets up a crate for holding UI assets (.js, .css, ...)
- I've added an empty asset file named `ui-v0.0.0.zip` in this PR as a placeholder
- Whenever there's a new UI release on [restate-web-ui](https://github.com/restatedev/restate-web-ui), a PR will be made to update the UI artifact (ui-v0.0.0.zip).
- In the next PR, I'll add a GitHub workflow to check that the UI artifact matches the published version on [restate-web-ui](https://github.com/restatedev/restate-web-ui).