### PR TITLE
Enable Restate runtime to trace across processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5610,6 +5610,7 @@ dependencies = [
  "hyper-util",
  "metrics",
  "once_cell",
+ "opentelemetry",
  "parking_lot",
  "pin-project",
  "prost",
@@ -5631,6 +5632,7 @@ dependencies = [
  "tonic-build",
  "tower",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,6 +33,7 @@ humantime = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 metrics = { workspace = true }
+opentelemetry = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }
@@ -56,6 +57,7 @@ tonic = { workspace = true, features = [
 ] }
 tower = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/types/protobuf/restate/node.proto
+++ b/crates/types/protobuf/restate/node.proto
@@ -31,7 +31,10 @@ message Header {
   /// the message producer to ensure that the response is sent to the original
   /// producer (generational node id).
   optional uint64 in_response_to = 6;
+  optional SpanContext span_context = 7;
 }
+
+message SpanContext { map<string, string> fields = 1; }
 
 // First message sent to an ingress after starting the connection. The message
 // must be sent before any other message.


### PR DESCRIPTION
Enable Restate runtime to trace across processes

Summary:
Handle propagation of span context across nodes

Fixes #2155

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2167).
* #2168
* __->__ #2167