### PR TITLE
Move announce_leadership message into the background

### DIFF
--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -109,6 +109,8 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     /// Log-server tasks
     LogletWriter,
+    /// Background task which should not fail
+    Background,
 }
 
 impl TaskKind {


### PR DESCRIPTION
In order to not block the PP while writing the announce_leadership message to Bifrost, this commit moves it into the background.

This is a temporary solution until we have a better approach.

This fixes #2133.