### PR TITLE
Timeout error includes the total time spent

### DIFF
--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -179,11 +179,10 @@ impl OwnedConnection {
         &self,
         timeout: Duration,
     ) -> Result<SendPermit<'_, M>, NetworkError> {
+        let start = Instant::now();
         let permit = tokio::time::timeout(timeout, self.sender.reserve())
             .await
-            .map_err(|_| {
-                NetworkError::Timeout("deadline exceeded while waiting for network send capacity")
-            })?
+            .map_err(|_| NetworkError::Timeout(start.elapsed()))?
             .map_err(|_| NetworkError::ConnectionClosed(self.peer))?;
         Ok(SendPermit {
             permit,

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -104,9 +104,7 @@ where
         let peer = peer.into();
         let connection = tokio::time::timeout(timeout, networking.node_connection(peer))
             .await
-            .map_err(|_| {
-                NetworkError::Timeout("deadline exceeded while waiting to establish connection")
-            })??;
+            .map_err(|_| NetworkError::Timeout(start.elapsed()))??;
         let outgoing = Outgoing::new(peer, msg).assign_connection(connection);
         self.call_outgoing_timeout(outgoing, timeout - start.elapsed())
             .await
@@ -148,7 +146,7 @@ where
         let remaining = timeout - start.elapsed();
         tokio::time::timeout(remaining, token.recv())
             .await
-            .map_err(|_| NetworkError::Timeout("deadline exceeded while waiting for rpc response"))?
+            .map_err(|_| NetworkError::Timeout(start.elapsed()))?
             // We only fail here if the response tracker was dropped.
             .map_err(NetworkError::Shutdown)
     }

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -207,7 +207,6 @@ macro_rules! define_message {
 //       @response_target = TargetName::AttachResponse,
 //   }
 // ```
-#[allow(unused_macros)]
 macro_rules! define_rpc {
     (
         @request = $request:ty,


### PR DESCRIPTION
Summary:

Helps when logging the error to know how much time was spent.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2300).
* #2304
* #2301
* __->__ #2300