### PR TITLE
Make PartitionProcessorManager asynchronous and handle shut down of PPs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7014,6 +7014,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ulid",
 ]
 
 [[package]]

--- a/crates/core/src/network/partition_processor_rpc_client.rs
+++ b/crates/core/src/network/partition_processor_rpc_client.rs
@@ -50,6 +50,8 @@ pub enum PartitionProcessorRpcClientError {
     Internal(String),
     #[error("partition processor starting")]
     Starting,
+    #[error("partition processor stopping")]
+    Stopping,
 }
 
 impl PartitionProcessorRpcClientError {
@@ -65,7 +67,8 @@ impl PartitionProcessorRpcClientError {
             | PartitionProcessorRpcClientError::UnknownPartition(_)
             | PartitionProcessorRpcClientError::UnknownNode(_)
             | PartitionProcessorRpcClientError::NotLeader(_)
-            | PartitionProcessorRpcClientError::Starting => {
+            | PartitionProcessorRpcClientError::Starting
+            | PartitionProcessorRpcClientError::Stopping => {
                 // These are pre-flight error that we can distinguish,
                 // and for which we know for certain that no message was proposed yet to the log.
                 true
@@ -89,6 +92,7 @@ impl From<PartitionProcessorRpcError> for PartitionProcessorRpcClientError {
                 PartitionProcessorRpcClientError::Internal(msg)
             }
             PartitionProcessorRpcError::Starting => PartitionProcessorRpcClientError::Starting,
+            PartitionProcessorRpcError::Stopping => PartitionProcessorRpcClientError::Stopping,
         }
     }
 }

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -8,12 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::pin::Pin;
-use std::task::{ready, Poll};
-
 use futures::FutureExt;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
 use strum::EnumProperty;
 use tokio::runtime::RuntimeMetrics;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
 use crate::ShutdownError;
@@ -235,5 +235,32 @@ impl RuntimeHandle {
     /// the runtime has been terminated.
     pub fn is_cancellation_requested(&self) -> bool {
         self.cancellation_token.is_cancelled()
+    }
+}
+
+pub struct RuntimeRootTaskHandle<T> {
+    pub(crate) cancellation_token: CancellationToken,
+    pub(crate) inner_handle: oneshot::Receiver<T>,
+}
+
+impl<T> RuntimeRootTaskHandle<T> {
+    /// Trigger graceful shutdown of the runtime root task. Shutdown is not guaranteed, it depends
+    /// on whether the root task awaits the cancellation token or not.
+    pub fn cancel(&self) {
+        self.cancellation_token.cancel()
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
+    }
+}
+
+impl<T> std::future::Future for RuntimeRootTaskHandle<T> {
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(
+            ready!(self.inner_handle.poll_unpin(cx)).expect("runtime panicked unexpectedly"),
+        )
     }
 }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -251,6 +251,7 @@ where
         self,
         mut updateable_options: impl LiveLoad<InvokerOptions> + Send + 'static,
     ) -> anyhow::Result<()> {
+        debug!("Starting the invoker");
         let Service {
             tmp_dir,
             inner: mut service,

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -81,6 +81,8 @@ pub enum PartitionProcessorRpcError {
     Internal(String),
     #[error("partition processor starting")]
     Starting,
+    #[error("partition processor stopping")]
+    Stopping,
 }
 
 impl PartitionProcessorRpcError {
@@ -91,6 +93,7 @@ impl PartitionProcessorRpcError {
             PartitionProcessorRpcError::Busy => false,
             PartitionProcessorRpcError::Internal(_) => false,
             PartitionProcessorRpcError::Starting => false,
+            PartitionProcessorRpcError::Stopping => false,
         }
     }
 }

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -41,6 +41,16 @@ pub enum ProcessorCommand {
     Leader,
 }
 
+impl ProcessorCommand {
+    pub fn as_run_mode(&self) -> Option<RunMode> {
+        match self {
+            ProcessorCommand::Stop => None,
+            ProcessorCommand::Follower => Some(RunMode::Follower),
+            ProcessorCommand::Leader => Some(RunMode::Leader),
+        }
+    }
+}
+
 impl From<RunMode> for ProcessorCommand {
     fn from(value: RunMode) -> Self {
         match value {

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -69,6 +69,7 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+ulid = { workspace = true }
 
 [dev-dependencies]
 restate-bifrost = { workspace = true, features = ["test-util"] }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -265,6 +265,7 @@ where
 {
     #[instrument(level = "error", skip_all, fields(partition_id = %self.partition_id, is_leader = tracing::field::Empty))]
     pub async fn run(mut self) -> anyhow::Result<()> {
+        debug!("Starting the partition processor");
         let res = self.run_inner().await;
 
         // Drain control_rx

--- a/crates/worker/src/partition_processor_manager/message_handler.rs
+++ b/crates/worker/src/partition_processor_manager/message_handler.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_core::network::{Incoming, MessageHandler};
+use restate_core::worker_api::ProcessorsManagerHandle;
+use restate_core::{task_center, TaskKind};
+use restate_types::net::partition_processor_manager::{
+    CreateSnapshotRequest, CreateSnapshotResponse, SnapshotError,
+};
+use tracing::{debug, warn};
+
+/// RPC message handler for Partition Processor management operations.
+pub struct PartitionProcessorManagerMessageHandler {
+    processors_manager_handle: ProcessorsManagerHandle,
+}
+
+impl PartitionProcessorManagerMessageHandler {
+    pub fn new(
+        processors_manager_handle: ProcessorsManagerHandle,
+    ) -> PartitionProcessorManagerMessageHandler {
+        Self {
+            processors_manager_handle,
+        }
+    }
+}
+
+impl MessageHandler for PartitionProcessorManagerMessageHandler {
+    type MessageType = CreateSnapshotRequest;
+
+    async fn on_message(&self, msg: Incoming<Self::MessageType>) {
+        debug!("Received '{:?}' from {}", msg.body(), msg.peer());
+
+        let processors_manager_handle = self.processors_manager_handle.clone();
+        task_center()
+            .spawn_child(
+                TaskKind::Disposable,
+                "create-snapshot-request-rpc",
+                None,
+                async move {
+                    let create_snapshot_result = processors_manager_handle
+                        .create_snapshot(msg.body().partition_id)
+                        .await;
+                    debug!(
+                        partition_id = ?msg.body().partition_id,
+                        result = ?create_snapshot_result,
+                        "Create snapshot completed",
+                    );
+
+                    match create_snapshot_result.as_ref() {
+                        Ok(snapshot_id) => msg.to_rpc_response(CreateSnapshotResponse {
+                            result: Ok(*snapshot_id),
+                        }),
+                        Err(error) => msg.to_rpc_response(CreateSnapshotResponse {
+                            result: Err(SnapshotError::SnapshotCreationFailed(error.to_string())),
+                        }),
+                    }
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        warn!(result = ?create_snapshot_result, "Failed to send response: {}", e);
+                        anyhow::anyhow!("Failed to send response to create snapshot request: {}", e)
+                    })
+                },
+            )
+            .map_err(|e| {
+                warn!("Failed to spawn request handler: {}", e);
+            })
+            .ok();
+    }
+}

--- a/crates/worker/src/partition_processor_manager/mod.rs
+++ b/crates/worker/src/partition_processor_manager/mod.rs
@@ -511,15 +511,25 @@ impl<T: TransportConnect> PartitionProcessorManager<T> {
         use ProcessorsManagerCommand::*;
         match command {
             CreateSnapshot(partition_id, sender) => {
-                self.running_partition_processors
-                    .get(&partition_id)
-                    .map(|store| {
-                        let ProcessorState::Started(state) = store else {
-                            return None;
-                        };
-
-                        Some(state.create_snapshot(sender))
-                    });
+                if let Some(processor_state) = self.running_partition_processors.get(&partition_id)
+                {
+                    match processor_state {
+                        ProcessorState::Starting(_) => {
+                            let _ = sender.send(Err(anyhow::anyhow!(
+                                "Partition processors '{}' is still starting",
+                                partition_id
+                            )));
+                        }
+                        ProcessorState::Started(started_processor) => {
+                            started_processor.create_snapshot(sender);
+                        }
+                    }
+                } else {
+                    let _ = sender.send(Err(anyhow::anyhow!(
+                        "Partition processor '{}' not found",
+                        partition_id
+                    )));
+                }
             }
             GetState(sender) => {
                 let _ = sender.send(self.get_state());

--- a/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
+++ b/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
@@ -1,0 +1,267 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use futures::future::OptionFuture;
+use restate_core::cancellation_watcher;
+use restate_partition_store::PartitionStoreManager;
+use restate_storage_api::fsm_table::ReadOnlyFsmTable;
+use restate_storage_api::StorageError;
+use restate_types::config::{Configuration, StorageOptions};
+use restate_types::identifiers::PartitionId;
+use restate_types::live::LiveLoad;
+use restate_types::logs::{Lsn, SequenceNumber};
+use std::collections::BTreeMap;
+use tokio::sync::watch;
+use tokio::time;
+use tokio::time::MissedTickBehavior;
+use tracing::{debug, trace, warn};
+
+/// Monitors the persisted log lsns and notifies the partition processor manager about it. The
+/// current approach requires flushing the memtables to make sure that data has been persisted.
+/// An alternative approach could be to register an event listener on flush events and using
+/// table properties to retrieve the flushed log lsn. However, this requires that we update our
+/// RocksDB binding to expose event listeners and table properties :-(
+pub struct PersistedLogLsnWatchdog {
+    configuration: Box<dyn LiveLoad<StorageOptions> + Send + Sync + 'static>,
+    partition_store_manager: PartitionStoreManager,
+    watch_tx: watch::Sender<BTreeMap<PartitionId, Lsn>>,
+    persisted_lsns: BTreeMap<PartitionId, Lsn>,
+    persist_lsn_interval: Option<time::Interval>,
+    persist_lsn_threshold: Lsn,
+}
+
+impl PersistedLogLsnWatchdog {
+    pub fn new(
+        mut configuration: impl LiveLoad<StorageOptions> + Send + Sync + 'static,
+        partition_store_manager: PartitionStoreManager,
+        watch_tx: watch::Sender<BTreeMap<PartitionId, Lsn>>,
+    ) -> Self {
+        let options = configuration.live_load();
+
+        let (persist_lsn_interval, persist_lsn_threshold) = Self::create_persist_lsn(options);
+
+        PersistedLogLsnWatchdog {
+            configuration: Box::new(configuration),
+            partition_store_manager,
+            watch_tx,
+            persisted_lsns: BTreeMap::default(),
+            persist_lsn_interval,
+            persist_lsn_threshold,
+        }
+    }
+
+    fn create_persist_lsn(options: &StorageOptions) -> (Option<time::Interval>, Lsn) {
+        let persist_lsn_interval = options.persist_lsn_interval.map(|duration| {
+            let mut interval = time::interval(duration.into());
+            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            interval
+        });
+
+        let persist_lsn_threshold = Lsn::from(options.persist_lsn_threshold);
+
+        (persist_lsn_interval, persist_lsn_threshold)
+    }
+
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        debug!("Start running persisted lsn watchdog");
+
+        let mut shutdown = std::pin::pin!(cancellation_watcher());
+        let mut config_watcher = Configuration::watcher();
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => {
+                    break;
+                },
+                _ = OptionFuture::from(self.persist_lsn_interval.as_mut().map(|interval| interval.tick())) => {
+                    let result = self.update_persisted_lsns().await;
+
+                    if let Err(err) = result {
+                        warn!("Failed updating the persisted applied lsns. This might prevent the log from being trimmed: {err}");
+                    }
+                }
+                _ = config_watcher.changed() => {
+                    self.on_config_update();
+                }
+            }
+        }
+
+        debug!("Stop persisted lsn watchdog");
+        Ok(())
+    }
+
+    fn on_config_update(&mut self) {
+        debug!("Updating the persisted log lsn watchdog");
+        let options = self.configuration.live_load();
+
+        (self.persist_lsn_interval, self.persist_lsn_threshold) = Self::create_persist_lsn(options);
+    }
+
+    async fn update_persisted_lsns(&mut self) -> Result<(), StorageError> {
+        let partition_stores = self
+            .partition_store_manager
+            .get_all_partition_stores()
+            .await;
+
+        let mut new_persisted_lsns = BTreeMap::new();
+        let mut modified = false;
+
+        for mut partition_store in partition_stores {
+            let partition_id = partition_store.partition_id();
+
+            let applied_lsn = partition_store.get_applied_lsn().await?;
+
+            if let Some(applied_lsn) = applied_lsn {
+                let previously_applied_lsn = self
+                    .persisted_lsns
+                    .get(&partition_id)
+                    .cloned()
+                    .unwrap_or(Lsn::INVALID);
+
+                // only flush if there was some activity compared to the last check
+                if applied_lsn >= previously_applied_lsn + self.persist_lsn_threshold {
+                    // since we cannot be sure that we have read the applied lsn from disk, we need
+                    // to flush the memtables to be sure that it is persisted
+                    trace!(
+                        partition_id = %partition_id,
+                        applied_lsn = %applied_lsn,
+                        "Flush partition store to persist applied lsn"
+                    );
+                    partition_store.flush_memtables(true).await?;
+                    new_persisted_lsns.insert(partition_id, applied_lsn);
+                    modified = true;
+                } else {
+                    new_persisted_lsns.insert(partition_id, previously_applied_lsn);
+                }
+            }
+        }
+
+        if modified {
+            self.persisted_lsns = new_persisted_lsns.clone();
+            // ignore send failures which should only occur during shutdown
+            let _ = self.watch_tx.send(new_persisted_lsns);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::partition_processor_manager::persisted_lsn_watchdog::PersistedLogLsnWatchdog;
+    use restate_core::{TaskKind, TestCoreEnv};
+    use restate_partition_store::{OpenMode, PartitionStoreManager};
+    use restate_rocksdb::RocksDbManager;
+    use restate_storage_api::fsm_table::FsmTable;
+    use restate_storage_api::Transaction;
+    use restate_types::config::{CommonOptions, RocksDbOptions, StorageOptions};
+    use restate_types::identifiers::{PartitionId, PartitionKey};
+    use restate_types::live::Constant;
+    use restate_types::logs::{Lsn, SequenceNumber};
+    use std::collections::BTreeMap;
+    use std::ops::RangeInclusive;
+    use std::time::Duration;
+    use test_log::test;
+    use tokio::sync::watch;
+    use tokio::time::Instant;
+
+    #[test(tokio::test(start_paused = true))]
+    async fn persisted_log_lsn_watchdog_detects_applied_lsns() -> anyhow::Result<()> {
+        let node_env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let storage_options = StorageOptions::default();
+        let rocksdb_options = RocksDbOptions::default();
+
+        node_env.tc.run_in_scope_sync("db-manager-init", None, || {
+            RocksDbManager::init(Constant::new(CommonOptions::default()))
+        });
+
+        let all_partition_keys = RangeInclusive::new(0, PartitionKey::MAX);
+        let partition_store_manager = PartitionStoreManager::create(
+            Constant::new(storage_options.clone()).boxed(),
+            Constant::new(rocksdb_options.clone()).boxed(),
+            &[(PartitionId::MIN, all_partition_keys.clone())],
+        )
+        .await?;
+
+        let mut partition_store = partition_store_manager
+            .open_partition_store(
+                PartitionId::MIN,
+                all_partition_keys,
+                OpenMode::CreateIfMissing,
+                &rocksdb_options,
+            )
+            .await
+            .expect("partition store present");
+
+        let (watch_tx, mut watch_rx) = watch::channel(BTreeMap::default());
+
+        let watchdog = PersistedLogLsnWatchdog::new(
+            Constant::new(storage_options.clone()),
+            partition_store_manager.clone(),
+            watch_tx,
+        );
+
+        let now = Instant::now();
+
+        node_env.tc.spawn(
+            TaskKind::Watchdog,
+            "persiste-log-lsn-test",
+            None,
+            watchdog.run(),
+        )?;
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), watch_rx.changed())
+                .await
+                .is_err()
+        );
+        let mut txn = partition_store.transaction();
+        let lsn = Lsn::OLDEST + Lsn::from(storage_options.persist_lsn_threshold);
+        txn.put_applied_lsn(lsn).await;
+        txn.commit().await?;
+
+        watch_rx.changed().await?;
+        assert_eq!(watch_rx.borrow().get(&PartitionId::MIN), Some(&lsn));
+        let persist_lsn_interval: Duration = storage_options
+            .persist_lsn_interval
+            .expect("should be enabled")
+            .into();
+        assert!(now.elapsed() >= persist_lsn_interval);
+
+        // we are short by one to hit the persist lsn threshold
+        let next_lsn = lsn.prev() + Lsn::from(storage_options.persist_lsn_threshold);
+        let mut txn = partition_store.transaction();
+        txn.put_applied_lsn(next_lsn).await;
+        txn.commit().await?;
+
+        // await the persist lsn interval so that we have a chance to see the update
+        tokio::time::sleep(persist_lsn_interval).await;
+
+        // we should not receive a new notification because we haven't reached the threshold yet
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), watch_rx.changed())
+                .await
+                .is_err()
+        );
+
+        let next_persisted_lsn = next_lsn + Lsn::from(1);
+        let mut txn = partition_store.transaction();
+        txn.put_applied_lsn(next_persisted_lsn).await;
+        txn.commit().await?;
+
+        watch_rx.changed().await?;
+        assert_eq!(
+            watch_rx.borrow().get(&PartitionId::MIN),
+            Some(&next_persisted_lsn)
+        );
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::partition::PartitionProcessorControlCommand;
+use crate::partition_processor_manager::Error;
+use restate_core::metadata_store::{MetadataStoreClient, ReadModifyWriteError};
+use restate_core::network::Incoming;
+use restate_core::{ShutdownError, TaskCenter, TaskId};
+use restate_invoker_impl::ChannelStatusReader;
+use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
+use restate_types::epoch::EpochMetadata;
+use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, SnapshotId};
+use restate_types::metadata_store::keys::partition_processor_epoch_key;
+use restate_types::net::partition_processor::PartitionProcessorRpcRequest;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::GenerationalNodeId;
+use std::ops::RangeInclusive;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+pub enum ProcessorState {
+    Starting(JoinHandle<()>),
+    Started(StartedProcessor),
+}
+
+impl ProcessorState {
+    pub async fn stop(self, task_center: &TaskCenter) {
+        match self {
+            Self::Started(processor) => {
+                let handle = task_center.cancel_task(processor.task_id);
+
+                if let Some(handle) = handle {
+                    debug!("Asked by cluster-controller to stop partition");
+                    if let Err(err) = handle.await {
+                        warn!("Partition processor crashed while shutting down: {err}");
+                    }
+                }
+            }
+            Self::Starting(handle) => handle.abort(),
+        };
+    }
+}
+
+pub struct StartedProcessor {
+    partition_id: PartitionId,
+    task_id: TaskId,
+    _created_at: MillisSinceEpoch,
+    key_range: RangeInclusive<PartitionKey>,
+    planned_mode: RunMode,
+    running_for_leadership_with_epoch: Option<LeaderEpoch>,
+    handle: PartitionProcessorHandle,
+    status_reader: ChannelStatusReader,
+    rpc_tx: mpsc::Sender<Incoming<PartitionProcessorRpcRequest>>,
+    watch_rx: watch::Receiver<PartitionProcessorStatus>,
+}
+
+impl StartedProcessor {
+    pub fn new(
+        partition_id: PartitionId,
+        task_id: TaskId,
+        key_range: RangeInclusive<PartitionKey>,
+        handle: PartitionProcessorHandle,
+        status_reader: ChannelStatusReader,
+        rpc_tx: mpsc::Sender<Incoming<PartitionProcessorRpcRequest>>,
+        watch_rx: watch::Receiver<PartitionProcessorStatus>,
+    ) -> Self {
+        Self {
+            partition_id,
+            task_id,
+            _created_at: MillisSinceEpoch::now(),
+            key_range,
+            planned_mode: RunMode::Follower,
+            running_for_leadership_with_epoch: None,
+            handle,
+            status_reader,
+            rpc_tx,
+            watch_rx,
+        }
+    }
+
+    pub fn step_down(&mut self) -> Result<(), Error> {
+        if self.planned_mode != RunMode::Follower {
+            debug!("Asked by cluster-controller to demote partition to follower");
+            self.handle.step_down()?;
+        }
+
+        self.running_for_leadership_with_epoch = None;
+        self.planned_mode = RunMode::Follower;
+
+        Ok(())
+    }
+
+    pub async fn run_for_leader(
+        &mut self,
+        metadata_store_client: MetadataStoreClient,
+        node_id: GenerationalNodeId,
+    ) -> Result<(), Error> {
+        // run for leadership if there is no ongoing attempt or our current attempt is proven to be
+        // unsuccessful because we have already seen a higher leader epoch.
+        if self.running_for_leadership_with_epoch.is_none()
+            || self
+                .running_for_leadership_with_epoch
+                .is_some_and(|my_leader_epoch| {
+                    my_leader_epoch
+                        < self
+                            .watch_rx
+                            .borrow()
+                            .last_observed_leader_epoch
+                            .unwrap_or(LeaderEpoch::INITIAL)
+                })
+        {
+            // todo alternative could be to let the CC decide the leader epoch
+            let leader_epoch =
+                Self::obtain_next_epoch(metadata_store_client, self.partition_id, node_id).await?;
+            debug!(%leader_epoch, "Asked by cluster-controller to promote partition to leader");
+            self.running_for_leadership_with_epoch = Some(leader_epoch);
+            self.handle.run_for_leader(leader_epoch)?;
+        }
+
+        self.planned_mode = RunMode::Leader;
+
+        Ok(())
+    }
+
+    async fn obtain_next_epoch(
+        metadata_store_client: MetadataStoreClient,
+        partition_id: PartitionId,
+        node_id: GenerationalNodeId,
+    ) -> Result<LeaderEpoch, ReadModifyWriteError> {
+        let epoch: EpochMetadata = metadata_store_client
+            .read_modify_write(partition_processor_epoch_key(partition_id), |epoch| {
+                let next_epoch = epoch
+                    .map(|epoch: EpochMetadata| epoch.claim_leadership(node_id, partition_id))
+                    .unwrap_or_else(|| EpochMetadata::new(node_id, partition_id));
+
+                Ok(next_epoch)
+            })
+            .await?;
+        Ok(epoch.epoch())
+    }
+
+    #[inline]
+    pub fn partition_id(&self) -> PartitionId {
+        self.partition_id
+    }
+
+    #[inline]
+    pub fn key_range(&self) -> &RangeInclusive<PartitionKey> {
+        &self.key_range
+    }
+
+    #[inline]
+    pub fn invoker_status_reader(&self) -> &ChannelStatusReader {
+        &self.status_reader
+    }
+
+    #[inline]
+    pub fn partition_processor_status(&self) -> PartitionProcessorStatus {
+        self.watch_rx.borrow().clone()
+    }
+
+    #[inline]
+    pub fn planned_mode(&self) -> RunMode {
+        self.planned_mode
+    }
+
+    pub fn try_send_rpc(
+        &self,
+        rpc: Incoming<PartitionProcessorRpcRequest>,
+    ) -> Result<(), TrySendError<Incoming<PartitionProcessorRpcRequest>>> {
+        self.rpc_tx.try_send(rpc)
+    }
+
+    pub fn create_snapshot(
+        &self,
+        result_tx: oneshot::Sender<anyhow::Result<SnapshotId>>,
+    ) -> Result<(), PartitionProcessorHandleError> {
+        self.handle.create_snapshot(Some(result_tx))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PartitionProcessorHandleError {
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
+    #[error("command could not be sent")]
+    FailedSend,
+}
+
+impl<T> From<TrySendError<T>> for PartitionProcessorHandleError {
+    fn from(value: TrySendError<T>) -> Self {
+        match value {
+            TrySendError::Full(_) => PartitionProcessorHandleError::FailedSend,
+            TrySendError::Closed(_) => PartitionProcessorHandleError::Shutdown(ShutdownError),
+        }
+    }
+}
+
+pub struct PartitionProcessorHandle {
+    control_tx: mpsc::Sender<PartitionProcessorControlCommand>,
+}
+
+impl PartitionProcessorHandle {
+    pub fn new(control_tx: mpsc::Sender<PartitionProcessorControlCommand>) -> Self {
+        Self { control_tx }
+    }
+
+    fn step_down(&self) -> Result<(), PartitionProcessorHandleError> {
+        self.control_tx
+            .try_send(PartitionProcessorControlCommand::StepDown)?;
+        Ok(())
+    }
+
+    fn run_for_leader(
+        &self,
+        leader_epoch: LeaderEpoch,
+    ) -> Result<(), PartitionProcessorHandleError> {
+        self.control_tx
+            .try_send(PartitionProcessorControlCommand::RunForLeader(leader_epoch))?;
+        Ok(())
+    }
+
+    fn create_snapshot(
+        &self,
+        sender: Option<oneshot::Sender<anyhow::Result<SnapshotId>>>,
+    ) -> Result<(), PartitionProcessorHandleError> {
+        self.control_tx
+            .try_send(PartitionProcessorControlCommand::CreateSnapshot(sender))?;
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -9,55 +9,372 @@
 // by the Apache License, Version 2.0.
 
 use crate::partition::PartitionProcessorControlCommand;
-use crate::partition_processor_manager::Error;
-use restate_core::metadata_store::{MetadataStoreClient, ReadModifyWriteError};
+use assert2::let_assert;
 use restate_core::network::Incoming;
-use restate_core::{ShutdownError, TaskCenter, TaskId};
+use restate_core::{TaskCenter, TaskKind};
 use restate_invoker_impl::ChannelStatusReader;
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
-use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, SnapshotId};
-use restate_types::metadata_store::keys::partition_processor_epoch_key;
-use restate_types::net::partition_processor::PartitionProcessorRpcRequest;
+use restate_types::net::partition_processor::{
+    PartitionProcessorRpcError, PartitionProcessorRpcRequest,
+};
 use restate_types::time::MillisSinceEpoch;
-use restate_types::GenerationalNodeId;
 use std::ops::RangeInclusive;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, oneshot, watch};
-use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use ulid::Ulid;
 
-pub enum ProcessorState {
-    Starting(JoinHandle<()>),
-    Started(StartedProcessor),
+pub type LeaderEpochToken = Ulid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProcessorStateError {
+    #[error("partition processor is busy")]
+    Busy,
+    #[error("partition processor is shutting down")]
+    ShuttingDown,
 }
 
-impl ProcessorState {
-    pub async fn stop(self, task_center: &TaskCenter) {
-        match self {
-            Self::Started(processor) => {
-                let handle = task_center.cancel_task(processor.task_id);
-
-                if let Some(handle) = handle {
-                    debug!("Asked by cluster-controller to stop partition");
-                    if let Err(err) = handle.await {
-                        warn!("Partition processor crashed while shutting down: {err}");
-                    }
-                }
-            }
-            Self::Starting(handle) => handle.abort(),
-        };
+impl<T> From<TrySendError<T>> for ProcessorStateError {
+    fn from(value: TrySendError<T>) -> Self {
+        match value {
+            TrySendError::Full(_) => ProcessorStateError::Busy,
+            TrySendError::Closed(_) => ProcessorStateError::ShuttingDown,
+        }
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum LeaderState {
+    Leader(LeaderEpoch),
+    AwaitingLeaderEpoch(LeaderEpochToken),
+    Follower,
+}
+
+#[derive(Debug)]
+pub enum ProcessorState {
+    Starting {
+        target_run_mode: RunMode,
+    },
+    Started {
+        processor: Option<StartedProcessor>,
+        leader_state: LeaderState,
+    },
+    Stopping {
+        processor: Option<StartedProcessor>,
+        restart_as: Option<RunMode>,
+    },
+}
+
+impl ProcessorState {
+    pub fn starting(target_run_mode: RunMode) -> Self {
+        Self::Starting { target_run_mode }
+    }
+
+    pub fn stopping(processor: StartedProcessor) -> Self {
+        Self::Stopping {
+            processor: Some(processor),
+            restart_as: None,
+        }
+    }
+
+    pub fn started(processor: StartedProcessor) -> Self {
+        Self::Started {
+            processor: Some(processor),
+            leader_state: LeaderState::Follower,
+        }
+    }
+
+    pub fn stop(&mut self) {
+        match self {
+            ProcessorState::Starting { .. } => {
+                // let's see whether we can stop a starting PP eagerly
+                *self = ProcessorState::Stopping {
+                    restart_as: None,
+                    processor: None,
+                }
+            }
+            ProcessorState::Started { processor, .. } => {
+                let processor = processor.take().expect("must be some");
+                processor.cancel();
+                *self = ProcessorState::Stopping {
+                    restart_as: None,
+                    processor: Some(processor),
+                };
+            }
+            ProcessorState::Stopping { restart_as, .. } => {
+                *restart_as = None;
+            }
+        };
+    }
+
+    pub fn run_as_follower(&mut self) -> Result<(), ProcessorStateError> {
+        match self {
+            ProcessorState::Starting {
+                target_run_mode, ..
+            } => {
+                *target_run_mode = RunMode::Follower;
+            }
+            ProcessorState::Started {
+                processor,
+                leader_state,
+            } => {
+                match leader_state {
+                    LeaderState::Leader(_) => {
+                        processor.as_ref().expect("must be some").step_down()?;
+                        *leader_state = LeaderState::Follower;
+                    }
+                    LeaderState::AwaitingLeaderEpoch(_) => {
+                        *leader_state = LeaderState::Follower;
+                    }
+                    LeaderState::Follower => {
+                        // nothing to do
+                    }
+                }
+            }
+            ProcessorState::Stopping { restart_as, .. } => {
+                *restart_as = Some(RunMode::Follower);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns a new [`LeaderEpochToken`] if a new leader epoch should be obtained.
+    pub fn run_as_leader(&mut self) -> Option<LeaderEpochToken> {
+        match self {
+            ProcessorState::Starting { target_run_mode } => {
+                *target_run_mode = RunMode::Leader;
+                None
+            }
+            ProcessorState::Started {
+                processor,
+                leader_state,
+            } => {
+                match leader_state {
+                    LeaderState::Leader(leader_epoch) => {
+                        // our processor that is supposed to be the leader has observed a newer leader epoch
+                        if *leader_epoch
+                            < processor
+                                .as_ref()
+                                .expect("must be some")
+                                .last_observed_leader_epoch()
+                                .unwrap_or(LeaderEpoch::INITIAL)
+                        {
+                            let leader_epoch_token = LeaderEpochToken::new();
+                            *leader_state = LeaderState::AwaitingLeaderEpoch(leader_epoch_token);
+                            Some(leader_epoch_token)
+                        } else {
+                            None
+                        }
+                    }
+                    LeaderState::AwaitingLeaderEpoch(_) => {
+                        // still waiting for pending leader epoch
+                        None
+                    }
+                    LeaderState::Follower => {
+                        let leader_epoch_token = LeaderEpochToken::new();
+                        *leader_state = LeaderState::AwaitingLeaderEpoch(leader_epoch_token);
+                        Some(leader_epoch_token)
+                    }
+                }
+            }
+            ProcessorState::Stopping { restart_as, .. } => {
+                *restart_as = Some(RunMode::Leader);
+                None
+            }
+        }
+    }
+
+    pub fn on_leader_epoch_obtained(
+        &mut self,
+        leader_epoch: LeaderEpoch,
+        leader_epoch_token: LeaderEpochToken,
+    ) -> Result<(), ProcessorStateError> {
+        match self {
+            ProcessorState::Starting { .. } => {
+                debug!("Received leader epoch while starting partition processor. Probably originated from a previous attempt.");
+            }
+            ProcessorState::Started {
+                processor,
+                leader_state,
+            } => match leader_state {
+                LeaderState::Leader(_) => {
+                    debug!("Received leader epoch while already being leader. Ignoring.");
+                }
+                LeaderState::AwaitingLeaderEpoch(token) => {
+                    if *token == leader_epoch_token {
+                        processor
+                            .as_ref()
+                            .expect("must be some")
+                            .run_for_leader(leader_epoch)?;
+                        debug!(%leader_epoch, "Instruct partition processor to run as leader.");
+                        *leader_state = LeaderState::Leader(leader_epoch);
+                    } else {
+                        debug!("Received leader epoch token does not match the expected token. Ignoring.");
+                    }
+                }
+                LeaderState::Follower => {
+                    debug!("Received leader epoch while being in follower state. Ignoring.");
+                }
+            },
+            ProcessorState::Stopping { .. } => {
+                debug!("Received leader epoch while stopping partition processor. Ignoring.");
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn is_valid_leader_epoch_token(&self, leader_epoch_token: LeaderEpochToken) -> bool {
+        match self {
+            ProcessorState::Starting { .. } => false,
+            ProcessorState::Started { leader_state, .. } => {
+                matches!(leader_state, LeaderState::AwaitingLeaderEpoch(token) if *token == leader_epoch_token)
+            }
+            ProcessorState::Stopping { .. } => false,
+        }
+    }
+
+    pub fn partition_processor_status(&self) -> Option<PartitionProcessorStatus> {
+        match self {
+            ProcessorState::Starting { target_run_mode } => {
+                let status = PartitionProcessorStatus {
+                    planned_mode: *target_run_mode,
+                    ..Default::default()
+                };
+
+                Some(status)
+            }
+            ProcessorState::Started {
+                processor,
+                leader_state,
+            } => {
+                let mut status = processor
+                    .as_ref()
+                    .expect("must be some")
+                    .watch_rx
+                    .borrow()
+                    .clone();
+
+                // update the planned mode based on the current leader state
+                status.planned_mode = match leader_state {
+                    LeaderState::Leader(_) => RunMode::Leader,
+                    LeaderState::AwaitingLeaderEpoch(_) => RunMode::Leader,
+                    LeaderState::Follower => RunMode::Follower,
+                };
+
+                Some(status)
+            }
+            ProcessorState::Stopping { .. } => {
+                // todo report stopping status back to the cluster controller
+                None
+            }
+        }
+    }
+
+    pub fn try_send_rpc(
+        &self,
+        partition_id: PartitionId,
+        partition_processor_rpc: Incoming<PartitionProcessorRpcRequest>,
+        task_center: &TaskCenter,
+    ) {
+        match self {
+            ProcessorState::Starting { .. } => {
+                let _ = task_center.spawn(
+                    TaskKind::Disposable,
+                    "partition-processor-rpc",
+                    None,
+                    async move {
+                        partition_processor_rpc
+                            .into_outgoing(Err(PartitionProcessorRpcError::Starting))
+                            .send()
+                            .await
+                            .map_err(Into::into)
+                    },
+                );
+            }
+            ProcessorState::Started { processor, .. } => {
+                if let Err(err) = processor
+                    .as_ref()
+                    .expect("must be some")
+                    .try_send_rpc(partition_processor_rpc)
+                {
+                    match err {
+                        TrySendError::Full(req) => {
+                            let _ = task_center.spawn(
+                                TaskKind::Disposable,
+                                "partition-processor-rpc",
+                                None,
+                                async move {
+                                    req.into_outgoing(Err(PartitionProcessorRpcError::Busy))
+                                        .send()
+                                        .await
+                                        .map_err(Into::into)
+                                },
+                            );
+                        }
+                        TrySendError::Closed(req) => {
+                            let _ = task_center.spawn(
+                                TaskKind::Disposable,
+                                "partition-processor-rpc",
+                                None,
+                                async move {
+                                    req.into_outgoing(Err(PartitionProcessorRpcError::NotLeader(
+                                        partition_id,
+                                    )))
+                                    .send()
+                                    .await
+                                    .map_err(Into::into)
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            ProcessorState::Stopping { .. } => {
+                let _ = task_center.spawn(
+                    TaskKind::Disposable,
+                    "partition-processor-rpc",
+                    None,
+                    async move {
+                        partition_processor_rpc
+                            .into_outgoing(Err(PartitionProcessorRpcError::Stopping))
+                            .send()
+                            .await
+                            .map_err(Into::into)
+                    },
+                );
+            }
+        }
+    }
+
+    pub fn create_snapshot(&self, result_tx: oneshot::Sender<anyhow::Result<SnapshotId>>) {
+        match self {
+            ProcessorState::Starting { .. } => {
+                let _ = result_tx.send(Err(anyhow::anyhow!("Partition processor is starting")));
+            }
+            ProcessorState::Started { processor, .. } => {
+                processor
+                    .as_ref()
+                    .expect("must be some")
+                    .create_snapshot(result_tx);
+            }
+            ProcessorState::Stopping { .. } => {
+                let _ = result_tx.send(Err(anyhow::anyhow!("Partition processor is stopping")));
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct StartedProcessor {
+    cancellation_token: CancellationToken,
     partition_id: PartitionId,
-    task_id: TaskId,
     _created_at: MillisSinceEpoch,
     key_range: RangeInclusive<PartitionKey>,
-    planned_mode: RunMode,
-    running_for_leadership_with_epoch: Option<LeaderEpoch>,
-    handle: PartitionProcessorHandle,
+    control_tx: mpsc::Sender<PartitionProcessorControlCommand>,
     status_reader: ChannelStatusReader,
     rpc_tx: mpsc::Sender<Incoming<PartitionProcessorRpcRequest>>,
     watch_rx: watch::Receiver<PartitionProcessorStatus>,
@@ -65,92 +382,45 @@ pub struct StartedProcessor {
 
 impl StartedProcessor {
     pub fn new(
+        cancellation_token: CancellationToken,
         partition_id: PartitionId,
-        task_id: TaskId,
         key_range: RangeInclusive<PartitionKey>,
-        handle: PartitionProcessorHandle,
+        control_tx: mpsc::Sender<PartitionProcessorControlCommand>,
         status_reader: ChannelStatusReader,
         rpc_tx: mpsc::Sender<Incoming<PartitionProcessorRpcRequest>>,
         watch_rx: watch::Receiver<PartitionProcessorStatus>,
     ) -> Self {
         Self {
+            cancellation_token,
             partition_id,
-            task_id,
             _created_at: MillisSinceEpoch::now(),
             key_range,
-            planned_mode: RunMode::Follower,
-            running_for_leadership_with_epoch: None,
-            handle,
+            control_tx,
             status_reader,
             rpc_tx,
             watch_rx,
         }
     }
 
-    pub fn step_down(&mut self) -> Result<(), Error> {
-        if self.planned_mode != RunMode::Follower {
-            debug!("Asked by cluster-controller to demote partition to follower");
-            self.handle.step_down()?;
-        }
-
-        self.running_for_leadership_with_epoch = None;
-        self.planned_mode = RunMode::Follower;
-
-        Ok(())
+    fn cancel(&self) {
+        self.cancellation_token.cancel();
     }
 
-    pub async fn run_for_leader(
-        &mut self,
-        metadata_store_client: MetadataStoreClient,
-        node_id: GenerationalNodeId,
-    ) -> Result<(), Error> {
-        // run for leadership if there is no ongoing attempt or our current attempt is proven to be
-        // unsuccessful because we have already seen a higher leader epoch.
-        if self.running_for_leadership_with_epoch.is_none()
-            || self
-                .running_for_leadership_with_epoch
-                .is_some_and(|my_leader_epoch| {
-                    my_leader_epoch
-                        < self
-                            .watch_rx
-                            .borrow()
-                            .last_observed_leader_epoch
-                            .unwrap_or(LeaderEpoch::INITIAL)
-                })
-        {
-            // todo alternative could be to let the CC decide the leader epoch
-            let leader_epoch =
-                Self::obtain_next_epoch(metadata_store_client, self.partition_id, node_id).await?;
-            debug!(%leader_epoch, "Asked by cluster-controller to promote partition to leader");
-            self.running_for_leadership_with_epoch = Some(leader_epoch);
-            self.handle.run_for_leader(leader_epoch)?;
-        }
-
-        self.planned_mode = RunMode::Leader;
-
-        Ok(())
+    fn last_observed_leader_epoch(&self) -> Option<LeaderEpoch> {
+        self.watch_rx.borrow().last_observed_leader_epoch
     }
 
-    async fn obtain_next_epoch(
-        metadata_store_client: MetadataStoreClient,
-        partition_id: PartitionId,
-        node_id: GenerationalNodeId,
-    ) -> Result<LeaderEpoch, ReadModifyWriteError> {
-        let epoch: EpochMetadata = metadata_store_client
-            .read_modify_write(partition_processor_epoch_key(partition_id), |epoch| {
-                let next_epoch = epoch
-                    .map(|epoch: EpochMetadata| epoch.claim_leadership(node_id, partition_id))
-                    .unwrap_or_else(|| EpochMetadata::new(node_id, partition_id));
-
-                Ok(next_epoch)
-            })
-            .await?;
-        Ok(epoch.epoch())
+    pub fn step_down(&self) -> Result<(), TrySendError<PartitionProcessorControlCommand>> {
+        self.control_tx
+            .try_send(PartitionProcessorControlCommand::StepDown)
     }
 
-    #[inline]
-    pub fn partition_id(&self) -> PartitionId {
-        self.partition_id
+    pub fn run_for_leader(
+        &self,
+        leader_epoch: LeaderEpoch,
+    ) -> Result<(), TrySendError<PartitionProcessorControlCommand>> {
+        self.control_tx
+            .try_send(PartitionProcessorControlCommand::RunForLeader(leader_epoch))
     }
 
     #[inline]
@@ -163,16 +433,6 @@ impl StartedProcessor {
         &self.status_reader
     }
 
-    #[inline]
-    pub fn partition_processor_status(&self) -> PartitionProcessorStatus {
-        self.watch_rx.borrow().clone()
-    }
-
-    #[inline]
-    pub fn planned_mode(&self) -> RunMode {
-        self.planned_mode
-    }
-
     pub fn try_send_rpc(
         &self,
         rpc: Incoming<PartitionProcessorRpcRequest>,
@@ -182,8 +442,7 @@ impl StartedProcessor {
 
     pub fn create_snapshot(&self, result_tx: oneshot::Sender<anyhow::Result<SnapshotId>>) {
         if let Err(err) =
-            self.handle
-                .control_tx
+            self.control_tx
                 .try_send(PartitionProcessorControlCommand::CreateSnapshot(Some(
                     result_tx,
                 )))
@@ -211,47 +470,5 @@ impl StartedProcessor {
                 }
             }
         }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum PartitionProcessorHandleError {
-    #[error(transparent)]
-    Shutdown(#[from] ShutdownError),
-    #[error("command could not be sent")]
-    FailedSend,
-}
-
-impl<T> From<TrySendError<T>> for PartitionProcessorHandleError {
-    fn from(value: TrySendError<T>) -> Self {
-        match value {
-            TrySendError::Full(_) => PartitionProcessorHandleError::FailedSend,
-            TrySendError::Closed(_) => PartitionProcessorHandleError::Shutdown(ShutdownError),
-        }
-    }
-}
-
-pub struct PartitionProcessorHandle {
-    control_tx: mpsc::Sender<PartitionProcessorControlCommand>,
-}
-
-impl PartitionProcessorHandle {
-    pub fn new(control_tx: mpsc::Sender<PartitionProcessorControlCommand>) -> Self {
-        Self { control_tx }
-    }
-
-    fn step_down(&self) -> Result<(), PartitionProcessorHandleError> {
-        self.control_tx
-            .try_send(PartitionProcessorControlCommand::StepDown)?;
-        Ok(())
-    }
-
-    fn run_for_leader(
-        &self,
-        leader_epoch: LeaderEpoch,
-    ) -> Result<(), PartitionProcessorHandleError> {
-        self.control_tx
-            .try_send(PartitionProcessorControlCommand::RunForLeader(leader_epoch))?;
-        Ok(())
     }
 }

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -1,0 +1,253 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::invoker_integration::EntryEnricher;
+use crate::partition::invoker_storage_reader::InvokerStorageReader;
+use crate::partition_processor_manager::processor_state::{
+    PartitionProcessorHandle, StartedProcessor,
+};
+use crate::partition_processor_manager::{EventSender, ManagerEvent, ProcessorEvent};
+use crate::PartitionProcessorBuilder;
+use restate_bifrost::Bifrost;
+use restate_core::metadata_store::MetadataStoreClient;
+use restate_core::{task_center, Metadata, RuntimeError, TaskId, TaskKind};
+use restate_invoker_impl::Service as InvokerService;
+use restate_partition_store::{OpenMode, PartitionStore, PartitionStoreManager};
+use restate_service_protocol::codec::ProtobufRawEntryCodec;
+use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
+use restate_types::config::Configuration;
+use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::live::Live;
+use restate_types::schema::Schema;
+use restate_types::GenerationalNodeId;
+use std::ops::RangeInclusive;
+use tokio::sync::{mpsc, watch};
+use tracing::instrument;
+
+pub struct SpawnPartitionProcessorTask {
+    task_name: &'static str,
+    node_id: GenerationalNodeId,
+    partition_id: PartitionId,
+    run_mode: RunMode,
+    key_range: RangeInclusive<PartitionKey>,
+    configuration: Live<Configuration>,
+    metadata: Metadata,
+    bifrost: Bifrost,
+    partition_store_manager: PartitionStoreManager,
+    metadata_store_client: MetadataStoreClient,
+    events: EventSender,
+}
+
+impl SpawnPartitionProcessorTask {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        task_name: &'static str,
+        node_id: GenerationalNodeId,
+        partition_id: PartitionId,
+        run_mode: RunMode,
+        key_range: RangeInclusive<PartitionKey>,
+        configuration: Live<Configuration>,
+        metadata: Metadata,
+        bifrost: Bifrost,
+        partition_store_manager: PartitionStoreManager,
+        metadata_store_client: MetadataStoreClient,
+        events: EventSender,
+    ) -> Self {
+        Self {
+            task_name,
+            node_id,
+            partition_id,
+            run_mode,
+            key_range,
+            configuration,
+            metadata,
+            bifrost,
+            partition_store_manager,
+            metadata_store_client,
+            events,
+        }
+    }
+
+    #[instrument(
+        skip_all,
+        fields(
+            partition_id=%self.partition_id,
+            run_mode=%self.run_mode,
+        )
+    )]
+    pub async fn run(self) {
+        let Self {
+            task_name,
+            node_id,
+            partition_id,
+            run_mode,
+            key_range,
+            configuration,
+            metadata,
+            bifrost,
+            partition_store_manager,
+            metadata_store_client,
+            events,
+        } = self;
+
+        let mut status = match Self::start(
+            task_name,
+            node_id,
+            partition_id,
+            key_range,
+            configuration,
+            metadata,
+            bifrost,
+            partition_store_manager,
+            events.clone(),
+        )
+        .await
+        {
+            Ok(status) => status,
+            Err(err) => {
+                let _ = events
+                    .send(ManagerEvent {
+                        partition_id,
+                        event: ProcessorEvent::StartFailed(err),
+                    })
+                    .await;
+
+                return;
+            }
+        };
+
+        if run_mode == RunMode::Leader {
+            let _ = status.run_for_leader(metadata_store_client, node_id).await;
+        }
+
+        let _ = events
+            .send(ManagerEvent {
+                partition_id: status.partition_id(),
+                event: ProcessorEvent::Started(status),
+            })
+            .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn start(
+        task_name: &'static str,
+        node_id: GenerationalNodeId,
+        partition_id: PartitionId,
+        key_range: RangeInclusive<PartitionKey>,
+        configuration: Live<Configuration>,
+        metadata: Metadata,
+        bifrost: Bifrost,
+        partition_store_manager: PartitionStoreManager,
+        events: EventSender,
+    ) -> anyhow::Result<StartedProcessor> {
+        let config = configuration.pinned();
+        let schema = metadata.updateable_schema();
+        let invoker: InvokerService<
+            InvokerStorageReader<PartitionStore>,
+            EntryEnricher<Schema, ProtobufRawEntryCodec>,
+            Schema,
+        > = InvokerService::from_options(
+            &config.common.service_client,
+            &config.worker.invoker,
+            EntryEnricher::new(schema.clone()),
+            schema,
+        )?;
+
+        let status_reader = invoker.status_reader();
+
+        let (control_tx, control_rx) = mpsc::channel(2);
+        let (rpc_tx, rpc_rx) = mpsc::channel(128);
+        let status = PartitionProcessorStatus::new();
+        let (watch_tx, watch_rx) = watch::channel(status.clone());
+
+        let options = &configuration.pinned().worker;
+
+        let pp_builder = PartitionProcessorBuilder::new(
+            node_id,
+            partition_id,
+            key_range.clone(),
+            status,
+            options,
+            control_rx,
+            rpc_rx,
+            watch_tx,
+            invoker.handle(),
+        );
+
+        let invoker_name = Box::leak(Box::new(format!("invoker-{}", partition_id)));
+        let invoker_config = configuration.clone().map(|c| &c.worker.invoker);
+
+        let tc = task_center();
+        let maybe_task_id: Result<TaskId, RuntimeError> = tc.clone().start_runtime(
+            TaskKind::PartitionProcessor,
+            task_name,
+            Some(pp_builder.partition_id),
+            {
+                let options = options.clone();
+                let key_range = key_range.clone();
+                let partition_store = partition_store_manager
+                    .open_partition_store(
+                        partition_id,
+                        key_range,
+                        OpenMode::CreateIfMissing,
+                        &options.storage.rocksdb,
+                    )
+                    .await?;
+                move || async move {
+                    tc.spawn_child(
+                        TaskKind::SystemService,
+                        invoker_name,
+                        Some(pp_builder.partition_id),
+                        invoker.run(invoker_config),
+                    )?;
+
+                    let err = pp_builder
+                        .build::<ProtobufRawEntryCodec>(tc, bifrost, partition_store, configuration)
+                        .await?
+                        .run()
+                        .await
+                        .err();
+
+                    let _ = events
+                        .send(ManagerEvent {
+                            partition_id,
+                            event: ProcessorEvent::Stopped(err),
+                        })
+                        .await;
+
+                    Ok(())
+                }
+            },
+        );
+
+        let task_id = match maybe_task_id {
+            Ok(task_id) => Ok(task_id),
+            Err(RuntimeError::AlreadyExists(name)) => {
+                panic!(
+                    "The partition processor runtime {} is already running!",
+                    name
+                )
+            }
+            Err(RuntimeError::Shutdown(e)) => Err(e),
+        }?;
+
+        let state = StartedProcessor::new(
+            partition_id,
+            task_id,
+            key_range,
+            PartitionProcessorHandle::new(control_tx),
+            status_reader,
+            rpc_tx,
+            watch_rx,
+        );
+
+        Ok(state)
+    }
+}


### PR DESCRIPTION
This PR consists of a few initial commits that split the `PartitionProcessorManager` into more manageable modules. It also fixes some minor things like improving the error handling for partition processor rpcs. The main change is the last commit which tries to fix the lifecycle management of partition processors. The idea is that we are awaiting the termination of the runtime root task (the one running the partition processor) before removing the partition processor from the `processor_states` map maintained by the `PartitionProcessorManager`. That way we avoid creating multiple partition processor runtimes for the same `PartitionId`.

This fixes https://github.com/restatedev/restate/issues/2258.