### PR TITLE
[restatectl] Show result of `logs reconfigure`

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -89,7 +89,18 @@ message SealAndExtendChainRequest {
   string params = 5;
 }
 
-message SealAndExtendChainResponse {}
+message SealedSegment {
+  // segment provider
+  string provider = 1;
+  // segment params
+  string params = 2;
+  // tail offset lsn
+  uint64 tail_offset = 3;
+}
+message SealAndExtendChainResponse {
+  uint32 new_segment_index = 1;
+  SealedSegment sealed_segment = 2;
+}
 
 message FindTailRequest { uint32 log_id = 1; }
 

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -1017,12 +1017,12 @@ impl LogsController {
                     BifrostAdmin::new(&bifrost, &metadata_writer, &metadata_store_client);
 
                 match bifrost_admin.seal(log_id, segment_index).await {
-                    Ok(tail_state) => {
-                        if tail_state.is_sealed() {
+                    Ok(sealed_segment) => {
+                        if sealed_segment.tail.is_sealed() {
                             Event::SealSucceeded {
                                 log_id,
                                 segment_index,
-                                seal_lsn: tail_state.offset(),
+                                seal_lsn: sealed_segment.tail.offset(),
                             }
                         } else {
                             Event::SealFailed {

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -467,10 +467,12 @@ impl BifrostInner {
         let loglet = provider
             .get_loglet(log_id, segment.index(), &segment.config.params)
             .await?;
+
         Ok(LogletWrapper::new(
             segment.index(),
             segment.base_lsn,
             segment.tail_lsn,
+            segment.config.clone(),
             loglet,
         ))
     }

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -21,7 +21,7 @@ use tracing::info;
 
 use restate_core::{task_center, TaskHandle, TaskKind};
 use restate_test_util::let_assert;
-use restate_types::logs::metadata::SegmentIndex;
+use restate_types::logs::metadata::{LogletConfig, SegmentIndex};
 use restate_types::logs::{KeyFilter, Lsn, SequenceNumber, TailState};
 
 use super::Loglet;
@@ -55,7 +55,13 @@ async fn wait_for_trim(loglet: &LogletWrapper, required_trim_point: Lsn) -> anyh
 /// provide contiguous offsets that start from Lsn::OLDEST.
 pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
     setup_panic_handler();
-    let loglet = LogletWrapper::new(SegmentIndex::from(1), Lsn::OLDEST, None, loglet);
+    let loglet = LogletWrapper::new(
+        SegmentIndex::from(1),
+        Lsn::OLDEST,
+        None,
+        LogletConfig::for_testing(),
+        loglet,
+    );
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -221,7 +227,13 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
 /// starts from Lsn::OLDEST.
 pub async fn single_loglet_readstream(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
     setup_panic_handler();
-    let loglet = LogletWrapper::new(SegmentIndex::from(1), Lsn::OLDEST, None, loglet);
+    let loglet = LogletWrapper::new(
+        SegmentIndex::from(1),
+        Lsn::OLDEST,
+        None,
+        LogletConfig::for_testing(),
+        loglet,
+    );
 
     let read_from_offset = Lsn::new(6);
     let mut reader = loglet
@@ -294,7 +306,13 @@ pub async fn single_loglet_readstream_with_trims(
     loglet: Arc<dyn Loglet>,
 ) -> googletest::Result<()> {
     setup_panic_handler();
-    let loglet = LogletWrapper::new(SegmentIndex::from(1), Lsn::OLDEST, None, loglet);
+    let loglet = LogletWrapper::new(
+        SegmentIndex::from(1),
+        Lsn::OLDEST,
+        None,
+        LogletConfig::for_testing(),
+        loglet,
+    );
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -395,7 +413,13 @@ pub async fn single_loglet_readstream_with_trims(
 /// Validates that appends fail after find_tail() returned Sealed()
 pub async fn append_after_seal(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
     setup_panic_handler();
-    let loglet = LogletWrapper::new(SegmentIndex::from(1), Lsn::OLDEST, None, loglet);
+    let loglet = LogletWrapper::new(
+        SegmentIndex::from(1),
+        Lsn::OLDEST,
+        None,
+        LogletConfig::for_testing(),
+        loglet,
+    );
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -432,7 +456,13 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
     const CONCURRENT_APPENDERS: usize = 20;
 
     setup_panic_handler();
-    let loglet = LogletWrapper::new(SegmentIndex::from(1), Lsn::OLDEST, None, loglet);
+    let loglet = LogletWrapper::new(
+        SegmentIndex::from(1),
+        Lsn::OLDEST,
+        None,
+        LogletConfig::for_testing(),
+        loglet,
+    );
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
@@ -577,7 +607,13 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
 /// Validates that an empty loglet can be sealed
 pub async fn seal_empty(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
     setup_panic_handler();
-    let loglet = LogletWrapper::new(SegmentIndex::from(1), Lsn::OLDEST, None, loglet);
+    let loglet = LogletWrapper::new(
+        SegmentIndex::from(1),
+        Lsn::OLDEST,
+        None,
+        LogletConfig::for_testing(),
+        loglet,
+    );
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use futures::{Stream, StreamExt};
 use tracing::instrument;
 
-use restate_types::logs::metadata::SegmentIndex;
+use restate_types::logs::metadata::{LogletConfig, SegmentIndex};
 use restate_types::logs::{KeyFilter, LogletOffset, Lsn, SequenceNumber};
 use restate_types::logs::{Record, TailState};
 
@@ -42,6 +42,7 @@ pub struct LogletWrapper {
     pub(crate) base_lsn: Lsn,
     /// If set, it points to the first first LSN outside the boundary of this loglet (bifrost's tail semantics)
     pub(crate) tail_lsn: Option<Lsn>,
+    pub(crate) config: LogletConfig,
     loglet: Arc<dyn Loglet>,
 }
 
@@ -50,12 +51,14 @@ impl LogletWrapper {
         segment_index: SegmentIndex,
         base_lsn: Lsn,
         tail_lsn: Option<Lsn>,
+        config: LogletConfig,
         loglet: Arc<dyn Loglet>,
     ) -> Self {
         Self {
             segment_index,
             base_lsn,
             tail_lsn,
+            config,
             loglet,
         }
     }

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -117,6 +117,17 @@ pub struct LogletConfig {
     index: SegmentIndex,
 }
 
+impl LogletConfig {
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn for_testing() -> Self {
+        Self {
+            kind: ProviderKind::InMemory,
+            params: LogletParams(ByteString::default()),
+            index: 0.into(),
+        }
+    }
+}
+
 /// The configuration of a single loglet segment. This holds information needed
 /// for a loglet kind to construct a configured loglet instance modulo the log-id
 /// and start-lsn. It's provided by bifrost on loglet creation. This allows the


### PR DESCRIPTION
[restatectl] Show result of `logs reconfigure`

# Example output:

```
restatectl log reconfigure --log-id 0 --provider replicated
✅ Log reconfiguration
 └ Segment Index: 2

Sealed segment
 ├ Index: 1
 ├ Tail LSN: 2
 ├ Provider: replicated
 ├ Loglet ID: 0_1
 ├ Sequencer: N0:1
 ├ Replication: {node: 1}
 └ Node Set: [N0]
```
