### PR TITLE
Stablize CI tests

### DIFF
--- a/crates/local-cluster-runner/src/lib.rs
+++ b/crates/local-cluster-runner/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs,
     future::Future,
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
@@ -9,6 +10,12 @@ use tracing::info;
 
 pub mod cluster;
 pub mod node;
+
+/// Used to store marker files of "used" ports to avoid confilcts
+///
+/// Please make sure the path `$TMP_DIR/restate_test_ports` is deleted
+/// before starting tests
+const PORTS_POOL: &str = "restate_test_ports";
 
 pub fn shutdown() -> impl Future<Output = &'static str> {
     let mut interrupt = tokio::signal::unix::signal(SignalKind::interrupt())
@@ -28,8 +35,32 @@ pub fn shutdown() -> impl Future<Output = &'static str> {
 }
 
 pub fn random_socket_address() -> io::Result<SocketAddr> {
-    let listener = TcpListener::bind((IpAddr::V4(Ipv4Addr::LOCALHOST), 0))?;
-    let socket_addr = listener.local_addr()?;
+    let base_path = std::env::temp_dir().join(PORTS_POOL);
+    // this can happen repeatedly but it's a test so it's okay
+    fs::create_dir_all(&base_path)?;
 
-    Ok(socket_addr)
+    loop {
+        let listener = TcpListener::bind((IpAddr::V4(Ipv4Addr::LOCALHOST), 0))?;
+        let socket_addr = listener.local_addr()?;
+
+        let port_file = base_path.join(socket_addr.port().to_string());
+        match fs::metadata(&port_file) {
+            Ok(_) => {
+                // file exists! try again
+                continue;
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                // touch the file
+                fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .create_new(true)
+                    .write(true)
+                    .open(port_file)?;
+
+                return Ok(socket_addr);
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }

--- a/justfile
+++ b/justfile
@@ -119,6 +119,8 @@ run *flags: (_target-installed target)
     cargo run {{ _target-option }} {{ flags }}
 
 test: (_target-installed target)
+    # remove possible old test ports
+    rm -rf /tmp/restate_test_ports
     cargo nextest run {{ _target-option }} --all-features --target-dir target/tests
 
 test-package package *flags:


### PR DESCRIPTION
Stablize CI tests

Summary:
This fixes the issue with ports conflicts by marking used
ports under /tmp/restate_test_ports
