### PR TITLE
[restatectl] Implementing `logs find-tail` subcommand

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -16,21 +16,23 @@ import "google/protobuf/empty.proto";
 package restate.cluster_ctrl;
 
 service ClusterCtrlSvc {
-  rpc GetClusterState(ClusterStateRequest) returns (ClusterStateResponse);
+  rpc GetClusterState(ClusterStateRequest) returns(ClusterStateResponse);
 
-  rpc ListLogs(ListLogsRequest) returns (ListLogsResponse);
+  rpc ListLogs(ListLogsRequest) returns(ListLogsResponse);
 
-  rpc DescribeLog(DescribeLogRequest) returns (DescribeLogResponse);
+  rpc DescribeLog(DescribeLogRequest) returns(DescribeLogResponse);
 
-  rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
+  rpc ListNodes(ListNodesRequest) returns(ListNodesResponse);
 
-  rpc TrimLog(TrimLogRequest) returns (google.protobuf.Empty);
+  rpc TrimLog(TrimLogRequest) returns(google.protobuf.Empty);
 
   rpc CreatePartitionSnapshot(CreatePartitionSnapshotRequest)
-      returns (CreatePartitionSnapshotResponse);
+      returns(CreatePartitionSnapshotResponse);
 
   rpc SealAndExtendChain(SealAndExtendChainRequest)
-      returns (SealAndExtendChainResponse);
+      returns(SealAndExtendChainResponse);
+
+  rpc FindTail(FindTailRequest) returns(FindTailResponse);
 }
 
 message ClusterStateRequest {}
@@ -44,11 +46,7 @@ message ListLogsResponse {
   bytes logs = 1;
 }
 
-enum TailState {
-  TailState_UNKNOWN = 0;
-  OPEN = 1;
-  SEALED = 2;
-}
+enum TailState { TailState_UNKNOWN = 0; OPEN = 1; SEALED = 2; }
 
 message DescribeLogRequest { uint32 log_id = 1; }
 
@@ -92,3 +90,12 @@ message SealAndExtendChainRequest {
 }
 
 message SealAndExtendChainResponse {}
+
+message FindTailRequest { uint32 log_id = 1; }
+
+message FindTailResponse {
+  uint32 log_id = 1;
+  uint32 segment_index = 2;
+  TailState tail_state = 3;
+  uint64 tail_lsn = 4;
+}

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -22,6 +22,7 @@ use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::Version;
 
 use crate::error::AdminError;
+use crate::loglet_wrapper::LogletWrapper;
 use crate::{Bifrost, Error, Result};
 
 /// Bifrost's Admin API
@@ -108,6 +109,10 @@ impl<'a> BifrostAdmin<'a> {
         self.add_segment_with_params(log_id, segment_index, tail.offset(), provider, params)
             .await?;
         Ok(())
+    }
+
+    pub async fn writeable_loglet(&self, log_id: LogId) -> Result<LogletWrapper> {
+        self.inner.writeable_loglet(log_id).await
     }
 
     #[instrument(level = "debug", skip(self), err)]

--- a/tools/restatectl/src/commands/log/find_tail.rs
+++ b/tools/restatectl/src/commands/log/find_tail.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use cling::prelude::*;
+use restate_cli_util::_comfy_table::{Cell, Color, Table};
+use restate_cli_util::ui::console::StyledTable;
+use tonic::codec::CompressionEncoding;
+
+use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
+use restate_admin::cluster_controller::protobuf::{FindTailRequest, TailState};
+use restate_cli_util::c_println;
+
+use crate::app::ConnectionInfo;
+use crate::util::grpc_connect;
+
+use super::LogIdRange;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "find_tail")]
+pub struct FindTailOpts {
+    /// The log id(s) to find its tail.
+    #[arg(required = true)]
+    log_id: Vec<LogIdRange>,
+}
+
+async fn find_tail(connection: &ConnectionInfo, opts: &FindTailOpts) -> anyhow::Result<()> {
+    let channel = grpc_connect(connection.cluster_controller.clone())
+        .await
+        .with_context(|| {
+            format!(
+                "cannot connect to cluster controller at {}",
+                connection.cluster_controller
+            )
+        })?;
+    let mut client =
+        ClusterCtrlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
+
+    let mut chain_table = Table::new_styled();
+    let header_row = vec!["LOG-ID", "SEGMENT", "STATE", "TAIL-LSN"];
+
+    chain_table.set_styled_header(header_row);
+
+    for log_id in opts.log_id.clone().into_iter().flatten() {
+        let find_tail_request = FindTailRequest { log_id };
+        let response = match client.find_tail(find_tail_request).await {
+            Ok(response) => response.into_inner(),
+            Err(err) => {
+                chain_table.add_row(vec![
+                    Cell::new(log_id),
+                    Cell::new(err.code()).fg(Color::DarkRed),
+                    Cell::new(err.message()).fg(Color::DarkRed),
+                ]);
+                continue;
+            }
+        };
+
+        chain_table.add_row(vec![
+            Cell::new(response.log_id),
+            Cell::new(response.segment_index),
+            Cell::new(
+                TailState::try_from(response.tail_state)
+                    .map(|state| state.as_str_name())
+                    .unwrap_or("unknown"),
+            ),
+            Cell::new(response.tail_lsn),
+        ]);
+    }
+
+    c_println!("{}", chain_table);
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/log/mod.rs
+++ b/tools/restatectl/src/commands/log/mod.rs
@@ -10,16 +10,20 @@
 
 mod describe_log;
 mod dump_log;
+mod find_tail;
 mod gen_metadata;
 pub mod list_logs;
 mod reconfigure;
 mod trim_log;
+
+use std::{ops::RangeInclusive, str::FromStr};
 
 use cling::prelude::*;
 
 use restate_cli_util::_comfy_table::{Cell, Color};
 use restate_cli_util::c_println;
 use restate_types::logs::metadata::{ProviderKind, Segment};
+use restate_types::logs::LogId;
 use restate_types::replicated_loglet::ReplicatedLogletParams;
 
 #[derive(Run, Subcommand, Clone)]
@@ -37,6 +41,67 @@ pub enum Logs {
     /// Reconfigure a log by sealing the tail segment
     /// and extending the chain with a new one
     Reconfigure(reconfigure::ReconfigureOpts),
+    /// Find and show tail state of a log
+    FindTail(find_tail::FindTailOpts),
+}
+
+#[derive(Parser, Collect, Clone, Debug)]
+struct LogIdRange {
+    from: u32,
+    to: u32,
+}
+
+impl LogIdRange {
+    fn new(from: u32, to: u32) -> anyhow::Result<Self> {
+        if from > to {
+            anyhow::bail!(
+                "Invalid log id range: {}..{}, start must be <= end range",
+                from,
+                to
+            )
+        } else {
+            Ok(LogIdRange { from, to })
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = u32> {
+        self.from..=self.to
+    }
+}
+
+impl From<&LogId> for LogIdRange {
+    fn from(log_id: &LogId) -> Self {
+        let id = (*log_id).into();
+        LogIdRange::new(id, id).unwrap()
+    }
+}
+
+impl IntoIterator for LogIdRange {
+    type IntoIter = RangeInclusive<u32>;
+    type Item = u32;
+    fn into_iter(self) -> Self::IntoIter {
+        self.from..=self.to
+    }
+}
+
+impl FromStr for LogIdRange {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split("-").collect();
+        match parts.len() {
+            1 => {
+                let n = parts[0].parse()?;
+                Ok(LogIdRange::new(n, n)?)
+            }
+            2 => {
+                let from = parts[0].parse()?;
+                let to = parts[1].parse()?;
+                Ok(LogIdRange::new(from, to)?)
+            }
+            _ => anyhow::bail!("Invalid log id or log range: {}", s),
+        }
+    }
 }
 
 pub fn render_loglet_params<F>(params: &Option<ReplicatedLogletParams>, render_fn: F) -> Cell


### PR DESCRIPTION
[restatectl] Implementing `logs find-tail` subcommand

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2118).
* #2109
* #2106
* __->__ #2118