### PR TITLE
Deprecate GetProcessorsState

### DIFF
--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -33,6 +33,7 @@ message Version { uint32 value = 1; }
 // The handle name or type tag of the message. For every target there must be
 // exactly one message handler implementation.
 enum TargetName {
+  reserved 7, 8;
   TargetName_UNKNOWN = 0;
   METADATA_MANAGER = 1;
   INGRESS = 2;
@@ -40,8 +41,6 @@ enum TargetName {
   LOCAL_METADATA_STORE_CLIENT = 4;
   ATTACH_REQUEST = 5;
   ATTACH_RESPONSE = 6;
-  GET_PROCESSORS_STATE_REQUEST = 7;
-  PROCESSORS_STATE_RESPONSE = 8;
   CONTROL_PROCESSORS = 9;
   // LogServer
   LOG_SERVER_STORE = 10;

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -8,34 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
-use crate::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
+use crate::cluster::cluster_state::RunMode;
 use crate::identifiers::{PartitionId, SnapshotId};
 use crate::net::{define_message, TargetName};
 
 use crate::net::define_rpc;
 use crate::Version;
-
-define_rpc! {
-    @request = GetProcessorsState,
-    @response = ProcessorsStateResponse,
-    @request_target = TargetName::GetProcessorsStateRequest,
-    @response_target = TargetName::ProcessorsStateResponse,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct GetProcessorsState {}
-
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProcessorsStateResponse {
-    #[serde_as(as = "serde_with::Seq<(_, _)>")]
-    pub state: BTreeMap<PartitionId, PartitionProcessorStatus>,
-}
 
 define_message! {
     @message = ControlProcessors,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -54,12 +54,9 @@ use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::cluster_controller::AttachRequest;
 use restate_types::net::cluster_controller::{Action, AttachResponse};
 use restate_types::net::metadata::MetadataKind;
+use restate_types::net::partition_processor_manager::CreateSnapshotRequest;
 use restate_types::net::partition_processor_manager::{
-    ControlProcessor, ControlProcessors, CreateSnapshotResponse, GetProcessorsState,
-    ProcessorCommand, SnapshotError,
-};
-use restate_types::net::partition_processor_manager::{
-    CreateSnapshotRequest, ProcessorsStateResponse,
+    ControlProcessor, ControlProcessors, CreateSnapshotResponse, ProcessorCommand, SnapshotError,
 };
 use restate_types::partition_table::PartitionTable;
 use restate_types::protobuf::common::WorkerStatus;
@@ -91,8 +88,6 @@ pub struct PartitionProcessorManager<T> {
     metadata_store_client: MetadataStoreClient,
     partition_store_manager: PartitionStoreManager,
     attach_router: RpcRouter<AttachRequest>,
-    incoming_get_state:
-        Pin<Box<dyn Stream<Item = Incoming<GetProcessorsState>> + Send + Sync + 'static>>,
     incoming_update_processors:
         Pin<Box<dyn Stream<Item = Incoming<ControlProcessors>> + Send + Sync + 'static>>,
     networking: Networking<T>,
@@ -391,7 +386,6 @@ impl<T: TransportConnect> PartitionProcessorManager<T> {
         bifrost: Bifrost,
     ) -> Self {
         let attach_router = RpcRouter::new(router_builder);
-        let incoming_get_state = router_builder.subscribe_to_stream(2);
         let incoming_update_processors = router_builder.subscribe_to_stream(2);
 
         let (tx, rx) = mpsc::channel(updateable_config.pinned().worker.internal_queue_length());
@@ -404,7 +398,6 @@ impl<T: TransportConnect> PartitionProcessorManager<T> {
             metadata,
             metadata_store_client,
             partition_store_manager,
-            incoming_get_state,
             incoming_update_processors,
             networking,
             bifrost,
@@ -508,9 +501,6 @@ impl<T: TransportConnect> PartitionProcessorManager<T> {
                 Some(command) = self.rx.recv() => {
                     self.on_command(command);
                 }
-                Some(get_state) = self.incoming_get_state.next() => {
-                    self.on_get_state(get_state);
-                }
                 Some(update_processors) = self.incoming_update_processors.next() => {
                     if let Err(err) = self.on_control_processors(update_processors).await {
                         warn!("failed processing control processors command: {err}");
@@ -579,23 +569,6 @@ impl<T: TransportConnect> PartitionProcessorManager<T> {
                 (*partition_id, status)
             })
             .collect()
-    }
-
-    fn on_get_state(&self, get_state_msg: Incoming<GetProcessorsState>) {
-        let state = self.get_state();
-
-        // ignore shutdown errors.
-        let _ = self.task_center.spawn(
-            restate_core::TaskKind::Disposable,
-            "get-processors-state-response",
-            None,
-            async move {
-                Ok(get_state_msg
-                    .to_rpc_response(ProcessorsStateResponse { state })
-                    .send()
-                    .await?)
-            },
-        );
     }
 
     fn on_command(&mut self, command: ProcessorsManagerCommand) {


### PR DESCRIPTION
Deprecate GetProcessorsState

Summary:
This is now handled by the GetNodeState which is more generic and is
supported by all nodes regardless if they are Workers or not
