### PR TITLE
Fix the StartMessage retry count

### DIFF
--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -171,6 +171,19 @@ impl InvocationTaskError {
         true
     }
 
+    pub(crate) fn should_bump_start_message_retry_count_since_last_stored_entry(&self) -> bool {
+        !matches!(
+            self,
+            InvocationTaskError::JournalReader(_)
+                | InvocationTaskError::StateReader(_)
+                | InvocationTaskError::NoDeploymentForService
+                | InvocationTaskError::BadNegotiatedServiceProtocolVersion(_)
+                | InvocationTaskError::UnknownDeployment(_)
+                | InvocationTaskError::ResumeWithWrongServiceProtocolVersion(_)
+                | InvocationTaskError::IncompatibleServiceEndpoint(_, _)
+        )
+    }
+
     pub(crate) fn next_retry_interval_override(&self) -> Option<Duration> {
         match self {
             InvocationTaskError::ErrorMessageReceived {

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -873,7 +873,10 @@ where
         error: InvocationTaskError,
         mut ism: InvocationStateMachine,
     ) {
-        match ism.handle_task_error(error.next_retry_interval_override()) {
+        match ism.handle_task_error(
+            error.next_retry_interval_override(),
+            error.should_bump_start_message_retry_count_since_last_stored_entry(),
+        ) {
             Some(next_retry_timer_duration) if error.is_transient() => {
                 counter!(INVOKER_INVOCATION_TASK,
                     "status" => TASK_OP_FAILED,
@@ -946,7 +949,7 @@ where
             partition,
             invocation_id,
             ism.invocation_target.clone(),
-            ism.retry_count_since_last_stored_entry,
+            ism.start_message_retry_count_since_last_stored_entry,
             storage_reader,
             self.invocation_tasks_tx.clone(),
             completions_rx,


### PR DESCRIPTION
Now it won't count anymore failures that happen before the retry attempt "hits" the endpoint.