### PR TITLE
Consider generational aspect of sequencer when deciding whether reconfiguration is needed

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -404,9 +404,7 @@ impl LogletConfiguration {
             #[cfg(feature = "replicated-loglet")]
             LogletConfiguration::Replicated(configuration) => {
                 // todo check also whether we can improve the nodeset based on the observed cluster state
-                observed_cluster_state
-                    .dead_nodes
-                    .contains(&configuration.sequencer.as_plain())
+                !observed_cluster_state.is_node_alive(configuration.sequencer)
             }
             LogletConfiguration::Local(_) => false,
             #[cfg(any(test, feature = "memory-loglet"))]


### PR DESCRIPTION
This fixes https://github.com/restatedev/restate/issues/2116 and is based on #2115.