### PR TITLE
[Bifrost] Appender should retry on retryable errors

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
@@ -239,7 +239,7 @@ impl RemoteSequencerConnection {
         let (tx, rx) = mpsc::unbounded_channel();
 
         task_center().spawn(
-            TaskKind::Disposable,
+            TaskKind::NetworkMessageHandler,
             "remote-sequencer-connection",
             None,
             Self::handle_appended_responses(known_global_tail, connection.clone(), rx),

--- a/crates/core/src/task_center_types.rs
+++ b/crates/core/src/task_center_types.rs
@@ -115,7 +115,8 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "wait", runtime = "default"))]
     SequencerAppender,
     // -- Replicated loglet tasks
-    /// Receives messages from remote sequencers on nodes with local sequencer.
+    /// Receives messages from remote sequencers on nodes with local sequencer. This is also used
+    /// in remote sequencer to handle responses of rpc messages.
     #[strum(props(OnCancel = "abort", runtime = "default"))]
     NetworkMessageHandler,
     ReplicatedLogletReadStream,


### PR DESCRIPTION

Also RemoteSequencer now runs append responses handler on default runtime
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2279).
* #2281
* #2280
* __->__ #2279