### PR TITLE
Pin critical replicated loglet tasks to default runtime

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -187,13 +187,11 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
                 let key_value = entry.insert(Arc::new(loglet));
                 let loglet = Arc::downgrade(key_value.value());
                 let _ = self.task_center.spawn(
-                    TaskKind::Watchdog,
+                    TaskKind::BifrostBackgroundLowPriority,
                     "periodic-tail-checker",
                     None,
-                    async move {
-                        // todo: configuration
-                        PeriodicTailChecker::run(loglet_id, loglet, Duration::from_secs(2)).await
-                    },
+                    // todo: configuration
+                    PeriodicTailChecker::run(loglet_id, loglet, Duration::from_secs(2)),
                 );
                 Arc::clone(key_value.value())
             }

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -113,7 +113,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
             otel.name="replicated_loglet::sequencer::appender: run"
         )
     )]
-    pub async fn run(mut self) {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         let mut wave = 0;
         // initial wave has 0 replicated and 0 gray listed node
         let mut state = SequencerAppenderState::Wave {
@@ -200,6 +200,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                 unreachable!()
             }
         }
+        Ok(())
     }
 
     async fn wave(&mut self, mut graylist: NodeSet, wave: usize) -> SequencerAppenderState {

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -90,10 +90,14 @@ pub enum TaskKind {
     Shuffle,
     Cleaner,
     MetadataStore,
+    Background,
     // -- Bifrost Tasks
     /// A background task that the system needs for its operation. The task requires a system
     /// shutdown on errors and the system will wait for its graceful cancellation on shutdown.
+    #[strum(props(runtime = "default"))]
     BifrostBackgroundHighPriority,
+    #[strum(props(OnCancel = "abort", runtime = "default"))]
+    BifrostBackgroundLowPriority,
     /// A background appender. The task will log on errors but the system will wait for its
     /// graceful cancellation on shutdown.
     #[strum(props(OnCancel = "wait", OnError = "log"))]
@@ -103,14 +107,16 @@ pub enum TaskKind {
     LogletProvider,
     #[strum(props(OnCancel = "abort"))]
     Watchdog,
+    #[strum(props(OnCancel = "wait", runtime = "default"))]
+    SequencerAppender,
+    // -- Replicated loglet tasks
+    /// Receives messages from remote sequencers on nodes with local sequencer.
+    #[strum(props(OnCancel = "abort", runtime = "default"))]
     NetworkMessageHandler,
-    // Replicated loglet tasks
     ReplicatedLogletReadStream,
     #[strum(props(OnCancel = "abort"))]
-    /// Log-server tasks
+    // -- Log-server tasks
     LogletWriter,
-    /// Background task which should not fail
-    Background,
 }
 
 impl TaskKind {


### PR DESCRIPTION

This PR pins some tasks to the default tokio runtime in case they need to be independent from any PP runtime. This addresses a bug where a sequencer appender is aborted leaving a gap in the offset space. Future appends after this point will never succeed because log-servers' local commit offset will always be behind this point.
