### PR TITLE
[restatectl] Introduces replicated-loglet top-level command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6886,6 +6886,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_with",
  "sha2",
+ "smallvec",
  "static_assertions",
  "strum 0.26.2",
  "syn 2.0.85",

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -761,8 +761,7 @@ impl LogsControllerInner {
         match event {
             Event::WriteLogsSucceeded(version) => {
                 self.on_logs_written(version);
-                // todo prevent clone by adding support for passing in Arcs
-                metadata_writer.submit(self.current_logs.deref().clone());
+                metadata_writer.submit(self.current_logs.clone());
             }
             Event::WriteLogsFailed {
                 logs,
@@ -939,7 +938,7 @@ impl LogsController {
             || metadata_store_client.get_or_insert(BIFROST_CONFIG_KEY.clone(), Logs::default),
         )
         .await?;
-        metadata_writer.update(logs).await?;
+        metadata_writer.update(Arc::new(logs)).await?;
 
         //todo(azmy): make configurable
         let retry_policy = RetryPolicy::exponential(
@@ -1127,7 +1126,7 @@ impl LogsController {
                                 Ok(result) => {
                                     let logs = result.expect("should be present");
                                     // we are only failing if we are shutting down
-                                    let _ = metadata_writer.update(logs).await;
+                                    let _ = metadata_writer.update(Arc::new(logs)).await;
                                     Event::NewLogs
                                 }
                                 Err(err) => {

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -739,7 +739,7 @@ impl LogsControllerInner {
                 observed_cluster_state,
                 |seal_lsn, provider_kind, loglet_params| {
                     let mut chain_builder = logs_builder
-                        .chain(log_id)
+                        .chain(*log_id)
                         .expect("Log with '{log_id}' should be present");
 
                     chain_builder.append_segment(seal_lsn, provider_kind, loglet_params)

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -391,7 +391,9 @@ impl<T: TransportConnect> Service<T> {
         )
         .await?;
 
-        self.metadata_writer.update(partition_table).await?;
+        self.metadata_writer
+            .update(Arc::new(partition_table))
+            .await?;
 
         Ok(())
     }

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -11,9 +11,15 @@
 pub mod error;
 mod updater;
 
-use crate::schema_registry::error::{SchemaError, SchemaRegistryError, ServiceError};
-use crate::schema_registry::updater::SchemaUpdater;
 use http::Uri;
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::subscriber::NoSubscriber;
+
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::{metadata, MetadataWriter};
 use restate_service_protocol::discovery::{DiscoverEndpoint, DiscoveredEndpoint, ServiceDiscovery};
@@ -27,11 +33,9 @@ use restate_types::schema::subscriptions::{
     ListSubscriptionFilter, Subscription, SubscriptionResolver, SubscriptionValidator,
 };
 use restate_types::schema::Schema;
-use std::borrow::Borrow;
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::time::Duration;
-use tracing::subscriber::NoSubscriber;
+
+use crate::schema_registry::error::{SchemaError, SchemaRegistryError, ServiceError};
+use crate::schema_registry::updater::SchemaUpdater;
 
 /// Whether to force the registration of an existing endpoint or not
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -167,7 +171,9 @@ impl<V> SchemaRegistry<V> {
                 .get_deployment_and_services(&new_deployment_id)
                 .expect("deployment was just added");
 
-            self.metadata_writer.update(schema_information).await?;
+            self.metadata_writer
+                .update(Arc::new(schema_information))
+                .await?;
 
             (new_deployment_id, services)
         };
@@ -198,7 +204,9 @@ impl<V> SchemaRegistry<V> {
                 },
             )
             .await?;
-        self.metadata_writer.update(schema_registry).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_registry))
+            .await?;
 
         Ok(())
     }
@@ -235,7 +243,9 @@ impl<V> SchemaRegistry<V> {
             .resolve_latest_service(&service_name)
             .expect("service was just modified");
 
-        self.metadata_writer.update(schema_information).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_information))
+            .await?;
 
         Ok(response)
     }
@@ -267,7 +277,9 @@ impl<V> SchemaRegistry<V> {
             )
             .await?;
 
-        self.metadata_writer.update(schema_information).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_information))
+            .await?;
 
         Ok(())
     }
@@ -367,7 +379,9 @@ where
         let subscription = schema_information
             .get_subscription(subscription_id.expect("subscription was just added"))
             .expect("subscription was just added");
-        self.metadata_writer.update(schema_information).await?;
+        self.metadata_writer
+            .update(Arc::new(schema_information))
+            .await?;
 
         Ok(subscription)
     }

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = []
-replicated-loglet = ["restate-types/replicated-loglet"]
+replicated-loglet = []
 memory-loglet = ["restate-types/memory-loglet"]
 test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util"]
 

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -7,6 +7,7 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use std::sync::Arc;
 
 use tracing::warn;
 
@@ -53,7 +54,7 @@ pub async fn spawn_environment(
         .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
         .await
         .expect("to store bifrost config in metadata store");
-    metadata_writer.submit(logs);
+    metadata_writer.submit(Arc::new(logs));
     spawn_metadata_manager(&tc, metadata_manager).expect("metadata manager starts");
     tc
 }

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -804,7 +804,7 @@ mod tests {
             let old_version = bifrost.inner.metadata.logs_version();
 
             let mut builder = bifrost.inner.metadata.logs_ref().clone().into_builder();
-            let mut chain_builder = builder.chain(&LOG_ID).unwrap();
+            let mut chain_builder = builder.chain(LOG_ID).unwrap();
             assert_eq!(1, chain_builder.num_segments());
             let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);
             // deliberately skips Lsn::from(6) to create a zombie record in segment 1. Segment 1 now has 4 records.

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -195,8 +195,7 @@ impl<'a> BifrostAdmin<'a> {
                 let logs = logs.ok_or(Error::UnknownLogId(log_id))?;
 
                 let mut builder = logs.into_builder();
-                let mut chain_builder =
-                    builder.chain(&log_id).ok_or(Error::UnknownLogId(log_id))?;
+                let mut chain_builder = builder.chain(log_id).ok_or(Error::UnknownLogId(log_id))?;
 
                 if chain_builder.tail().index() != last_segment_index {
                     // tail is not what we expected.

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::ops::Deref;
+use std::sync::Arc;
 
 use tracing::{info, instrument};
 
@@ -218,7 +219,7 @@ impl<'a> BifrostAdmin<'a> {
             .await
             .map_err(|e| e.transpose())?;
 
-        self.metadata_writer.update(logs).await?;
+        self.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())
     }
 }

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -761,7 +761,7 @@ mod tests {
             // when it's implemented)
             let old_version = bifrost.inner.metadata.logs_version();
             let mut builder = bifrost.inner.metadata.logs_ref().clone().into_builder();
-            let mut chain_builder = builder.chain(&LOG_ID).unwrap();
+            let mut chain_builder = builder.chain(LOG_ID).unwrap();
             assert_eq!(1, chain_builder.num_segments());
             let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);
             chain_builder.append_segment(
@@ -982,7 +982,7 @@ mod tests {
             // prepare a chain that starts from Lsn 10 (we expect trim from OLDEST -> 9)
             let old_version = bifrost.inner.metadata.logs_version();
             let mut builder = bifrost.inner.metadata.logs_ref().clone().into_builder();
-            let mut chain_builder = builder.chain(&LOG_ID).unwrap();
+            let mut chain_builder = builder.chain(LOG_ID).unwrap();
             assert_eq!(1, chain_builder.num_segments());
             let new_segment_params = new_single_node_loglet_params(ProviderKind::Local);
             chain_builder.append_segment(Lsn::new(10), ProviderKind::Local, new_segment_params)?;

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -159,6 +159,10 @@ impl Metadata {
         Pinned::new(&self.inner.schema)
     }
 
+    pub fn schema_snapshot(&self) -> Arc<Schema> {
+        self.inner.schema.load_full()
+    }
+
     pub fn schema_version(&self) -> Version {
         self.inner.schema.load().version()
     }

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -184,7 +184,8 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             )
             .await
             .expect("to store nodes config in metadata store");
-        self.metadata_writer.submit(self.nodes_config.clone());
+        self.metadata_writer
+            .submit(Arc::new(self.nodes_config.clone()));
 
         let logs = bootstrap_logs_metadata(
             self.provider_kind,
@@ -195,7 +196,7 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
             .await
             .expect("to store bifrost config in metadata store");
-        self.metadata_writer.submit(logs.clone());
+        self.metadata_writer.submit(Arc::new(logs));
 
         self.metadata_store_client
             .put(
@@ -205,7 +206,7 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             )
             .await
             .expect("to store partition table in metadata store");
-        self.metadata_writer.submit(self.partition_table);
+        self.metadata_writer.submit(Arc::new(self.partition_table));
 
         self.metadata_store_client
             .put(

--- a/crates/local-cluster-runner/Cargo.toml
+++ b/crates/local-cluster-runner/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 [dependencies]
 restate-metadata-store = { workspace = true }
 # nb features here will also affect the compiled restate-server binary in integration tests
-restate-types = { workspace = true, features = ["unsafe-mutable-config", "replicated-loglet"] }
+restate-types = { workspace = true, features = ["unsafe-mutable-config"] }
 
 arc-swap = { workspace = true }
 clap = { workspace = true }

--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -17,7 +17,7 @@ restate-bifrost = { workspace = true }
 restate-core = { workspace = true }
 restate-metadata-store = { workspace = true }
 restate-rocksdb = { workspace = true }
-restate-types = { workspace = true, features = ["replicated-loglet"] }
+restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/log-server/build.rs
+++ b/crates/log-server/build.rs
@@ -22,6 +22,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
         .extern_path(".restate.cluster", "::restate_types::protobuf::cluster")
+        .extern_path(
+            ".restate.log_server_common",
+            "::restate_types::protobuf::log_server_common",
+        )
         .compile_protos(
             &["./protobuf/log_server_svc.proto"],
             &["protobuf", "../types/protobuf"],

--- a/crates/log-server/protobuf/log_server_svc.proto
+++ b/crates/log-server/protobuf/log_server_svc.proto
@@ -9,9 +9,7 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "restate/common.proto";
-import "restate/node.proto";
+import "restate/log_server_common.proto";
 
 package restate.log_server;
 
@@ -21,13 +19,22 @@ service LogServerSvc {
 }
 
 message GetDigestRequest {
-  uint32 loglet_id = 1;
+  uint64 loglet_id = 1;
   // inclusive
   uint32 from_offset = 2;
   // inclusive
   uint32 to_offset = 3;
 }
-message GetDigestResponse {}
 
-message GetLogletInfoRequest { uint32 loglet_id = 1; }
-message GetLogletInfoResponse {}
+message GetDigestResponse {
+  restate.log_server_common.Digest digest = 1;
+}
+
+message GetLogletInfoRequest {
+  uint64 loglet_id = 1;
+
+}
+
+message GetLogletInfoResponse {
+ restate.log_server_common.LogletInfo info = 1;
+}

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -462,7 +462,7 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_get_records(&mut self, msg: Incoming<GetRecords>) {
-        let mut log_store = self.log_store.clone();
+        let log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
         let _ = self.task_center.spawn(
@@ -497,7 +497,7 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_get_digest(&mut self, msg: Incoming<GetDigest>) {
-        let mut log_store = self.log_store.clone();
+        let log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
         let _ = self.task_center.spawn(
@@ -537,7 +537,7 @@ impl<S: LogStore> LogletWorker<S> {
         //
         // fails on shutdown, in this case, we ignore the request
         let mut loglet_state = self.loglet_state.clone();
-        let mut log_store = self.log_store.clone();
+        let log_store = self.log_store.clone();
         let _ = self
             .task_center
             .spawn(TaskKind::Disposable, "logserver-trim", None, async move {
@@ -661,7 +661,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -738,7 +738,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -900,7 +900,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -1066,7 +1066,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -1284,7 +1284,7 @@ mod tests {
         const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
 
         let (tc, log_store) = setup().await?;
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
@@ -1494,7 +1494,7 @@ mod tests {
         assert_that!(gap.to, eq(LogletOffset::new(6)));
 
         // Make sure that we can load the local-tail correctly when loading the loglet_state
-        let mut loglet_state_map = LogletStateMap::default();
+        let loglet_state_map = LogletStateMap::default();
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         assert_that!(loglet_state.trim_point(), eq(LogletOffset::new(6)));
         assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::new(7)));

--- a/crates/log-server/src/logstore.rs
+++ b/crates/log-server/src/logstore.rs
@@ -36,29 +36,29 @@ pub trait LogStore: Clone + Send + 'static {
     ) -> impl Future<Output = Result<LogletState, OperationError>> + Send;
 
     fn enqueue_store(
-        &mut self,
+        &self,
         store_message: Store,
         set_sequencer_in_metadata: bool,
     ) -> impl Future<Output = Result<AsyncToken, OperationError>> + Send;
 
     fn enqueue_seal(
-        &mut self,
+        &self,
         seal_message: Seal,
     ) -> impl Future<Output = Result<AsyncToken, OperationError>> + Send;
 
     fn enqueue_trim(
-        &mut self,
+        &self,
         trim_message: Trim,
     ) -> impl Future<Output = Result<AsyncToken, OperationError>> + Send;
 
     fn read_records(
-        &mut self,
+        &self,
         get_records_message: GetRecords,
         loglet_state: &LogletState,
     ) -> impl Future<Output = Result<Records, OperationError>> + Send;
 
     fn get_records_digest(
-        &mut self,
+        &self,
         get_records_message: GetDigest,
         loglet_state: &LogletState,
     ) -> impl Future<Output = Result<Digest, OperationError>> + Send;

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -197,7 +197,7 @@ impl LogStore for RocksDbLogStore {
     }
 
     async fn enqueue_store(
-        &mut self,
+        &self,
         store_message: Store,
         set_sequencer_in_metadata: bool,
     ) -> Result<AsyncToken, OperationError> {
@@ -210,16 +210,16 @@ impl LogStore for RocksDbLogStore {
             .await
     }
 
-    async fn enqueue_seal(&mut self, seal_message: Seal) -> Result<AsyncToken, OperationError> {
+    async fn enqueue_seal(&self, seal_message: Seal) -> Result<AsyncToken, OperationError> {
         self.writer_handle.enqueue_seal(seal_message).await
     }
 
-    async fn enqueue_trim(&mut self, trim_message: Trim) -> Result<AsyncToken, OperationError> {
+    async fn enqueue_trim(&self, trim_message: Trim) -> Result<AsyncToken, OperationError> {
         self.writer_handle.enqueue_trim(trim_message).await
     }
 
     async fn read_records(
-        &mut self,
+        &self,
         msg: GetRecords,
         loglet_state: &LogletState,
     ) -> Result<Records, OperationError> {
@@ -359,7 +359,7 @@ impl LogStore for RocksDbLogStore {
     }
 
     async fn get_records_digest(
-        &mut self,
+        &self,
         msg: GetDigest,
         loglet_state: &LogletState,
     ) -> Result<Digest, OperationError> {
@@ -561,7 +561,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn test_load_loglet_state() -> Result<()> {
-        let (tc, mut log_store) = setup().await?;
+        let (tc, log_store) = setup().await?;
         // fresh/unknown loglet
         let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
         let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
@@ -653,7 +653,7 @@ mod tests {
 
     #[test(tokio::test(start_paused = true))]
     async fn test_digest() -> Result<()> {
-        let (tc, mut log_store) = setup().await?;
+        let (tc, log_store) = setup().await?;
         let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
         let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
         let sequencer_1 = GenerationalNodeId::new(5, 213);

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use anyhow::Context;
 use tonic::codec::CompressionEncoding;
 use tracing::{debug, info, instrument};
@@ -241,7 +243,7 @@ impl LogServerService {
             .await
             .map_err(|e| e.transpose())?;
 
-        metadata_writer.update(nodes_config).await?;
+        metadata_writer.update(Arc::new(nodes_config)).await?;
         info!("Log-store self-provisioning is complete, the node's log-store is now in read-write state");
         Ok(target_storage_state)
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -12,6 +12,8 @@ mod cluster_marker;
 mod network_server;
 mod roles;
 
+use std::sync::Arc;
+
 use tracing::{debug, error, info, trace};
 
 use codederror::CodedError;
@@ -312,7 +314,7 @@ impl Node {
 
         let nodes_config =
             Self::upsert_node_config(&self.metadata_store_client, &config.common).await?;
-        metadata_writer.update(nodes_config).await?;
+        metadata_writer.update(Arc::new(nodes_config)).await?;
 
         if config.common.allow_bootstrap {
             // todo write bootstrap state

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [features]
 default = []
 
-replicated-loglet = []
 memory-loglet = []
 schemars = ["dep:schemars", "restate-serde-util/schema"]
 unsafe-mutable-config = []
@@ -61,6 +60,7 @@ serde_json = { workspace = true }
 serde_path_to_error = { version = "0.1" }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
+smallvec = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -102,6 +102,7 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
             &[
                 "./protobuf/restate/common.proto",
                 "./protobuf/restate/cluster.proto",
+                "./protobuf/restate/log_server_common.proto",
                 "./protobuf/restate/node.proto",
             ],
             &["protobuf"],

--- a/crates/types/protobuf/restate/log_server_common.proto
+++ b/crates/types/protobuf/restate/log_server_common.proto
@@ -1,0 +1,69 @@
+
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package restate.log_server_common;
+
+enum Status {
+  Status_UNKNOWN = 0;
+  // Operation was successful
+  OK = 1;
+  // The node's storage system is disabled and cannot accept operations at the moment.
+  DISABLED = 2;
+  // If the operation expired or not completed due to load shedding. The operation can be
+  // retried by the client. It's guaranteed that this store has not been persisted by the node.
+  DROPPED = 3;
+  // Operation rejected on a sealed loglet
+  SEALED = 4;
+  // Loglet is being sealed and operation cannot be accepted
+  SEALING = 5;
+  // Operation has been rejected. Operation requires that the sender is the authoritative
+  // sequencer.
+  SEQUENCER_MISMATCH = 6;
+  // This indicates that the operation cannot be accepted due to the offset being out of bounds.
+  // For instance, if a store is sent to a log-server that with a lagging local commit offset.
+  OUT_OF_BOUNDS = 7;
+  // The record is malformed, this could be because it has too many records or any other reason
+  // that leads the server to reject processing it.
+  MALFORMED = 8;
+}
+
+
+message ResponseHeader {
+  Status status = 1;
+  uint32 local_tail = 2;
+  uint32 known_global_tail = 3;
+  bool sealed = 4;
+}
+
+message DigestEntry {
+  uint32 from_offset = 1;
+  uint32 to_offset = 2;
+  RecordStatus status = 3;
+}
+
+enum RecordStatus {
+  RecordStatus_UNKNOWN = 0;
+  TRIMMED = 1;
+  ARCHIVED = 2;
+  EXISTS = 3;
+}
+
+message Digest {
+  ResponseHeader header = 1;
+  repeated DigestEntry entries = 2;
+}
+
+message LogletInfo {
+  ResponseHeader header = 1;
+  uint32 trim_point = 2;
+}

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -36,8 +36,6 @@ pub struct BifrostOptions {
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     /// Configuration of local loglet provider
     pub local: LocalLogletOptions,
-    #[cfg(feature = "replicated-loglet")]
-    /// [IN DEVELOPMENT]
     /// Configuration of replicated loglet provider
     pub replicated_loglet: ReplicatedLogletOptions,
 
@@ -92,7 +90,6 @@ impl Default for BifrostOptions {
     fn default() -> Self {
         Self {
             default_provider: ProviderKind::Local,
-            #[cfg(feature = "replicated-loglet")]
             replicated_loglet: ReplicatedLogletOptions::default(),
             local: LocalLogletOptions::default(),
             read_retry_policy: RetryPolicy::exponential(
@@ -207,7 +204,6 @@ impl Default for LocalLogletOptions {
     }
 }
 
-#[cfg(feature = "replicated-loglet")]
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -240,7 +236,6 @@ pub struct ReplicatedLogletOptions {
     pub log_server_retry_policy: RetryPolicy,
 }
 
-#[cfg(feature = "replicated-loglet")]
 impl Default for ReplicatedLogletOptions {
     fn default() -> Self {
         Self {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -38,7 +38,6 @@ pub mod net;
 pub mod nodes_config;
 pub mod partition_table;
 pub mod protobuf;
-#[cfg(feature = "replicated-loglet")]
 pub mod replicated_loglet;
 pub mod retries;
 pub mod schema;

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -19,12 +19,10 @@ use crate::storage::StorageEncode;
 pub mod builder;
 pub mod metadata;
 mod record;
-#[cfg(feature = "replicated-loglet")]
 mod record_cache;
 mod tail;
 
 pub use record::Record;
-#[cfg(feature = "replicated-loglet")]
 pub use record_cache::RecordCache;
 pub use tail::*;
 

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -12,6 +12,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use bitflags::bitflags;
+use prost_dto::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
 
 use super::TargetName;
@@ -21,11 +22,12 @@ use crate::replicated_loglet::ReplicatedLogletId;
 use crate::time::MillisSinceEpoch;
 use crate::GenerationalNodeId;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::Status")]
 #[repr(u8)]
 pub enum Status {
     /// Operation was successful
-    Ok = 0,
+    Ok = 1,
     /// The node's storage system is disabled and cannot accept operations at the moment.
     Disabled,
     /// If the operation expired or not completed due to load shedding. The operation can be
@@ -131,7 +133,8 @@ impl LogServerRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::ResponseHeader")]
 pub struct LogServerResponseHeader {
     /// The position after the last locally committed record on this node
     pub local_tail: LogletOffset,
@@ -342,9 +345,11 @@ pub struct GetLogletInfo {
     pub header: LogServerRequestHeader,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::LogletInfo")]
 pub struct LogletInfo {
     #[serde(flatten)]
+    #[proto(required)]
     pub header: LogServerResponseHeader,
     pub trim_point: LogletOffset,
 }
@@ -618,7 +623,8 @@ pub struct GetDigest {
     pub to_offset: LogletOffset,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::DigestEntry")]
 #[display("[{from_offset}..{to_offset}] -> {status} ({})",  self.len())]
 pub struct DigestEntry {
     // inclusive
@@ -627,8 +633,11 @@ pub struct DigestEntry {
     pub status: RecordStatus,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, derive_more::Display, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Eq, PartialEq, derive_more::Display, Serialize, Deserialize, IntoProto, FromProto,
+)]
 #[repr(u8)]
+#[proto(target = "crate::protobuf::log_server_common::RecordStatus")]
 pub enum RecordStatus {
     #[display("T")]
     Trimmed,
@@ -654,9 +663,11 @@ impl DigestEntry {
 }
 
 /// Response to a `GetDigest` request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
+#[proto(target = "crate::protobuf::log_server_common::Digest")]
 pub struct Digest {
     #[serde(flatten)]
+    #[proto(required)]
     pub header: LogServerResponseHeader,
     // If the node's local trim-point (or archival-point) overlaps with the digest range, an entry will be
     // added to include where the trim-gap ends. Otherwise, offsets for non-existing records

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use enum_map::Enum;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
@@ -69,10 +71,10 @@ pub enum MetadataKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize, derive_more::From)]
 pub enum MetadataContainer {
-    NodesConfiguration(NodesConfiguration),
-    PartitionTable(PartitionTable),
-    Logs(Logs),
-    Schema(Schema),
+    NodesConfiguration(Arc<NodesConfiguration>),
+    PartitionTable(Arc<PartitionTable>),
+    Logs(Arc<Logs>),
+    Schema(Arc<Schema>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -11,14 +11,12 @@
 pub mod cluster_controller;
 pub mod codec;
 mod error;
-#[cfg(feature = "replicated-loglet")]
 pub mod log_server;
 pub mod metadata;
 pub mod node;
 pub mod partition_processor;
 pub mod partition_processor_manager;
 pub mod remote_query_scanner;
-#[cfg(feature = "replicated-loglet")]
 pub mod replicated_loglet;
 
 // re-exports for convenience

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -196,3 +196,14 @@ pub mod node {
         }
     }
 }
+
+pub mod log_server_common {
+
+    include!(concat!(env!("OUT_DIR"), "/restate.log_server_common.rs"));
+
+    impl std::fmt::Display for RecordStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Display::fmt(&crate::net::log_server::RecordStatus::from(*self as i32), f)
+        }
+    }
+}

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use super::ReplicationProperty;
 use crate::logs::metadata::SegmentIndex;
@@ -106,6 +107,25 @@ impl ReplicatedLogletId {
 impl Display for ReplicatedLogletId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}_{}", self.log_id(), self.segment_index())
+    }
+}
+
+impl FromStr for ReplicatedLogletId {
+    type Err = <u64 as FromStr>::Err;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains('_') {
+            let parts: Vec<&str> = s.split('_').collect();
+            let log_id: u32 = parts[0].parse()?;
+            let segment_index: u32 = parts[1].parse()?;
+            Ok(ReplicatedLogletId::new(
+                LogId::from(log_id),
+                SegmentIndex::from(segment_index),
+            ))
+        } else {
+            // treat the string as raw replicated log-id
+            let id: u64 = s.parse()?;
+            Ok(ReplicatedLogletId(id))
+        }
     }
 }
 

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
@@ -170,7 +171,7 @@ fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (TaskCenter,
             .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
             .await
             .expect("to store bifrost config in metadata store");
-        metadata_writer.submit(logs);
+        metadata_writer.submit(Arc::new(logs));
         spawn_metadata_manager(&task_center, metadata_manager).expect("metadata manager starts");
 
         let bifrost_svc = BifrostService::new(task_center, metadata)

--- a/tools/mock-service-endpoint/Cargo.toml
+++ b/tools/mock-service-endpoint/Cargo.toml
@@ -17,7 +17,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["server"] }
 hyper-util = { workspace = true, features = ["full"] }
 restate-service-protocol = { workspace = true, features = ["message", "codec"] }
-restate-types = { workspace = true, features = ["replicated-loglet"] }
+restate-types = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [features]
 default = ["replicated-loglet", "memory-loglet"]
 replicated-loglet = [
-    "restate-types/replicated-loglet",
     "restate-bifrost/replicated-loglet",
 ]
 memory-loglet = ["restate-types/memory-loglet", "restate-bifrost/memory-loglet", "restate-admin/memory-loglet"]

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -21,6 +21,7 @@ use crate::commands::log::Logs;
 use crate::commands::metadata::Metadata;
 use crate::commands::node::Nodes;
 use crate::commands::partition::Partitions;
+use crate::commands::replicated_loglet::ReplicatedLoglet;
 use crate::commands::snapshot::Snapshot;
 
 #[derive(Run, Parser, Clone)]
@@ -67,6 +68,9 @@ pub enum Command {
     /// Partition processor snapshots
     #[clap(subcommand)]
     Snapshots(Snapshot),
+    /// Commands that operate on replicated loglets
+    #[clap(subcommand)]
+    ReplicatedLoglet(ReplicatedLoglet),
 }
 
 fn init(common_opts: &CommonOpts) {

--- a/tools/restatectl/src/commands/replicated_loglet/info.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/info.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use cling::prelude::*;
+
+use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
+use restate_admin::cluster_controller::protobuf::ListLogsRequest;
+use restate_cli_util::{c_indentln, c_println};
+use restate_types::logs::metadata::Logs;
+use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::storage::StorageCodec;
+use restate_types::Versioned;
+use tonic::codec::CompressionEncoding;
+
+use crate::app::ConnectionInfo;
+use crate::util::grpc_connect;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "get_info")]
+pub struct InfoOpts {
+    /// The replicated loglet id
+    loglet_id: ReplicatedLogletId,
+}
+
+async fn get_info(connection: &ConnectionInfo, opts: &InfoOpts) -> anyhow::Result<()> {
+    let channel = grpc_connect(connection.cluster_controller.clone())
+        .await
+        .with_context(|| {
+            format!(
+                "cannot connect to cluster controller at {}",
+                connection.cluster_controller
+            )
+        })?;
+    let mut client =
+        ClusterCtrlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
+
+    let req = ListLogsRequest::default();
+    let response = client.list_logs(req).await?.into_inner();
+
+    let mut buf = response.logs;
+    let logs = StorageCodec::decode::<Logs, _>(&mut buf)?;
+    c_println!("Log Configuration ({})", logs.version());
+
+    let Some(loglet_ref) = logs.get_replicated_loglet(&opts.loglet_id) else {
+        return Err(anyhow::anyhow!("loglet {} not found", opts.loglet_id));
+    };
+
+    c_println!("Loglet Referenced in: ");
+    for (log_id, segment) in &loglet_ref.references {
+        c_indentln!(2, "- LogId={}, Segment={}", log_id, segment);
+    }
+    c_println!();
+    c_println!("Loglet Parameters:");
+    c_indentln!(
+        2,
+        "Loglet Id: {} ({})",
+        loglet_ref.params.loglet_id,
+        *loglet_ref.params.loglet_id
+    );
+    c_indentln!(2, "Sequencer: {}", loglet_ref.params.sequencer);
+    c_indentln!(2, "Replication: {}", loglet_ref.params.replication);
+    c_indentln!(2, "Node Set: {}", loglet_ref.params.nodeset);
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/replicated_loglet/mod.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/mod.rs
@@ -8,12 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod cluster;
-mod display_util;
-pub mod dump;
-pub mod log;
-pub mod metadata;
-pub mod node;
-pub mod partition;
-pub mod replicated_loglet;
-pub mod snapshot;
+mod info;
+
+use cling::prelude::*;
+
+#[derive(Run, Subcommand, Clone)]
+pub enum ReplicatedLoglet {
+    /// View loglet info
+    Info(info::InfoOpts),
+}


### PR DESCRIPTION

Currently this only implements a very basic `info`. Note that the command is built merely as an example, it's UI/UX and behaviour will change by follow-ups.

Pass by stringified log_id (`<log_id>_<segment>`)
```
cargo run -q --bin restatectl -- replicated-loglet info 1_0                                                                              ✘ 1
Log Configuration (v1)
Loglet Referenced in:
    - LogId=1, Segment=0

Loglet Parameters:
    Loglet Id: 1_0 (4294967296)
    Sequencer: N1:1
    Replication: {node: 2}
    Node Set: [N3, N2, N1]
```

Or raw loglet id (`<loglet_id>`)
```
cargo run -q --bin restatectl -- replicated-loglet info 1_0                                                                              ✘ 1
Log Configuration (v1)
Loglet Referenced in:
    - LogId=1, Segment=0

Loglet Parameters:
    Loglet Id: 1_0 (4294967296)
    Sequencer: N1:1
    Replication: {node: 2}
    Node Set: [N3, N2, N1]

```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2231).
* #2257
* #2256
* __->__ #2231
* #2230
* #2229
* #2222