### PR TITLE
Add restatectl nodes --extra mode with GetIdent server info

### DIFF
--- a/tools/restatectl/src/commands/node/list_nodes.rs
+++ b/tools/restatectl/src/commands/node/list_nodes.rs
@@ -8,11 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Context;
+use chrono::TimeDelta;
 use cling::prelude::*;
 use itertools::Itertools;
+use tokio::task::JoinSet;
 use tonic::codec::CompressionEncoding;
 
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
@@ -20,8 +22,12 @@ use restate_admin::cluster_controller::protobuf::ListNodesRequest;
 use restate_cli_util::_comfy_table::{Cell, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::{duration_to_human_rough, Tense};
+use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
+use restate_core::network::protobuf::node_svc::IdentResponse;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;
+use restate_types::PlainNodeId;
 
 use crate::app::ConnectionInfo;
 use crate::util::grpc_connect;
@@ -35,7 +41,7 @@ pub struct ListNodesOpts {
     pub(crate) extra: bool,
 }
 
-pub async fn list_nodes(connection: &ConnectionInfo, _opts: &ListNodesOpts) -> anyhow::Result<()> {
+pub async fn list_nodes(connection: &ConnectionInfo, opts: &ListNodesOpts) -> anyhow::Result<()> {
     let channel = grpc_connect(connection.cluster_controller.clone())
         .await
         .with_context(|| {
@@ -57,12 +63,26 @@ pub async fn list_nodes(connection: &ConnectionInfo, _opts: &ListNodesOpts) -> a
         StorageCodec::decode::<NodesConfiguration, _>(&mut response.nodes_configuration)?;
     let nodes = nodes_configuration.iter().collect::<BTreeMap<_, _>>();
 
+    let nodes_extra_info = if opts.extra {
+        fetch_extra_info(&nodes_configuration).await?
+    } else {
+        HashMap::new()
+    };
+
     c_println!("Node Configuration ({})", nodes_configuration.version());
 
     let mut nodes_table = Table::new_styled();
-    nodes_table.set_styled_header(vec!["NODE", "GEN", "NAME", "ADDRESS", "ROLES"]);
-    for (node_id, node_config) in nodes {
-        let node_row = vec![
+    let mut header = vec!["NODE", "GEN", "NAME", "ADDRESS", "ROLES"];
+    if opts.extra {
+        header.extend(vec![
+            "UPTIME", "STATUS", "ADMIN", "WORKER", "LOG-SVR", "META", "NODES-V", "LOGS-V",
+            "SCHEMA-V", "PART-V",
+        ]);
+    }
+    nodes_table.set_styled_header(header);
+
+    for (node_id, node_config) in nodes.clone() {
+        let mut node_row = vec![
             Cell::new(node_id.to_string()),
             Cell::new(node_config.current_generation.generation().to_string()),
             Cell::new(node_config.name.clone()),
@@ -77,9 +97,90 @@ pub async fn list_nodes(connection: &ConnectionInfo, _opts: &ListNodesOpts) -> a
                     .join(" | "),
             ),
         ];
+
+        if opts.extra {
+            node_row.extend(render_extra_columns(
+                nodes_extra_info.get(&node_id),
+                |ident_response| {
+                    vec![
+                        duration_to_human_rough(
+                            TimeDelta::seconds(ident_response.age_s as i64),
+                            Tense::Present,
+                        ),
+                        // We reuse the prost-generated Debug formatting but cut out the "Unknown"s
+                        format!("{:?}", ident_response.status()).replace("Unknown", "-"),
+                        format!("{:?}", ident_response.admin_status()).replace("Unknown", "-"),
+                        format!("{:?}", ident_response.worker_status()).replace("Unknown", "-"),
+                        format!("{:?}", ident_response.log_server_status()).replace("Unknown", "-"),
+                        format!("{:?}", ident_response.metadata_server_status())
+                            .replace("Unknown", "-"),
+                        format!("{}", ident_response.nodes_config_version),
+                        format!("{}", ident_response.logs_version),
+                        format!("{}", ident_response.schema_version),
+                        format!("{}", ident_response.partition_table_version),
+                    ]
+                    .iter()
+                    .map(Cell::new)
+                    .collect()
+                },
+            ));
+        }
         nodes_table.add_row(node_row);
     }
     c_println!("{}", nodes_table);
 
     Ok(())
+}
+
+fn render_extra_columns<F>(ident_response: Option<&IdentResponse>, f: F) -> Vec<Cell>
+where
+    F: FnOnce(&IdentResponse) -> Vec<Cell>,
+{
+    ident_response
+        .map(f)
+        .unwrap_or(vec![Cell::new("N/A"), Cell::new("Unknown")])
+}
+
+async fn fetch_extra_info(
+    nodes_configuration: &NodesConfiguration,
+) -> anyhow::Result<HashMap<PlainNodeId, IdentResponse>> {
+    let mut get_ident_tasks = JoinSet::<anyhow::Result<IdentResponse>>::new();
+
+    for (node_id, node_config) in nodes_configuration.iter() {
+        let address = node_config.address.clone();
+        let get_ident = async move {
+            let node_channel = grpc_connect(address).await?;
+            let mut node_svc_client =
+                NodeSvcClient::new(node_channel).accept_compressed(CompressionEncoding::Gzip);
+
+            Ok(node_svc_client
+                .get_ident(())
+                .await
+                .map_err(|e| {
+                    // we ignore individual errors in table rendering so this is the only place to log them
+                    c_println!("failed to call GetIdent for node {}: {:?}", node_id, e);
+                    anyhow::anyhow!(e)
+                })?
+                .into_inner())
+        };
+        get_ident_tasks.spawn(async move {
+            match tokio::time::timeout(std::time::Duration::from_secs(1), get_ident).await {
+                Ok(res) => res,
+                Err(e) => {
+                    c_println!("timeout calling GetIdent for node {}", node_id);
+                    Err(e.into())
+                }
+            }
+        });
+    }
+
+    let mut ident_responses = HashMap::new();
+    while let Some(Ok(Ok(ident_response))) = get_ident_tasks.join_next().await {
+        ident_responses.insert(
+            PlainNodeId::from(ident_response.node_id.expect("has node_id").id),
+            ident_response,
+        );
+    }
+
+    Ok(ident_responses)
 }


### PR DESCRIPTION
A new optional argument augments the node list table with additional metadata from all reachable nodes obtained from the NodeSvc::GetIdent operation.

Sample output:

```
> restatectl nodes list --extra
Node Configuration (v11)
 NODE  GEN  NAME           ADDRESS                                                                 ROLES                  UPTIME   STATUS   ADMIN  WORKER  LOG-SVR  META   NODES-V  LOGS-V  SCHEMA-V  PART-V
 N1    2    metadata-node  unix:/Users/pavel/restate/restate/restate-data/metadata-node/node.sock  Admin | MetadataStore  5 hours  Alive    Ready  -       -        Ready  11       6       0         1
 N2    2    node-1         unix:/Users/pavel/restate/restate/restate-data/node-1/node.sock         LogServer | Worker     5 hours  Alive    -      Ready   Ready    -      11       6       0         1
 N3    2    node-2         unix:/Users/pavel/restate/restate/restate-data/node-2/node.sock         LogServer | Worker     5 hours  Alive    -      Ready   Ready    -      11       6       0         1
 N4    2    node-3         unix:/Users/pavel/restate/restate/restate-data/node-3/node.sock         LogServer | Worker     N/A      Unknown
```

Note that N4 is intentionally down to demonstrate unreachable server display.