### PR TITLE
[LogController] Detect log being sealed

### DIFF
--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -59,6 +59,14 @@ pub struct AdminOptions {
     /// operations.
     pub log_trim_threshold: u64,
 
+    /// # Log Tail Update interval
+    ///
+    /// Controls the interval at which cluster controller tries to refind the tails of logs. This
+    /// is a safety-net check in case of a concurrent cluster controller crash.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub log_tail_update_interval: humantime::Duration,
+
     /// # Default replication strategy
     ///
     /// The default replication strategy to be used by the cluster controller to schedule partition
@@ -105,6 +113,7 @@ impl Default for AdminOptions {
             default_replication_strategy: ReplicationStrategy::OnAllNodes,
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
+            log_tail_update_interval: Duration::from_secs(5 * 60).into(),
         }
     }
 }


### PR DESCRIPTION
[LogController] Detect log being sealed

Summary:
Detect if a log is sealed (or being sealed).

This is done by periodically running find-tail on all logs and change the state
if a sealed tail is found

Fixes #2083
