### PR TITLE
Node base Role that runs on all nodes to

### DIFF
--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -758,7 +758,7 @@ mod tests {
     use restate_test_util::{assert_eq, let_assert};
     use restate_types::net::codec::WireDecode;
     use restate_types::net::metadata::{GetMetadataRequest, MetadataMessage};
-    use restate_types::net::partition_processor_manager::GetProcessorsState;
+    use restate_types::net::node::GetNodeState;
     use restate_types::net::{
         AdvertisedAddress, ProtocolVersion, CURRENT_PROTOCOL_VERSION,
         MIN_SUPPORTED_PROTOCOL_VERSION,
@@ -1030,7 +1030,7 @@ mod tests {
                 .await
                 .into_test_result()?;
 
-                let request = GetProcessorsState {};
+                let request = GetNodeState {};
                 let partition_table_version = metadata.partition_table_version().next();
                 let header = Header::new(
                     metadata.nodes_config_version(),

--- a/crates/node/src/roles/base.rs
+++ b/crates/node/src/roles/base.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::pin::Pin;
+
+use anyhow::Context;
+use futures::{Stream, StreamExt};
+
+use restate_core::{
+    cancellation_watcher,
+    network::{Incoming, MessageRouterBuilder, NetworkError},
+    task_center,
+    worker_api::ProcessorsManagerHandle,
+    ShutdownError, TaskKind,
+};
+use restate_types::net::node::{GetNodeState, NodeStateResponse};
+
+pub struct BaseRole {
+    processor_manager_handle: Option<ProcessorsManagerHandle>,
+    incoming_node_state:
+        Pin<Box<dyn Stream<Item = Incoming<GetNodeState>> + Send + Sync + 'static>>,
+}
+
+impl BaseRole {
+    pub fn create(
+        router_builder: &mut MessageRouterBuilder,
+        processor_manager_handle: Option<ProcessorsManagerHandle>,
+    ) -> Self {
+        let incoming_node_state = router_builder.subscribe_to_stream(2);
+
+        Self {
+            processor_manager_handle,
+            incoming_node_state,
+        }
+    }
+
+    pub fn start(self) -> anyhow::Result<()> {
+        let tc = task_center();
+        tc.spawn_child(TaskKind::RoleRunner, "base-role-service", None, async {
+            let cancelled = cancellation_watcher();
+
+            tokio::select! {
+                result = self.run() => {
+                    result
+                }
+                _ = cancelled =>{
+                    Ok(())
+                }
+            }
+        })
+        .context("Failed to start base service")?;
+
+        Ok(())
+    }
+
+    async fn run(mut self) -> anyhow::Result<()> {
+        while let Some(request) = self.incoming_node_state.next().await {
+            // handle request
+            self.handle_get_node_state(request).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_get_node_state(
+        &self,
+        msg: Incoming<GetNodeState>,
+    ) -> Result<(), ShutdownError> {
+        let parition_state = if let Some(ref handle) = self.processor_manager_handle {
+            Some(handle.get_state().await?)
+        } else {
+            None
+        };
+
+        // only return error if Shutdown
+        if let Err(NetworkError::Shutdown(err)) = msg
+            .to_rpc_response(NodeStateResponse {
+                paritions_processor_state: parition_state,
+            })
+            .try_send()
+            .map_err(|err| err.source)
+        {
+            return Err(err);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/node/src/roles/mod.rs
+++ b/crates/node/src/roles/mod.rs
@@ -9,7 +9,9 @@
 // by the Apache License, Version 2.0.
 
 mod admin;
+mod base;
 mod worker;
 
 pub use admin::{AdminRole, AdminRoleBuildError};
+pub use base::BaseRole;
 pub use worker::{WorkerRole, WorkerRoleBuildError};

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -15,6 +15,7 @@ use restate_bifrost::Bifrost;
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::Networking;
 use restate_core::network::TransportConnect;
+use restate_core::worker_api::ProcessorsManagerHandle;
 use restate_core::{cancellation_watcher, task_center, Metadata, MetadataKind};
 use restate_core::{ShutdownError, TaskKind};
 use restate_metadata_store::MetadataStoreClient;
@@ -92,6 +93,10 @@ impl<T: TransportConnect> WorkerRole<T> {
         .await?;
 
         Ok(WorkerRole { worker, metadata })
+    }
+
+    pub fn parition_processor_manager_handle(&self) -> ProcessorsManagerHandle {
+        self.worker.parition_processor_manager_handle()
     }
 
     pub fn storage_query_context(&self) -> &QueryContext {

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -69,6 +69,9 @@ enum TargetName {
   // Partition Processor
   PARTITION_CREATE_SNAPSHOT_REQUEST = 50;
   PARTITION_CREATE_SNAPSHOT_RESPONSE = 51;
+  // Node
+  NODE_GET_NODE_STATE_REQUEST = 60;
+  NODE_GET_NODE_STATE_RESPONSE = 61;
 }
 
 // ** Health & Per-role Status

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -15,6 +15,7 @@ pub mod ingress;
 #[cfg(feature = "replicated-loglet")]
 pub mod log_server;
 pub mod metadata;
+pub mod node;
 pub mod partition_processor_manager;
 #[cfg(feature = "replicated-loglet")]
 pub mod replicated_loglet;

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use super::TargetName;
+use crate::{cluster::cluster_state::PartitionProcessorStatus, identifiers::PartitionId};
+
+super::define_rpc! {
+    @request=GetNodeState,
+    @response=NodeStateResponse,
+    @request_target=TargetName::NodeGetNodeStateRequest,
+    @response_target=TargetName::NodeGetNodeStateResponse,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct GetNodeState {}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeStateResponse {
+    /// State of paritions processor per parition. Is set to None if this node is not a `Worker` node
+    #[serde_as(as = "Option<serde_with::Seq<(_, _)>>")]
+    pub paritions_processor_state: Option<BTreeMap<PartitionId, PartitionProcessorStatus>>,
+}


### PR DESCRIPTION
Node base Role that runs on all nodes to

Summary:
Introduce a new `base` role that is hosted
by all nodes. This allows to handle common
node related messages like `GetNodeState`

Fixes #2082

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2157).
* #2158
* __->__ #2157