### PR TITLE
Allow users to customize inactivity_timeout and abort_timeout on a service basis.

### DIFF
--- a/cli/src/commands/services/config/edit.rs
+++ b/cli/src/commands/services/config/edit.rs
@@ -85,6 +85,16 @@ fn write_out_edit_toml(w: &mut impl io::Write, service_type: ServiceType) -> Res
         writeln!(w)?;
     }
 
+    write_prefixed_lines(w, "# ", super::patch::INACTIVITY_TIMEOUT_EDIT_DESCRIPTION)?;
+    writeln!(w, "# Example:")?;
+    writeln!(w, "# inactivity_timeout = \"1min\"")?;
+    writeln!(w)?;
+
+    write_prefixed_lines(w, "# ", super::patch::ABORT_TIMEOUT_EDIT_DESCRIPTION)?;
+    writeln!(w, "# Example:")?;
+    writeln!(w, "# abort_timeout = \"10min\"")?;
+    writeln!(w)?;
+
     Ok(())
 }
 

--- a/crates/admin-rest-model/src/services.rs
+++ b/crates/admin-rest-model/src/services.rs
@@ -54,6 +54,45 @@ pub struct ModifyServiceRequest {
     )]
     #[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
     pub workflow_completion_retention: Option<Duration>,
+
+    /// # Inactivity timeout
+    ///
+    /// This timer guards against stalled service/handler invocations. Once it expires,
+    /// Restate triggers a graceful termination by asking the service invocation to
+    /// suspend (which preserves intermediate progress).
+    ///
+    /// The 'abort timeout' is used to abort the invocation, in case it doesn't react to
+    /// the request to suspend.
+    ///
+    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format or the ISO8601.
+    ///
+    /// This overrides the default inactivity timeout set in invoker options.
+    #[serde(
+        default,
+        with = "serde_with::As::<Option<restate_serde_util::DurationString>>"
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
+    pub inactivity_timeout: Option<Duration>,
+
+    /// # Abort timeout
+    ///
+    /// This timer guards against stalled service/handler invocations that are supposed to
+    /// terminate. The abort timeout is started after the 'inactivity timeout' has expired
+    /// and the service/handler invocation has been asked to gracefully terminate. Once the
+    /// timer expires, it will abort the service/handler invocation.
+    ///
+    /// This timer potentially **interrupts** user code. If the user code needs longer to
+    /// gracefully terminate, then this value needs to be set accordingly.
+    ///
+    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format or the ISO8601.
+    ///
+    /// This overrides the default abort timeout set in invoker options.
+    #[serde(
+        default,
+        with = "serde_with::As::<Option<restate_serde_util::DurationString>>"
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
+    pub abort_timeout: Option<Duration>,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -84,6 +84,8 @@ pub async fn modify_service<V>(
         public,
         idempotency_retention,
         workflow_completion_retention,
+        inactivity_timeout,
+        abort_timeout,
     }): Json<ModifyServiceRequest>,
 ) -> Result<Json<ServiceMetadata>, MetaApiError> {
     let mut modify_request = vec![];
@@ -99,6 +101,12 @@ pub async fn modify_service<V>(
         modify_request.push(ModifyServiceChange::WorkflowCompletionRetention(
             new_workflow_completion_retention,
         ));
+    }
+    if let Some(inactivity_timeout) = inactivity_timeout {
+        modify_request.push(ModifyServiceChange::InactivityTimeout(inactivity_timeout));
+    }
+    if let Some(abort_timeout) = abort_timeout {
+        modify_request.push(ModifyServiceChange::AbortTimeout(abort_timeout));
     }
 
     if modify_request.is_empty() {

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -65,6 +65,8 @@ pub enum ModifyServiceChange {
     Public(bool),
     IdempotencyRetention(Duration),
     WorkflowCompletionRetention(Duration),
+    InactivityTimeout(Duration),
+    AbortTimeout(Duration),
 }
 
 /// Responsible for updating the registered schema information. This includes the discovery of

--- a/crates/admin/src/schema_registry/updater.rs
+++ b/crates/admin/src/schema_registry/updater.rs
@@ -207,6 +207,8 @@ impl SchemaUpdater {
                     } else {
                         None
                     },
+                    inactivity_timeout: None,
+                    abort_timeout: None,
                 }
             };
 
@@ -428,6 +430,12 @@ impl SchemaUpdater {
                             h.target_meta.completion_retention =
                                 Some(new_workflow_completion_retention);
                         }
+                    }
+                    ModifyServiceChange::InactivityTimeout(inactivity_timeout) => {
+                        schemas.inactivity_timeout = Some(inactivity_timeout);
+                    }
+                    ModifyServiceChange::AbortTimeout(abort_timeout) => {
+                        schemas.abort_timeout = Some(abort_timeout);
                     }
                 }
             }

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -113,6 +113,8 @@ mod mocks {
                 public: invocation_target_metadata.public,
                 idempotency_retention: DEFAULT_IDEMPOTENCY_RETENTION.into(),
                 workflow_completion_retention: None,
+                inactivity_timeout: None,
+                abort_timeout: None,
             });
             self.1
                 .add(service_name, [(handler_name, invocation_target_metadata)]);


### PR DESCRIPTION
Fix #1994

Some screenshots:

* get the default configuration:

![Screenshot from 2024-10-17 18-07-37](https://github.com/user-attachments/assets/b774b28e-3d3b-44cb-a554-133259d43911)

* Use the `conf edit` command with the editor:

![Screenshot from 2024-10-17 18-08-23](https://github.com/user-attachments/assets/e5cb5d10-d380-4478-b91f-41a9413eaa89)
![Screenshot from 2024-10-17 18-08-36](https://github.com/user-attachments/assets/a265039d-11d1-4705-8303-0248bf6acfa2)

* After the edit of the configuration:

![Screenshot from 2024-10-17 18-08-54](https://github.com/user-attachments/assets/a3de0d18-14d4-4d1f-93d2-b419837095bc)
