### PR TITLE
LogServer observability gRPC service stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6323,6 +6323,7 @@ name = "restate-log-server"
 version = "1.1.3"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitflags 2.6.0",
  "bytes",
  "chrono",
@@ -6333,6 +6334,9 @@ dependencies = [
  "googletest",
  "metrics",
  "pin-project",
+ "prost",
+ "prost-dto",
+ "prost-types",
  "restate-bifrost",
  "restate-core",
  "restate-metadata-store",
@@ -6351,6 +6355,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tonic",
+ "tonic-build",
  "tracing",
  "tracing-subscriber",
  "tracing-test",

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -306,6 +306,7 @@ mod tests {
     use googletest::prelude::*;
     use test_log::test;
 
+    use restate_core::network::NetworkServerBuilder;
     use restate_core::TestCoreEnvBuilder;
     use restate_log_server::LogServerService;
     use restate_rocksdb::RocksDbManager;
@@ -335,6 +336,7 @@ mod tests {
 
         let mut node_env =
             TestCoreEnvBuilder::with_incoming_only_connector().add_mock_nodes_config();
+        let mut server_builder = NetworkServerBuilder::default();
 
         let logserver_rpc = LogServersRpc::new(&mut node_env.router_builder);
         let sequencer_rpc = SequencersRpc::new(&mut node_env.router_builder);
@@ -360,7 +362,7 @@ mod tests {
                 RocksDbManager::init(config.clone().map(|c| &c.common));
 
                 log_server
-                    .start(node_env.metadata_writer.clone())
+                    .start(node_env.metadata_writer.clone(), &mut server_builder)
                     .await
                     .into_test_result()?;
 

--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [features]
 default = []
+clients = []
 test-util = []
 
 [dependencies]
@@ -19,6 +20,7 @@ restate-rocksdb = { workspace = true }
 restate-types = { workspace = true, features = ["replicated-loglet"] }
 
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -34,13 +36,19 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 smallvec = { workspace = true }
 static_assertions = { workspace = true }
+prost = { workspace = true }
+prost-dto = { workspace = true }
+prost-types = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
+tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip"] }
 tracing = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
+[build-dependencies]
+tonic-build = { workspace = true }
 
 [dev-dependencies]
 restate-bifrost = { workspace = true, features = ["test-util"] }

--- a/crates/log-server/build.rs
+++ b/crates/log-server/build.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    tonic_build::configure()
+        .bytes(["."])
+        .file_descriptor_set_path(out_dir.join("log_server_svc_descriptor.bin"))
+        .client_mod_attribute("log_server", "#[cfg(feature = \"clients\")]")
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .extern_path(".restate.common", "::restate_types::protobuf::common")
+        .extern_path(".restate.cluster", "::restate_types::protobuf::cluster")
+        .compile_protos(
+            &["./protobuf/log_server_svc.proto"],
+            &["protobuf", "../types/protobuf"],
+        )?;
+
+    Ok(())
+}

--- a/crates/log-server/protobuf/log_server_svc.proto
+++ b/crates/log-server/protobuf/log_server_svc.proto
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "restate/common.proto";
+import "restate/node.proto";
+
+package restate.log_server;
+
+service LogServerSvc {
+  rpc GetDigest(GetDigestRequest) returns (GetDigestResponse);
+  rpc GetLogletInfo(GetLogletInfoRequest) returns (GetLogletInfoResponse);
+}
+
+message GetDigestRequest {
+  uint32 loglet_id = 1;
+  // inclusive
+  uint32 from_offset = 2;
+  // inclusive
+  uint32 to_offset = 3;
+}
+message GetDigestResponse {}
+
+message GetLogletInfoRequest { uint32 loglet_id = 1; }
+message GetLogletInfoResponse {}

--- a/crates/log-server/src/grpc_svc_handler.rs
+++ b/crates/log-server/src/grpc_svc_handler.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+use async_trait::async_trait;
+use tonic::{Request, Response, Status};
+
+use restate_types::logs::RecordCache;
+
+use crate::logstore::LogStore;
+use crate::protobuf::log_server_svc_server::LogServerSvc;
+use crate::protobuf::{
+    GetDigestRequest, GetDigestResponse, GetLogletInfoRequest, GetLogletInfoResponse,
+};
+
+pub struct LogServerSvcHandler<S> {
+    _log_store: S,
+    _record_cache: RecordCache,
+}
+
+impl<S> LogServerSvcHandler<S>
+where
+    S: LogStore + Clone + Sync + Send + 'static,
+{
+    pub fn new(_log_store: S, _record_cache: RecordCache) -> Self {
+        Self {
+            _log_store,
+            _record_cache,
+        }
+    }
+}
+
+#[async_trait]
+impl<S> LogServerSvc for LogServerSvcHandler<S>
+where
+    S: LogStore + Clone + Sync + Send + 'static,
+{
+    async fn get_digest(
+        &self,
+        _request: Request<GetDigestRequest>,
+    ) -> Result<Response<GetDigestResponse>, Status> {
+        todo!()
+    }
+
+    async fn get_loglet_info(
+        &self,
+        _request: Request<GetLogletInfoRequest>,
+    ) -> Result<Response<GetLogletInfoResponse>, Status> {
+        todo!()
+    }
+}

--- a/crates/log-server/src/lib.rs
+++ b/crates/log-server/src/lib.rs
@@ -9,11 +9,13 @@
 // by the Apache License, Version 2.0.
 
 mod error;
+mod grpc_svc_handler;
 mod loglet_worker;
 mod logstore;
 mod metadata;
 mod metric_definitions;
 mod network;
+pub mod protobuf;
 mod rocksdb_logstore;
 mod service;
 

--- a/crates/log-server/src/protobuf.rs
+++ b/crates/log-server/src/protobuf.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+tonic::include_proto!("restate.log_server");
+
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    tonic::include_file_descriptor_set!("log_server_svc_descriptor");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -280,7 +280,7 @@ impl Node {
         })
     }
 
-    pub async fn start(self) -> Result<(), anyhow::Error> {
+    pub async fn start(mut self) -> Result<(), anyhow::Error> {
         let tc = task_center();
 
         let config = self.updateable_config.pinned();
@@ -392,12 +392,9 @@ impl Node {
 
         #[cfg(feature = "replicated-loglet")]
         if let Some(log_server) = self.log_server {
-            tc.spawn(
-                TaskKind::SystemBoot,
-                "log-server-init",
-                None,
-                log_server.start(metadata_writer),
-            )?;
+            log_server
+                .start(metadata_writer, &mut self.server_builder)
+                .await?;
         }
 
         if let Some(admin_role) = self.admin_role {


### PR DESCRIPTION

This introduces as new gRPC service stub for logservers, the service interface is only a stub at the moment, future PRs will include the implementation and the concrete message formats.

LogServerSvc is registered as expected. This doesn't have access to the request pump at the moment. I expect us to create a channel between the grpc handler and RequestPumb to request access to LogletWorkers and such.
```console
2024-10-24T15:57:07.926744Z DEBUG restate_core::network::server_builder
  Registering gRPC service to node-rpc-server
    svc: "restate.log_server.LogServerSvc"
```
