### PR TITLE
Add simple retry mechanism in Shuffle if writing to Bifrost fails

### DIFF
--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use super::error::*;
+use std::sync::Arc;
 
 use crate::rest_api::create_envelope_header;
 use crate::state::AdminServiceState;
@@ -95,7 +96,7 @@ pub async fn delete_invocation<V>(
 
     let result = append_envelope_to_bifrost(
         &state.bifrost,
-        Envelope::new(create_envelope_header(partition_key), cmd),
+        Arc::new(Envelope::new(create_envelope_header(partition_key), cmd)),
     )
     .await;
 

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -12,6 +12,7 @@ use super::create_envelope_header;
 use super::error::*;
 use crate::schema_registry::ModifyServiceChange;
 use crate::state::AdminServiceState;
+use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::Json;
@@ -175,10 +176,10 @@ pub async fn modify_service_state<V>(
 
     let result = append_envelope_to_bifrost(
         &state.bifrost,
-        Envelope::new(
+        Arc::new(Envelope::new(
             create_envelope_header(partition_key),
             Command::PatchState(patch_state),
-        ),
+        )),
     )
     .await;
 

--- a/crates/ingress-dispatcher/src/dispatcher.rs
+++ b/crates/ingress-dispatcher/src/dispatcher.rs
@@ -131,7 +131,7 @@ impl DispatchIngressRequest for IngressDispatcher {
             dedup_source,
             msg_index,
         );
-        let (log_id, lsn) = append_envelope_to_bifrost(&self.bifrost, envelope).await?;
+        let (log_id, lsn) = append_envelope_to_bifrost(&self.bifrost, Arc::new(envelope)).await?;
 
         debug!(
             log_id = %log_id,

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -233,7 +233,7 @@ pub enum Error {
 /// it needs access to [`metadata()`].
 pub async fn append_envelope_to_bifrost(
     bifrost: &Bifrost,
-    envelope: Envelope,
+    envelope: Arc<Envelope>,
 ) -> Result<(LogId, Lsn), Error> {
     let partition_id = {
         // make sure we drop pinned partition table before awaiting
@@ -244,7 +244,7 @@ pub async fn append_envelope_to_bifrost(
     let log_id = LogId::from(*partition_id);
     // todo: Pass the envelope as `Arc` to `append_envelope_to_bifrost` instead. Possibly use
     // triomphe's UniqueArc for a mutable Arc during construction.
-    let lsn = bifrost.append(log_id, Arc::new(envelope)).await?;
+    let lsn = bifrost.append(log_id, envelope).await?;
 
     Ok((log_id, lsn))
 }

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -23,6 +23,7 @@ use restate_wal_protocol::{
     append_envelope_to_bifrost, Command, Destination, Envelope, Header, Source,
 };
 use std::ops::RangeInclusive;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, instrument, warn};
@@ -143,7 +144,7 @@ where
             if SystemTime::now() >= expiration_time {
                 append_envelope_to_bifrost(
                     bifrost,
-                    Envelope {
+                    Arc::new(Envelope {
                         header: Header {
                             source: bifrost_envelope_source.clone(),
                             dest: Destination::Processor {
@@ -152,7 +153,7 @@ where
                             },
                         },
                         command: Command::PurgeInvocation(PurgeInvocationRequest { invocation_id }),
-                    },
+                    }),
                 )
                 .await
                 .context("Cannot append to bifrost")?;

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -261,13 +261,14 @@ where
 }
 
 mod state_machine {
+    use pin_project::pin_project;
     use std::cmp::Ordering;
     use std::future::Future;
     use std::pin::Pin;
-
-    use pin_project::pin_project;
+    use std::sync::Arc;
+    use std::time::Duration;
     use tokio_util::sync::ReusableBoxFuture;
-    use tracing::trace;
+    use tracing::{debug, trace};
 
     use restate_storage_api::outbox_table::OutboxMessage;
     use restate_types::message::MessageIndex;
@@ -290,7 +291,7 @@ mod state_machine {
     enum State<SendFuture> {
         Idle,
         ReadingOutbox,
-        Sending(#[pin] SendFuture),
+        Sending(#[pin] SendFuture, Arc<Envelope>),
     }
 
     #[pin_project]
@@ -319,7 +320,7 @@ mod state_machine {
     impl<'a, OutboxReader, SendOp, SendFuture> StateMachine<'a, OutboxReader, SendOp, SendFuture>
     where
         SendFuture: Future<Output = Result<(), anyhow::Error>>,
-        SendOp: Fn(Envelope) -> SendFuture,
+        SendOp: Fn(Arc<Envelope>) -> SendFuture,
         OutboxReader: shuffle::OutboxReader + Send + Sync + 'static,
     {
         pub(super) fn new(
@@ -364,13 +365,13 @@ mod state_machine {
 
                             match seq_number.cmp(this.current_sequence_number) {
                                 Ordering::Equal => {
-                                    let send_future =
-                                        (this.send_operation)(wrap_outbox_message_in_envelope(
-                                            message,
-                                            seq_number,
-                                            this.metadata,
-                                        ));
-                                    this.state.set(State::Sending(send_future));
+                                    let envelope = Arc::new(wrap_outbox_message_in_envelope(
+                                        message.clone(),
+                                        seq_number,
+                                        this.metadata,
+                                    ));
+                                    let send_future = (this.send_operation)(Arc::clone(&envelope));
+                                    this.state.set(State::Sending(send_future, envelope));
                                     break;
                                 }
                                 Ordering::Greater => {
@@ -402,30 +403,42 @@ mod state_machine {
 
                             *this.current_sequence_number = seq_number;
 
-                            let send_future = (this.send_operation)(
-                                wrap_outbox_message_in_envelope(message, seq_number, this.metadata),
-                            );
+                            let envelope = Arc::new(wrap_outbox_message_in_envelope(
+                                message,
+                                seq_number,
+                                this.metadata,
+                            ));
+                            let send_future = (this.send_operation)(Arc::clone(&envelope));
 
-                            this.state.set(State::Sending(send_future));
+                            this.state.set(State::Sending(send_future, envelope));
                         } else {
                             this.state.set(State::Idle);
                         }
                     }
-                    StateProj::Sending(send_future) => {
-                        send_future.await?;
+                    StateProj::Sending(send_future, envelope) => {
+                        if let Err(err) = send_future.await {
+                            debug!("Retrying failed shuffle attempt: {err}");
 
-                        let successfully_shuffled_sequence_number = *this.current_sequence_number;
-                        *this.current_sequence_number += 1;
+                            let send_future = (this.send_operation)(Arc::clone(envelope));
+                            let envelope = Arc::clone(envelope);
+                            this.state.set(State::Sending(send_future, envelope));
 
-                        this.read_future.set(get_next_message(
-                            this.outbox_reader
-                                .take()
-                                .expect("outbox reader should be available"),
-                            *this.current_sequence_number,
-                        ));
-                        this.state.set(State::ReadingOutbox);
+                            tokio::time::sleep(Duration::from_millis(250)).await;
+                        } else {
+                            let successfully_shuffled_sequence_number =
+                                *this.current_sequence_number;
+                            *this.current_sequence_number += 1;
 
-                        return Ok(successfully_shuffled_sequence_number);
+                            this.read_future.set(get_next_message(
+                                this.outbox_reader
+                                    .take()
+                                    .expect("outbox reader should be available"),
+                                *this.current_sequence_number,
+                            ));
+                            this.state.set(State::ReadingOutbox);
+
+                            return Ok(successfully_shuffled_sequence_number);
+                        }
                     }
                 }
             }


### PR DESCRIPTION

With this commit we will indefinitely retry a failed write attempt to Bifrost
until we succeed.
