### PR TITLE
Always clean up leadership state if the partition processor stops

### DIFF
--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -15,6 +15,7 @@ use bytestring::ByteString;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::fmt;
+use std::fmt::Formatter;
 use std::hash::Hash;
 use std::mem::size_of;
 use std::str::FromStr;
@@ -855,7 +856,6 @@ impl FromStr for LambdaARN {
 }
 
 #[derive(
-    Debug,
     PartialOrd,
     PartialEq,
     Eq,
@@ -897,7 +897,14 @@ impl Default for PartitionProcessorRpcRequestId {
 
 impl fmt::Display for PartitionProcessorRpcRequestId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for PartitionProcessorRpcRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // use the same formatting for debug and display to show a consistent representation
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/crates/worker/src/partition/leadership.rs
+++ b/crates/worker/src/partition/leadership.rs
@@ -208,7 +208,7 @@ where
     #[instrument(level = "debug", skip_all, fields(leader_epoch = %leader_epoch))]
     pub async fn run_for_leader(&mut self, leader_epoch: LeaderEpoch) -> Result<(), Error> {
         if self.is_new_leader_epoch(leader_epoch) {
-            self.become_follower().await?;
+            self.become_follower().await;
             self.announce_leadership(leader_epoch).await?;
             debug!("Running for leadership.");
         } else {
@@ -305,7 +305,7 @@ where
         Ok(())
     }
 
-    pub async fn step_down(&mut self) -> Result<(), Error> {
+    pub async fn step_down(&mut self) {
         debug!("Stepping down. Being a role model for Joe.");
         self.become_follower().await
     }
@@ -326,7 +326,7 @@ where
                 match leader_epoch.cmp(&announce_leader.leader_epoch) {
                     Ordering::Less => {
                         debug!("Lost leadership campaign. Becoming an obedient follower.");
-                        self.become_follower().await?;
+                        self.become_follower().await;
                     }
                     Ordering::Equal => {
                         debug!("Won the leadership campaign. Becoming the strong leader now.");
@@ -345,7 +345,7 @@ where
                             new_leader_epoch = %announce_leader.leader_epoch,
                             "Every reign must end. Stepping down and becoming an obedient follower."
                         );
-                        self.become_follower().await?;
+                        self.become_follower().await;
                     }
                     Ordering::Equal => {
                         warn!("Observed another leadership announcement for my own leadership. This should never happen and indicates a bug!");
@@ -491,7 +491,7 @@ where
         Ok(invoker_rx)
     }
 
-    async fn become_follower(&mut self) -> Result<(), Error> {
+    async fn become_follower(&mut self) {
         match &mut self.state {
             State::Follower => {}
             State::Candidate { appender_task, .. } => {
@@ -510,7 +510,10 @@ where
                 let cleaner_handle =
                     OptionFuture::from(task_center().cancel_task(*cleaner_task_id));
 
-                let (shuffle_result, cleaner_result, abort_result) = tokio::join!(
+                // It's ok to not check the abort_result because either it succeeded or the invoker
+                // is not running. If the invoker is not running, and we are not shutting down, then
+                // we will fail the next time we try to invoke.
+                let (shuffle_result, cleaner_result, _abort_result) = tokio::join!(
                     shuffle_handle,
                     cleaner_handle,
                     self.invoker_tx.abort_all_partition((
@@ -518,8 +521,6 @@ where
                         *leader_epoch
                     )),
                 );
-
-                abort_result.map_err(Error::Invoker)?;
 
                 if let Some(shuffle_result) = shuffle_result {
                     shuffle_result.expect("graceful termination of shuffle task");
@@ -545,7 +546,6 @@ where
         }
 
         self.state = State::Follower;
-        Ok(())
     }
 
     pub async fn handle_actions(
@@ -1199,7 +1199,7 @@ mod tests {
 
             assert!(matches!(state.state, State::Leader(_)));
 
-            state.step_down().await?;
+            state.step_down().await;
 
             assert!(matches!(state.state, State::Follower));
 


### PR DESCRIPTION
It is important to always fail the pending rpcs if the partition processor
stops. Otherwise the ingress might be hanging because a partition processor
failure does not entail a process crash. 

The very concrete problem that I observed was when shutting down a PP, we are also shutting down the corresponding invoker. If shutting down the invoker completes first, then we would fail when `become_follower` where we check the `abort_handle` and never complete the pending rpcs.