### PR TITLE
Don't start admin node for replicated loglet cluster tests 

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -408,9 +408,7 @@ impl LogletConfiguration {
             #[cfg(feature = "replicated-loglet")]
             LogletConfiguration::Replicated(configuration) => {
                 // todo check also whether we can improve the nodeset based on the observed cluster state
-                observed_cluster_state
-                    .dead_nodes
-                    .contains(&configuration.sequencer.as_plain())
+                !observed_cluster_state.is_node_alive(configuration.sequencer)
             }
             LogletConfiguration::Local(_) => false,
             #[cfg(any(test, feature = "memory-loglet"))]

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -613,6 +613,7 @@ impl LogsControllerInner {
             )?;
 
             if let Some(logs) = builder.build_if_modified() {
+                debug!("Proposing new logs configuration: {logs:?}");
                 self.logs_write_in_progress = Some(logs.version());
                 let logs = Arc::new(logs);
                 effects.push(Effect::WriteLogs {

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -143,9 +143,10 @@ impl Node {
             .build()
     }
 
-    // Creates a group of Nodes with a single metadata node "metadata-node", and a given number
-    // of other nodes ["node-1", ..] each with the provided roles. Node name, roles,
-    // bind/advertise addresses, and the metadata address from the base_config will all be overwritten.
+    // Creates a group of Nodes with a single metadata node "metadata-node" running the
+    // metadata-store and the admin role, and a given number of other nodes ["node-1", ..] each with
+    // the provided roles. Node name, roles, bind/advertise addresses, and the metadata address from
+    // the base_config will all be overwritten.
     pub fn new_test_nodes_with_metadata(
         base_config: Configuration,
         binary_source: BinarySource,
@@ -156,6 +157,7 @@ impl Node {
 
         {
             let mut base_config = base_config.clone();
+            // let any node write the initial NodesConfiguration
             base_config.common.allow_bootstrap = true;
             base_config.common.force_node_id = Some(PlainNodeId::new(1));
             nodes.push(Self::new_test_node(
@@ -168,7 +170,6 @@ impl Node {
 
         for node in 1..=size {
             let mut base_config = base_config.clone();
-            base_config.common.allow_bootstrap = false;
             base_config.common.force_node_id = Some(PlainNodeId::new(node + 1));
             nodes.push(Self::new_test_node(
                 format!("node-{node}"),

--- a/crates/node/src/network_server/handler/cluster_ctrl.rs
+++ b/crates/node/src/network_server/handler/cluster_ctrl.rs
@@ -33,7 +33,7 @@ use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::{StorageCodec, StorageEncode};
 use restate_types::{Version, Versioned};
 
-use crate::network_server::AdminDependencies;
+use crate::network_server::ClusterControllerDependencies;
 
 pub struct ClusterCtrlSvcHandler {
     metadata_store_client: MetadataStoreClient,
@@ -43,7 +43,7 @@ pub struct ClusterCtrlSvcHandler {
 }
 
 impl ClusterCtrlSvcHandler {
-    pub fn new(admin_deps: AdminDependencies) -> Self {
+    pub fn new(admin_deps: ClusterControllerDependencies) -> Self {
         Self {
             controller_handle: admin_deps.cluster_controller_handle,
             metadata_store_client: admin_deps.metadata_store_client,

--- a/crates/node/src/network_server/mod.rs
+++ b/crates/node/src/network_server/mod.rs
@@ -15,4 +15,4 @@ mod prometheus_helpers;
 mod service;
 mod state;
 
-pub use service::{AdminDependencies, NetworkServer, WorkerDependencies};
+pub use service::{ClusterControllerDependencies, NetworkServer, WorkerDependencies};

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -64,6 +64,9 @@ pub struct AdminOptions {
     /// The default replication strategy to be used by the cluster controller to schedule partition
     /// processors.
     pub default_replication_strategy: ReplicationStrategy,
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub disable_cluster_controller: bool,
 }
 
 impl AdminOptions {
@@ -79,6 +82,13 @@ impl AdminOptions {
             Semaphore::MAX_PERMITS - 1,
         )
     }
+
+    pub fn is_cluster_controller_enabled(&self) -> bool {
+        #[cfg(not(any(test, feature = "test-util")))]
+        return true;
+        #[cfg(any(test, feature = "test-util"))]
+        return !self.disable_cluster_controller;
+    }
 }
 
 impl Default for AdminOptions {
@@ -93,6 +103,8 @@ impl Default for AdminOptions {
             log_trim_interval: Some(Duration::from_secs(60 * 60).into()),
             log_trim_threshold: 1000,
             default_replication_strategy: ReplicationStrategy::OnAllNodes,
+            #[cfg(any(test, feature = "test-util"))]
+            disable_cluster_controller: false,
         }
     }
 }

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -94,7 +94,7 @@ impl TestEnv {
 }
 
 pub async fn run_in_test_env<F, O>(
-    base_config: Configuration,
+    mut base_config: Configuration,
     sequencer: GenerationalNodeId,
     replication: ReplicationProperty,
     log_server_count: u32,
@@ -104,6 +104,8 @@ where
     F: FnMut(TestEnv) -> O,
     O: std::future::Future<Output = googletest::Result<()>> + Send,
 {
+    // disable the cluster controller to allow us to manually set the logs configuration
+    base_config.admin.disable_cluster_controller = true;
     let nodes = Node::new_test_nodes_with_metadata(
         base_config,
         BinarySource::CargoTest,


### PR DESCRIPTION
The replicated loglet cluster tests assume that they are in control
of configuring the loglet. This only works if the cluster does not
start a `LogsController`. This is achieved by starting these tests w/o
Role::Admin. With the `LogController`, it happened that the log was
automatically reconfigured since the configured sequencer did not 
respond to heartbeats.