### PR TITLE
Debug logging around Ingress PP node routing and partition refreshes

### DIFF
--- a/crates/core/src/network/partition_processor_rpc_client.rs
+++ b/crates/core/src/network/partition_processor_rpc_client.rs
@@ -334,6 +334,12 @@ where
             .get_node_by_partition(partition_id)
             .ok_or(PartitionProcessorRpcClientError::UnknownNode(partition_id))?;
 
+        trace!(
+            %partition_id,
+            "Sending PartitionProcessor RPC request to node: {}",
+            node_id
+        );
+
         let rpc_result = self
             .rpc_router
             .call(


### PR DESCRIPTION
Additional trace-level logging for some cases that might help for troubleshooting partition routing; increase log level to warn for error cases to highlight that nodes might be operating with stale information.