### PR TITLE
Add support for co-locating sequencers and partition processor leaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5365,6 +5365,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper-util",
+ "itertools 0.13.0",
  "mime_guess",
  "okapi-operation",
  "prost",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -44,6 +44,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper-util = { workspace = true }
+itertools = { workspace = true }
 mime_guess = { version = "2.0.5", optional = true }
 okapi-operation = { version = "0.3.0-rc2", features = ["axum-integration"] }
 prost = { workspace = true }

--- a/crates/types/src/cluster_controller.rs
+++ b/crates/types/src/cluster_controller.rs
@@ -13,9 +13,10 @@ use crate::identifiers::{PartitionId, PartitionKey};
 use crate::partition_table::PartitionTable;
 use crate::{flexbuffers_storage_encode_decode, PlainNodeId, Version, Versioned};
 use serde_with::serde_as;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, HashSet};
 use std::num::NonZero;
 use std::ops::RangeInclusive;
+use xxhash_rust::xxh3::Xxh3Builder;
 
 /// Replication strategy for partition processors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -106,7 +107,7 @@ pub struct TargetPartitionState {
     /// Node which is the designated leader
     pub leader: Option<PlainNodeId>,
     /// Set of nodes that should run a partition processor for this partition
-    pub node_set: BTreeSet<PlainNodeId>,
+    pub node_set: HashSet<PlainNodeId, Xxh3Builder>,
     pub replication_strategy: ReplicationStrategy,
 }
 
@@ -119,7 +120,7 @@ impl TargetPartitionState {
             partition_key_range,
             replication_strategy,
             leader: None,
-            node_set: BTreeSet::default(),
+            node_set: HashSet::default(),
         }
     }
 

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -217,6 +217,13 @@ impl NodesConfiguration {
         })
     }
 
+    pub fn has_worker_role(&self, node_id: &PlainNodeId) -> bool {
+        self.nodes.get(node_id).is_some_and(|maybe| match maybe {
+            MaybeNode::Node(node) => node.has_role(Role::Worker),
+            _ => false,
+        })
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (PlainNodeId, &'_ NodeConfig)> {
         self.nodes.iter().filter_map(|(k, v)| {
             if let MaybeNode::Node(node) = v {


### PR DESCRIPTION
Let Scheduler respect replicated loglet placements

Let LogsController respect the preferred sequencer node

This fixes #2081.