### PR TITLE
Verify the committed UI artifact matches the published artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,3 +150,13 @@ jobs:
     uses: restatedev/sdk-rust/.github/workflows/integration.yaml@main
     with:
       restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
+
+  restate-ui:
+    name: Validate Restate UI artifact
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify the committed UI artifact matches the published one in restate-web-ui
+        run: ./tools/scripts/verify-ui-artifact

--- a/tools/scripts/verify-ui-artifact
+++ b/tools/scripts/verify-ui-artifact
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+COMMITTED_UI_VERSION=$(ls ./crates/web-ui/assets/*.zip | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*')
+COMMITTED_SHA256_CHECKSUM=$(shasum -a 256 ./crates/web-ui/assets/ui-$COMMITTED_UI_VERSION.zip | awk '{print $1}')
+echo "Committed artifact for $COMMITTED_UI_VERSION has SHA256 checksum of $COMMITTED_SHA256_CHECKSUM"
+
+curl -O -L -s https://github.com/restatedev/restate-web-ui/releases/download/$COMMITTED_UI_VERSION/ui-$COMMITTED_UI_VERSION.zip
+PUBLISHED_SHA256_CHECKSUM=$(shasum -a 256 ui-$COMMITTED_UI_VERSION.zip | awk '{print $1}')
+echo "Published artifact for $COMMITTED_UI_VERSION has SHA256 checksum of $PUBLISHED_SHA256_CHECKSUM"
+
+rm ui-$COMMITTED_UI_VERSION.zip
+
+if [ "$COMMITTED_SHA256_CHECKSUM" != "$PUBLISHED_SHA256_CHECKSUM" ]; then
+    echo "❌ The committed artifact cannot be verified."
+    exit 1
+else
+    echo "✅ The committed artifact is verified."
+fi


### PR DESCRIPTION
- Adds a script to verify the committed ui artifact is matches the published one in restate-web-ui repo
- Runs the script in github workflows


<img width="849" alt="Screenshot 2024-10-15 at 11 08 46" src="https://github.com/user-attachments/assets/0be261a6-312e-4e70-b898-607a676e2ced">

<img width="1231" alt="Screenshot 2024-10-15 at 11 14 32" src="https://github.com/user-attachments/assets/41fea3ea-15a2-4fc1-aabe-d7359a1f6244">
<img width="1226" alt="Screenshot 2024-10-15 at 11 13 50" src="https://github.com/user-attachments/assets/a773fd50-2229-44b4-98d2-6851b95e73b8">

