### PR TITLE
Otel papercut fixes

### DIFF
--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -381,14 +381,13 @@ macro_rules! invocation_span {
             $crate::invocation_span!(
                 level = $lvl,
                 relation = $relation,
-                prefix = $prefix,
                 name = format!("{} {}", $prefix, $target.short()),
                 attributes=attributes,
                 fields=($($field = $field_value),*)
             )
         }
     };
-    (level= $lvl:expr, relation = $relation:expr, prefix= $prefix:expr, id= $id:expr, name= $name:expr, tags=($($($key:ident).+ = $value:expr),*), fields=($($field:ident = $field_value:expr),*)) => {
+    (level= $lvl:expr, relation = $relation:expr, id= $id:expr, name= $name:expr, tags=($($($key:ident).+ = $value:expr),*), fields=($($field:ident = $field_value:expr),*)) => {
         {
             use opentelemetry::KeyValue;
 
@@ -400,14 +399,13 @@ macro_rules! invocation_span {
             $crate::invocation_span!(
                 level = $lvl,
                 relation = $relation,
-                prefix = $prefix,
-                name = format!("{} {}", $prefix, $name),
+                name = $name,
                 attributes=attributes,
                 fields=($($field = $field_value),*)
             )
         }
     };
-    (level= $lvl:expr, relation=$relation:expr, prefix= $prefix:expr, name= $name:expr, attributes=$attributes:ident, fields=($($field:ident = $field_value:expr),*)) => {
+    (level= $lvl:expr, relation=$relation:expr, name= $name:expr, attributes=$attributes:ident, fields=($($field:ident = $field_value:expr),*)) => {
         {
             use opentelemetry::{KeyValue, Context, trace::{Tracer, Link, TracerProvider, TraceContextExt}};
             use restate_types::invocation::SpanRelation;
@@ -487,6 +485,16 @@ macro_rules! info_invocation_span {
             level = ::tracing::Level::INFO,
             relation = $relation,
             prefix = $prefix,
+            id = $id,
+            name = $name,
+            tags = ($($($key).+ = $value),*),
+            fields = ()
+        )
+    };
+    (relation=$relation:expr, id= $id:expr, name= $name:expr, tags=($($($key:ident).+ = $value:expr),*)) => {
+        $crate::invocation_span!(
+            level = ::tracing::Level::INFO,
+            relation = $relation,
             id = $id,
             name = $name,
             tags = ($($($key).+ = $value),*),

--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -123,7 +123,7 @@ pub struct CommonOptionCliOverride {
     /// through [opentelemetry_otlp](https://docs.rs/opentelemetry-otlp/0.12.0/opentelemetry_otlp/).
     ///
     /// To configure the sampling, please refer to the [opentelemetry autoconfigure docs](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#sampler).
-    #[clap(long, env = "RESTATE_SERVICES_RUNTIME_ENDPOINT", global = true)]
+    #[clap(long, env = "RESTATE_TRACING_SERVICES_ENDPOINT", global = true)]
     pub tracing_services_endpoint: Option<String>,
 
     /// # Distributed Tracing JSON Export Path


### PR DESCRIPTION
1. Remove unnecessary duplicate names eg 'sleep sleep'
2. Emit spans for Run entries
3. Clap env var RESTATE_SERVICES_RUNTIME_ENDPOINT -> RESTATE_TRACING_SERVICES_ENDPOINT