### PR TITLE
Generic `Reciprocal` type to avoid responding with wrong message

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -170,12 +170,13 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             while let Some(Ok((node_id, result))) = join_set.join_next().await {
                 match result {
                     Ok(response) => {
-                        let (from, msg) = response.split();
+                        let peer = *response.peer();
+                        let msg = response.into_body();
                         nodes.insert(
                             node_id,
                             NodeState::Alive(AliveNode {
                                 last_heartbeat_at: MillisSinceEpoch::now(),
-                                generational_node_id: *from.peer(),
+                                generational_node_id: peer,
                                 partitions: msg.state,
                             }),
                         );

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -235,7 +235,7 @@ impl RequestPump {
             }
         };
 
-        let task = WaitAppendedTask {
+        let task = WaitForCommitTask {
             reciprocal,
             loglet_commit,
             global_tail: global_tail.clone(),
@@ -356,13 +356,13 @@ impl From<ReplicatedLogletError> for SequencerStatus {
     }
 }
 
-struct WaitAppendedTask {
+struct WaitForCommitTask {
     loglet_commit: LogletCommit,
-    reciprocal: Reciprocal,
+    reciprocal: Reciprocal<Appended>,
     global_tail: TailOffsetWatch,
 }
 
-impl WaitAppendedTask {
+impl WaitForCommitTask {
     async fn run(self) -> anyhow::Result<()> {
         let appended = match self.loglet_commit.await {
             Ok(offset) => Appended {

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -96,7 +96,7 @@ struct MetadataMessageHandler {
 impl MetadataMessageHandler {
     fn send_metadata(
         &self,
-        to: Reciprocal,
+        to: Reciprocal<MetadataMessage>,
         metadata_kind: MetadataKind,
         min_version: Option<Version>,
     ) {
@@ -108,24 +108,24 @@ impl MetadataMessageHandler {
         };
     }
 
-    fn send_nodes_config(&self, to: Reciprocal, version: Option<Version>) {
+    fn send_nodes_config(&self, to: Reciprocal<MetadataMessage>, version: Option<Version>) {
         let config = self.metadata.nodes_config_snapshot();
         self.send_metadata_internal(to, version, config.deref(), "nodes_config");
     }
 
-    fn send_partition_table(&self, to: Reciprocal, version: Option<Version>) {
+    fn send_partition_table(&self, to: Reciprocal<MetadataMessage>, version: Option<Version>) {
         let partition_table = self.metadata.partition_table_snapshot();
         self.send_metadata_internal(to, version, partition_table.deref(), "partition_table");
     }
 
-    fn send_logs(&self, to: Reciprocal, version: Option<Version>) {
+    fn send_logs(&self, to: Reciprocal<MetadataMessage>, version: Option<Version>) {
         let logs = self.metadata.logs_ref();
         if logs.version() != Version::INVALID {
             self.send_metadata_internal(to, version, logs.deref(), "logs");
         }
     }
 
-    fn send_schema(&self, to: Reciprocal, version: Option<Version>) {
+    fn send_schema(&self, to: Reciprocal<MetadataMessage>, version: Option<Version>) {
         let schema = self.metadata.schema();
         if schema.version != Version::INVALID {
             self.send_metadata_internal(to, version, schema.deref(), "schema");
@@ -134,7 +134,7 @@ impl MetadataMessageHandler {
 
     fn send_metadata_internal<T>(
         &self,
-        to: Reciprocal,
+        to: Reciprocal<MetadataMessage>,
         version: Option<Version>,
         metadata: &T,
         metadata_name: &str,

--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -146,12 +146,9 @@ impl MessageHandler for IngressDispatcher {
     type MessageType = IngressMessage;
 
     async fn on_message(&self, msg: Incoming<Self::MessageType>) {
-        let (reciprocal, msg) = msg.split();
-        trace!(
-            "Processing message '{}' from '{}'",
-            msg.kind(),
-            reciprocal.peer()
-        );
+        let peer = *msg.peer();
+        let msg = msg.into_body();
+        trace!("Processing message '{}' from '{}'", msg.kind(), peer);
 
         match msg {
             IngressMessage::InvocationResponse(invocation_response) => {
@@ -174,7 +171,7 @@ impl MessageHandler for IngressDispatcher {
                         );
                     } else {
                         trace!(
-                            partition_processor_peer = %reciprocal.peer(),
+                            partition_processor_peer = %peer,
                             "Sent response of invocation {:?} out",
                             invocation_response.invocation_id
                         );
@@ -202,7 +199,7 @@ impl MessageHandler for IngressDispatcher {
                         );
                     } else {
                         trace!(
-                            partition_processor_peer = %reciprocal.peer(),
+                            partition_processor_peer = %peer,
                             "Sent response of invocation out"
                         );
                     }

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -21,6 +21,8 @@ use crate::schema::Schema;
 use crate::Version;
 use crate::Versioned;
 
+use super::RpcRequest;
+
 #[derive(
     Debug,
     Clone,
@@ -35,6 +37,9 @@ pub enum MetadataMessage {
     MetadataUpdate(MetadataUpdate),
 }
 
+impl RpcRequest for MetadataMessage {
+    type ResponseMessage = MetadataMessage;
+}
 define_message! {
     @message = MetadataMessage,
     @target = TargetName::MetadataManager,


### PR DESCRIPTION
Generic `Reciprocal` type to avoid responding with wrong message

Summary:
After I made a mistake of responding to an incoming message with the
wrong resposne type. I think a Reciprocal should be typed with the
expected response message.

After changing this the compiler didn't pass the code where the bug was
