### PR TITLE
[Bifrost] FindTail tries the sequencer node first

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -164,11 +164,7 @@ impl RequestPump {
             header: CommonResponseHeader {
                 known_global_tail: Some(tail.offset()),
                 sealed: Some(tail.is_sealed()),
-                status: if tail.is_sealed() {
-                    SequencerStatus::Sealed
-                } else {
-                    SequencerStatus::Ok
-                },
+                status: SequencerStatus::Ok,
             },
         };
 

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -181,7 +181,7 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
                     params,
                     self.networking.clone(),
                     self.logserver_rpc_routers.clone(),
-                    &self.sequencer_rpc_routers,
+                    self.sequencer_rpc_routers.clone(),
                     self.record_cache.clone(),
                 );
                 let key_value = entry.insert(Arc::new(loglet));

--- a/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
@@ -16,7 +16,7 @@ use restate_core::network::MessageRouterBuilder;
 use restate_types::net::log_server::{
     GetDigest, GetLogletInfo, GetRecords, Release, Seal, Store, Trim, WaitForTail,
 };
-use restate_types::net::replicated_loglet::Append;
+use restate_types::net::replicated_loglet::{Append, GetSequencerState};
 
 /// Used by replicated loglets to send requests and receive responses from log-servers
 /// Cloning this is cheap and all clones will share the same internal trackers.
@@ -64,6 +64,7 @@ impl LogServersRpc {
 #[derive(Clone)]
 pub struct SequencersRpc {
     pub append: RpcRouter<Append>,
+    pub get_seq_state: RpcRouter<GetSequencerState>,
 }
 
 impl SequencersRpc {
@@ -71,7 +72,11 @@ impl SequencersRpc {
     /// responses are routed correctly.
     pub fn new(router_builder: &mut MessageRouterBuilder) -> Self {
         let append = RpcRouter::new(router_builder);
+        let get_seq_state = RpcRouter::new(router_builder);
 
-        Self { append }
+        Self {
+            append,
+            get_seq_state,
+        }
     }
 }

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -37,7 +37,7 @@ define_rpc! {
 }
 
 /// Status of sequencer response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_more::IsVariant)]
 pub enum SequencerStatus {
     /// Ok is returned when request is accepted and processes
     /// successfully. Hence response body is valid


### PR DESCRIPTION

For non-sequencer nodes, we'll attempt to contact the sequencer first if possible (no higher generation exists, and it's network-reachable) before trying to perform quorum check to determine the global tail.

Validated on a test cluster.
