### PR TITLE
[Code Style] Switch to rustfmt nightly and configure import formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: nightly,stable # last is default
           components: clippy
           rustflags: ""
           cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly,stable # last is default
-          components: clippy
+          components: clippy,rustfmt
           rustflags: ""
           cache: false
 

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/benchmarks/benches/throughput_parallel.rs
+++ b/benchmarks/benches/throughput_parallel.rs
@@ -12,18 +12,14 @@
 //! running on localhost:9080 in order to run.
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use futures_util::stream::FuturesUnordered;
-use futures_util::StreamExt;
-use http::header::CONTENT_TYPE;
-use http::Uri;
+use futures_util::{stream::FuturesUnordered, StreamExt};
+use http::{header::CONTENT_TYPE, Uri};
 use pprof::criterion::{Output, PProfProfiler};
 use rand::distributions::{Alphanumeric, DistString};
 use restate_benchmarks::{parse_benchmark_settings, BenchmarkSettings};
 use restate_rocksdb::RocksDbManager;
 use tokio::runtime::Builder;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 fn throughput_benchmark(criterion: &mut Criterion) {
     tracing_subscriber::registry()

--- a/benchmarks/benches/throughput_sequential.rs
+++ b/benchmarks/benches/throughput_sequential.rs
@@ -12,14 +12,11 @@
 //! running on localhost:9080 in order to run.
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use http::header::CONTENT_TYPE;
-use http::Uri;
+use http::{header::CONTENT_TYPE, Uri};
 use pprof::criterion::{Output, PProfProfiler};
 use restate_rocksdb::RocksDbManager;
 use tokio::runtime::Builder;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 fn throughput_benchmark(criterion: &mut Criterion) {
     tracing_subscriber::registry()

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -11,22 +11,20 @@
 #![allow(clippy::async_yields_async)]
 
 //! Utilities for benchmarking the Restate runtime
-use std::num::NonZeroU16;
-use std::time::Duration;
+use std::{num::NonZeroU16, time::Duration};
 
 use futures_util::{future, TryFutureExt};
-use http::header::CONTENT_TYPE;
-use http::Uri;
+use http::{header::CONTENT_TYPE, Uri};
 use pprof::flamegraph::Options;
 use restate_core::{TaskCenter, TaskCenterBuilder, TaskKind};
 use restate_node::Node;
 use restate_rocksdb::RocksDbManager;
-use restate_types::config::{
-    CommonOptionsBuilder, Configuration, ConfigurationBuilder, WorkerOptionsBuilder,
+use restate_types::{
+    config::{CommonOptionsBuilder, Configuration, ConfigurationBuilder, WorkerOptionsBuilder},
+    config_loader::ConfigLoaderBuilder,
+    live::Constant,
+    retries::RetryPolicy,
 };
-use restate_types::config_loader::ConfigLoaderBuilder;
-use restate_types::live::Constant;
-use restate_types::retries::RetryPolicy;
 use tokio::runtime::Runtime;
 use tracing::warn;
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::error::Error;
+
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -11,12 +11,13 @@
 use anyhow::Result;
 use cling::prelude::*;
 use figment::Profile;
+use restate_cli_util::{CliContext, CommonOpts};
 use tracing::info;
 
-use restate_cli_util::{CliContext, CommonOpts};
-
-use crate::cli_env::{CliEnv, EnvironmentSource};
-use crate::commands::*;
+use crate::{
+    cli_env::{CliEnv, EnvironmentSource},
+    commands::*,
+};
 
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]

--- a/cli/src/cli_env.rs
+++ b/cli/src/cli_env.rs
@@ -10,16 +10,19 @@
 
 //! Resolves restate's CLI default data/config directory paths
 
-use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, Result};
-use figment::providers::{Format, Serialized, Toml};
-use figment::{Figment, Profile};
+use figment::{
+    providers::{Format, Serialized, Toml},
+    Figment, Profile,
+};
+use restate_cli_util::OsEnv;
 use serde::{Deserialize, Serialize};
 use url::Url;
-
-use restate_cli_util::OsEnv;
 
 use crate::app::GlobalOpts;
 

--- a/cli/src/clients/admin_client.rs
+++ b/cli/src/clients/admin_client.rs
@@ -10,21 +10,19 @@
 
 //! A wrapper client for admin HTTP service.
 
+use std::time::Duration;
+
 use anyhow::bail;
 use http::StatusCode;
 use restate_admin_rest_model::version::{AdminApiVersion, VersionInformation};
 use restate_cli_util::{c_warn, CliContext};
 use serde::{de::DeserializeOwned, Serialize};
-use std::time::Duration;
 use thiserror::Error;
 use tracing::{debug, info};
 use url::Url;
 
-use crate::build_info;
-use crate::cli_env::CliEnv;
-use crate::clients::AdminClientInterface;
-
 use super::errors::ApiError;
+use crate::{build_info, cli_env::CliEnv, clients::AdminClientInterface};
 
 /// Min/max supported admin API versions
 pub const MIN_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V1;

--- a/cli/src/clients/admin_interface.rs
+++ b/cli/src/clients/admin_interface.rs
@@ -9,13 +9,10 @@
 // by the Apache License, Version 2.0.
 use std::fmt::Display;
 
-use super::admin_client::Envelope;
-use super::AdminClient;
-
-use restate_admin_rest_model::deployments::*;
-use restate_admin_rest_model::services::*;
-use restate_admin_rest_model::version::VersionInformation;
+use restate_admin_rest_model::{deployments::*, services::*, version::VersionInformation};
 use restate_types::schema::service::ServiceMetadata;
+
+use super::{admin_client::Envelope, AdminClient};
 
 pub trait AdminClientInterface {
     /// Check if the admin service is healthy by invoking /health

--- a/cli/src/clients/cloud/client.rs
+++ b/cli/src/clients/cloud/client.rs
@@ -13,17 +13,14 @@
 use std::time::Duration;
 
 use http::StatusCode;
+use restate_cli_util::CliContext;
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 use tracing::{debug, info};
 use url::Url;
 
-use restate_cli_util::CliContext;
-
-use crate::build_info;
-use crate::cli_env::CliEnv;
-
 use super::super::errors::ApiError;
+use crate::{build_info, cli_env::CliEnv};
 
 #[derive(Error, Debug)]
 #[error(transparent)]

--- a/cli/src/clients/cloud/interface.rs
+++ b/cli/src/clients/cloud/interface.rs
@@ -8,9 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::client::Envelope;
-
-use super::{generated::*, CloudClient};
+use super::{client::Envelope, generated::*, CloudClient};
 
 pub trait CloudClientInterface {
     async fn list_accounts(&self) -> reqwest::Result<Envelope<ListAccountsResponse>>;

--- a/cli/src/clients/cloud/mod.rs
+++ b/cli/src/clients/cloud/mod.rs
@@ -11,8 +11,7 @@
 mod client;
 mod interface;
 
-pub use self::client::CloudClient;
-pub use self::interface::CloudClientInterface;
+pub use self::{client::CloudClient, interface::CloudClientInterface};
 
 pub mod generated {
     #![allow(clippy::to_string_trait_impl)]

--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -10,23 +10,23 @@
 
 //! A set of common queries needed by the CLI
 
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::str::FromStr;
+use std::{collections::HashMap, fmt::Display, str::FromStr};
 
 use anyhow::Result;
-use arrow::array::{Array, ArrayAccessor, AsArray, StringArray};
-use arrow::datatypes::{ArrowTemporalType, Date64Type};
-use arrow::record_batch::RecordBatch;
+use arrow::{
+    array::{Array, ArrayAccessor, AsArray, StringArray},
+    datatypes::{ArrowTemporalType, Date64Type},
+    record_batch::RecordBatch,
+};
 use arrow_convert::{ArrowDeserialize, ArrowField};
 use bytes::Bytes;
 use chrono::{DateTime, Duration, Local, TimeZone};
 use clap::ValueEnum;
-
 use restate_service_protocol::awakeable_id::AwakeableIdentifier;
-use restate_types::identifiers::DeploymentId;
-use restate_types::identifiers::{InvocationId, ServiceId};
-use restate_types::invocation::ServiceType;
+use restate_types::{
+    identifiers::{DeploymentId, InvocationId, ServiceId},
+    invocation::ServiceType,
+};
 
 use super::DataFusionHttpClient;
 

--- a/cli/src/clients/datafusion_http_client.rs
+++ b/cli/src/clients/datafusion_http_client.rs
@@ -10,22 +10,25 @@
 
 //! A wrapper client for the datafusion HTTP service.
 
-use super::errors::ApiError;
-
-use crate::cli_env::CliEnv;
-use crate::clients::AdminClient;
-use arrow::array::{AsArray, StructArray};
-use arrow::datatypes::{ArrowPrimitiveType, Int64Type, SchemaRef};
-use arrow::error::ArrowError;
-use arrow::ipc::reader::StreamReader;
-use arrow::record_batch::RecordBatch;
-use arrow_convert::deserialize::{arrow_array_deserialize_iterator, ArrowDeserialize};
-use arrow_convert::field::ArrowField;
+use arrow::{
+    array::{AsArray, StructArray},
+    datatypes::{ArrowPrimitiveType, Int64Type, SchemaRef},
+    error::ArrowError,
+    ipc::reader::StreamReader,
+    record_batch::RecordBatch,
+};
+use arrow_convert::{
+    deserialize::{arrow_array_deserialize_iterator, ArrowDeserialize},
+    field::ArrowField,
+};
 use bytes::Buf;
 use itertools::Itertools;
 use serde::Serialize;
 use thiserror::Error;
 use tracing::{debug, info};
+
+use super::errors::ApiError;
+use crate::{cli_env::CliEnv, clients::AdminClient};
 
 #[derive(Error, Debug)]
 #[error(transparent)]

--- a/cli/src/clients/errors.rs
+++ b/cli/src/clients/errors.rs
@@ -8,10 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_cli_util::ui::stylesheet::Style;
 use serde::Deserialize;
 use url::Url;
-
-use restate_cli_util::ui::stylesheet::Style;
 
 use crate::console::Styled;
 

--- a/cli/src/clients/mod.rs
+++ b/cli/src/clients/mod.rs
@@ -16,8 +16,10 @@ pub mod datafusion_helpers;
 mod datafusion_http_client;
 mod errors;
 
-pub use self::admin_client::AdminClient;
-pub use self::admin_client::Error as MetasClientError;
-pub use self::admin_client::{MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION};
-pub use self::admin_interface::AdminClientInterface;
-pub use self::datafusion_http_client::DataFusionHttpClient;
+pub use self::{
+    admin_client::{
+        AdminClient, Error as MetasClientError, MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION,
+    },
+    admin_interface::AdminClientInterface,
+    datafusion_http_client::DataFusionHttpClient,
+};

--- a/cli/src/commands/cloud/environments/configure.rs
+++ b/cli/src/commands/cloud/environments/configure.rs
@@ -14,9 +14,8 @@ use anyhow::{Context, Result};
 use cling::prelude::*;
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use toml_edit::{table, value, DocumentMut};
-
 use restate_cli_util::{c_error, c_success};
+use toml_edit::{table, value, DocumentMut};
 
 use crate::{
     cli_env::CliEnv,

--- a/cli/src/commands/cloud/environments/tunnel/local.rs
+++ b/cli/src/commands/cloud/environments/tunnel/local.rs
@@ -8,18 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
-use std::future::Future;
-
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::Result;
 use http::{Request, StatusCode, Uri};
 use http_body_util::BodyExt;
-use hyper::body::Incoming;
-use hyper::Response;
+use hyper::{body::Incoming, Response};
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use reqwest::Body;
@@ -31,10 +31,8 @@ use tower::Service;
 use tracing::{error, info};
 use url::Url;
 
-use crate::cli_env::CliEnv;
-use crate::clients::cloud::generated::DescribeEnvironmentResponse;
-
 use super::renderer::{LocalRenderer, TunnelRenderer};
+use crate::{cli_env::CliEnv, clients::cloud::generated::DescribeEnvironmentResponse};
 
 pub(crate) async fn run_local(
     env: &CliEnv,

--- a/cli/src/commands/cloud/environments/tunnel/mod.rs
+++ b/cli/src/commands/cloud/environments/tunnel/mod.rs
@@ -8,21 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use cling::prelude::*;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use remote::RemotePort;
+use restate_cli_util::CliContext;
 use tokio_util::sync::CancellationToken;
 
-use restate_cli_util::CliContext;
-
-use crate::cli_env::EnvironmentType;
-use crate::clients::cloud::{CloudClient, CloudClientInterface};
-use crate::{build_info, cli_env::CliEnv};
+use crate::{
+    build_info,
+    cli_env::{CliEnv, EnvironmentType},
+    clients::cloud::{CloudClient, CloudClientInterface},
+};
 
 mod local;
 mod remote;

--- a/cli/src/commands/cloud/environments/tunnel/renderer.rs
+++ b/cli/src/commands/cloud/environments/tunnel/renderer.rs
@@ -8,24 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::hash::Hasher;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::OnceLock;
-use std::{io::Write, sync::Arc};
+use std::{
+    hash::Hasher,
+    io::Write,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, OnceLock,
+    },
+};
 
 use arc_swap::ArcSwapOption;
 use comfy_table::{Cell, Table};
-use crossterm::cursor::MoveTo;
-use crossterm::execute;
 use crossterm::{
-    queue,
+    cursor::MoveTo,
+    execute, queue,
     terminal::{BeginSynchronizedUpdate, Clear, ClearType},
 };
-
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::output::Console;
-use restate_cli_util::ui::stylesheet;
-use restate_cli_util::{c_indent_table, c_println, c_tip, c_warn, CliContext};
+use restate_cli_util::{
+    c_indent_table, c_println, c_tip, c_warn,
+    ui::{console::StyledTable, output::Console, stylesheet},
+    CliContext,
+};
 
 use super::remote::RemotePort;
 

--- a/cli/src/commands/cloud/environments/tunnel/request_identity.rs
+++ b/cli/src/commands/cloud/environments/tunnel/request_identity.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashSet;
+
 use http::HeaderMap;
 use serde::Deserialize;
-use std::collections::HashSet;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{cli_env::CliEnv, console};
 use anyhow::Result;
 use cling::prelude::*;
+
+use crate::{cli_env::CliEnv, console};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_edit")]

--- a/cli/src/commands/config/list_environments.rs
+++ b/cli/src/commands/config/list_environments.rs
@@ -15,7 +15,6 @@ use figment::{
     providers::{Format, Serialized, Toml},
     Figment, Profile,
 };
-
 use restate_cli_util::c_println;
 
 use crate::{

--- a/cli/src/commands/config/use_environment.rs
+++ b/cli/src/commands/config/use_environment.rs
@@ -10,7 +10,6 @@
 
 use anyhow::Result;
 use cling::prelude::*;
-
 use restate_cli_util::c_success;
 
 use crate::cli_env::CliEnv;

--- a/cli/src/commands/config/view.rs
+++ b/cli/src/commands/config/view.rs
@@ -10,7 +10,6 @@
 
 use anyhow::Result;
 use cling::prelude::*;
-
 use restate_cli_util::c_println;
 
 use crate::{cli_env::CliEnv, console};

--- a/cli/src/commands/deployments/describe.rs
+++ b/cli/src/commands/deployments/describe.rs
@@ -13,22 +13,31 @@ use std::collections::HashMap;
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
-
 use restate_admin_rest_model::deployments::ServiceNameRevPair;
-use restate_cli_util::ui::console::{Styled, StyledTable};
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::ui::watcher::Watch;
-use restate_cli_util::{c_eprintln, c_indent_table, c_indentln, c_println, c_title};
+use restate_cli_util::{
+    c_eprintln, c_indent_table, c_indentln, c_println, c_title,
+    ui::{
+        console::{Styled, StyledTable},
+        stylesheet::Style,
+        watcher::Watch,
+    },
+};
 use restate_types::schema::service::ServiceMetadata;
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::count_deployment_active_inv_by_method;
-use crate::clients::{AdminClient, AdminClientInterface};
-use crate::ui::deployments::{
-    add_deployment_to_kv_table, calculate_deployment_status, render_active_invocations,
-    render_deployment_status,
+use crate::{
+    cli_env::CliEnv,
+    clients::{
+        datafusion_helpers::count_deployment_active_inv_by_method, AdminClient,
+        AdminClientInterface,
+    },
+    ui::{
+        deployments::{
+            add_deployment_to_kv_table, calculate_deployment_status, render_active_invocations,
+            render_deployment_status,
+        },
+        service_handlers::icon_for_service_type,
+    },
 };
-use crate::ui::service_handlers::icon_for_service_type;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_describe")]

--- a/cli/src/commands/deployments/list.rs
+++ b/cli/src/commands/deployments/list.rs
@@ -13,22 +13,25 @@ use std::collections::HashMap;
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
-
 use restate_admin_rest_model::deployments::{Deployment, DeploymentResponse, ServiceNameRevPair};
-use restate_cli_util::c_error;
-use restate_cli_util::ui::console::{Styled, StyledTable};
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::ui::watcher::Watch;
-use restate_types::identifiers::DeploymentId;
-use restate_types::schema::service::ServiceMetadata;
+use restate_cli_util::{
+    c_error,
+    ui::{
+        console::{Styled, StyledTable},
+        stylesheet::Style,
+        watcher::Watch,
+    },
+};
+use restate_types::{identifiers::DeploymentId, schema::service::ServiceMetadata};
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::count_deployment_active_inv;
-use crate::clients::AdminClientInterface;
-use crate::console::c_println;
-use crate::ui::deployments::{
-    calculate_deployment_status, render_active_invocations, render_deployment_status,
-    render_deployment_type, render_deployment_url, DeploymentStatus,
+use crate::{
+    cli_env::CliEnv,
+    clients::{datafusion_helpers::count_deployment_active_inv, AdminClientInterface},
+    console::c_println,
+    ui::deployments::{
+        calculate_deployment_status, render_active_invocations, render_deployment_status,
+        render_deployment_type, render_deployment_url, DeploymentStatus,
+    },
 };
 
 #[derive(Run, Parser, Collect, Clone)]

--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -8,29 +8,38 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
-use std::str::FromStr;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+    str::FromStr,
+};
 
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::Table;
 use http::{HeaderName, HeaderValue, StatusCode, Uri};
 use indicatif::ProgressBar;
-
 use restate_admin_rest_model::deployments::{Deployment, RegisterDeploymentRequest};
-use restate_cli_util::ui::console::{confirm_or_exit, Styled, StyledTable};
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::{c_eprintln, c_error, c_indent_table, c_indentln, c_success, c_warn};
-use restate_types::identifiers::LambdaARN;
-use restate_types::schema::service::ServiceMetadata;
+use restate_cli_util::{
+    c_eprintln, c_error, c_indent_table, c_indentln, c_success, c_warn,
+    ui::{
+        console::{confirm_or_exit, Styled, StyledTable},
+        stylesheet::Style,
+    },
+};
+use restate_types::{identifiers::LambdaARN, schema::service::ServiceMetadata};
 
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface, MetasClientError};
-use crate::console::c_println;
-use crate::ui::deployments::render_deployment_url;
-use crate::ui::service_handlers::{
-    create_service_handlers_table, create_service_handlers_table_diff, icon_for_service_type,
+use crate::{
+    cli_env::CliEnv,
+    clients::{AdminClient, AdminClientInterface, MetasClientError},
+    console::c_println,
+    ui::{
+        deployments::render_deployment_url,
+        service_handlers::{
+            create_service_handlers_table, create_service_handlers_table_diff,
+            icon_for_service_type,
+        },
+    },
 };
 
 #[derive(Run, Parser, Collect, Clone)]

--- a/cli/src/commands/deployments/remove.rs
+++ b/cli/src/commands/deployments/remove.rs
@@ -14,22 +14,31 @@ use anyhow::{bail, Result};
 use cling::prelude::*;
 use comfy_table::Table;
 use indoc::indoc;
-
 use restate_admin_rest_model::deployments::ServiceNameRevPair;
-use restate_cli_util::ui::console::{confirm_or_exit, Styled, StyledTable};
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::{c_eprintln, c_error, c_indentln, c_success};
+use restate_cli_util::{
+    c_eprintln, c_error, c_indentln, c_success,
+    ui::{
+        console::{confirm_or_exit, Styled, StyledTable},
+        stylesheet::Style,
+    },
+};
 use restate_types::schema::service::ServiceMetadata;
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::count_deployment_active_inv_by_method;
-use crate::clients::{AdminClient, AdminClientInterface};
-use crate::console::c_println;
-use crate::ui::deployments::{
-    add_deployment_to_kv_table, calculate_deployment_status, render_active_invocations,
-    render_deployment_status,
+use crate::{
+    cli_env::CliEnv,
+    clients::{
+        datafusion_helpers::count_deployment_active_inv_by_method, AdminClient,
+        AdminClientInterface,
+    },
+    console::c_println,
+    ui::{
+        deployments::{
+            add_deployment_to_kv_table, calculate_deployment_status, render_active_invocations,
+            render_deployment_status,
+        },
+        service_handlers::icon_for_service_type,
+    },
 };
-use crate::ui::service_handlers::icon_for_service_type;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[clap(visible_alias = "rm")]

--- a/cli/src/commands/examples.rs
+++ b/cli/src/commands/examples.rs
@@ -8,22 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::fmt;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use cling::prelude::*;
 use convert_case::{Case, Casing};
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::Select;
+use dialoguer::{theme::ColorfulTheme, Select};
 use futures::StreamExt;
-use octocrab::models::repos::Asset;
-use octocrab::repos::RepoHandler;
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
-
+use octocrab::{models::repos::Asset, repos::RepoHandler};
 use restate_cli_util::ui::stylesheet::Style;
+use tokio::{fs::File, io::AsyncWriteExt};
 
 use crate::console::{c_println, Styled};
 

--- a/cli/src/commands/invocations/cancel.rs
+++ b/cli/src/commands/invocations/cancel.rs
@@ -9,16 +9,20 @@
 // by the Apache License, Version 2.0.
 use anyhow::{bail, Result};
 use cling::prelude::*;
-
-use restate_cli_util::ui::console::{confirm_or_exit, Styled};
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::{c_println, c_success};
+use restate_cli_util::{
+    c_println, c_success,
+    ui::{
+        console::{confirm_or_exit, Styled},
+        stylesheet::Style,
+    },
+};
 use restate_types::identifiers::InvocationId;
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::find_active_invocations_simple;
-use crate::clients::{self, AdminClientInterface};
-use crate::ui::invocations::render_simple_invocation_list;
+use crate::{
+    cli_env::CliEnv,
+    clients::{self, datafusion_helpers::find_active_invocations_simple, AdminClientInterface},
+    ui::invocations::render_simple_invocation_list,
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_cancel")]

--- a/cli/src/commands/invocations/describe.rs
+++ b/cli/src/commands/invocations/describe.rs
@@ -13,16 +13,19 @@ use cling::prelude::*;
 use comfy_table::Table;
 use dialoguer::console::style;
 use indoc::indoc;
+use restate_cli_util::{
+    c_println, c_tip, c_title,
+    ui::{console::StyledTable, duration_to_human_rough, watcher::Watch},
+};
 
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::duration_to_human_rough;
-use restate_cli_util::ui::watcher::Watch;
-use restate_cli_util::{c_println, c_tip, c_title};
-
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::{get_invocation, get_invocation_journal, InvocationState};
-use crate::clients::{self};
-use crate::ui::invocations::{add_invocation_to_kv_table, format_journal_entry, invocation_status};
+use crate::{
+    cli_env::CliEnv,
+    clients::{
+        datafusion_helpers::{get_invocation, get_invocation_journal, InvocationState},
+        {self},
+    },
+    ui::invocations::{add_invocation_to_kv_table, format_journal_entry, invocation_status},
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_describe")]

--- a/cli/src/commands/invocations/list.rs
+++ b/cli/src/commands/invocations/list.rs
@@ -8,22 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
-use std::time::Instant;
+use std::{collections::HashSet, time::Instant};
 
 use anyhow::Result;
 use cling::prelude::*;
 use indicatif::ProgressBar;
 use itertools::Itertools;
+use restate_cli_util::{
+    c_eprintln,
+    ui::{console::Styled, stylesheet::Style, watcher::Watch},
+};
 
-use restate_cli_util::c_eprintln;
-use restate_cli_util::ui::console::Styled;
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::ui::watcher::Watch;
-
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::{find_active_invocations, InvocationState};
-use crate::ui::invocations::render_invocation_compact;
+use crate::{
+    cli_env::CliEnv,
+    clients::datafusion_helpers::{find_active_invocations, InvocationState},
+    ui::invocations::render_invocation_compact,
+};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(visible_alias = "ls")]

--- a/cli/src/commands/invocations/purge.rs
+++ b/cli/src/commands/invocations/purge.rs
@@ -8,16 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::find_active_invocations_simple;
-use crate::clients::{self, AdminClientInterface};
-use crate::ui::invocations::render_simple_invocation_list;
-
 use anyhow::{bail, Result};
 use cling::prelude::*;
-use restate_cli_util::ui::console::confirm_or_exit;
-use restate_cli_util::{c_println, c_success};
+use restate_cli_util::{c_println, c_success, ui::console::confirm_or_exit};
 use restate_types::identifiers::InvocationId;
+
+use crate::{
+    cli_env::CliEnv,
+    clients::{self, datafusion_helpers::find_active_invocations_simple, AdminClientInterface},
+    ui::invocations::render_simple_invocation_list,
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_purge")]

--- a/cli/src/commands/services/config/edit.rs
+++ b/cli/src/commands/services/config/edit.rs
@@ -8,15 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface};
+use std::{fs::File, io};
+
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use restate_admin_rest_model::services::ModifyServiceRequest;
 use restate_types::invocation::ServiceType;
-use std::fs::File;
-use std::io;
 use tempfile::tempdir;
+
+use crate::{
+    cli_env::CliEnv,
+    clients::{AdminClient, AdminClientInterface},
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_edit")]

--- a/cli/src/commands/services/config/patch.rs
+++ b/cli/src/commands/services/config/patch.rs
@@ -8,16 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface};
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::Table;
 use const_format::concatcp;
 use restate_admin_rest_model::services::ModifyServiceRequest;
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
+use restate_cli_util::{
+    c_println,
+    ui::console::{confirm_or_exit, StyledTable},
+};
 use restate_serde_util::DurationString;
+
+use crate::{
+    cli_env::CliEnv,
+    clients::{AdminClient, AdminClientInterface},
+};
 
 pub(super) const DURATION_EDIT_DESCRIPTION: &str = "Can be configured using the humantime format (https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) or the ISO8601.";
 pub(super) const IDEMPOTENCY_RETENTION_EDIT_DESCRIPTION: &str = concatcp!(

--- a/cli/src/commands/services/config/view.rs
+++ b/cli/src/commands/services/config/view.rs
@@ -75,7 +75,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
 
     let mut table = Table::new_styled();
     table.add_kv_row("Name:", &service.name);
-    table.add_kv_row("Service type:", &format!("{:?}", service.ty));
+    table.add_kv_row("Service type:", format!("{:?}", service.ty));
     c_println!("{table}");
     c_println!();
 

--- a/cli/src/commands/services/config/view.rs
+++ b/cli/src/commands/services/config/view.rs
@@ -8,15 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface};
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::Table;
 use indoc::indoc;
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::{c_println, c_tip};
+use restate_cli_util::{c_println, c_tip, ui::console::StyledTable};
 use restate_types::invocation::ServiceType;
+
+use crate::{
+    cli_env::CliEnv,
+    clients::{AdminClient, AdminClientInterface},
+};
 
 // TODO we could infer this text from the OpenAPI docs!
 pub(super) const PUBLIC_DESCRIPTION: &str = indoc! {

--- a/cli/src/commands/services/describe.rs
+++ b/cli/src/commands/services/describe.rs
@@ -50,7 +50,7 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
 
     let mut table = Table::new_styled();
     table.add_kv_row("Name:", &service.name);
-    table.add_kv_row("Service type:", &format!("{:?}", service.ty));
+    table.add_kv_row("Service type:", format!("{:?}", service.ty));
     table.add_kv_row("Revision:", service.revision);
     table.add_kv_row("Public:", service.public);
     table.add_kv_row("Deployment ID:", service.deployment_id);

--- a/cli/src/commands/services/describe.rs
+++ b/cli/src/commands/services/describe.rs
@@ -8,23 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
 use indicatif::ProgressBar;
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::watcher::Watch;
-use restate_cli_util::{c_println, c_title};
-
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::count_deployment_active_inv;
-use crate::clients::{AdminClient, AdminClientInterface};
-use crate::ui::deployments::{
-    add_deployment_to_kv_table, render_active_invocations, render_deployment_type,
-    render_deployment_url,
+use restate_cli_util::{
+    c_println, c_title,
+    ui::{console::StyledTable, watcher::Watch},
 };
-use crate::ui::service_handlers::create_service_handlers_table;
 
-use anyhow::Result;
+use crate::{
+    cli_env::CliEnv,
+    clients::{datafusion_helpers::count_deployment_active_inv, AdminClient, AdminClientInterface},
+    ui::{
+        deployments::{
+            add_deployment_to_kv_table, render_active_invocations, render_deployment_type,
+            render_deployment_url,
+        },
+        service_handlers::create_service_handlers_table,
+    },
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_describe")]

--- a/cli/src/commands/services/list.rs
+++ b/cli/src/commands/services/list.rs
@@ -13,18 +13,21 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::Table;
-
 use restate_admin_rest_model::deployments::DeploymentResponse;
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::watcher::Watch;
-use restate_cli_util::{c_error, c_println};
-use restate_types::identifiers::DeploymentId;
-use restate_types::schema::service::HandlerMetadata;
+use restate_cli_util::{
+    c_error, c_println,
+    ui::{console::StyledTable, watcher::Watch},
+};
+use restate_types::{identifiers::DeploymentId, schema::service::HandlerMetadata};
 
-use crate::cli_env::CliEnv;
-use crate::clients::AdminClientInterface;
-use crate::ui::deployments::{render_deployment_type, render_deployment_url};
-use crate::ui::service_handlers::{icon_for_is_public, icon_for_service_type};
+use crate::{
+    cli_env::CliEnv,
+    clients::AdminClientInterface,
+    ui::{
+        deployments::{render_deployment_type, render_deployment_url},
+        service_handlers::{icon_for_is_public, icon_for_service_type},
+    },
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[clap(visible_alias = "ls")]

--- a/cli/src/commands/services/status/agg_status.rs
+++ b/cli/src/commands/services/status/agg_status.rs
@@ -10,12 +10,13 @@
 
 use anyhow::Result;
 use indicatif::ProgressBar;
-
 use restate_cli_util::{c_error, c_title};
 
 use super::{render_locked_keys, render_services_status, Status};
-use crate::clients::datafusion_helpers::{get_locked_keys_status, get_service_status};
-use crate::clients::{AdminClient, AdminClientInterface, DataFusionHttpClient};
+use crate::clients::{
+    datafusion_helpers::{get_locked_keys_status, get_service_status},
+    AdminClient, AdminClientInterface, DataFusionHttpClient,
+};
 
 pub async fn run_aggregated_status(
     opts: &Status,

--- a/cli/src/commands/services/status/detailed_status.rs
+++ b/cli/src/commands/services/status/detailed_status.rs
@@ -10,15 +10,16 @@
 
 use anyhow::Result;
 use indicatif::ProgressBar;
-
 use restate_cli_util::c_title;
 
 use super::{render_locked_keys, render_services_status, Status};
-use crate::clients::datafusion_helpers::{
-    get_locked_keys_status, get_service_invocations, get_service_status,
+use crate::{
+    clients::{
+        datafusion_helpers::{get_locked_keys_status, get_service_invocations, get_service_status},
+        AdminClient, AdminClientInterface, DataFusionHttpClient,
+    },
+    ui::invocations::render_invocation_compact,
 };
-use crate::clients::{AdminClient, AdminClientInterface, DataFusionHttpClient};
-use crate::ui::invocations::render_invocation_compact;
 
 pub async fn run_detailed_status(
     service_name: &str,

--- a/cli/src/commands/services/status/mod.rs
+++ b/cli/src/commands/services/status/mod.rs
@@ -15,21 +15,27 @@ use anyhow::Result;
 use chrono_humanize::Tense;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
-
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::{Styled, StyledTable};
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::ui::watcher::Watch;
-use restate_cli_util::ui::{duration_to_human_precise, duration_to_human_rough};
+use restate_cli_util::{
+    c_println,
+    ui::{
+        console::{Styled, StyledTable},
+        duration_to_human_precise, duration_to_human_rough,
+        stylesheet::Style,
+        watcher::Watch,
+    },
+};
 use restate_types::schema::service::ServiceMetadata;
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::{
-    InvocationState, ServiceHandlerLockedKeysMap, ServiceStatus, ServiceStatusMap,
+use crate::{
+    cli_env::CliEnv,
+    clients::{
+        datafusion_helpers::{
+            InvocationState, ServiceHandlerLockedKeysMap, ServiceStatus, ServiceStatusMap,
+        },
+        AdminClient,
+    },
+    ui::{invocations::invocation_status, service_handlers::icon_for_service_type},
 };
-use crate::clients::AdminClient;
-use crate::ui::invocations::invocation_status;
-use crate::ui::service_handlers::icon_for_service_type;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_status")]

--- a/cli/src/commands/sql.rs
+++ b/cli/src/commands/sql.rs
@@ -9,25 +9,24 @@
 // by the Apache License, Version 2.0.
 //
 
-use std::io;
-use std::time::Instant;
+use std::{io, time::Instant};
 
 use anyhow::Result;
-use arrow::error::ArrowError;
-use arrow::util::display::ArrayFormatter;
-use arrow::util::display::FormatOptions;
+use arrow::{
+    error::ArrowError,
+    util::display::{ArrayFormatter, FormatOptions},
+};
 use cling::prelude::*;
-use comfy_table::Cell;
-use comfy_table::Table;
-use serde::Deserialize;
-use serde::Serialize;
-
-use restate_cli_util::c_eprintln;
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::Styled;
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::ui::watcher::Watch;
+use comfy_table::{Cell, Table};
+use restate_cli_util::{
+    c_eprintln, c_println,
+    ui::{
+        console::{Styled, StyledTable},
+        stylesheet::Style,
+        watcher::Watch,
+    },
+};
+use serde::{Deserialize, Serialize};
 
 use crate::cli_env::CliEnv;
 

--- a/cli/src/commands/state/clear.rs
+++ b/cli/src/commands/state/clear.rs
@@ -15,12 +15,16 @@ use cling::prelude::*;
 use comfy_table::{Cell, Table};
 use crossterm::style::Stylize;
 use itertools::Itertools;
-use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
-use restate_cli_util::{c_indent_table, c_println};
+use restate_cli_util::{
+    c_indent_table, c_println,
+    ui::console::{confirm_or_exit, StyledTable},
+};
 
-use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::get_state_keys;
-use crate::commands::state::util::{compute_version, update_state};
+use crate::{
+    cli_env::CliEnv,
+    clients::datafusion_helpers::get_state_keys,
+    commands::state::util::{compute_version, update_state},
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_clear")]

--- a/cli/src/commands/state/edit.rs
+++ b/cli/src/commands/state/edit.rs
@@ -11,15 +11,18 @@
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
+use restate_cli_util::{
+    c_println, c_title,
+    ui::console::{confirm_or_exit, StyledTable},
+};
 use tempfile::tempdir;
 
-use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
-use restate_cli_util::{c_println, c_title};
-
-use crate::cli_env::CliEnv;
-use crate::commands::state::util::{
-    as_json, compute_version, from_json, get_current_state, pretty_print_json, read_json_file,
-    update_state, write_json_file,
+use crate::{
+    cli_env::CliEnv,
+    commands::state::util::{
+        as_json, compute_version, from_json, get_current_state, pretty_print_json, read_json_file,
+        update_state, write_json_file,
+    },
 };
 
 #[derive(Run, Parser, Collect, Clone)]

--- a/cli/src/commands/state/get.rs
+++ b/cli/src/commands/state/get.rs
@@ -11,13 +11,15 @@
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
+use restate_cli_util::{
+    c_println, c_title,
+    ui::{console::StyledTable, watcher::Watch},
+};
 
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::watcher::Watch;
-use restate_cli_util::{c_println, c_title};
-
-use crate::cli_env::CliEnv;
-use crate::commands::state::util::{as_json, get_current_state, pretty_print_json_object};
+use crate::{
+    cli_env::CliEnv,
+    commands::state::util::{as_json, get_current_state, pretty_print_json_object},
+};
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_get")]

--- a/cli/src/commands/state/util.rs
+++ b/cli/src/commands/state/util.rs
@@ -8,28 +8,31 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
 
 use anyhow::{anyhow, bail, Context};
 use arrow_convert::{ArrowDeserialize, ArrowField};
-use base64::alphabet::URL_SAFE;
-use base64::engine::{Engine, GeneralPurpose, GeneralPurposeConfig};
+use base64::{
+    alphabet::URL_SAFE,
+    engine::{Engine, GeneralPurpose, GeneralPurposeConfig},
+};
 use bytes::Bytes;
 use comfy_table::{Cell, Table};
 use itertools::Itertools;
-use restate_cli_util::c_warn;
+use restate_admin_rest_model::services::ModifyServiceStateRequest;
+use restate_cli_util::{c_warn, ui::console::StyledTable};
+use restate_types::{invocation::ServiceType, state_mut::StateMutationVersion};
 use serde_json::Value;
 
-use restate_admin_rest_model::services::ModifyServiceStateRequest;
-use restate_cli_util::ui::console::StyledTable;
-use restate_types::invocation::ServiceType;
-use restate_types::state_mut::StateMutationVersion;
-
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface, MetasClientError};
+use crate::{
+    cli_env::CliEnv,
+    clients::{AdminClient, AdminClientInterface, MetasClientError},
+};
 
 #[derive(Debug, Clone, PartialEq, ArrowField, ArrowDeserialize)]
 pub struct StateEntriesQueryResult {

--- a/cli/src/commands/whoami.rs
+++ b/cli/src/commands/whoami.rs
@@ -12,17 +12,18 @@ use cling::prelude::*;
 use comfy_table::Table;
 use figment::Profile;
 use itertools::Itertools;
+use restate_admin_rest_model::version::AdminApiVersion;
+use restate_cli_util::{
+    c_eprintln, c_error, c_println, c_success, ui::duration_to_human_rough, CliContext,
+};
+use restate_types::art::render_restate_logo;
 use strum::IntoEnumIterator;
 
-use restate_admin_rest_model::version::AdminApiVersion;
-use restate_cli_util::ui::duration_to_human_rough;
-use restate_cli_util::{c_eprintln, c_error, c_println, c_success, CliContext};
-use restate_types::art::render_restate_logo;
-
-use crate::build_info;
-use crate::cli_env::{CliEnv, EnvironmentType};
-use crate::clients::AdminClientInterface;
-use crate::clients::{MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION};
+use crate::{
+    build_info,
+    cli_env::{CliEnv, EnvironmentType},
+    clients::{AdminClientInterface, MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION},
+};
 
 #[derive(Run, Parser, Clone)]
 #[cling(run = "run")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,9 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use cling::prelude::*;
 use std::io::Write;
 
+use cling::prelude::*;
 use crossterm::execute;
 use restate_cli::CliApp;
 

--- a/cli/src/ui/deployments.rs
+++ b/cli/src/ui/deployments.rs
@@ -11,12 +11,12 @@
 use std::collections::HashMap;
 
 use comfy_table::{Cell, Color, Table};
-
 use restate_admin_rest_model::deployments::{Deployment, ServiceNameRevPair};
 use restate_cli_util::ui::console::StyledTable;
-use restate_types::identifiers::DeploymentId;
-use restate_types::schema::deployment::ProtocolType;
-use restate_types::schema::service::ServiceMetadata;
+use restate_types::{
+    identifiers::DeploymentId,
+    schema::{deployment::ProtocolType, service::ServiceMetadata},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeploymentStatus {

--- a/cli/src/ui/deployments.rs
+++ b/cli/src/ui/deployments.rs
@@ -151,7 +151,7 @@ pub fn add_deployment_to_kv_table(deployment: &Deployment, table: &mut Table) {
     for (header, value) in additional_headers.iter() {
         table.add_kv_row(
             "Deployment Additional Header:",
-            &format!("{}: {}", header, value.to_str().unwrap_or("<BINARY>")),
+            format!("{}: {}", header, value.to_str().unwrap_or("<BINARY>")),
         );
     }
 

--- a/cli/src/ui/invocations.rs
+++ b/cli/src/ui/invocations.rs
@@ -10,19 +10,19 @@
 
 use chrono_humanize::Tense;
 use comfy_table::{Attribute, Cell, Table};
-use dialoguer::console::Style as DStyle;
-use dialoguer::console::StyledObject;
-use dialoguer::console::{style, Style};
-use restate_cli_util::c_indent_table;
-use restate_cli_util::c_indentln;
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::Icon;
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::duration_to_human_precise;
+use dialoguer::console::{style, Style as DStyle, Style, StyledObject};
+use restate_cli_util::{
+    c_indent_table, c_indentln, c_println,
+    ui::{
+        console::{Icon, StyledTable},
+        duration_to_human_precise,
+    },
+};
 
-use crate::clients::datafusion_helpers::{Invocation, InvocationState};
-use crate::clients::datafusion_helpers::{InvocationCompletion, JournalEntryType};
-use crate::clients::datafusion_helpers::{JournalEntry, SimpleInvocation};
+use crate::clients::datafusion_helpers::{
+    Invocation, InvocationCompletion, InvocationState, JournalEntry, JournalEntryType,
+    SimpleInvocation,
+};
 
 pub fn invocation_status_note(invocation: &Invocation) -> String {
     let mut msg = String::new();

--- a/cli/src/ui/service_handlers.rs
+++ b/cli/src/ui/service_handlers.rs
@@ -9,10 +9,8 @@
 // by the Apache License, Version 2.0.
 
 use comfy_table::{Cell, Color, Table};
-
 use restate_cli_util::ui::console::{Icon, StyledTable};
-use restate_types::invocation::ServiceType;
-use restate_types::schema::service::HandlerMetadata;
+use restate_types::{invocation::ServiceType, schema::service::HandlerMetadata};
 
 pub fn create_service_handlers_table(handlers: &[HandlerMetadata]) -> Table {
     let mut table = Table::new_styled();

--- a/crates/admin-rest-model/src/deployments.rs
+++ b/crates/admin-rest-model/src/deployments.rs
@@ -8,17 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use http::Uri;
-use http::Version;
+use std::time::SystemTime;
+
+use http::{Uri, Version};
 use restate_serde_util::SerdeableHeaderHashMap;
-use restate_types::identifiers::ServiceRevision;
-use restate_types::identifiers::{DeploymentId, LambdaARN};
-use restate_types::schema::deployment::DeploymentType;
-use restate_types::schema::deployment::{DeploymentMetadata, ProtocolType};
-use restate_types::schema::service::ServiceMetadata;
+use restate_types::{
+    identifiers::{DeploymentId, LambdaARN, ServiceRevision},
+    schema::{
+        deployment::{DeploymentMetadata, DeploymentType, ProtocolType},
+        service::ServiceMetadata,
+    },
+};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::time::SystemTime;
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/admin-rest-model/src/handlers.rs
+++ b/crates/admin-rest-model/src/handlers.rs
@@ -8,9 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::{Deserialize, Serialize};
-
 use restate_types::schema::service::HandlerMetadata;
+use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-rest-model/src/services.rs
+++ b/crates/admin-rest-model/src/services.rs
@@ -8,12 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
+use bytes::Bytes;
 use restate_types::schema::service::ServiceMetadata;
+use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/admin-rest-model/src/subscriptions.rs
+++ b/crates/admin-rest-model/src/subscriptions.rs
@@ -11,11 +11,9 @@
 use std::collections::HashMap;
 
 use http::Uri;
+use restate_types::{identifiers::SubscriptionId, schema::subscriptions::Subscription};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-
-use restate_types::identifiers::SubscriptionId;
-use restate_types::schema::subscriptions::Subscription;
 
 #[serde_as]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/admin-rest-model/src/version.rs
+++ b/crates/admin-rest-model/src/version.rs
@@ -8,8 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
+
+use serde::{Deserialize, Serialize};
 
 /// Version of the admin API to allow CLIs to detect if they are incompatible with a server.
 ///

--- a/crates/admin/build.rs
+++ b/crates/admin/build.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -8,20 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
 
+use restate_core::{
+    network::{
+        rpc_router::RpcRouter, MessageRouterBuilder, Networking, Outgoing, TransportConnect,
+    },
+    Metadata, ShutdownError, TaskCenter, TaskHandle,
+};
+use restate_types::{
+    cluster::cluster_state::{AliveNode, ClusterState, DeadNode, NodeState},
+    net::partition_processor_manager::GetProcessorsState,
+    nodes_config::Role,
+    time::MillisSinceEpoch,
+    Version,
+};
 use tokio::sync::watch;
-
-use restate_core::network::rpc_router::RpcRouter;
-use restate_core::network::{MessageRouterBuilder, Networking, Outgoing, TransportConnect};
-use restate_core::{Metadata, ShutdownError, TaskCenter, TaskHandle};
-use restate_types::cluster::cluster_state::{AliveNode, ClusterState, DeadNode, NodeState};
-use restate_types::net::partition_processor_manager::GetProcessorsState;
-use restate_types::nodes_config::Role;
-use restate_types::time::MillisSinceEpoch;
-use restate_types::Version;
 
 pub struct ClusterStateRefresher<T> {
     task_center: TaskCenter,

--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -8,10 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::cluster::cluster_state::{ClusterState, NodeState, RunMode};
-use restate_types::identifiers::PartitionId;
-use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
 use std::collections::{HashMap, HashSet};
+
+use restate_types::{
+    cluster::cluster_state::{ClusterState, NodeState, RunMode},
+    identifiers::PartitionId,
+    GenerationalNodeId, NodeId, PlainNodeId,
+};
 use xxhash_rust::xxh3::Xxh3Builder;
 
 /// Represents the scheduler's observed state of the cluster. The scheduler will use this
@@ -119,18 +122,25 @@ impl ObservedPartitionState {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use googletest::{
+        assert_that, elements_are,
+        prelude::{empty, eq},
+        unordered_elements_are,
+    };
+    use restate_types::{
+        cluster::cluster_state::{
+            AliveNode, ClusterState, DeadNode, NodeState, PartitionProcessorStatus, RunMode,
+        },
+        identifiers::PartitionId,
+        time::MillisSinceEpoch,
+        GenerationalNodeId, PlainNodeId, Version,
+    };
+
     use crate::cluster_controller::observed_cluster_state::{
         ObservedClusterState, ObservedPartitionState,
     };
-    use googletest::prelude::{empty, eq};
-    use googletest::{assert_that, elements_are, unordered_elements_are};
-    use restate_types::cluster::cluster_state::{
-        AliveNode, ClusterState, DeadNode, NodeState, PartitionProcessorStatus, RunMode,
-    };
-    use restate_types::identifiers::PartitionId;
-    use restate_types::time::MillisSinceEpoch;
-    use restate_types::{GenerationalNodeId, PlainNodeId, Version};
-    use std::collections::{BTreeMap, HashMap};
 
     impl ObservedClusterState {
         pub fn remove_node_from_partition(

--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -8,14 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::error::*;
-use crate::state::AdminServiceState;
-
-use crate::schema_registry::{ApplyMode, Force};
-use axum::extract::{Path, Query, State};
-use axum::http::{header, StatusCode};
-use axum::response::IntoResponse;
-use axum::Json;
+use axum::{
+    extract::{Path, Query, State},
+    http::{header, StatusCode},
+    response::IntoResponse,
+    Json,
+};
 use http::uri::Scheme;
 use okapi_operation::*;
 use restate_admin_rest_model::deployments::*;
@@ -24,6 +22,12 @@ use restate_service_client::Endpoint;
 use restate_service_protocol::discovery::DiscoverEndpoint;
 use restate_types::identifiers::{DeploymentId, InvalidLambdaARN};
 use serde::Deserialize;
+
+use super::error::*;
+use crate::{
+    schema_registry::{ApplyMode, Force},
+    state::AdminServiceState,
+};
 
 /// Create deployment and return discovered services.
 #[openapi(

--- a/crates/admin/src/rest_api/error.rs
+++ b/crates/admin/src/rest_api/error.rs
@@ -8,22 +8,29 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use codederror::{Code, CodedError};
+use okapi_operation::{
+    anyhow::Error,
+    okapi,
+    okapi::{map, openapi3::Responses},
+    Components, ToMediaTypes, ToResponses,
+};
+use restate_core::ShutdownError;
+use restate_types::{
+    identifiers::{DeploymentId, SubscriptionId},
+    invocation::ServiceType,
+};
+use schemars::JsonSchema;
+use serde::Serialize;
+
 use crate::schema_registry::error::{
     DeploymentError, SchemaError, SchemaRegistryError, ServiceError,
 };
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
-use codederror::{Code, CodedError};
-use okapi_operation::anyhow::Error;
-use okapi_operation::okapi::map;
-use okapi_operation::okapi::openapi3::Responses;
-use okapi_operation::{okapi, Components, ToMediaTypes, ToResponses};
-use restate_core::ShutdownError;
-use restate_types::identifiers::{DeploymentId, SubscriptionId};
-use restate_types::invocation::ServiceType;
-use schemars::JsonSchema;
-use serde::Serialize;
 
 /// This error is used by handlers to propagate API errors,
 /// and later converted to a response through the IntoResponse implementation

--- a/crates/admin/src/rest_api/handlers.rs
+++ b/crates/admin/src/rest_api/handlers.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::error::*;
-
-use crate::state::AdminServiceState;
-use axum::extract::{Path, State};
-use axum::Json;
+use axum::{
+    extract::{Path, State},
+    Json,
+};
 use okapi_operation::*;
 use restate_admin_rest_model::handlers::*;
 use restate_types::schema::service::HandlerMetadata;
+
+use super::error::*;
+use crate::state::AdminServiceState;
 
 /// List discovered handlers for service
 #[openapi(

--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -8,19 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::error::*;
 use std::sync::Arc;
 
-use crate::rest_api::create_envelope_header;
-use crate::state::AdminServiceState;
-use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
 use okapi_operation::*;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
-use restate_types::invocation::{InvocationTermination, PurgeInvocationRequest};
+use restate_types::{
+    identifiers::{InvocationId, WithPartitionKey},
+    invocation::{InvocationTermination, PurgeInvocationRequest},
+};
 use restate_wal_protocol::{append_envelope_to_bifrost, Command, Envelope};
 use serde::Deserialize;
 use tracing::warn;
+
+use super::error::*;
+use crate::{rest_api::create_envelope_header, state::AdminServiceState};
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub enum DeletionMode {

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -19,10 +19,11 @@ mod services;
 mod subscriptions;
 mod version;
 
-use okapi_operation::axum_integration::{delete, get, patch, post};
-use okapi_operation::*;
-use restate_types::identifiers::PartitionKey;
-use restate_types::schema::subscriptions::SubscriptionValidator;
+use okapi_operation::{
+    axum_integration::{delete, get, patch, post},
+    *,
+};
+use restate_types::{identifiers::PartitionKey, schema::subscriptions::SubscriptionValidator};
 use restate_wal_protocol::{Destination, Header, Source};
 
 use crate::state::AdminServiceState;

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -8,25 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::create_envelope_header;
-use super::error::*;
-use crate::schema_registry::ModifyServiceChange;
-use crate::state::AdminServiceState;
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
-use axum::Json;
+use axum::{
+    extract::{Path, State},
+    Json,
+};
 use bytes::Bytes;
 use http::StatusCode;
 use okapi_operation::*;
-use restate_admin_rest_model::services::ListServicesResponse;
-use restate_admin_rest_model::services::*;
+use restate_admin_rest_model::services::{ListServicesResponse, *};
 use restate_errors::warn_it;
-use restate_types::identifiers::{ServiceId, WithPartitionKey};
-use restate_types::schema::service::ServiceMetadata;
-use restate_types::state_mut::ExternalStateMutation;
+use restate_types::{
+    identifiers::{ServiceId, WithPartitionKey},
+    schema::service::ServiceMetadata,
+    state_mut::ExternalStateMutation,
+};
 use restate_wal_protocol::{append_envelope_to_bifrost, Command, Envelope};
 use tracing::{debug, warn};
+
+use super::{create_envelope_header, error::*};
+use crate::{schema_registry::ModifyServiceChange, state::AdminServiceState};
 
 /// List services
 #[openapi(

--- a/crates/admin/src/rest_api/subscriptions.rs
+++ b/crates/admin/src/rest_api/subscriptions.rs
@@ -8,19 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use axum::{
+    extract::{Path, Query, State},
+    http,
+    http::StatusCode,
+    Json,
+};
+use okapi_operation::*;
+use restate_admin_rest_model::subscriptions::*;
+use restate_errors::warn_it;
+use restate_types::{
+    identifiers::SubscriptionId,
+    schema::subscriptions::{ListSubscriptionFilter, SubscriptionValidator},
+};
+
 use super::error::*;
 use crate::state::AdminServiceState;
-
-use restate_admin_rest_model::subscriptions::*;
-use restate_types::schema::subscriptions::{ListSubscriptionFilter, SubscriptionValidator};
-
-use axum::extract::Query;
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use axum::{http, Json};
-use okapi_operation::*;
-use restate_errors::warn_it;
-use restate_types::identifiers::SubscriptionId;
 
 /// Create subscription.
 #[openapi(

--- a/crates/admin/src/schema_registry/error.rs
+++ b/crates/admin/src/schema_registry/error.rs
@@ -9,14 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use http::Uri;
-
-use restate_core::metadata_store::ReadModifyWriteError;
-use restate_core::ShutdownError;
-use restate_types::endpoint_manifest;
-use restate_types::errors::GenericError;
-use restate_types::identifiers::DeploymentId;
-use restate_types::invocation::ServiceType;
-use restate_types::schema::invocation_target::BadInputContentType;
+use restate_core::{metadata_store::ReadModifyWriteError, ShutdownError};
+use restate_types::{
+    endpoint_manifest, errors::GenericError, identifiers::DeploymentId, invocation::ServiceType,
+    schema::invocation_target::BadInputContentType,
+};
 
 use crate::schema_registry::ServiceName;
 

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -11,27 +11,29 @@
 pub mod error;
 mod updater;
 
-use crate::schema_registry::error::{SchemaError, SchemaRegistryError, ServiceError};
-use crate::schema_registry::updater::SchemaUpdater;
+use std::{borrow::Borrow, collections::HashMap, ops::Deref, time::Duration};
+
 use http::Uri;
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_core::{metadata, MetadataWriter};
+use restate_core::{metadata, metadata_store::MetadataStoreClient, MetadataWriter};
 use restate_service_protocol::discovery::{DiscoverEndpoint, DiscoveredEndpoint, ServiceDiscovery};
-use restate_types::identifiers::{DeploymentId, ServiceRevision, SubscriptionId};
-use restate_types::metadata_store::keys::SCHEMA_INFORMATION_KEY;
-use restate_types::schema::deployment::{
-    DeliveryOptions, Deployment, DeploymentMetadata, DeploymentResolver,
+use restate_types::{
+    identifiers::{DeploymentId, ServiceRevision, SubscriptionId},
+    metadata_store::keys::SCHEMA_INFORMATION_KEY,
+    schema::{
+        deployment::{DeliveryOptions, Deployment, DeploymentMetadata, DeploymentResolver},
+        service::{HandlerMetadata, ServiceMetadata, ServiceMetadataResolver},
+        subscriptions::{
+            ListSubscriptionFilter, Subscription, SubscriptionResolver, SubscriptionValidator,
+        },
+        Schema,
+    },
 };
-use restate_types::schema::service::{HandlerMetadata, ServiceMetadata, ServiceMetadataResolver};
-use restate_types::schema::subscriptions::{
-    ListSubscriptionFilter, Subscription, SubscriptionResolver, SubscriptionValidator,
-};
-use restate_types::schema::Schema;
-use std::borrow::Borrow;
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::time::Duration;
 use tracing::subscriber::NoSubscriber;
+
+use crate::schema_registry::{
+    error::{SchemaError, SchemaRegistryError, ServiceError},
+    updater::SchemaUpdater,
+};
 
 /// Whether to force the registration of an existing endpoint or not
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -13,21 +13,20 @@ use std::sync::Arc;
 use axum::error_handling::HandleErrorLayer;
 use http::StatusCode;
 use restate_bifrost::Bifrost;
-use restate_types::config::AdminOptions;
-use restate_types::live::LiveLoad;
+use restate_core::{
+    metadata_store::MetadataStoreClient,
+    network::{net_util, protobuf::node_svc::node_svc_client::NodeSvcClient},
+    MetadataWriter,
+};
+use restate_service_protocol::discovery::ServiceDiscovery;
+use restate_types::{
+    config::AdminOptions, live::LiveLoad, net::BindAddress,
+    schema::subscriptions::SubscriptionValidator,
+};
 use tonic::transport::Channel;
 use tower::ServiceBuilder;
 
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_core::network::net_util;
-use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::MetadataWriter;
-use restate_service_protocol::discovery::ServiceDiscovery;
-use restate_types::net::BindAddress;
-use restate_types::schema::subscriptions::SubscriptionValidator;
-
-use crate::schema_registry::SchemaRegistry;
-use crate::{rest_api, state, storage_query};
+use crate::{rest_api, schema_registry::SchemaRegistry, state, storage_query};
 
 #[derive(Debug, thiserror::Error)]
 #[error("could not create the service client: {0}")]

--- a/crates/admin/src/state.rs
+++ b/crates/admin/src/state.rs
@@ -9,10 +9,11 @@
 // by the Apache License, Version 2.0.
 //
 
-use crate::schema_registry::SchemaRegistry;
 use restate_bifrost::Bifrost;
 use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
 use tonic::transport::Channel;
+
+use crate::schema_registry::SchemaRegistry;
 
 #[derive(Clone, derive_builder::Builder)]
 pub struct AdminServiceState<V> {

--- a/crates/admin/src/storage_query/error.rs
+++ b/crates/admin/src/storage_query/error.rs
@@ -8,14 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::Json;
-
-use okapi_operation::anyhow::Error;
-use okapi_operation::okapi::map;
-use okapi_operation::okapi::openapi3::Responses;
-use okapi_operation::{okapi, Components, ToMediaTypes, ToResponses};
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use okapi_operation::{
+    anyhow::Error,
+    okapi,
+    okapi::{map, openapi3::Responses},
+    Components, ToMediaTypes, ToResponses,
+};
 use schemars::JsonSchema;
 use serde::Serialize;
 

--- a/crates/admin/src/storage_query/mod.rs
+++ b/crates/admin/src/storage_query/mod.rs
@@ -11,8 +11,9 @@
 mod error;
 mod query;
 
-use axum::{routing::post, Router};
 use std::sync::Arc;
+
+use axum::{routing::post, Router};
 
 use crate::state::QueryServiceState;
 

--- a/crates/admin/src/storage_query/query.rs
+++ b/crates/admin/src/storage_query/query.rs
@@ -8,25 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-
-use arrow_flight::decode::FlightRecordBatchStream;
-use arrow_flight::error::FlightError;
-use arrow_flight::FlightData;
-use axum::extract::State;
-use axum::response::{IntoResponse, Response};
-use axum::{http, Json};
-use bytes::Bytes;
-use datafusion::arrow::array::{
-    Array, ArrayRef, AsArray, BinaryArray, GenericByteArray, StringArray,
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
 };
-use datafusion::arrow::buffer::{OffsetBuffer, ScalarBuffer};
-use datafusion::arrow::datatypes::{ByteArrayType, DataType, Field, FieldRef, Schema, SchemaRef};
-use datafusion::arrow::error::ArrowError;
-use datafusion::arrow::ipc::writer::StreamWriter;
-use datafusion::arrow::record_batch::RecordBatch;
+
+use arrow_flight::{decode::FlightRecordBatchStream, error::FlightError, FlightData};
+use axum::{
+    extract::State,
+    http,
+    response::{IntoResponse, Response},
+    Json,
+};
+use bytes::Bytes;
+use datafusion::arrow::{
+    array::{Array, ArrayRef, AsArray, BinaryArray, GenericByteArray, StringArray},
+    buffer::{OffsetBuffer, ScalarBuffer},
+    datatypes::{ByteArrayType, DataType, Field, FieldRef, Schema, SchemaRef},
+    error::ArrowError,
+    ipc::writer::StreamWriter,
+    record_batch::RecordBatch,
+};
 use futures::{ready, Stream, StreamExt, TryStreamExt};
 use http_body::Frame;
 use http_body_util::StreamBody;

--- a/crates/admin/src/web_ui.rs
+++ b/crates/admin/src/web_ui.rs
@@ -8,8 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use axum::response::{IntoResponse, Redirect, Response};
-use axum::routing::get;
+use axum::{
+    response::{IntoResponse, Redirect, Response},
+    routing::get,
+};
 use http::{header, HeaderValue, StatusCode, Uri};
 use http_body_util::Full;
 

--- a/crates/base64-util/src/lib.rs
+++ b/crates/base64-util/src/lib.rs
@@ -8,8 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use base64::alphabet;
-use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
+use base64::{
+    alphabet,
+    engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+};
 
 // We have this custom configuration for padding because Node's base64url implementation will omit padding,
 // but the spec https://datatracker.ietf.org/doc/html/rfc4648#section-5 doesn't specify that padding MUST be omitted.

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -11,16 +11,21 @@
 use std::ops::Range;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use futures::stream::{FuturesOrdered, FuturesUnordered};
-use futures::StreamExt;
+use futures::{
+    stream::{FuturesOrdered, FuturesUnordered},
+    StreamExt,
+};
 use restate_bifrost::{Bifrost, BifrostService};
 use restate_core::metadata;
 use restate_rocksdb::{DbName, RocksDbManager};
-use restate_types::config::{
-    BifrostOptionsBuilder, CommonOptionsBuilder, ConfigurationBuilder, LocalLogletOptionsBuilder,
+use restate_types::{
+    config::{
+        BifrostOptionsBuilder, CommonOptionsBuilder, ConfigurationBuilder,
+        LocalLogletOptionsBuilder,
+    },
+    live::Live,
+    logs::LogId,
 };
-use restate_types::live::Live;
-use restate_types::logs::LogId;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 mod util;

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -8,17 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tracing::warn;
-
 use restate_core::{
     spawn_metadata_manager, MetadataBuilder, MetadataManager, TaskCenter, TaskCenterBuilder,
 };
 use restate_metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
-use restate_types::config::Configuration;
-use restate_types::live::Constant;
-use restate_types::logs::metadata::ProviderKind;
-use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
+use restate_types::{
+    config::Configuration, live::Constant, logs::metadata::ProviderKind,
+    metadata_store::keys::BIFROST_CONFIG_KEY,
+};
+use tracing::warn;
 
 pub async fn spawn_environment(
     config: Configuration,

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -8,22 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 
-use restate_types::storage::StorageEncode;
+use restate_types::{
+    config::Configuration,
+    live::Live,
+    logs::{metadata::SegmentIndex, LogId, Lsn, Record},
+    retries::RetryIter,
+    storage::StorageEncode,
+};
 use tracing::{debug, info, instrument};
 
-use restate_types::config::Configuration;
-use restate_types::live::Live;
-use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{LogId, Lsn, Record};
-use restate_types::retries::RetryIter;
-
-use crate::bifrost::BifrostInner;
-use crate::loglet::AppendError;
-use crate::loglet_wrapper::LogletWrapper;
-use crate::{Error, InputRecord, Result};
+use crate::{
+    bifrost::BifrostInner, loglet::AppendError, loglet_wrapper::LogletWrapper, Error, InputRecord,
+    Result,
+};
 
 #[derive(Clone, derive_more::Debug)]
 pub struct Appender {

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -12,16 +12,12 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 use pin_project::pin_project;
-use restate_types::logs::Record;
+use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskHandle};
+use restate_types::{identifiers::PartitionId, logs::Record, storage::StorageEncode};
 use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{trace, warn};
 
-use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskHandle};
-use restate_types::identifiers::PartitionId;
-use restate_types::storage::StorageEncode;
-
-use crate::error::EnqueueError;
-use crate::{Appender, InputRecord, Result};
+use crate::{error::EnqueueError, Appender, InputRecord, Result};
 
 /// Performs appends in the background concurrently while maintaining the order of records
 /// produced from the same producer. It runs as a background task and batches records whenever

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -8,24 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::sync::OnceLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, OnceLock,
+};
 
 use enum_map::EnumMap;
-
 use restate_core::{Metadata, MetadataKind, TargetVersion};
-use restate_types::logs::metadata::{MaybeSegment, ProviderKind, Segment};
-use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, TailState};
-use restate_types::storage::StorageEncode;
-use restate_types::Version;
+use restate_types::{
+    logs::{
+        metadata::{MaybeSegment, ProviderKind, Segment},
+        KeyFilter, LogId, Lsn, SequenceNumber, TailState,
+    },
+    storage::StorageEncode,
+    Version,
+};
 
-use crate::appender::Appender;
-use crate::background_appender::BackgroundAppender;
-use crate::loglet::LogletProvider;
-use crate::loglet_wrapper::LogletWrapper;
-use crate::watchdog::WatchdogSender;
-use crate::{Error, FindTailAttributes, InputRecord, LogReadStream, Result};
+use crate::{
+    appender::Appender, background_appender::BackgroundAppender, loglet::LogletProvider,
+    loglet_wrapper::LogletWrapper, watchdog::WatchdogSender, Error, FindTailAttributes,
+    InputRecord, LogReadStream, Result,
+};
 
 /// Bifrost is Restate's durable interconnect system
 ///
@@ -506,29 +509,32 @@ impl MaybeLoglet {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::sync::atomic::AtomicUsize;
 
     use googletest::prelude::*;
+    use restate_core::{metadata, task_center, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
+    use restate_rocksdb::RocksDbManager;
+    use restate_types::{
+        config::CommonOptions,
+        live::Constant,
+        logs::{
+            metadata::{new_single_node_loglet_params, SegmentIndex},
+            SequenceNumber,
+        },
+        metadata_store::keys::BIFROST_CONFIG_KEY,
+        partition_table::PartitionTable,
+        Versioned,
+    };
     use test_log::test;
     use tokio::time::Duration;
     use tracing::info;
     use tracing_test::traced_test;
 
-    use restate_core::{metadata, TaskKind, TestCoreEnv};
-    use restate_core::{task_center, TestCoreEnvBuilder};
-    use restate_rocksdb::RocksDbManager;
-    use restate_types::config::CommonOptions;
-    use restate_types::live::Constant;
-    use restate_types::logs::metadata::{new_single_node_loglet_params, SegmentIndex};
-    use restate_types::logs::SequenceNumber;
-    use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
-    use restate_types::partition_table::PartitionTable;
-    use restate_types::Versioned;
-
-    use crate::providers::memory_loglet::{self};
-    use crate::BifrostAdmin;
+    use super::*;
+    use crate::{
+        providers::memory_loglet::{self},
+        BifrostAdmin,
+    };
 
     #[tokio::test]
     #[traced_test]

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -10,20 +10,21 @@
 
 use std::ops::Deref;
 
-use tracing::{info, instrument};
-
 use restate_core::{MetadataKind, MetadataWriter};
 use restate_metadata_store::MetadataStoreClient;
-use restate_types::config::Configuration;
-use restate_types::logs::builder::BuilderError;
-use restate_types::logs::metadata::{LogletParams, Logs, ProviderKind, SegmentIndex};
-use restate_types::logs::{LogId, Lsn, TailState};
-use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
-use restate_types::Version;
+use restate_types::{
+    config::Configuration,
+    logs::{
+        builder::BuilderError,
+        metadata::{LogletParams, Logs, ProviderKind, SegmentIndex},
+        LogId, Lsn, TailState,
+    },
+    metadata_store::keys::BIFROST_CONFIG_KEY,
+    Version,
+};
+use tracing::{info, instrument};
 
-use crate::error::AdminError;
-use crate::loglet_wrapper::LogletWrapper;
-use crate::{Bifrost, Error, Result};
+use crate::{error::AdminError, loglet_wrapper::LogletWrapper, Bifrost, Error, Result};
 
 /// Bifrost's Admin API
 #[derive(Clone, Copy)]

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -11,9 +11,10 @@
 use std::sync::Arc;
 
 use restate_core::{ShutdownError, SyncError};
-use restate_types::errors::MaybeRetryableError;
-use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{LogId, Lsn};
+use restate_types::{
+    errors::MaybeRetryableError,
+    logs::{metadata::SegmentIndex, LogId, Lsn},
+};
 
 use crate::loglet::OperationError;
 

--- a/crates/bifrost/src/loglet/error.rs
+++ b/crates/bifrost/src/loglet/error.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 use restate_core::{network::NetworkError, ShutdownError};
 use restate_types::errors::{IntoMaybeRetryable, MaybeRetryableError};

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -8,26 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
-use std::sync::atomic::AtomicUsize;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::BTreeSet,
+    sync::{atomic::AtomicUsize, Arc},
+    time::Duration,
+};
 
 use googletest::prelude::*;
-use tokio::sync::Barrier;
-use tokio::task::{JoinHandle, JoinSet};
+use restate_core::{task_center, TaskHandle, TaskKind};
+use restate_test_util::let_assert;
+use restate_types::logs::{
+    metadata::{LogletConfig, SegmentIndex},
+    KeyFilter, Lsn, SequenceNumber, TailState,
+};
+use tokio::{
+    sync::Barrier,
+    task::{JoinHandle, JoinSet},
+};
 use tokio_stream::StreamExt;
 use tracing::info;
 
-use restate_core::{task_center, TaskHandle, TaskKind};
-use restate_test_util::let_assert;
-use restate_types::logs::metadata::{LogletConfig, SegmentIndex};
-use restate_types::logs::{KeyFilter, Lsn, SequenceNumber, TailState};
-
 use super::Loglet;
-use crate::loglet::AppendError;
-use crate::loglet_wrapper::LogletWrapper;
-use crate::setup_panic_handler;
+use crate::{loglet::AppendError, loglet_wrapper::LogletWrapper, setup_panic_handler};
 
 async fn wait_for_trim(loglet: &LogletWrapper, required_trim_point: Lsn) -> anyhow::Result<()> {
     for _ in 0..3 {

--- a/crates/bifrost/src/loglet/mod.rs
+++ b/crates/bifrost/src/loglet/mod.rs
@@ -15,23 +15,21 @@ mod provider;
 pub mod util;
 
 // exports
-pub use error::*;
-use futures::stream::BoxStream;
-pub use provider::{LogletProvider, LogletProviderFactory};
-use tokio::sync::oneshot;
-
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{ready, Poll};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Poll},
+};
 
 use async_trait::async_trait;
-use futures::{FutureExt, Stream};
-
+pub use error::*;
+use futures::{stream::BoxStream, FutureExt, Stream};
+pub use provider::{LogletProvider, LogletProviderFactory};
 use restate_core::ShutdownError;
 use restate_types::logs::{KeyFilter, LogletOffset, Record, TailState};
+use tokio::sync::oneshot;
 
-use crate::LogEntry;
-use crate::Result;
+use crate::{LogEntry, Result};
 
 /// A loglet represents a logical log stream provided by a provider implementation.
 ///

--- a/crates/bifrost/src/loglet/provider.rs
+++ b/crates/bifrost/src/loglet/provider.rs
@@ -11,9 +11,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
+use restate_types::logs::{
+    metadata::{LogletParams, ProviderKind, SegmentIndex},
+    LogId,
+};
 
 use super::{Loglet, OperationError};
 use crate::Result;

--- a/crates/bifrost/src/loglet/util.rs
+++ b/crates/bifrost/src/loglet/util.rs
@@ -9,10 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use restate_core::ShutdownError;
+use restate_types::logs::TailState;
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
-
-use restate_types::logs::TailState;
 
 use super::LogletOffset;
 

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -8,21 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::task::Poll;
-
-use std::pin::Pin;
-use std::sync::Arc;
+use std::{pin::Pin, sync::Arc, task::Poll};
 
 use futures::{Stream, StreamExt};
+use restate_types::logs::{
+    metadata::{LogletConfig, SegmentIndex},
+    KeyFilter, LogletOffset, Lsn, Record, SequenceNumber, TailState,
+};
 use tracing::instrument;
 
-use restate_types::logs::metadata::{LogletConfig, SegmentIndex};
-use restate_types::logs::{KeyFilter, LogletOffset, Lsn, SequenceNumber};
-use restate_types::logs::{Record, TailState};
-
-use crate::loglet::{AppendError, Loglet, OperationError, SendableLogletReadStream};
-use crate::Result;
-use crate::{Commit, LogEntry, LsnExt};
+use crate::{
+    loglet::{AppendError, Loglet, OperationError, SendableLogletReadStream},
+    Commit, LogEntry, LsnExt, Result,
+};
 
 #[cfg(any(test, feature = "test-util"))]
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/bifrost/src/providers/local_loglet/keys.rs
+++ b/crates/bifrost/src/providers/local_loglet/keys.rs
@@ -11,7 +11,6 @@
 use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-
 use restate_types::logs::{LogletOffset, SequenceNumber};
 
 pub(crate) const DATA_KEY_PREFIX_LENGTH: usize = size_of::<u8>() + size_of::<u64>();

--- a/crates/bifrost/src/providers/local_loglet/log_state.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_state.rs
@@ -9,18 +9,16 @@
 // by the Apache License, Version 2.0.
 
 use bytes::BytesMut;
+use restate_types::{flexbuffers_storage_encode_decode, logs::LogletOffset, storage::StorageCodec};
 use rocksdb::MergeOperands;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tracing::{error, trace, warn};
 
-use restate_types::flexbuffers_storage_encode_decode;
-use restate_types::logs::LogletOffset;
-use restate_types::storage::StorageCodec;
-
-use super::keys::{MetadataKey, MetadataKind};
-
-use super::LogStoreError;
+use super::{
+    keys::{MetadataKey, MetadataKind},
+    LogStoreError,
+};
 
 /// Bundles one or more updates to log state. LogState updates are applied via
 /// a rocksdb merge operator

--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -10,20 +10,23 @@
 
 use std::sync::Arc;
 
-use restate_types::errors::MaybeRetryableError;
-use rocksdb::{BoundColumnFamily, DBCompressionType, SliceTransform, DB};
-use static_assertions::const_assert;
-
 use restate_rocksdb::{
     CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
 };
-use restate_types::config::{LocalLogletOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
-use restate_types::storage::{StorageDecodeError, StorageEncodeError};
+use restate_types::{
+    config::{LocalLogletOptions, RocksDbOptions},
+    errors::MaybeRetryableError,
+    live::BoxedLiveLoad,
+    storage::{StorageDecodeError, StorageEncodeError},
+};
+use rocksdb::{BoundColumnFamily, DBCompressionType, SliceTransform, DB};
+use static_assertions::const_assert;
 
-use super::keys::{MetadataKey, MetadataKind, DATA_KEY_PREFIX_LENGTH};
-use super::log_state::{log_state_full_merge, log_state_partial_merge, LogState};
-use super::log_store_writer::LogStoreWriter;
+use super::{
+    keys::{MetadataKey, MetadataKind, DATA_KEY_PREFIX_LENGTH},
+    log_state::{log_state_full_merge, log_state_partial_merge, LogState},
+    log_store_writer::LogStoreWriter,
+};
 
 // matches the default directory name
 pub(crate) const DB_NAME: &str = "local-loglet";

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -8,31 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use bytes::BytesMut;
 use futures::StreamExt as FutureStreamExt;
 use metrics::histogram;
-use rocksdb::{BoundColumnFamily, WriteBatch};
-use tokio::sync::{mpsc, oneshot};
-use tokio_stream::wrappers::ReceiverStream;
-use tokio_stream::StreamExt as TokioStreamExt;
-use tracing::{debug, error, trace, warn};
-
 use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
-use restate_types::config::LocalLogletOptions;
-use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::{LogletOffset, Record, SequenceNumber};
-
-use super::keys::{MetadataKey, MetadataKind, RecordKey};
-use super::log_state::LogStateUpdates;
-use super::log_store::{DATA_CF, METADATA_CF};
-use super::metric_definitions::{
-    BIFROST_LOCAL_WRITE_BATCH_COUNT, BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES,
+use restate_types::{
+    config::LocalLogletOptions,
+    live::BoxedLiveLoad,
+    logs::{LogletOffset, Record, SequenceNumber},
 };
-use super::record_format::{encode_record_and_split, FORMAT_FOR_NEW_APPENDS};
+use rocksdb::{BoundColumnFamily, WriteBatch};
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::{wrappers::ReceiverStream, StreamExt as TokioStreamExt};
+use tracing::{debug, error, trace, warn};
+
+use super::{
+    keys::{MetadataKey, MetadataKind, RecordKey},
+    log_state::LogStateUpdates,
+    log_store::{DATA_CF, METADATA_CF},
+    metric_definitions::{BIFROST_LOCAL_WRITE_BATCH_COUNT, BIFROST_LOCAL_WRITE_BATCH_SIZE_BYTES},
+    record_format::{encode_record_and_split, FORMAT_FOR_NEW_APPENDS},
+};
 use crate::loglet::OperationError;
 
 type Ack = oneshot::Sender<Result<(), OperationError>>;

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -8,23 +8,31 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{hash_map, HashMap};
-use std::sync::Arc;
+use std::{
+    collections::{hash_map, HashMap},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
+use restate_types::{
+    config::{LocalLogletOptions, RocksDbOptions},
+    live::BoxedLiveLoad,
+    logs::{
+        metadata::{LogletParams, ProviderKind, SegmentIndex},
+        LogId,
+    },
+};
 use tracing::debug;
 
-use restate_types::config::{LocalLogletOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
-
-use super::log_store::RocksDbLogStore;
-use super::log_store_writer::RocksDbLogWriterHandle;
-use super::{metric_definitions, LocalLoglet};
-use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
-use crate::Error;
+use super::{
+    log_store::RocksDbLogStore, log_store_writer::RocksDbLogWriterHandle, metric_definitions,
+    LocalLoglet,
+};
+use crate::{
+    loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError},
+    Error,
+};
 
 pub struct Factory {
     options: BoxedLiveLoad<LocalLogletOptions>,

--- a/crates/bifrost/src/providers/local_loglet/read_stream.rs
+++ b/crates/bifrost/src/providers/local_loglet/read_stream.rs
@@ -8,27 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::task::Poll;
+use std::{
+    sync::{atomic::Ordering, Arc},
+    task::Poll,
+};
 
 use bytes::BytesMut;
-use futures::stream::BoxStream;
-use futures::{Stream, StreamExt};
-use rocksdb::{DBRawIteratorWithThreadMode, DB};
-use tracing::{debug, error, warn};
-
+use futures::{stream::BoxStream, Stream, StreamExt};
 use restate_core::ShutdownError;
 use restate_rocksdb::RocksDbPerfGuard;
 use restate_types::logs::{KeyFilter, LogletOffset, SequenceNumber, TailState};
+use rocksdb::{DBRawIteratorWithThreadMode, DB};
+use tracing::{debug, error, warn};
 
-use crate::loglet::{Loglet, LogletReadStream, OperationError};
-use crate::providers::local_loglet::record_format::decode_and_filter_record;
-use crate::providers::local_loglet::LogStoreError;
-use crate::{LogEntry, Result};
-
-use super::keys::RecordKey;
-use super::LocalLoglet;
+use super::{keys::RecordKey, LocalLoglet};
+use crate::{
+    loglet::{Loglet, LogletReadStream, OperationError},
+    providers::local_loglet::{record_format::decode_and_filter_record, LogStoreError},
+    LogEntry, Result,
+};
 
 pub(crate) struct LocalLogletReadStream {
     loglet_id: u64,

--- a/crates/bifrost/src/providers/local_loglet/record_format.rs
+++ b/crates/bifrost/src/providers/local_loglet/record_format.rs
@@ -11,11 +11,12 @@
 use std::ops::Deref;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-
-use restate_types::flexbuffers_storage_encode_decode;
-use restate_types::logs::{KeyFilter, Keys, MatchKeyQuery, Record};
-use restate_types::storage::{PolyBytes, StorageCodec, StorageCodecKind, StorageDecodeError};
-use restate_types::time::NanosSinceEpoch;
+use restate_types::{
+    flexbuffers_storage_encode_decode,
+    logs::{KeyFilter, Keys, MatchKeyQuery, Record},
+    storage::{PolyBytes, StorageCodec, StorageCodecKind, StorageDecodeError},
+    time::NanosSinceEpoch,
+};
 
 // use legacy for new appends until enough minor/major versions are released after current (1.0.x)
 // to allow for backwards compatibility.
@@ -254,18 +255,19 @@ fn read_created_at<B: Buf>(buf: &mut B) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::Arc;
 
     use bytes::BytesMut;
     use googletest::prelude::*;
-
     use restate_types::logs::Keys;
+
+    use super::*;
 
     #[test]
     fn test_record_format() {
-        use super::RecordFormat;
         use std::convert::TryFrom;
+
+        use super::RecordFormat;
         assert_eq!(RecordFormat::try_from(0x02).unwrap(), RecordFormat::Legacy);
         assert_eq!(
             RecordFormat::try_from(0x03).unwrap(),

--- a/crates/bifrost/src/providers/replicated_loglet/error.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/error.rs
@@ -11,10 +11,11 @@
 use std::sync::Arc;
 
 use restate_core::ShutdownError;
-use restate_types::errors::MaybeRetryableError;
-use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::LogId;
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::{
+    errors::MaybeRetryableError,
+    logs::{metadata::SegmentIndex, LogId},
+    replicated_loglet::ReplicatedLogletId,
+};
 
 use crate::loglet::OperationError;
 

--- a/crates/bifrost/src/providers/replicated_loglet/log_server_manager.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/log_server_manager.rs
@@ -10,14 +10,13 @@
 
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
-use tokio::sync::Mutex;
-
 use restate_core::network::{NetworkError, Networking, TransportConnect, WeakConnection};
 use restate_types::{
     logs::{LogletOffset, SequenceNumber, TailState},
     replicated_loglet::{NodeSet, ReplicatedLogletId},
     PlainNodeId,
 };
+use tokio::sync::Mutex;
 
 use crate::loglet::util::TailOffsetWatch;
 

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -11,32 +11,29 @@
 // todo(asoli): remove when fleshed out
 #![allow(dead_code)]
 
-use std::pin::Pin;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 use futures::{Stream, StreamExt};
-use restate_types::errors::MaybeRetryableError;
+use restate_core::{
+    cancellation_watcher,
+    network::{Incoming, MessageRouterBuilder, PeerMetadataVersion, Reciprocal, TransportConnect},
+    task_center, Metadata, MetadataKind, SyncError, TargetVersion, TaskKind,
+};
+use restate_types::{
+    config::ReplicatedLogletOptions,
+    errors::MaybeRetryableError,
+    logs::{LogletOffset, SequenceNumber},
+    net::replicated_loglet::{
+        Append, Appended, CommonRequestHeader, CommonResponseHeader, GetSequencerState,
+        SequencerState, SequencerStatus,
+    },
+};
 use tracing::trace;
 
-use restate_core::network::{
-    Incoming, MessageRouterBuilder, PeerMetadataVersion, Reciprocal, TransportConnect,
+use super::{
+    error::ReplicatedLogletError, loglet::ReplicatedLoglet, provider::ReplicatedLogletProvider,
 };
-use restate_core::{
-    cancellation_watcher, task_center, Metadata, MetadataKind, SyncError, TargetVersion, TaskKind,
-};
-use restate_types::config::ReplicatedLogletOptions;
-use restate_types::logs::{LogletOffset, SequenceNumber};
-use restate_types::net::replicated_loglet::{
-    Append, Appended, CommonRequestHeader, CommonResponseHeader, GetSequencerState, SequencerState,
-    SequencerStatus,
-};
-
-use super::error::ReplicatedLogletError;
-use super::loglet::ReplicatedLoglet;
-use super::provider::ReplicatedLogletProvider;
-use crate::loglet::util::TailOffsetWatch;
-use crate::loglet::{AppendError, Loglet, LogletCommit, OperationError};
+use crate::loglet::{util::TailOffsetWatch, AppendError, Loglet, LogletCommit, OperationError};
 
 type MessageStream<T> = Pin<Box<dyn Stream<Item = Incoming<T>> + Send + Sync + 'static>>;
 

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -8,29 +8,36 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
+use restate_core::{
+    network::{MessageRouterBuilder, Networking, TransportConnect},
+    TaskCenter, TaskKind,
+};
+use restate_metadata_store::MetadataStoreClient;
+use restate_types::{
+    config::Configuration,
+    logs::{
+        metadata::{LogletParams, ProviderKind, SegmentIndex},
+        LogId, RecordCache,
+    },
+    replicated_loglet::ReplicatedLogletParams,
+};
 use tracing::trace;
 
-use restate_core::network::{MessageRouterBuilder, Networking, TransportConnect};
-use restate_core::{TaskCenter, TaskKind};
-use restate_metadata_store::MetadataStoreClient;
-use restate_types::config::Configuration;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::{LogId, RecordCache};
-use restate_types::replicated_loglet::ReplicatedLogletParams;
-
-use super::loglet::ReplicatedLoglet;
-use super::metric_definitions;
-use super::network::RequestPump;
-use super::rpc_routers::{LogServersRpc, SequencersRpc};
-use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
-use crate::providers::replicated_loglet::error::ReplicatedLogletError;
-use crate::providers::replicated_loglet::tasks::PeriodicTailChecker;
-use crate::Error;
+use super::{
+    loglet::ReplicatedLoglet,
+    metric_definitions,
+    network::RequestPump,
+    rpc_routers::{LogServersRpc, SequencersRpc},
+};
+use crate::{
+    loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError},
+    providers::replicated_loglet::{error::ReplicatedLogletError, tasks::PeriodicTailChecker},
+    Error,
+};
 
 pub struct Factory<T> {
     task_center: TaskCenter,

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream.rs
@@ -11,14 +11,15 @@
 use std::task::{ready, Poll};
 
 use futures::{FutureExt, Stream, StreamExt};
+use restate_core::TaskHandle;
+use restate_types::logs::LogletOffset;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
-use restate_core::TaskHandle;
-use restate_types::logs::LogletOffset;
-
-use crate::loglet::{LogletReadStream, OperationError};
-use crate::LogEntry;
+use crate::{
+    loglet::{LogletReadStream, OperationError},
+    LogEntry,
+};
 
 pub(crate) struct ReplicatedLogletReadStream {
     // the next record this stream will attempt to return when polled

--- a/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
@@ -16,8 +16,6 @@ use std::{
     },
 };
 
-use tokio::sync::{mpsc, Mutex, OwnedSemaphorePermit, Semaphore};
-
 use restate_core::{
     network::{
         rpc_router::{RpcRouter, RpcToken},
@@ -33,6 +31,7 @@ use restate_types::{
     replicated_loglet::ReplicatedLogletParams,
     GenerationalNodeId,
 };
+use tokio::sync::{mpsc, Mutex, OwnedSemaphorePermit, Semaphore};
 
 use super::rpc_routers::SequencersRpc;
 use crate::loglet::{
@@ -481,7 +480,6 @@ mod test {
     };
 
     use rand::Rng;
-
     use restate_core::{
         network::{Incoming, MessageHandler, MockConnector},
         TaskCenterBuilder, TestCoreEnv, TestCoreEnvBuilder,

--- a/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{hash_map, HashMap};
-use std::fmt::Debug;
-use std::fmt::Display;
+use std::{
+    collections::{hash_map, HashMap},
+    fmt::{Debug, Display},
+};
 
-use restate_types::nodes_config::{NodesConfiguration, StorageState};
-use restate_types::replicated_loglet::{NodeSet, ReplicationProperty};
-use restate_types::Merge;
-use restate_types::PlainNodeId;
+use restate_types::{
+    nodes_config::{NodesConfiguration, StorageState},
+    replicated_loglet::{NodeSet, ReplicationProperty},
+    Merge, PlainNodeId,
+};
 
 /// NodeSetChecker maintains a set of nodes that can be tagged with
 /// an attribute, and provides an API for querying the replication properties of
@@ -326,12 +328,10 @@ impl FMajorityResult {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use googletest::prelude::*;
-
     use restate_types::Version;
 
+    use super::*;
     use crate::providers::replicated_loglet::test_util::{
         generate_logserver_node, generate_logserver_nodes_config,
     };

--- a/crates/bifrost/src/providers/replicated_loglet/replication/spread_selector.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/spread_selector.rs
@@ -14,9 +14,10 @@ use std::sync::Arc;
 #[cfg(any(test, feature = "test-util"))]
 use parking_lot::Mutex;
 use rand::prelude::*;
-
-use restate_types::nodes_config::NodesConfiguration;
-use restate_types::replicated_loglet::{NodeSet, ReplicationProperty, Spread};
+use restate_types::{
+    nodes_config::NodesConfiguration,
+    replicated_loglet::{NodeSet, ReplicationProperty, Spread},
+};
 
 use crate::providers::replicated_loglet::replication::NodeSetChecker;
 
@@ -187,13 +188,10 @@ impl FixedSpreadSelector {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use googletest::prelude::*;
+    use restate_types::{nodes_config::StorageState, PlainNodeId};
 
-    use restate_types::nodes_config::StorageState;
-    use restate_types::PlainNodeId;
-
+    use super::*;
     use crate::providers::replicated_loglet::test_util::generate_logserver_nodes_config;
 
     #[test]

--- a/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/rpc_routers.rs
@@ -11,12 +11,11 @@
 // todo(asoli): remove once this is used
 #![allow(dead_code)]
 
-use restate_core::network::rpc_router::RpcRouter;
-use restate_core::network::MessageRouterBuilder;
-use restate_types::net::log_server::{
-    GetDigest, GetLogletInfo, GetRecords, Release, Seal, Store, Trim, WaitForTail,
+use restate_core::network::{rpc_router::RpcRouter, MessageRouterBuilder};
+use restate_types::net::{
+    log_server::{GetDigest, GetLogletInfo, GetRecords, Release, Seal, Store, Trim, WaitForTail},
+    replicated_loglet::{Append, GetSequencerState},
 };
-use restate_types::net::replicated_loglet::{Append, GetSequencerState};
 
 /// Used by replicated loglets to send requests and receive responses from log-servers
 /// Cloning this is cheap and all clones will share the same internal trackers.

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -15,8 +15,6 @@ use std::{
 };
 
 use futures::{stream::FuturesUnordered, StreamExt};
-use tokio::{sync::OwnedSemaphorePermit, time::timeout};
-
 use restate_core::{
     cancellation_token,
     network::{
@@ -33,6 +31,7 @@ use restate_types::{
     replicated_loglet::NodeSet,
     time::MillisSinceEpoch,
 };
+use tokio::{sync::OwnedSemaphorePermit, time::timeout};
 use tracing::trace;
 
 use super::{RecordsExt, SequencerSharedState};

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/mod.rs
@@ -15,10 +15,6 @@ use std::sync::{
     Arc,
 };
 
-use tokio::sync::Semaphore;
-use tokio_util::task::TaskTracker;
-use tracing::{debug, trace};
-
 use restate_core::{
     network::{rpc_router::RpcRouter, Networking, TransportConnect},
     task_center, ShutdownError,
@@ -30,6 +26,9 @@ use restate_types::{
     replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty},
     GenerationalNodeId,
 };
+use tokio::sync::Semaphore;
+use tokio_util::task::TaskTracker;
+use tracing::{debug, trace};
 
 use self::appender::SequencerAppender;
 use super::{

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
@@ -8,17 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_core::{
+    cancellation_watcher,
+    network::{rpc_router::RpcRouter, Networking, TransportConnect},
+    ShutdownError,
+};
+use restate_types::{
+    net::log_server::GetLogletInfo,
+    replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams},
+};
 use tracing::{info, instrument, trace};
 
-use restate_core::network::rpc_router::RpcRouter;
-use restate_core::network::{Networking, TransportConnect};
-use restate_core::{cancellation_watcher, ShutdownError};
-use restate_types::net::log_server::GetLogletInfo;
-use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams};
-
 use super::{FindTailOnNode, NodeTailStatus};
-use crate::loglet::util::TailOffsetWatch;
-use crate::providers::replicated_loglet::replication::NodeSetChecker;
+use crate::{
+    loglet::util::TailOffsetWatch, providers::replicated_loglet::replication::NodeSetChecker,
+};
 
 /// Attempts to detect if the loglet has been sealed or if there is a seal in progress by
 /// consulting nodes until it reaches f-majority, and it stops at the first sealed response

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -10,26 +10,34 @@
 
 use std::time::Duration;
 
+use restate_core::{
+    network::{
+        rpc_router::{RpcError, RpcRouter},
+        Networking, Outgoing, TransportConnect,
+    },
+    TaskCenter,
+};
+use restate_types::{
+    config::Configuration,
+    logs::{metadata::SegmentIndex, LogId, LogletOffset, RecordCache, SequenceNumber},
+    net::{
+        log_server::{GetLogletInfo, LogServerRequestHeader, Status, WaitForTail},
+        replicated_loglet::{CommonRequestHeader, GetSequencerState},
+    },
+    replicated_loglet::{EffectiveNodeSet, ReplicatedLogletId, ReplicatedLogletParams},
+    PlainNodeId,
+};
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, instrument, trace, warn};
 
-use restate_core::network::rpc_router::{RpcError, RpcRouter};
-use restate_core::network::{Networking, Outgoing, TransportConnect};
-use restate_core::TaskCenter;
-use restate_types::config::Configuration;
-use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{LogId, LogletOffset, RecordCache, SequenceNumber};
-use restate_types::net::log_server::{GetLogletInfo, LogServerRequestHeader, Status, WaitForTail};
-use restate_types::net::replicated_loglet::{CommonRequestHeader, GetSequencerState};
-use restate_types::replicated_loglet::{
-    EffectiveNodeSet, ReplicatedLogletId, ReplicatedLogletParams,
-};
-use restate_types::PlainNodeId;
-
 use super::{NodeTailStatus, RepairTail, RepairTailResult, SealTask};
-use crate::loglet::util::TailOffsetWatch;
-use crate::providers::replicated_loglet::replication::NodeSetChecker;
-use crate::providers::replicated_loglet::rpc_routers::{LogServersRpc, SequencersRpc};
+use crate::{
+    loglet::util::TailOffsetWatch,
+    providers::replicated_loglet::{
+        replication::NodeSetChecker,
+        rpc_routers::{LogServersRpc, SequencersRpc},
+    },
+};
 
 /// Represents a task to determine and repair the tail of the loglet by consulting f-majority
 /// nodes in the nodeset assuming we are not the sequencer node.

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
@@ -19,10 +19,8 @@ pub use check_seal::*;
 pub use find_tail::*;
 pub use periodic_tail_checker::*;
 pub use repair_tail::*;
+use restate_types::{logs::LogletOffset, Merge};
 pub use seal::*;
-
-use restate_types::logs::LogletOffset;
-use restate_types::Merge;
 
 #[derive(Debug, Default, PartialEq, Eq, derive_more::Display)]
 enum NodeTailStatus {

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
@@ -8,17 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Weak;
-use std::time::Duration;
-
-use tokio::time::Instant;
-use tracing::{debug, trace};
+use std::{sync::Weak, time::Duration};
 
 use restate_core::network::TransportConnect;
 use restate_types::replicated_loglet::ReplicatedLogletId;
+use tokio::time::Instant;
+use tracing::{debug, trace};
 
-use crate::loglet::{Loglet, OperationError};
-use crate::providers::replicated_loglet::loglet::ReplicatedLoglet;
+use crate::{
+    loglet::{Loglet, OperationError},
+    providers::replicated_loglet::loglet::ReplicatedLoglet,
+};
 
 pub struct PeriodicTailChecker {}
 

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
@@ -10,19 +10,23 @@
 
 use std::time::Duration;
 
-use restate_core::network::{Networking, TransportConnect};
-use restate_core::{ShutdownError, TaskCenter};
-use restate_types::logs::{KeyFilter, LogletOffset, RecordCache, SequenceNumber};
-use restate_types::net::log_server::{GetDigest, LogServerRequestHeader};
-use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams};
+use restate_core::{
+    network::{Networking, TransportConnect},
+    ShutdownError, TaskCenter,
+};
+use restate_types::{
+    logs::{KeyFilter, LogletOffset, RecordCache, SequenceNumber},
+    net::log_server::{GetDigest, LogServerRequestHeader},
+    replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams},
+};
 use tokio::task::JoinSet;
 use tracing::{trace, warn};
 
-use crate::loglet::util::TailOffsetWatch;
-use crate::providers::replicated_loglet::read_path::ReadStreamTask;
-use crate::providers::replicated_loglet::rpc_routers::LogServersRpc;
-
 use super::digests::Digests;
+use crate::{
+    loglet::util::TailOffsetWatch,
+    providers::replicated_loglet::{read_path::ReadStreamTask, rpc_routers::LogServersRpc},
+};
 
 /// # Overview
 ///

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/seal.rs
@@ -8,24 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_core::{
+    network::{
+        rpc_router::{RpcError, RpcRouter},
+        Incoming, Networking, TransportConnect,
+    },
+    TaskCenter, TaskKind,
+};
+use restate_types::{
+    config::Configuration,
+    logs::{LogletOffset, SequenceNumber},
+    net::log_server::{LogServerRequestHeader, Seal, Sealed, Status},
+    replicated_loglet::{EffectiveNodeSet, NodeSet, ReplicatedLogletId, ReplicatedLogletParams},
+    retries::RetryPolicy,
+    GenerationalNodeId, PlainNodeId,
+};
 use tokio::sync::mpsc;
 use tracing::{debug, trace};
 
-use restate_core::network::rpc_router::{RpcError, RpcRouter};
-use restate_core::network::{Incoming, Networking, TransportConnect};
-use restate_core::{TaskCenter, TaskKind};
-use restate_types::config::Configuration;
-use restate_types::logs::{LogletOffset, SequenceNumber};
-use restate_types::net::log_server::{LogServerRequestHeader, Seal, Sealed, Status};
-use restate_types::replicated_loglet::{
-    EffectiveNodeSet, NodeSet, ReplicatedLogletId, ReplicatedLogletParams,
+use crate::{
+    loglet::util::TailOffsetWatch,
+    providers::replicated_loglet::{error::ReplicatedLogletError, replication::NodeSetChecker},
 };
-use restate_types::retries::RetryPolicy;
-use restate_types::{GenerationalNodeId, PlainNodeId};
-
-use crate::loglet::util::TailOffsetWatch;
-use crate::providers::replicated_loglet::error::ReplicatedLogletError;
-use crate::providers::replicated_loglet::replication::NodeSetChecker;
 
 /// Sends a seal request to as many log-servers in the nodeset
 ///

--- a/crates/bifrost/src/providers/replicated_loglet/test_util.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/test_util.rs
@@ -8,10 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::nodes_config::{
-    LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState,
+use restate_types::{
+    nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState},
+    GenerationalNodeId, PlainNodeId, Version,
 };
-use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
 pub fn generate_logserver_node(
     id: impl Into<PlainNodeId>,

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -8,37 +8,33 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::ready;
-use std::task::Poll;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Poll},
+};
 
-use futures::future::BoxFuture;
-use futures::stream::BoxStream;
-use futures::stream::FusedStream;
-use futures::Stream;
-use futures::StreamExt;
+use futures::{
+    future::BoxFuture,
+    stream::{BoxStream, FusedStream},
+    Stream, StreamExt,
+};
 use pin_project::pin_project;
+use restate_core::{MetadataKind, ShutdownError};
+use restate_types::{
+    logs::{
+        metadata::MaybeSegment, KeyFilter, LogId, Lsn, MatchKeyQuery, SequenceNumber, TailState,
+    },
+    Version, Versioned,
+};
 
-use restate_core::MetadataKind;
-use restate_core::ShutdownError;
-use restate_types::logs::metadata::MaybeSegment;
-use restate_types::logs::KeyFilter;
-use restate_types::logs::MatchKeyQuery;
-use restate_types::logs::SequenceNumber;
-use restate_types::logs::TailState;
-use restate_types::logs::{LogId, Lsn};
-use restate_types::Version;
-use restate_types::Versioned;
-
-use crate::bifrost::BifrostInner;
-use crate::bifrost::MaybeLoglet;
-use crate::loglet::OperationError;
-use crate::loglet_wrapper::LogletReadStreamWrapper;
-use crate::Error;
-use crate::LogEntry;
-use crate::Result;
+use crate::{
+    bifrost::{BifrostInner, MaybeLoglet},
+    loglet::OperationError,
+    loglet_wrapper::LogletReadStreamWrapper,
+    Error, LogEntry, Result,
+};
 
 /// A read stream reads from the virtual log. The stream provides a unified view over
 /// the virtual log addressing space in the face of seals, reconfiguration, and trims.
@@ -435,26 +431,28 @@ fn deliver_trim_gap(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::sync::atomic::AtomicUsize;
 
     use googletest::prelude::*;
-    use tokio_stream::StreamExt;
-    use tracing::info;
-    use tracing_test::traced_test;
-
     use restate_core::{
         metadata, task_center, MetadataKind, TargetVersion, TaskKind, TestCoreEnvBuilder,
     };
     use restate_rocksdb::RocksDbManager;
-    use restate_types::config::{CommonOptions, Configuration};
-    use restate_types::live::{Constant, Live};
-    use restate_types::logs::metadata::{new_single_node_loglet_params, ProviderKind};
-    use restate_types::logs::{KeyFilter, SequenceNumber};
-    use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
-    use restate_types::Versioned;
+    use restate_types::{
+        config::{CommonOptions, Configuration},
+        live::{Constant, Live},
+        logs::{
+            metadata::{new_single_node_loglet_params, ProviderKind},
+            KeyFilter, SequenceNumber,
+        },
+        metadata_store::keys::BIFROST_CONFIG_KEY,
+        Versioned,
+    };
+    use tokio_stream::StreamExt;
+    use tracing::info;
+    use tracing_test::traced_test;
 
+    use super::*;
     use crate::{setup_panic_handler, BifrostAdmin, BifrostService, FindTailAttributes};
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -9,13 +9,13 @@
 // by the Apache License, Version 2.0.
 
 use core::str;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
-use restate_types::logs::{BodyWithKeys, HasRecordKeys, Keys, Lsn, Record};
-use restate_types::logs::{LogletOffset, SequenceNumber};
-use restate_types::storage::{PolyBytes, StorageDecode, StorageDecodeError, StorageEncode};
-use restate_types::time::NanosSinceEpoch;
+use restate_types::{
+    logs::{BodyWithKeys, HasRecordKeys, Keys, LogletOffset, Lsn, Record, SequenceNumber},
+    storage::{PolyBytes, StorageDecode, StorageDecodeError, StorageEncode},
+    time::NanosSinceEpoch,
+};
 
 use crate::LsnExt;
 

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -8,24 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context;
 use enum_map::EnumMap;
-use restate_types::config::Configuration;
-use restate_types::live::Live;
+use restate_core::{cancellation_watcher, Metadata, TaskCenter, TaskKind};
+use restate_types::{config::Configuration, live::Live, logs::metadata::ProviderKind};
 use tracing::{debug, error, trace};
 
-use restate_core::{cancellation_watcher, Metadata, TaskCenter, TaskKind};
-use restate_types::logs::metadata::ProviderKind;
-
-use crate::bifrost::BifrostInner;
-use crate::providers::local_loglet;
 #[cfg(any(test, feature = "memory-loglet"))]
 use crate::providers::memory_loglet;
-use crate::watchdog::{Watchdog, WatchdogCommand};
-use crate::{loglet::LogletProviderFactory, Bifrost};
+use crate::{
+    bifrost::BifrostInner,
+    loglet::LogletProviderFactory,
+    providers::local_loglet,
+    watchdog::{Watchdog, WatchdogCommand},
+    Bifrost,
+};
 
 pub struct BifrostService {
     task_center: TaskCenter,

--- a/crates/bifrost/src/types.rs
+++ b/crates/bifrost/src/types.rs
@@ -11,7 +11,6 @@
 use std::task::{ready, Poll};
 
 use futures::FutureExt;
-
 use restate_types::logs::{LogletOffset, Lsn, SequenceNumber};
 
 use crate::loglet::AppendError;
@@ -129,8 +128,9 @@ impl std::future::Future for Commit {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::LsnExt;
     use restate_types::logs::{LogletOffset, Lsn, SequenceNumber};
+
+    use crate::types::LsnExt;
 
     #[test]
     fn lsn_to_offset() {

--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
 use enum_map::Enum;
@@ -18,8 +17,7 @@ use restate_types::logs::metadata::ProviderKind;
 use tokio::task::JoinSet;
 use tracing::{debug, trace, warn};
 
-use crate::bifrost::BifrostInner;
-use crate::loglet::LogletProvider;
+use crate::{bifrost::BifrostInner, loglet::LogletProvider};
 
 pub type WatchdogSender = tokio::sync::mpsc::UnboundedSender<WatchdogCommand>;
 type WatchdogReceiver = tokio::sync::mpsc::UnboundedReceiver<WatchdogCommand>;

--- a/crates/cli-util/src/context.rs
+++ b/crates/cli-util/src/context.rs
@@ -8,18 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::IsTerminal;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::{
+    io::IsTerminal,
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use arc_swap::ArcSwap;
 use dotenvy::dotenv;
 use tracing::info;
 use tracing_log::AsTrace;
 
-use crate::opts::{CommonOpts, ConfirmMode, NetworkOpts, TableStyle, TimeFormat, UiOpts};
-use crate::os_env::OsEnv;
+use crate::{
+    opts::{CommonOpts, ConfirmMode, NetworkOpts, TableStyle, TimeFormat, UiOpts},
+    os_env::OsEnv,
+};
 
 static GLOBAL_CLI_CONTEXT: OnceLock<ArcSwap<CliContext>> = OnceLock::new();
 

--- a/crates/cli-util/src/lib.rs
+++ b/crates/cli-util/src/lib.rs
@@ -13,10 +13,9 @@ mod opts;
 mod os_env;
 pub mod ui;
 
+// Re-export comfy-table for console c_* macros
+pub use comfy_table as _comfy_table;
 pub use context::CliContext;
 pub use opts::CommonOpts;
 pub use os_env::OsEnv;
-
-// Re-export comfy-table for console c_* macros
-pub use comfy_table as _comfy_table;
 pub use unicode_width as _unicode_width;

--- a/crates/cli-util/src/os_env.rs
+++ b/crates/cli-util/src/os_env.rs
@@ -52,8 +52,7 @@ mod test_os_env {
     }
 }
 
-#[cfg(any(test, feature = "test-util"))]
-pub use test_os_env::OsEnv;
-
 #[cfg(not(any(test, feature = "test-util")))]
 pub use os_env::OsEnv;
+#[cfg(any(test, feature = "test-util"))]
+pub use test_os_env::OsEnv;

--- a/crates/cli-util/src/ui/console.rs
+++ b/crates/cli-util/src/ui/console.rs
@@ -24,10 +24,10 @@
 
 use std::fmt::{Display, Formatter};
 
+use dialoguer::console::Style as DStyle;
+
 use super::stylesheet::Style;
 use crate::context::CliContext;
-
-use dialoguer::console::Style as DStyle;
 
 /// Emoji that fallback to a string if colors are disabled.
 #[derive(Copy, Clone)]

--- a/crates/cli-util/src/ui/output.rs
+++ b/crates/cli-util/src/ui/output.rs
@@ -8,10 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Write;
-use std::sync::{Arc, Mutex};
-
-use std::sync::OnceLock;
+use std::{
+    fmt::Write,
+    sync::{Arc, Mutex, OnceLock},
+};
 
 const BUF_INITIAL_CAPACITY: usize = 2048;
 

--- a/crates/cli-util/src/ui/stylesheet.rs
+++ b/crates/cli-util/src/ui/stylesheet.rs
@@ -8,10 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::context::CliContext;
-use crate::opts::TableStyle;
-
 use super::console::{Icon, StyledTable};
+use crate::{context::CliContext, opts::TableStyle};
 
 pub const SUCCESS_ICON: Icon = Icon("✅", "[OK]:");
 pub const ERR_ICON: Icon = Icon("❌", "[ERR]:");

--- a/crates/cli-util/src/ui/watcher.rs
+++ b/crates/cli-util/src/ui/watcher.rs
@@ -8,21 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::future::Future;
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 use anyhow::Result;
 use cling::Collect;
-use crossterm::style::ResetColor;
-use crossterm::terminal::{
-    BeginSynchronizedUpdate, Clear, ClearType, EndSynchronizedUpdate, EnterAlternateScreen,
-    LeaveAlternateScreen,
+use crossterm::{
+    cursor, execute, queue,
+    style::ResetColor,
+    terminal::{
+        BeginSynchronizedUpdate, Clear, ClearType, EndSynchronizedUpdate, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
 };
-use crossterm::{cursor, execute, queue};
-
-use crate::ui::console::Icon;
 
 use super::output::Console;
+use crate::ui::console::Icon;
 
 #[derive(clap::Args, Clone, Collect, Debug)]
 pub struct Watch {

--- a/crates/codederror/derive/src/ast.rs
+++ b/crates/codederror/derive/src/ast.rs
@@ -11,12 +11,15 @@
 //! Some parts copied from https://github.com/dtolnay/thiserror/blob/39aaeb00ff270a49e3c254d7b38b10e934d3c7a5/impl/src/ast.rs
 //! License Apache-2.0 or MIT
 
-use crate::attr::{self, Attrs};
-use crate::generics::ParamsInScope;
 use proc_macro2::Span;
 use syn::{
     Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Generics, Ident, Index, Member, Result,
     Type,
+};
+
+use crate::{
+    attr::{self, Attrs},
+    generics::ParamsInScope,
 };
 
 pub enum Input<'a> {

--- a/crates/codederror/derive/src/attr.rs
+++ b/crates/codederror/derive/src/attr.rs
@@ -11,8 +11,10 @@
 //! Some parts copied from https://github.com/dtolnay/thiserror/blob/39aaeb00ff270a49e3c254d7b38b10e934d3c7a5/impl/src/attr.rs
 //! License Apache-2.0 or MIT
 
-use syn::parse::{Nothing, ParseStream};
-use syn::{Attribute, Error as SynError, Path, Result};
+use syn::{
+    parse::{Nothing, ParseStream},
+    Attribute, Error as SynError, Path, Result,
+};
 
 pub struct Attrs<'a> {
     // We parse these just to figure out who should we delegate to during codegen

--- a/crates/codederror/derive/src/expand.rs
+++ b/crates/codederror/derive/src/expand.rs
@@ -13,12 +13,13 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
-use syn::spanned::Spanned;
-use syn::{Data, DeriveInput, Member, Result, Visibility};
+use syn::{spanned::Spanned, Data, DeriveInput, Member, Result, Visibility};
 
-use crate::ast::{Enum, Field, Input, Struct};
-use crate::attr::Code;
-use crate::generics::InferredBounds;
+use crate::{
+    ast::{Enum, Field, Input, Struct},
+    attr::Code,
+    generics::InferredBounds,
+};
 
 pub fn derive(node: &DeriveInput) -> Result<TokenStream> {
     let input = Input::from_syn(node)?;

--- a/crates/codederror/derive/src/generics.rs
+++ b/crates/codederror/derive/src/generics.rs
@@ -11,12 +11,14 @@
 //! Some parts copied from https://github.com/dtolnay/thiserror/blob/39aaeb00ff270a49e3c254d7b38b10e934d3c7a5/impl/src/generics.rs
 //! License Apache-2.0 or MIT
 
+use std::collections::{btree_map::Entry, BTreeMap as Map, BTreeSet as Set};
+
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap as Map, BTreeSet as Set};
-use syn::punctuated::Punctuated;
-use syn::{parse_quote, GenericArgument, Generics, Ident, PathArguments, Token, Type, WhereClause};
+use syn::{
+    parse_quote, punctuated::Punctuated, GenericArgument, Generics, Ident, PathArguments, Token,
+    Type, WhereClause,
+};
 
 pub struct ParamsInScope<'a> {
     names: Set<&'a Ident>,

--- a/crates/codederror/derive/src/valid.rs
+++ b/crates/codederror/derive/src/valid.rs
@@ -8,9 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::ast::{Enum, Field, Input, Struct, Variant};
-use crate::attr::Attrs;
 use syn::{Error, Result};
+
+use crate::{
+    ast::{Enum, Field, Input, Struct, Variant},
+    attr::Attrs,
+};
 
 impl Input<'_> {
     pub(crate) fn validate(&self) -> Result<()> {

--- a/crates/codederror/src/lib.rs
+++ b/crates/codederror/src/lib.rs
@@ -91,9 +91,11 @@
 //!
 //! [`thiserror`]: https://docs.rs/thiserror
 
-use std::fmt;
-use std::fmt::{Debug, Display};
-use std::ops::Deref;
+use std::{
+    fmt,
+    fmt::{Debug, Display},
+    ops::Deref,
+};
 
 pub use codederror_derive::*;
 

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,7 +17,6 @@ mod task_center;
 mod task_center_types;
 pub mod worker_api;
 pub use error::*;
-
 pub use metadata::{
     spawn_metadata_manager, Metadata, MetadataBuilder, MetadataKind, MetadataManager,
     MetadataWriter, SyncError, TargetVersion,

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -10,27 +10,27 @@
 
 mod manager;
 
-pub use manager::{MetadataManager, TargetVersion};
-pub use restate_types::net::metadata::MetadataKind;
-
 use std::sync::{Arc, OnceLock};
 
 use arc_swap::{ArcSwap, AsRaw};
 use enum_map::EnumMap;
+pub use manager::{MetadataManager, TargetVersion};
+pub use restate_types::net::metadata::MetadataKind;
+use restate_types::{
+    live::{Live, Pinned},
+    logs::metadata::Logs,
+    net::metadata::MetadataContainer,
+    nodes_config::NodesConfiguration,
+    partition_table::PartitionTable,
+    schema::Schema,
+    GenerationalNodeId, Version, Versioned,
+};
 use tokio::sync::{mpsc, oneshot, watch};
 
-use restate_types::live::{Live, Pinned};
-use restate_types::logs::metadata::Logs;
-use restate_types::net::metadata::MetadataContainer;
-use restate_types::nodes_config::NodesConfiguration;
-use restate_types::partition_table::PartitionTable;
-use restate_types::schema::Schema;
-use restate_types::{GenerationalNodeId, Version, Versioned};
-
-use crate::metadata::manager::Command;
-use crate::metadata_store::ReadError;
-use crate::network::WeakConnection;
-use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
+use crate::{
+    metadata::manager::Command, metadata_store::ReadError, network::WeakConnection, ShutdownError,
+    TaskCenter, TaskId, TaskKind,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SyncError {

--- a/crates/core/src/metadata_store/mod.rs
+++ b/crates/core/src/metadata_store/mod.rs
@@ -11,20 +11,26 @@
 pub mod providers;
 mod test_util;
 
-#[cfg(any(test, feature = "test-util"))]
-use crate::metadata_store::test_util::InMemoryMetadataStore;
+use std::{
+    future::Future,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use bytestring::ByteString;
-use restate_types::errors::GenericError;
-use restate_types::retries::RetryPolicy;
-use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
-use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
-use std::future::Future;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tracing::log::trace;
-use tracing::{debug, info};
+use restate_types::{
+    errors::GenericError,
+    flexbuffers_storage_encode_decode,
+    retries::RetryPolicy,
+    storage::{StorageCodec, StorageDecode, StorageEncode},
+    Version, Versioned,
+};
+use tracing::{debug, info, log::trace};
+
+#[cfg(any(test, feature = "test-util"))]
+use crate::metadata_store::test_util::InMemoryMetadataStore;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ReadError {

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -1,11 +1,12 @@
-use crate::metadata_store::{
-    MetadataStore, Precondition, ReadError, Version, VersionedValue, WriteError,
-};
 use anyhow::Context;
 use bytes::Bytes;
 use bytestring::ByteString;
 use etcd_client::{
     Client, Compare, CompareOp, Error as EtcdError, GetOptions, KeyValue, KvClient, Txn, TxnOp,
+};
+
+use crate::metadata_store::{
+    MetadataStore, Precondition, ReadError, Version, VersionedValue, WriteError,
 };
 
 impl From<EtcdError> for ReadError {

--- a/crates/core/src/metadata_store/test_util.rs
+++ b/crates/core/src/metadata_store/test_util.rs
@@ -8,11 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::metadata_store::{MetadataStore, Precondition, ReadError, VersionedValue, WriteError};
+use std::{collections::HashMap, sync::Mutex};
+
 use bytestring::ByteString;
 use restate_types::Version;
-use std::collections::HashMap;
-use std::sync::Mutex;
+
+use crate::metadata_store::{MetadataStore, Precondition, ReadError, VersionedValue, WriteError};
 
 #[derive(Debug, Default)]
 pub struct InMemoryMetadataStore {

--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -8,8 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::net::{CodecError, MIN_SUPPORTED_PROTOCOL_VERSION};
-use restate_types::nodes_config::NodesConfigError;
+use restate_types::{
+    net::{CodecError, MIN_SUPPORTED_PROTOCOL_VERSION},
+    nodes_config::NodesConfigError,
+};
 
 use crate::{ShutdownError, SyncError};
 

--- a/crates/core/src/network/handshake.rs
+++ b/crates/core/src/network/handshake.rs
@@ -11,8 +11,10 @@
 use std::time::Duration;
 
 use futures::Stream;
-use restate_types::net::{ProtocolVersion, CURRENT_PROTOCOL_VERSION};
-use restate_types::protobuf::node::{message, Header, Hello, Message, Welcome};
+use restate_types::{
+    net::{ProtocolVersion, CURRENT_PROTOCOL_VERSION},
+    protobuf::node::{message, Header, Hello, Message, Welcome},
+};
 use tokio_stream::StreamExt;
 
 use super::error::ProtocolError;

--- a/crates/core/src/network/message_router.rs
+++ b/crates/core/src/network/message_router.rs
@@ -8,25 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::pin::Pin;
-use std::sync::Arc;
+use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
 use futures::Stream;
-
-use restate_types::net::codec::{Targeted, WireDecode};
-use restate_types::net::CodecError;
-use restate_types::net::ProtocolVersion;
-use restate_types::net::TargetName;
-use restate_types::protobuf::node::message::BinaryMessage;
+use restate_types::{
+    net::{
+        codec::{Targeted, WireDecode},
+        CodecError, ProtocolVersion, TargetName,
+    },
+    protobuf::node::message::BinaryMessage,
+};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 
-use crate::is_cancellation_requested;
-
 use super::{Incoming, RouterError};
+use crate::is_cancellation_requested;
 
 /// Implement this trait to process network messages for a specific target
 /// (e.g. TargetName = METADATA_MANAGER).

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -22,17 +22,15 @@ pub mod rpc_router;
 pub mod transport_connector;
 mod types;
 
+#[cfg(any(test, feature = "test-util"))]
+pub use connection::test_util::*;
 pub use connection::{OwnedConnection, WeakConnection};
 pub use connection_manager::ConnectionManager;
 pub use error::*;
 pub use message_router::*;
 pub use network_sender::*;
 pub use networking::Networking;
-pub use transport_connector::{GrpcConnector, TransportConnect};
-pub use types::*;
-
-#[cfg(any(test, feature = "test-util"))]
-pub use connection::test_util::*;
-
 #[cfg(any(test, feature = "test-util"))]
 pub use transport_connector::test_util::*;
+pub use transport_connector::{GrpcConnector, TransportConnect};
+pub use types::*;

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -8,25 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::future::Future;
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{fmt::Debug, future::Future, net::SocketAddr, path::PathBuf, time::Duration};
 
-use crate::{cancellation_watcher, task_center, ShutdownError, TaskCenter, TaskKind};
 use http::Uri;
-use hyper::body::{Body, Incoming};
-use hyper::rt::{Read, Write};
+use hyper::{
+    body::{Body, Incoming},
+    rt::{Read, Write},
+};
 use hyper_util::rt::TokioIo;
-use tokio::io;
-use tokio::net::{TcpListener, UnixListener, UnixStream};
+use restate_types::{
+    errors::GenericError,
+    net::{AdvertisedAddress, BindAddress},
+};
+use tokio::{
+    io,
+    net::{TcpListener, UnixListener, UnixStream},
+};
 use tokio_util::net::Listener;
 use tonic::transport::{Channel, Endpoint};
 use tracing::{debug, info, instrument, Span};
 
-use restate_types::errors::GenericError;
-use restate_types::net::{AdvertisedAddress, BindAddress};
+use crate::{cancellation_watcher, task_center, ShutdownError, TaskCenter, TaskKind};
 
 pub fn create_tonic_channel_from_advertised_address(address: AdvertisedAddress) -> Channel {
     match address {

--- a/crates/core/src/network/networking.rs
+++ b/crates/core/src/network/networking.rs
@@ -8,20 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
+use restate_types::{
+    config::NetworkingOptions,
+    net::codec::{Targeted, WireEncode},
+    GenerationalNodeId, NodeId,
+};
 use tracing::{debug, instrument, trace};
 
-use restate_types::config::NetworkingOptions;
-use restate_types::net::codec::{Targeted, WireEncode};
-use restate_types::{GenerationalNodeId, NodeId};
-
 use super::{
-    ConnectionManager, HasConnection, NetworkError, NetworkSendError, NetworkSender, NoConnection,
-    Outgoing, OwnedConnection, WeakConnection,
+    ConnectionManager, GrpcConnector, HasConnection, NetworkError, NetworkSendError, NetworkSender,
+    NoConnection, Outgoing, OwnedConnection, TransportConnect, WeakConnection,
 };
-use super::{GrpcConnector, TransportConnect};
 use crate::Metadata;
 
 /// Access to node-to-node networking infrastructure.

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -8,20 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::{
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
-use dashmap::mapref::entry::Entry;
-use dashmap::DashMap;
-use futures::stream::BoxStream;
-use futures::StreamExt;
-use restate_types::NodeId;
-use tokio::sync::oneshot;
-use tokio::time::Instant;
+use dashmap::{mapref::entry::Entry, DashMap};
+use futures::{stream::BoxStream, StreamExt};
+use restate_types::{
+    net::{
+        codec::{Targeted, WireDecode, WireEncode},
+        RpcRequest,
+    },
+    NodeId,
+};
+use tokio::{sync::oneshot, time::Instant};
 use tracing::{error, warn};
-
-use restate_types::net::codec::{Targeted, WireDecode, WireEncode};
-use restate_types::net::RpcRequest;
 
 use super::{
     HasConnection, Incoming, MessageHandler, MessageRouterBuilder, NetworkError, NetworkSendError,
@@ -370,15 +372,16 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::network::{PeerMetadataVersion, WeakConnection};
-
-    use super::*;
     use futures::future::join_all;
-    use restate_types::net::codec::encode_default;
-    use restate_types::net::{CodecError, TargetName};
-    use restate_types::GenerationalNodeId;
+    use restate_types::{
+        net::{codec::encode_default, CodecError, TargetName},
+        GenerationalNodeId,
+    };
     use serde::{Deserialize, Serialize};
     use tokio::sync::Barrier;
+
+    use super::*;
+    use crate::network::{PeerMetadataVersion, WeakConnection};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct TestRequest {

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -12,17 +12,14 @@ use std::future::Future;
 
 use dashmap::DashMap;
 use futures::{Stream, StreamExt};
+use restate_types::{
+    config::NetworkingOptions, net::AdvertisedAddress, nodes_config::NodesConfiguration,
+    protobuf::node::Message, GenerationalNodeId,
+};
 use tonic::transport::Channel;
 use tracing::trace;
 
-use restate_types::config::NetworkingOptions;
-use restate_types::net::AdvertisedAddress;
-use restate_types::nodes_config::NodesConfiguration;
-use restate_types::protobuf::node::Message;
-use restate_types::GenerationalNodeId;
-
-use super::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use super::{NetworkError, ProtocolError};
+use super::{protobuf::node_svc::node_svc_client::NodeSvcClient, NetworkError, ProtocolError};
 use crate::network::net_util::create_tonic_channel_from_advertised_address;
 
 pub trait TransportConnect: Send + Sync + 'static {
@@ -86,25 +83,24 @@ impl TransportConnect for GrpcConnector {
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
 
-    use super::*;
-
-    use std::sync::Arc;
-    use std::time::Instant;
+    use std::{sync::Arc, time::Instant};
 
     use futures::{Stream, StreamExt};
     use parking_lot::Mutex;
+    use restate_types::{
+        nodes_config::NodesConfiguration,
+        protobuf::node::{message::BinaryMessage, Message},
+        GenerationalNodeId,
+    };
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
     use tracing::info;
 
-    use restate_types::nodes_config::NodesConfiguration;
-    use restate_types::protobuf::node::message::BinaryMessage;
-    use restate_types::protobuf::node::Message;
-    use restate_types::GenerationalNodeId;
-
-    use super::{NetworkError, ProtocolError};
-    use crate::network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection};
-    use crate::{TaskCenter, TaskHandle, TaskKind};
+    use super::{NetworkError, ProtocolError, *};
+    use crate::{
+        network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection},
+        TaskCenter, TaskHandle, TaskKind,
+    };
 
     #[derive(Clone)]
     pub struct MockConnector {

--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -8,21 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::marker::PhantomData;
-use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    marker::PhantomData,
+    sync::{atomic::AtomicU64, Arc},
+    time::{Duration, Instant},
+};
 
-use restate_types::net::codec::{Targeted, WireEncode};
-use restate_types::net::RpcRequest;
-use restate_types::protobuf::node::Header;
-use restate_types::{GenerationalNodeId, NodeId, Version};
+use restate_types::{
+    net::{
+        codec::{Targeted, WireEncode},
+        RpcRequest,
+    },
+    protobuf::node::Header,
+    GenerationalNodeId, NodeId, Version,
+};
 
+use super::{
+    connection::OwnedConnection, metric_definitions::CONNECTION_SEND_DURATION, NetworkError,
+    NetworkSendError, WeakConnection,
+};
 use crate::with_metadata;
-
-use super::connection::OwnedConnection;
-use super::metric_definitions::CONNECTION_SEND_DURATION;
-use super::{NetworkError, NetworkSendError, WeakConnection};
 
 static NEXT_MSG_ID: AtomicU64 = const { AtomicU64::new(1) };
 

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -8,29 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::panic::AssertUnwindSafe;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    panic::AssertUnwindSafe,
+    sync::{
+        atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicUsize, Ordering},
+        Arc, OnceLock,
+    },
+    time::{Duration, Instant},
+};
 
 use futures::{Future, FutureExt};
 use metrics::{counter, gauge};
 use parking_lot::Mutex;
-use tokio::runtime::RuntimeMetrics;
-use tokio::task::LocalSet;
-use tokio::task_local;
+use restate_types::{config::CommonOptions, identifiers::PartitionId, GenerationalNodeId};
+use tokio::{runtime::RuntimeMetrics, task::LocalSet, task_local};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 use tracing::{debug, error, info, instrument, trace, warn};
 
-use restate_types::config::CommonOptions;
-use restate_types::identifiers::PartitionId;
-use restate_types::GenerationalNodeId;
-
-use crate::metric_definitions::{TC_FINISHED, TC_SPAWN, TC_STATUS_COMPLETED, TC_STATUS_FAILED};
 use crate::{
-    metric_definitions, Metadata, RuntimeHandle, ShutdownError, ShutdownSourceErr, TaskHandle,
-    TaskId, TaskKind,
+    metric_definitions,
+    metric_definitions::{TC_FINISHED, TC_SPAWN, TC_STATUS_COMPLETED, TC_STATUS_FAILED},
+    Metadata, RuntimeHandle, ShutdownError, ShutdownSourceErr, TaskHandle, TaskId, TaskKind,
 };
 
 static WORKER_ID: AtomicUsize = const { AtomicUsize::new(0) };
@@ -1078,12 +1077,12 @@ pub fn is_cancellation_requested() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use googletest::prelude::*;
     use restate_test_util::assert_eq;
     use restate_types::config::CommonOptionsBuilder;
     use tracing_test::traced_test;
+
+    use super::*;
 
     #[tokio::test(start_paused = true)]
     #[traced_test]

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -8,8 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::pin::Pin;
-use std::task::{ready, Poll};
+use std::{
+    pin::Pin,
+    task::{ready, Poll},
+};
 
 use futures::FutureExt;
 use strum::EnumProperty;

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -8,34 +8,36 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::marker::PhantomData;
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{marker::PhantomData, str::FromStr, sync::Arc};
 
 use futures::Stream;
-
-use restate_types::cluster_controller::{ReplicationStrategy, SchedulingPlan};
-use restate_types::config::NetworkingOptions;
-use restate_types::logs::metadata::{bootstrap_logs_metadata, ProviderKind};
-use restate_types::metadata_store::keys::{
-    BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY, SCHEDULING_PLAN_KEY,
+use restate_types::{
+    cluster_controller::{ReplicationStrategy, SchedulingPlan},
+    config::NetworkingOptions,
+    logs::metadata::{bootstrap_logs_metadata, ProviderKind},
+    metadata_store::keys::{
+        BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY, SCHEDULING_PLAN_KEY,
+    },
+    net::{
+        codec::{Targeted, WireDecode},
+        metadata::MetadataKind,
+        AdvertisedAddress,
+    },
+    nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role},
+    partition_table::PartitionTable,
+    protobuf::node::Message,
+    GenerationalNodeId, Version,
 };
-use restate_types::net::codec::{Targeted, WireDecode};
-use restate_types::net::metadata::MetadataKind;
-use restate_types::net::AdvertisedAddress;
-use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
-use restate_types::partition_table::PartitionTable;
-use restate_types::protobuf::node::Message;
-use restate_types::{GenerationalNodeId, Version};
 
-use crate::metadata_store::{MetadataStoreClient, Precondition};
-use crate::network::{
-    ConnectionManager, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder,
-    NetworkError, Networking, ProtocolError, TransportConnect,
+use crate::{
+    metadata_store::{MetadataStoreClient, Precondition},
+    network::{
+        ConnectionManager, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder,
+        NetworkError, Networking, ProtocolError, TransportConnect,
+    },
+    spawn_metadata_manager, Metadata, MetadataBuilder, MetadataManager, MetadataWriter, TaskCenter,
+    TaskCenterBuilder, TaskId,
 };
-use crate::{spawn_metadata_manager, MetadataBuilder, TaskId};
-use crate::{Metadata, MetadataManager, MetadataWriter};
-use crate::{TaskCenter, TaskCenterBuilder};
 
 pub struct TestCoreEnvBuilder<T> {
     pub tc: TaskCenter,

--- a/crates/core/src/worker_api/partition_processor_manager.rs
+++ b/crates/core/src/worker_api/partition_processor_manager.rs
@@ -8,9 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tokio::sync::{mpsc, oneshot};
-
 use restate_types::identifiers::{PartitionId, SnapshotId};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::ShutdownError;
 

--- a/crates/errors/src/fmt.rs
+++ b/crates/errors/src/fmt.rs
@@ -27,8 +27,9 @@
 //! # }
 //! ```
 
-use codederror::Code;
 use std::fmt;
+
+use codederror::Code;
 
 /// Check module documentation for more details.
 #[macro_export]

--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -10,9 +10,12 @@
 
 //! This crate contains a collection of utils to interact with the filesystem.
 
-use std::env::temp_dir;
-use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::{
+    env::temp_dir,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
 use tokio::io;
 use tracing::{info, trace};
 

--- a/crates/futures-util/src/command.rs
+++ b/crates/futures-util/src/command.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::fmt::Debug;
+use std::{fmt, fmt::Debug};
 
 use tokio::sync::oneshot;
 
@@ -167,12 +166,11 @@ impl<T: Send, R: Send> From<Command<T, R>> for (T, CommandResponseSender<R>) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
+    use restate_test_util::assert_eq;
     use test_log::test;
     use tokio::sync::mpsc;
 
-    use restate_test_util::assert_eq;
+    use super::*;
 
     #[test(tokio::test)]
     async fn test_back_and_forth() {

--- a/crates/futures-util/src/pipe.rs
+++ b/crates/futures-util/src/pipe.rs
@@ -8,18 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::future::{poll_fn, Future};
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{ready, Context, Poll};
-
-use pin_project::pin_project;
-use tokio::sync::mpsc;
+use std::{
+    future::{poll_fn, Future},
+    marker::PhantomData,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
 
 pub use input::*;
 pub use multi_input::*;
 pub use multi_target::*;
+use pin_project::pin_project;
 pub use target::*;
+use tokio::sync::mpsc;
 
 #[derive(Debug, Copy, Clone, PartialEq, thiserror::Error)]
 pub enum PipeError {
@@ -488,9 +489,9 @@ mod multi_target {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use futures::future;
+
+    use super::*;
 
     #[tokio::test]
     async fn pipe_bounded_to_bounded() {

--- a/crates/ingress-dispatcher/src/lib.rs
+++ b/crates/ingress-dispatcher/src/lib.rs
@@ -8,25 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Display;
-use std::future::Future;
-use std::hash::Hash;
+use std::{fmt::Display, future::Future, hash::Hash};
 
 use bytes::Bytes;
-use tokio::sync::oneshot;
-
 use restate_core::metadata;
-use restate_types::identifiers::{
-    partitioner, IngressRequestId, InvocationId, PartitionKey, WithPartitionKey,
+use restate_types::{
+    identifiers::{partitioner, IngressRequestId, InvocationId, PartitionKey, WithPartitionKey},
+    ingress::IngressResponseResult,
+    invocation::{
+        AttachInvocationRequest, InvocationQuery, InvocationResponse, InvocationTarget,
+        InvocationTargetType, ServiceInvocation, ServiceInvocationResponseSink, SpanRelation,
+        SubmitNotificationSink, VirtualObjectHandlerType, WorkflowHandlerType,
+    },
+    message::MessageIndex,
+    schema::subscriptions::{EventReceiverServiceType, Sink, Subscription},
 };
-use restate_types::ingress::IngressResponseResult;
-use restate_types::invocation::{
-    AttachInvocationRequest, InvocationQuery, InvocationResponse, InvocationTarget,
-    InvocationTargetType, ServiceInvocation, ServiceInvocationResponseSink, SpanRelation,
-    SubmitNotificationSink, VirtualObjectHandlerType, WorkflowHandlerType,
-};
-use restate_types::message::MessageIndex;
-use restate_types::schema::subscriptions::{EventReceiverServiceType, Sink, Subscription};
+use tokio::sync::oneshot;
 
 mod dispatcher;
 pub mod error;
@@ -281,11 +278,11 @@ impl IngressDispatcherRequest {
 
 #[cfg(feature = "test-util")]
 pub mod test_util {
-    use super::*;
-
-    use crate::error::IngressDispatchError;
     use restate_test_util::let_assert;
     use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::error::IngressDispatchError;
 
     #[derive(Clone)]
     pub struct MockDispatcher {

--- a/crates/ingress-http/src/handler/awakeables.rs
+++ b/crates/ingress-http/src/handler/awakeables.rs
@@ -8,21 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::path_parsing::AwakeableRequestType;
-use super::Handler;
-use super::HandlerError;
+use std::str::FromStr;
 
 use bytes::Bytes;
 use http::{Method, Request, Response, StatusCode};
-use http_body_util::BodyExt;
-use http_body_util::Full;
-use restate_ingress_dispatcher::DispatchIngressRequest;
-use restate_ingress_dispatcher::IngressDispatcherRequest;
+use http_body_util::{BodyExt, Full};
+use restate_ingress_dispatcher::{DispatchIngressRequest, IngressDispatcherRequest};
 use restate_service_protocol::awakeable_id::AwakeableIdentifier;
-use restate_types::errors::{codes, InvocationError};
-use restate_types::invocation::{InvocationResponse, ResponseResult};
-use std::str::FromStr;
+use restate_types::{
+    errors::{codes, InvocationError},
+    invocation::{InvocationResponse, ResponseResult},
+};
 use tracing::{info, trace, warn};
+
+use super::{path_parsing::AwakeableRequestType, Handler, HandlerError};
 
 impl<Schemas, Dispatcher, StorageReader> Handler<Schemas, Dispatcher, StorageReader>
 where

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -8,14 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::APPLICATION_JSON;
+use std::string;
 
 use bytes::Bytes;
 use http::{header, Response, StatusCode};
-use restate_types::errors::{IdDecodeError, InvocationError};
-use restate_types::schema::invocation_target::InputValidationError;
+use restate_types::{
+    errors::{IdDecodeError, InvocationError},
+    schema::invocation_target::InputValidationError,
+};
 use serde::Serialize;
-use std::string;
+
+use super::APPLICATION_JSON;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum HandlerError {

--- a/crates/ingress-http/src/handler/health.rs
+++ b/crates/ingress-http/src/handler/health.rs
@@ -11,9 +11,8 @@
 use bytes::Bytes;
 use http::{header, Method, Request, Response, StatusCode};
 use http_body_util::Full;
-use serde::Serialize;
-
 use restate_types::schema::service::ServiceMetadataResolver;
+use serde::Serialize;
 
 use super::{Handler, APPLICATION_JSON};
 use crate::handler::error::HandlerError;

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -11,17 +11,17 @@
 use bytes::Bytes;
 use http::{Method, Request, Response};
 use http_body_util::Full;
+use restate_ingress_dispatcher::{DispatchIngressRequest, IngressDispatcherRequest};
+use restate_types::{
+    identifiers::IdempotencyId, invocation::InvocationQuery,
+    schema::invocation_target::InvocationTargetResolver,
+};
 use tracing::warn;
 
-use restate_ingress_dispatcher::DispatchIngressRequest;
-use restate_ingress_dispatcher::IngressDispatcherRequest;
-use restate_types::identifiers::IdempotencyId;
-use restate_types::invocation::InvocationQuery;
-use restate_types::schema::invocation_target::InvocationTargetResolver;
-
-use super::path_parsing::{InvocationRequestType, InvocationTargetType, TargetType};
-use super::Handler;
-use super::HandlerError;
+use super::{
+    path_parsing::{InvocationRequestType, InvocationTargetType, TargetType},
+    Handler, HandlerError,
+};
 use crate::{GetOutputResult, InvocationStorageReader};
 
 impl<Schemas, Dispatcher, StorageReader> Handler<Schemas, Dispatcher, StorageReader>

--- a/crates/ingress-http/src/handler/mod.rs
+++ b/crates/ingress-http/src/handler/mod.rs
@@ -20,21 +20,21 @@ mod tests;
 mod tracing;
 mod workflow;
 
-use std::convert::Infallible;
-use std::task::{Context, Poll};
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
 
 use error::HandlerError;
-use futures::future::BoxFuture;
-use futures::FutureExt;
+use futures::{future::BoxFuture, FutureExt};
 use http_body_util::Full;
-use hyper::http::HeaderValue;
-use hyper::{Request, Response};
+use hyper::{http::HeaderValue, Request, Response};
 use path_parsing::RequestType;
-
 use restate_ingress_dispatcher::DispatchIngressRequest;
-use restate_types::live::Live;
-use restate_types::schema::invocation_target::InvocationTargetResolver;
-use restate_types::schema::service::ServiceMetadataResolver;
+use restate_types::{
+    live::Live,
+    schema::{invocation_target::InvocationTargetResolver, service::ServiceMetadataResolver},
+};
 
 use super::*;
 

--- a/crates/ingress-http/src/handler/path_parsing.rs
+++ b/crates/ingress-http/src/handler/path_parsing.rs
@@ -9,11 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use http::Uri;
-
 use restate_types::schema::service::ServiceMetadataResolver;
 
-use super::Handler;
-use super::HandlerError;
+use super::{Handler, HandlerError};
 use crate::InvocationStorageReader;
 
 pub(crate) enum WorkflowRequestType {

--- a/crates/ingress-http/src/handler/responses.rs
+++ b/crates/ingress-http/src/handler/responses.rs
@@ -11,15 +11,13 @@
 use bytes::Bytes;
 use http::{header, HeaderName, Response};
 use http_body_util::Full;
+use restate_types::{
+    identifiers::InvocationId, ingress::IngressResponseResult, invocation::InvocationTarget,
+    schema::invocation_target::InvocationTargetMetadata,
+};
 use tracing::{info, trace};
 
-use restate_types::identifiers::InvocationId;
-use restate_types::ingress::IngressResponseResult;
-use restate_types::invocation::InvocationTarget;
-use restate_types::schema::invocation_target::InvocationTargetMetadata;
-
-use crate::handler::error::HandlerError;
-use crate::handler::Handler;
+use crate::handler::{error::HandlerError, Handler};
 
 pub(crate) const IDEMPOTENCY_EXPIRES: HeaderName = HeaderName::from_static("idempotency-expires");
 /// Contains the string representation of the invocation id

--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -15,27 +15,28 @@ use bytestring::ByteString;
 use http::{header, HeaderMap, HeaderName, Method, Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full};
 use metrics::{counter, histogram};
-use serde::de::IntoDeserializer;
-use serde::{Deserialize, Serialize};
+use restate_ingress_dispatcher::{DispatchIngressRequest, IngressDispatcherRequest};
+use restate_types::{
+    identifiers::InvocationId,
+    invocation::{
+        Header, InvocationTarget, InvocationTargetType, ServiceInvocation, Source, SpanRelation,
+        WorkflowHandlerType,
+    },
+    schema::invocation_target::{InvocationTargetMetadata, InvocationTargetResolver},
+};
+use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use serde_with::serde_as;
 use tracing::{info, trace, warn, Instrument};
 
-use restate_ingress_dispatcher::{DispatchIngressRequest, IngressDispatcherRequest};
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::{
-    Header, InvocationTarget, InvocationTargetType, ServiceInvocation, Source, SpanRelation,
-    WorkflowHandlerType,
+use super::{
+    path_parsing::{InvokeType, ServiceRequestType, TargetType},
+    tracing::prepare_tracing_span,
+    Handler, HandlerError, APPLICATION_JSON,
 };
-use restate_types::schema::invocation_target::{
-    InvocationTargetMetadata, InvocationTargetResolver,
+use crate::{
+    handler::responses::{IDEMPOTENCY_EXPIRES, X_RESTATE_ID},
+    metric_definitions::{INGRESS_REQUESTS, INGRESS_REQUEST_DURATION, REQUEST_COMPLETED},
 };
-
-use super::path_parsing::{InvokeType, ServiceRequestType, TargetType};
-use super::tracing::prepare_tracing_span;
-use super::HandlerError;
-use super::{Handler, APPLICATION_JSON};
-use crate::handler::responses::{IDEMPOTENCY_EXPIRES, X_RESTATE_ID};
-use crate::metric_definitions::{INGRESS_REQUESTS, INGRESS_REQUEST_DURATION, REQUEST_COMPLETED};
 
 pub(crate) const IDEMPOTENCY_KEY: HeaderName = HeaderName::from_static("idempotency-key");
 const DELAY_QUERY_PARAM: &str = "delay";

--- a/crates/ingress-http/src/handler/tests.rs
+++ b/crates/ingress-http/src/handler/tests.rs
@@ -8,41 +8,37 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use bytes::Bytes;
 use bytestring::ByteString;
 use googletest::prelude::*;
-use http::StatusCode;
-use http::{HeaderValue, Method, Request, Response};
+use http::{HeaderValue, Method, Request, Response, StatusCode};
 use http_body_util::{BodyExt, Empty, Full};
-use restate_types::live::Live;
+use restate_core::TestCoreEnv;
+use restate_ingress_dispatcher::{
+    test_util::MockDispatcher, IngressDispatcherRequest, IngressInvocationResponse,
+    SubmittedInvocationNotification,
+};
+use restate_test_util::{assert, assert_eq};
+use restate_types::{
+    identifiers::{IdempotencyId, InvocationId, ServiceId},
+    ingress::{IngressResponseResult, InvocationResponse},
+    invocation::{
+        Header, InvocationQuery, InvocationTarget, InvocationTargetType, VirtualObjectHandlerType,
+        WorkflowHandlerType,
+    },
+    live::Live,
+    schema::invocation_target::{
+        InputContentType, InputRules, InputValidationRule, InvocationTargetMetadata,
+        OutputContentTypeRule, OutputRules,
+    },
+};
 use tokio::sync::mpsc;
 use tower::ServiceExt;
 use tracing_test::traced_test;
 
-use restate_core::TestCoreEnv;
-use restate_ingress_dispatcher::test_util::MockDispatcher;
-use restate_ingress_dispatcher::IngressDispatcherRequest;
-use restate_ingress_dispatcher::{IngressInvocationResponse, SubmittedInvocationNotification};
-use restate_test_util::{assert, assert_eq};
-use restate_types::identifiers::{IdempotencyId, InvocationId, ServiceId};
-use restate_types::ingress::{IngressResponseResult, InvocationResponse};
-use restate_types::invocation::{
-    Header, InvocationQuery, InvocationTarget, InvocationTargetType, VirtualObjectHandlerType,
-    WorkflowHandlerType,
-};
-use restate_types::schema::invocation_target::{
-    InputContentType, InputRules, InputValidationRule, InvocationTargetMetadata,
-    OutputContentTypeRule, OutputRules,
-};
-
-use super::health::HealthResponse;
-use super::mocks::*;
-use super::service_handler::*;
-use super::ConnectInfo;
-use super::Handler;
+use super::{health::HealthResponse, mocks::*, service_handler::*, ConnectInfo, Handler};
 use crate::handler::responses::X_RESTATE_ID;
 
 #[tokio::test]

--- a/crates/ingress-http/src/handler/tracing.rs
+++ b/crates/ingress-http/src/handler/tracing.rs
@@ -8,14 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::ConnectInfo;
-
 use http::Request;
-use opentelemetry::global::ObjectSafeSpan;
-use opentelemetry::trace::{SpanContext, TraceContextExt};
+use opentelemetry::{
+    global::ObjectSafeSpan,
+    trace::{SpanContext, TraceContextExt},
+};
 use restate_tracing_instrumentation as instrumentation;
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::{InvocationTarget, SpanRelation};
+use restate_types::{
+    identifiers::InvocationId,
+    invocation::{InvocationTarget, SpanRelation},
+};
+
+use super::ConnectInfo;
 
 pub(crate) fn prepare_tracing_span<B>(
     invocation_id: &InvocationId,

--- a/crates/ingress-http/src/handler/workflow.rs
+++ b/crates/ingress-http/src/handler/workflow.rs
@@ -11,17 +11,14 @@
 use bytes::Bytes;
 use http::{Method, Request, Response};
 use http_body_util::Full;
+use restate_ingress_dispatcher::{DispatchIngressRequest, IngressDispatcherRequest};
+use restate_types::{
+    identifiers::ServiceId, invocation::InvocationQuery,
+    schema::invocation_target::InvocationTargetResolver,
+};
 use tracing::{info, warn};
 
-use restate_ingress_dispatcher::DispatchIngressRequest;
-use restate_ingress_dispatcher::IngressDispatcherRequest;
-use restate_types::identifiers::ServiceId;
-use restate_types::invocation::InvocationQuery;
-use restate_types::schema::invocation_target::InvocationTargetResolver;
-
-use super::path_parsing::WorkflowRequestType;
-use super::Handler;
-use super::HandlerError;
+use super::{path_parsing::WorkflowRequestType, Handler, HandlerError};
 use crate::{GetOutputResult, InvocationStorageReader};
 
 impl<Schemas, Dispatcher, StorageReader> Handler<Schemas, Dispatcher, StorageReader>

--- a/crates/ingress-http/src/layers/load_shed.rs
+++ b/crates/ingress-http/src/layers/load_shed.rs
@@ -8,18 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::metric_definitions::{INGRESS_REQUESTS, REQUEST_ADMITTED, REQUEST_DENIED_THROTTLE};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
 use futures::ready;
 use http::{Request, Response, StatusCode};
 use metrics::counter;
 use pin_project_lite::pin_project;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tower::{Layer, Service};
 use tracing::warn;
+
+use crate::metric_definitions::{INGRESS_REQUESTS, REQUEST_ADMITTED, REQUEST_DENIED_THROTTLE};
 
 // This service is inspired by tower-util LoadShed and ConcurrencyLimit, but returns a http response.
 

--- a/crates/ingress-http/src/layers/tracing_context_extractor.rs
+++ b/crates/ingress-http/src/layers/tracing_context_extractor.rs
@@ -8,10 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::task::{Context, Poll};
+
 use http::{HeaderMap, Request};
 use opentelemetry::propagation::{Extractor, TextMapPropagator};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use std::task::{Context, Poll};
 use tower::{Layer, Service};
 
 pub struct HttpTraceContextExtractorLayer;

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -13,12 +13,11 @@ mod layers;
 mod metric_definitions;
 mod server;
 
-pub use server::{HyperServerIngress, IngressServerError, StartSignal};
+use std::net::{IpAddr, SocketAddr};
 
 use bytes::Bytes;
-use restate_types::ingress::InvocationResponse;
-use restate_types::invocation::InvocationQuery;
-use std::net::{IpAddr, SocketAddr};
+use restate_types::{ingress::InvocationResponse, invocation::InvocationQuery};
+pub use server::{HyperServerIngress, IngressServerError, StartSignal};
 
 /// Client connection information for a given RPC request
 #[derive(Clone, Copy, Debug)]
@@ -58,21 +57,24 @@ mod mocks {
     use std::collections::HashMap;
 
     use anyhow::Error;
+    use restate_types::{
+        identifiers::DeploymentId,
+        ingress::InvocationResponse,
+        invocation::{
+            InvocationQuery, InvocationTargetType, ServiceType, VirtualObjectHandlerType,
+        },
+        schema::{
+            invocation_target::{
+                test_util::MockInvocationTargetResolver, InvocationTargetMetadata,
+                InvocationTargetResolver, DEFAULT_IDEMPOTENCY_RETENTION,
+            },
+            service::{
+                test_util::MockServiceMetadataResolver, HandlerMetadata, ServiceMetadata,
+                ServiceMetadataResolver,
+            },
+        },
+    };
     use serde::{Deserialize, Serialize};
-
-    use restate_types::identifiers::DeploymentId;
-    use restate_types::ingress::InvocationResponse;
-    use restate_types::invocation::{
-        InvocationQuery, InvocationTargetType, ServiceType, VirtualObjectHandlerType,
-    };
-    use restate_types::schema::invocation_target::test_util::MockInvocationTargetResolver;
-    use restate_types::schema::invocation_target::{
-        InvocationTargetMetadata, InvocationTargetResolver, DEFAULT_IDEMPOTENCY_RETENTION,
-    };
-    use restate_types::schema::service::test_util::MockServiceMetadataResolver;
-    use restate_types::schema::service::{
-        HandlerMetadata, ServiceMetadata, ServiceMetadataResolver,
-    };
 
     use super::*;
 

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -8,30 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::{convert::Infallible, future::Future, net::SocketAddr};
 
-use crate::handler::Handler;
 use codederror::CodedError;
 use http::{Request, Response};
 use http_body_util::Full;
 use hyper::body::Incoming;
-use hyper_util::rt::TokioIo;
-use hyper_util::server::conn::auto;
+use hyper_util::{rt::TokioIo, server::conn::auto};
 use restate_core::{cancellation_watcher, task_center, TaskKind};
 use restate_ingress_dispatcher::{DispatchIngressRequest, IngressDispatcher};
-use restate_types::config::IngressOptions;
-use restate_types::live::Live;
-use restate_types::schema::invocation_target::InvocationTargetResolver;
-use restate_types::schema::service::ServiceMetadataResolver;
-use std::convert::Infallible;
-use std::future::Future;
-use std::net::SocketAddr;
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::oneshot;
+use restate_types::{
+    config::IngressOptions,
+    live::Live,
+    schema::{invocation_target::InvocationTargetResolver, service::ServiceMetadataResolver},
+};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::oneshot,
+};
 use tower::{ServiceBuilder, ServiceExt};
-use tower_http::cors::CorsLayer;
-use tower_http::normalize_path::NormalizePathLayer;
+use tower_http::{cors::CorsLayer, normalize_path::NormalizePathLayer};
 use tracing::{info, warn};
+
+use super::*;
+use crate::handler::Handler;
 
 pub type StartSignal = oneshot::Receiver<SocketAddr>;
 
@@ -238,24 +238,24 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::mocks::*;
-    use super::*;
-
-    use http_body_util::BodyExt;
-    use http_body_util::Full;
-    use hyper_util::client::legacy::Client;
-    use hyper_util::rt::TokioExecutor;
-    use restate_core::{TaskCenter, TaskKind, TestCoreEnv};
-    use restate_ingress_dispatcher::test_util::MockDispatcher;
-    use restate_ingress_dispatcher::{IngressDispatcherRequest, IngressInvocationResponse};
-    use restate_test_util::assert_eq;
-    use restate_types::identifiers::InvocationId;
-    use restate_types::ingress::IngressResponseResult;
-    use serde::{Deserialize, Serialize};
     use std::net::SocketAddr;
-    use tokio::sync::{mpsc, Semaphore};
-    use tokio::task::JoinHandle;
+
+    use http_body_util::{BodyExt, Full};
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+    use restate_core::{TaskCenter, TaskKind, TestCoreEnv};
+    use restate_ingress_dispatcher::{
+        test_util::MockDispatcher, IngressDispatcherRequest, IngressInvocationResponse,
+    };
+    use restate_test_util::assert_eq;
+    use restate_types::{identifiers::InvocationId, ingress::IngressResponseResult};
+    use serde::{Deserialize, Serialize};
+    use tokio::{
+        sync::{mpsc, Semaphore},
+        task::JoinHandle,
+    };
     use tracing_test::traced_test;
+
+    use super::{mocks::*, *};
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     pub struct GreetingRequest {

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -8,31 +8,36 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::fmt;
-use std::sync::Arc;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt,
+    sync::Arc,
+};
 
 use base64::Engine;
 use bytes::Bytes;
 use metrics::counter;
 use opentelemetry::trace::TraceContextExt;
-use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
-use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
-use rdkafka::error::KafkaError;
-use rdkafka::message::BorrowedMessage;
-use rdkafka::{ClientConfig, Message};
-use tokio::sync::oneshot;
-use tracing::{debug, info, info_span, Instrument};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
-
+use rdkafka::{
+    consumer::{
+        stream_consumer::StreamPartitionQueue, Consumer, DefaultConsumerContext, StreamConsumer,
+    },
+    error::KafkaError,
+    message::BorrowedMessage,
+    ClientConfig, Message,
+};
 use restate_core::{cancellation_watcher, TaskCenter, TaskId, TaskKind};
 use restate_ingress_dispatcher::{
     DeduplicationId, DispatchIngressRequest, IngressDispatcher, IngressDispatcherRequest,
 };
-use restate_types::invocation::{Header, SpanRelation};
-use restate_types::message::MessageIndex;
-use restate_types::schema::subscriptions::{EventReceiverServiceType, Sink, Subscription};
+use restate_types::{
+    invocation::{Header, SpanRelation},
+    message::MessageIndex,
+    schema::subscriptions::{EventReceiverServiceType, Sink, Subscription},
+};
+use tokio::sync::oneshot;
+use tracing::{debug, info, info_span, Instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::metric_definitions::KAFKA_INGRESS_REQUESTS;
 

--- a/crates/ingress-kafka/src/lib.rs
+++ b/crates/ingress-kafka/src/lib.rs
@@ -12,9 +12,8 @@ mod consumer_task;
 mod metric_definitions;
 mod subscription_controller;
 
-use tokio::sync::mpsc;
-
 pub use subscription_controller::{Command, Error, Service};
+use tokio::sync::mpsc;
 
 pub type SubscriptionCommandSender = mpsc::Sender<Command>;
 pub type SubscriptionCommandReceiver = mpsc::Receiver<Command>;

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -8,21 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::consumer_task::MessageSender;
-use super::*;
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
-use crate::subscription_controller::task_orchestrator::TaskOrchestrator;
 use rdkafka::error::KafkaError;
 use restate_core::{cancellation_watcher, task_center};
 use restate_ingress_dispatcher::IngressDispatcher;
-use restate_types::config::IngressOptions;
-use restate_types::identifiers::SubscriptionId;
-use restate_types::live::LiveLoad;
-use restate_types::retries::RetryPolicy;
-use restate_types::schema::subscriptions::{Source, Subscription};
-use std::time::Duration;
+use restate_types::{
+    config::IngressOptions,
+    identifiers::SubscriptionId,
+    live::LiveLoad,
+    retries::RetryPolicy,
+    schema::subscriptions::{Source, Subscription},
+};
 use tokio::sync::mpsc;
+
+use super::{consumer_task::MessageSender, *};
+use crate::subscription_controller::task_orchestrator::TaskOrchestrator;
 
 #[derive(Debug)]
 pub enum Command {
@@ -174,17 +175,22 @@ impl Service {
 }
 
 mod task_orchestrator {
-    use crate::consumer_task;
+    use std::{collections::HashMap, time::SystemTime};
+
     use restate_core::task_center;
     use restate_timer_queue::TimerQueue;
-    use restate_types::identifiers::SubscriptionId;
-    use restate_types::retries::{RetryIter, RetryPolicy};
-    use std::collections::HashMap;
-    use std::time::SystemTime;
-    use tokio::sync::oneshot;
-    use tokio::task;
-    use tokio::task::{JoinError, JoinSet};
+    use restate_types::{
+        identifiers::SubscriptionId,
+        retries::{RetryIter, RetryPolicy},
+    };
+    use tokio::{
+        sync::oneshot,
+        task,
+        task::{JoinError, JoinSet},
+    };
     use tracing::{debug, warn};
+
+    use crate::consumer_task;
 
     struct TaskState {
         // We use this to restart the consumer task in case of a failure

--- a/crates/invoker-api/src/effects.rs
+++ b/crates/invoker-api/src/effects.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::deployment::PinnedDeployment;
-use restate_types::errors::InvocationError;
-use restate_types::identifiers::EntryIndex;
-use restate_types::identifiers::InvocationId;
-use restate_types::journal::enriched::EnrichedRawEntry;
 use std::collections::HashSet;
+
+use restate_types::{
+    deployment::PinnedDeployment,
+    errors::InvocationError,
+    identifiers::{EntryIndex, InvocationId},
+    journal::enriched::EnrichedRawEntry,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/invoker-api/src/entry_enricher.rs
+++ b/crates/invoker-api/src/entry_enricher.rs
@@ -8,10 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::errors::InvocationError;
-use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
-use restate_types::journal::enriched::EnrichedRawEntry;
-use restate_types::journal::raw::PlainRawEntry;
+use restate_types::{
+    errors::InvocationError,
+    invocation::{InvocationTarget, ServiceInvocationSpanContext},
+    journal::{enriched::EnrichedRawEntry, raw::PlainRawEntry},
+};
 
 pub trait EntryEnricher {
     fn enrich_entry(
@@ -24,14 +25,19 @@ pub trait EntryEnricher {
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
-    use super::*;
-
-    use restate_types::identifiers::{InvocationId, InvocationUuid};
-    use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
-    use restate_types::journal::enriched::{
-        AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
+    use restate_types::{
+        identifiers::{InvocationId, InvocationUuid},
+        invocation::{InvocationTarget, ServiceInvocationSpanContext},
+        journal::{
+            enriched::{
+                AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader,
+                EnrichedRawEntry,
+            },
+            raw::{PlainEntryHeader, RawEntry},
+        },
     };
-    use restate_types::journal::raw::{PlainEntryHeader, RawEntry};
+
+    use super::*;
 
     #[derive(Debug, Default, Clone)]
     pub struct MockEntryEnricher;

--- a/crates/invoker-api/src/handle.rs
+++ b/crates/invoker-api/src/handle.rs
@@ -8,18 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::Effect;
-use super::JournalMetadata;
+use std::{future::Future, ops::RangeInclusive};
 
 use restate_errors::NotRunningError;
-use restate_types::identifiers::PartitionKey;
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionLeaderEpoch};
-use restate_types::invocation::InvocationTarget;
-use restate_types::journal::raw::PlainRawEntry;
-use restate_types::journal::Completion;
-use std::future::Future;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch},
+    invocation::InvocationTarget,
+    journal::{raw::PlainRawEntry, Completion},
+};
 use tokio::sync::mpsc;
+
+use super::{Effect, JournalMetadata};
 
 #[derive(Debug, Default)]
 pub enum InvokeInputJournal {

--- a/crates/invoker-api/src/journal_reader.rs
+++ b/crates/invoker-api/src/journal_reader.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use futures::Stream;
-use restate_types::deployment::PinnedDeployment;
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::ServiceInvocationSpanContext;
-use restate_types::journal::raw::PlainRawEntry;
-use restate_types::journal::EntryIndex;
-use restate_types::time::MillisSinceEpoch;
 use std::future::Future;
+
+use futures::Stream;
+use restate_types::{
+    deployment::PinnedDeployment,
+    identifiers::InvocationId,
+    invocation::ServiceInvocationSpanContext,
+    journal::{raw::PlainRawEntry, EntryIndex},
+    time::MillisSinceEpoch,
+};
 
 /// Metadata associated with a journal
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/invoker-api/src/lib.rs
+++ b/crates/invoker-api/src/lib.rs
@@ -24,21 +24,19 @@ pub use status_handle::{InvocationErrorReport, InvocationStatusReport, StatusHan
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
-    use super::*;
+    use std::{convert::Infallible, iter::empty, marker::PhantomData, ops::RangeInclusive};
+
     use bytes::Bytes;
     use restate_errors::NotRunningError;
-    use restate_types::identifiers::{
-        EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch, ServiceId,
+    use restate_types::{
+        identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch, ServiceId},
+        invocation::{InvocationTarget, ServiceInvocationSpanContext},
+        journal::{raw::PlainRawEntry, Completion},
+        time::MillisSinceEpoch,
     };
-    use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
-    use restate_types::journal::raw::PlainRawEntry;
-    use restate_types::journal::Completion;
-    use restate_types::time::MillisSinceEpoch;
-    use std::convert::Infallible;
-    use std::iter::empty;
-    use std::marker::PhantomData;
-    use std::ops::RangeInclusive;
     use tokio::sync::mpsc::Sender;
+
+    use super::*;
 
     #[derive(Debug, Clone)]
     pub struct EmptyStorageReader;

--- a/crates/invoker-api/src/state_reader.rs
+++ b/crates/invoker-api/src/state_reader.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
+
 use bytes::Bytes;
 use restate_types::identifiers::ServiceId;
-use std::future::Future;
 
 /// Container for the eager state returned by [`StateReader`]
 pub struct EagerState<I> {

--- a/crates/invoker-api/src/status_handle.rs
+++ b/crates/invoker-api/src/status_handle.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{future::Future, ops::RangeInclusive, time::SystemTime};
+
 use codederror::Code;
-use restate_types::errors::InvocationError;
-use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey};
-use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
-use restate_types::journal::{EntryIndex, EntryType};
-use std::future::Future;
-use std::ops::RangeInclusive;
-use std::time::SystemTime;
+use restate_types::{
+    errors::InvocationError,
+    identifiers::{
+        DeploymentId, InvocationId, LeaderEpoch, PartitionId, PartitionKey, PartitionLeaderEpoch,
+    },
+    journal::{EntryIndex, EntryType},
+};
 
 // -- Status data structure
 

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -8,12 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::RangeInclusive;
+
 use restate_errors::NotRunningError;
 use restate_invoker_api::{Effect, InvocationStatusReport, InvokeInputJournal, StatusHandle};
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch};
-use restate_types::invocation::InvocationTarget;
-use restate_types::journal::Completion;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch},
+    invocation::InvocationTarget,
+    journal::Completion,
+};
 use tokio::sync::mpsc;
 
 // -- Input messages

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -8,14 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::{fmt, time::Duration};
 
-use restate_types::journal::Completion;
-use restate_types::retries;
-use std::fmt;
-use std::time::Duration;
-use tokio::sync::mpsc;
-use tokio::task::AbortHandle;
+use restate_types::{journal::Completion, retries};
+use tokio::{sync::mpsc, task::AbortHandle};
+
+use super::*;
 
 /// Component encapsulating the business logic of the invocation state machine
 #[derive(Debug)]
@@ -328,17 +326,19 @@ impl InvocationStateMachine {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::time::Duration;
 
-    use googletest::matchers::{eq, some};
-    use googletest::prelude::err;
-    use googletest::{assert_that, pat};
+    use googletest::{
+        assert_that,
+        matchers::{eq, some},
+        pat,
+        prelude::err,
+    };
+    use restate_test_util::check;
     use test_log::test;
     use tokio::sync::mpsc::error::TryRecvError;
 
-    use restate_test_util::check;
+    use super::*;
 
     #[test]
     fn handle_error_when_waiting_for_retry() {

--- a/crates/invoker-impl/src/state_machine_manager.rs
+++ b/crates/invoker-impl/src/state_machine_manager.rs
@@ -8,11 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
 use std::ops::RangeInclusive;
 
 use restate_invoker_api::Effect;
 use restate_types::identifiers::PartitionKey;
+
+use super::*;
 
 /// Tree of [InvocationStateMachine] held by the [Service].
 #[derive(Debug)]

--- a/crates/invoker-impl/src/status_store.rs
+++ b/crates/invoker-impl/src/status_store.rs
@@ -8,11 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::time::SystemTime;
 
 use restate_invoker_api::status_handle::{InvocationStatusReport, InvocationStatusReportInner};
 
-use std::time::SystemTime;
+use super::*;
 
 #[derive(Default, Debug)]
 pub(super) struct InvocationStatusStore(

--- a/crates/local-cluster-runner/examples/three_nodes_and_metadata.rs
+++ b/crates/local-cluster-runner/examples/three_nodes_and_metadata.rs
@@ -1,21 +1,19 @@
-use std::num::NonZeroU16;
-use std::time::Duration;
+use std::{num::NonZeroU16, time::Duration};
 
 use enumset::enum_set;
 use futures::StreamExt;
 use regex::Regex;
-use tracing::{error, info};
-
 use restate_local_cluster_runner::{
     cluster::Cluster,
     node::{BinarySource, Node},
     shutdown,
 };
-use restate_types::logs::metadata::ProviderKind::Replicated;
 use restate_types::{
     config::{Configuration, LogFormat},
+    logs::metadata::ProviderKind::Replicated,
     nodes_config::Role,
 };
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() {

--- a/crates/local-cluster-runner/src/cluster/mod.rs
+++ b/crates/local-cluster-runner/src/cluster/mod.rs
@@ -6,11 +6,10 @@ use std::{
 };
 
 use futures::future::{self};
+use restate_types::errors::GenericError;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use typed_builder::TypedBuilder;
-
-use restate_types::errors::GenericError;
 
 use crate::node::{HealthCheck, HealthError, Node, NodeStartError, StartedNode};
 

--- a/crates/local-cluster-runner/src/main.rs
+++ b/crates/local-cluster-runner/src/main.rs
@@ -2,9 +2,8 @@ use std::{path::PathBuf, time::Duration};
 
 use clap::Parser;
 use clap_verbosity_flag::InfoLevel;
-use tracing::{error, info};
-
 use restate_local_cluster_runner::{cluster::Cluster, shutdown};
+use tracing::{error, info};
 
 #[derive(Debug, Clone, clap::Parser)]
 #[command(author, version, about)]

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -18,18 +18,6 @@ use enumset::{enum_set, EnumSet};
 use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use regex::{Regex, RegexSet};
-use rev_lines::RevLines;
-use serde::{Deserialize, Serialize};
-use tokio::{
-    fs::File,
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    sync::mpsc,
-    task::JoinHandle,
-};
-use tokio::{process::Command, sync::mpsc::Sender};
-use tracing::{error, info};
-use typed_builder::TypedBuilder;
-
 use restate_types::{
     config::{Configuration, MetadataStoreClient},
     errors::GenericError,
@@ -38,6 +26,17 @@ use restate_types::{
     nodes_config::{NodesConfiguration, Role},
     PlainNodeId,
 };
+use rev_lines::RevLines;
+use serde::{Deserialize, Serialize};
+use tokio::{
+    fs::File,
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+    sync::{mpsc, mpsc::Sender},
+    task::JoinHandle,
+};
+use tracing::{error, info};
+use typed_builder::TypedBuilder;
 
 use crate::random_socket_address;
 

--- a/crates/log-server/src/logstore.rs
+++ b/crates/log-server/src/logstore.rs
@@ -11,12 +11,13 @@
 use std::future::Future;
 
 use futures::FutureExt;
-use tokio::sync::oneshot;
-
 use restate_bifrost::loglet::OperationError;
 use restate_core::ShutdownError;
-use restate_types::net::log_server::{Digest, GetDigest, GetRecords, Records, Seal, Store, Trim};
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::{
+    net::log_server::{Digest, GetDigest, GetRecords, Records, Seal, Store, Trim},
+    replicated_loglet::ReplicatedLogletId,
+};
+use tokio::sync::oneshot;
 
 use crate::metadata::{LogStoreMarker, LogletState};
 

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -8,19 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
 
 use chrono::Utc;
+use restate_bifrost::loglet::{util::TailOffsetWatch, OperationError};
+use restate_core::ShutdownError;
+use restate_types::{
+    logs::{LogletOffset, SequenceNumber, TailState},
+    replicated_loglet::ReplicatedLogletId,
+    GenerationalNodeId, PlainNodeId,
+};
 use tokio::sync::watch;
 use xxhash_rust::xxh3::Xxh3Builder;
-
-use restate_bifrost::loglet::util::TailOffsetWatch;
-use restate_bifrost::loglet::OperationError;
-use restate_core::ShutdownError;
-use restate_types::logs::{LogletOffset, SequenceNumber, TailState};
-use restate_types::replicated_loglet::ReplicatedLogletId;
-use restate_types::{GenerationalNodeId, PlainNodeId};
 
 use crate::logstore::LogStore;
 

--- a/crates/log-server/src/network.rs
+++ b/crates/log-server/src/network.rs
@@ -12,29 +12,32 @@
 //!
 //! We maintain a stream per message type for fine-grain per-message-type control over the queue
 //! depth, head-of-line blocking issues, and priority of consumption.
-use std::collections::{hash_map, HashMap};
-use std::pin::Pin;
+use std::{
+    collections::{hash_map, HashMap},
+    pin::Pin,
+};
 
 use anyhow::Context;
-use futures::stream::FuturesUnordered;
-use futures::Stream;
+use futures::{stream::FuturesUnordered, Stream};
+use restate_core::{
+    cancellation_watcher,
+    network::{Incoming, MessageRouterBuilder},
+    Metadata, TaskCenter,
+};
+use restate_types::{
+    config::Configuration, health::HealthStatus, live::Live, net::log_server::*,
+    nodes_config::StorageState, protobuf::common::LogServerStatus,
+    replicated_loglet::ReplicatedLogletId,
+};
 use tokio_stream::StreamExt as TokioStreamExt;
 use tracing::{debug, trace};
 use xxhash_rust::xxh3::Xxh3Builder;
 
-use restate_core::network::{Incoming, MessageRouterBuilder};
-use restate_core::{cancellation_watcher, Metadata, TaskCenter};
-use restate_types::config::Configuration;
-use restate_types::health::HealthStatus;
-use restate_types::live::Live;
-use restate_types::net::log_server::*;
-use restate_types::nodes_config::StorageState;
-use restate_types::protobuf::common::LogServerStatus;
-use restate_types::replicated_loglet::ReplicatedLogletId;
-
-use crate::loglet_worker::{LogletWorker, LogletWorkerHandle};
-use crate::logstore::LogStore;
-use crate::metadata::LogletStateMap;
+use crate::{
+    loglet_worker::{LogletWorker, LogletWorkerHandle},
+    logstore::LogStore,
+    metadata::LogletStateMap,
+};
 
 const DEFAULT_WRITERS_CAPACITY: usize = 128;
 

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -10,22 +10,25 @@
 
 use std::sync::Arc;
 
-use restate_types::health::HealthStatus;
-use restate_types::logs::RecordCache;
-use restate_types::protobuf::common::LogServerStatus;
+use restate_core::{ShutdownError, TaskCenter};
+use restate_rocksdb::{CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager};
+use restate_types::{
+    config::{LogServerOptions, RocksDbOptions},
+    health::HealthStatus,
+    live::BoxedLiveLoad,
+    logs::RecordCache,
+    protobuf::common::LogServerStatus,
+};
 use rocksdb::{DBCompressionType, SliceTransform};
 use static_assertions::const_assert;
 
-use restate_core::{ShutdownError, TaskCenter};
-use restate_rocksdb::{CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager};
-use restate_types::config::{LogServerOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
-
-use super::writer::LogStoreWriter;
-use super::{RocksDbLogStore, RocksDbLogStoreError};
-use super::{DATA_CF, DB_NAME, METADATA_CF};
-use crate::rocksdb_logstore::keys::KeyPrefix;
-use crate::rocksdb_logstore::metadata_merge::{metadata_full_merge, metadata_partial_merge};
+use super::{
+    writer::LogStoreWriter, RocksDbLogStore, RocksDbLogStoreError, DATA_CF, DB_NAME, METADATA_CF,
+};
+use crate::rocksdb_logstore::{
+    keys::KeyPrefix,
+    metadata_merge::{metadata_full_merge, metadata_partial_merge},
+};
 
 const DATA_CF_BUDGET_RATIO: f64 = 0.85;
 const_assert!(DATA_CF_BUDGET_RATIO < 1.0);

--- a/crates/log-server/src/rocksdb_logstore/error.rs
+++ b/crates/log-server/src/rocksdb_logstore/error.rs
@@ -12,10 +12,8 @@ use std::sync::Arc;
 
 use restate_bifrost::loglet::OperationError;
 use restate_core::ShutdownError;
-use restate_types::errors::MaybeRetryableError;
-use restate_types::logs::LogletOffset;
-
 use restate_rocksdb::RocksError;
+use restate_types::{errors::MaybeRetryableError, logs::LogletOffset};
 
 use super::record_format::RecordDecodeError;
 

--- a/crates/log-server/src/rocksdb_logstore/keys.rs
+++ b/crates/log-server/src/rocksdb_logstore/keys.rs
@@ -11,9 +11,7 @@
 use std::mem::size_of;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-
-use restate_types::logs::LogletOffset;
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::{logs::LogletOffset, replicated_loglet::ReplicatedLogletId};
 
 // log-store marker
 pub(super) const MARKER_KEY: &[u8] = b"storage-marker";

--- a/crates/log-server/src/rocksdb_logstore/mod.rs
+++ b/crates/log-server/src/rocksdb_logstore/mod.rs
@@ -16,9 +16,9 @@ mod record_format;
 mod store;
 mod writer;
 
-pub use self::builder::RocksDbLogStoreBuilder;
-pub use self::store::RocksDbLogStore;
 pub(crate) use error::*;
+
+pub use self::{builder::RocksDbLogStoreBuilder, store::RocksDbLogStore};
 
 // matches the default directory name
 const DB_NAME: &str = "log-server";

--- a/crates/log-server/src/rocksdb_logstore/record_format.rs
+++ b/crates/log-server/src/rocksdb_logstore/record_format.rs
@@ -9,10 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-
-use restate_types::logs::{KeyFilter, Keys, MatchKeyQuery, Record};
-use restate_types::storage::{PolyBytes, StorageEncode};
-use restate_types::time::NanosSinceEpoch;
+use restate_types::{
+    logs::{KeyFilter, Keys, MatchKeyQuery, Record},
+    storage::{PolyBytes, StorageEncode},
+    time::NanosSinceEpoch,
+};
 
 #[derive(Debug, derive_more::TryFrom, Eq, PartialEq, Ord, PartialOrd)]
 #[try_from(repr)]

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -9,26 +9,25 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::Context;
+use restate_core::{network::MessageRouterBuilder, Metadata, MetadataWriter, TaskCenter, TaskKind};
+use restate_metadata_store::MetadataStoreClient;
+use restate_types::{
+    config::Configuration,
+    health::HealthStatus,
+    live::Live,
+    logs::RecordCache,
+    metadata_store::keys::NODES_CONFIG_KEY,
+    nodes_config::{NodesConfiguration, StorageState},
+    protobuf::common::LogServerStatus,
+    GenerationalNodeId,
+};
 use tracing::{debug, info, instrument};
 
-use restate_core::network::MessageRouterBuilder;
-use restate_core::{Metadata, MetadataWriter, TaskCenter, TaskKind};
-use restate_metadata_store::MetadataStoreClient;
-use restate_types::config::Configuration;
-use restate_types::health::HealthStatus;
-use restate_types::live::Live;
-use restate_types::logs::RecordCache;
-use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
-use restate_types::nodes_config::{NodesConfiguration, StorageState};
-use restate_types::protobuf::common::LogServerStatus;
-use restate_types::GenerationalNodeId;
-
-use crate::error::LogServerBuildError;
-use crate::logstore::LogStore;
-use crate::metadata::LogStoreMarker;
-use crate::metric_definitions::describe_metrics;
-use crate::network::RequestPump;
-use crate::rocksdb_logstore::RocksDbLogStoreBuilder;
+use crate::{
+    error::LogServerBuildError, logstore::LogStore, metadata::LogStoreMarker,
+    metric_definitions::describe_metrics, network::RequestPump,
+    rocksdb_logstore::RocksDbLogStoreBuilder,
+};
 
 pub struct LogServerService {
     health_status: HealthStatus<LogServerStatus>,

--- a/crates/metadata-store/build.rs
+++ b/crates/metadata-store/build.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/crates/metadata-store/src/local/grpc/client.rs
+++ b/crates/metadata-store/src/local/grpc/client.rs
@@ -10,19 +10,19 @@
 
 use async_trait::async_trait;
 use bytestring::ByteString;
-use tonic::transport::Channel;
-use tonic::{Code, Status};
-
-use restate_core::metadata_store::{
-    MetadataStore, Precondition, ReadError, VersionedValue, WriteError,
+use restate_core::{
+    metadata_store::{MetadataStore, Precondition, ReadError, VersionedValue, WriteError},
+    network::net_util::create_tonic_channel_from_advertised_address,
 };
-use restate_core::network::net_util::create_tonic_channel_from_advertised_address;
-use restate_types::net::AdvertisedAddress;
-use restate_types::Version;
+use restate_types::{net::AdvertisedAddress, Version};
+use tonic::{transport::Channel, Code, Status};
 
-use crate::grpc_svc::metadata_store_svc_client::MetadataStoreSvcClient;
-use crate::grpc_svc::{DeleteRequest, GetRequest, PutRequest};
-use crate::local::grpc::pb_conversions::ConversionError;
+use crate::{
+    grpc_svc::{
+        metadata_store_svc_client::MetadataStoreSvcClient, DeleteRequest, GetRequest, PutRequest,
+    },
+    local::grpc::pb_conversions::ConversionError,
+};
 
 /// Client end to interact with the [`LocalMetadataStore`].
 #[derive(Debug, Clone)]

--- a/crates/metadata-store/src/local/grpc/handler.rs
+++ b/crates/metadata-store/src/local/grpc/handler.rs
@@ -8,13 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvc;
-use crate::grpc_svc::{DeleteRequest, GetRequest, GetResponse, GetVersionResponse, PutRequest};
-use crate::local::grpc::pb_conversions::ConversionError;
-use crate::local::store::{Error, MetadataStoreRequest, RequestSender};
 use async_trait::async_trait;
 use tokio::sync::oneshot;
 use tonic::{Request, Response, Status};
+
+use crate::{
+    grpc_svc::{
+        metadata_store_svc_server::MetadataStoreSvc, DeleteRequest, GetRequest, GetResponse,
+        GetVersionResponse, PutRequest,
+    },
+    local::{
+        grpc::pb_conversions::ConversionError,
+        store::{Error, MetadataStoreRequest, RequestSender},
+    },
+};
 
 /// Grpc svc handler for the [`LocalMetadataStore`].
 #[derive(Debug)]

--- a/crates/metadata-store/src/local/grpc/mod.rs
+++ b/crates/metadata-store/src/local/grpc/mod.rs
@@ -12,10 +12,13 @@ pub mod client;
 pub mod handler;
 
 pub mod pb_conversions {
-    use crate::grpc_svc;
-    use crate::grpc_svc::{GetResponse, GetVersionResponse, PreconditionKind};
     use restate_core::metadata_store::{Precondition, VersionedValue};
     use restate_types::Version;
+
+    use crate::{
+        grpc_svc,
+        grpc_svc::{GetResponse, GetVersionResponse, PreconditionKind},
+    };
 
     #[derive(Debug, thiserror::Error)]
     pub enum ConversionError {

--- a/crates/metadata-store/src/local/service.rs
+++ b/crates/metadata-store/src/local/service.rs
@@ -11,23 +11,23 @@
 use http::Request;
 use hyper::body::Incoming;
 use hyper_util::service::TowerToHyperService;
-use restate_types::health::HealthStatus;
-use tonic::body::boxed;
-use tonic::server::NamedService;
+use restate_core::{network::net_util, task_center, ShutdownError, TaskKind};
+use restate_rocksdb::RocksError;
+use restate_types::{
+    config::{MetadataStoreOptions, RocksDbOptions},
+    health::HealthStatus,
+    live::BoxedLiveLoad,
+    protobuf::common::MetadataServerStatus,
+};
+use tonic::{body::boxed, server::NamedService};
 use tower::ServiceExt;
 use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
 
-use restate_core::network::net_util;
-use restate_core::{task_center, ShutdownError, TaskKind};
-use restate_rocksdb::RocksError;
-use restate_types::config::{MetadataStoreOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
-use restate_types::protobuf::common::MetadataServerStatus;
-
-use crate::grpc_svc;
-use crate::grpc_svc::metadata_store_svc_server::MetadataStoreSvcServer;
-use crate::local::grpc::handler::LocalMetadataStoreHandler;
-use crate::local::store::LocalMetadataStore;
+use crate::{
+    grpc_svc,
+    grpc_svc::metadata_store_svc_server::MetadataStoreSvcServer,
+    local::{grpc::handler::LocalMetadataStoreHandler, store::LocalMetadataStore},
+};
 
 pub struct LocalMetadataStoreService {
     health_status: HealthStatus<MetadataServerStatus>,

--- a/crates/metadata-store/src/local/store.rs
+++ b/crates/metadata-store/src/local/store.rs
@@ -8,22 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use bytes::BytesMut;
 use bytestring::ByteString;
-use restate_core::cancellation_watcher;
-use restate_core::metadata_store::{Precondition, VersionedValue};
+use restate_core::{
+    cancellation_watcher,
+    metadata_store::{Precondition, VersionedValue},
+};
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
 };
-use restate_types::config::{MetadataStoreOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
-use restate_types::storage::{
-    StorageCodec, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError,
+use restate_types::{
+    config::{MetadataStoreOptions, RocksDbOptions},
+    live::BoxedLiveLoad,
+    storage::{StorageCodec, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError},
+    Version,
 };
-use restate_types::Version;
 use rocksdb::{BoundColumnFamily, DBCompressionType, WriteBatch, WriteOptions, DB};
-use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, trace};
 

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -9,27 +9,30 @@
 // by the Apache License, Version 2.0.
 
 use bytestring::ByteString;
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
+use futures::{stream::FuturesUnordered, StreamExt};
+use restate_core::{
+    network::FailingConnector, TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder,
+};
+use restate_rocksdb::RocksDbManager;
+use restate_types::{
+    config::{
+        self, reset_base_temp_dir_and_retain, Configuration, MetadataStoreClientOptions,
+        MetadataStoreClientOptionsBuilder, MetadataStoreOptions, RocksDbOptions,
+    },
+    flexbuffers_storage_encode_decode,
+    health::HealthStatus,
+    live::{BoxedLiveLoad, Live},
+    net::{AdvertisedAddress, BindAddress},
+    protobuf::common::MetadataServerStatus,
+    Version, Versioned,
+};
 use serde::{Deserialize, Serialize};
 use test_log::test;
 
-use restate_core::network::FailingConnector;
-use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
-use restate_rocksdb::RocksDbManager;
-use restate_types::config::{
-    self, reset_base_temp_dir_and_retain, Configuration, MetadataStoreClientOptions,
-    MetadataStoreClientOptionsBuilder, MetadataStoreOptions, RocksDbOptions,
+use crate::{
+    local::{grpc::client::LocalMetadataStoreClient, service::LocalMetadataStoreService},
+    MetadataStoreClient, Precondition, WriteError,
 };
-use restate_types::health::HealthStatus;
-use restate_types::live::{BoxedLiveLoad, Live};
-use restate_types::net::{AdvertisedAddress, BindAddress};
-use restate_types::protobuf::common::MetadataServerStatus;
-use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
-
-use crate::local::grpc::client::LocalMetadataStoreClient;
-use crate::local::service::LocalMetadataStoreService;
-use crate::{MetadataStoreClient, Precondition, WriteError};
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Serialize, Deserialize)]
 struct Value {

--- a/crates/node/src/cluster_marker.rs
+++ b/crates/node/src/cluster_marker.rs
@@ -8,11 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{cmp::Ordering, fs::OpenOptions, path::Path};
+
 use restate_types::config::node_filepath;
 use semver::Version;
-use std::cmp::Ordering;
-use std::fs::OpenOptions;
-use std::path::Path;
 use tracing::info;
 
 const CLUSTER_MARKER_FILE_NAME: &str = ".cluster-marker";
@@ -232,15 +231,15 @@ fn validate_and_update_cluster_marker_inner(
 
 #[cfg(test)]
 mod tests {
+    use std::{fs, fs::OpenOptions, path::Path};
+
+    use semver::Version;
+    use tempfile::tempdir;
+
     use crate::cluster_marker::{
         validate_and_update_cluster_marker_inner, ClusterMarker, ClusterValidationError,
         CompatibilityInformation, CLUSTER_MARKER_FILE_NAME, COMPATIBILITY_INFORMATION,
     };
-    use semver::Version;
-    use std::fs;
-    use std::fs::OpenOptions;
-    use std::path::Path;
-    use tempfile::tempdir;
 
     fn read_cluster_marker(path: impl AsRef<Path>) -> anyhow::Result<ClusterMarker> {
         let bytes = fs::read(path)?;

--- a/crates/node/src/network_server/handler/cluster_ctrl.rs
+++ b/crates/node/src/network_server/handler/cluster_ctrl.rs
@@ -11,28 +11,32 @@
 use std::time::Duration;
 
 use bytes::{Bytes, BytesMut};
+use restate_admin::cluster_controller::{
+    protobuf::{
+        cluster_ctrl_svc_server::ClusterCtrlSvc, ClusterStateRequest, ClusterStateResponse,
+        CreatePartitionSnapshotRequest, CreatePartitionSnapshotResponse, DescribeLogRequest,
+        DescribeLogResponse, FindTailRequest, FindTailResponse, ListLogsRequest, ListLogsResponse,
+        ListNodesRequest, ListNodesResponse, SealAndExtendChainRequest, SealAndExtendChainResponse,
+        SealedSegment, TailState, TrimLogRequest,
+    },
+    ClusterControllerHandle,
+};
+use restate_bifrost::{Bifrost, BifrostAdmin, Error as BiforstError};
 use restate_core::MetadataWriter;
+use restate_metadata_store::MetadataStoreClient;
+use restate_types::{
+    identifiers::PartitionId,
+    logs::{
+        metadata::{Logs, ProviderKind, SegmentIndex},
+        LogId, Lsn, SequenceNumber,
+    },
+    metadata_store::keys::{BIFROST_CONFIG_KEY, NODES_CONFIG_KEY},
+    nodes_config::NodesConfiguration,
+    storage::{StorageCodec, StorageEncode},
+    Version, Versioned,
+};
 use tonic::{async_trait, Request, Response, Status};
 use tracing::{debug, info};
-
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_server::ClusterCtrlSvc;
-use restate_admin::cluster_controller::protobuf::{
-    ClusterStateRequest, ClusterStateResponse, CreatePartitionSnapshotRequest,
-    CreatePartitionSnapshotResponse, DescribeLogRequest, DescribeLogResponse, FindTailRequest,
-    FindTailResponse, ListLogsRequest, ListLogsResponse, ListNodesRequest, ListNodesResponse,
-    SealAndExtendChainRequest, SealAndExtendChainResponse, SealedSegment, TailState,
-    TrimLogRequest,
-};
-use restate_admin::cluster_controller::ClusterControllerHandle;
-use restate_bifrost::{Bifrost, BifrostAdmin, Error as BiforstError};
-use restate_metadata_store::MetadataStoreClient;
-use restate_types::identifiers::PartitionId;
-use restate_types::logs::metadata::{Logs, ProviderKind, SegmentIndex};
-use restate_types::logs::{LogId, Lsn, SequenceNumber};
-use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, NODES_CONFIG_KEY};
-use restate_types::nodes_config::NodesConfiguration;
-use restate_types::storage::{StorageCodec, StorageEncode};
-use restate_types::{Version, Versioned};
 
 use crate::network_server::ClusterControllerDependencies;
 

--- a/crates/node/src/network_server/handler/mod.rs
+++ b/crates/node/src/network_server/handler/mod.rs
@@ -15,15 +15,16 @@ use std::fmt::Write;
 
 use axum::extract::State;
 use metrics_exporter_prometheus::formatting;
+use restate_rocksdb::{CfName, RocksDbManager};
 use rocksdb::statistics::{Histogram, Ticker};
 
-use restate_rocksdb::{CfName, RocksDbManager};
-
-use crate::network_server::prometheus_helpers::{
-    format_rocksdb_histogram_for_prometheus, format_rocksdb_property_for_prometheus,
-    format_rocksdb_stat_ticker_for_prometheus, MetricUnit,
+use crate::network_server::{
+    prometheus_helpers::{
+        format_rocksdb_histogram_for_prometheus, format_rocksdb_property_for_prometheus,
+        format_rocksdb_stat_ticker_for_prometheus, MetricUnit,
+    },
+    state::NodeCtrlHandlerState,
 };
-use crate::network_server::state::NodeCtrlHandlerState;
 
 const ROCKSDB_TICKERS: &[Ticker] = &[
     Ticker::BlockCacheBytesRead,

--- a/crates/node/src/network_server/handler/node.rs
+++ b/crates/node/src/network_server/handler/node.rs
@@ -8,23 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use arrow_flight::encode::FlightDataEncoderBuilder;
-use arrow_flight::error::FlightError;
+use arrow_flight::{encode::FlightDataEncoderBuilder, error::FlightError};
 use enumset::EnumSet;
-use futures::stream::BoxStream;
-use futures::TryStreamExt;
+use futures::{stream::BoxStream, TryStreamExt};
+use restate_core::{
+    metadata,
+    network::{
+        protobuf::node_svc::{
+            node_svc_server::NodeSvc, IdentResponse, StorageQueryRequest, StorageQueryResponse,
+        },
+        ConnectionManager, GrpcConnector, ProtocolError,
+    },
+    TaskCenter,
+};
+use restate_types::{health::Health, nodes_config::Role, protobuf::node::Message};
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
-
-use restate_core::network::protobuf::node_svc::node_svc_server::NodeSvc;
-use restate_core::network::protobuf::node_svc::IdentResponse;
-use restate_core::network::protobuf::node_svc::{StorageQueryRequest, StorageQueryResponse};
-use restate_core::network::ProtocolError;
-use restate_core::network::{ConnectionManager, GrpcConnector};
-use restate_core::{metadata, TaskCenter};
-use restate_types::health::Health;
-use restate_types::nodes_config::Role;
-use restate_types::protobuf::node::Message;
 
 use crate::network_server::WorkerDependencies;
 

--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -10,9 +10,7 @@
 
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_tracing_context::TracingContextLayer;
-use metrics_util::layers::Layer;
-use metrics_util::MetricKindMask;
-
+use metrics_util::{layers::Layer, MetricKindMask};
 use restate_types::config::CommonOptions;
 
 /// The set of labels that are allowed to be extracted from tracing context to be used in metrics.

--- a/crates/node/src/network_server/multiplex.rs
+++ b/crates/node/src/network_server/multiplex.rs
@@ -13,16 +13,17 @@
 //! Mostly copied from axum example: https://github.com/tokio-rs/axum/blob/791d5038a927add3f8ff1d5c1010cd0b24fdda77/examples/rest-grpc-multiplex/src/multiplex_service.rs
 //! License MIT
 
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
+
 use axum::{
     http::header::CONTENT_TYPE,
     response::{IntoResponse, Response},
 };
 use futures::{future::BoxFuture, ready};
 use hyper::Request;
-use std::{
-    convert::Infallible,
-    task::{Context, Poll},
-};
 use tower::Service;
 
 pub struct MultiplexService<A, B> {

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -12,30 +12,31 @@ use axum::routing::get;
 use http::Request;
 use hyper::body::Incoming;
 use hyper_util::service::TowerToHyperService;
-use tonic::body::boxed;
-use tonic::codec::CompressionEncoding;
+use restate_admin::cluster_controller::{
+    protobuf::cluster_ctrl_svc_server::ClusterCtrlSvcServer, ClusterControllerHandle,
+};
+use restate_bifrost::Bifrost;
+use restate_core::{
+    network::{
+        net_util::run_hyper_server, protobuf::node_svc::node_svc_server::NodeSvcServer,
+        ConnectionManager, GrpcConnector,
+    },
+    task_center, MetadataWriter,
+};
+use restate_metadata_store::MetadataStoreClient;
+use restate_storage_query_datafusion::context::QueryContext;
+use restate_types::{config::CommonOptions, health::Health, protobuf::common::NodeStatus};
+use tonic::{body::boxed, codec::CompressionEncoding};
 use tower::ServiceExt;
 use tower_http::trace::TraceLayer;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_server::ClusterCtrlSvcServer;
-use restate_admin::cluster_controller::ClusterControllerHandle;
-use restate_bifrost::Bifrost;
-use restate_core::network::net_util::run_hyper_server;
-use restate_core::network::protobuf::node_svc::node_svc_server::NodeSvcServer;
-use restate_core::network::{ConnectionManager, GrpcConnector};
-use restate_core::{task_center, MetadataWriter};
-use restate_metadata_store::MetadataStoreClient;
-use restate_storage_query_datafusion::context::QueryContext;
-use restate_types::config::CommonOptions;
-use restate_types::health::Health;
-use restate_types::protobuf::common::NodeStatus;
-
-use crate::network_server::handler;
-use crate::network_server::handler::cluster_ctrl::ClusterCtrlSvcHandler;
-use crate::network_server::handler::node::NodeSvcHandler;
-use crate::network_server::metrics::install_global_prometheus_recorder;
-use crate::network_server::multiplex::MultiplexService;
-use crate::network_server::state::NodeCtrlHandlerStateBuilder;
+use crate::network_server::{
+    handler,
+    handler::{cluster_ctrl::ClusterCtrlSvcHandler, node::NodeSvcHandler},
+    metrics::install_global_prometheus_recorder,
+    multiplex::MultiplexService,
+    state::NodeCtrlHandlerStateBuilder,
+};
 
 pub struct NetworkServer {
     health: Health,

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -10,29 +10,31 @@
 
 use std::time::Duration;
 
-use restate_types::health::HealthStatus;
-use tokio::sync::oneshot;
-
 use codederror::CodedError;
-use restate_admin::cluster_controller;
-use restate_admin::cluster_controller::ClusterControllerHandle;
-use restate_admin::service::AdminService;
+use restate_admin::{
+    cluster_controller, cluster_controller::ClusterControllerHandle, service::AdminService,
+};
 use restate_bifrost::Bifrost;
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_core::network::net_util::create_tonic_channel_from_advertised_address;
-use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::network::MessageRouterBuilder;
-use restate_core::network::Networking;
-use restate_core::network::TransportConnect;
-use restate_core::{task_center, Metadata, MetadataWriter, TaskCenter, TaskKind};
+use restate_core::{
+    metadata_store::MetadataStoreClient,
+    network::{
+        net_util::create_tonic_channel_from_advertised_address,
+        protobuf::node_svc::node_svc_client::NodeSvcClient, MessageRouterBuilder, Networking,
+        TransportConnect,
+    },
+    task_center, Metadata, MetadataWriter, TaskCenter, TaskKind,
+};
 use restate_service_client::{AssumeRoleCacheMode, ServiceClient};
 use restate_service_protocol::discovery::ServiceDiscovery;
-use restate_types::config::Configuration;
-use restate_types::config::IngressOptions;
-use restate_types::live::Live;
-use restate_types::net::AdvertisedAddress;
-use restate_types::protobuf::common::AdminStatus;
-use restate_types::retries::RetryPolicy;
+use restate_types::{
+    config::{Configuration, IngressOptions},
+    health::HealthStatus,
+    live::Live,
+    net::AdvertisedAddress,
+    protobuf::common::AdminStatus,
+    retries::RetryPolicy,
+};
+use tokio::sync::oneshot;
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum AdminRoleBuildError {

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -9,25 +9,24 @@
 // by the Apache License, Version 2.0.
 
 use codederror::CodedError;
-use tokio::sync::oneshot;
-
 use restate_bifrost::Bifrost;
-use restate_core::network::MessageRouterBuilder;
-use restate_core::network::Networking;
-use restate_core::network::TransportConnect;
-use restate_core::{cancellation_watcher, task_center, Metadata, MetadataKind};
-use restate_core::{ShutdownError, TaskKind};
+use restate_core::{
+    cancellation_watcher,
+    network::{MessageRouterBuilder, Networking, TransportConnect},
+    task_center, Metadata, MetadataKind, ShutdownError, TaskKind,
+};
 use restate_metadata_store::MetadataStoreClient;
 use restate_storage_query_datafusion::context::QueryContext;
-use restate_types::config::Configuration;
-use restate_types::health::HealthStatus;
-use restate_types::live::Live;
-use restate_types::protobuf::common::WorkerStatus;
-use restate_types::schema::subscriptions::SubscriptionResolver;
-use restate_types::schema::Schema;
-use restate_types::Version;
-use restate_worker::SubscriptionController;
-use restate_worker::Worker;
+use restate_types::{
+    config::Configuration,
+    health::HealthStatus,
+    live::Live,
+    protobuf::common::WorkerStatus,
+    schema::{subscriptions::SubscriptionResolver, Schema},
+    Version,
+};
+use restate_worker::{SubscriptionController, Worker};
+use tokio::sync::oneshot;
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum WorkerRoleError {

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -14,13 +14,15 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use restate_core::TaskCenterBuilder;
 use restate_partition_store::{OpenMode, PartitionStore, PartitionStoreManager};
 use restate_rocksdb::RocksDbManager;
-use restate_storage_api::deduplication_table::{
-    DedupSequenceNumber, DeduplicationTable, ProducerId,
+use restate_storage_api::{
+    deduplication_table::{DedupSequenceNumber, DeduplicationTable, ProducerId},
+    Transaction,
 };
-use restate_storage_api::Transaction;
-use restate_types::config::{CommonOptions, WorkerOptions};
-use restate_types::identifiers::{PartitionId, PartitionKey};
-use restate_types::live::Constant;
+use restate_types::{
+    config::{CommonOptions, WorkerOptions},
+    identifiers::{PartitionId, PartitionKey},
+    live::Constant,
+};
 use tokio::runtime::Builder;
 
 async fn writing_to_rocksdb(mut rocksdb: PartitionStore) {

--- a/crates/partition-store/src/deduplication_table/mod.rs
+++ b/crates/partition-store/src/deduplication_table/mod.rs
@@ -12,21 +12,21 @@ use std::io::Cursor;
 
 use futures::Stream;
 use futures_util::stream;
-
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::deduplication_table::{
-    DedupInformation, DedupSequenceNumber, DeduplicationTable, ProducerId,
-    ReadOnlyDeduplicationTable,
+use restate_storage_api::{
+    deduplication_table::{
+        DedupInformation, DedupSequenceNumber, DeduplicationTable, ProducerId,
+        ReadOnlyDeduplicationTable,
+    },
+    Result, StorageError,
 };
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::PartitionId;
-use restate_types::storage::StorageCodec;
+use restate_types::{identifiers::PartitionId, storage::StorageCodec};
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::TableKind::Deduplication;
 use crate::{
-    PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
-    TableScanIterationDecision,
+    keys::{define_table_key, KeyKind, TableKey},
+    PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess,
+    TableKind::Deduplication,
+    TableScan, TableScanIterationDecision,
 };
 
 define_table_key!(

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -8,17 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::future;
-use std::future::Future;
+use std::{future, future::Future};
 
-use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
-use restate_storage_api::Result;
-use restate_types::identifiers::PartitionId;
-use restate_types::storage::{StorageDecode, StorageEncode};
+use restate_storage_api::{
+    fsm_table::{FsmTable, ReadOnlyFsmTable},
+    Result,
+};
+use restate_types::{
+    identifiers::PartitionId,
+    storage::{StorageDecode, StorageEncode},
+};
 
-use crate::keys::{define_table_key, KeyKind};
-use crate::TableKind::PartitionStateMachine;
-use crate::{PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess};
+use crate::{
+    keys::{define_table_key, KeyKind},
+    PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess,
+    TableKind::PartitionStateMachine,
+};
 
 define_table_key!(
     PartitionStateMachine,

--- a/crates/partition-store/src/idempotency_table/mod.rs
+++ b/crates/partition-store/src/idempotency_table/mod.rs
@@ -8,22 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::owned_iter::OwnedIterator;
-use crate::scan::TableScan;
-use crate::{PartitionStore, TableKind};
-use crate::{PartitionStoreTransaction, StorageAccess};
+use std::ops::RangeInclusive;
+
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
-use restate_storage_api::idempotency_table::{
-    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
+use restate_storage_api::{
+    idempotency_table::{IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable},
+    Result, StorageError,
 };
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
-use restate_types::storage::StorageCodec;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{IdempotencyId, PartitionKey, WithPartitionKey},
+    storage::StorageCodec,
+};
+
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    owned_iter::OwnedIterator,
+    scan::TableScan,
+    PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
+};
 
 define_table_key!(
     TableKind::Idempotency,

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -8,24 +8,32 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::owned_iter::OwnedIterator;
-use crate::TableScan::FullScanPartitionKeyRange;
-use crate::{PartitionStore, TableKind, TableScanIterationDecision};
-use crate::{PartitionStoreTransaction, StorageAccess};
+use std::ops::RangeInclusive;
+
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::invocation_status_table::{
-    CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation, InvocationStatus,
-    InvocationStatusTable, InvocationStatusV2, PreFlightInvocationMetadata,
-    ReadOnlyInvocationStatusTable, ScheduledInvocation, SourceTable,
+use restate_storage_api::{
+    invocation_status_table::{
+        CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation, InvocationStatus,
+        InvocationStatusTable, InvocationStatusV2, PreFlightInvocationMetadata,
+        ReadOnlyInvocationStatusTable, ScheduledInvocation, SourceTable,
+    },
+    Result, StorageError,
 };
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
-use restate_types::invocation::InvocationTarget;
-use restate_types::storage::StorageCodec;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey},
+    invocation::InvocationTarget,
+    storage::StorageCodec,
+};
+
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    owned_iter::OwnedIterator,
+    PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
+    TableScan::FullScanPartitionKeyRange,
+    TableScanIterationDecision,
+};
 
 // TODO remove this once we remove the old InvocationStatus
 define_table_key!(

--- a/crates/partition-store/src/journal_table/mod.rs
+++ b/crates/partition-store/src/journal_table/mod.rs
@@ -8,24 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::TableKey;
-use crate::keys::{define_table_key, KeyKind};
-use crate::owned_iter::OwnedIterator;
-use crate::scan::TableScan::FullScanPartitionKeyRange;
-use crate::TableKind::Journal;
-use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess};
-use crate::{TableScan, TableScanIterationDecision};
+use std::{io::Cursor, ops::RangeInclusive};
+
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::journal_table::{JournalEntry, JournalTable, ReadOnlyJournalTable};
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{
-    EntryIndex, InvocationId, InvocationUuid, JournalEntryId, PartitionKey, WithPartitionKey,
+use restate_storage_api::{
+    journal_table::{JournalEntry, JournalTable, ReadOnlyJournalTable},
+    Result, StorageError,
 };
-use restate_types::storage::StorageCodec;
-use std::io::Cursor;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{
+        EntryIndex, InvocationId, InvocationUuid, JournalEntryId, PartitionKey, WithPartitionKey,
+    },
+    storage::StorageCodec,
+};
+
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    owned_iter::OwnedIterator,
+    scan::TableScan::FullScanPartitionKeyRange,
+    PartitionStore, PartitionStoreTransaction, StorageAccess,
+    TableKind::Journal,
+    TableScan, TableScanIterationDecision,
+};
 
 define_table_key!(
     Journal,
@@ -210,10 +216,10 @@ impl<'a> JournalTable for PartitionStoreTransaction<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::journal_table::write_journal_entry_key;
-    use crate::keys::TableKey;
     use bytes::Bytes;
     use restate_types::identifiers::{InvocationId, InvocationUuid};
+
+    use crate::{journal_table::write_journal_entry_key, keys::TableKey};
 
     fn journal_entry_key(invocation_id: &InvocationId, journal_index: u32) -> Bytes {
         write_journal_entry_key(invocation_id, journal_index)

--- a/crates/partition-store/src/keys.rs
+++ b/crates/partition-store/src/keys.rs
@@ -314,13 +314,13 @@ macro_rules! define_table_key {
     })
 }
 
-use crate::PaddedPartitionId;
-use crate::TableKind;
 pub(crate) use define_table_key;
-use restate_storage_api::deduplication_table::ProducerId;
-use restate_storage_api::timer_table::TimerKeyKind;
-use restate_storage_api::StorageError;
+use restate_storage_api::{
+    deduplication_table::ProducerId, timer_table::TimerKeyKind, StorageError,
+};
 use restate_types::identifiers::InvocationUuid;
+
+use crate::{PaddedPartitionId, TableKind};
 
 pub(crate) trait KeyCodec: Sized {
     fn encode<B: BufMut>(&self, target: &mut B);
@@ -621,10 +621,11 @@ pub(crate) fn deserialize<T: KeyCodec, B: Buf>(source: &mut B) -> crate::Result<
 #[cfg(test)]
 #[allow(dead_code)]
 mod tests {
-    use super::*;
     use bytes::BytesMut;
     use restate_test_util::let_assert;
     use strum::IntoEnumIterator;
+
+    use super::*;
 
     #[test]
     fn write_read_round_trip() {

--- a/crates/partition-store/src/outbox_table/mod.rs
+++ b/crates/partition-store/src/outbox_table/mod.rs
@@ -8,19 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::Cursor;
-use std::ops::RangeInclusive;
+use std::{io::Cursor, ops::RangeInclusive};
 
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::outbox_table::{OutboxMessage, OutboxTable, ReadOnlyOutboxTable};
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::PartitionId;
-use restate_types::storage::StorageCodec;
+use restate_storage_api::{
+    outbox_table::{OutboxMessage, OutboxTable, ReadOnlyOutboxTable},
+    Result, StorageError,
+};
+use restate_types::{identifiers::PartitionId, storage::StorageCodec};
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::TableKind::Outbox;
 use crate::{
-    PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
+    keys::{define_table_key, KeyKind, TableKey},
+    PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess,
+    TableKind::Outbox,
+    TableScan,
 };
 
 define_table_key!(

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -8,40 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-use std::path::PathBuf;
-use std::slice;
-use std::sync::Arc;
+use std::{ops::RangeInclusive, path::PathBuf, slice, sync::Arc};
 
-use bytes::Bytes;
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use codederror::CodedError;
-use restate_rocksdb::CfName;
-use restate_rocksdb::IoMode;
-use restate_rocksdb::Priority;
-use restate_storage_api::fsm_table::ReadOnlyFsmTable;
-use restate_types::config::Configuration;
-use rocksdb::DBCompressionType;
-use rocksdb::DBPinnableSlice;
-use rocksdb::DBRawIteratorWithThreadMode;
-use rocksdb::PrefixRange;
-use rocksdb::ReadOptions;
-use rocksdb::{BoundColumnFamily, SliceTransform};
-use static_assertions::const_assert_eq;
-
 use enum_map::Enum;
 use restate_core::ShutdownError;
-use restate_rocksdb::{RocksDb, RocksError};
-use restate_storage_api::{Storage, StorageError, Transaction};
+use restate_rocksdb::{CfName, IoMode, Priority, RocksDb, RocksError};
+use restate_storage_api::{fsm_table::ReadOnlyFsmTable, Storage, StorageError, Transaction};
+use restate_types::{
+    config::Configuration,
+    identifiers::{PartitionId, PartitionKey, WithPartitionKey},
+    storage::{StorageCodec, StorageDecode, StorageEncode},
+};
+use rocksdb::{
+    BoundColumnFamily, DBCompressionType, DBPinnableSlice, DBRawIteratorWithThreadMode,
+    PrefixRange, ReadOptions, SliceTransform,
+};
+use static_assertions::const_assert_eq;
 
-use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
-use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
-
-use crate::keys::KeyKind;
-use crate::keys::TableKey;
-use crate::scan::PhysicalScan;
-use crate::scan::TableScan;
-use crate::snapshots::LocalPartitionSnapshot;
+use crate::{
+    keys::{KeyKind, TableKey},
+    scan::{PhysicalScan, TableScan},
+    snapshots::LocalPartitionSnapshot,
+};
 
 pub type DB = rocksdb::DB;
 
@@ -475,8 +465,9 @@ impl Storage for PartitionStore {
 
 impl StorageAccess for PartitionStore {
     type DBAccess<'a>
-    = DB where
-        Self: 'a,;
+        = DB
+    where
+        Self: 'a;
 
     fn iterator_from<K: TableKey>(
         &self,
@@ -647,7 +638,10 @@ impl<'a> Transaction for PartitionStoreTransaction<'a> {
 }
 
 impl<'a> StorageAccess for PartitionStoreTransaction<'a> {
-    type DBAccess<'b> = DB where Self: 'b;
+    type DBAccess<'b>
+        = DB
+    where
+        Self: 'b;
 
     fn iterator_from<K: TableKey>(
         &self,

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -8,25 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
-
-use rocksdb::ExportImportFilesMetaData;
-use tokio::sync::Mutex;
-use tracing::{debug, error, info, warn};
+use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
 };
-use restate_types::config::{RocksDbOptions, StorageOptions};
-use restate_types::identifiers::{PartitionId, PartitionKey};
-use restate_types::live::{BoxedLiveLoad, LiveLoad};
+use restate_types::{
+    config::{RocksDbOptions, StorageOptions},
+    identifiers::{PartitionId, PartitionKey},
+    live::{BoxedLiveLoad, LiveLoad},
+};
+use rocksdb::ExportImportFilesMetaData;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
 
-use crate::cf_options;
-use crate::snapshots::LocalPartitionSnapshot;
-use crate::PartitionStore;
-use crate::DB;
+use crate::{cf_options, snapshots::LocalPartitionSnapshot, PartitionStore, DB};
 
 const DB_NAME: &str = "db";
 const PARTITION_CF_PREFIX: &str = "data-";

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -8,24 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::owned_iter::OwnedIterator;
-use crate::scan::TableScan;
-use crate::{PartitionStore, TableKind, TableScanIterationDecision};
-use crate::{PartitionStoreTransaction, StorageAccess};
+use std::ops::RangeInclusive;
+
 use anyhow::anyhow;
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::promise_table::{
-    OwnedPromiseRow, Promise, PromiseTable, ReadOnlyPromiseTable,
+use restate_storage_api::{
+    promise_table::{OwnedPromiseRow, Promise, PromiseTable, ReadOnlyPromiseTable},
+    Result, StorageError,
 };
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
-use restate_types::storage::StorageCodec;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{PartitionKey, ServiceId, WithPartitionKey},
+    storage::StorageCodec,
+};
+
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    owned_iter::OwnedIterator,
+    scan::TableScan,
+    PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
+    TableScanIterationDecision,
+};
 
 define_table_key!(
     TableKind::Promise,

--- a/crates/partition-store/src/scan.rs
+++ b/crates/partition-store/src/scan.rs
@@ -8,15 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{KeyCodec, KeyKind, TableKey};
-use crate::scan::TableScan::{
-    FullScanPartitionKeyRange, KeyRangeInclusiveInSinglePartition, SinglePartition,
-    SinglePartitionKeyPrefix,
-};
-use crate::{PaddedPartitionId, ScanMode, TableKind};
+use std::ops::RangeInclusive;
+
 use bytes::BytesMut;
 use restate_types::identifiers::{PartitionId, PartitionKey};
-use std::ops::RangeInclusive;
+
+use crate::{
+    keys::{KeyCodec, KeyKind, TableKey},
+    scan::TableScan::{
+        FullScanPartitionKeyRange, KeyRangeInclusiveInSinglePartition, SinglePartition,
+        SinglePartitionKeyPrefix,
+    },
+    PaddedPartitionId, ScanMode, TableKind,
+};
 
 // Note: we take extra arguments like (PartitionId or PartitionKey) only to make sure that
 // call-sites know what they are opting to. Those values might not actually be used to perform the
@@ -139,11 +143,12 @@ fn try_increment(bytes: &mut BytesMut) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::scan::try_increment;
+    use std::{collections::BTreeMap, ops::Add};
+
     use bytes::{BufMut, BytesMut};
     use num_bigint::BigUint;
-    use std::collections::BTreeMap;
-    use std::ops::Add;
+
+    use crate::scan::try_increment;
 
     fn verify_binary_increment(bytes: &mut BytesMut) {
         let as_number = BigUint::from_bytes_be(bytes);

--- a/crates/partition-store/src/service_status_table/mod.rs
+++ b/crates/partition-store/src/service_status_table/mod.rs
@@ -8,23 +8,29 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::owned_iter::OwnedIterator;
-use crate::TableScan::FullScanPartitionKeyRange;
-use crate::{PartitionStore, TableKind};
-use crate::{PartitionStoreTransaction, StorageAccess};
+use std::ops::RangeInclusive;
+
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::service_status_table::{
-    ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus, VirtualObjectStatusTable,
+use restate_storage_api::{
+    service_status_table::{
+        ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus, VirtualObjectStatusTable,
+    },
+    Result, StorageError,
 };
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::WithPartitionKey;
-use restate_types::identifiers::{PartitionKey, ServiceId};
-use restate_types::storage::StorageCodec;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{PartitionKey, ServiceId, WithPartitionKey},
+    storage::StorageCodec,
+};
+
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    owned_iter::OwnedIterator,
+    PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
+    TableScan::FullScanPartitionKeyRange,
+};
 
 define_table_key!(
     TableKind::ServiceStatus,

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -1,13 +1,12 @@
-use std::ops::RangeInclusive;
-use std::path::PathBuf;
+use std::{ops::RangeInclusive, path::PathBuf};
 
+use restate_types::{
+    identifiers::{PartitionId, PartitionKey, SnapshotId},
+    logs::Lsn,
+};
 use rocksdb::LiveFile;
 use serde::{Deserialize, Serialize};
-use serde_with::hex::Hex;
-use serde_with::{serde_as, DeserializeAs, SerializeAs};
-
-use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId};
-use restate_types::logs::Lsn;
+use serde_with::{hex::Hex, serde_as, DeserializeAs, SerializeAs};
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SnapshotFormatVersion {

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -8,22 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::owned_iter::OwnedIterator;
-use crate::TableKind::State;
-use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess};
-use crate::{TableScan, TableScanIterationDecision};
+use std::{future, future::Future, ops::RangeInclusive};
+
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::state_table::{ReadOnlyStateTable, StateTable};
-use restate_storage_api::{Result, StorageError};
+use restate_storage_api::{
+    state_table::{ReadOnlyStateTable, StateTable},
+    Result, StorageError,
+};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
-use std::future;
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    owned_iter::OwnedIterator,
+    PartitionStore, PartitionStoreTransaction, StorageAccess,
+    TableKind::State,
+    TableScan, TableScanIterationDecision,
+};
 
 define_table_key!(
     State,
@@ -221,10 +225,13 @@ fn decode_user_state_key_value(k: &[u8], v: &[u8]) -> Result<(Bytes, Bytes)> {
 
 #[cfg(test)]
 mod tests {
-    use crate::keys::TableKey;
-    use crate::state_table::{user_state_key_from_slice, write_state_entry_key};
     use bytes::{Bytes, BytesMut};
     use restate_types::identifiers::ServiceId;
+
+    use crate::{
+        keys::TableKey,
+        state_table::{user_state_key_from_slice, write_state_entry_key},
+    };
 
     static EMPTY: Bytes = Bytes::from_static(b"");
 

--- a/crates/partition-store/src/timer_table/mod.rs
+++ b/crates/partition-store/src/timer_table/mod.rs
@@ -10,18 +10,23 @@
 
 use futures::Stream;
 use futures_util::stream;
-
 use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable};
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{InvocationUuid, PartitionId};
-use restate_types::storage::StorageCodec;
+use restate_storage_api::{
+    timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable},
+    Result, StorageError,
+};
+use restate_types::{
+    identifiers::{InvocationUuid, PartitionId},
+    storage::StorageCodec,
+};
 
-use crate::keys::{define_table_key, KeyKind, TableKey};
-use crate::TableKind::Timers;
-use crate::TableScanIterationDecision::Emit;
-use crate::{PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess};
-use crate::{TableScan, TableScanIterationDecision};
+use crate::{
+    keys::{define_table_key, KeyKind, TableKey},
+    PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess,
+    TableKind::Timers,
+    TableScan, TableScanIterationDecision,
+    TableScanIterationDecision::Emit,
+};
 
 define_table_key!(
     Timers,
@@ -217,13 +222,13 @@ impl<'a> TimerTable for PartitionStoreTransaction<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::timer_table::TimerKey;
     use rand::Rng;
     use restate_storage_api::timer_table::TimerKeyKindDiscriminants;
-    use restate_types::identifiers::InvocationUuid;
-    use restate_types::invocation::InvocationTarget;
+    use restate_types::{identifiers::InvocationUuid, invocation::InvocationTarget};
     use strum::VariantArray;
+
+    use super::*;
+    use crate::timer_table::TimerKey;
 
     const FIXTURE_INVOCATION: InvocationUuid = InvocationUuid::from_u128(12345678900001);
 

--- a/crates/partition-store/tests/idempotency_table_test/mod.rs
+++ b/crates/partition-store/tests/idempotency_table_test/mod.rs
@@ -12,12 +12,13 @@
 #![allow(clippy::borrow_interior_mutable_const)]
 #![allow(clippy::declare_interior_mutable_const)]
 
-use crate::storage_test_environment;
-use restate_storage_api::idempotency_table::{
-    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
+use restate_storage_api::{
+    idempotency_table::{IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable},
+    Transaction,
 };
-use restate_storage_api::Transaction;
 use restate_types::identifiers::{IdempotencyId, InvocationId, InvocationUuid};
+
+use crate::storage_test_environment;
 
 const FIXTURE_INVOCATION_1: InvocationUuid = InvocationUuid::from_u128(12345678900001);
 const FIXTURE_INVOCATION_2: InvocationUuid = InvocationUuid::from_u128(12345678900002);

--- a/crates/partition-store/tests/inbox_table_test/mod.rs
+++ b/crates/partition-store/tests/inbox_table_test/mod.rs
@@ -8,14 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{assert_stream_eq, mock_state_mutation};
 use once_cell::sync::Lazy;
 use restate_partition_store::PartitionStore;
-use restate_storage_api::inbox_table::{
-    InboxEntry, InboxTable, ReadOnlyInboxTable, SequenceNumberInboxEntry,
+use restate_storage_api::{
+    inbox_table::{InboxEntry, InboxTable, ReadOnlyInboxTable, SequenceNumberInboxEntry},
+    Transaction,
 };
-use restate_storage_api::Transaction;
 use restate_types::identifiers::{InvocationId, ServiceId};
+
+use crate::{assert_stream_eq, mock_state_mutation};
 
 static INBOX_ENTRIES: Lazy<Vec<SequenceNumberInboxEntry>> = Lazy::new(|| {
     vec![

--- a/crates/partition-store/tests/integration_test.rs
+++ b/crates/partition-store/tests/integration_test.rs
@@ -8,23 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::pin::pin;
+use std::{collections::HashMap, fmt::Debug, ops::RangeInclusive, pin::pin};
 
 use futures::Stream;
-use tokio_stream::StreamExt;
-
 use restate_core::TaskCenterBuilder;
 use restate_partition_store::{OpenMode, PartitionStore, PartitionStoreManager};
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::StorageError;
-use restate_types::config::{CommonOptions, WorkerOptions};
-use restate_types::identifiers::{InvocationId, PartitionId, PartitionKey, ServiceId};
-use restate_types::invocation::{InvocationTarget, ServiceInvocation, Source};
-use restate_types::live::{Constant, Live};
-use restate_types::state_mut::ExternalStateMutation;
+use restate_types::{
+    config::{CommonOptions, WorkerOptions},
+    identifiers::{InvocationId, PartitionId, PartitionKey, ServiceId},
+    invocation::{InvocationTarget, ServiceInvocation, Source},
+    live::{Constant, Live},
+    state_mut::ExternalStateMutation,
+};
+use tokio_stream::StreamExt;
 
 mod idempotency_table_test;
 mod inbox_table_test;

--- a/crates/partition-store/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/tests/invocation_status_table_test/mod.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::borrow_interior_mutable_const)]
 #![allow(clippy::declare_interior_mutable_const)]
 
-use super::{assert_stream_eq, storage_test_environment};
+use std::{collections::HashSet, time::Duration};
 
 use bytestring::ByteString;
 use once_cell::sync::Lazy;
@@ -20,13 +20,15 @@ use restate_storage_api::invocation_status_table::{
     InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable, JournalMetadata,
     SourceTable, StatusTimestamps,
 };
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::{
-    InvocationTarget, ServiceInvocationSpanContext, Source, VirtualObjectHandlerType,
+use restate_types::{
+    identifiers::InvocationId,
+    invocation::{
+        InvocationTarget, ServiceInvocationSpanContext, Source, VirtualObjectHandlerType,
+    },
+    time::MillisSinceEpoch,
 };
-use restate_types::time::MillisSinceEpoch;
-use std::collections::HashSet;
-use std::time::Duration;
+
+use super::{assert_stream_eq, storage_test_environment};
 
 const INVOCATION_TARGET_1: InvocationTarget = InvocationTarget::VirtualObject {
     name: ByteString::from_static("abc"),

--- a/crates/partition-store/tests/journal_table_test/mod.rs
+++ b/crates/partition-store/tests/journal_table_test/mod.rs
@@ -8,21 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::storage_test_environment;
+use std::{pin::pin, time::Duration};
 
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures_util::StreamExt;
 use once_cell::sync::Lazy;
-use restate_storage_api::journal_table::{JournalEntry, JournalTable};
-use restate_storage_api::Transaction;
-use restate_types::identifiers::{InvocationId, InvocationUuid};
-use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
-use restate_types::journal::enriched::{
-    CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
+use restate_storage_api::{
+    journal_table::{JournalEntry, JournalTable},
+    Transaction,
 };
-use std::pin::pin;
-use std::time::Duration;
+use restate_types::{
+    identifiers::{InvocationId, InvocationUuid},
+    invocation::{InvocationTarget, ServiceInvocationSpanContext},
+    journal::enriched::{CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry},
+};
+
+use crate::storage_test_environment;
 
 // false positive because of Bytes
 #[allow(clippy::declare_interior_mutable_const)]

--- a/crates/partition-store/tests/outbox_table_test/mod.rs
+++ b/crates/partition-store/tests/outbox_table_test/mod.rs
@@ -8,10 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mock_random_service_invocation;
 use restate_partition_store::PartitionStore;
-use restate_storage_api::outbox_table::{OutboxMessage, OutboxTable};
-use restate_storage_api::Transaction;
+use restate_storage_api::{
+    outbox_table::{OutboxMessage, OutboxTable},
+    Transaction,
+};
+
+use crate::mock_random_service_invocation;
 
 fn mock_outbox_message() -> OutboxMessage {
     OutboxMessage::ServiceInvocation(mock_random_service_invocation())

--- a/crates/partition-store/tests/promise_table_test/mod.rs
+++ b/crates/partition-store/tests/promise_table_test/mod.rs
@@ -12,15 +12,18 @@
 #![allow(clippy::borrow_interior_mutable_const)]
 #![allow(clippy::declare_interior_mutable_const)]
 
-use crate::storage_test_environment;
 use bytes::Bytes;
 use bytestring::ByteString;
-use restate_storage_api::promise_table::{
-    Promise, PromiseState, PromiseTable, ReadOnlyPromiseTable,
+use restate_storage_api::{
+    promise_table::{Promise, PromiseState, PromiseTable, ReadOnlyPromiseTable},
+    Transaction,
 };
-use restate_storage_api::Transaction;
-use restate_types::identifiers::{InvocationId, InvocationUuid, JournalEntryId, ServiceId};
-use restate_types::journal::EntryResult;
+use restate_types::{
+    identifiers::{InvocationId, InvocationUuid, JournalEntryId, ServiceId},
+    journal::EntryResult,
+};
+
+use crate::storage_test_environment;
 
 const SERVICE_ID_1: ServiceId = ServiceId::from_static(10, "MySvc", "a");
 const SERVICE_ID_2: ServiceId = ServiceId::from_static(11, "MySvc", "b");

--- a/crates/partition-store/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/tests/snapshots_test/mod.rs
@@ -1,18 +1,21 @@
-use std::ops::RangeInclusive;
-use std::time::SystemTime;
-use tempfile::tempdir;
+use std::{ops::RangeInclusive, time::SystemTime};
 
-use restate_partition_store::snapshots::{
-    LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion,
+use restate_partition_store::{
+    snapshots::{LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion},
+    PartitionStore, PartitionStoreManager,
 };
-use restate_partition_store::{PartitionStore, PartitionStoreManager};
-use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
-use restate_storage_api::Transaction;
-use restate_types::config::WorkerOptions;
-use restate_types::identifiers::{PartitionKey, SnapshotId};
-use restate_types::live::Live;
-use restate_types::logs::Lsn;
-use restate_types::time::MillisSinceEpoch;
+use restate_storage_api::{
+    fsm_table::{FsmTable, ReadOnlyFsmTable},
+    Transaction,
+};
+use restate_types::{
+    config::WorkerOptions,
+    identifiers::{PartitionKey, SnapshotId},
+    live::Live,
+    logs::Lsn,
+    time::MillisSinceEpoch,
+};
+use tempfile::tempdir;
 
 pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_store: PartitionStore) {
     insert_test_data(&mut partition_store).await;

--- a/crates/partition-store/tests/state_table_test/mod.rs
+++ b/crates/partition-store/tests/state_table_test/mod.rs
@@ -8,12 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{assert_stream_eq, storage_test_environment};
 use bytes::Bytes;
 use restate_partition_store::PartitionStore;
-use restate_storage_api::state_table::{ReadOnlyStateTable, StateTable};
-use restate_storage_api::Transaction;
+use restate_storage_api::{
+    state_table::{ReadOnlyStateTable, StateTable},
+    Transaction,
+};
 use restate_types::identifiers::ServiceId;
+
+use crate::{assert_stream_eq, storage_test_environment};
 
 async fn populate_data<T: StateTable>(table: &mut T) {
     table

--- a/crates/partition-store/tests/timer_table_test/mod.rs
+++ b/crates/partition-store/tests/timer_table_test/mod.rs
@@ -8,16 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mock_service_invocation;
-use futures_util::StreamExt;
-use googletest::matchers::eq;
-use googletest::{assert_that, pat};
-use restate_partition_store::PartitionStore;
-use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable};
-use restate_storage_api::Transaction;
-use restate_types::identifiers::{InvocationId, InvocationUuid, ServiceId};
-use restate_types::invocation::ServiceInvocation;
 use std::pin::pin;
+
+use futures_util::StreamExt;
+use googletest::{assert_that, matchers::eq, pat};
+use restate_partition_store::PartitionStore;
+use restate_storage_api::{
+    timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable},
+    Transaction,
+};
+use restate_types::{
+    identifiers::{InvocationId, InvocationUuid, ServiceId},
+    invocation::ServiceInvocation,
+};
+
+use crate::mock_service_invocation;
 
 const FIXTURE_INVOCATION_UUID: InvocationUuid = InvocationUuid::from_u128(12345678900001);
 const FIXTURE_INVOCATION: InvocationId = InvocationId::from_parts(1337, FIXTURE_INVOCATION_UUID);

--- a/crates/queue/benches/queue_benchmark.rs
+++ b/crates/queue/benches/queue_benchmark.rs
@@ -8,10 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{path, time::Duration};
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use restate_queue::SegmentQueue;
-use std::path;
-use std::time::Duration;
 use tempfile::tempdir;
 use tokio::runtime::Builder;
 

--- a/crates/queue/src/io.rs
+++ b/crates/queue/src/io.rs
@@ -8,10 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::collections::VecDeque;
-use std::path::PathBuf;
+use std::{collections::VecDeque, path::PathBuf};
+
+use serde::{de::DeserializeOwned, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 
 const ENCODE_ERR_MSG: &str =

--- a/crates/queue/src/lib.rs
+++ b/crates/queue/src/lib.rs
@@ -15,10 +15,10 @@ pub use segmented_queue::SegmentQueue;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use restate_types::identifiers::InvocationId;
     use tempfile::tempdir;
+
+    use super::*;
 
     #[tokio::test]
     async fn simple_example() {

--- a/crates/queue/src/segmented_queue.rs
+++ b/crates/queue/src/segmented_queue.rs
@@ -8,17 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::io;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::collections::VecDeque;
-use std::fmt::Debug;
-use std::mem;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::VecDeque,
+    fmt::Debug,
+    mem,
+    path::{Path, PathBuf},
+};
+
+use serde::{de::DeserializeOwned, Serialize};
 use tokio::task::JoinHandle;
 
-use crate::segmented_queue::Segment::{
-    LoadedFromDisk, LoadingFromDisk, Mutable, OnDisk, StoringToDisk,
+use crate::{
+    io,
+    segmented_queue::Segment::{LoadedFromDisk, LoadingFromDisk, Mutable, OnDisk, StoringToDisk},
 };
 
 ///

--- a/crates/rocksdb/src/background.rs
+++ b/crates/rocksdb/src/background.rs
@@ -14,10 +14,12 @@ use derive_builder::Builder;
 use metrics::{gauge, histogram};
 use tokio::sync::oneshot;
 
-use crate::metric_definitions::{
-    STORAGE_BG_TASK_RUN_DURATION, STORAGE_BG_TASK_TOTAL_DURATION, STORAGE_BG_TASK_WAIT_DURATION,
+use crate::{
+    metric_definitions::{
+        STORAGE_BG_TASK_RUN_DURATION, STORAGE_BG_TASK_TOTAL_DURATION, STORAGE_BG_TASK_WAIT_DURATION,
+    },
+    Priority, OP_TYPE, PRIORITY, STORAGE_BG_TASK_IN_FLIGHT,
 };
-use crate::{Priority, OP_TYPE, PRIORITY, STORAGE_BG_TASK_IN_FLIGHT};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -8,23 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
-use std::sync::{Arc, OnceLock};
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize},
+        Arc, OnceLock,
+    },
+    time::Instant,
+};
 
 use parking_lot::RwLock;
+use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
+use restate_serde_util::ByteCount;
+use restate_types::{
+    config::{CommonOptions, Configuration, RocksDbOptions, StatisticsLevel},
+    live::{BoxedLiveLoad, LiveLoad},
+};
 use rocksdb::{BlockBasedOptions, Cache, WriteBufferManager};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
-use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
-use restate_serde_util::ByteCount;
-use restate_types::config::{CommonOptions, Configuration, RocksDbOptions, StatisticsLevel};
-use restate_types::live::{BoxedLiveLoad, LiveLoad};
-
-use crate::background::ReadyStorageTask;
-use crate::{metric_definitions, DbName, DbSpec, Priority, RocksAccess, RocksDb, RocksError};
+use crate::{
+    background::ReadyStorageTask, metric_definitions, DbName, DbSpec, Priority, RocksAccess,
+    RocksDb, RocksError,
+};
 
 static DB_MANAGER: OnceLock<RocksDbManager> = OnceLock::new();
 

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -16,37 +16,25 @@ mod metric_definitions;
 mod perf;
 mod rock_access;
 
-use metrics::counter;
-use metrics::gauge;
-use metrics::histogram;
+use std::{path::PathBuf, sync::Arc, time::Instant};
+
+use metrics::{counter, gauge, histogram};
 use restate_core::ShutdownError;
 use restate_types::config::RocksDbOptions;
-use tracing::debug;
-use tracing::error;
-use tracing::info;
-use tracing::warn;
-
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Instant;
-
-use rocksdb::checkpoint::Checkpoint;
-use rocksdb::statistics::Histogram;
-use rocksdb::statistics::HistogramData;
-use rocksdb::statistics::Ticker;
-use rocksdb::ExportImportFilesMetaData;
+use rocksdb::{
+    checkpoint::Checkpoint,
+    statistics::{Histogram, HistogramData, Ticker},
+    ExportImportFilesMetaData,
+};
+use tracing::{debug, error, info, warn};
 
 // re-exports
 pub use self::db_manager::RocksDbManager;
-pub use self::db_spec::*;
-pub use self::error::*;
-pub use self::perf::RocksDbPerfGuard;
-pub use self::rock_access::RocksAccess;
-
-use self::background::ReadyStorageTask;
-use self::background::StorageTask;
-use self::background::StorageTaskKind;
-use self::metric_definitions::*;
+use self::{
+    background::{ReadyStorageTask, StorageTask, StorageTaskKind},
+    metric_definitions::*,
+};
+pub use self::{db_spec::*, error::*, perf::RocksDbPerfGuard, rock_access::RocksAccess};
 
 type BoxedCfMatcher = Box<dyn CfNameMatch + Send + Sync>;
 type BoxedCfOptionUpdater = Box<dyn Fn(rocksdb::Options) -> rocksdb::Options + Send + Sync>;

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -8,19 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
-use rocksdb::perf::MemoryUsageBuilder;
-use rocksdb::ExportImportFilesMetaData;
-use rocksdb::{ColumnFamilyDescriptor, ImportColumnFamilyOptions};
+use rocksdb::{
+    perf::MemoryUsageBuilder, ColumnFamilyDescriptor, ExportImportFilesMetaData,
+    ImportColumnFamilyOptions,
+};
 use tracing::trace;
 
-use crate::BoxedCfMatcher;
-use crate::BoxedCfOptionUpdater;
-use crate::CfName;
-use crate::DbSpec;
-use crate::RocksError;
+use crate::{BoxedCfMatcher, BoxedCfOptionUpdater, CfName, DbSpec, RocksError};
 
 /// Operations in this trait can be IO blocking, prefer using `RocksDb` for efficient async access
 /// to the database.

--- a/crates/serde-util/src/byte_count.rs
+++ b/crates/serde-util/src/byte_count.rs
@@ -8,13 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::{self, Display};
-use std::num::{NonZeroU64, NonZeroUsize};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Display},
+    num::{NonZeroU64, NonZeroUsize},
+    str::FromStr,
+};
 
 use bytesize::ByteSize;
-use serde::de::Visitor;
-use serde::{de, de::Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de,
+    de::{Deserialize, Visitor},
+    Deserializer, Serialize, Serializer,
+};
 use serde_with::{DeserializeAs, SerializeAs};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy, Hash)]
@@ -306,9 +311,9 @@ impl<'de> DeserializeAs<'de, NonZeroU64> for ByteCount<false> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use serde::Deserialize;
+
+    use super::*;
 
     #[derive(Serialize, Deserialize)]
     struct Config(ByteCount<true>);

--- a/crates/serde-util/src/duration.rs
+++ b/crates/serde-util/src/duration.rs
@@ -18,10 +18,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::de::{Error, IntoDeserializer};
-use serde::{Deserialize, Deserializer, Serializer};
-use serde_with::{DeserializeAs, SerializeAs};
 use std::time::Duration;
+
+use serde::{
+    de::{Error, IntoDeserializer},
+    Deserialize, Deserializer, Serializer,
+};
+use serde_with::{DeserializeAs, SerializeAs};
 
 /// Serializable/Deserializable duration to use with serde_with.
 ///
@@ -64,11 +67,10 @@ impl SerializeAs<std::time::Duration> for DurationString {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use serde::{Deserialize, Serialize};
-
     use serde_with::serde_as;
+
+    use super::*;
 
     #[serde_as]
     #[derive(Serialize, Deserialize)]

--- a/crates/serde-util/src/header_map.rs
+++ b/crates/serde-util/src/header_map.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{collections::HashMap, fmt};
+
 use http::{HeaderName, HeaderValue};
-use serde::de::{MapAccess, Visitor};
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
-use std::fmt;
+use serde::{
+    de::{MapAccess, Visitor},
+    ser::SerializeMap,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 /// Proxy type to implement HashMap<HeaderName, HeaderValue> ser/de
 /// Use it directly or with `#[serde(with = "serde_with::As::<serde_with::FromInto<restate_serde_util::SerdeableHeaderMap>>")]`.

--- a/crates/serde-util/src/proto.rs
+++ b/crates/serde-util/src/proto.rs
@@ -9,8 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use bytes::Bytes;
-use serde::de::Error;
-use serde::Deserialize;
+use serde::{de::Error, Deserialize};
 use serde_with::{DeserializeAs, SerializeAs};
 
 /// SerializeAs/DeserializeAs to implement ser/de trait for prost types

--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -8,27 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::proxy::ProxyConnector;
-
-use crate::utils::ErrorExt;
+use std::{error::Error, fmt::Debug, future, future::Future};
 
 use bytes::Bytes;
-use futures::future::Either;
-use futures::FutureExt;
-use http::uri::Scheme;
-use http::Version;
+use futures::{future::Either, FutureExt};
+use http::{uri::Scheme, Version};
 use http_body_util::BodyExt;
-use hyper::body::Body;
-use hyper::http::uri::PathAndQuery;
-use hyper::http::HeaderValue;
-use hyper::{HeaderMap, Method, Request, Response, Uri};
+use hyper::{
+    body::Body,
+    http::{uri::PathAndQuery, HeaderValue},
+    HeaderMap, Method, Request, Response, Uri,
+};
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use restate_types::config::HttpOptions;
-use std::error::Error;
-use std::fmt::Debug;
-use std::future;
-use std::future::Future;
+
+use super::proxy::ProxyConnector;
+use crate::utils::ErrorExt;
 
 type ProxiedHttpsConnector = ProxyConnector<HttpsConnector<HttpConnector>>;
 type ProxiedHttpConnector = ProxyConnector<HttpConnector>;

--- a/crates/service-client/src/lambda.rs
+++ b/crates/service-client/src/lambda.rs
@@ -11,35 +11,37 @@
 //! Some parts copied from https://github.com/awslabs/aws-sdk-rust/blob/0.55.x/sdk/aws-config/src/sts/assume_role.rs
 //! License Apache-2.0
 
-use crate::aws_hyper_client::{CryptoMode, HyperClientBuilder};
-use crate::utils::ErrorExt;
+use std::{collections::HashMap, error::Error, fmt::Debug, future::Future, sync::Arc};
+
 use arc_swap::ArcSwap;
 use assume_role::AssumeRoleProvider;
 use aws_config::BehaviorVersion;
-use aws_sdk_lambda::config::Region;
-use aws_sdk_lambda::error::{DisplayErrorContext, SdkError};
-use aws_sdk_lambda::operation::invoke::InvokeError;
-use aws_sdk_lambda::primitives::Blob;
-use base64::display::Base64Display;
-use base64::Engine;
+use aws_sdk_lambda::{
+    config::Region,
+    error::{DisplayErrorContext, SdkError},
+    operation::invoke::InvokeError,
+    primitives::Blob,
+};
+use base64::{display::Base64Display, Engine};
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures::future::{BoxFuture, Shared};
-use futures::{FutureExt, TryFutureExt};
-use http::uri::PathAndQuery;
-use http::{HeaderMap, HeaderValue, Method, Response};
+use futures::{
+    future::{BoxFuture, Shared},
+    FutureExt, TryFutureExt,
+};
+use http::{uri::PathAndQuery, HeaderMap, HeaderValue, Method, Response};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Body;
-use restate_types::config::AwsOptions;
-use restate_types::identifiers::LambdaARN;
-use serde::ser::Error as _;
-use serde::ser::SerializeMap;
-use serde::{Deserialize, Serialize, Serializer};
-use std::collections::HashMap;
-use std::error::Error;
-use std::fmt::Debug;
-use std::future::Future;
-use std::sync::Arc;
+use restate_types::{config::AwsOptions, identifiers::LambdaARN};
+use serde::{
+    ser::{Error as _, SerializeMap},
+    Deserialize, Serialize, Serializer,
+};
+
+use crate::{
+    aws_hyper_client::{CryptoMode, HyperClientBuilder},
+    utils::ErrorExt,
+};
 
 /// # AssumeRole Cache Mode
 ///
@@ -371,11 +373,11 @@ where
 }
 
 mod assume_role {
-    use aws_credential_types::provider::error::CredentialsError;
-    use aws_credential_types::provider::future::ProvideCredentials;
+    use std::time::SystemTime;
+
+    use aws_credential_types::provider::{error::CredentialsError, future::ProvideCredentials};
     use aws_sdk_lambda::error::SdkError;
     use aws_sdk_sts::operation::assume_role::AssumeRoleError;
-    use std::time::SystemTime;
 
     /// AssumeRoleProvider implements ProvideCredentials by assuming a provided role
     /// It is materially very similar to AssumeRoleProvider in the aws-config crate, except

--- a/crates/service-client/src/lib.rs
+++ b/crates/service-client/src/lib.rs
@@ -8,30 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::http::HttpClient;
-use crate::lambda::LambdaClient;
+use core::fmt;
+use std::{error::Error, fmt::Formatter, future, future::Future, sync::Arc};
 
-pub use crate::http::HttpError;
-pub use crate::lambda::AssumeRoleCacheMode;
-use crate::request_identity::SignRequest;
 use ::http::Version;
 use arc_swap::ArcSwapOption;
 use bytes::Bytes;
 use bytestring::ByteString;
-use core::fmt;
 use futures::FutureExt;
 use http_body_util::Full;
-use hyper::body::Body;
-use hyper::header::HeaderValue;
-use hyper::http::uri::PathAndQuery;
-use hyper::{HeaderMap, Response, Uri};
-use restate_types::config::ServiceClientOptions;
-use restate_types::identifiers::LambdaARN;
-use std::error::Error;
-use std::fmt::Formatter;
-use std::future;
-use std::future::Future;
-use std::sync::Arc;
+use hyper::{body::Body, header::HeaderValue, http::uri::PathAndQuery, HeaderMap, Response, Uri};
+use restate_types::{config::ServiceClientOptions, identifiers::LambdaARN};
+
+use crate::{http::HttpClient, lambda::LambdaClient, request_identity::SignRequest};
+pub use crate::{http::HttpError, lambda::AssumeRoleCacheMode};
 
 mod aws_hyper_client;
 mod http;

--- a/crates/service-client/src/proxy.rs
+++ b/crates/service-client/src/proxy.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::task::{Context, Poll};
+
 use hyper::Uri;
 use restate_types::config::ProxyUri;
-use std::task::{Context, Poll};
 use tower_service::Service;
 
 #[derive(Clone, Debug)]

--- a/crates/service-client/src/request_identity/mod.rs
+++ b/crates/service-client/src/request_identity/mod.rs
@@ -8,9 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use hyper::header::HeaderName;
-
-use hyper::HeaderMap;
+use hyper::{header::HeaderName, HeaderMap};
 
 pub(crate) mod v1;
 

--- a/crates/service-client/src/request_identity/v1.rs
+++ b/crates/service-client/src/request_identity/v1.rs
@@ -8,14 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::fmt::{Debug, Formatter};
-use std::path::PathBuf;
-use std::time::SystemTime;
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+    path::PathBuf,
+    time::SystemTime,
+};
 
-use hyper::header::{HeaderName, HeaderValue};
-use hyper::HeaderMap;
-
+use hyper::{
+    header::{HeaderName, HeaderValue},
+    HeaderMap,
+};
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde::Serialize;
 use tracing::info;
@@ -145,12 +148,10 @@ impl<'key, 'aud> super::SignRequest for Signer<'key, 'aud> {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashSet, io::Write};
+
     use super::*;
-
     use crate::request_identity::SignRequest;
-
-    use std::collections::HashSet;
-    use std::io::Write;
 
     static PRIVATE_KEY: &[u8] = br#"-----BEGIN PRIVATE KEY-----
 MC4CAQAwBQYDK2VwBCIEIPe++4ZTPQDF81otpoU/mOGHC2vOAVp9WbiCblvn3nXO

--- a/crates/service-protocol/src/awakeable_id.rs
+++ b/crates/service-protocol/src/awakeable_id.rs
@@ -8,14 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{fmt::Display, mem::size_of, str::FromStr};
+
 use base64::Engine as _;
 use bytes::{BufMut, BytesMut};
-use restate_types::errors::IdDecodeError;
-use restate_types::identifiers::{EncodedInvocationId, EntryIndex, InvocationId, ResourceId};
-use restate_types::{IdDecoder, IdEncoder, IdResourceType};
-use std::fmt::Display;
-use std::mem::size_of;
-use std::str::FromStr;
+use restate_types::{
+    errors::IdDecodeError,
+    identifiers::{EncodedInvocationId, EntryIndex, InvocationId, ResourceId},
+    IdDecoder, IdEncoder, IdResourceType,
+};
 
 #[derive(Debug, Clone)]
 pub struct AwakeableIdentifier {

--- a/crates/service-protocol/src/codec.rs
+++ b/crates/service-protocol/src/codec.rs
@@ -8,15 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{fmt::Debug, mem};
+
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use prost::Message;
-use restate_types::invocation::Header;
-use restate_types::journal::enriched::{EnrichedEntryHeader, EnrichedRawEntry};
-use restate_types::journal::raw::*;
-use restate_types::journal::{CompletionResult, Entry, EntryType};
-use restate_types::service_protocol;
-use std::fmt::Debug;
-use std::mem;
+use restate_types::{
+    invocation::Header,
+    journal::{
+        enriched::{EnrichedEntryHeader, EnrichedRawEntry},
+        raw::*,
+        CompletionResult, Entry, EntryType,
+    },
+    service_protocol,
+};
 
 /// This macro generates the pattern matching with arms per entry.
 /// For each entry it first executes `Message#decode` and then `try_into()`.
@@ -167,28 +171,33 @@ impl RawEntryCodec for ProtobufRawEntryCodec {
 mod test_util {
     use std::str::FromStr;
 
-    use super::*;
+    use restate_types::{
+        identifiers::InvocationId,
+        invocation::{InvocationTarget, VirtualObjectHandlerType},
+        journal::{
+            enriched::{
+                AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader,
+                EnrichedRawEntry,
+            },
+            AwakeableEntry, CancelInvocationEntry, CancelInvocationTarget, CompletableEntry,
+            CompleteAwakeableEntry, EntryResult, GetCallInvocationIdEntry,
+            GetCallInvocationIdResult, GetStateKeysEntry, GetStateKeysResult, InputEntry,
+            OutputEntry,
+        },
+        service_protocol::{
+            awakeable_entry_message, call_entry_message, cancel_invocation_entry_message,
+            complete_awakeable_entry_message, get_call_invocation_id_entry_message,
+            get_state_entry_message, get_state_keys_entry_message, output_entry_message,
+            AwakeableEntryMessage, CallEntryMessage, CancelInvocationEntryMessage,
+            ClearAllStateEntryMessage, ClearStateEntryMessage, CompleteAwakeableEntryMessage,
+            Failure, GetCallInvocationIdEntryMessage, GetStateEntryMessage,
+            GetStateKeysEntryMessage, InputEntryMessage, OneWayCallEntryMessage,
+            OutputEntryMessage, SetStateEntryMessage,
+        },
+    };
 
+    use super::*;
     use crate::awakeable_id::AwakeableIdentifier;
-    use restate_types::identifiers::InvocationId;
-    use restate_types::invocation::{InvocationTarget, VirtualObjectHandlerType};
-    use restate_types::journal::enriched::{
-        AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
-    };
-    use restate_types::journal::{
-        AwakeableEntry, CancelInvocationEntry, CancelInvocationTarget, CompletableEntry,
-        CompleteAwakeableEntry, EntryResult, GetCallInvocationIdEntry, GetCallInvocationIdResult,
-        GetStateKeysEntry, GetStateKeysResult, InputEntry, OutputEntry,
-    };
-    use restate_types::service_protocol::{
-        awakeable_entry_message, call_entry_message, cancel_invocation_entry_message,
-        complete_awakeable_entry_message, get_call_invocation_id_entry_message,
-        get_state_entry_message, get_state_keys_entry_message, output_entry_message,
-        AwakeableEntryMessage, CallEntryMessage, CancelInvocationEntryMessage,
-        ClearAllStateEntryMessage, ClearStateEntryMessage, CompleteAwakeableEntryMessage, Failure,
-        GetCallInvocationIdEntryMessage, GetStateEntryMessage, GetStateKeysEntryMessage,
-        InputEntryMessage, OneWayCallEntryMessage, OutputEntryMessage, SetStateEntryMessage,
-    };
 
     impl ProtobufRawEntryCodec {
         pub fn serialize(entry: Entry) -> PlainRawEntry {
@@ -500,10 +509,10 @@ mod test_util {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use bytes::Bytes;
     use restate_types::journal::EntryResult;
+
+    use super::*;
 
     #[test]
     fn complete_invoke() {

--- a/crates/service-protocol/src/discovery.rs
+++ b/crates/service-protocol/src/discovery.rs
@@ -8,36 +8,42 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fmt::Display,
+    ops::{Deref, RangeInclusive},
+};
+
 use bytes::Bytes;
 use bytestring::ByteString;
 use codederror::CodedError;
-use http::header::{ACCEPT, CONTENT_TYPE};
-use http::response::Parts as ResponseParts;
-use http::uri::PathAndQuery;
-use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri, Version};
-use http_body_util::BodyExt;
-use http_body_util::Empty;
+use http::{
+    header::{ACCEPT, CONTENT_TYPE},
+    response::Parts as ResponseParts,
+    uri::PathAndQuery,
+    HeaderMap, HeaderName, HeaderValue, StatusCode, Uri, Version,
+};
+use http_body_util::{BodyExt, Empty};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use restate_errors::{META0003, META0012, META0013, META0014, META0015};
 use restate_service_client::{Endpoint, Method, Parts, Request, ServiceClient, ServiceClientError};
-use restate_types::endpoint_manifest;
-use restate_types::errors::GenericError;
-use restate_types::identifiers::LambdaARN;
-use restate_types::retries::{RetryIter, RetryPolicy};
-use restate_types::schema::deployment::ProtocolType;
-use restate_types::service_discovery::{
-    ServiceDiscoveryProtocolVersion, MAX_SERVICE_DISCOVERY_PROTOCOL_VERSION,
-    MIN_SERVICE_DISCOVERY_PROTOCOL_VERSION,
+use restate_types::{
+    endpoint_manifest,
+    errors::GenericError,
+    identifiers::LambdaARN,
+    retries::{RetryIter, RetryPolicy},
+    schema::deployment::ProtocolType,
+    service_discovery::{
+        ServiceDiscoveryProtocolVersion, MAX_SERVICE_DISCOVERY_PROTOCOL_VERSION,
+        MIN_SERVICE_DISCOVERY_PROTOCOL_VERSION,
+    },
+    service_protocol::{
+        ServiceProtocolVersion, MAX_SERVICE_PROTOCOL_VERSION, MAX_SERVICE_PROTOCOL_VERSION_VALUE,
+        MIN_SERVICE_PROTOCOL_VERSION,
+    },
 };
-use restate_types::service_protocol::{
-    ServiceProtocolVersion, MAX_SERVICE_PROTOCOL_VERSION, MAX_SERVICE_PROTOCOL_VERSION_VALUE,
-    MIN_SERVICE_PROTOCOL_VERSION,
-};
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::ops::{Deref, RangeInclusive};
 use strum::IntoEnumIterator;
 use tracing::{debug, warn};
 
@@ -447,17 +453,20 @@ impl ServiceDiscovery {
 
 #[cfg(test)]
 mod tests {
-    use crate::discovery::endpoint_manifest::ProtocolMode;
+    use std::collections::HashMap;
+
+    use http::{Uri, Version};
+    use restate_service_client::Endpoint;
+    use restate_types::{
+        endpoint_manifest, service_discovery::ServiceDiscoveryProtocolVersion,
+        service_protocol::MAX_SERVICE_PROTOCOL_VERSION,
+    };
+
     use crate::discovery::{
+        endpoint_manifest::ProtocolMode,
         parse_service_discovery_protocol_version_from_content_type, DiscoveryError,
         ServiceDiscovery, SERVICE_DISCOVERY_PROTOCOL_V1_HEADER_VALUE,
     };
-    use http::{Uri, Version};
-    use restate_service_client::Endpoint;
-    use restate_types::endpoint_manifest;
-    use restate_types::service_discovery::ServiceDiscoveryProtocolVersion;
-    use restate_types::service_protocol::MAX_SERVICE_PROTOCOL_VERSION;
-    use std::collections::HashMap;
 
     #[test]
     fn fail_on_invalid_min_protocol_version_with_bad_response() {

--- a/crates/service-protocol/src/message/encoding.rs
+++ b/crates/service-protocol/src/message/encoding.rs
@@ -8,17 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::header::UnknownMessageType;
-use super::*;
-
 use std::mem;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use bytes_utils::SegmentedBuf;
-use restate_types::journal::raw::{PlainEntryHeader, RawEntry};
-use restate_types::service_protocol::ServiceProtocolVersion;
+use restate_types::{
+    journal::raw::{PlainEntryHeader, RawEntry},
+    service_protocol::ServiceProtocolVersion,
+};
 use size::Size;
 use tracing::warn;
+
+use super::{header::UnknownMessageType, *};
 
 #[derive(Debug, codederror::CodedError, thiserror::Error)]
 #[code(restate_errors::RT0012)]
@@ -362,11 +363,11 @@ fn raw_header_to_message_type(entry_header: &PlainEntryHeader) -> MessageType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::codec::ProtobufRawEntryCodec;
     use restate_test_util::{assert, assert_eq, let_assert};
     use restate_types::journal::raw::RawEntryCodec;
+
+    use super::*;
+    use crate::codec::ProtobufRawEntryCodec;
 
     #[test]
     fn fill_decoder_with_several_messages() {

--- a/crates/service-protocol/src/message/mod.rs
+++ b/crates/service-protocol/src/message/mod.rs
@@ -11,13 +11,14 @@
 //! Module containing definitions of Protocol messages,
 //! including encoding and decoding of headers and message payloads.
 
+use std::time::Duration;
+
 use bytes::Bytes;
 use prost::Message;
-use restate_types::journal::raw::PlainRawEntry;
-use restate_types::journal::CompletionResult;
-use restate_types::journal::{Completion, EntryIndex};
-use restate_types::service_protocol;
-use std::time::Duration;
+use restate_types::{
+    journal::{raw::PlainRawEntry, Completion, CompletionResult, EntryIndex},
+    service_protocol,
+};
 
 mod encoding;
 mod header;

--- a/crates/storage-api/src/deduplication_table/mod.rs
+++ b/crates/storage-api/src/deduplication_table/mod.rs
@@ -8,13 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{protobuf_storage_encode_decode, Result};
+use std::{cmp::Ordering, future::Future};
+
 use bytestring::ByteString;
 use futures_util::Stream;
-use restate_types::identifiers::{LeaderEpoch, PartitionId};
-use restate_types::message::MessageIndex;
-use std::cmp::Ordering;
-use std::future::Future;
+use restate_types::{
+    identifiers::{LeaderEpoch, PartitionId},
+    message::MessageIndex,
+};
+
+use crate::{protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DedupInformation {

--- a/crates/storage-api/src/fsm_table/mod.rs
+++ b/crates/storage-api/src/fsm_table/mod.rs
@@ -8,12 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{protobuf_storage_encode_decode, Result};
-use futures_util::FutureExt;
-use restate_types::logs::Lsn;
-use restate_types::message::MessageIndex;
-use restate_types::storage::{StorageDecode, StorageEncode};
 use std::future::Future;
+
+use futures_util::FutureExt;
+use restate_types::{
+    logs::Lsn,
+    message::MessageIndex,
+    storage::{StorageDecode, StorageEncode},
+};
+
+use crate::{protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Clone, Copy, derive_more::From, derive_more::Into)]
 pub struct SequenceNumber(u64);

--- a/crates/storage-api/src/idempotency_table/mod.rs
+++ b/crates/storage-api/src/idempotency_table/mod.rs
@@ -8,12 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{protobuf_storage_encode_decode, Result};
+use std::{future::Future, ops::RangeInclusive};
 
 use futures_util::Stream;
 use restate_types::identifiers::{IdempotencyId, InvocationId, PartitionKey};
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use super::{protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IdempotencyMetadata {

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::promise_table::ReadOnlyPromiseTable;
-use crate::{protobuf_storage_encode_decode, Result};
+use std::{future::Future, ops::RangeInclusive};
+
 use futures_util::Stream;
-use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey};
-use restate_types::message::MessageIndex;
-use restate_types::state_mut::ExternalStateMutation;
-use std::future::Future;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey},
+    message::MessageIndex,
+    state_mut::ExternalStateMutation,
+};
+
+use crate::{promise_table::ReadOnlyPromiseTable, protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum InboxEntry {

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -8,21 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{protobuf_storage_encode_decode, Result};
+use std::{collections::HashSet, future::Future, ops::RangeInclusive, time::Duration};
+
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures_util::Stream;
-use restate_types::deployment::PinnedDeployment;
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey};
-use restate_types::invocation::{
-    Header, InvocationInput, InvocationTarget, ResponseResult, ServiceInvocation,
-    ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
+use restate_types::{
+    deployment::PinnedDeployment,
+    identifiers::{EntryIndex, InvocationId, PartitionKey},
+    invocation::{
+        Header, InvocationInput, InvocationTarget, ResponseResult, ServiceInvocation,
+        ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
+    },
+    time::MillisSinceEpoch,
 };
-use restate_types::time::MillisSinceEpoch;
-use std::collections::HashSet;
-use std::future::Future;
-use std::ops::RangeInclusive;
-use std::time::Duration;
+
+use crate::{protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceTable {
@@ -582,9 +583,9 @@ pub trait InvocationStatusTable: ReadOnlyInvocationStatusTable {
 
 #[cfg(any(test, feature = "test-util"))]
 mod test_util {
-    use super::*;
-
     use restate_types::invocation::VirtualObjectHandlerType;
+
+    use super::*;
 
     impl InFlightInvocationMetadata {
         pub fn mock() -> Self {

--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -8,13 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{protobuf_storage_encode_decode, Result};
+use std::{future::Future, ops::RangeInclusive};
+
 use futures_util::Stream;
-use restate_types::identifiers::{EntryIndex, InvocationId, JournalEntryId, PartitionKey};
-use restate_types::journal::enriched::EnrichedRawEntry;
-use restate_types::journal::{CompletionResult, EntryType};
-use std::future::Future;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{EntryIndex, InvocationId, JournalEntryId, PartitionKey},
+    journal::{enriched::EnrichedRawEntry, CompletionResult, EntryType},
+};
+
+use crate::{protobuf_storage_encode_decode, Result};
 
 /// Different types of journal entries persisted by the runtime
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/storage-api/src/outbox_table/mod.rs
+++ b/crates/storage-api/src/outbox_table/mod.rs
@@ -7,11 +7,14 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use std::{future::Future, ops::RangeInclusive};
+
+use restate_types::{
+    identifiers::{PartitionKey, WithPartitionKey},
+    invocation::{InvocationResponse, InvocationTermination, ServiceInvocation},
+};
+
 use crate::{protobuf_storage_encode_decode, Result};
-use restate_types::identifiers::{PartitionKey, WithPartitionKey};
-use restate_types::invocation::{InvocationResponse, InvocationTermination, ServiceInvocation};
-use std::future::Future;
-use std::ops::RangeInclusive;
 
 /// Types of outbox messages.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/storage-api/src/promise_table/mod.rs
+++ b/crates/storage-api/src/promise_table/mod.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{protobuf_storage_encode_decode, Result};
+use std::{future::Future, ops::RangeInclusive};
 
 use bytestring::ByteString;
 use futures_util::Stream;
-use restate_types::identifiers::{JournalEntryId, PartitionKey, ServiceId};
-use restate_types::journal::EntryResult;
-use std::future::Future;
-use std::ops::RangeInclusive;
+use restate_types::{
+    identifiers::{JournalEntryId, PartitionKey, ServiceId},
+    journal::EntryResult,
+};
+
+use super::{protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PromiseState {

--- a/crates/storage-api/src/service_status_table/mod.rs
+++ b/crates/storage-api/src/service_status_table/mod.rs
@@ -8,11 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{protobuf_storage_encode_decode, Result};
+use std::{future::Future, ops::RangeInclusive};
+
 use futures_util::Stream;
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId};
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use crate::{protobuf_storage_encode_decode, Result};
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub enum VirtualObjectStatus {

--- a/crates/storage-api/src/state_table/mod.rs
+++ b/crates/storage-api/src/state_table/mod.rs
@@ -8,11 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
+use std::future::Future;
+
 use bytes::Bytes;
 use futures_util::Stream;
 use restate_types::identifiers::ServiceId;
-use std::future::Future;
+
+use crate::Result;
 
 pub trait ReadOnlyStateTable {
     fn get_user_state(

--- a/crates/storage-api/src/timer_table/mod.rs
+++ b/crates/storage-api/src/timer_table/mod.rs
@@ -8,13 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{protobuf_storage_encode_decode, Result};
+use std::{cmp::Ordering, future::Future};
+
 use futures_util::Stream;
-use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
-use restate_types::invocation::ServiceInvocation;
-use restate_types::time::MillisSinceEpoch;
-use std::cmp::Ordering;
-use std::future::Future;
+use restate_types::{
+    identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey},
+    invocation::ServiceInvocation,
+    time::MillisSinceEpoch,
+};
+
+use crate::{protobuf_storage_encode_decode, Result};
 
 /// # Important
 /// We use the [`TimerKey`] to read the timers in an absolute order. The timer service

--- a/crates/storage-query-datafusion/src/analyzer.rs
+++ b/crates/storage-query-datafusion/src/analyzer.rs
@@ -8,12 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion::common::Column;
-use datafusion::config::ConfigOptions;
-use datafusion::logical_expr::{Join, LogicalPlan};
-use datafusion::optimizer::analyzer::AnalyzerRule;
-use datafusion::prelude::Expr;
+use datafusion::{
+    common::{
+        tree_node::{Transformed, TransformedResult, TreeNode},
+        Column,
+    },
+    config::ConfigOptions,
+    logical_expr::{Join, LogicalPlan},
+    optimizer::analyzer::AnalyzerRule,
+    prelude::Expr,
+};
 
 pub(crate) struct UseSymmetricHashJoinWhenPartitionKeyIsPresent;
 

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -8,29 +8,31 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::max;
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{cmp::max, fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use codederror::CodedError;
-use datafusion::error::DataFusionError;
-use datafusion::execution::context::SQLOptions;
-use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-use datafusion::execution::SessionStateBuilder;
-use datafusion::physical_optimizer::optimizer::PhysicalOptimizer;
-use datafusion::physical_plan::SendableRecordBatchStream;
-use datafusion::prelude::{SessionConfig, SessionContext};
-
+use datafusion::{
+    error::DataFusionError,
+    execution::{
+        context::SQLOptions,
+        runtime_env::{RuntimeConfig, RuntimeEnv},
+        SessionStateBuilder,
+    },
+    physical_optimizer::optimizer::PhysicalOptimizer,
+    physical_plan::SendableRecordBatchStream,
+    prelude::{SessionConfig, SessionContext},
+};
 use restate_core::worker_api::ProcessorsManagerHandle;
 use restate_invoker_api::StatusHandle;
 use restate_partition_store::PartitionStoreManager;
-use restate_types::config::QueryEngineOptions;
-use restate_types::errors::GenericError;
-use restate_types::identifiers::PartitionId;
-use restate_types::live::Live;
-use restate_types::schema::deployment::DeploymentResolver;
-use restate_types::schema::service::ServiceMetadataResolver;
+use restate_types::{
+    config::QueryEngineOptions,
+    errors::GenericError,
+    identifiers::PartitionId,
+    live::Live,
+    schema::{deployment::DeploymentResolver, service::ServiceMetadataResolver},
+};
 
 use crate::{analyzer, physical_optimizer};
 

--- a/crates/storage-query-datafusion/src/deployment/row.rs
+++ b/crates/storage-query-datafusion/src/deployment/row.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_types::schema::deployment::{Deployment, DeploymentType};
+
 use super::schema::SysDeploymentBuilder;
 use crate::table_util::format_using;
-use restate_types::schema::deployment::{Deployment, DeploymentType};
 
 #[inline]
 pub(crate) fn append_deployment_row(

--- a/crates/storage-query-datafusion/src/deployment/schema.rs
+++ b/crates/storage-query-datafusion/src/deployment/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_deployment(
     /// The ID of the service deployment.

--- a/crates/storage-query-datafusion/src/deployment/table.rs
+++ b/crates/storage-query-datafusion/src/deployment/table.rs
@@ -10,22 +10,25 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::logical_expr::Expr;
-use datafusion::physical_plan::stream::RecordBatchReceiverStream;
-use datafusion::physical_plan::SendableRecordBatchStream;
-use restate_types::live::Live;
+use datafusion::{
+    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
+    logical_expr::Expr,
+    physical_plan::{stream::RecordBatchReceiverStream, SendableRecordBatchStream},
+};
+use restate_types::{
+    identifiers::ServiceRevision,
+    live::Live,
+    schema::deployment::{Deployment, DeploymentResolver},
+};
 use tokio::sync::mpsc::Sender;
 
-use restate_types::identifiers::ServiceRevision;
-use restate_types::schema::deployment::{Deployment, DeploymentResolver};
-
 use super::schema::SysDeploymentBuilder;
-use crate::context::QueryContext;
-use crate::deployment::row::append_deployment_row;
-use crate::table_providers::{GenericTableProvider, Scan};
-use crate::table_util::Builder;
+use crate::{
+    context::QueryContext,
+    deployment::row::append_deployment_row,
+    table_providers::{GenericTableProvider, Scan},
+    table_util::Builder,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/idempotency/row.rs
+++ b/crates/storage-query-datafusion/src/idempotency/row.rs
@@ -8,11 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::schema::SysIdempotencyBuilder;
-
-use crate::table_util::format_using;
 use restate_storage_api::idempotency_table::IdempotencyMetadata;
 use restate_types::identifiers::{IdempotencyId, WithPartitionKey};
+
+use super::schema::SysIdempotencyBuilder;
+use crate::table_util::format_using;
 
 #[inline]
 pub(crate) fn append_idempotency_row(

--- a/crates/storage-query-datafusion/src/idempotency/schema.rs
+++ b/crates/storage-query-datafusion/src/idempotency/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_idempotency(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -8,21 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
 use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::idempotency_table::{IdempotencyMetadata, ReadOnlyIdempotencyTable};
 use restate_types::identifiers::{IdempotencyId, PartitionKey};
 
-use super::row::append_idempotency_row;
-use super::schema::SysIdempotencyBuilder;
-use crate::context::{QueryContext, SelectPartitions};
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use super::{row::append_idempotency_row, schema::SysIdempotencyBuilder};
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/idempotency/tests.rs
+++ b/crates/storage-query-datafusion/src/idempotency/tests.rs
@@ -8,18 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mocks::*;
-use crate::row;
 use bytestring::ByteString;
-use datafusion::arrow::array::LargeStringArray;
-use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::{array::LargeStringArray, record_batch::RecordBatch};
 use futures::StreamExt;
-use googletest::all;
-use googletest::prelude::{assert_that, eq};
+use googletest::{
+    all,
+    prelude::{assert_that, eq},
+};
 use restate_core::TaskCenterBuilder;
-use restate_storage_api::idempotency_table::{IdempotencyMetadata, IdempotencyTable};
-use restate_storage_api::Transaction;
+use restate_storage_api::{
+    idempotency_table::{IdempotencyMetadata, IdempotencyTable},
+    Transaction,
+};
 use restate_types::identifiers::{IdempotencyId, InvocationId};
+
+use crate::{mocks::*, row};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_idempotency_key() {

--- a/crates/storage-query-datafusion/src/inbox/row.rs
+++ b/crates/storage-query-datafusion/src/inbox/row.rs
@@ -8,10 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::schema::SysInboxBuilder;
-use crate::table_util::format_using;
 use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
 use restate_types::identifiers::WithPartitionKey;
+
+use super::schema::SysInboxBuilder;
+use crate::table_util::format_using;
 
 #[inline]
 pub(crate) fn append_inbox_row(

--- a/crates/storage-query-datafusion/src/inbox/schema.rs
+++ b/crates/storage-query-datafusion/src/inbox/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_inbox(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -8,21 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
 use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::inbox_table::{ReadOnlyInboxTable, SequenceNumberInboxEntry};
 use restate_types::identifiers::PartitionKey;
 
-use crate::context::{QueryContext, SelectPartitions};
-use crate::inbox::row::append_inbox_row;
-use crate::inbox::schema::SysInboxBuilder;
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    inbox::{row::append_inbox_row, schema::SysInboxBuilder},
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/inbox/tests.rs
+++ b/crates/storage-query-datafusion/src/inbox/tests.rs
@@ -8,18 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mocks::*;
-use crate::row;
-use datafusion::arrow::array::{LargeStringArray, UInt64Array};
-use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::{
+    array::{LargeStringArray, UInt64Array},
+    record_batch::RecordBatch,
+};
 use futures::StreamExt;
-use googletest::all;
-use googletest::prelude::{assert_that, eq};
+use googletest::{
+    all,
+    prelude::{assert_that, eq},
+};
 use restate_core::TaskCenterBuilder;
-use restate_storage_api::inbox_table::{InboxEntry, InboxTable};
-use restate_storage_api::Transaction;
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::InvocationTarget;
+use restate_storage_api::{
+    inbox_table::{InboxEntry, InboxTable},
+    Transaction,
+};
+use restate_types::{identifiers::InvocationId, invocation::InvocationTarget};
+
+use crate::{mocks::*, row};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_inbox() {

--- a/crates/storage-query-datafusion/src/invocation_state/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/row.rs
@@ -8,11 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::invocation_state::schema::SysInvocationStateBuilder;
-use crate::table_util::format_using;
 use restate_invoker_api::InvocationStatusReport;
-use restate_types::identifiers::WithPartitionKey;
-use restate_types::time::MillisSinceEpoch;
+use restate_types::{identifiers::WithPartitionKey, time::MillisSinceEpoch};
+
+use crate::{invocation_state::schema::SysInvocationStateBuilder, table_util::format_using};
 
 #[inline]
 pub(crate) fn append_invocation_state_row(

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_invocation_state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -8,24 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::logical_expr::Expr;
-use datafusion::physical_plan::stream::RecordBatchReceiverStream;
-use datafusion::physical_plan::SendableRecordBatchStream;
-use tokio::sync::mpsc::Sender;
-
+use datafusion::{
+    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
+    logical_expr::Expr,
+    physical_plan::{stream::RecordBatchReceiverStream, SendableRecordBatchStream},
+};
 use restate_invoker_api::{InvocationStatusReport, StatusHandle};
 use restate_types::identifiers::{PartitionKey, WithPartitionKey};
+use tokio::sync::mpsc::Sender;
 
-use crate::context::QueryContext;
-use crate::invocation_state::row::append_invocation_state_row;
-use crate::invocation_state::schema::SysInvocationStateBuilder;
-use crate::table_providers::{GenericTableProvider, Scan};
-use crate::table_util::Builder;
+use crate::{
+    context::QueryContext,
+    invocation_state::{row::append_invocation_state_row, schema::SysInvocationStateBuilder},
+    table_providers::{GenericTableProvider, Scan},
+    table_util::Builder,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -8,14 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::invocation_status::schema::{SysInvocationStatusBuilder, SysInvocationStatusRowBuilder};
-use crate::table_util::format_using;
 use restate_storage_api::invocation_status_table::{
     InFlightInvocationMetadata, InvocationStatus, JournalMetadata, SourceTable, StatusTimestamps,
 };
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
-use restate_types::invocation::{
-    ResponseResult, ServiceInvocationSpanContext, ServiceType, Source, TraceId,
+use restate_types::{
+    identifiers::{InvocationId, WithPartitionKey},
+    invocation::{ResponseResult, ServiceInvocationSpanContext, ServiceType, Source, TraceId},
+};
+
+use crate::{
+    invocation_status::schema::{SysInvocationStatusBuilder, SysInvocationStatusRowBuilder},
+    table_util::format_using,
 };
 
 #[inline]

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_invocation_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -8,23 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
 use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadOnlyInvocationStatusTable,
 };
 use restate_types::identifiers::{InvocationId, PartitionKey};
 
-use crate::context::{QueryContext, SelectPartitions};
-use crate::invocation_status::row::append_invocation_status_row;
-use crate::invocation_status::schema::SysInvocationStatusBuilder;
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    invocation_status::{row::append_invocation_status_row, schema::SysInvocationStatusBuilder},
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/journal/row.rs
+++ b/crates/storage-query-datafusion/src/journal/row.rs
@@ -8,18 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::journal::schema::SysJournalBuilder;
-
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
-
 use restate_storage_api::journal_table::JournalEntry;
-use restate_types::identifiers::{JournalEntryId, WithInvocationId, WithPartitionKey};
-use restate_types::journal::enriched::EnrichedEntryHeader;
-use restate_types::journal::{CompletePromiseEntry, GetPromiseEntry, PeekPromiseEntry};
+use restate_types::{
+    identifiers::{JournalEntryId, WithInvocationId, WithPartitionKey},
+    journal::{
+        enriched::EnrichedEntryHeader, CompletePromiseEntry, Entry, GetPromiseEntry,
+        PeekPromiseEntry,
+    },
+};
 
-use crate::log_data_corruption_error;
-use crate::table_util::format_using;
-use restate_types::journal::Entry;
+use crate::{
+    journal::schema::SysJournalBuilder, log_data_corruption_error, table_util::format_using,
+};
 
 #[inline]
 pub(crate) fn append_journal_row(

--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_journal(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -8,20 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use futures::Stream;
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
+use futures::Stream;
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::journal_table::{JournalEntry, ReadOnlyJournalTable};
 use restate_types::identifiers::{JournalEntryId, PartitionKey};
 
-use crate::context::{QueryContext, SelectPartitions};
-use crate::journal::row::append_journal_row;
-use crate::journal::schema::SysJournalBuilder;
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    journal::{row::append_journal_row, schema::SysJournalBuilder},
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/journal/tests.rs
+++ b/crates/storage-query-datafusion/src/journal/tests.rs
@@ -8,26 +8,34 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mocks::*;
-use crate::row;
 use bytes::Bytes;
-use datafusion::arrow::array::{Int64Array, LargeStringArray, UInt32Array};
-use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::{
+    array::{Int64Array, LargeStringArray, UInt32Array},
+    record_batch::RecordBatch,
+};
 use futures::StreamExt;
-use googletest::all;
-use googletest::prelude::{assert_that, eq};
+use googletest::{
+    all,
+    prelude::{assert_that, eq},
+};
 use prost::Message;
 use restate_core::TaskCenterBuilder;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
-use restate_storage_api::journal_table::{JournalEntry, JournalTable};
-use restate_storage_api::Transaction;
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::InvocationTarget;
-use restate_types::journal::enriched::{
-    CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
+use restate_storage_api::{
+    journal_table::{JournalEntry, JournalTable},
+    Transaction,
 };
-use restate_types::journal::{Entry, EntryType, InputEntry};
-use restate_types::service_protocol;
+use restate_types::{
+    identifiers::InvocationId,
+    invocation::InvocationTarget,
+    journal::{
+        enriched::{CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry},
+        Entry, EntryType, InputEntry,
+    },
+    service_protocol,
+};
+
+use crate::{mocks::*, row};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_entries() {

--- a/crates/storage-query-datafusion/src/keyed_service_status/row.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/row.rs
@@ -8,10 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::keyed_service_status::schema::SysKeyedServiceStatusBuilder;
-use crate::table_util::format_using;
 use restate_storage_api::service_status_table::VirtualObjectStatus;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
+
+use crate::{keyed_service_status::schema::SysKeyedServiceStatusBuilder, table_util::format_using};
 
 #[inline]
 pub(crate) fn append_virtual_object_status_row(

--- a/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_keyed_service_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/keyed_service_status/table.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/table.rs
@@ -8,23 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
 use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::service_status_table::{
     ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus,
 };
 use restate_types::identifiers::{PartitionKey, ServiceId};
 
-use crate::context::{QueryContext, SelectPartitions};
-use crate::keyed_service_status::row::append_virtual_object_status_row;
-use crate::keyed_service_status::schema::SysKeyedServiceStatusBuilder;
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    keyed_service_status::{
+        row::append_virtual_object_status_row, schema::SysKeyedServiceStatusBuilder,
+    },
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -8,30 +8,31 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::ops::RangeInclusive;
+use std::{fmt::Debug, marker::PhantomData, ops::RangeInclusive};
 
 use async_trait::async_trait;
-use datafusion::arrow::array::ArrayRef;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::execution::SendableRecordBatchStream;
+use datafusion::{
+    arrow::{array::ArrayRef, record_batch::RecordBatch},
+    execution::SendableRecordBatchStream,
+};
 use googletest::matcher::{Matcher, MatcherResult};
-
 use restate_core::task_center;
-use restate_invoker_api::status_handle::test_util::MockStatusHandle;
-use restate_invoker_api::StatusHandle;
+use restate_invoker_api::{status_handle::test_util::MockStatusHandle, StatusHandle};
 use restate_partition_store::{OpenMode, PartitionStore, PartitionStoreManager};
 use restate_rocksdb::RocksDbManager;
-use restate_types::config::{CommonOptions, QueryEngineOptions, WorkerOptions};
-use restate_types::errors::GenericError;
-use restate_types::identifiers::{DeploymentId, PartitionId, PartitionKey, ServiceRevision};
-use restate_types::invocation::ServiceType;
-use restate_types::live::{Constant, Live};
-use restate_types::schema::deployment::test_util::MockDeploymentMetadataRegistry;
-use restate_types::schema::deployment::{Deployment, DeploymentResolver};
-use restate_types::schema::service::test_util::MockServiceMetadataResolver;
-use restate_types::schema::service::{ServiceMetadata, ServiceMetadataResolver};
+use restate_types::{
+    config::{CommonOptions, QueryEngineOptions, WorkerOptions},
+    errors::GenericError,
+    identifiers::{DeploymentId, PartitionId, PartitionKey, ServiceRevision},
+    invocation::ServiceType,
+    live::{Constant, Live},
+    schema::{
+        deployment::{test_util::MockDeploymentMetadataRegistry, Deployment, DeploymentResolver},
+        service::{
+            test_util::MockServiceMetadataResolver, ServiceMetadata, ServiceMetadataResolver,
+        },
+    },
+};
 
 use super::context::QueryContext;
 use crate::context::SelectPartitions;

--- a/crates/storage-query-datafusion/src/partition_store_scanner.rs
+++ b/crates/storage-query-datafusion/src/partition_store_scanner.rs
@@ -8,17 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
+use std::{fmt::Debug, ops::RangeInclusive};
 
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::execution::SendableRecordBatchStream;
-use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use datafusion::{
+    arrow::datatypes::SchemaRef, execution::SendableRecordBatchStream,
+    physical_plan::stream::RecordBatchReceiverStream,
+};
 use futures::{Stream, StreamExt};
-use tracing::warn;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_types::identifiers::{PartitionId, PartitionKey};
+use tracing::warn;
 
 use crate::table_providers::ScanPartition;
 

--- a/crates/storage-query-datafusion/src/physical_optimizer.rs
+++ b/crates/storage-query-datafusion/src/physical_optimizer.rs
@@ -8,16 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion::config::ConfigOptions;
-use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::PhysicalExprRef;
-use datafusion::physical_optimizer::PhysicalOptimizerRule;
-use datafusion::physical_plan::joins::{
-    HashJoinExec, StreamJoinPartitionMode, SymmetricHashJoinExec,
-};
-use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
+
+use datafusion::{
+    common::tree_node::{Transformed, TransformedResult, TreeNode},
+    config::ConfigOptions,
+    physical_expr::{expressions::Column, PhysicalExprRef},
+    physical_optimizer::PhysicalOptimizerRule,
+    physical_plan::{
+        joins::{HashJoinExec, StreamJoinPartitionMode, SymmetricHashJoinExec},
+        ExecutionPlan,
+    },
+};
 
 pub(crate) struct JoinRewrite;
 

--- a/crates/storage-query-datafusion/src/promise/row.rs
+++ b/crates/storage-query-datafusion/src/promise/row.rs
@@ -8,13 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::schema::SysPromiseBuilder;
-
-use crate::table_util::format_using;
 use restate_storage_api::promise_table::{OwnedPromiseRow, PromiseState};
-use restate_types::errors::InvocationError;
-use restate_types::identifiers::WithPartitionKey;
-use restate_types::journal::EntryResult;
+use restate_types::{errors::InvocationError, identifiers::WithPartitionKey, journal::EntryResult};
+
+use super::schema::SysPromiseBuilder;
+use crate::table_util::format_using;
 
 #[inline]
 pub(crate) fn append_promise_row(

--- a/crates/storage-query-datafusion/src/promise/schema.rs
+++ b/crates/storage-query-datafusion/src/promise/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_promise(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -8,21 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
 
 use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::promise_table::{OwnedPromiseRow, ReadOnlyPromiseTable};
 use restate_types::identifiers::PartitionKey;
 
-use super::row::append_promise_row;
-use super::schema::SysPromiseBuilder;
-use crate::context::{QueryContext, SelectPartitions};
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use super::{row::append_promise_row, schema::SysPromiseBuilder};
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/service/row.rs
+++ b/crates/storage-query-datafusion/src/service/row.rs
@@ -8,11 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::schema::SysServiceBuilder;
+use restate_types::{invocation::ServiceType, schema::service::ServiceMetadata};
 
+use super::schema::SysServiceBuilder;
 use crate::table_util::format_using;
-use restate_types::invocation::ServiceType;
-use restate_types::schema::service::ServiceMetadata;
 
 #[inline]
 pub(crate) fn append_service_row(

--- a/crates/storage-query-datafusion/src/service/schema.rs
+++ b/crates/storage-query-datafusion/src/service/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(sys_service(
     /// The name of the registered user service.

--- a/crates/storage-query-datafusion/src/service/table.rs
+++ b/crates/storage-query-datafusion/src/service/table.rs
@@ -10,21 +10,24 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::logical_expr::Expr;
-use datafusion::physical_plan::stream::RecordBatchReceiverStream;
-use datafusion::physical_plan::SendableRecordBatchStream;
-use restate_types::live::Live;
+use datafusion::{
+    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
+    logical_expr::Expr,
+    physical_plan::{stream::RecordBatchReceiverStream, SendableRecordBatchStream},
+};
+use restate_types::{
+    live::Live,
+    schema::service::{ServiceMetadata, ServiceMetadataResolver},
+};
 use tokio::sync::mpsc::Sender;
 
-use restate_types::schema::service::{ServiceMetadata, ServiceMetadataResolver};
-
 use super::schema::SysServiceBuilder;
-use crate::context::QueryContext;
-use crate::service::row::append_service_row;
-use crate::table_providers::{GenericTableProvider, Scan};
-use crate::table_util::Builder;
+use crate::{
+    context::QueryContext,
+    service::row::append_service_row,
+    table_providers::{GenericTableProvider, Scan},
+    table_util::Builder,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/state/row.rs
+++ b/crates/storage-query-datafusion/src/state/row.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::state::schema::StateBuilder;
 use bytes::Bytes;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
+
+use crate::state::schema::StateBuilder;
 
 #[inline]
 pub(crate) fn append_state_row(

--- a/crates/storage-query-datafusion/src/state/schema.rs
+++ b/crates/storage-query-datafusion/src/state/schema.rs
@@ -10,9 +10,9 @@
 
 #![allow(dead_code)]
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_table!(state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -8,22 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{fmt::Debug, ops::RangeInclusive, sync::Arc};
+
 use bytes::Bytes;
-use std::fmt::Debug;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
-
 use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::state_table::ReadOnlyStateTable;
 use restate_types::identifiers::{PartitionKey, ServiceId};
 
-use crate::context::{QueryContext, SelectPartitions};
-use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::state::row::append_state_row;
-use crate::state::schema::StateBuilder;
-use crate::table_providers::PartitionedTableProvider;
+use crate::{
+    context::{QueryContext, SelectPartitions},
+    partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition},
+    state::{row::append_state_row, schema::StateBuilder},
+    table_providers::PartitionedTableProvider,
+};
 
 pub(crate) fn register_self(
     ctx: &QueryContext,

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -8,11 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
+
 use crate::{
     deployment, idempotency, inbox, invocation_state, invocation_status, journal,
     keyed_service_status, promise, service, state,
 };
-use std::borrow::Cow;
 
 /// List of available table docs. Whenever you add aa new table, add its table docs to
 /// this array. This will ensure that the table docs will be included in the automatic

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -8,27 +8,29 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
-use std::fmt::{Debug, Formatter};
-use std::ops::RangeInclusive;
-use std::sync::Arc;
-
-use async_trait::async_trait;
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::common::DataFusionError;
-use datafusion::datasource::{TableProvider, TableType};
-use datafusion::execution::context::TaskContext;
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
-use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PlanProperties,
-    SendableRecordBatchStream,
+use std::{
+    any::Any,
+    fmt::{Debug, Formatter},
+    ops::RangeInclusive,
+    sync::Arc,
 };
 
+use async_trait::async_trait;
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    common::DataFusionError,
+    datasource::{TableProvider, TableType},
+    execution::context::TaskContext,
+    logical_expr::{Expr, TableProviderFilterPushDown},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PlanProperties,
+        SendableRecordBatchStream,
+    },
+};
 use restate_types::identifiers::{PartitionId, PartitionKey};
 
-use crate::context::SelectPartitions;
-use crate::table_util::compute_ordering;
+use crate::{context::SelectPartitions, table_util::compute_ordering};
 
 pub(crate) trait ScanPartition: Send + Sync + Debug + 'static {
     fn scan_partition(

--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -8,11 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::physical_expr::expressions::col;
-use datafusion::physical_expr::PhysicalSortExpr;
 use std::fmt::Write;
+
+use datafusion::{
+    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
+    physical_expr::{expressions::col, PhysicalSortExpr},
+};
 use tracing::error;
 
 #[macro_export]

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -8,28 +8,36 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mocks::*;
-use crate::row;
-use datafusion::arrow::array::{LargeStringArray, UInt64Array};
-use datafusion::arrow::record_batch::RecordBatch;
-use futures::StreamExt;
-use googletest::all;
-use googletest::prelude::{assert_that, eq};
-use restate_core::TaskCenterBuilder;
-use restate_invoker_api::status_handle::test_util::MockStatusHandle;
-use restate_invoker_api::status_handle::InvocationStatusReportInner;
-use restate_invoker_api::{InvocationErrorReport, InvocationStatusReport};
-use restate_storage_api::invocation_status_table::{
-    InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
-};
-use restate_storage_api::Transaction;
-use restate_types::errors::InvocationError;
-use restate_types::identifiers::LeaderEpoch;
-use restate_types::identifiers::PartitionId;
-use restate_types::identifiers::{DeploymentId, InvocationId};
-use restate_types::invocation::InvocationTarget;
-use restate_types::journal::EntryType;
 use std::time::{Duration, SystemTime};
+
+use datafusion::arrow::{
+    array::{LargeStringArray, UInt64Array},
+    record_batch::RecordBatch,
+};
+use futures::StreamExt;
+use googletest::{
+    all,
+    prelude::{assert_that, eq},
+};
+use restate_core::TaskCenterBuilder;
+use restate_invoker_api::{
+    status_handle::{test_util::MockStatusHandle, InvocationStatusReportInner},
+    InvocationErrorReport, InvocationStatusReport,
+};
+use restate_storage_api::{
+    invocation_status_table::{
+        InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
+    },
+    Transaction,
+};
+use restate_types::{
+    errors::InvocationError,
+    identifiers::{DeploymentId, InvocationId, LeaderEpoch, PartitionId},
+    invocation::InvocationTarget,
+    journal::EntryType,
+};
+
+use crate::{mocks::*, row};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_sys_invocation() {

--- a/crates/storage-query-postgres/src/extended_query.rs
+++ b/crates/storage-query-postgres/src/extended_query.rs
@@ -8,14 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
-use pgwire::api::portal::Portal;
-use pgwire::api::query::ExtendedQueryHandler;
-use pgwire::api::results::{DescribePortalResponse, DescribeStatementResponse, Response};
-use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
-use pgwire::api::ClientInfo;
-use pgwire::error::{PgWireError, PgWireResult};
 use std::sync::Arc;
+
+use async_trait::async_trait;
+use pgwire::{
+    api::{
+        portal::Portal,
+        query::ExtendedQueryHandler,
+        results::{DescribePortalResponse, DescribeStatementResponse, Response},
+        stmt::{NoopQueryParser, StoredStatement},
+        ClientInfo,
+    },
+    error::{PgWireError, PgWireResult},
+};
 
 #[derive(Debug, Clone)]
 pub struct NoopExtendedQueryHandler {

--- a/crates/storage-query-postgres/src/service.rs
+++ b/crates/storage-query-postgres/src/service.rs
@@ -8,19 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::pgwire_server::{spawn_connection, HandlerFactory};
+use std::{io::ErrorKind, net::SocketAddr, sync::Arc};
+
 use codederror::CodedError;
 use restate_core::cancellation_watcher;
 use restate_storage_query_datafusion::context::QueryContext;
-
-use restate_types::config::QueryEngineOptions;
-use restate_types::errors::GenericError;
-use std::io::ErrorKind;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::net::TcpListener;
-use tokio::select;
+use restate_types::{config::QueryEngineOptions, errors::GenericError};
+use tokio::{net::TcpListener, select};
 use tracing::warn;
+
+use crate::pgwire_server::{spawn_connection, HandlerFactory};
 
 #[derive(Debug, thiserror::Error, CodedError)]
 pub enum Error {

--- a/crates/test-util/src/matchers.rs
+++ b/crates/test-util/src/matchers.rs
@@ -11,15 +11,14 @@
 //! This module contains a collection of matchers
 
 pub use googletest::matchers::*;
-
 #[cfg(feature = "prost")]
 pub use prost::protobuf_decoded;
 #[cfg(feature = "prost")]
 mod prost {
+    use std::{fmt::Debug, marker::PhantomData};
+
     use googletest::matcher::{Matcher, MatcherResult};
     use prost::bytes;
-    use std::fmt::Debug;
-    use std::marker::PhantomData;
 
     struct ProtobufDecodeMatcher<InnerMatcher, B>(InnerMatcher, PhantomData<B>);
 
@@ -62,11 +61,11 @@ mod prost {
 
     #[cfg(test)]
     mod tests {
-        use super::*;
-
         use googletest::{assert_that, matchers::eq};
         use prost::Message;
         use prost_types::Timestamp;
+
+        use super::*;
 
         #[test]
         fn timestamp() {

--- a/crates/timer-queue/src/lib.rs
+++ b/crates/timer-queue/src/lib.rs
@@ -8,9 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::{Ordering, Reverse};
-use std::collections::BinaryHeap;
-use std::time::SystemTime;
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::BinaryHeap,
+    time::SystemTime,
+};
 
 #[derive(Debug)]
 pub struct Timer<T> {
@@ -95,10 +97,12 @@ impl<T> FromIterator<(SystemTime, T)> for TimerQueue<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{
+        ops::Add,
+        time::{Duration, Instant, SystemTime},
+    };
 
-    use std::ops::Add;
-    use std::time::{Duration, Instant, SystemTime};
+    use super::*;
 
     #[tokio::test]
     async fn test_simple_timer() {

--- a/crates/timer/src/lib.rs
+++ b/crates/timer/src/lib.rs
@@ -15,8 +15,10 @@ use std::future::Future;
 mod service;
 
 use restate_types::timer::Timer;
-pub use service::clock::{Clock, TokioClock};
-pub use service::TimerService;
+pub use service::{
+    clock::{Clock, TokioClock},
+    TimerService,
+};
 
 pub trait TimerReader<T>
 where

--- a/crates/timer/src/service/clock.rs
+++ b/crates/timer/src/service/clock.rs
@@ -8,10 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    future::Future,
+    ops::Add,
+    time::{Duration, SystemTime},
+};
+
 use restate_types::time::MillisSinceEpoch;
-use std::future::Future;
-use std::ops::Add;
-use std::time::{Duration, SystemTime};
 
 pub trait Clock {
     type SleepFuture: Future<Output = ()>;
@@ -42,13 +45,17 @@ impl Clock for TokioClock {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::service::clock::Clock;
+    use std::{
+        cmp::{Ordering, Reverse},
+        collections::BinaryHeap,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
     use futures_util::future::{BoxFuture, FutureExt};
     use restate_types::time::MillisSinceEpoch;
-    use std::cmp::{Ordering, Reverse};
-    use std::collections::BinaryHeap;
-    use std::sync::{Arc, Mutex};
-    use std::time::Duration;
+
+    use crate::service::clock::Clock;
 
     #[derive(Debug, Clone)]
     pub struct ManualClock {

--- a/crates/timer/src/service/mod.rs
+++ b/crates/timer/src/service/mod.rs
@@ -10,14 +10,17 @@
 
 #![allow(clippy::enum_variant_names)]
 
+use std::{
+    collections::HashSet,
+    fmt::Debug,
+    future,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll, Waker},
+};
+
 use pin_project::pin_project;
 use restate_types::timer::TimerKey;
-use std::collections::HashSet;
-use std::fmt::Debug;
-use std::future;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{ready, Context, Poll, Waker};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::trace;
 

--- a/crates/timer/src/service/tests.rs
+++ b/crates/timer/src/service/tests.rs
@@ -8,21 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::service::clock::tests::ManualClock;
-use crate::service::clock::TokioClock;
-use crate::{Timer, TimerReader, TimerService};
+use std::{
+    cmp::Ordering,
+    collections::BTreeMap,
+    fmt::Debug,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime},
+};
+
 use futures_util::FutureExt;
 use restate_test_util::let_assert;
-use restate_types::time::MillisSinceEpoch;
-use restate_types::timer::TimerKey;
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use std::fmt::Debug;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use restate_types::{time::MillisSinceEpoch, timer::TimerKey};
 use test_log::test;
 use tokio::sync::oneshot;
+
+use crate::{
+    service::clock::{tests::ManualClock, TokioClock},
+    Timer, TimerReader, TimerService,
+};
 
 #[derive(Debug, Clone)]
 struct MockTimerReader<T>

--- a/crates/tracing-instrumentation/src/exporter.rs
+++ b/crates/tracing-instrumentation/src/exporter.rs
@@ -8,15 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
 use arc_swap::ArcSwap;
 use futures::future::BoxFuture;
-use opentelemetry::trace::TraceError;
-use opentelemetry::{Key, KeyValue, StringValue, Value};
-use opentelemetry_sdk::export::trace::{SpanData, SpanExporter};
-use opentelemetry_sdk::Resource;
+use opentelemetry::{trace::TraceError, Key, KeyValue, StringValue, Value};
+use opentelemetry_sdk::{
+    export::trace::{SpanData, SpanExporter},
+    Resource,
+};
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 /// `RPC_SERVICE` is used to override `service.name` on the `SpanBuilder`
 const RPC_SERVICE: Key = Key::from_static_str("rpc.service");

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -12,29 +12,30 @@
 mod exporter;
 mod pretty;
 
-use crate::exporter::ResourceModifyingSpanExporter;
-use crate::pretty::PrettyFields;
-use opentelemetry::trace::{TraceError, TracerProvider};
-use opentelemetry::KeyValue;
+use std::{collections::HashMap, env, fmt::Display};
+
+use opentelemetry::{
+    trace::{TraceError, TracerProvider},
+    KeyValue,
+};
 use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonExporter;
 use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
 use opentelemetry_sdk::trace::BatchSpanProcessor;
 use pretty::Pretty;
 use restate_types::config::{CommonOptions, LogFormat};
-use std::collections::HashMap;
-use std::env;
-use std::fmt::Display;
-use tonic::codegen::http::HeaderMap;
-use tonic::metadata::MetadataMap;
+use tonic::{codegen::http::HeaderMap, metadata::MetadataMap};
 use tracing::{info, warn, Level};
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::filter::{Filtered, ParseError};
-use tracing_subscriber::fmt::time::SystemTime;
-use tracing_subscriber::fmt::writer::MakeWriterExt;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::reload::Handle;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer, Registry};
+use tracing_subscriber::{
+    filter::{Filtered, ParseError},
+    fmt::{time::SystemTime, writer::MakeWriterExt},
+    layer::SubscriberExt,
+    reload::Handle,
+    util::SubscriberInitExt,
+    EnvFilter, Layer, Registry,
+};
+
+use crate::{exporter::ResourceModifyingSpanExporter, pretty::PrettyFields};
 
 #[derive(Debug, thiserror::Error)]
 #[error("could not initialize tracing {trace_error}")]

--- a/crates/tracing-instrumentation/src/pretty.rs
+++ b/crates/tracing-instrumentation/src/pretty.rs
@@ -12,20 +12,22 @@
 // https://github.com/tokio-rs/tracing/blob/8aae1c37b091963aafdd336b1168fe5a24c0b4f0/tracing-subscriber/src/fmt/format/pretty.rs
 // License MIT
 
-use super::*;
+use std::{fmt, fmt::Debug};
 
 use nu_ansi_term::{Color, Style};
-use std::fmt;
-use std::fmt::Debug;
 use tracing::{
     field::{self, Field},
     span, Event, Level, Subscriber,
 };
-use tracing_subscriber::field::{MakeVisitor, RecordFields, VisitFmt, VisitOutput};
-use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::fmt::time::FormatTime;
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
-use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{
+    field::{MakeVisitor, RecordFields, VisitFmt, VisitOutput},
+    fmt::{
+        format::Writer, time::FormatTime, FmtContext, FormatEvent, FormatFields, FormattedFields,
+    },
+    registry::LookupSpan,
+};
+
+use super::*;
 
 struct FmtLevel<'a> {
     level: &'a Level,

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -8,10 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    env,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
 use jsonptr::Pointer;
-use std::env;
-use std::fs::File;
-use std::path::{Path, PathBuf};
 use typify::{TypeSpace, TypeSpaceSettings};
 
 fn main() -> std::io::Result<()> {

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -8,16 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
-use std::time::Instant;
+use std::{collections::BTreeMap, time::Instant};
 
 use prost_dto::IntoProto;
 use serde::{Deserialize, Serialize};
 
-use crate::identifiers::{LeaderEpoch, PartitionId};
-use crate::logs::Lsn;
-use crate::time::MillisSinceEpoch;
-use crate::{GenerationalNodeId, PlainNodeId, Version};
+use crate::{
+    identifiers::{LeaderEpoch, PartitionId},
+    logs::Lsn,
+    time::MillisSinceEpoch,
+    GenerationalNodeId, PlainNodeId, Version,
+};
 
 /// A container for health information about every node and partition in the
 /// cluster.

--- a/crates/types/src/cluster_controller.rs
+++ b/crates/types/src/cluster_controller.rs
@@ -8,15 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cluster::cluster_state::RunMode;
-use crate::identifiers::{PartitionId, PartitionKey};
-use crate::partition_table::PartitionTable;
-use crate::{flexbuffers_storage_encode_decode, PlainNodeId, Version, Versioned};
+use std::{
+    collections::{BTreeMap, HashSet},
+    num::NonZero,
+    ops::RangeInclusive,
+};
+
 use serde_with::serde_as;
-use std::collections::{BTreeMap, HashSet};
-use std::num::NonZero;
-use std::ops::RangeInclusive;
 use xxhash_rust::xxh3::Xxh3Builder;
+
+use crate::{
+    cluster::cluster_state::RunMode,
+    flexbuffers_storage_encode_decode,
+    identifiers::{PartitionId, PartitionKey},
+    partition_table::PartitionTable,
+    PlainNodeId, Version, Versioned,
+};
 
 /// Replication strategy for partition processors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -8,15 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::QueryEngineOptions;
-use crate::cluster_controller::ReplicationStrategy;
+use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
+
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::net::SocketAddr;
-use std::num::NonZeroUsize;
-use std::path::PathBuf;
-use std::time::Duration;
 use tokio::sync::Semaphore;
+
+use super::QueryEngineOptions;
+use crate::cluster_controller::ReplicationStrategy;
 
 /// # Admin server options
 #[serde_as]

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -8,20 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
-use std::path::PathBuf;
-use std::time::Duration;
-
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use std::{num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use restate_serde_util::{ByteCount, NonZeroByteCount};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use tracing::warn;
 
-use crate::logs::metadata::ProviderKind;
-use crate::retries::RetryPolicy;
-
 use super::{CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
+use crate::{logs::metadata::ProviderKind, retries::RetryPolicy};
 
 /// # Bifrost options
 #[serde_as]

--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -8,18 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroU64;
-use std::path::PathBuf;
+use std::{num::NonZeroU64, path::PathBuf};
 
 use humantime::Duration;
 use serde::Serialize;
 use serde_with::{serde_as, skip_serializing_none};
 
-use crate::net::{AdvertisedAddress, BindAddress};
-use crate::nodes_config::Role;
-use crate::PlainNodeId;
-
 use super::LogFormat;
+use crate::{
+    net::{AdvertisedAddress, BindAddress},
+    nodes_config::Role,
+    PlainNodeId,
+};
 
 #[serde_as]
 #[skip_serializing_none]

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -8,21 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    num::{NonZeroU16, NonZeroU32, NonZeroUsize},
+    path::PathBuf,
+    str::FromStr,
+    time::Duration,
+};
+
 use enumset::EnumSet;
 use once_cell::sync::Lazy;
 use restate_serde_util::{NonZeroByteCount, SerdeableHeaderHashMap};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::time::Duration;
 
 use super::{AwsOptions, HttpOptions, PerfStatsLevel, RocksDbOptions};
-use crate::net::{AdvertisedAddress, BindAddress};
-use crate::nodes_config::Role;
-use crate::retries::RetryPolicy;
-use crate::PlainNodeId;
+use crate::{
+    net::{AdvertisedAddress, BindAddress},
+    nodes_config::Role,
+    retries::RetryPolicy,
+    PlainNodeId,
+};
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
 
@@ -567,9 +572,8 @@ impl Default for TracingOptions {
 }
 #[cfg(test)]
 mod tests {
-    use crate::nodes_config::Role;
-
     use super::CommonOptions;
+    use crate::nodes_config::Role;
 
     #[test]
     fn roles_compat_test() {

--- a/crates/types/src/config/http.rs
+++ b/crates/types/src/config/http.rs
@@ -8,12 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::str::FromStr;
-use std::time::Duration;
+use std::{fmt, str::FromStr, time::Duration};
 
-use http::uri::{InvalidUri, Parts, Scheme};
-use http::Uri;
+use http::{
+    uri::{InvalidUri, Parts, Scheme},
+    Uri,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 

--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::SocketAddr;
-use std::num::NonZeroUsize;
+use std::{net::SocketAddr, num::NonZeroUsize};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -8,13 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use std::{num::NonZeroUsize, path::PathBuf};
 
 use restate_serde_util::NonZeroByteCount;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use tracing::warn;
 
 use super::{CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};

--- a/crates/types/src/config/metadata_store.rs
+++ b/crates/types/src/config/metadata_store.rs
@@ -8,13 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use std::{num::NonZeroUsize, path::PathBuf};
 
 use restate_serde_util::NonZeroByteCount;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use tracing::warn;
 
 use super::{data_dir, CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -27,7 +27,10 @@ mod query_engine;
 mod rocksdb;
 mod worker;
 
+use std::{path::PathBuf, sync::Arc};
+
 pub use admin::*;
+use arc_swap::ArcSwap;
 pub use aws::*;
 pub use bifrost::*;
 #[cfg(feature = "clap")]
@@ -39,22 +42,15 @@ pub use kafka::*;
 pub use log_server::*;
 pub use metadata_store::*;
 pub use networking::*;
+use once_cell::sync::Lazy;
 pub use query_engine::*;
 pub use rocksdb::*;
-pub use worker::*;
-
-use std::path::PathBuf;
-use std::sync::Arc;
-
-use arc_swap::ArcSwap;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+pub use worker::*;
 
 use super::live::{LiveLoad, Pinned};
-use crate::errors::GenericError;
-use crate::live::Live;
-use crate::nodes_config::Role;
+use crate::{errors::GenericError, live::Live, nodes_config::Role};
 
 #[cfg(any(test, feature = "test-util"))]
 enum TempOrPath {

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;

--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -8,13 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::SocketAddr;
-use std::num::NonZeroUsize;
-
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use std::{net::SocketAddr, num::NonZeroUsize};
 
 use restate_serde_util::NonZeroByteCount;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 /// # Storage query engine options
 #[serde_as]

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -10,10 +10,9 @@
 
 use std::num::{NonZeroU32, NonZeroUsize};
 
+use restate_serde_util::NonZeroByteCount;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-
-use restate_serde_util::NonZeroByteCount;
 
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, derive_builder::Builder)]

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -8,18 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use std::num::{NonZeroU16, NonZeroUsize};
-use std::path::PathBuf;
-use std::time::Duration;
-use tracing::warn;
+use std::{
+    num::{NonZeroU16, NonZeroUsize},
+    path::PathBuf,
+    time::Duration,
+};
 
 use restate_serde_util::NonZeroByteCount;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use tracing::warn;
 
 use super::{CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
-use crate::identifiers::PartitionId;
-use crate::retries::RetryPolicy;
+use crate::{identifiers::PartitionId, retries::RetryPolicy};
 
 /// # Worker options
 #[serde_as]

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -8,16 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
-use crate::config::Configuration;
-use figment::providers::{Env, Format, Serialized, Toml};
-use figment::Figment;
+use figment::{
+    providers::{Env, Format, Serialized, Toml},
+    Figment,
+};
 use notify_debouncer_mini::{
     new_debouncer, DebounceEventResult, DebouncedEvent, DebouncedEventKind,
 };
 use tracing::{error, info, warn};
+
+use crate::config::Configuration;
 
 #[derive(thiserror::Error, codederror::CodedError, Debug)]
 #[code(restate_errors::RT0002)]

--- a/crates/types/src/deployment.rs
+++ b/crates/types/src/deployment.rs
@@ -8,18 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::mem::size_of;
-use std::str::FromStr;
+use std::{fmt, mem::size_of, str::FromStr};
 
 use ulid::Ulid;
 
-use crate::base62_util::base62_max_length_for_type;
-use crate::errors::IdDecodeError;
-use crate::id_util::{IdDecoder, IdEncoder, IdResourceType};
-use crate::identifiers::{DeploymentId, ResourceId, TimestampAwareId};
-use crate::service_protocol::ServiceProtocolVersion;
-use crate::time::MillisSinceEpoch;
+use crate::{
+    base62_util::base62_max_length_for_type,
+    errors::IdDecodeError,
+    id_util::{IdDecoder, IdEncoder, IdResourceType},
+    identifiers::{DeploymentId, ResourceId, TimestampAwareId},
+    service_protocol::ServiceProtocolVersion,
+    time::MillisSinceEpoch,
+};
 
 impl ResourceId for DeploymentId {
     const SIZE_IN_BYTES: usize = size_of::<u128>();

--- a/crates/types/src/epoch.rs
+++ b/crates/types/src/epoch.rs
@@ -10,8 +10,11 @@
 
 #![allow(dead_code)]
 
-use crate::identifiers::{LeaderEpoch, PartitionId};
-use crate::{flexbuffers_storage_encode_decode, GenerationalNodeId, Version, Versioned};
+use crate::{
+    flexbuffers_storage_encode_decode,
+    identifiers::{LeaderEpoch, PartitionId},
+    GenerationalNodeId, Version, Versioned,
+};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EpochMetadata {
@@ -71,9 +74,11 @@ flexbuffers_storage_encode_decode!(EpochMetadata);
 
 #[cfg(test)]
 mod tests {
-    use crate::epoch::EpochMetadata;
-    use crate::identifiers::{LeaderEpoch, PartitionId};
-    use crate::GenerationalNodeId;
+    use crate::{
+        epoch::EpochMetadata,
+        identifiers::{LeaderEpoch, PartitionId},
+        GenerationalNodeId,
+    };
 
     #[test]
     fn basic_operations() {

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -8,10 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
-use std::borrow::Cow;
-use std::convert::Into;
-use std::fmt;
+use std::{any::Any, borrow::Cow, convert::Into, fmt};
 
 /// Error type which abstracts away the actual [`std::error::Error`] type. Use this type
 /// if you don't know the actual error type or if it is not important.

--- a/crates/types/src/health.rs
+++ b/crates/types/src/health.rs
@@ -10,10 +10,12 @@
 
 use tokio::sync::watch;
 
-use crate::protobuf::common::{
-    AdminStatus, LogServerStatus, MetadataServerStatus, NodeStatus, WorkerStatus,
+use crate::{
+    protobuf::common::{
+        AdminStatus, LogServerStatus, MetadataServerStatus, NodeStatus, WorkerStatus,
+    },
+    Merge,
 };
-use crate::Merge;
 
 /// All clones will share the same underlying channel
 #[derive(Clone, Debug)]

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -10,15 +10,16 @@
 
 //! Resource identifier helpers and core structures
 
-use std::fmt::Write;
-use std::str::FromStr;
+use std::{fmt::Write, str::FromStr};
 
 use num_traits::PrimInt;
 
-use crate::base62_util::{base62_encode_fixed_width, base62_max_length_for_type};
-use crate::errors::IdDecodeError;
-use crate::identifiers::ResourceId;
-use crate::macros::prefixed_ids;
+use crate::{
+    base62_util::{base62_encode_fixed_width, base62_max_length_for_type},
+    errors::IdDecodeError,
+    identifiers::ResourceId,
+    macros::prefixed_ids,
+};
 
 pub const ID_RESOURCE_SEPARATOR: char = '_';
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -10,24 +10,21 @@
 
 //! Restate uses many identifiers to uniquely identify its services and entities.
 
+use std::{fmt, hash::Hash, mem::size_of, str::FromStr};
+
 use bytes::Bytes;
 use bytestring::ByteString;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
-use std::fmt;
-use std::hash::Hash;
-use std::mem::size_of;
-use std::str::FromStr;
 use ulid::Ulid;
 
-use crate::base62_util::base62_encode_fixed_width;
-use crate::base62_util::base62_max_length_for_type;
-use crate::errors::IdDecodeError;
-use crate::id_util::IdDecoder;
-use crate::id_util::IdEncoder;
-use crate::id_util::IdResourceType;
-use crate::invocation::{InvocationTarget, InvocationTargetType, WorkflowHandlerType};
-use crate::time::MillisSinceEpoch;
+use crate::{
+    base62_util::{base62_encode_fixed_width, base62_max_length_for_type},
+    errors::IdDecodeError,
+    id_util::{IdDecoder, IdEncoder, IdResourceType},
+    invocation::{InvocationTarget, InvocationTargetType, WorkflowHandlerType},
+    time::MillisSinceEpoch,
+};
 
 /// Identifying the leader epoch of a partition processor
 #[derive(
@@ -684,9 +681,9 @@ impl WithPartitionKey for IdempotencyId {
 pub type ServiceRevision = u32;
 
 pub mod partitioner {
-    use super::PartitionKey;
-
     use std::hash::{Hash, Hasher};
+
+    use super::PartitionKey;
 
     /// Computes the [`PartitionKey`] based on xxh3 hashing.
     pub struct HashPartitioner;
@@ -985,10 +982,12 @@ impl From<u128> for SnapshotId {
 
 #[cfg(any(test, feature = "test-util"))]
 mod mocks {
-    use super::*;
+    use rand::{
+        distributions::{Alphanumeric, DistString},
+        Rng,
+    };
 
-    use rand::distributions::{Alphanumeric, DistString};
-    use rand::Rng;
+    use super::*;
 
     impl InvocationUuid {
         pub fn mock_generate(invocation_target: &InvocationTarget) -> Self {
@@ -1054,10 +1053,10 @@ mod mocks {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::invocation::VirtualObjectHandlerType;
     use rand::distributions::{Alphanumeric, DistString};
+
+    use super::*;
+    use crate::invocation::VirtualObjectHandlerType;
 
     #[test]
     fn service_id_and_invocation_id_partition_key_should_match() {

--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -8,11 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::errors::InvocationError;
-use crate::identifiers::{IngressRequestId, InvocationId};
-use crate::invocation::InvocationTarget;
-use crate::GenerationalNodeId;
 use bytes::Bytes;
+
+use crate::{
+    errors::InvocationError,
+    identifiers::{IngressRequestId, InvocationId},
+    invocation::InvocationTarget,
+    GenerationalNodeId,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct IngressResponseEnvelope<T> {

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -10,24 +10,24 @@
 
 //! This module contains all the core types representing a service invocation.
 
-use crate::errors::InvocationError;
-use crate::identifiers::{
-    EntryIndex, IdempotencyId, IngressRequestId, InvocationId, PartitionKey, ServiceId,
-    WithPartitionKey,
-};
-use crate::time::MillisSinceEpoch;
-use crate::GenerationalNodeId;
+use std::{fmt, hash::Hash, str::FromStr, time::Duration};
+
 use bytes::Bytes;
 use bytestring::ByteString;
-use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceState};
-use serde_with::{serde_as, FromInto};
-use std::fmt;
-use std::hash::Hash;
-use std::str::FromStr;
-use std::time::Duration;
-
 // Re-exporting opentelemetry [`TraceId`] to avoid having to import opentelemetry in all crates.
 pub use opentelemetry::trace::TraceId;
+use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceState};
+use serde_with::{serde_as, FromInto};
+
+use crate::{
+    errors::InvocationError,
+    identifiers::{
+        EntryIndex, IdempotencyId, IngressRequestId, InvocationId, PartitionKey, ServiceId,
+        WithPartitionKey,
+    },
+    time::MillisSinceEpoch,
+    GenerationalNodeId,
+};
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -808,9 +808,9 @@ impl WithPartitionKey for AttachInvocationRequest {
 
 #[cfg(any(test, feature = "test-util"))]
 mod mocks {
-    use super::*;
-
     use rand::distributions::{Alphanumeric, DistString};
+
+    use super::*;
 
     fn generate_string() -> ByteString {
         Alphanumeric

--- a/crates/types/src/journal/enriched.rs
+++ b/crates/types/src/journal/enriched.rs
@@ -8,12 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::raw::*;
-use super::*;
-
-use crate::identifiers::InvocationId;
-use crate::invocation::{InvocationTarget, ServiceInvocationSpanContext};
 use std::time::Duration;
+
+use super::{raw::*, *};
+use crate::{
+    identifiers::InvocationId,
+    invocation::{InvocationTarget, ServiceInvocationSpanContext},
+};
 
 pub type EnrichedEntryHeader = EntryHeader<CallEnrichmentResult, AwakeableEnrichmentResult>;
 pub type EnrichedRawEntry = RawEntry<CallEnrichmentResult, AwakeableEnrichmentResult>;

--- a/crates/types/src/journal/entries.rs
+++ b/crates/types/src/journal/entries.rs
@@ -10,13 +10,15 @@
 
 //! A Restate journal is represented by Restate entries, each of them recording a specific action taken by the user code.
 
-use super::*;
-
-use crate::errors::{InvocationError, InvocationErrorCode};
-use crate::identifiers::EntryIndex;
-use crate::invocation::Header;
-use crate::time::MillisSinceEpoch;
 use std::fmt;
+
+use super::*;
+use crate::{
+    errors::{InvocationError, InvocationErrorCode},
+    identifiers::EntryIndex,
+    invocation::Header,
+    time::MillisSinceEpoch,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Entry {

--- a/crates/types/src/journal/mod.rs
+++ b/crates/types/src/journal/mod.rs
@@ -16,9 +16,10 @@ mod entries;
 pub mod raw;
 
 // Re-export all the entries
-use crate::invocation::ResponseResult;
 use bytes::Bytes;
 use bytestring::ByteString;
 pub use entries::*;
+
+use crate::invocation::ResponseResult;
 
 pub type EntryIndex = u32;

--- a/crates/types/src/journal/raw.rs
+++ b/crates/types/src/journal/raw.rs
@@ -10,10 +10,10 @@
 
 //! Raw entries carry the serialized representation of entries.
 
-use super::*;
-
-use crate::invocation::Header;
 use std::fmt::Debug;
+
+use super::*;
+use crate::invocation::Header;
 
 /// This struct represents headers as they are received from the wire.
 pub type PlainEntryHeader = EntryHeader<(), ()>;

--- a/crates/types/src/live.rs
+++ b/crates/types/src/live.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 use arc_swap::ArcSwap;
 use dyn_clone::DynClone;

--- a/crates/types/src/logs/builder.rs
+++ b/crates/types/src/logs/builder.rs
@@ -8,13 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroU32;
-use std::ops::Deref;
+use std::{num::NonZeroU32, ops::Deref};
 
-use super::metadata::{
-    Chain, LogletConfig, LogletParams, Logs, MaybeSegment, ProviderKind, SegmentIndex,
+use super::{
+    metadata::{Chain, LogletConfig, LogletParams, Logs, MaybeSegment, ProviderKind, SegmentIndex},
+    LogId, Lsn,
 };
-use super::{LogId, Lsn};
 use crate::Version;
 
 #[derive(Debug, Default, Clone)]
@@ -167,12 +166,16 @@ impl Deref for ChainBuilder<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::logs::metadata::{LogletParams, MaybeSegment, ProviderKind, Segment};
-    use crate::logs::SequenceNumber;
-    use crate::{Version, Versioned};
     use googletest::prelude::*;
 
     use super::*;
+    use crate::{
+        logs::{
+            metadata::{LogletParams, MaybeSegment, ProviderKind, Segment},
+            SequenceNumber,
+        },
+        Version, Versioned,
+    };
 
     #[test]
     fn test_default_builder() -> googletest::Result<()> {

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -8,8 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::str::FromStr;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    str::FromStr,
+};
 
 use bytestring::ByteString;
 use enum_map::Enum;
@@ -18,8 +20,11 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use super::builder::LogsBuilder;
-use crate::logs::{LogId, Lsn, SequenceNumber};
-use crate::{flexbuffers_storage_encode_decode, Version, Versioned};
+use crate::{
+    flexbuffers_storage_encode_decode,
+    logs::{LogId, Lsn, SequenceNumber},
+    Version, Versioned,
+};
 
 // Starts with 0 being the oldest loglet in the chain.
 #[derive(

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -13,8 +13,7 @@ use std::ops::{Add, RangeInclusive};
 use bytes::{Buf, BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
 
-use crate::identifiers::PartitionId;
-use crate::storage::StorageEncode;
+use crate::{identifiers::PartitionId, storage::StorageEncode};
 
 pub mod builder;
 pub mod metadata;

--- a/crates/types/src/logs/record.rs
+++ b/crates/types/src/logs/record.rs
@@ -12,12 +12,13 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::storage::{
-    EncodedPolyBytes, PolyBytes, StorageCodec, StorageDecode, StorageDecodeError, StorageEncode,
-};
-use crate::time::NanosSinceEpoch;
-
 use super::{KeyFilter, Keys, MatchKeyQuery};
+use crate::{
+    storage::{
+        EncodedPolyBytes, PolyBytes, StorageCodec, StorageDecode, StorageDecodeError, StorageEncode,
+    },
+    time::NanosSinceEpoch,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {

--- a/crates/types/src/metadata_store.rs
+++ b/crates/types/src/metadata_store.rs
@@ -11,8 +11,9 @@
 pub mod keys {
     //! Keys of values stored in the metadata store
 
-    use crate::identifiers::PartitionId;
     use bytestring::ByteString;
+
+    use crate::identifiers::PartitionId;
 
     pub static NODES_CONFIG_KEY: ByteString = ByteString::from_static("nodes_config");
     pub static BIFROST_CONFIG_KEY: ByteString = ByteString::from_static("bifrost_config");

--- a/crates/types/src/net/cluster_controller.rs
+++ b/crates/types/src/net/cluster_controller.rs
@@ -10,12 +10,12 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::cluster::cluster_state::RunMode;
-use crate::identifiers::PartitionId;
-use crate::net::TargetName;
-use crate::partition_table::KeyRange;
-
-use crate::net::define_rpc;
+use crate::{
+    cluster::cluster_state::RunMode,
+    identifiers::PartitionId,
+    net::{define_rpc, TargetName},
+    partition_table::KeyRange,
+};
 
 define_rpc! {
     @request = AttachRequest,

--- a/crates/types/src/net/codec.rs
+++ b/crates/types/src/net/codec.rs
@@ -11,15 +11,16 @@
 use std::sync::Arc;
 
 use bytes::{Buf, BufMut, BytesMut};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 
-use crate::net::CodecError;
-use crate::protobuf::common::ProtocolVersion;
-use crate::protobuf::common::TargetName;
-use crate::protobuf::node::message;
-use crate::protobuf::node::message::BinaryMessage;
-use crate::storage::{decode_from_flexbuffers, encode_as_flexbuffers};
+use crate::{
+    net::CodecError,
+    protobuf::{
+        common::{ProtocolVersion, TargetName},
+        node::{message, message::BinaryMessage},
+    },
+    storage::{decode_from_flexbuffers, encode_as_flexbuffers},
+};
 
 pub trait Targeted {
     const TARGET: TargetName;

--- a/crates/types/src/net/ingress.rs
+++ b/crates/types/src/net/ingress.rs
@@ -10,8 +10,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::ingress::{InvocationResponse, SubmittedInvocationNotification};
-use crate::net::{define_message, TargetName};
+use crate::{
+    ingress::{InvocationResponse, SubmittedInvocationNotification},
+    net::{define_message, TargetName},
+};
 
 #[derive(
     Debug,

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -8,18 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
 use super::TargetName;
-use crate::logs::{KeyFilter, LogletOffset, Record, SequenceNumber, TailState};
-use crate::net::define_rpc;
-use crate::replicated_loglet::ReplicatedLogletId;
-use crate::time::MillisSinceEpoch;
-use crate::GenerationalNodeId;
+use crate::{
+    logs::{KeyFilter, LogletOffset, Record, SequenceNumber, TailState},
+    net::define_rpc,
+    replicated_loglet::ReplicatedLogletId,
+    time::MillisSinceEpoch,
+    GenerationalNodeId,
+};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[repr(u8)]

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -12,16 +12,15 @@ use enum_map::Enum;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
-use crate::logs::metadata::Logs;
-use crate::net::define_message;
-use crate::net::TargetName;
-use crate::nodes_config::NodesConfiguration;
-use crate::partition_table::PartitionTable;
-use crate::schema::Schema;
-use crate::Version;
-use crate::Versioned;
-
 use super::RpcRequest;
+use crate::{
+    logs::metadata::Logs,
+    net::{define_message, TargetName},
+    nodes_config::NodesConfiguration,
+    partition_table::PartitionTable,
+    schema::Schema,
+    Version, Versioned,
+};
 
 #[derive(
     Debug,

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -20,17 +20,17 @@ pub mod partition_processor_manager;
 pub mod replicated_loglet;
 
 // re-exports for convenience
+use std::{
+    net::{AddrParseError, SocketAddr},
+    path::PathBuf,
+    str::FromStr,
+};
+
 pub use error::*;
-
-use std::net::{AddrParseError, SocketAddr};
-use std::path::PathBuf;
-use std::str::FromStr;
-
 use http::Uri;
 
 use self::codec::{Targeted, WireEncode};
-pub use crate::protobuf::common::ProtocolVersion;
-pub use crate::protobuf::common::TargetName;
+pub use crate::protobuf::common::{ProtocolVersion, TargetName};
 
 pub static MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::Flexbuffers;
 pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::Flexbuffers;

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -13,12 +13,12 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
-use crate::identifiers::{PartitionId, SnapshotId};
-use crate::net::{define_message, TargetName};
-
-use crate::net::define_rpc;
-use crate::Version;
+use crate::{
+    cluster::cluster_state::{PartitionProcessorStatus, RunMode},
+    identifiers::{PartitionId, SnapshotId},
+    net::{define_message, define_rpc, TargetName},
+    Version,
+};
 
 define_rpc! {
     @request = GetProcessorsState,

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -10,16 +10,19 @@
 
 //! Defines messages between replicated loglet instances
 
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use serde::{Deserialize, Serialize};
 
 use super::TargetName;
-use crate::logs::metadata::SegmentIndex;
-use crate::logs::{LogId, LogletOffset, Record, SequenceNumber, TailState};
-use crate::net::define_rpc;
-use crate::replicated_loglet::ReplicatedLogletId;
+use crate::{
+    logs::{metadata::SegmentIndex, LogId, LogletOffset, Record, SequenceNumber, TailState},
+    net::define_rpc,
+    replicated_loglet::ReplicatedLogletId,
+};
 
 // ----- ReplicatedLoglet Sequencer API -----
 define_rpc! {

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -16,9 +16,10 @@ use std::collections::HashMap;
 use enumset::{EnumSet, EnumSetType};
 use serde_with::serde_as;
 
-use crate::net::AdvertisedAddress;
-use crate::{flexbuffers_storage_encode_decode, GenerationalNodeId, NodeId, PlainNodeId};
-use crate::{Version, Versioned};
+use crate::{
+    flexbuffers_storage_encode_decode, net::AdvertisedAddress, GenerationalNodeId, NodeId,
+    PlainNodeId, Version, Versioned,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum NodesConfigError {
@@ -329,9 +330,9 @@ flexbuffers_storage_encode_decode!(NodesConfiguration);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use restate_test_util::assert_eq;
+
+    use super::*;
 
     #[test]
     fn test_upsert_node() {

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -8,11 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeMap;
-use std::ops::RangeInclusive;
+use std::{collections::BTreeMap, ops::RangeInclusive};
 
-use crate::identifiers::{PartitionId, PartitionKey};
-use crate::{flexbuffers_storage_encode_decode, Version, Versioned};
+use crate::{
+    flexbuffers_storage_encode_decode,
+    identifiers::{PartitionId, PartitionKey},
+    Version, Versioned,
+};
 
 #[derive(Debug, thiserror::Error)]
 #[error("Cannot find partition for partition key '{0}'")]
@@ -362,13 +364,16 @@ mod tests {
     use bytes::BytesMut;
     use test_log::test;
 
-    use crate::identifiers::{PartitionId, PartitionKey};
-    use crate::partition_table::{
-        EqualSizedPartitionPartitioner, FindPartition, Partition, PartitionTable,
-        PartitionTableBuilder,
+    use crate::{
+        flexbuffers_storage_encode_decode,
+        identifiers::{PartitionId, PartitionKey},
+        partition_table::{
+            EqualSizedPartitionPartitioner, FindPartition, Partition, PartitionTable,
+            PartitionTableBuilder,
+        },
+        storage::StorageCodec,
+        Version,
     };
-    use crate::storage::StorageCodec;
-    use crate::{flexbuffers_storage_encode_decode, Version};
 
     #[test]
     fn partitioner_produces_consecutive_ranges() {

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -61,11 +61,11 @@ pub mod cluster {
 }
 
 pub mod node {
-    use crate::GenerationalNodeId;
-
-    use crate::net::{ProtocolVersion, CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION};
-
     use self::message::{BinaryMessage, ConnectionControl, Signal};
+    use crate::{
+        net::{ProtocolVersion, CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION},
+        GenerationalNodeId,
+    };
 
     include!(concat!(env!("OUT_DIR"), "/restate.node.rs"));
 

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -8,18 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashSet,
+    fmt::{Display, Formatter},
+};
 
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use serde_with::DisplayFromStr;
 
 use super::ReplicationProperty;
-use crate::logs::metadata::SegmentIndex;
-use crate::logs::LogId;
-use crate::nodes_config::NodesConfiguration;
-use crate::{GenerationalNodeId, PlainNodeId};
+use crate::{
+    logs::{metadata::SegmentIndex, LogId},
+    nodes_config::NodesConfiguration,
+    GenerationalNodeId, PlainNodeId,
+};
 
 /// Configuration parameters of a replicated loglet segment
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]

--- a/crates/types/src/replicated_loglet/replication_property.rs
+++ b/crates/types/src/replicated_loglet/replication_property.rs
@@ -8,9 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{btree_map, BTreeMap};
-use std::fmt::{Display, Formatter};
-use std::num::NonZeroU8;
+use std::{
+    collections::{btree_map, BTreeMap},
+    fmt::{Display, Formatter},
+    num::NonZeroU8,
+};
 
 use enum_map::Enum;
 
@@ -157,8 +159,9 @@ impl Display for ReplicationProperty {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use googletest::prelude::*;
+
+    use super::*;
 
     #[test]
     fn test_location_scope() {

--- a/crates/types/src/retries.rs
+++ b/crates/types/src/retries.rs
@@ -10,11 +10,7 @@
 
 //! A core aspect of Restate is its ability to retry invocations. This module contains the types defining retries.
 
-use std::borrow::Cow;
-use std::cmp;
-use std::future::Future;
-use std::num::NonZeroUsize;
-use std::time::Duration;
+use std::{borrow::Cow, cmp, future::Future, num::NonZeroUsize, time::Duration};
 
 use rand::Rng;
 
@@ -314,10 +310,15 @@ impl<'a> ExactSizeIterator for RetryIter<'a> {}
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+    };
+
     use super::*;
-    use std::future;
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::Arc;
 
     #[test]
     fn no_retry_policy() {

--- a/crates/types/src/schema/deployment.rs
+++ b/crates/types/src/schema/deployment.rs
@@ -8,21 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 //
-use std::collections::HashMap;
-use std::fmt;
-use std::fmt::{Display, Formatter};
-use std::ops::RangeInclusive;
+use std::{
+    collections::HashMap,
+    fmt,
+    fmt::{Display, Formatter},
+    ops::RangeInclusive,
+};
 
 use bytestring::ByteString;
-use http::header::{HeaderName, HeaderValue};
-use http::Uri;
+use http::{
+    header::{HeaderName, HeaderValue},
+    Uri,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::identifiers::{DeploymentId, LambdaARN, ServiceRevision};
-use crate::schema::service::ServiceMetadata;
-use crate::schema::Schema;
-use crate::time::MillisSinceEpoch;
+use crate::{
+    identifiers::{DeploymentId, LambdaARN, ServiceRevision},
+    schema::{service::ServiceMetadata, Schema},
+    time::MillisSinceEpoch,
+};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -132,11 +137,11 @@ impl From<DeploymentTypeShadow> for DeploymentType {
 
 #[cfg(test)]
 mod serde_tests {
-    use crate::{identifiers::LambdaARN, storage::StorageCodec};
     use bytestring::ByteString;
     use http::Uri;
 
     use super::{DeploymentType, ProtocolType};
+    use crate::{identifiers::LambdaARN, storage::StorageCodec};
 
     #[derive(serde::Serialize, serde::Deserialize)]
     enum OldDeploymentType {
@@ -301,10 +306,10 @@ pub trait DeploymentResolver {
 
 #[cfg(feature = "test-util")]
 pub mod test_util {
-    use super::*;
-
-    use crate::service_protocol::MAX_SERVICE_PROTOCOL_VERSION_VALUE;
     use std::collections::HashMap;
+
+    use super::*;
+    use crate::service_protocol::MAX_SERVICE_PROTOCOL_VERSION_VALUE;
 
     impl Deployment {
         pub fn mock() -> Deployment {

--- a/crates/types/src/schema/invocation_target.rs
+++ b/crates/types/src/schema/invocation_target.rs
@@ -8,9 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::str::FromStr;
-use std::time::Duration;
-use std::{cmp, fmt};
+use std::{cmp, fmt, str::FromStr, time::Duration};
 
 use bytes::Bytes;
 use bytestring::ByteString;
@@ -415,9 +413,9 @@ impl fmt::Display for OutputContentTypeRule {
 #[cfg(feature = "test-util")]
 #[allow(dead_code)]
 pub mod test_util {
-    use super::*;
-
     use std::collections::HashMap;
+
+    use super::*;
 
     #[derive(Debug, Clone)]
     pub struct MockService(HashMap<String, InvocationTargetMetadata>);

--- a/crates/types/src/schema/mod.rs
+++ b/crates/types/src/schema/mod.rs
@@ -17,13 +17,15 @@ use std::collections::HashMap;
 
 use serde_with::serde_as;
 
-use self::deployment::DeploymentSchemas;
-use self::deployment::DeploymentType;
-use self::service::ServiceSchemas;
-use self::subscriptions::Subscription;
-use crate::identifiers::{DeploymentId, SubscriptionId};
-use crate::Version;
-use crate::Versioned;
+use self::{
+    deployment::{DeploymentSchemas, DeploymentType},
+    service::ServiceSchemas,
+    subscriptions::Subscription,
+};
+use crate::{
+    identifiers::{DeploymentId, SubscriptionId},
+    Version, Versioned,
+};
 
 /// The schema information
 #[serde_as]
@@ -88,9 +90,8 @@ impl Versioned for Schema {
 }
 
 pub mod storage {
-    use crate::flexbuffers_storage_encode_decode;
-
     use super::Schema;
+    use crate::flexbuffers_storage_encode_decode;
 
     flexbuffers_storage_encode_decode!(Schema);
 }
@@ -98,13 +99,14 @@ pub mod storage {
 #[cfg(feature = "test-util")]
 mod test_util {
 
-    use super::*;
-
-    use super::invocation_target::InvocationTargetResolver;
-    use super::service::ServiceMetadata;
-    use super::service::ServiceMetadataResolver;
-    use crate::identifiers::ServiceRevision;
     use restate_test_util::{assert, assert_eq};
+
+    use super::{
+        invocation_target::InvocationTargetResolver,
+        service::{ServiceMetadata, ServiceMetadataResolver},
+        *,
+    };
+    use crate::identifiers::ServiceRevision;
 
     impl Schema {
         #[track_caller]

--- a/crates/types/src/schema/service.rs
+++ b/crates/types/src/schema/service.rs
@@ -8,18 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use super::invocation_target::InvocationTargetMetadata;
-use super::Schema;
-use crate::identifiers::{DeploymentId, ServiceRevision};
-use crate::invocation::{
-    InvocationTargetType, ServiceType, VirtualObjectHandlerType, WorkflowHandlerType,
+use super::{invocation_target::InvocationTargetMetadata, Schema};
+use crate::{
+    identifiers::{DeploymentId, ServiceRevision},
+    invocation::{
+        InvocationTargetType, ServiceType, VirtualObjectHandlerType, WorkflowHandlerType,
+    },
 };
 
 #[serde_as]
@@ -238,9 +237,9 @@ impl ServiceMetadataResolver for Schema {
 #[cfg(feature = "test-util")]
 #[allow(dead_code)]
 pub mod test_util {
-    use super::*;
-
     use std::collections::HashMap;
+
+    use super::*;
 
     #[derive(Debug, Default, Clone)]
     pub struct MockServiceMetadataResolver(HashMap<String, ServiceMetadata>);

--- a/crates/types/src/schema/subscriptions.rs
+++ b/crates/types/src/schema/subscriptions.rs
@@ -8,17 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::Schema;
-use crate::config::IngressOptions;
-use crate::errors::GenericError;
-use crate::identifiers::SubscriptionId;
+use crate::{config::IngressOptions, errors::GenericError, identifiers::SubscriptionId};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/types/src/service_protocol.rs
+++ b/crates/types/src/service_protocol.rs
@@ -8,8 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::errors::InvocationError;
 use std::ops::RangeInclusive;
+
+use crate::errors::InvocationError;
 
 // Range of supported service protocol versions by this server
 pub const MIN_SERVICE_PROTOCOL_VERSION: ServiceProtocolVersion = ServiceProtocolVersion::V1;
@@ -77,7 +78,6 @@ impl From<crate::invocation::Header> for Header {
 /// These are used by the [`codec::ProtobufRawEntryCodec`].
 mod pb_into {
     use super::*;
-
     use crate::journal::{
         AwakeableEntry, CancelInvocationEntry, CancelInvocationTarget, ClearStateEntry,
         CompleteAwakeableEntry, CompletePromiseEntry, CompleteResult, CompletionResult, Entry,

--- a/crates/types/src/state_mut.rs
+++ b/crates/types/src/state_mut.rs
@@ -8,8 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+};
 
 use base64::Engine;
 use bytes::Bytes;

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -8,14 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::mem;
-use std::sync::Arc;
+use std::{mem, sync::Arc};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use downcast_rs::{impl_downcast, DowncastSync};
-use serde::de::{DeserializeOwned, Error as DeserializationError};
-use serde::ser::Error as SerializationError;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{DeserializeOwned, Error as DeserializationError},
+    ser::Error as SerializationError,
+    Deserialize, Serialize,
+};
 use tracing::error;
 
 use crate::errors::GenericError;
@@ -397,10 +398,11 @@ pub fn decode_from_flexbuffers<T: DeserializeOwned, B: Buf>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use bytes::Bytes;
 
     use super::*;
-    use std::sync::Arc;
 
     #[test]
     fn test_polybytes() {

--- a/crates/types/src/subscription.rs
+++ b/crates/types/src/subscription.rs
@@ -8,16 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::mem::size_of;
-use std::str::FromStr;
+use std::{fmt, mem::size_of, str::FromStr};
 
-use crate::base62_util::base62_max_length_for_type;
-use crate::errors::IdDecodeError;
-use crate::id_util::{IdDecoder, IdEncoder, IdResourceType};
-use crate::identifiers::{ResourceId, SubscriptionId, TimestampAwareId};
-use crate::time::MillisSinceEpoch;
 use ulid::Ulid;
+
+use crate::{
+    base62_util::base62_max_length_for_type,
+    errors::IdDecodeError,
+    id_util::{IdDecoder, IdEncoder, IdResourceType},
+    identifiers::{ResourceId, SubscriptionId, TimestampAwareId},
+    time::MillisSinceEpoch,
+};
 
 impl ResourceId for SubscriptionId {
     const SIZE_IN_BYTES: usize = size_of::<u128>();

--- a/crates/types/src/time.rs
+++ b/crates/types/src/time.rs
@@ -8,10 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::fmt::Display;
-use std::ops::Add;
-use std::time::{Duration, SystemTime};
+use std::{
+    fmt,
+    fmt::Display,
+    ops::Add,
+    time::{Duration, SystemTime},
+};
 
 /// Milliseconds since the unix epoch
 #[derive(
@@ -179,9 +181,9 @@ impl From<prost_types::Timestamp> for NanosSinceEpoch {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::time::SystemTime;
+
+    use super::*;
 
     #[test]
     fn millis_should_not_overflow() {

--- a/crates/types/src/timer.rs
+++ b/crates/types/src/timer.rs
@@ -8,10 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{borrow::Borrow, fmt::Debug, hash::Hash};
+
 use crate::time::MillisSinceEpoch;
-use std::borrow::Borrow;
-use std::fmt::Debug;
-use std::hash::Hash;
 
 pub trait Timer: Hash + Eq + Borrow<Self::TimerKey> {
     type TimerKey: TimerKey + Send;

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -10,8 +10,10 @@
 
 use std::ops::RangeInclusive;
 
-use restate_types::identifiers::{LeaderEpoch, PartitionKey};
-use restate_types::GenerationalNodeId;
+use restate_types::{
+    identifiers::{LeaderEpoch, PartitionKey},
+    GenerationalNodeId,
+};
 
 /// Announcing a new leader. This message can be written by any component to make the specified
 /// partition processor the leader.
@@ -29,11 +31,13 @@ pub struct AnnounceLeader {
 
 #[cfg(test)]
 mod tests {
-    use crate::control::AnnounceLeader;
     use bytes::BytesMut;
-    use restate_types::identifiers::LeaderEpoch;
-    use restate_types::storage::StorageCodec;
-    use restate_types::{flexbuffers_storage_encode_decode, GenerationalNodeId};
+    use restate_types::{
+        flexbuffers_storage_encode_decode, identifiers::LeaderEpoch, storage::StorageCodec,
+        GenerationalNodeId,
+    };
+
+    use crate::control::AnnounceLeader;
 
     #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct OldAnnounceLeader {

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -14,21 +14,23 @@ use bytes::{Bytes, BytesMut};
 use restate_bifrost::Bifrost;
 use restate_core::{metadata, ShutdownError};
 use restate_storage_api::deduplication_table::DedupInformation;
-use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey};
-use restate_types::invocation::{
-    AttachInvocationRequest, InvocationResponse, InvocationTermination, PurgeInvocationRequest,
-    ServiceInvocation,
+use restate_types::{
+    flexbuffers_storage_encode_decode,
+    identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey},
+    invocation::{
+        AttachInvocationRequest, InvocationResponse, InvocationTermination, PurgeInvocationRequest,
+        ServiceInvocation,
+    },
+    logs,
+    logs::{HasRecordKeys, Keys, LogId, Lsn, MatchKeyQuery},
+    message::MessageIndex,
+    partition_table::{FindPartition, PartitionTableError},
+    state_mut::ExternalStateMutation,
+    storage::{StorageCodec, StorageDecodeError, StorageEncodeError},
+    GenerationalNodeId, PlainNodeId, Version,
 };
-use restate_types::message::MessageIndex;
-use restate_types::state_mut::ExternalStateMutation;
-use restate_types::{flexbuffers_storage_encode_decode, logs, PlainNodeId, Version};
 
-use crate::control::AnnounceLeader;
-use crate::timer::TimerKeyValue;
-use restate_types::logs::{HasRecordKeys, Keys, LogId, Lsn, MatchKeyQuery};
-use restate_types::partition_table::{FindPartition, PartitionTableError};
-use restate_types::storage::{StorageCodec, StorageDecodeError, StorageEncodeError};
-use restate_types::GenerationalNodeId;
+use crate::{control::AnnounceLeader, timer::TimerKeyValue};
 
 pub mod control;
 pub mod timer;

--- a/crates/wal-protocol/src/timer.rs
+++ b/crates/wal-protocol/src/timer.rs
@@ -8,13 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    borrow::Borrow,
+    fmt,
+    hash::{Hash, Hasher},
+};
+
 use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind};
-use restate_types::identifiers::{EntryIndex, InvocationId};
-use restate_types::invocation::ServiceInvocation;
-use restate_types::time::MillisSinceEpoch;
-use std::borrow::Borrow;
-use std::fmt;
-use std::hash::{Hash, Hasher};
+use restate_types::{
+    identifiers::{EntryIndex, InvocationId},
+    invocation::ServiceInvocation,
+    time::MillisSinceEpoch,
+};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/web-ui/build.rs
+++ b/crates/web-ui/build.rs
@@ -8,9 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
-use std::fs::DirEntry;
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    fs::DirEntry,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("assets");

--- a/crates/worker/src/handle.rs
+++ b/crates/worker/src/handle.rs
@@ -9,8 +9,7 @@
 // by the Apache License, Version 2.0.
 use std::future::Future;
 
-use restate_types::invocation::InvocationTermination;
-use restate_types::state_mut::ExternalStateMutation;
+use restate_types::{invocation::InvocationTermination, state_mut::ExternalStateMutation};
 
 use crate::WorkerHandleError;
 

--- a/crates/worker/src/ingress_integration.rs
+++ b/crates/worker/src/ingress_integration.rs
@@ -12,19 +12,20 @@ use anyhow::{anyhow, Error};
 use restate_core::metadata;
 use restate_ingress_http::{GetOutputResult, InvocationStorageReader};
 use restate_partition_store::PartitionStoreManager;
-use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
+use restate_storage_api::{
+    idempotency_table::ReadOnlyIdempotencyTable,
+    invocation_status_table::{InvocationStatus, ReadOnlyInvocationStatusTable},
+    service_status_table::{ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus},
 };
-use restate_storage_api::service_status_table::{
-    ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus,
+use restate_types::{
+    identifiers::WithPartitionKey,
+    ingress::{IngressResponseResult, InvocationResponse},
+    invocation::{
+        InvocationQuery, InvocationTarget, InvocationTargetType, ResponseResult,
+        WorkflowHandlerType,
+    },
+    partition_table::FindPartition,
 };
-use restate_types::identifiers::WithPartitionKey;
-use restate_types::ingress::{IngressResponseResult, InvocationResponse};
-use restate_types::invocation::{
-    InvocationQuery, InvocationTarget, InvocationTargetType, ResponseResult, WorkflowHandlerType,
-};
-use restate_types::partition_table::FindPartition;
 
 #[derive(Debug, Clone)]
 pub struct InvocationStorageReaderImpl {

--- a/crates/worker/src/invoker_integration.rs
+++ b/crates/worker/src/invoker_integration.rs
@@ -8,31 +8,31 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::{marker::PhantomData, str::FromStr};
 
 use anyhow::anyhow;
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
-
 use restate_service_protocol::awakeable_id::AwakeableIdentifier;
-use restate_types::errors::{codes, InvocationError};
-use restate_types::identifiers::InvocationId;
-use restate_types::invocation::{
-    InvocationTarget, InvocationTargetType, ServiceInvocationSpanContext, ServiceType, SpanRelation,
+use restate_types::{
+    errors::{codes, InvocationError},
+    identifiers::InvocationId,
+    invocation::{
+        InvocationTarget, InvocationTargetType, ServiceInvocationSpanContext, ServiceType,
+        SpanRelation,
+    },
+    journal::{
+        enriched::{
+            AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
+        },
+        raw::{PlainEntryHeader, PlainRawEntry, RawEntry, RawEntryCodec},
+        CancelInvocationEntry, CancelInvocationTarget, CompleteAwakeableEntry, Entry, EntryType,
+        InvokeEntry, InvokeRequest, OneWayCallEntry,
+    },
+    live::Live,
+    schema::invocation_target::InvocationTargetResolver,
 };
-use restate_types::journal::enriched::{
-    AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
-};
-use restate_types::journal::raw::{PlainEntryHeader, PlainRawEntry, RawEntry, RawEntryCodec};
-use restate_types::journal::{
-    CancelInvocationEntry, CancelInvocationTarget, CompleteAwakeableEntry, Entry, InvokeEntry,
-    OneWayCallEntry,
-};
-use restate_types::journal::{EntryType, InvokeRequest};
-use restate_types::live::Live;
-use restate_types::schema::invocation_target::InvocationTargetResolver;
 
 #[derive(Clone)]
 pub(super) struct EntryEnricher<Schemas, Codec> {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -21,16 +21,12 @@ mod subscription_controller;
 mod subscription_integration;
 
 use codederror::CodedError;
-use tokio::sync::oneshot;
-
-pub use crate::subscription_controller::SubscriptionController;
-pub use crate::subscription_integration::SubscriptionControllerHandle;
-
 use restate_bifrost::Bifrost;
-use restate_core::network::MessageRouterBuilder;
-use restate_core::network::Networking;
-use restate_core::network::TransportConnect;
-use restate_core::{cancellation_watcher, task_center, Metadata, TaskKind};
+use restate_core::{
+    cancellation_watcher,
+    network::{MessageRouterBuilder, Networking, TransportConnect},
+    task_center, Metadata, TaskKind,
+};
 use restate_ingress_dispatcher::IngressDispatcher;
 use restate_ingress_http::HyperServerIngress;
 use restate_ingress_kafka::Service as IngressKafkaService;
@@ -39,17 +35,22 @@ use restate_metadata_store::MetadataStoreClient;
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_storage_query_postgres::service::PostgresQueryService;
-use restate_types::config::Configuration;
-use restate_types::health::HealthStatus;
-use restate_types::live::Live;
-use restate_types::protobuf::common::WorkerStatus;
-use restate_types::schema::Schema;
+use restate_types::{
+    config::Configuration, health::HealthStatus, live::Live, protobuf::common::WorkerStatus,
+    schema::Schema,
+};
+use tokio::sync::oneshot;
 
-pub use self::error::*;
-pub use self::handle::*;
-use crate::ingress_integration::InvocationStorageReaderImpl;
-use crate::partition::invoker_storage_reader::InvokerStorageReader;
-use crate::partition_processor_manager::PartitionProcessorManager;
+pub use self::{error::*, handle::*};
+use crate::{
+    ingress_integration::InvocationStorageReaderImpl,
+    partition::invoker_storage_reader::InvokerStorageReader,
+    partition_processor_manager::PartitionProcessorManager,
+};
+pub use crate::{
+    subscription_controller::SubscriptionController,
+    subscription_integration::SubscriptionControllerHandle,
+};
 
 type PartitionProcessorBuilder = partition::PartitionProcessorBuilder<
     InvokerChannelServiceHandle<InvokerStorageReader<PartitionStore>>,

--- a/crates/worker/src/partition/action_effect_handler.rs
+++ b/crates/worker/src/partition/action_effect_handler.rs
@@ -8,21 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{btree_map, BTreeMap};
-use std::ops::RangeInclusive;
-use std::sync::Arc;
-use std::time::SystemTime;
+use std::{
+    collections::{btree_map, BTreeMap},
+    ops::RangeInclusive,
+    sync::Arc,
+    time::SystemTime,
+};
 
 use restate_bifrost::Bifrost;
 use restate_core::{task_center, Metadata};
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
-use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
-use restate_types::logs::LogId;
-use restate_types::partition_table::FindPartition;
-use restate_types::time::MillisSinceEpoch;
-use restate_types::Version;
-use restate_wal_protocol::timer::TimerKeyValue;
-use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
+use restate_types::{
+    identifiers::{PartitionId, PartitionKey, WithPartitionKey},
+    logs::LogId,
+    partition_table::FindPartition,
+    time::MillisSinceEpoch,
+    Version,
+};
+use restate_wal_protocol::{timer::TimerKeyValue, Command, Destination, Envelope, Header, Source};
 
 use super::leadership::ActionEffect;
 

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -8,6 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::{
+    ops::RangeInclusive,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
 use anyhow::Context;
 use futures::StreamExt;
 use restate_bifrost::Bifrost;
@@ -15,16 +21,14 @@ use restate_core::cancellation_watcher;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadOnlyInvocationStatusTable,
 };
-use restate_types::identifiers::WithPartitionKey;
-use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
-use restate_types::invocation::PurgeInvocationRequest;
-use restate_types::GenerationalNodeId;
+use restate_types::{
+    identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey},
+    invocation::PurgeInvocationRequest,
+    GenerationalNodeId,
+};
 use restate_wal_protocol::{
     append_envelope_to_bifrost, Command, Destination, Envelope, Header, Source,
 };
-use std::ops::RangeInclusive;
-use std::sync::Arc;
-use std::time::{Duration, SystemTime};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, instrument, warn};
 
@@ -166,7 +170,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::future::Future;
 
     use futures::{stream, Stream};
     use googletest::prelude::*;
@@ -174,12 +178,15 @@ mod tests {
     use restate_storage_api::invocation_status_table::{
         CompletedInvocation, InFlightInvocationMetadata, InvocationStatus,
     };
-    use restate_types::identifiers::{InvocationId, InvocationUuid};
-    use restate_types::invocation::InvocationTarget;
-    use restate_types::partition_table::{FindPartition, PartitionTable};
-    use restate_types::Version;
-    use std::future::Future;
+    use restate_types::{
+        identifiers::{InvocationId, InvocationUuid},
+        invocation::InvocationTarget,
+        partition_table::{FindPartition, PartitionTable},
+        Version,
+    };
     use test_log::test;
+
+    use super::*;
 
     #[allow(dead_code)]
     struct MockInvocationStatusReader(Vec<(InvocationId, InvocationStatus)>);

--- a/crates/worker/src/partition/invoker_storage_reader.rs
+++ b/crates/worker/src/partition/invoker_storage_reader.rs
@@ -8,18 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::vec::IntoIter;
+
 use bytes::Bytes;
 use futures::{stream, StreamExt, TryStreamExt};
 use restate_invoker_api::{EagerState, JournalMetadata};
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
+use restate_storage_api::{
+    invocation_status_table::{InvocationStatus, ReadOnlyInvocationStatusTable},
+    journal_table::{JournalEntry, ReadOnlyJournalTable},
+    state_table::ReadOnlyStateTable,
 };
-use restate_storage_api::journal_table::{JournalEntry, ReadOnlyJournalTable};
-use restate_storage_api::state_table::ReadOnlyStateTable;
-use restate_types::identifiers::InvocationId;
-use restate_types::identifiers::ServiceId;
-use restate_types::journal::raw::PlainRawEntry;
-use std::vec::IntoIter;
+use restate_types::{
+    identifiers::{InvocationId, ServiceId},
+    journal::raw::PlainRawEntry,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum InvokerStorageReaderError {

--- a/crates/worker/src/partition/snapshot_producer.rs
+++ b/crates/worker/src/partition/snapshot_producer.rs
@@ -8,15 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::PathBuf;
-use std::time::SystemTime;
+use std::{path::PathBuf, time::SystemTime};
 
 use anyhow::bail;
-use tracing::{info, warn};
-
-use restate_partition_store::snapshots::{PartitionSnapshotMetadata, SnapshotFormatVersion};
-use restate_partition_store::PartitionStore;
+use restate_partition_store::{
+    snapshots::{PartitionSnapshotMetadata, SnapshotFormatVersion},
+    PartitionStore,
+};
 use restate_types::identifiers::SnapshotId;
+use tracing::{info, warn};
 
 /// Encapsulates producing a Restate partition snapshot out of a partition store.
 pub struct SnapshotProducer {}

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -8,17 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_invoker_api::InvokeInputJournal;
-use restate_storage_api::outbox_table::OutboxMessage;
-use restate_storage_api::timer_table::TimerKey;
-use restate_types::identifiers::{EntryIndex, InvocationId};
-use restate_types::ingress;
-use restate_types::ingress::IngressResponseEnvelope;
-use restate_types::invocation::InvocationTarget;
-use restate_types::journal::Completion;
-use restate_types::message::MessageIndex;
-use restate_wal_protocol::timer::TimerKeyValue;
 use std::time::Duration;
+
+use restate_invoker_api::InvokeInputJournal;
+use restate_storage_api::{outbox_table::OutboxMessage, timer_table::TimerKey};
+use restate_types::{
+    identifiers::{EntryIndex, InvocationId},
+    ingress,
+    ingress::IngressResponseEnvelope,
+    invocation::InvocationTarget,
+    journal::Completion,
+    message::MessageIndex,
+};
+use restate_wal_protocol::timer::TimerKeyValue;
 
 pub type ActionCollector = Vec<Action>;
 

--- a/crates/worker/src/partition/state_machine/tests/delayed_send.rs
+++ b/crates/worker/src/partition/state_machine/tests/delayed_send.rs
@@ -8,13 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::time::{Duration, SystemTime};
 
 use restate_storage_api::inbox_table::ReadOnlyInboxTable;
-use restate_types::invocation::SubmitNotificationSink;
-use restate_types::time::MillisSinceEpoch;
-use std::time::{Duration, SystemTime};
+use restate_types::{invocation::SubmitNotificationSink, time::MillisSinceEpoch};
 use test_log::test;
+
+use super::*;
 
 #[test(tokio::test)]
 async fn send_with_delay() {

--- a/crates/worker/src/partition/state_machine/tests/fixtures.rs
+++ b/crates/worker/src/partition/state_machine/tests/fixtures.rs
@@ -8,20 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::partition::state_machine::tests::TestEnv;
-use crate::partition::state_machine::Action;
 use bytes::Bytes;
 use googletest::prelude::*;
 use restate_invoker_api::InvokeInputJournal;
 use restate_storage_api::journal_table::JournalEntry;
-use restate_types::identifiers::{InvocationId, ServiceId};
-use restate_types::invocation::{
-    InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext, Source,
-};
-use restate_types::journal::enriched::{
-    CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
+use restate_types::{
+    identifiers::{InvocationId, ServiceId},
+    invocation::{InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext, Source},
+    journal::enriched::{CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry},
 };
 use restate_wal_protocol::Command;
+
+use crate::partition::state_machine::{tests::TestEnv, Action};
 
 pub fn completed_invoke_entry(invocation_id: InvocationId) -> JournalEntry {
     JournalEntry::Entry(EnrichedRawEntry::new(

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -8,25 +8,26 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::time::Duration;
 
-use restate_storage_api::idempotency_table::{
-    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
+use restate_storage_api::{
+    idempotency_table::{IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable},
+    inbox_table::{InboxEntry, ReadOnlyInboxTable, SequenceNumberInboxEntry},
+    invocation_status_table::{CompletedInvocation, SourceTable, StatusTimestamps},
+    timer_table::{Timer, TimerKey, TimerKeyKind},
 };
-use restate_storage_api::inbox_table::{InboxEntry, ReadOnlyInboxTable, SequenceNumberInboxEntry};
-use restate_storage_api::invocation_status_table::{
-    CompletedInvocation, SourceTable, StatusTimestamps,
-};
-use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind};
-use restate_types::errors::GONE_INVOCATION_ERROR;
-use restate_types::identifiers::{IdempotencyId, IngressRequestId};
-use restate_types::invocation::{
-    AttachInvocationRequest, InvocationQuery, InvocationTarget, PurgeInvocationRequest,
-    SubmitNotificationSink,
+use restate_types::{
+    errors::GONE_INVOCATION_ERROR,
+    identifiers::{IdempotencyId, IngressRequestId},
+    invocation::{
+        AttachInvocationRequest, InvocationQuery, InvocationTarget, PurgeInvocationRequest,
+        SubmitNotificationSink,
+    },
 };
 use restate_wal_protocol::timer::TimerKeyValue;
-use std::time::Duration;
 use test_log::test;
+
+use super::*;
 
 #[test(tokio::test)]
 async fn start_and_complete_idempotent_invocation() {

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -8,19 +8,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{fixtures, matchers, *};
-
-use assert2::assert;
-use assert2::let_assert;
+use assert2::{assert, let_assert};
 use googletest::any;
 use prost::Message;
-use restate_storage_api::journal_table::JournalTable;
-use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable};
-use restate_types::identifiers::EntryIndex;
-use restate_types::invocation::TerminationFlavor;
-use restate_types::journal::enriched::EnrichedEntryHeader;
-use restate_types::service_protocol;
+use restate_storage_api::{
+    journal_table::JournalTable,
+    timer_table::{Timer, TimerKey, TimerKeyKind, TimerTable},
+};
+use restate_types::{
+    identifiers::EntryIndex, invocation::TerminationFlavor, journal::enriched::EnrichedEntryHeader,
+    service_protocol,
+};
 use test_log::test;
+
+use super::{fixtures, matchers, *};
 
 #[test(tokio::test)]
 async fn kill_inboxed_invocation() -> anyhow::Result<()> {

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -12,21 +12,22 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use googletest::prelude::*;
 use restate_storage_api::timer_table::{TimerKey, TimerKeyKind};
-use restate_types::errors::codes;
-use restate_types::identifiers::EntryIndex;
-use restate_types::invocation::{InvocationTermination, TerminationFlavor};
-use restate_types::journal::enriched::EnrichedRawEntry;
-use restate_types::journal::{Completion, CompletionResult};
+use restate_types::{
+    errors::codes,
+    identifiers::EntryIndex,
+    invocation::{InvocationTermination, TerminationFlavor},
+    journal::{enriched::EnrichedRawEntry, Completion, CompletionResult},
+};
 
 pub mod storage {
-    use super::*;
     use restate_service_protocol::codec::ProtobufRawEntryCodec;
+    use restate_storage_api::{
+        inbox_table::{InboxEntry, SequenceNumberInboxEntry},
+        journal_table::JournalEntry,
+    };
+    use restate_types::{identifiers::InvocationId, invocation::InvocationTarget, journal::Entry};
 
-    use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
-    use restate_storage_api::journal_table::JournalEntry;
-    use restate_types::identifiers::InvocationId;
-    use restate_types::invocation::InvocationTarget;
-    use restate_types::journal::Entry;
+    use super::*;
 
     pub fn invocation_inbox_entry(
         invocation_id: InvocationId,
@@ -48,10 +49,10 @@ pub mod storage {
 }
 
 pub mod actions {
-    use super::*;
-
-    use crate::partition::state_machine::Action;
     use restate_types::identifiers::InvocationId;
+
+    use super::*;
+    use crate::partition::state_machine::Action;
 
     pub fn invoke_for_id(invocation_id: InvocationId) -> impl Matcher<ActualT = Action> {
         pat!(Action::Invoke {

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -8,20 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::time::Duration;
 
-use restate_storage_api::invocation_status_table::{
-    CompletedInvocation, SourceTable, StatusTimestamps,
+use restate_storage_api::{
+    invocation_status_table::{CompletedInvocation, SourceTable, StatusTimestamps},
+    service_status_table::ReadOnlyVirtualObjectStatusTable,
+    timer_table::{Timer, TimerKey, TimerKeyKind},
 };
-use restate_storage_api::service_status_table::ReadOnlyVirtualObjectStatusTable;
-use restate_storage_api::timer_table::{Timer, TimerKey, TimerKeyKind};
-use restate_types::errors::WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR;
-use restate_types::invocation::{
-    AttachInvocationRequest, InvocationQuery, InvocationTarget, PurgeInvocationRequest,
+use restate_types::{
+    errors::WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR,
+    invocation::{
+        AttachInvocationRequest, InvocationQuery, InvocationTarget, PurgeInvocationRequest,
+    },
 };
 use restate_wal_protocol::timer::TimerKeyValue;
-use std::time::Duration;
 use test_log::test;
+
+use super::*;
 
 #[test(tokio::test)]
 async fn start_workflow_method() {

--- a/crates/worker/src/partition/state_machine/utils.rs
+++ b/crates/worker/src/partition/state_machine/utils.rs
@@ -8,10 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tracing::{debug_span, event_enabled, trace_span, Level, Span};
-
 use restate_types::{identifiers::InvocationId, invocation::InvocationTarget};
 use restate_wal_protocol::Command;
+use tracing::{debug_span, event_enabled, trace_span, Level, Span};
 
 pub(super) trait SpanExt {
     fn record_invocation_id(&self, id: &InvocationId);

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -9,8 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::outbox_table::OutboxMessage;
-use restate_types::identifiers::{EntryIndex, InvocationId};
-use restate_types::invocation::{InvocationResponse, ResponseResult};
+use restate_types::{
+    identifiers::{EntryIndex, InvocationId},
+    invocation::{InvocationResponse, ResponseResult},
+};
 use restate_wal_protocol::Command;
 
 pub(crate) type InvokerEffect = restate_invoker_api::Effect;

--- a/crates/worker/src/subscription_controller.rs
+++ b/crates/worker/src/subscription_controller.rs
@@ -10,8 +10,7 @@
 
 use std::future::Future;
 
-use restate_types::identifiers::SubscriptionId;
-use restate_types::schema::subscriptions::Subscription;
+use restate_types::{identifiers::SubscriptionId, schema::subscriptions::Subscription};
 
 use crate::WorkerHandleError;
 

--- a/crates/worker/src/subscription_integration.rs
+++ b/crates/worker/src/subscription_integration.rs
@@ -8,13 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 use restate_ingress_kafka::SubscriptionCommandSender;
-use restate_types::config::IngressOptions;
-use restate_types::identifiers::SubscriptionId;
-use restate_types::schema::subscriptions::{Subscription, SubscriptionValidator};
+use restate_types::{
+    config::IngressOptions,
+    identifiers::SubscriptionId,
+    schema::subscriptions::{Subscription, SubscriptionValidator},
+};
 
 use crate::{SubscriptionController, WorkerHandleError};
 

--- a/justfile
+++ b/justfile
@@ -71,10 +71,10 @@ clean:
     cargo clean
 
 fmt:
-    cargo fmt --all
+    cargo +nightly fmt --all
 
 check-fmt:
-    cargo fmt --all -- --check
+    cargo +nightly fmt --all -- --check
 
 clippy: (_target-installed target)
     cargo clippy {{ _target-option }} --all-targets --workspace -- -D warnings

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ check-fmt:
     cargo +nightly fmt --all -- --check
 
 clippy: (_target-installed target)
-    cargo clippy {{ _target-option }} --all-targets --workspace -- -D warnings
+    cargo +stable clippy {{ _target-option }} --all-targets --workspace -- -D warnings
 
 # Runs all lints (fmt, clippy, deny)
 lint: check-fmt clippy check-deny

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ check-fmt:
     cargo +nightly fmt --all -- --check
 
 clippy: (_target-installed target)
-    cargo +stable clippy {{ _target-option }} --all-targets --workspace -- -D warnings
+    cargo clippy {{ _target-option }} --all-targets --workspace -- -D warnings
 
 # Runs all lints (fmt, clippy, deny)
 lint: check-fmt clippy check-deny

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.80.1"
 profile = "minimal"
-components = ["rustfmt", "clippy"]
+components = ["clippy"]

--- a/server/build.rs
+++ b/server/build.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::error::Error;
+
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -8,30 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::error::Error;
-use std::io::IsTerminal;
-use std::io::Write as _;
-use std::ops::Div;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{
+    error::Error,
+    io::{IsTerminal, Write as _},
+    ops::Div,
+    path::PathBuf,
+    time::Duration,
+};
 
 use clap::Parser;
 use codederror::CodedError;
-use tokio::io;
-use tracing::error;
-use tracing::{info, trace, warn};
-
-use restate_core::TaskCenterBuilder;
-use restate_core::TaskKind;
+use restate_core::{TaskCenterBuilder, TaskKind};
 use restate_errors::fmt::RestateCode;
 use restate_rocksdb::RocksDbManager;
 use restate_server::build_info;
-use restate_tracing_instrumentation::init_tracing_and_logging;
-use restate_tracing_instrumentation::TracingGuard;
-use restate_types::art::render_restate_logo;
-use restate_types::config::CommonOptionCliOverride;
-use restate_types::config::{node_dir, Configuration};
-use restate_types::config_loader::ConfigLoaderBuilder;
+use restate_tracing_instrumentation::{init_tracing_and_logging, TracingGuard};
+use restate_types::{
+    art::render_restate_logo,
+    config::{node_dir, CommonOptionCliOverride, Configuration},
+    config_loader::ConfigLoaderBuilder,
+};
+use tokio::io;
+use tracing::{error, info, trace, warn};
 
 mod signal;
 

--- a/server/src/signal.rs
+++ b/server/src/signal.rs
@@ -10,10 +10,9 @@
 
 use std::io::Write;
 
+use restate_types::config::Configuration;
 use tokio::signal::unix::{signal, SignalKind};
 use tracing::{info, warn};
-
-use restate_types::config::Configuration;
 
 pub(super) async fn shutdown() -> &'static str {
     let signal = tokio::select! {

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -1,5 +1,4 @@
-use std::num::NonZeroU16;
-use std::time::Duration;
+use std::{num::NonZeroU16, time::Duration};
 
 use enumset::enum_set;
 use futures_util::StreamExt;
@@ -8,8 +7,9 @@ use restate_local_cluster_runner::{
     cluster::Cluster,
     node::{BinarySource, Node},
 };
-use restate_types::logs::metadata::ProviderKind;
-use restate_types::{config::Configuration, nodes_config::Role, PlainNodeId};
+use restate_types::{
+    config::Configuration, logs::metadata::ProviderKind, nodes_config::Role, PlainNodeId,
+};
 use test_log::test;
 
 mod common;

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -2,24 +2,26 @@
 use std::{sync::Arc, time::Duration};
 
 use enumset::{enum_set, EnumSet};
-use googletest::internal::test_outcome::TestAssertionFailure;
-use googletest::IntoTestResult;
-
+use googletest::{internal::test_outcome::TestAssertionFailure, IntoTestResult};
 use restate_bifrost::{loglet::Loglet, Bifrost, BifrostAdmin, FindTailAttributes};
-use restate_core::metadata_store::Precondition;
-use restate_core::{metadata_store::MetadataStoreClient, MetadataWriter, TaskCenterBuilder};
+use restate_core::{
+    metadata_store::{MetadataStoreClient, Precondition},
+    MetadataWriter, TaskCenterBuilder,
+};
 use restate_local_cluster_runner::{
     cluster::{Cluster, MaybeTempDir, StartedCluster},
     node::{BinarySource, Node},
 };
 use restate_rocksdb::RocksDbManager;
-use restate_types::logs::builder::LogsBuilder;
-use restate_types::logs::metadata::{Chain, LogletParams, SegmentIndex};
-use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::{
     config::Configuration,
     live::Live,
-    logs::{metadata::ProviderKind, LogId},
+    logs::{
+        builder::LogsBuilder,
+        metadata::{Chain, LogletParams, ProviderKind, SegmentIndex},
+        LogId,
+    },
+    metadata_store::keys::BIFROST_CONFIG_KEY,
     net::{AdvertisedAddress, BindAddress},
     nodes_config::Role,
     replicated_loglet::{ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty},

--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -6,8 +6,6 @@ mod tests {
 
     use googletest::prelude::*;
     use restate_bifrost::loglet::AppendError;
-    use test_log::test;
-
     use restate_types::{
         config::Configuration,
         logs::{Keys, LogletOffset, Record, TailState},
@@ -16,6 +14,7 @@ mod tests {
         time::NanosSinceEpoch,
         GenerationalNodeId,
     };
+    use test_log::test;
 
     use super::common::replicated_loglet::run_in_test_env;
 

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -12,14 +12,15 @@ use std::time::Instant;
 
 use bytes::BytesMut;
 use hdrhistogram::Histogram;
-use tracing::info;
-
 use restate_bifrost::Bifrost;
 use restate_core::TaskCenter;
 use restate_types::logs::{LogId, WithKeys};
+use tracing::info;
 
-use crate::util::{print_latencies, DummyPayload};
-use crate::Arguments;
+use crate::{
+    util::{print_latencies, DummyPayload},
+    Arguments,
+};
 
 const LOG_ID: LogId = LogId::new(0);
 

--- a/tools/bifrost-benchpress/src/lib.rs
+++ b/tools/bifrost-benchpress/src/lib.rs
@@ -12,8 +12,7 @@ use std::path::PathBuf;
 
 use restate_types::config::CommonOptionCliOverride;
 
-use self::append_latency::AppendLatencyOpts;
-use self::write_to_read::WriteToReadOpts;
+use self::{append_latency::AppendLatencyOpts, write_to_read::WriteToReadOpts};
 
 pub mod append_latency;
 pub mod util;

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -10,13 +10,14 @@
 
 use std::time::Duration;
 
+use bifrost_benchpress::{
+    append_latency,
+    util::{print_prometheus_stats, print_rocksdb_stats},
+    write_to_read, Arguments, Command,
+};
 use clap::Parser;
 use codederror::CodedError;
 use metrics_exporter_prometheus::PrometheusBuilder;
-use tracing::trace;
-
-use bifrost_benchpress::util::{print_prometheus_stats, print_rocksdb_stats};
-use bifrost_benchpress::{append_latency, write_to_read, Arguments, Command};
 use restate_bifrost::{Bifrost, BifrostService};
 use restate_core::{
     spawn_metadata_manager, MetadataBuilder, MetadataManager, TaskCenter, TaskCenterBuilder,
@@ -25,16 +26,18 @@ use restate_errors::fmt::RestateCode;
 use restate_metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
 use restate_tracing_instrumentation::init_tracing_and_logging;
-use restate_types::config::{
-    reset_base_temp_dir, reset_base_temp_dir_and_retain, set_base_temp_dir, Configuration,
+use restate_types::{
+    config::{
+        reset_base_temp_dir, reset_base_temp_dir_and_retain, set_base_temp_dir, Configuration,
+    },
+    config_loader::ConfigLoaderBuilder,
+    live::Live,
+    metadata_store::keys::BIFROST_CONFIG_KEY,
 };
-use restate_types::config_loader::ConfigLoaderBuilder;
-use restate_types::live::Live;
-use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
-
 // Configure jemalloc similar to mimic restate server
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
+use tracing::trace;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/tools/bifrost-benchpress/src/util.rs
+++ b/tools/bifrost-benchpress/src/util.rs
@@ -8,8 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::Write;
-use std::time::Duration;
+use std::{io::Write, time::Duration};
 
 use hdrhistogram::Histogram;
 use metrics_exporter_prometheus::PrometheusHandle;

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -14,14 +14,15 @@ use anyhow::Result;
 use bytes::BytesMut;
 use futures::StreamExt;
 use hdrhistogram::Histogram;
-use tracing::info;
-
 use restate_bifrost::Bifrost;
 use restate_core::{TaskCenter, TaskHandle, TaskKind};
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, WithKeys};
+use tracing::info;
 
-use crate::util::{print_latencies, DummyPayload};
-use crate::Arguments;
+use crate::{
+    util::{print_latencies, DummyPayload},
+    Arguments,
+};
 
 const LOG_ID: LogId = LogId::new(0);
 

--- a/tools/restatectl/build.rs
+++ b/tools/restatectl/build.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::error::Error;
+
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -11,17 +11,13 @@
 use std::str::FromStr;
 
 use cling::prelude::*;
-
-use restate_cli_util::CliContext;
-use restate_cli_util::CommonOpts;
+use restate_cli_util::{CliContext, CommonOpts};
 use restate_types::net::AdvertisedAddress;
 
-use crate::commands::cluster::overview::ClusterStatusOpts;
-use crate::commands::log::Logs;
-use crate::commands::metadata::Metadata;
-use crate::commands::node::Nodes;
-use crate::commands::partition::Partitions;
-use crate::commands::snapshot::Snapshot;
+use crate::commands::{
+    cluster::overview::ClusterStatusOpts, log::Logs, metadata::Metadata, node::Nodes,
+    partition::Partitions, snapshot::Snapshot,
+};
 
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]

--- a/tools/restatectl/src/commands/cluster/overview.rs
+++ b/tools/restatectl/src/commands/cluster/overview.rs
@@ -1,12 +1,15 @@
 use clap::Parser;
 use cling::{Collect, Run};
-
 use restate_cli_util::c_println;
 
-use crate::app::ConnectionInfo;
-use crate::commands::log::list_logs::{list_logs, ListLogsOpts};
-use crate::commands::node::list_nodes::{list_nodes, ListNodesOpts};
-use crate::commands::partition::list::{list_partitions, ListPartitionsOpts};
+use crate::{
+    app::ConnectionInfo,
+    commands::{
+        log::list_logs::{list_logs, ListLogsOpts},
+        node::list_nodes::{list_nodes, ListNodesOpts},
+        partition::list::{list_partitions, ListPartitionsOpts},
+    },
+};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "cluster_status")]

--- a/tools/restatectl/src/commands/display_util.rs
+++ b/tools/restatectl/src/commands/display_util.rs
@@ -1,7 +1,10 @@
-use chrono::{DateTime, Local};
-use restate_cli_util::_comfy_table::{Cell, Color};
-use restate_cli_util::ui::{timestamp_as_human_duration, Tense};
 use std::time::SystemTime;
+
+use chrono::{DateTime, Local};
+use restate_cli_util::{
+    _comfy_table::{Cell, Color},
+    ui::{timestamp_as_human_duration, Tense},
+};
 
 pub fn render_as_duration(ts: Option<prost_types::Timestamp>, tense: Tense) -> Cell {
     let ts: Option<SystemTime> = ts

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -12,23 +12,24 @@ use anyhow::Context;
 use cling::prelude::*;
 use itertools::Itertools;
 use log::render_loglet_params;
-
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::{DescribeLogRequest, ListLogsRequest};
-use restate_cli_util::_comfy_table::{Cell, Color, Table};
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::StyledTable;
-use restate_types::logs::metadata::{Chain, Logs, ProviderKind, Segment, SegmentIndex};
-use restate_types::nodes_config::NodesConfiguration;
-use restate_types::replicated_loglet::ReplicatedLogletParams;
-use restate_types::storage::StorageCodec;
-use tonic::codec::CompressionEncoding;
-use tonic::transport::Channel;
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, DescribeLogRequest, ListLogsRequest,
+};
+use restate_cli_util::{
+    _comfy_table::{Cell, Color, Table},
+    c_println,
+    ui::console::StyledTable,
+};
+use restate_types::{
+    logs::metadata::{Chain, Logs, ProviderKind, Segment, SegmentIndex},
+    nodes_config::NodesConfiguration,
+    replicated_loglet::ReplicatedLogletParams,
+    storage::StorageCodec,
+};
+use tonic::{codec::CompressionEncoding, transport::Channel};
 
 use super::LogIdRange;
-use crate::app::ConnectionInfo;
-use crate::commands::log;
-use crate::util::grpc_connect;
+use crate::{app::ConnectionInfo, commands::log, util::grpc_connect};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "describe_logs")]

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -8,25 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::max;
-use std::path::PathBuf;
+use std::{cmp::max, path::PathBuf};
 
 use anyhow::{bail, Context};
 use cling::prelude::*;
 use futures_util::StreamExt;
+use restate_bifrost::{BifrostService, FindTailAttributes};
+use restate_core::{network::MessageRouterBuilder, MetadataBuilder, MetadataManager, TaskKind};
+use restate_rocksdb::RocksDbManager;
+use restate_types::{
+    config::Configuration,
+    live::Live,
+    logs::{KeyFilter, LogId, Lsn, SequenceNumber},
+};
+use restate_wal_protocol::Envelope;
 use tracing::{debug, info};
 
-use restate_bifrost::{BifrostService, FindTailAttributes};
-use restate_core::network::MessageRouterBuilder;
-use restate_core::{MetadataBuilder, MetadataManager, TaskKind};
-use restate_rocksdb::RocksDbManager;
-use restate_types::config::Configuration;
-use restate_types::live::Live;
-use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
-use restate_wal_protocol::Envelope;
-
-use crate::environment::metadata_store;
-use crate::environment::task_center::run_in_task_center;
+use crate::environment::{metadata_store, task_center::run_in_task_center};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/log/find_tail.rs
+++ b/tools/restatectl/src/commands/log/find_tail.rs
@@ -10,18 +10,18 @@
 
 use anyhow::Context;
 use cling::prelude::*;
-use restate_cli_util::_comfy_table::{Cell, Color, Table};
-use restate_cli_util::ui::console::StyledTable;
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, FindTailRequest, TailState,
+};
+use restate_cli_util::{
+    _comfy_table::{Cell, Color, Table},
+    c_println,
+    ui::console::StyledTable,
+};
 use tonic::codec::CompressionEncoding;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::{FindTailRequest, TailState};
-use restate_cli_util::c_println;
-
-use crate::app::ConnectionInfo;
-use crate::util::grpc_connect;
-
 use super::LogIdRange;
+use crate::{app::ConnectionInfo, util::grpc_connect};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "find_tail")]

--- a/tools/restatectl/src/commands/log/gen_metadata.rs
+++ b/tools/restatectl/src/commands/log/gen_metadata.rs
@@ -11,14 +11,15 @@
 use std::num::{NonZeroU32, NonZeroU8};
 
 use cling::prelude::*;
-
-use restate_types::logs::builder::LogsBuilder;
-use restate_types::logs::metadata::{Chain, LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
-use restate_types::replicated_loglet::{
-    NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty,
+use restate_types::{
+    logs::{
+        builder::LogsBuilder,
+        metadata::{Chain, LogletParams, ProviderKind, SegmentIndex},
+        LogId,
+    },
+    replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty},
+    GenerationalNodeId, PlainNodeId,
 };
-use restate_types::{GenerationalNodeId, PlainNodeId};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -12,21 +12,29 @@ use std::collections::BTreeMap;
 
 use anyhow::Context;
 use cling::prelude::*;
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, ListLogsRequest,
+};
+use restate_cli_util::{
+    _comfy_table::{Cell, Table},
+    c_println,
+    ui::console::StyledTable,
+};
+use restate_types::{
+    logs::{
+        metadata::{Chain, Logs},
+        LogId,
+    },
+    storage::StorageCodec,
+    Versioned,
+};
 use tonic::codec::CompressionEncoding;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::ListLogsRequest;
-use restate_cli_util::_comfy_table::{Cell, Table};
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::StyledTable;
-use restate_types::logs::metadata::{Chain, Logs};
-use restate_types::logs::LogId;
-use restate_types::storage::StorageCodec;
-use restate_types::Versioned;
-
-use crate::app::ConnectionInfo;
-use crate::commands::log::{deserialize_replicated_log_params, render_loglet_params};
-use crate::util::grpc_connect;
+use crate::{
+    app::ConnectionInfo,
+    commands::log::{deserialize_replicated_log_params, render_loglet_params},
+    util::grpc_connect,
+};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(visible_alias = "ls")]

--- a/tools/restatectl/src/commands/log/mod.rs
+++ b/tools/restatectl/src/commands/log/mod.rs
@@ -19,12 +19,17 @@ mod trim_log;
 use std::{ops::RangeInclusive, str::FromStr};
 
 use cling::prelude::*;
-
-use restate_cli_util::_comfy_table::{Cell, Color};
-use restate_cli_util::c_println;
-use restate_types::logs::metadata::{ProviderKind, Segment};
-use restate_types::logs::LogId;
-use restate_types::replicated_loglet::ReplicatedLogletParams;
+use restate_cli_util::{
+    _comfy_table::{Cell, Color},
+    c_println,
+};
+use restate_types::{
+    logs::{
+        metadata::{ProviderKind, Segment},
+        LogId,
+    },
+    replicated_loglet::ReplicatedLogletParams,
+};
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Logs {

--- a/tools/restatectl/src/commands/log/reconfigure.rs
+++ b/tools/restatectl/src/commands/log/reconfigure.rs
@@ -12,23 +12,23 @@ use std::num::{NonZeroU32, NonZeroU8};
 
 use anyhow::Context;
 use cling::prelude::*;
-use tonic::codec::CompressionEncoding;
-use tonic::transport::Channel;
-
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::{ListLogsRequest, SealAndExtendChainRequest};
-use restate_cli_util::{c_eprintln, c_println};
-use restate_types::logs::metadata::{Logs, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
-use restate_types::protobuf::common::Version;
-use restate_types::replicated_loglet::{
-    NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty,
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, ListLogsRequest, SealAndExtendChainRequest,
 };
-use restate_types::storage::StorageCodec;
-use restate_types::{GenerationalNodeId, PlainNodeId};
+use restate_cli_util::{c_eprintln, c_println};
+use restate_types::{
+    logs::{
+        metadata::{Logs, ProviderKind, SegmentIndex},
+        LogId,
+    },
+    protobuf::common::Version,
+    replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty},
+    storage::StorageCodec,
+    GenerationalNodeId, PlainNodeId,
+};
+use tonic::{codec::CompressionEncoding, transport::Channel};
 
-use crate::app::ConnectionInfo;
-use crate::util::grpc_connect;
+use crate::{app::ConnectionInfo, util::grpc_connect};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "reconfigure")]

--- a/tools/restatectl/src/commands/log/trim_log.rs
+++ b/tools/restatectl/src/commands/log/trim_log.rs
@@ -10,14 +10,13 @@
 
 use anyhow::Context;
 use cling::prelude::*;
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, TrimLogRequest,
+};
+use restate_cli_util::c_println;
 use tonic::codec::CompressionEncoding;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::TrimLogRequest;
-use restate_cli_util::c_println;
-
-use crate::app::ConnectionInfo;
-use crate::util::grpc_connect;
+use crate::{app::ConnectionInfo, util::grpc_connect};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -11,17 +11,16 @@
 use bytestring::ByteString;
 use clap::Parser;
 use cling::{Collect, Run};
+use restate_rocksdb::RocksDbManager;
+use restate_types::{config::Configuration, live::Live};
 use tracing::debug;
 
-use restate_rocksdb::RocksDbManager;
-use restate_types::config::Configuration;
-use restate_types::live::Live;
-
-use crate::commands::metadata::{
-    create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
+use crate::{
+    commands::metadata::{
+        create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
+    },
+    environment::{metadata_store, task_center::run_in_task_center},
 };
-use crate::environment::metadata_store;
-use crate::environment::task_center::run_in_task_center;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -8,16 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use cling::prelude::*;
-
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_metadata_store::local::create_client;
-use restate_types::config::MetadataStoreClientOptions;
-use restate_types::net::AdvertisedAddress;
-use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
+use restate_types::{
+    config::MetadataStoreClientOptions, flexbuffers_storage_encode_decode, net::AdvertisedAddress,
+    Version, Versioned,
+};
 
 mod get;
 mod patch;

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -12,19 +12,17 @@ use bytestring::ByteString;
 use clap::Parser;
 use cling::{Collect, Run};
 use json_patch::Patch;
-use tracing::debug;
-
 use restate_core::metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
-use restate_types::config::Configuration;
-use restate_types::live::Live;
-use restate_types::Version;
+use restate_types::{config::Configuration, live::Live, Version};
+use tracing::debug;
 
-use crate::commands::metadata::{
-    create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
+use crate::{
+    commands::metadata::{
+        create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
+    },
+    environment::{metadata_store::start_metadata_store, task_center::run_in_task_center},
 };
-use crate::environment::metadata_store::start_metadata_store;
-use crate::environment::task_center::run_in_task_center;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -15,8 +15,10 @@ use clap_stdin::FileOrStdin;
 use cling::{Collect, Run};
 use serde_json::Value;
 
-use crate::commands::metadata::patch::{patch_value, PatchValueOpts};
-use crate::commands::metadata::MetadataCommonOpts;
+use crate::commands::metadata::{
+    patch::{patch_value, PatchValueOpts},
+    MetadataCommonOpts,
+};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/node/list_nodes.rs
+++ b/tools/restatectl/src/commands/node/list_nodes.rs
@@ -8,30 +8,29 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, HashMap};
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 
 use anyhow::Context;
 use chrono::TimeDelta;
 use cling::prelude::*;
 use itertools::Itertools;
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, ListNodesRequest,
+};
+use restate_cli_util::{
+    _comfy_table::{Cell, Table},
+    c_println,
+    ui::{console::StyledTable, duration_to_human_rough, Tense},
+};
+use restate_core::network::protobuf::node_svc::{node_svc_client::NodeSvcClient, IdentResponse};
+use restate_types::{nodes_config::NodesConfiguration, storage::StorageCodec, PlainNodeId};
 use tokio::task::JoinSet;
 use tonic::codec::CompressionEncoding;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::ListNodesRequest;
-use restate_cli_util::_comfy_table::{Cell, Table};
-use restate_cli_util::c_println;
-use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::ui::{duration_to_human_rough, Tense};
-use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::network::protobuf::node_svc::IdentResponse;
-use restate_types::nodes_config::NodesConfiguration;
-use restate_types::storage::StorageCodec;
-use restate_types::PlainNodeId;
-
-use crate::app::ConnectionInfo;
-use crate::util::grpc_connect;
+use crate::{app::ConnectionInfo, util::grpc_connect};
 
 // Default timeout for the [optional] GetIdent call made to all nodes
 const GET_IDENT_TIMEOUT_1S: Duration = Duration::from_secs(1);

--- a/tools/restatectl/src/commands/partition/gen_metadata.rs
+++ b/tools/restatectl/src/commands/partition/gen_metadata.rs
@@ -11,9 +11,7 @@
 use std::num::NonZeroU32;
 
 use cling::prelude::*;
-
-use restate_types::partition_table::PartitionTable;
-use restate_types::Version;
+use restate_types::{partition_table::PartitionTable, Version};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]

--- a/tools/restatectl/src/commands/snapshot/create_snapshot.rs
+++ b/tools/restatectl/src/commands/snapshot/create_snapshot.rs
@@ -10,14 +10,13 @@
 
 use anyhow::Context;
 use cling::prelude::*;
+use restate_admin::cluster_controller::protobuf::{
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, CreatePartitionSnapshotRequest,
+};
+use restate_cli_util::c_println;
 use tonic::codec::CompressionEncoding;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::CreatePartitionSnapshotRequest;
-use restate_cli_util::c_println;
-
-use crate::app::ConnectionInfo;
-use crate::util::grpc_connect;
+use crate::{app::ConnectionInfo, util::grpc_connect};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(visible_alias = "create")]

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -8,15 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tracing::info;
-
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_core::{TaskCenter, TaskKind};
+use restate_core::{metadata_store::MetadataStoreClient, TaskCenter, TaskKind};
 use restate_metadata_store::local::LocalMetadataStoreService;
-use restate_types::config::{MetadataStoreClientOptions, MetadataStoreOptions, RocksDbOptions};
-use restate_types::health::HealthStatus;
-use restate_types::live::BoxedLiveLoad;
-use restate_types::protobuf::common::MetadataServerStatus;
+use restate_types::{
+    config::{MetadataStoreClientOptions, MetadataStoreOptions, RocksDbOptions},
+    health::HealthStatus,
+    live::BoxedLiveLoad,
+    protobuf::common::MetadataServerStatus,
+};
+use tracing::info;
 
 pub async fn start_metadata_store(
     metadata_store_client_options: MetadataStoreClientOptions,

--- a/tools/restatectl/src/environment/task_center.rs
+++ b/tools/restatectl/src/environment/task_center.rs
@@ -8,15 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::future::Future;
-use std::path::PathBuf;
-
-use tracing::warn;
+use std::{future::Future, path::PathBuf};
 
 use restate_core::{TaskCenter, TaskCenterBuilder};
-use restate_types::config::Configuration;
-use restate_types::config_loader::ConfigLoaderBuilder;
-use restate_types::live::Pinned;
+use restate_types::{config::Configuration, config_loader::ConfigLoaderBuilder, live::Pinned};
+use tracing::warn;
 
 /// Loads configuration, creates a task center, executes the supplied function body in scope of TC, and shuts down.
 pub async fn run_in_task_center<F, O>(config_file: Option<&PathBuf>, fn_body: F) -> O::Output

--- a/tools/restatectl/src/main.rs
+++ b/tools/restatectl/src/main.rs
@@ -8,9 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use cling::prelude::*;
 use std::io::Write;
 
+use cling::prelude::*;
 use crossterm::execute;
 use restatectl::CliApp;
 

--- a/tools/restatectl/src/util.rs
+++ b/tools/restatectl/src/util.rs
@@ -11,8 +11,7 @@
 use hyper_util::rt::TokioIo;
 use restate_cli_util::CliContext;
 use restate_types::net::AdvertisedAddress;
-use tokio::io;
-use tokio::net::UnixStream;
+use tokio::{io, net::UnixStream};
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 

--- a/tools/service-protocol-wireshark-dissector/src/lib.rs
+++ b/tools/service-protocol-wireshark-dissector/src/lib.rs
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use bytes::Bytes;
-use mlua::prelude::*;
-use mlua::{Table, Value};
-
-use restate_service_protocol::codec::ProtobufRawEntryCodec;
-use restate_service_protocol::message::{Decoder, MessageType, ProtocolMessage};
+use mlua::{prelude::*, Table, Value};
+use restate_service_protocol::{
+    codec::ProtobufRawEntryCodec,
+    message::{Decoder, MessageType, ProtocolMessage},
+};
 use restate_types::service_protocol::ServiceProtocolVersion;
 
 #[derive(Debug, thiserror::Error)]

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -8,34 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::Write;
-use std::time::Duration;
-use std::{env, io};
+use std::{env, io, io::Write, time::Duration};
 
 use anyhow::bail;
 use reqwest::header::ACCEPT;
-use schemars::gen::SchemaSettings;
-use tonic::transport::{Channel, Uri};
-
 use restate_admin::service::AdminService;
 use restate_bifrost::Bifrost;
-use restate_core::network::protobuf::node_svc::node_svc_client::NodeSvcClient;
-use restate_core::TaskKind;
-use restate_core::TestCoreEnv;
+use restate_core::{
+    network::protobuf::node_svc::node_svc_client::NodeSvcClient, TaskKind, TestCoreEnv,
+};
 use restate_service_client::{AssumeRoleCacheMode, ServiceClient};
 use restate_service_protocol::discovery::ServiceDiscovery;
 use restate_storage_query_datafusion::table_docs;
-use restate_types::config::Configuration;
-use restate_types::identifiers::SubscriptionId;
-use restate_types::invocation::InvocationTermination;
-use restate_types::live::Constant;
-use restate_types::retries::RetryPolicy;
-use restate_types::schema::subscriptions::Subscription;
-use restate_types::schema::subscriptions::SubscriptionValidator;
-use restate_types::state_mut::ExternalStateMutation;
-use restate_worker::SubscriptionController;
-use restate_worker::WorkerHandle;
-use restate_worker::WorkerHandleError;
+use restate_types::{
+    config::Configuration,
+    identifiers::SubscriptionId,
+    invocation::InvocationTermination,
+    live::Constant,
+    retries::RetryPolicy,
+    schema::subscriptions::{Subscription, SubscriptionValidator},
+    state_mut::ExternalStateMutation,
+};
+use restate_worker::{SubscriptionController, WorkerHandle, WorkerHandleError};
+use schemars::gen::SchemaSettings;
+use tonic::transport::{Channel, Uri};
 
 fn generate_config_schema() -> anyhow::Result<()> {
     let schema = SchemaSettings::draft2019_09()


### PR DESCRIPTION
This change reformats our codebase using the nightly-only rustfmt options:

```toml
group_imports = "StdExternalCrate"
imports_granularity = "Crate"
```