### PR TITLE
Compose ReplicatedLogletId out of LogId + SegmentIndex 

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -35,7 +35,9 @@ use restate_types::logs::{LogId, Lsn};
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::nodes_config::Role;
 use restate_types::partition_table::PartitionTable;
-use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletParams, ReplicationProperty};
+use restate_types::replicated_loglet::{
+    NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty,
+};
 use restate_types::{logs, Version, Versioned};
 
 use crate::cluster_controller::observed_cluster_state::ObservedClusterState;
@@ -188,7 +190,7 @@ impl LogState {
                 log_id,
             } => {
                 if let Some(loglet_configuration) =
-                    try_provisioning(*provider_kind, observed_cluster_state)
+                    try_provisioning(*log_id, *provider_kind, observed_cluster_state)
                 {
                     let chain =
                         Chain::new(*provider_kind, loglet_configuration.to_loglet_params()?);
@@ -269,6 +271,7 @@ impl LogState {
 /// Try provisioning a new log for the given [`ProviderKind`] based on the observed cluster state.
 /// If this is possible, then this function returns some [`LogletConfiguration`].
 fn try_provisioning(
+    log_id: LogId,
     provider_kind: ProviderKind,
     observed_cluster_state: &ObservedClusterState,
 ) -> Option<LogletConfiguration> {
@@ -283,10 +286,12 @@ fn try_provisioning(
             Some(LogletConfiguration::Memory(log_id))
         }
         #[cfg(feature = "replicated-loglet")]
-        ProviderKind::Replicated => {
-            build_new_replicated_loglet_configuration(observed_cluster_state, None)
-                .map(LogletConfiguration::Replicated)
-        }
+        ProviderKind::Replicated => build_new_replicated_loglet_configuration(
+            ReplicatedLogletId::new(log_id, SegmentIndex::OLDEST),
+            observed_cluster_state,
+            None,
+        )
+        .map(LogletConfiguration::Replicated),
     }
 }
 
@@ -294,6 +299,7 @@ fn try_provisioning(
 /// and the previous configuration.
 #[cfg(feature = "replicated-loglet")]
 fn build_new_replicated_loglet_configuration(
+    loglet_id: ReplicatedLogletId,
     observed_cluster_state: &ObservedClusterState,
     previous_configuration: Option<&ReplicatedLogletParams>,
 ) -> Option<ReplicatedLogletParams> {
@@ -321,7 +327,7 @@ fn build_new_replicated_loglet_configuration(
         }
 
         Some(ReplicatedLogletParams {
-            loglet_id: rng.next_u64().into(),
+            loglet_id,
             sequencer: **log_servers
                 .iter()
                 .choose(&mut rng)
@@ -332,7 +338,7 @@ fn build_new_replicated_loglet_configuration(
         })
     } else if let Some(sequencer) = log_servers.iter().choose(&mut rng) {
         previous_configuration.cloned().map(|mut configuration| {
-            configuration.loglet_id = rng.next_u64().into();
+            configuration.loglet_id = loglet_id;
             configuration.sequencer = **sequencer;
             configuration
         })
@@ -399,6 +405,7 @@ impl LogletConfiguration {
             #[cfg(feature = "replicated-loglet")]
             LogletConfiguration::Replicated(configuration) => {
                 build_new_replicated_loglet_configuration(
+                    configuration.loglet_id.next(),
                     observed_cluster_state,
                     Some(configuration),
                 )

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -365,7 +365,7 @@ mod tests {
     // ** Single-node replicated-loglet smoke tests **
     #[test(tokio::test(start_paused = true))]
     async fn test_append_local_sequencer_single_node() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new(122);
+        let loglet_id = ReplicatedLogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -403,7 +403,7 @@ mod tests {
     // ** Single-node replicated-loglet seal **
     #[test(tokio::test(start_paused = true))]
     async fn test_seal_local_sequencer_single_node() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new(122);
+        let loglet_id = ReplicatedLogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -445,7 +445,7 @@ mod tests {
     // ** Single-node replicated-loglet read-stream **
     #[test(tokio::test(start_paused = true))]
     async fn replicated_loglet_single_loglet_readstream() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new(122);
+        let loglet_id = ReplicatedLogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -461,7 +461,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn replicated_loglet_single_append_after_seal() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new(122);
+        let loglet_id = ReplicatedLogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -477,7 +477,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn replicated_loglet_single_append_after_seal_concurrent() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new(122);
+        let loglet_id = ReplicatedLogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -493,7 +493,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn replicated_loglet_single_seal_empty() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new(122);
+        let loglet_id = ReplicatedLogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -653,7 +653,7 @@ mod tests {
     #[test(tokio::test(start_paused = true))]
     async fn test_simple_store_flow() -> Result<()> {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new(1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
         let mut loglet_state_map = LogletStateMap::default();
@@ -730,7 +730,7 @@ mod tests {
     #[test(tokio::test(start_paused = true))]
     async fn test_store_and_seal() -> Result<()> {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new(1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
         let mut loglet_state_map = LogletStateMap::default();
@@ -892,7 +892,7 @@ mod tests {
     async fn test_repair_store() -> Result<()> {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
         const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new(1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
         let mut loglet_state_map = LogletStateMap::default();
@@ -1058,7 +1058,7 @@ mod tests {
     #[test(tokio::test(start_paused = true))]
     async fn test_simple_get_records_flow() -> Result<()> {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new(1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
         let mut loglet_state_map = LogletStateMap::default();
@@ -1276,7 +1276,7 @@ mod tests {
     #[test(tokio::test(start_paused = true))]
     async fn test_trim_basics() -> Result<()> {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new(1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
         let mut loglet_state_map = LogletStateMap::default();

--- a/crates/log-server/src/rocksdb_logstore/keys.rs
+++ b/crates/log-server/src/rocksdb_logstore/keys.rs
@@ -73,7 +73,7 @@ impl KeyPrefix {
 
     fn decode<B: Buf>(buf: &mut B) -> KeyPrefix {
         let kind = KeyPrefixKind::try_from(buf.get_u8()).expect("recognized key kind");
-        let loglet_id = ReplicatedLogletId::new(buf.get_u64());
+        let loglet_id = ReplicatedLogletId::from(buf.get_u64());
         Self { kind, loglet_id }
     }
 

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -551,8 +551,8 @@ mod tests {
     async fn test_load_loglet_state() -> Result<()> {
         let (tc, mut log_store) = setup().await?;
         // fresh/unknown loglet
-        let loglet_id_1 = ReplicatedLogletId::new(88);
-        let loglet_id_2 = ReplicatedLogletId::new(89);
+        let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
+        let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
         let sequencer_1 = GenerationalNodeId::new(5, 213);
         let sequencer_2 = GenerationalNodeId::new(2, 212);
 
@@ -642,8 +642,8 @@ mod tests {
     #[test(tokio::test(start_paused = true))]
     async fn test_digest() -> Result<()> {
         let (tc, mut log_store) = setup().await?;
-        let loglet_id_1 = ReplicatedLogletId::new(88);
-        let loglet_id_2 = ReplicatedLogletId::new(89);
+        let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
+        let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
         let sequencer_1 = GenerationalNodeId::new(5, 213);
         let sequencer_2 = GenerationalNodeId::new(2, 212);
 

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -35,12 +35,24 @@ use crate::{flexbuffers_storage_encode_decode, Version, Versioned};
     Serialize,
     Deserialize,
     derive_more::From,
-    derive_more::Display,
     derive_more::Into,
+    derive_more::Display,
 )]
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct SegmentIndex(pub(crate) u32);
+
+impl SegmentIndex {
+    pub const OLDEST: SegmentIndex = SegmentIndex(0);
+
+    pub fn next(&self) -> SegmentIndex {
+        SegmentIndex(
+            self.0
+                .checked_add(1)
+                .expect("we should never create more than 2^32 segments"),
+        )
+    }
+}
 
 /// Log metadata is the map of logs known to the system with the corresponding chain.
 /// Metadata updates are versioned and atomic.

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -9,16 +9,17 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use serde_with::DisplayFromStr;
 
+use super::ReplicationProperty;
+use crate::logs::metadata::SegmentIndex;
+use crate::logs::LogId;
 use crate::nodes_config::NodesConfiguration;
 use crate::{GenerationalNodeId, PlainNodeId};
-
-use super::ReplicationProperty;
 
 /// Configuration parameters of a replicated loglet segment
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
@@ -64,15 +65,47 @@ impl ReplicatedLogletParams {
     derive_more::From,
     derive_more::Deref,
     derive_more::Into,
-    derive_more::Display,
 )]
 #[serde(transparent)]
 #[repr(transparent)]
 pub struct ReplicatedLogletId(u64);
 
 impl ReplicatedLogletId {
-    pub const fn new(id: u64) -> Self {
+    /// Creates a new [`ReplicatedLogletId`] from a [`LogId`] and a [`SegmentIndex`]. The upper
+    /// 32 bits are the log_id and the lower are the segment_index.
+    pub fn new(log_id: LogId, segment_index: SegmentIndex) -> Self {
+        let id = u64::from(u32::from(log_id)) << 32 | u64::from(u32::from(segment_index));
         Self(id)
+    }
+
+    /// It's your responsibility that the value has the right meaning.
+    pub const fn new_unchecked(v: u64) -> Self {
+        Self(v)
+    }
+
+    /// Creates a new [`ReplicatedLogletId`] by incrementing the lower 32 bits (segment index part).
+    pub fn next(&self) -> Self {
+        assert!(
+            self.0 & 0xFFFFFFFF < u64::from(u32::MAX),
+            "Segment part must not overflow into the LogId part"
+        );
+        Self(self.0 + 1)
+    }
+
+    fn log_id(&self) -> LogId {
+        LogId::new(u32::try_from(self.0 >> 32).expect("upper 32 bits should fit into u32"))
+    }
+
+    fn segment_index(&self) -> SegmentIndex {
+        SegmentIndex::from(
+            u32::try_from(self.0 & 0xFFFFFFFF).expect("lower 32 bits should fit into u32"),
+        )
+    }
+}
+
+impl Display for ReplicatedLogletId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}_{}", self.log_id(), self.segment_index())
     }
 }
 

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -14,7 +14,7 @@ use restate_local_cluster_runner::{
 };
 use restate_rocksdb::RocksDbManager;
 use restate_types::logs::builder::LogsBuilder;
-use restate_types::logs::metadata::{Chain, LogletParams};
+use restate_types::logs::metadata::{Chain, LogletParams, SegmentIndex};
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::{
     config::Configuration,
@@ -134,7 +134,7 @@ where
         cluster.wait_healthy(Duration::from_secs(30)).await?;
 
         let loglet_params = ReplicatedLogletParams {
-            loglet_id: ReplicatedLogletId::new(1),
+            loglet_id: ReplicatedLogletId::new(LogId::from(1u32), SegmentIndex::OLDEST),
             sequencer,
             replication,
             // node 1 is the metadata, 2..=count+1 are logservers


### PR DESCRIPTION
This commits makes the ReplicatedLogletId generation deterministic as
it now composes from the LogId + SegmentIndex.

This fixes https://github.com/restatedev/restate/issues/2086.

This PR is based on #2058.