### PR TITLE
Display sequencer node in partition processors table

### DIFF
--- a/tools/restatectl/src/commands/cluster/overview.rs
+++ b/tools/restatectl/src/commands/cluster/overview.rs
@@ -32,7 +32,7 @@ async fn cluster_status(
     list_logs(connection, &ListLogsOpts {}).await?;
     c_println!();
 
-    list_partitions(connection, &ListPartitionsOpts {}).await?;
+    list_partitions(connection, &ListPartitionsOpts::default()).await?;
 
     Ok(())
 }

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -39,14 +39,11 @@ use crate::util::grpc_connect;
 #[cling(run = "list_partitions")]
 #[clap(alias = "ls")]
 #[command(
-    after_long_help = "In addition to partition processors, this command will \
-    display and highlight the current sequencer for each partition's log when \
-    the reported applied LSN is within the tail segment of a replicated loglet.\
-    \
-    When ANSI color is enabled, the this command will also highlight when the \
-    partition processor sees itself as the leader, when the observed leadership \
-    epoch is not the latest, and when the partition leader and the loglet \
-    sequencer are on the same node (for replicated loglets)."
+    after_long_help = "In addition to partition processors, the command displays the current \
+    sequencer for the partition's log when the reported applied LSN falls within the tail a \
+    replicated segment, under the heading SEQNCR. If ANSI color is enabled, the leadership epoch \
+    and the active sequencer will be highlighted in green they are the most recent and co-located \
+    with the leader processor, respectively."
 )]
 pub struct ListPartitionsOpts {
     /// Sort order
@@ -142,7 +139,7 @@ pub async fn list_partitions(
         "STATUS",
         "LEADER",
         "EPOCH",
-        "LL-SEQ",
+        "SEQNCR",
         "APPLIED",
         "PERSISTED",
         "SKIPPED",

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -16,10 +16,6 @@ use cling::prelude::*;
 use itertools::Itertools;
 use tonic::codec::CompressionEncoding;
 
-use crate::app::ConnectionInfo;
-use crate::commands::display_util::render_as_duration;
-use crate::commands::log::deserialize_replicated_log_params;
-use crate::util::grpc_connect;
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_admin::cluster_controller::protobuf::{ClusterStateRequest, ListLogsRequest};
 use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
@@ -33,6 +29,11 @@ use restate_types::protobuf::cluster::{
 };
 use restate_types::storage::StorageCodec;
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+
+use crate::app::ConnectionInfo;
+use crate::commands::display_util::render_as_duration;
+use crate::commands::log::deserialize_replicated_log_params;
+use crate::util::grpc_connect;
 
 #[derive(Run, Parser, Collect, Clone, Debug, Default)]
 #[cling(run = "list_partitions")]
@@ -162,7 +163,7 @@ pub async fn list_partitions(
                     let in_tail = processor
                         .status
                         .last_applied_log_lsn
-                        .map(|lsn| Lsn::from(lsn))
+                        .map(Lsn::from)
                         .is_some_and(|applied_lsn| applied_lsn.ge(&tail.base_lsn));
                     (
                         in_tail,


### PR DESCRIPTION
The loglet segment is inferred by the admin node based on the reported applied LSN from the partition.

`restatectl partitions list` now:

- includes the loglet sequencer node id, if the partition processor is using a replicated loglet and its applied LSN is in the tail segment
- highlights when the given node is the leader for the partition, and when the sequencer in use matches the PP node id (leaders only)
- de-emphasized active followers (no longer green)
- supports ordering the partition table display by partition id (default), or node id, or leadership status (active > follower)

`restatectl status` will also get these improvements.

Sample output:

<img width="888" alt="image" src="https://github.com/user-attachments/assets/22647fe9-b947-4a25-856b-132ae7e6c420">
