### PR TITLE
[Bifrost] Run trim tests on replicated loglet in single node mode

### DIFF
--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -387,11 +387,26 @@ pub async fn single_loglet_readstream_with_trims(
         loglet.append(format!("record{}", i).into()).await?;
     }
 
+    // When reading record 8, it's acceptable to observe the record, or the trim gap. Both are
+    // acceptable because replicated loglet read stream's readhead cannot be completely disabled.
+    // Its minimum is to immediately read the next record after consuming the last one, so we'll
+    // see record8 because it's already cached.
+    //
     // read stream should send a gap from 8->10
     let record = read_stream.next().await.unwrap()?;
     assert_that!(record.sequence_number(), eq(Lsn::new(8)));
-    assert!(record.is_trim_gap());
-    assert_that!(record.trim_gap_to_sequence_number(), eq(Some(Lsn::new(10))));
+    if record.is_trim_gap() {
+        assert!(record.is_trim_gap());
+        assert_that!(record.trim_gap_to_sequence_number(), eq(Some(Lsn::new(10))));
+    } else {
+        // data record.
+        assert_that!(record.decode_unchecked::<String>(), eq("record8"));
+        // next record should be the trim gap
+        let record = read_stream.next().await.unwrap()?;
+        assert_that!(record.sequence_number(), eq(Lsn::new(9)));
+        assert!(record.is_trim_gap());
+        assert_that!(record.trim_gap_to_sequence_number(), eq(Some(Lsn::new(10))));
+    }
 
     for i in 11..=20 {
         let record = read_stream.next().await.unwrap()?;

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -29,6 +29,7 @@ use crate::providers::replicated_loglet::metric_definitions::{
     BIFROST_REPLICATED_READ_TOTAL,
 };
 use crate::providers::replicated_loglet::rpc_routers::LogServersRpc;
+use crate::providers::replicated_loglet::tasks::GetTrimPointTask;
 use crate::LogEntry;
 
 #[derive(Debug, thiserror::Error)]
@@ -98,8 +99,13 @@ impl ReadStreamTask {
         if move_beyond_global_tail && read_to.is_none() {
             panic!("read_to must be set if move_beyond_global_tail=true");
         }
-        // todo(asoli): configuration
-        let (tx, rx) = mpsc::channel(100);
+        let (tx, rx) = mpsc::channel(
+            Configuration::pinned()
+                .bifrost
+                .replicated_loglet
+                .readahead_records
+                .into(),
+        );
         // Reading from INVALID resets to OLDEST.
         let from_offset = from_offset.max(LogletOffset::OLDEST);
 
@@ -139,12 +145,19 @@ impl ReadStreamTask {
         // Channel size. This is the largest number of records we will try to readahead, if we can
         // acquire the capacity for it.
         //
-        // clamped to the channel capacity, ideally, the same value should be used to configure the
-        let readahead_max = 100.min(self.tx.max_capacity());
+        let readahead_max = self.tx.max_capacity();
         debug_assert!(readahead_max <= u16::MAX.into());
         // This is automatically capped. This is the minimum number of slots that needs to be
         // available in order to trigger fetching a new batch.
-        let readahead_trigger = 50;
+        let readahead_trigger = {
+            let ratio = Configuration::pinned()
+                .bifrost
+                .replicated_loglet
+                .readahead_trigger_ratio
+                .clamp(0.0, 1.0) as f64;
+            let trigger = (readahead_max as f64 * ratio).ceil() as usize;
+            1.max(trigger)
+        };
         debug_assert!(readahead_trigger >= 1 && readahead_trigger <= self.tx.max_capacity());
 
         let mut tail_subscriber = self.global_tail_watch.subscribe();
@@ -162,9 +175,35 @@ impl ReadStreamTask {
             self.last_known_tail = tail_subscriber.borrow_and_update().offset();
         }
 
-        // todo(asoli): [important] Need to fire up a FindTail task in the background? It depends on whether we
-        // are on the sequencer node or not. We might ask Bifrost's watchdog instead to dedupe
-        // FindTails and time-throttle them.
+        // Our initial knowledge of the trim point is determined by this request. Note that we
+        // might not observe some of the future trim point updates if we already have the records
+        // in the record cache. If we failed to determine the trim point, we'll ignore it and
+        // continue.
+        let trim_point = match GetTrimPointTask::new(
+            &self.my_params,
+            self.logservers_rpc.clone(),
+            self.global_tail_watch.clone(),
+        )
+        .run(networking.clone())
+        .await
+        {
+            Ok(trim_point) => trim_point,
+            Err(e) => {
+                info!(
+                    loglet_id = %self.my_params.loglet_id,
+                    offset = %self.read_pointer,
+                    "Could not determine the trim point while creating the read stream: {e}. \
+                        This should not impact reading if records are cached in memory of if \
+                        log-servers came back alive later.",
+                );
+                None
+            }
+        };
+
+        // [important]
+        // We rely on the periodic task owned by the provider to refresh our view of the tail.
+        // This is our fallback mechanism to get observer updates to the global tail if we are not
+        // the sequencer not, and if no network messages came through with updates recently.
         'main: loop {
             // Read and ship records to the tx channel if there is capacity. We do not attempt to
             // read records if we cannot reserve capacity to avoid wasting resources.
@@ -224,7 +263,6 @@ impl ReadStreamTask {
             if !self.can_advance() && !self.move_beyond_global_tail {
                 // HODL.
                 // todo(asoli): Measure tail-change wait time in histogram
-                // todo(asoli): (who's going to change this? - background FindTail?)
                 tail_subscriber
                     .changed()
                     .await
@@ -236,7 +274,6 @@ impl ReadStreamTask {
             }
             // We are only here because we should attempt to read something
             debug_assert!(self.last_known_tail > self.read_pointer);
-            // todo(asoli): do we need to check for trim point?
 
             // Do we have capacity for the next read?
             // - capacity is 100, watermark is 50; we reserve 100; but if readahead_max is 80, we
@@ -248,6 +285,23 @@ impl ReadStreamTask {
                 // fails if receiver is dropped (no more read stream)
                 .await
                 .map_err(OperationError::terminal)?;
+
+            // check for trim point
+            if trim_point.is_some_and(|trim_point| self.read_pointer <= trim_point) {
+                let trim_point = trim_point.unwrap();
+                let permit = permits.next().expect("must have at least one permit");
+                trace!(
+                    loglet_id = %self.my_params.loglet_id,
+                    offset = %self.read_pointer,
+                    "Shipping a trim gap since we are reading before the trim point. Trim gap from offset {} to offset {}",
+                    self.read_pointer,
+                    trim_point,
+                );
+                permit.send(Ok(LogEntry::new_trim_gap(self.read_pointer, trim_point)));
+                // fast-forward
+                self.read_pointer = trim_point.next();
+                continue 'main;
+            }
 
             // Read from logservers
             let effective_nodeset =

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/get_trim_point.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/get_trim_point.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use tokio::task::JoinSet;
+use tracing::trace;
+
+use restate_core::network::{Incoming, Networking, TransportConnect};
+use restate_core::task_center;
+use restate_types::config::Configuration;
+use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::net::log_server::{GetLogletInfo, LogServerRequestHeader, LogletInfo, Status};
+use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams};
+
+use crate::loglet::util::TailOffsetWatch;
+use crate::loglet::OperationError;
+use crate::providers::replicated_loglet::replication::NodeSetChecker;
+use crate::providers::replicated_loglet::rpc_routers::LogServersRpc;
+use crate::providers::replicated_loglet::tasks::util::{Disposition, RunOnSingleNode};
+
+#[derive(Debug, thiserror::Error)]
+#[error("could not determine the trim point of the loglet")]
+struct GetTrimPointError;
+
+/// Find the trim point for a loglet
+///
+/// The trim point doesn't require a quorum-check, the maximum observed trim-point on
+/// log-servers can be used, but we wait for write-quorum (or) f-majority whichever happens first
+/// before we respond to increase the chances of getting a reliable trim point.
+///
+/// We don't provide a guarantee that `get_trim_point` return an always increasing offset,
+/// and it should not be used in gap-detection in read streams. In read-streams, the
+/// observed trim_point in record header is what's used to perform the correct
+/// gap-detection.
+pub struct GetTrimPointTask<'a> {
+    my_params: &'a ReplicatedLogletParams,
+    logservers_rpc: LogServersRpc,
+    known_global_tail: TailOffsetWatch,
+}
+
+impl<'a> GetTrimPointTask<'a> {
+    pub fn new(
+        my_params: &'a ReplicatedLogletParams,
+        logservers_rpc: LogServersRpc,
+        known_global_tail: TailOffsetWatch,
+    ) -> Self {
+        Self {
+            my_params,
+            logservers_rpc,
+            known_global_tail,
+        }
+    }
+
+    pub async fn run<T: TransportConnect>(
+        self,
+        networking: Networking<T>,
+    ) -> Result<Option<LogletOffset>, OperationError> {
+        // Special case:
+        // If all nodes in the nodeset is in "provisioning", we can confidently short-circuit
+        // the result to None assuming that this loglet has never been trimmed.
+        if self
+            .my_params
+            .nodeset
+            .all_provisioning(&networking.metadata().nodes_config_ref())
+        {
+            return Ok(None);
+        }
+        // Use the entire nodeset except for StorageState::Disabled.
+        let effective_nodeset = EffectiveNodeSet::new(
+            &self.my_params.nodeset,
+            &networking.metadata().nodes_config_ref(),
+        );
+
+        trace!(
+            loglet_id = %self.my_params.loglet_id,
+            known_global_tail = %self.known_global_tail,
+            effective_nodeset = %effective_nodeset,
+            "Finding trim point for loglet"
+        );
+
+        let mut inflight_requests = JoinSet::new();
+        for node_id in effective_nodeset.iter().copied() {
+            let request = GetLogletInfo {
+                header: LogServerRequestHeader::new(
+                    self.my_params.loglet_id,
+                    self.known_global_tail.latest_offset(),
+                ),
+            };
+
+            inflight_requests.spawn({
+                let networking = networking.clone();
+                let trim_rpc_router = self.logservers_rpc.get_loglet_info.clone();
+                let known_global_tail = self.known_global_tail.clone();
+                let tc = task_center();
+
+                async move {
+                    let task = RunOnSingleNode::new(
+                        node_id,
+                        request,
+                        &trim_rpc_router,
+                        &known_global_tail,
+                        Configuration::pinned()
+                            .bifrost
+                            .replicated_loglet
+                            .log_server_retry_policy
+                            .clone(),
+                    );
+                    (
+                        node_id,
+                        tc.run_in_scope(
+                            "find-trimpoint-on-node",
+                            None,
+                            task.run(on_info_response, &networking),
+                        )
+                        .await,
+                    )
+                }
+            });
+        }
+
+        let mut nodeset_checker = NodeSetChecker::<'_, Option<LogletOffset>>::new(
+            &effective_nodeset,
+            &networking.metadata().nodes_config_ref(),
+            &self.my_params.replication,
+        );
+
+        let predicate = |o: &Option<LogletOffset>| o.is_some();
+        // Waiting for trim responses
+        while let Some(res) = inflight_requests.join_next().await {
+            let Ok((node_id, res)) = res else {
+                // task panicked or runtime is shutting down.
+                continue;
+            };
+            let Ok(res) = res else {
+                // GetLogletInfo task failed/aborted on this node. The inner task will log the error in this case.
+                continue;
+            };
+
+            // either f-majority or write-quorum is enough
+            nodeset_checker.set_attribute(node_id, Some(res));
+            if nodeset_checker.check_write_quorum(predicate)
+                || nodeset_checker.check_fmajority(predicate).passed()
+            {
+                break;
+            }
+        }
+
+        let results_from_nodes: Vec<_> = nodeset_checker.filter(predicate).collect();
+        if results_from_nodes.is_empty() {
+            // We didn't get _any_ responses!
+            return Err(OperationError::retryable(GetTrimPointError));
+        }
+
+        let max_trim_point = nodeset_checker
+            .filter(predicate)
+            .map(|(_, o)| o.unwrap()) // we filter Some already
+            .max()
+            .expect("at least one node returned trim point");
+        // Not enough nodes have successful responses
+        trace!(
+            loglet_id = %self.my_params.loglet_id,
+            known_global_tail = %self.known_global_tail,
+            effective_nodeset = %effective_nodeset,
+            "Trim point was determined to be {} calculated from this result set {:?}",
+            max_trim_point,
+            results_from_nodes,
+        );
+        // todo: assist in converging trim point of nodes are not aligned.
+        if max_trim_point == LogletOffset::INVALID {
+            Ok(None)
+        } else {
+            Ok(Some(max_trim_point))
+        }
+    }
+}
+
+fn on_info_response(msg: Incoming<LogletInfo>) -> Disposition<LogletOffset> {
+    if let Status::Ok = msg.body().header.status {
+        Disposition::Return(msg.body().trim_point)
+    } else {
+        trace!(
+            "GetLogletInfo request failed on node {}, status is {:?}",
+            msg.peer(),
+            msg.body().header.status
+        );
+        Disposition::Abort
+    }
+}

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/mod.rs
@@ -11,15 +11,20 @@
 mod check_seal;
 mod digests;
 mod find_tail;
+mod get_trim_point;
 mod periodic_tail_checker;
 mod repair_tail;
 mod seal;
+mod trim;
+mod util;
 
 pub use check_seal::*;
 pub use find_tail::*;
+pub use get_trim_point::*;
 pub use periodic_tail_checker::*;
 pub use repair_tail::*;
 pub use seal::*;
+pub use trim::*;
 
 use restate_types::logs::LogletOffset;
 use restate_types::Merge;

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
@@ -1,0 +1,205 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use tokio::task::JoinSet;
+use tracing::{debug, trace, warn};
+
+use restate_core::network::{Incoming, Networking, TransportConnect};
+use restate_core::task_center;
+use restate_types::config::Configuration;
+use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::net::log_server::{LogServerRequestHeader, Status, Trim, Trimmed};
+use restate_types::replicated_loglet::{EffectiveNodeSet, NodeSet, ReplicatedLogletParams};
+
+use crate::loglet::util::TailOffsetWatch;
+use crate::loglet::OperationError;
+use crate::providers::replicated_loglet::replication::NodeSetChecker;
+use crate::providers::replicated_loglet::rpc_routers::LogServersRpc;
+use crate::providers::replicated_loglet::tasks::util::RunOnSingleNode;
+
+use super::util::Disposition;
+
+#[derive(Debug, thiserror::Error)]
+#[error("trim loglet operation failed")]
+struct TrimError;
+
+/// Sends a trim request to as many log-servers in the nodeset.
+///
+/// We broadcast the trim to all nodes that we can, but only wait for write-quorum
+/// responses before acknowleding the trim.
+///
+/// The trim operation is idempotent. It's safe to trim a loglet if it's already partially or fully
+/// trimmed and if it's sealed.
+///
+/// Note that the trim task will clip the input trim-point to the last known global-tail of the
+/// loglet, it'll not attempt to perform a FindTail internally, the actual trim point
+/// might be higher if a node in the nodeset has higher trim point and it wasn't visited during
+/// this trim write-quorum check.
+///
+/// In other words, the trim operation confirms that at least write-quorum nodes in the nodeset
+/// are trimmed to the requested (possibly clamped) trim point or higher.
+///
+/// Any call to `get_trim_point()` that happen after this task should return the clamped trim point
+/// or higher.
+pub struct TrimTask<'a> {
+    my_params: &'a ReplicatedLogletParams,
+    logservers_rpc: LogServersRpc,
+    known_global_tail: TailOffsetWatch,
+}
+
+impl<'a> TrimTask<'a> {
+    pub fn new(
+        my_params: &'a ReplicatedLogletParams,
+        logservers_rpc: LogServersRpc,
+        known_global_tail: TailOffsetWatch,
+    ) -> Self {
+        Self {
+            my_params,
+            logservers_rpc,
+            known_global_tail,
+        }
+    }
+
+    pub async fn run<T: TransportConnect>(
+        self,
+        trim_point: LogletOffset,
+        networking: Networking<T>,
+    ) -> Result<(), OperationError> {
+        // Use the entire nodeset except for StorageState::Disabled.
+        let effective_nodeset = EffectiveNodeSet::new(
+            &self.my_params.nodeset,
+            &networking.metadata().nodes_config_ref(),
+        );
+        // caller might have already done this, but it's here for resilience against user error.
+        let trim_point = trim_point.min(self.known_global_tail.latest_offset().prev_unchecked());
+        if trim_point == LogletOffset::INVALID {
+            // nothing to trim, really.
+            debug!(
+                loglet_id = %self.my_params.loglet_id,
+                requested_trim_point = %trim_point,
+                known_global_tail = %self.known_global_tail,
+                "Will not send trim messages to log-servers since the effective trim_point requested is 0"
+            );
+            return Ok(());
+        }
+
+        let mut nodeset_checker = NodeSetChecker::<'_, bool>::new(
+            &effective_nodeset,
+            &networking.metadata().nodes_config_ref(),
+            &self.my_params.replication,
+        );
+
+        trace!(
+            loglet_id = %self.my_params.loglet_id,
+            trim_point = %trim_point,
+            known_global_tail = %self.known_global_tail,
+            effective_nodeset = %effective_nodeset,
+            "Trimming loglet"
+        );
+
+        let mut inflight_requests = JoinSet::new();
+        for node_id in effective_nodeset.iter().copied() {
+            let request = Trim {
+                header: LogServerRequestHeader::new(
+                    self.my_params.loglet_id,
+                    self.known_global_tail.latest_offset(),
+                ),
+                trim_point,
+            };
+
+            inflight_requests.spawn({
+                let networking = networking.clone();
+                let trim_rpc_router = self.logservers_rpc.trim.clone();
+                let known_global_tail = self.known_global_tail.clone();
+                let tc = task_center();
+
+                async move {
+                    let task = RunOnSingleNode::new(
+                        node_id,
+                        request,
+                        &trim_rpc_router,
+                        &known_global_tail,
+                        Configuration::pinned()
+                            .bifrost
+                            .replicated_loglet
+                            .log_server_retry_policy
+                            .clone(),
+                    );
+                    (
+                        node_id,
+                        tc.run_in_scope(
+                            "trim-on-node",
+                            None,
+                            task.run(on_trim_response, &networking),
+                        )
+                        .await,
+                    )
+                }
+            });
+        }
+
+        // Waiting for trim responses
+        while let Some(res) = inflight_requests.join_next().await {
+            let Ok((node_id, res)) = res else {
+                // task panicked or runtime is shutting down.
+                continue;
+            };
+            if res.is_err() {
+                // Trim task failed/aborted on this node. The inner task will log the error in this case.
+                continue;
+            };
+
+            nodeset_checker.set_attribute(node_id, true);
+            if nodeset_checker.check_write_quorum(|s| *s) {
+                // We have enough nodes with a trim point at or higher than what we requested.
+                // Let's keep the rest of the trim requests running in the background.
+                debug!(
+                    loglet_id = %self.my_params.loglet_id,
+                     trim_point = %trim_point,
+                    known_global_tail = %self.known_global_tail,
+                    "Loglet has been trimmed"
+                );
+                // continue to run the rest of trim requests in the background
+                inflight_requests.detach_all();
+                return Ok(());
+            }
+        }
+
+        let confirmed_nodes: NodeSet = nodeset_checker
+            .filter(|p| *p)
+            .map(|(node_id, _)| *node_id)
+            .collect();
+
+        // Not enough nodes have successful responses
+        warn!(
+            loglet_id = %self.my_params.loglet_id,
+             trim_point = %trim_point,
+            known_global_tail = %self.known_global_tail,
+            effective_nodeset = %effective_nodeset,
+            "Could not trim the loglet, since we could not confirm the new trim point with write-quorum nodes. Nodes that have confirmed are {}",
+            confirmed_nodes,
+        );
+
+        Err(OperationError::retryable(TrimError))
+    }
+}
+
+fn on_trim_response(msg: Incoming<Trimmed>) -> Disposition<()> {
+    if let Status::Ok = msg.body().header.status {
+        Disposition::Return(())
+    } else {
+        trace!(
+            "Trim request failed on node {}, status is {:?}",
+            msg.peer(),
+            msg.body().header.status
+        );
+        Disposition::Abort
+    }
+}

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/util.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/util.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tracing::{instrument, trace};
+
+use restate_core::network::rpc_router::RpcRouter;
+use restate_core::network::{Incoming, NetworkError, Networking, TransportConnect};
+use restate_core::ShutdownError;
+use restate_types::config::Configuration;
+use restate_types::net::log_server::{LogServerRequest, LogServerResponse};
+use restate_types::retries::RetryPolicy;
+use restate_types::PlainNodeId;
+
+use crate::loglet::util::TailOffsetWatch;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TaskError {
+    #[error("task was aborted based on a precondition check")]
+    Aborted,
+    #[error("task failed after exhausting all retries, total time spent is {0:?}")]
+    ExhaustedRetries(Duration),
+    #[error("task stopped due to ongoing system shutdown")]
+    Shutdown(#[from] ShutdownError),
+}
+
+#[allow(dead_code)]
+pub enum Disposition<T> {
+    Return(T),
+    Retry,
+    Abort,
+}
+
+#[allow(dead_code)]
+pub fn passthrough<I>(msg: Incoming<I>) -> Disposition<I> {
+    Disposition::Return(msg.into_body())
+}
+
+pub struct RunOnSingleNode<'a, T: LogServerRequest> {
+    node_id: PlainNodeId,
+    request: T,
+    rpc_router: &'a RpcRouter<T>,
+    known_global_tail: &'a TailOffsetWatch,
+    retry_policy: RetryPolicy,
+}
+
+impl<'a, T: LogServerRequest> RunOnSingleNode<'a, T>
+where
+    T: LogServerRequest + Clone,
+    T::ResponseMessage: LogServerResponse,
+{
+    pub fn new(
+        node_id: PlainNodeId,
+        request: T,
+        rpc_router: &'a RpcRouter<T>,
+        known_global_tail: &'a TailOffsetWatch,
+        retry_policy: RetryPolicy,
+    ) -> Self {
+        Self {
+            node_id,
+            request,
+            rpc_router,
+            known_global_tail,
+            retry_policy,
+        }
+    }
+
+    /// Send a message to a single node and handles network-related failures with retries.
+    #[instrument(skip_all, fields(loglet_id = %self.request.header().loglet_id, message = self.request.kind()))]
+    pub async fn run<O, N: TransportConnect>(
+        mut self,
+        on_response: impl Fn(Incoming<T::ResponseMessage>) -> Disposition<O>,
+        networking: &'a Networking<N>,
+    ) -> Result<O, TaskError> {
+        let start = Instant::now();
+        let loglet_id = self.request.header().loglet_id;
+        let request_timeout = Configuration::pinned()
+            .bifrost
+            .replicated_loglet
+            .log_server_rpc_timeout;
+
+        let mut retry_iter = self.retry_policy.into_iter();
+
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            self.request
+                .refresh_header(self.known_global_tail.latest_offset());
+            let next_pause = retry_iter.next();
+
+            trace!(%loglet_id, "Sending {} message to node {}", self.request.kind(), self.node_id);
+            // loop and retry until this task is aborted.
+            let maybe_response = self
+                .rpc_router
+                .call_timeout(
+                    networking,
+                    self.node_id,
+                    self.request.clone(),
+                    request_timeout,
+                )
+                .await;
+
+            match maybe_response {
+                Ok(msg) => {
+                    // update our view of global tail if we observed higher tail in response.
+                    self.known_global_tail
+                        .notify_offset_update(msg.body().header().known_global_tail);
+                    match on_response(msg) {
+                        Disposition::Return(v) => return Ok(v),
+                        Disposition::Abort => return Err(TaskError::Aborted),
+                        Disposition::Retry if next_pause.is_some() => {
+                            trace!(
+                                %attempt,
+                                "Response received but a retry was requested. Will retry after {:?}",
+                                next_pause.unwrap()
+                            );
+                        } // fall-through
+                        Disposition::Retry => {
+                            // exhausted retries budget. We represent this by timeout.
+                            // give up.
+                            trace!(%attempt, "Exhausted retries");
+                            return Err(TaskError::ExhaustedRetries(start.elapsed()));
+                        }
+                    }
+                }
+                Err(NetworkError::Shutdown(err)) => {
+                    // We are shutting down
+                    return Err(TaskError::Shutdown(err));
+                }
+                // We'll retry in every other case of networking error
+                Err(e) if next_pause.is_some() => {
+                    trace!(
+                        ?e,
+                        %attempt,
+                        "Request failed. Will retry after {:?}",
+                        next_pause.unwrap()
+                    );
+                }
+                Err(e) => {
+                    trace!(
+                        ?e,
+                        %attempt,
+                        "Request failed. Exhausted attempts after spending {:?}",
+                        start.elapsed(),
+                    );
+                    // exhausted
+                    // give up.
+                    trace!(%attempt, "Exhausted retries");
+                    return Err(TaskError::ExhaustedRetries(start.elapsed()));
+                }
+            }
+
+            // Should we retry?
+            if let Some(pause) = next_pause {
+                tokio::time::sleep(pause).await;
+            } else {
+                // give up.
+                return Err(TaskError::ExhaustedRetries(start.elapsed()));
+            }
+        }
+    }
+}

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -23,7 +23,7 @@ use crate::LsnExt;
 ///
 /// The entry might represent a data record or a placeholder for a trim gap if the log is trimmed
 /// at this position.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LogEntry<S = Lsn> {
     offset: S,
     record: MaybeRecord<S>,
@@ -125,7 +125,7 @@ impl<S: Copy> LogEntry<S> {
     }
 }
 
-#[derive(Debug, derive_more::IsVariant)]
+#[derive(Debug, Clone, derive_more::IsVariant)]
 enum MaybeRecord<S = Lsn> {
     TrimGap(TrimGap<S>),
     Data(Record),

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -179,11 +179,10 @@ impl OwnedConnection {
         &self,
         timeout: Duration,
     ) -> Result<SendPermit<'_, M>, NetworkError> {
+        let start = Instant::now();
         let permit = tokio::time::timeout(timeout, self.sender.reserve())
             .await
-            .map_err(|_| {
-                NetworkError::Timeout("deadline exceeded while waiting for network send capacity")
-            })?
+            .map_err(|_| NetworkError::Timeout(start.elapsed()))?
             .map_err(|_| NetworkError::ConnectionClosed(self.peer))?;
         Ok(SendPermit {
             permit,

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -104,9 +104,7 @@ where
         let peer = peer.into();
         let connection = tokio::time::timeout(timeout, networking.node_connection(peer))
             .await
-            .map_err(|_| {
-                NetworkError::Timeout("deadline exceeded while waiting to establish connection")
-            })??;
+            .map_err(|_| NetworkError::Timeout(start.elapsed()))??;
         let outgoing = Outgoing::new(peer, msg).assign_connection(connection);
         self.call_outgoing_timeout(outgoing, timeout - start.elapsed())
             .await
@@ -148,7 +146,7 @@ where
         let remaining = timeout - start.elapsed();
         tokio::time::timeout(remaining, token.recv())
             .await
-            .map_err(|_| NetworkError::Timeout("deadline exceeded while waiting for rpc response"))?
+            .map_err(|_| NetworkError::Timeout(start.elapsed()))?
             // We only fail here if the response tracker was dropped.
             .map_err(NetworkError::Shutdown)
     }

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -178,7 +178,7 @@ impl LogStore for RocksDbLogStore {
         // If the loglet is trimmed (all records were removed) and we know the trim_point, then we
         // use the trim_point.next() as the local_tail.
         //
-        // Another way to describe this is `if trim_point => local_tail` but at this stage, I
+        // Another way to describe this is `if trim_point >= local_tail` but at this stage, I
         // prefer to be conservative and explicit to catch unintended corner cases.
         if local_tail == LogletOffset::OLDEST && trim_point > LogletOffset::INVALID {
             local_tail = trim_point.next();

--- a/crates/types/src/logs/record_cache.rs
+++ b/crates/types/src/logs/record_cache.rs
@@ -30,7 +30,7 @@ pub struct RecordCache {
 }
 
 impl RecordCache {
-    /// Creates a new instance of RecordCache. If memory budget is None
+    /// Creates a new instance of RecordCache. If memory budget is 0
     /// cache will be disabled
     pub fn new(memory_budget_bytes: usize) -> Self {
         let inner = if memory_budget_bytes > 0 {

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -207,7 +207,6 @@ macro_rules! define_message {
 //       @response_target = TargetName::AttachResponse,
 //   }
 // ```
-#[allow(unused_macros)]
 macro_rules! define_rpc {
     (
         @request = $request:ty,


### PR DESCRIPTION

This enables the full suite of loglet spec tests to run against replicated loglet in single node setup. This also adds a couple of configuration keys to allow users to control readahead triggers. Such triggers are used in tests to unblock the test behaviour. One caveat is that we cannot (and should not) disable readahead completely in replicated loglet, so due to its nature, the loglet spec test has been updated slightly to support this case.

Test Plan:
Unit tests
