### PR TITLE
Fix leadership deadlock by checking whether our attempt is still valid

### DIFF
--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -420,8 +420,6 @@ where
 
                             if is_leader {
                                 self.status.effective_mode = RunMode::Leader;
-                            } else {
-                                self.status.effective_mode = RunMode::Follower;
                             }
 
                             transaction = partition_store.transaction();
@@ -469,6 +467,7 @@ where
                     .step_down()
                     .await
                     .context("failed handling StepDown command")?;
+                self.status.effective_mode = RunMode::Follower;
             }
             PartitionProcessorControlCommand::CreateSnapshot(maybe_sender) => {
                 if self


### PR DESCRIPTION
This commit solves a problem where the PartitionProcessorManager thinks that
its PartitionProcessor can still win the leadership even though the PP has
lost its leadership to another PP.

This fixes https://github.com/restatedev/restate/issues/2112.