### PR TITLE
Separate Ingress from Worker role

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6429,6 +6429,7 @@ dependencies = [
  "restate-bifrost",
  "restate-core",
  "restate-errors",
+ "restate-ingress-http",
  "restate-log-server",
  "restate-metadata-store",
  "restate-rocksdb",

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -11,6 +11,7 @@
 mod handler;
 mod layers;
 mod metric_definitions;
+pub mod rpc_request_dispatcher;
 mod server;
 
 pub use server::{HyperServerIngress, IngressServerError, StartSignal};

--- a/crates/ingress-http/src/rpc_request_dispatcher.rs
+++ b/crates/ingress-http/src/rpc_request_dispatcher.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
 // All rights reserved.
 //
 // Use of this software is governed by the Business Source License
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::{RequestDispatcher, RequestDispatcherError};
 use anyhow::anyhow;
 use restate_core::network::partition_processor_rpc_client::{
     AttachInvocationResponse, GetInvocationOutputResponse,
@@ -16,7 +17,6 @@ use restate_core::network::partition_processor_rpc_client::{
     PartitionProcessorRpcClient, PartitionProcessorRpcClientError,
 };
 use restate_core::network::TransportConnect;
-use restate_ingress_http::{RequestDispatcher, RequestDispatcherError};
 use restate_types::identifiers::{PartitionProcessorRpcRequestId, WithInvocationId};
 use restate_types::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use restate_types::net::partition_processor::{InvocationOutput, SubmittedInvocationNotification};

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -171,6 +171,17 @@ impl Node {
         for node in 1..=size {
             let mut base_config = base_config.clone();
             base_config.common.force_node_id = Some(PlainNodeId::new(node));
+
+            // Create a separate ingress role when running a worker
+            let roles = if roles.contains(Role::Worker) {
+                base_config
+                    .ingress
+                    .experimental_feature_enable_separate_ingress_role = true;
+                roles | Role::HttpIngress
+            } else {
+                roles
+            };
+
             nodes.push(Self::new_test_node(
                 format!("node-{node}"),
                 base_config,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -22,6 +22,7 @@ restate-admin = { workspace = true }
 restate-bifrost = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
+restate-ingress-http = { workspace = true }
 restate-log-server = { workspace = true }
 restate-metadata-store = { workspace = true }
 restate-rocksdb = { workspace = true }

--- a/crates/node/src/roles/ingress.rs
+++ b/crates/node/src/roles/ingress.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_core::network::partition_processor_rpc_client::PartitionProcessorRpcClient;
+use restate_core::network::rpc_router::ConnectionAwareRpcRouter;
+use restate_core::network::{MessageRouterBuilder, Networking, TransportConnect};
+use restate_core::partitions::PartitionRouting;
+use restate_ingress_http::rpc_request_dispatcher::RpcRequestDispatcher;
+use restate_ingress_http::HyperServerIngress;
+use restate_types::config::IngressOptions;
+use restate_types::health::HealthStatus;
+use restate_types::live::{BoxedLiveLoad, Live};
+use restate_types::partition_table::PartitionTable;
+use restate_types::protobuf::common::IngressStatus;
+use restate_types::schema::Schema;
+
+type IngressHttp<T> = HyperServerIngress<Schema, RpcRequestDispatcher<T>>;
+
+pub struct IngressRole<T> {
+    ingress_http: IngressHttp<T>,
+}
+
+impl<T: TransportConnect> IngressRole<T> {
+    pub fn create(
+        mut ingress_options: BoxedLiveLoad<IngressOptions>,
+        health: HealthStatus<IngressStatus>,
+        networking: Networking<T>,
+        schema: Live<Schema>,
+        partition_table: Live<PartitionTable>,
+        partition_routing: PartitionRouting,
+        router_builder: &mut MessageRouterBuilder,
+    ) -> Self {
+        let rpc_router = ConnectionAwareRpcRouter::new(router_builder);
+
+        let dispatcher = RpcRequestDispatcher::new(PartitionProcessorRpcClient::new(
+            networking,
+            rpc_router,
+            partition_table,
+            partition_routing,
+        ));
+        let ingress_http = HyperServerIngress::from_options(
+            ingress_options.live_load(),
+            dispatcher,
+            schema,
+            health,
+        );
+
+        Self { ingress_http }
+    }
+
+    pub async fn run(self) -> anyhow::Result<()> {
+        self.ingress_http.run().await
+    }
+}

--- a/crates/node/src/roles/mod.rs
+++ b/crates/node/src/roles/mod.rs
@@ -10,8 +10,10 @@
 
 mod admin;
 mod base;
+mod ingress;
 mod worker;
 
 pub use admin::{AdminRole, AdminRoleBuildError};
 pub use base::BaseRole;
+pub use ingress::IngressRole;
 pub use worker::{WorkerRole, WorkerRoleBuildError};

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -25,7 +25,6 @@ use restate_types::health::HealthStatus;
 use restate_types::live::Live;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_types::schema::subscriptions::SubscriptionResolver;
-use restate_types::schema::Schema;
 use restate_types::Version;
 use restate_worker::SubscriptionController;
 use restate_worker::Worker;
@@ -63,14 +62,14 @@ pub enum WorkerRoleBuildError {
     ),
 }
 
-pub struct WorkerRole<T> {
+pub struct WorkerRole {
     metadata: Metadata,
-    worker: Worker<T>,
+    worker: Worker,
 }
 
-impl<T: TransportConnect> WorkerRole<T> {
+impl WorkerRole {
     #[allow(clippy::too_many_arguments)]
-    pub async fn create(
+    pub async fn create<T: TransportConnect>(
         health_status: HealthStatus<WorkerStatus>,
         metadata: Metadata,
         partition_routing: PartitionRouting,
@@ -79,7 +78,6 @@ impl<T: TransportConnect> WorkerRole<T> {
         networking: Networking<T>,
         bifrost: Bifrost,
         metadata_store_client: MetadataStoreClient,
-        updating_schema_information: Live<Schema>,
     ) -> Result<Self, WorkerRoleBuildError> {
         let worker = Worker::create(
             updateable_config,
@@ -89,7 +87,6 @@ impl<T: TransportConnect> WorkerRole<T> {
             networking,
             bifrost,
             router_builder,
-            updating_schema_information,
             metadata_store_client,
         )
         .await?;

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -118,3 +118,9 @@ enum MetadataServerStatus {
   MetadataServerStatus_READY = 1;
   MetadataServerStatus_STARTING_UP = 2;
 }
+
+enum IngressStatus {
+  IngressStatus_UNKNOWN = 0;
+  IngressStatus_READY = 1;
+  IngressStatus_STARTING_UP = 2;
+}

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -331,13 +331,14 @@ impl CommonOptions {
 impl Default for CommonOptions {
     fn default() -> Self {
         Self {
-            // todo (asoli): Remove this when:
+            // todo (asoli): Remove `- Role::LogServer` when:
             //   a. The safe rollback version supports log-server (at least supports parsing the
             //   config with the log-server role)
             //   b. When log-server becomes enabled by default.
             //
+            // todo remove `- Role::Ingress` when the safe rollback version supports ingress
             //   see "roles_compat_test" test below.
-            roles: EnumSet::all() - Role::LogServer,
+            roles: EnumSet::all() - Role::LogServer - Role::HttpIngress,
             node_name: None,
             force_node_id: None,
             cluster_name: "localcluster".to_owned(),
@@ -610,5 +611,8 @@ mod tests {
         // make sure we don't add log-server by default until previous version can parse nodes
         // configuration with this role.
         assert!(!opts.roles.contains(Role::LogServer));
+        // make sure we don't add ingress by default until previous version can parse nodes
+        // configuration with this role.
+        assert!(!opts.roles.contains(Role::HttpIngress));
     }
 }

--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -36,6 +36,15 @@ pub struct IngressOptions {
     concurrent_api_requests_limit: Option<NonZeroUsize>,
 
     kafka_clusters: Vec<KafkaClusterOptions>,
+
+    /// # Experimental feature to run the ingress independent of the worker role
+    ///
+    /// This feature is experimental and should be used with caution. It allows to run the ingress
+    /// role independent of the worker role. It requires that you configure the [`Role::Ingress`]
+    /// role for nodes explicitly. If you enable this feature, then you might not be able to roll
+    /// back to a previous version.
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    pub experimental_feature_enable_separate_ingress_role: bool,
 }
 
 impl IngressOptions {
@@ -65,6 +74,7 @@ impl Default for IngressOptions {
             // max is limited by Tower's LoadShedLayer.
             concurrent_api_requests_limit: None,
             kafka_clusters: Default::default(),
+            experimental_feature_enable_separate_ingress_role: false,
         }
     }
 }

--- a/crates/types/src/health.rs
+++ b/crates/types/src/health.rs
@@ -11,7 +11,7 @@
 use tokio::sync::watch;
 
 use crate::protobuf::common::{
-    AdminStatus, LogServerStatus, MetadataServerStatus, NodeStatus, WorkerStatus,
+    AdminStatus, IngressStatus, LogServerStatus, MetadataServerStatus, NodeStatus, WorkerStatus,
 };
 use crate::Merge;
 
@@ -23,6 +23,7 @@ pub struct Health {
     admin_status: watch::Sender<AdminStatus>,
     log_server_status: watch::Sender<LogServerStatus>,
     metadata_server_status: watch::Sender<MetadataServerStatus>,
+    ingress_status: watch::Sender<IngressStatus>,
 }
 
 impl Default for Health {
@@ -38,6 +39,7 @@ impl Health {
         let admin_status = watch::Sender::new(AdminStatus::Unknown);
         let log_server_status = watch::Sender::new(LogServerStatus::Unknown);
         let metadata_server_status = watch::Sender::new(MetadataServerStatus::Unknown);
+        let ingress_status = watch::Sender::new(IngressStatus::Unknown);
 
         Self {
             node_status,
@@ -45,6 +47,7 @@ impl Health {
             admin_status,
             log_server_status,
             metadata_server_status,
+            ingress_status,
         }
     }
 
@@ -82,6 +85,10 @@ impl Health {
 
     pub fn log_server_status(&self) -> HealthStatus<LogServerStatus> {
         HealthStatus(self.log_server_status.clone())
+    }
+
+    pub fn ingress_status(&self) -> HealthStatus<IngressStatus> {
+        HealthStatus(self.ingress_status.clone())
     }
 
     pub fn metadata_server_status(&self) -> HealthStatus<MetadataServerStatus> {

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -48,6 +48,7 @@ pub enum Role {
     MetadataStore,
     /// [IN DEVELOPMENT] Serves a log server for replicated loglets
     LogServer,
+    HttpIngress,
 }
 
 #[serde_as]


### PR DESCRIPTION
This commit separates the ingress from the worker role. To support backward compatibility this feature is not yet turned on by default and users need to enable it explicity via `experimental-feature-enable-separate-ingress-role` to be able to configure the ingress role separately. When enabled, users can place the ingress role on a set of freely chosen nodes.

This fixes #1312.