### PR TITLE
Introduce ConnectionAwareRpcRouter

### DIFF
--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -45,6 +45,9 @@ pub fn create_tonic_channel_from_advertised_address(address: AdvertisedAddress) 
             // todo: Make the channel settings configurable
             Channel::builder(uri)
                 .connect_timeout(Duration::from_secs(5))
+                // todo make http2 keep alive configurable
+                .http2_keep_alive_interval(Duration::from_secs(40))
+                .keep_alive_timeout(Duration::from_secs(20))
                 // todo: configure the channel from configuration file
                 .http2_adaptive_window(true)
                 .connect_lazy()


### PR DESCRIPTION
The ConnectionAwareRpcRouter adds support for monitoring the connection on which messages are sent. If the recipient uses the same channel to send responses, it can be used to monitor whether a response can still arrive or not.