### PR TITLE
MetadataContainer now holds Arcs

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -761,8 +761,7 @@ impl LogsControllerInner {
         match event {
             Event::WriteLogsSucceeded(version) => {
                 self.on_logs_written(version);
-                // todo prevent clone by adding support for passing in Arcs
-                metadata_writer.submit(self.current_logs.deref().clone());
+                metadata_writer.submit(self.current_logs.clone());
             }
             Event::WriteLogsFailed {
                 logs,
@@ -939,7 +938,7 @@ impl LogsController {
             || metadata_store_client.get_or_insert(BIFROST_CONFIG_KEY.clone(), Logs::default),
         )
         .await?;
-        metadata_writer.update(logs).await?;
+        metadata_writer.update(Arc::new(logs)).await?;
 
         //todo(azmy): make configurable
         let retry_policy = RetryPolicy::exponential(
@@ -1127,7 +1126,7 @@ impl LogsController {
                                 Ok(result) => {
                                     let logs = result.expect("should be present");
                                     // we are only failing if we are shutting down
-                                    let _ = metadata_writer.update(logs).await;
+                                    let _ = metadata_writer.update(Arc::new(logs)).await;
                                     Event::NewLogs
                                 }
                                 Err(err) => {

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -391,7 +391,9 @@ impl<T: TransportConnect> Service<T> {
         )
         .await?;
 
-        self.metadata_writer.update(partition_table).await?;
+        self.metadata_writer
+            .update(Arc::new(partition_table))
+            .await?;
 
         Ok(())
     }

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -11,9 +11,15 @@
 pub mod error;
 mod updater;
 
-use crate::schema_registry::error::{SchemaError, SchemaRegistryError, ServiceError};
-use crate::schema_registry::updater::SchemaUpdater;
 use http::Uri;
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::subscriber::NoSubscriber;
+
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::{metadata, MetadataWriter};
 use restate_service_protocol::discovery::{DiscoverEndpoint, DiscoveredEndpoint, ServiceDiscovery};
@@ -27,11 +33,9 @@ use restate_types::schema::subscriptions::{
     ListSubscriptionFilter, Subscription, SubscriptionResolver, SubscriptionValidator,
 };
 use restate_types::schema::Schema;
-use std::borrow::Borrow;
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::time::Duration;
-use tracing::subscriber::NoSubscriber;
+
+use crate::schema_registry::error::{SchemaError, SchemaRegistryError, ServiceError};
+use crate::schema_registry::updater::SchemaUpdater;
 
 /// Whether to force the registration of an existing endpoint or not
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -167,7 +171,9 @@ impl<V> SchemaRegistry<V> {
                 .get_deployment_and_services(&new_deployment_id)
                 .expect("deployment was just added");
 
-            self.metadata_writer.update(schema_information).await?;
+            self.metadata_writer
+                .update(Arc::new(schema_information))
+                .await?;
 
             (new_deployment_id, services)
         };
@@ -198,7 +204,9 @@ impl<V> SchemaRegistry<V> {
                 },
             )
             .await?;
-        self.metadata_writer.update(schema_registry).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_registry))
+            .await?;
 
         Ok(())
     }
@@ -235,7 +243,9 @@ impl<V> SchemaRegistry<V> {
             .resolve_latest_service(&service_name)
             .expect("service was just modified");
 
-        self.metadata_writer.update(schema_information).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_information))
+            .await?;
 
         Ok(response)
     }
@@ -267,7 +277,9 @@ impl<V> SchemaRegistry<V> {
             )
             .await?;
 
-        self.metadata_writer.update(schema_information).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_information))
+            .await?;
 
         Ok(())
     }
@@ -367,7 +379,9 @@ where
         let subscription = schema_information
             .get_subscription(subscription_id.expect("subscription was just added"))
             .expect("subscription was just added");
-        self.metadata_writer.update(schema_information).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_information))
+            .await?;
 
         Ok(subscription)
     }

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -7,6 +7,7 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use std::sync::Arc;
 
 use tracing::warn;
 
@@ -53,7 +54,7 @@ pub async fn spawn_environment(
         .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
         .await
         .expect("to store bifrost config in metadata store");
-    metadata_writer.submit(logs);
+    metadata_writer.submit(Arc::new(logs));
     spawn_metadata_manager(&tc, metadata_manager).expect("metadata manager starts");
     tc
 }

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::ops::Deref;
+use std::sync::Arc;
 
 use tracing::{info, instrument};
 
@@ -218,7 +219,7 @@ impl<'a> BifrostAdmin<'a> {
             .await
             .map_err(|e| e.transpose())?;
 
-        self.metadata_writer.update(logs).await?;
+        self.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())
     }
 }

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -159,6 +159,10 @@ impl Metadata {
         Pinned::new(&self.inner.schema)
     }
 
+    pub fn schema_snapshot(&self) -> Arc<Schema> {
+        self.inner.schema.load_full()
+    }
+
     pub fn schema_version(&self) -> Version {
         self.inner.schema.load().version()
     }

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -184,7 +184,8 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             )
             .await
             .expect("to store nodes config in metadata store");
-        self.metadata_writer.submit(self.nodes_config.clone());
+        self.metadata_writer
+            .submit(Arc::new(self.nodes_config.clone()));
 
         let logs = bootstrap_logs_metadata(
             self.provider_kind,
@@ -195,7 +196,7 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
             .await
             .expect("to store bifrost config in metadata store");
-        self.metadata_writer.submit(logs.clone());
+        self.metadata_writer.submit(Arc::new(logs));
 
         self.metadata_store_client
             .put(
@@ -205,7 +206,7 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             )
             .await
             .expect("to store partition table in metadata store");
-        self.metadata_writer.submit(self.partition_table);
+        self.metadata_writer.submit(Arc::new(self.partition_table));
 
         self.metadata_store_client
             .put(

--- a/crates/log-server/build.rs
+++ b/crates/log-server/build.rs
@@ -22,6 +22,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
         .extern_path(".restate.cluster", "::restate_types::protobuf::cluster")
+        .extern_path(
+            ".restate.log_server_common",
+            "::restate_types::protobuf::log_server_common",
+        )
         .compile_protos(
             &["./protobuf/log_server_svc.proto"],
             &["protobuf", "../types/protobuf"],

--- a/crates/log-server/protobuf/log_server_svc.proto
+++ b/crates/log-server/protobuf/log_server_svc.proto
@@ -9,9 +9,7 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "restate/common.proto";
-import "restate/node.proto";
+import "restate/log_server_common.proto";
 
 package restate.log_server;
 
@@ -21,13 +19,22 @@ service LogServerSvc {
 }
 
 message GetDigestRequest {
-  uint32 loglet_id = 1;
+  uint64 loglet_id = 1;
   // inclusive
   uint32 from_offset = 2;
   // inclusive
   uint32 to_offset = 3;
 }
-message GetDigestResponse {}
 
-message GetLogletInfoRequest { uint32 loglet_id = 1; }
-message GetLogletInfoResponse {}
+message GetDigestResponse {
+  restate.log_server_common.Digest digest = 1;
+}
+
+message GetLogletInfoRequest {
+  uint64 loglet_id = 1;
+
+}
+
+message GetLogletInfoResponse {
+ restate.log_server_common.LogletInfo info = 1;
+}

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -462,7 +462,7 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_get_records(&mut self, msg: Incoming<GetRecords>) {
-        let mut log_store = self.log_store.clone();
+        let log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
         let _ = self.task_center.spawn(
@@ -497,7 +497,7 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_get_digest(&mut self, msg: Incoming<GetDigest>) {
-        let mut log_store = self.log_store.clone();
+        let log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
         let _ = self.task_center.spawn(
@@ -537,7 +537,7 @@ impl<S: LogStore> LogletWorker<S> {
         //
         // fails on shutdown, in this case, we ignore the request
         let mut loglet_state = self.loglet_state.clone();
-        let mut log_store = self.log_store.clone();
+        let log_store = self.log_store.clone();
         let _ = self
             .task_center
             .spawn(TaskKind::Disposable, "logserver-trim", None, async move {
@@ -661,7 +661,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -738,7 +738,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -900,7 +900,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -1066,7 +1066,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -1284,7 +1284,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -1494,7 +1494,7 @@ mod tests {
         assert_that!(gap.to, eq(LogletOffset::new(6)));
 
         // Make sure that we can load the local-tail correctly when loading the loglet_state
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         assert_that!(loglet_state.trim_point(), eq(LogletOffset::new(6)));
         assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::new(7)));

--- a/crates/log-server/src/logstore.rs
+++ b/crates/log-server/src/logstore.rs
@@ -36,29 +36,29 @@ pub trait LogStore: Clone + Send + 'static {
     ) -> impl Future<Output = Result<LogletState, OperationError>> + Send;
 
     fn enqueue_store(
-        &mut self,
+        &self,
         store_message: Store,
         set_sequencer_in_metadata: bool,
     ) -> impl Future<Output = Result<AsyncToken, OperationError>> + Send;
 
     fn enqueue_seal(
-        &mut self,
+        &self,
         seal_message: Seal,
     ) -> impl Future<Output = Result<AsyncToken, OperationError>> + Send;
 
     fn enqueue_trim(
-        &mut self,
+        &self,
         trim_message: Trim,
     ) -> impl Future<Output = Result<AsyncToken, OperationError>> + Send;
 
     fn read_records(
-        &mut self,
+        &self,
         get_records_message: GetRecords,
         loglet_state: &LogletState,
     ) -> impl Future<Output = Result<Records, OperationError>> + Send;
 
     fn get_records_digest(
-        &mut self,
+        &self,
         get_records_message: GetDigest,
         loglet_state: &LogletState,
     ) -> impl Future<Output = Result<Digest, OperationError>> + Send;

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -197,7 +197,7 @@ impl LogStore for RocksDbLogStore {
     }
 
     async fn enqueue_store(
-        &mut self,
+        &self,
         store_message: Store,
         set_sequencer_in_metadata: bool,
     ) -> Result<AsyncToken, OperationError> {
@@ -210,16 +210,16 @@ impl LogStore for RocksDbLogStore {
             .await
     }
 
-    async fn enqueue_seal(&mut self, seal_message: Seal) -> Result<AsyncToken, OperationError> {
+    async fn enqueue_seal(&self, seal_message: Seal) -> Result<AsyncToken, OperationError> {
         self.writer_handle.enqueue_seal(seal_message).await
     }
 
-    async fn enqueue_trim(&mut self, trim_message: Trim) -> Result<AsyncToken, OperationError> {
+    async fn enqueue_trim(&self, trim_message: Trim) -> Result<AsyncToken, OperationError> {
         self.writer_handle.enqueue_trim(trim_message).await
     }
 
     async fn read_records(
-        &mut self,
+        &self,
         msg: GetRecords,
         loglet_state: &LogletState,
     ) -> Result<Records, OperationError> {
@@ -359,7 +359,7 @@ impl LogStore for RocksDbLogStore {
     }
 
     async fn get_records_digest(
-        &mut self,
+        &self,
         msg: GetDigest,
         loglet_state: &LogletState,
     ) -> Result<Digest, OperationError> {
@@ -561,7 +561,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn test_load_loglet_state() -> Result<()> {
-        let (tc, mut log_store) = setup().await?;
+        let (tc, log_store) = setup().await?;
         // fresh/unknown loglet
         let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
         let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
@@ -653,7 +653,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn test_digest() -> Result<()> {
-        let (tc, mut log_store) = setup().await?;
+        let (tc, log_store) = setup().await?;
         let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
         let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
         let sequencer_1 = GenerationalNodeId::new(5, 213);

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use anyhow::Context;
 use tonic::codec::CompressionEncoding;
 use tracing::{debug, info, instrument};
@@ -241,7 +243,7 @@ impl LogServerService {
             .await
             .map_err(|e| e.transpose())?;
 
-        metadata_writer.update(nodes_config).await?;
+        metadata_writer.update(Arc::new(nodes_config)).await?;
         info!("Log-store self-provisioning is complete, the node's log-store is now in read-write state");
         Ok(target_storage_state)
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -12,6 +12,8 @@ mod cluster_marker;
 mod network_server;
 mod roles;
 
+use std::sync::Arc;
+
 use tracing::{debug, error, info, trace};
 
 use codederror::CodedError;
@@ -312,7 +314,7 @@ impl Node {
 
         let nodes_config =
             Self::upsert_node_config(&self.metadata_store_client, &config.common).await?;
-        metadata_writer.update(nodes_config).await?;
+        metadata_writer.update(Arc::new(nodes_config)).await?;
 
         if config.common.allow_bootstrap {
             // todo write bootstrap state

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -102,6 +102,7 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
             &[
                 "./protobuf/restate/common.proto",
                 "./protobuf/restate/cluster.proto",
+                "./protobuf/restate/log_server_common.proto",
                 "./protobuf/restate/node.proto",
             ],
             &["protobuf"],

--- a/crates/types/protobuf/restate/log_server_common.proto
+++ b/crates/types/protobuf/restate/log_server_common.proto
@@ -1,0 +1,69 @@
+
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package restate.log_server_common;
+
+enum Status {
+  Status_UNKNOWN = 0;
+  // Operation was successful
+  OK = 1;
+  // The node's storage system is disabled and cannot accept operations at the moment.
+  DISABLED = 2;
+  // If the operation expired or not completed due to load shedding. The operation can be
+  // retried by the client. It's guaranteed that this store has not been persisted by the node.
+  DROPPED = 3;
+  // Operation rejected on a sealed loglet
+  SEALED = 4;
+  // Loglet is being sealed and operation cannot be accepted
+  SEALING = 5;
+  // Operation has been rejected. Operation requires that the sender is the authoritative
+  // sequencer.
+  SEQUENCER_MISMATCH = 6;
+  // This indicates that the operation cannot be accepted due to the offset being out of bounds.
+  // For instance, if a store is sent to a log-server that with a lagging local commit offset.
+  OUT_OF_BOUNDS = 7;
+  // The record is malformed, this could be because it has too many records or any other reason
+  // that leads the server to reject processing it.
+  MALFORMED = 8;
+}
+
+
+message ResponseHeader {
+  Status status = 1;
+  uint32 local_tail = 2;
+  uint32 known_global_tail = 3;
+  bool sealed = 4;
+}
+
+message DigestEntry {
+  uint32 from_offset = 1;
+  uint32 to_offset = 2;
+  RecordStatus status = 3;
+}
+
+enum RecordStatus {
+  RecordStatus_UNKNOWN = 0;
+  TRIMMED = 1;
+  ARCHIVED = 2;
+  EXISTS = 3;
+}
+
+message Digest {
+  ResponseHeader header = 1;
+  repeated DigestEntry entries = 2;
+}
+
+message LogletInfo {
+  ResponseHeader header = 1;
+  uint32 trim_point = 2;
+}

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -12,6 +12,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use bitflags::bitflags;
+use prost_dto::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
 
 use super::TargetName;
@@ -21,11 +22,12 @@ use crate::replicated_loglet::ReplicatedLogletId;
 use crate::time::MillisSinceEpoch;
 use crate::GenerationalNodeId;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::Status")]
 #[repr(u8)]
 pub enum Status {
     /// Operation was successful
-    Ok = 0,
+    Ok = 1,
     /// The node's storage system is disabled and cannot accept operations at the moment.
     Disabled,
     /// If the operation expired or not completed due to load shedding. The operation can be
@@ -131,7 +133,8 @@ impl LogServerRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::ResponseHeader")]
 pub struct LogServerResponseHeader {
     /// The position after the last locally committed record on this node
     pub local_tail: LogletOffset,
@@ -342,9 +345,11 @@ pub struct GetLogletInfo {
     pub header: LogServerRequestHeader,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::LogletInfo")]
 pub struct LogletInfo {
     #[serde(flatten)]
+    #[proto(required)]
     pub header: LogServerResponseHeader,
     pub trim_point: LogletOffset,
 }
@@ -618,7 +623,8 @@ pub struct GetDigest {
     pub to_offset: LogletOffset,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::DigestEntry")]
 #[display("[{from_offset}..{to_offset}] -> {status} ({})",  self.len())]
 pub struct DigestEntry {
     // inclusive
@@ -627,8 +633,11 @@ pub struct DigestEntry {
     pub status: RecordStatus,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, derive_more::Display, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Eq, PartialEq, derive_more::Display, Serialize, Deserialize, IntoProto, FromProto,
+)]
 #[repr(u8)]
+#[proto(target = "crate::protobuf::log_server_common::RecordStatus")]
 pub enum RecordStatus {
     #[display("T")]
     Trimmed,
@@ -654,9 +663,11 @@ impl DigestEntry {
 }
 
 /// Response to a `GetDigest` request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::Digest")]
 pub struct Digest {
     #[serde(flatten)]
+    #[proto(required)]
     pub header: LogServerResponseHeader,
     // If the node's local trim-point (or archival-point) overlaps with the digest range, an entry will be
     // added to include where the trim-gap ends. Otherwise, offsets for non-existing records

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use enum_map::Enum;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
@@ -69,10 +71,10 @@ pub enum MetadataKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, derive_more::From)]
 pub enum MetadataContainer {
-    NodesConfiguration(NodesConfiguration),
-    PartitionTable(PartitionTable),
-    Logs(Logs),
-    Schema(Schema),
+    NodesConfiguration(Arc<NodesConfiguration>),
+    PartitionTable(Arc<PartitionTable>),
+    Logs(Arc<Logs>),
+    Schema(Arc<Schema>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -196,3 +196,14 @@ pub mod node {
         }
     }
 }
+
+pub mod log_server_common {
+
+    include!(concat!(env!("OUT_DIR"), "/restate.log_server_common.rs"));
+
+    impl std::fmt::Display for RecordStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Display::fmt(&crate::net::log_server::RecordStatus::from(*self as i32), f)
+        }
+    }
+}

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
@@ -170,7 +171,7 @@ fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (TaskCenter,
             .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
             .await
             .expect("to store bifrost config in metadata store");
-        metadata_writer.submit(logs);
+        metadata_writer.submit(Arc::new(logs));
         spawn_metadata_manager(&task_center, metadata_manager).expect("metadata manager starts");
 
         let bifrost_svc = BifrostService::new(task_center, metadata)


### PR DESCRIPTION

MetadataContainer enum was ~450 bytes and it's being used often. It also forces users to clone input which is not great. The PR contains mostly mechanical changes.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2229).
* #2257
* #2256
* #2231
* #2230
* __->__ #2229
* #2222