### PR TITLE
Add service protocol version in SQL shell for sys_deployment and sys_invocation

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -46,6 +46,7 @@ const SYS_INVOCATION_VIEW: &str = "CREATE VIEW sys_invocation as SELECT
             ss.invoked_by_id,
             ss.invoked_by_target,
             ss.pinned_deployment_id,
+            ss.pinned_service_protocol_version,
             ss.trace_id,
             ss.journal_size,
             ss.created_at,

--- a/crates/storage-query-datafusion/src/deployment/row.rs
+++ b/crates/storage-query-datafusion/src/deployment/row.rs
@@ -32,4 +32,18 @@ pub(crate) fn append_deployment_row(
 
     row.endpoint(format_using(output, &deployment.metadata.address_display()));
     row.created_at(deployment.metadata.created_at.as_u64() as i64);
+    row.min_service_protocol_version(
+        deployment
+            .metadata
+            .supported_protocol_versions
+            .start()
+            .unsigned_abs(),
+    );
+    row.max_service_protocol_version(
+        deployment
+            .metadata
+            .supported_protocol_versions
+            .end()
+            .unsigned_abs(),
+    );
 }

--- a/crates/storage-query-datafusion/src/deployment/schema.rs
+++ b/crates/storage-query-datafusion/src/deployment/schema.rs
@@ -26,4 +26,10 @@ define_table!(sys_deployment(
 
     /// Timestamp indicating the deployment registration time.
     created_at: DataType::Date64,
+
+    /// Minimum supported protocol version.
+    min_service_protocol_version: DataType::UInt32,
+
+    /// Maximum supported protocol version.
+    max_service_protocol_version: DataType::UInt32
 ));

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -110,6 +110,12 @@ fn fill_in_flight_invocation_metadata(
     // journal_metadata and stats are filled by other functions
     if let Some(pinned_deployment) = meta.pinned_deployment {
         row.pinned_deployment_id(pinned_deployment.deployment_id.to_string());
+        row.pinned_service_protocol_version(
+            pinned_deployment
+                .service_protocol_version
+                .as_repr()
+                .unsigned_abs(),
+        );
     }
     fill_invoked_by(row, output, meta.source)
 }

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -67,6 +67,10 @@ define_table!(sys_invocation_status(
     /// this invocation.
     pinned_deployment_id: DataType::LargeUtf8,
 
+    /// The negotiated protocol version used for this invocation.
+    /// This gets set after the first journal entry has been stored for this invocation.
+    pinned_service_protocol_version: DataType::UInt32,
+
     /// The ID of the trace that is assigned to this invocation. Only relevant when tracing is
     /// enabled.
     trace_id: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -101,6 +101,7 @@ pub fn sys_invocation_table_docs() -> OwnedTableDocs {
         sys_invocation_status.remove("invoked_by_id").expect("invoked_by_id should exist"),
         sys_invocation_status.remove("invoked_by_target").expect("invoked_by_target should exist"),
         sys_invocation_status.remove("pinned_deployment_id").expect("pinned_deployment_id should exist"),
+        sys_invocation_status.remove("pinned_service_protocol_version").expect("pinned_service_protocol_version should exist"),
         sys_invocation_status.remove("trace_id").expect("trace_id should exist"),
         sys_invocation_status.remove("journal_size").expect("journal_size should exist"),
         sys_invocation_status.remove("created_at").expect("created_at should exist"),


### PR DESCRIPTION
Fix #1993, this is generally useful, and could have helped to write a migration script that interacts with protocol versions.