### PR TITLE
Decouple the QueryContext from a hard dependency on the PartitionStoreManager

### DIFF
--- a/crates/core/src/worker_api/partition_processor_manager.rs
+++ b/crates/core/src/worker_api/partition_processor_manager.rs
@@ -21,7 +21,6 @@ use crate::ShutdownError;
 
 #[derive(Debug)]
 pub enum ProcessorsManagerCommand {
-    GetLivePartitions(oneshot::Sender<Vec<PartitionId>>),
     CreateSnapshot(PartitionId, oneshot::Sender<anyhow::Result<SnapshotId>>),
     GetState(oneshot::Sender<BTreeMap<PartitionId, PartitionProcessorStatus>>),
 }
@@ -32,15 +31,6 @@ pub struct ProcessorsManagerHandle(mpsc::Sender<ProcessorsManagerCommand>);
 impl ProcessorsManagerHandle {
     pub fn new(sender: mpsc::Sender<ProcessorsManagerCommand>) -> Self {
         Self(sender)
-    }
-
-    pub async fn get_live_partitions(&self) -> Result<Vec<PartitionId>, ShutdownError> {
-        let (tx, rx) = oneshot::channel();
-        self.0
-            .send(ProcessorsManagerCommand::GetLivePartitions(tx))
-            .await
-            .unwrap();
-        rx.await.map_err(|_| ShutdownError)
     }
 
     pub async fn create_snapshot(&self, partition_id: PartitionId) -> anyhow::Result<SnapshotId> {

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -22,19 +22,21 @@ use super::row::append_idempotency_row;
 use super::schema::SysIdempotencyBuilder;
 use crate::context::{QueryContext, SelectPartitions};
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
 const NAME: &str = "sys_idempotency";
 
 pub(crate) fn register_self(
     ctx: &QueryContext,
     partition_selector: impl SelectPartitions,
-    partition_store_manager: PartitionStoreManager,
+    local_partition_store_manager: Option<PartitionStoreManager>,
 ) -> datafusion::common::Result<()> {
-    let local_scanner = Arc::new(LocalPartitionsScanner::new(
-        partition_store_manager,
-        IdempotencyScanner,
-    ));
+    let local_scanner = local_partition_store_manager.map(|partition_store_manager| {
+        Arc::new(LocalPartitionsScanner::new(
+            partition_store_manager,
+            IdempotencyScanner,
+        )) as Arc<dyn ScanPartition>
+    });
     let table = PartitionedTableProvider::new(
         partition_selector,
         SysIdempotencyBuilder::schema(),

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -21,19 +21,21 @@ use crate::context::{QueryContext, SelectPartitions};
 use crate::journal::row::append_journal_row;
 use crate::journal::schema::SysJournalBuilder;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
 const NAME: &str = "sys_journal";
 
 pub(crate) fn register_self(
     ctx: &QueryContext,
     partition_selector: impl SelectPartitions,
-    partition_store_manager: PartitionStoreManager,
+    local_partition_store_manager: Option<PartitionStoreManager>,
 ) -> datafusion::common::Result<()> {
-    let local_scanner = Arc::new(LocalPartitionsScanner::new(
-        partition_store_manager,
-        JournalScanner,
-    ));
+    let local_scanner = local_partition_store_manager.map(|partition_store_manager| {
+        Arc::new(LocalPartitionsScanner::new(
+            partition_store_manager,
+            JournalScanner,
+        )) as Arc<dyn ScanPartition>
+    });
     let journal_table = PartitionedTableProvider::new(
         partition_selector,
         SysJournalBuilder::schema(),

--- a/crates/storage-query-datafusion/src/keyed_service_status/table.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/table.rs
@@ -24,18 +24,20 @@ use crate::context::{QueryContext, SelectPartitions};
 use crate::keyed_service_status::row::append_virtual_object_status_row;
 use crate::keyed_service_status::schema::SysKeyedServiceStatusBuilder;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 const NAME: &str = "sys_keyed_service_status";
 
 pub(crate) fn register_self(
     ctx: &QueryContext,
     partition_selector: impl SelectPartitions,
-    partition_store_manager: PartitionStoreManager,
+    local_partition_store_manager: Option<PartitionStoreManager>,
 ) -> datafusion::common::Result<()> {
-    let local_scanner = Arc::new(LocalPartitionsScanner::new(
-        partition_store_manager,
-        VirtualObjectStatusScanner,
-    ));
+    let local_scanner = local_partition_store_manager.map(|partition_store_manager| {
+        Arc::new(LocalPartitionsScanner::new(
+            partition_store_manager,
+            VirtualObjectStatusScanner,
+        )) as Arc<dyn ScanPartition>
+    });
 
     let status_table = PartitionedTableProvider::new(
         partition_selector,

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -41,6 +41,7 @@ use datafusion::error::DataFusionError;
 #[cfg(test)]
 pub(crate) mod mocks;
 
+mod remote_invoker_status_handle;
 pub mod remote_query_scanner_client;
 mod remote_query_scanner_manager;
 #[cfg(test)]

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -169,7 +169,7 @@ impl MockQueryEngine {
             QueryContext::create(
                 &QueryEngineOptions::default(),
                 MockPartitionSelector,
-                manager,
+                Some(manager),
                 status,
                 Live::from_value(schemas),
                 Arc::new(NoopSvc),

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -22,19 +22,21 @@ use super::row::append_promise_row;
 use super::schema::SysPromiseBuilder;
 use crate::context::{QueryContext, SelectPartitions};
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
-use crate::table_providers::PartitionedTableProvider;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
 const NAME: &str = "sys_promise";
 
 pub(crate) fn register_self(
     ctx: &QueryContext,
     partition_selector: impl SelectPartitions,
-    partition_store_manager: PartitionStoreManager,
+    local_partition_store_manager: Option<PartitionStoreManager>,
 ) -> datafusion::common::Result<()> {
-    let local_scanner = Arc::new(LocalPartitionsScanner::new(
-        partition_store_manager,
-        PromiseScanner,
-    ));
+    let local_scanner = local_partition_store_manager.map(|partition_store_manager| {
+        Arc::new(LocalPartitionsScanner::new(
+            partition_store_manager,
+            PromiseScanner,
+        )) as Arc<dyn ScanPartition>
+    });
     let table = PartitionedTableProvider::new(
         partition_selector,
         SysPromiseBuilder::schema(),

--- a/crates/storage-query-datafusion/src/remote_invoker_status_handle.rs
+++ b/crates/storage-query-datafusion/src/remote_invoker_status_handle.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_invoker_api::{InvocationStatusReport, StatusHandle};
+use restate_types::identifiers::PartitionKey;
+use std::future::Future;
+use std::ops::RangeInclusive;
+use std::{future, iter};
+
+// todo implement [`StatusHandle`] for reading the status of remote invokers.
+pub struct RemoteInvokerStatusHandle;
+
+impl StatusHandle for RemoteInvokerStatusHandle {
+    type Iterator = iter::Empty<InvocationStatusReport>;
+
+    fn read_status(
+        &self,
+        _keys: RangeInclusive<PartitionKey>,
+    ) -> impl Future<Output = Self::Iterator> + Send {
+        future::ready(iter::empty())
+    }
+}

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -23,19 +23,21 @@ use crate::context::{QueryContext, SelectPartitions};
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::state::row::append_state_row;
 use crate::state::schema::StateBuilder;
-use crate::table_providers::PartitionedTableProvider;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
 const NAME: &str = "state";
 
 pub(crate) fn register_self(
     ctx: &QueryContext,
     partition_selector: impl SelectPartitions,
-    partition_store_manager: PartitionStoreManager,
+    local_partition_store_manager: Option<PartitionStoreManager>,
 ) -> datafusion::common::Result<()> {
-    let local_scanner = Arc::new(LocalPartitionsScanner::new(
-        partition_store_manager,
-        StateScanner,
-    ));
+    let local_scanner = local_partition_store_manager.map(|partition_store_manager| {
+        Arc::new(LocalPartitionsScanner::new(
+            partition_store_manager,
+            StateScanner,
+        )) as Arc<dyn ScanPartition>
+    });
     let table = PartitionedTableProvider::new(
         partition_selector,
         StateBuilder::schema(),

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -94,6 +94,10 @@ impl PartitionTable {
         self.partitions.iter_mut()
     }
 
+    pub fn partition_ids(&self) -> impl Iterator<Item = &PartitionId> {
+        self.partitions.keys()
+    }
+
     pub fn num_partitions(&self) -> u16 {
         u16::try_from(self.partitions.len()).expect("number of partitions should fit into u16")
     }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -36,7 +36,7 @@ use restate_ingress_kafka::Service as IngressKafkaService;
 use restate_invoker_impl::InvokerHandle as InvokerChannelServiceHandle;
 use restate_metadata_store::MetadataStoreClient;
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
-use restate_storage_query_datafusion::context::QueryContext;
+use restate_storage_query_datafusion::context::{QueryContext, SelectPartitionsFromMetadata};
 use restate_storage_query_datafusion::remote_query_scanner_client::create_remote_scanner_service;
 use restate_storage_query_datafusion::remote_query_scanner_server::RemoteQueryScannerServer;
 use restate_storage_query_postgres::service::PostgresQueryService;
@@ -169,8 +169,8 @@ impl<T: TransportConnect> Worker<T> {
 
         let storage_query_context = QueryContext::create(
             &config.admin.query_engine,
-            partition_processor_manager.handle(),
-            partition_store_manager.clone(),
+            SelectPartitionsFromMetadata::new(metadata),
+            Some(partition_store_manager.clone()),
             partition_processor_manager.invokers_status_reader(),
             schema.clone(),
             create_remote_scanner_service(networking, task_center(), router_builder),

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -574,10 +574,6 @@ impl<T: TransportConnect> PartitionProcessorManager<T> {
     fn on_command(&mut self, command: ProcessorsManagerCommand) {
         use ProcessorsManagerCommand::*;
         match command {
-            GetLivePartitions(sender) => {
-                let live_partitions = self.running_partition_processors.keys().cloned().collect();
-                let _ = sender.send(live_partitions);
-            }
             CreateSnapshot(partition_id, sender) => {
                 self.running_partition_processors
                     .get(&partition_id)


### PR DESCRIPTION
By not requiring a dependency on the PartitionStoreManager, we can now create the QueryContext on nodes which don't run the Worker role. This will allow us to use the QueryContext in the Admin component and to remove the unnecessary indirection of an additional grpc call.