### PR TITLE
[Local Cluster Example] Await shutdown signal concurrently with startup

### DIFF
--- a/crates/local-cluster-runner/examples/three_nodes_and_metadata.rs
+++ b/crates/local-cluster-runner/examples/three_nodes_and_metadata.rs
@@ -24,7 +24,7 @@ async fn main() {
     let mut base_config = Configuration::default();
     base_config.common.log_format = LogFormat::Compact;
     base_config.common.log_filter = "warn,restate=debug".to_string();
-    base_config.common.bootstrap_num_partitions = NonZeroU16::new(2).unwrap();
+    base_config.common.bootstrap_num_partitions = NonZeroU16::new(4).unwrap();
     base_config.bifrost.default_provider = Replicated;
 
     let nodes = Node::new_test_nodes_with_metadata(
@@ -43,23 +43,24 @@ async fn main() {
     let shutdown_fut = shutdown();
 
     let mut cluster = cluster.start().await.unwrap();
+    let mut admin_output = cluster.nodes[0].lines(Regex::new("Server listening").unwrap());
 
-    match cluster.nodes[0]
-        .lines(Regex::new("Server listening").unwrap())
-        .next()
-        .await
-    {
-        None => {
-            error!("metadata node exited early");
-            std::process::exit(1)
+    tokio::select! {
+        _ = shutdown_fut => {}
+
+        line = admin_output.next() => match line
+        {
+            None => {
+                error!("metadata node exited early");
+                std::process::exit(1)
+            }
+            Some(line) => {
+                info!("matched metadata logline: {line}")
+            }
         }
-        Some(line) => {
-            info!("matched metadata logline: {line}")
-        }
-    };
+    }
 
-    shutdown_fut.await;
-
+    drop(admin_output);
     cluster
         .graceful_shutdown(Duration::from_secs(5))
         .await

--- a/crates/local-cluster-runner/src/lib.rs
+++ b/crates/local-cluster-runner/src/lib.rs
@@ -39,7 +39,7 @@ pub fn shutdown() -> impl Future<Output = &'static str> {
 }
 
 pub fn random_socket_address() -> io::Result<SocketAddr> {
-    let base_path = std::env::var_os(RESTATE_TEST_PORTS_POOL_DIR)
+    let base_path = env::var_os(RESTATE_TEST_PORTS_POOL_DIR)
         .map(PathBuf::from)
         .unwrap_or_else(|| env::temp_dir().join(DEFAULTS_PORTS_POOL));
 

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -27,7 +27,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio::{process::Command, sync::mpsc::Sender};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use typed_builder::TypedBuilder;
 
 use restate_types::{
@@ -78,7 +78,7 @@ pub struct Node {
             pub fn with_roles(self, roles: EnumSet<Role>) {
                 self.base_config.common.roles = roles
             }
-        ))]
+    ))]
     base_config: Configuration,
     binary_source: BinarySource,
     #[builder(default)]
@@ -506,7 +506,10 @@ impl StartedNode {
                     nix::sys::signal::SIGKILL,
                 ) {
                     Ok(()) => (&mut self.status).await,
-                    Err(errno) => Err(io::Error::from_raw_os_error(errno as i32)),
+                    Err(errno) => match errno {
+                        nix::errno::Errno::ESRCH => Ok(ExitStatus::default()), // ignore "no such process"
+                        _ => Err(io::Error::from_raw_os_error(errno as i32)),
+                    },
                 }
             }
         }
@@ -523,11 +526,23 @@ impl StartedNode {
                     self.config.node_name(),
                     pid
                 );
-                nix::sys::signal::kill(
+                match nix::sys::signal::kill(
                     nix::unistd::Pid::from_raw(pid.try_into().unwrap()),
                     nix::sys::signal::SIGTERM,
-                )
-                .map_err(|errno| io::Error::from_raw_os_error(errno as i32))
+                ) {
+                    Ok(()) => Ok(()),
+                    Err(errno) => match errno {
+                        nix::errno::Errno::ESRCH => {
+                            warn!(
+                                "Node {} (pid {}) did not exist when sending SIGTERM",
+                                self.config.node_name(),
+                                pid
+                            );
+                            Ok(())
+                        }
+                        _ => Err(io::Error::from_raw_os_error(errno as i32)),
+                    },
+                }
             }
         }
     }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -530,18 +530,16 @@ impl StartedNode {
                     nix::unistd::Pid::from_raw(pid.try_into().unwrap()),
                     nix::sys::signal::SIGTERM,
                 ) {
-                    Ok(()) => Ok(()),
-                    Err(errno) => match errno {
-                        nix::errno::Errno::ESRCH => {
-                            warn!(
-                                "Node {} (pid {}) did not exist when sending SIGTERM",
-                                self.config.node_name(),
-                                pid
-                            );
-                            Ok(())
-                        }
-                        _ => Err(io::Error::from_raw_os_error(errno as i32)),
-                    },
+                    Err(nix::errno::Errno::ESRCH) => {
+                        warn!(
+                            "Node {} server process (pid {}) did not exist when sending SIGTERM",
+                            self.config.node_name(),
+                            pid
+                        );
+                        Ok(())
+                    }
+                    Err(errno) => Err(io::Error::from_raw_os_error(errno as i32)),
+                    _ => Ok(()),
                 }
             }
         }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -159,7 +159,7 @@ impl Node {
             let mut base_config = base_config.clone();
             // let any node write the initial NodesConfiguration
             base_config.common.allow_bootstrap = true;
-            base_config.common.force_node_id = Some(PlainNodeId::new(1));
+            base_config.common.force_node_id = Some(PlainNodeId::new(0));
             nodes.push(Self::new_test_node(
                 "metadata-node",
                 base_config,
@@ -170,7 +170,7 @@ impl Node {
 
         for node in 1..=size {
             let mut base_config = base_config.clone();
-            base_config.common.force_node_id = Some(PlainNodeId::new(node + 1));
+            base_config.common.force_node_id = Some(PlainNodeId::new(node));
             nodes.push(Self::new_test_node(
                 format!("node-{node}"),
                 base_config,
@@ -516,7 +516,7 @@ impl StartedNode {
     pub fn terminate(&self) -> io::Result<()> {
         match self.status {
             StartedNodeStatus::Exited(_) => Ok(()),
-            StartedNodeStatus::Failed(kind) => Err((kind).into()),
+            StartedNodeStatus::Failed(kind) => Err(kind.into()),
             StartedNodeStatus::Running { pid, .. } => {
                 info!(
                     "Sending SIGTERM to node {} (pid {})",
@@ -842,7 +842,7 @@ impl Searcher {
     }
 
     fn search(&self, regex: Regex) -> impl Stream<Item = String> + 'static {
-        let (sender, receiver) = mpsc::channel(1);
+        let (sender, receiver) = mpsc::channel(1000);
         let sender = Arc::new(sender);
         let sender_ptr = Arc::as_ptr(&sender);
         self.inner.rcu(|inner| {

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -857,7 +857,7 @@ impl Searcher {
     }
 
     fn search(&self, regex: Regex) -> impl Stream<Item = String> + 'static {
-        let (sender, receiver) = mpsc::channel(1000);
+        let (sender, receiver) = mpsc::channel(1);
         let sender = Arc::new(sender);
         let sender_ptr = Arc::as_ptr(&sender);
         self.inner.rcu(|inner| {


### PR DESCRIPTION
This fixes an issue where no log lines matching the metadata sever output prevents the
 signal handler from being awaited, blocking clean shutdown.
 
I also made the node naming 0-based so that we don't have confusing mismatches like `N0` actually being `node-1`.

Finally, this PR fixes a problem where the test runner would panic and leave _other_ server processes running, if one of the PIDs is already terminated by the time it tries to shut down. This could also also have occurred under a race condition where if SIGTERM was sent, timeout expires, but the server process exited on its own just before we could send it SIGKILL.

Testing:

```

# Admin node is killed externally (could also happen if it prints out ready status, and the admin server later panics)
> cargo run --example three_nodes_and_metadata -- --nocapture
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.64s
     Running `target/debug/examples/three_nodes_and_metadata --nocapture`
2024-10-28T10:40:37.010688Z  INFO restate_local_cluster_runner::cluster: Starting cluster test-cluster in /Users/pavel/restate/restate/restate-data
2024-10-28T10:40:37.014356Z  INFO restate_local_cluster_runner::node: Started node metadata-node in /Users/pavel/restate/restate/restate-data/metadata-node (pid 35734)
2024-10-28T10:40:37.279388Z  INFO restate_local_cluster_runner::node: Node metadata-node admin check is healthy after 2 attempts
2024-10-28T10:40:37.280864Z  INFO restate_local_cluster_runner::node: Started node node-1 in /Users/pavel/restate/restate/restate-data/node-1 (pid 35735)
2024-10-28T10:40:37.282128Z  INFO restate_local_cluster_runner::node: Started node node-2 in /Users/pavel/restate/restate/restate-data/node-2 (pid 35736)
2024-10-28T10:40:37.283317Z  INFO restate_local_cluster_runner::node: Started node node-3 in /Users/pavel/restate/restate/restate-data/node-3 (pid 35737)
2024-10-28T10:40:37.283881Z  INFO three_nodes_and_metadata: admin node ready: 2024-10-28T10:40:37.224665Z  INFO restate_node: Restate server is ready
2024-10-28T10:40:43.450347Z ERROR three_nodes_and_metadata: admin node exited
2024-10-28T10:40:43.450372Z  INFO three_nodes_and_metadata: cluster shutting down
2024-10-28T10:40:43.450378Z  INFO restate_local_cluster_runner::node: Node metadata-node exited with exit status: 0
2024-10-28T10:40:43.450393Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node metadata-node (pid 35734)
2024-10-28T10:40:43.450405Z  WARN restate_local_cluster_runner::node: Node metadata-node (pid 35734) did not exist when sending SIGTERM
2024-10-28T10:40:43.450420Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-1 (pid 35735)
2024-10-28T10:40:43.450450Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-2 (pid 35736)
2024-10-28T10:40:43.450509Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-3 (pid 35737)
2024-10-28T10:40:43.490788Z  INFO restate_local_cluster_runner::node: Node node-3 exited with exit status: 0
2024-10-28T10:40:43.491323Z  INFO restate_local_cluster_runner::node: Node node-2 exited with exit status: 0
2024-10-28T10:40:43.491448Z  INFO restate_local_cluster_runner::node: Node node-1 exited with exit status: 0

# Cluster stops normally on Ctrl+C both before and after admin node ready condition
> cargo run --example three_nodes_and_metadata -- --nocapture
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.63s
     Running `target/debug/examples/three_nodes_and_metadata --nocapture`
2024-10-28T10:40:48.255953Z  INFO restate_local_cluster_runner::cluster: Starting cluster test-cluster in /Users/pavel/restate/restate/restate-data
2024-10-28T10:40:48.259756Z  INFO restate_local_cluster_runner::node: Started node metadata-node in /Users/pavel/restate/restate/restate-data/metadata-node (pid 35760)
2024-10-28T10:40:48.526029Z  INFO restate_local_cluster_runner::node: Node metadata-node admin check is healthy after 2 attempts
2024-10-28T10:40:48.527452Z  INFO restate_local_cluster_runner::node: Started node node-1 in /Users/pavel/restate/restate/restate-data/node-1 (pid 35761)
2024-10-28T10:40:48.528464Z  INFO restate_local_cluster_runner::node: Started node node-2 in /Users/pavel/restate/restate/restate-data/node-2 (pid 35762)
2024-10-28T10:40:48.529522Z  INFO restate_local_cluster_runner::node: Started node node-3 in /Users/pavel/restate/restate/restate-data/node-3 (pid 35763)
2024-10-28T10:40:48.530022Z  INFO three_nodes_and_metadata: admin node ready: 2024-10-28T10:40:48.476172Z  INFO restate_node: Restate server is ready
^C2024-10-28T10:40:50.793767Z  INFO restate_local_cluster_runner: Received signal, starting cluster shutdown. signal=SIGINT
2024-10-28T10:40:50.793889Z  INFO three_nodes_and_metadata: cluster shutting down
2024-10-28T10:40:50.793965Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node metadata-node (pid 35760)
2024-10-28T10:40:50.794047Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-1 (pid 35761)
2024-10-28T10:40:50.794080Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-2 (pid 35762)
2024-10-28T10:40:50.794201Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-3 (pid 35763)
2024-10-28T10:40:50.807466Z  INFO restate_local_cluster_runner::node: Node metadata-node exited with exit status: 0
2024-10-28T10:40:55.795416Z  INFO restate_local_cluster_runner::node: Graceful shutdown deadline exceeded for node node-1
2024-10-28T10:40:55.795568Z  INFO restate_local_cluster_runner::node: Sending SIGKILL to node node-1 (pid 35761)
2024-10-28T10:40:55.795687Z  INFO restate_local_cluster_runner::node: Graceful shutdown deadline exceeded for node node-2
2024-10-28T10:40:55.795717Z  INFO restate_local_cluster_runner::node: Sending SIGKILL to node node-2 (pid 35762)
2024-10-28T10:40:55.795776Z  INFO restate_local_cluster_runner::node: Graceful shutdown deadline exceeded for node node-3
2024-10-28T10:40:55.795807Z  INFO restate_local_cluster_runner::node: Sending SIGKILL to node node-3 (pid 35763)
2024-10-28T10:40:55.829029Z  INFO restate_local_cluster_runner::node: Node node-2 exited with signal: 9 (SIGKILL)
2024-10-28T10:40:55.829264Z  INFO restate_local_cluster_runner::node: Node node-1 exited with signal: 9 (SIGKILL)
2024-10-28T10:40:55.832371Z  INFO restate_local_cluster_runner::node: Node node-3 exited with signal: 9 (SIGKILL)

# Admin node ready pattern never shows up, timeout waiting for it
> cargo run --example three_nodes_and_metadata -- --nocapture
   Compiling restate-local-cluster-runner v1.1.3 (/Users/pavel/restate/restate/crates/local-cluster-runner)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.28s
     Running `target/debug/examples/three_nodes_and_metadata --nocapture`
2024-10-28T10:41:08.755027Z  INFO restate_local_cluster_runner::cluster: Starting cluster test-cluster in /Users/pavel/restate/restate/restate-data
2024-10-28T10:41:08.757340Z  INFO restate_local_cluster_runner::node: Started node metadata-node in /Users/pavel/restate/restate/restate-data/metadata-node (pid 35794)
2024-10-28T10:41:09.278262Z  INFO restate_local_cluster_runner::node: Node metadata-node admin check is healthy after 3 attempts
2024-10-28T10:41:09.280842Z  INFO restate_local_cluster_runner::node: Started node node-1 in /Users/pavel/restate/restate/restate-data/node-1 (pid 35795)
2024-10-28T10:41:09.282382Z  INFO restate_local_cluster_runner::node: Started node node-2 in /Users/pavel/restate/restate/restate-data/node-2 (pid 35796)
2024-10-28T10:41:09.284029Z  INFO restate_local_cluster_runner::node: Started node node-3 in /Users/pavel/restate/restate/restate-data/node-3 (pid 35797)
2024-10-28T10:41:13.757011Z ERROR three_nodes_and_metadata: timeout waiting for admin node to start up
2024-10-28T10:41:13.757032Z  INFO three_nodes_and_metadata: cluster shutting down
2024-10-28T10:41:13.757049Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node metadata-node (pid 35794)
2024-10-28T10:41:13.757075Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-1 (pid 35795)
2024-10-28T10:41:13.757090Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-2 (pid 35796)
2024-10-28T10:41:13.757109Z  INFO restate_local_cluster_runner::node: Sending SIGTERM to node node-3 (pid 35797)
2024-10-28T10:41:13.767535Z  INFO restate_local_cluster_runner::node: Node metadata-node exited with exit status: 0
2024-10-28T10:41:13.958453Z  INFO restate_local_cluster_runner::node: Node node-1 exited with exit status: 0
2024-10-28T10:41:13.964841Z  INFO restate_local_cluster_runner::node: Node node-2 exited with exit status: 0
2024-10-28T10:41:13.964896Z  INFO restate_local_cluster_runner::node: Node node-3 exited with exit status: 0
```