### PR TITLE
Ingress explicitly detects PP routing decision errors

### DIFF
--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -81,6 +81,17 @@ pub enum PartitionProcessorRpcError {
     Internal(String),
 }
 
+impl PartitionProcessorRpcError {
+    pub fn likely_stale_route(&self) -> bool {
+        match self {
+            PartitionProcessorRpcError::NotLeader(_) => true,
+            PartitionProcessorRpcError::LostLeadership(_) => true,
+            PartitionProcessorRpcError::Busy => false,
+            PartitionProcessorRpcError::Internal(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PartitionProcessorRpcResponse {
     Appended,


### PR DESCRIPTION
When ingress makes a partition routing decision and gets an error that indicates it is operating with stale information, propagate this signal to the partition routing component.

Closes: #2215