### PR TITLE
Fix broken main

### DIFF
--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -90,6 +90,7 @@ impl PartitionProcessorRpcError {
             PartitionProcessorRpcError::LostLeadership(_) => true,
             PartitionProcessorRpcError::Busy => false,
             PartitionProcessorRpcError::Internal(_) => false,
+            PartitionProcessorRpcError::Starting => false,
         }
     }
 }


### PR DESCRIPTION
Fix broken main

Summary:
A merge conflict was not detected whcih caused the build
to fail only after merging
