### PR TITLE
Remove infinite retry policy from find tail in partition processor

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -217,7 +217,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
                     return Ok(latest_tail);
                 }
                 // We might have been sealed by external node and the sequencer is unaware. In this
-                // case, we run the a check seal task to determine if we suspect that sealing is
+                // case, we run a check seal task to determine if we suspect that sealing is
                 // happening.
                 let result = CheckSealTask::run(
                     &self.my_params,

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -181,7 +181,7 @@ impl RequestPump {
         let _ = reciprocal.prepare(sequencer_state).try_send();
     }
 
-    /// Infailable handle_append method
+    /// Infallible handle_append method
     #[instrument(
         level="trace",
         skip_all,

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -308,7 +308,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                 Ok(Some(result)) => result,
                 Ok(None) => break, // no more tasks
                 Err(elapsed) => {
-                    // if we have already ackowledged this append, it's okay to retire.
+                    // if we have already acknowledged this append, it's okay to retire.
                     if self.commit_resolver.is_none() {
                         tracing::debug!(%pending_servers, %wave, ?spread, ?elapsed, responses=?checker, "Some servers didn't store this batch, but append was committed, giving up");
                         return SequencerAppenderState::Done;

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -118,7 +118,7 @@ async fn replicated_loglet() -> googletest::Result<()> {
         3,
     );
 
-    let regex: Regex = "PartitionProcessor starting up".parse()?;
+    let regex: Regex = "Starting the partition processor".parse()?;
     let mut partition_processors_starting_up: Vec<_> =
         (1..=3).map(|idx| nodes[idx].lines(regex.clone())).collect();
 


### PR DESCRIPTION
Remove infinite retry policy from find tail in partition processor which is a problem in case that the PP wants to shut down. In this case it can happen that the `find_tail` operation also fails with a `ShutDown` error which we shouldn't retry.