### PR TITLE
object store metastore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,7 +3623,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.26.0",
  "rgb",
  "str_stack",
 ]
@@ -4607,18 +4607,27 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
+checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
+ "base64 0.22.0",
  "bytes",
  "chrono",
  "futures",
  "humantime",
+ "hyper 1.4.1",
  "itertools 0.13.0",
+ "md-5",
  "parking_lot",
  "percent-encoding",
+ "quick-xml 0.36.2",
+ "rand",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
  "snafu 0.8.5",
  "tokio",
  "tracing",
@@ -5482,6 +5491,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5808,6 +5827,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.11",
+ "rustls-native-certs 0.7.1",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -6084,6 +6104,7 @@ dependencies = [
  "axum",
  "bytes",
  "bytestring",
+ "ciborium",
  "dashmap",
  "derive_builder",
  "derive_more",
@@ -6100,6 +6121,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "metrics",
+ "object_store",
  "once_cell",
  "opentelemetry",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ bitflags = { version = "2.6.0" }
 bytes = { version = "1.7", features = ["serde"] }
 bytes-utils = "0.1.3"
 bytestring = { version = "1.2", features = ["serde"] }
+ciborium = { version = "0.2.2" }
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 comfy-table = { version = "7.1" }
 chrono-humanize = { version = "0.2.3" }
@@ -101,6 +102,7 @@ datafusion = { version = "42.0.0", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }
+object_store = { version = "0.11.1"}
 datafusion-expr = { version = "42.0.0" }
 derive_builder = "0.20.0"
 derive_more = { version = "1", features = ["full"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,6 +23,7 @@ assert2 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+ciborium = { workspace = true}
 dashmap = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
@@ -40,6 +41,7 @@ hyper-util = { workspace = true }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
 once_cell = { workspace = true }
+object_store = { workspace = true, features = ["aws"] }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 prost = { workspace = true }

--- a/crates/core/src/metadata_store/providers/mod.rs
+++ b/crates/core/src/metadata_store/providers/mod.rs
@@ -9,5 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod etcd;
+mod objstore;
 
 pub use etcd::EtcdMetadataStore;
+pub use objstore::create_object_store_based_meta_store;

--- a/crates/core/src/metadata_store/providers/objstore/glue.rs
+++ b/crates/core/src/metadata_store/providers/objstore/glue.rs
@@ -1,0 +1,175 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::pin;
+
+use bytestring::ByteString;
+use restate_types::Version;
+use tokio::sync::oneshot::Sender;
+use tracing::warn;
+
+use crate::cancellation_watcher;
+use crate::metadata_store::providers::objstore::optimistic_store::OptimisticLockingMetadataStoreBuilder;
+use crate::metadata_store::{MetadataStore, Precondition, ReadError, VersionedValue, WriteError};
+
+#[derive(Debug)]
+pub(crate) enum Commands {
+    Get {
+        key: ByteString,
+        tx: Sender<Result<Option<VersionedValue>, ReadError>>,
+    },
+    GetVersion {
+        key: ByteString,
+        tx: Sender<Result<Option<Version>, ReadError>>,
+    },
+    Put {
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+        tx: Sender<Result<(), WriteError>>,
+    },
+    Delete {
+        key: ByteString,
+        precondition: Precondition,
+        tx: Sender<Result<(), WriteError>>,
+    },
+}
+
+pub(crate) struct Server {
+    receiver: tokio::sync::mpsc::UnboundedReceiver<Commands>,
+    builder: OptimisticLockingMetadataStoreBuilder,
+}
+
+impl Server {
+    pub(crate) fn new(
+        builder: OptimisticLockingMetadataStoreBuilder,
+        receiver: tokio::sync::mpsc::UnboundedReceiver<Commands>,
+    ) -> Self {
+        Self { builder, receiver }
+    }
+
+    pub(crate) async fn run(self) -> anyhow::Result<()> {
+        let Server {
+            mut receiver,
+            builder,
+        } = self;
+
+        let mut shutdown = pin::pin!(cancellation_watcher());
+
+        let mut delegate = match builder.build().await {
+            Ok(delegate) => delegate,
+            Err(err) => {
+                warn!(error = ?err, "error while loading latest metastore version.");
+                return Err(err);
+            }
+        };
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => {
+                            // stop accepting messages
+                            return Ok(());
+                }
+                Some(cmd) = receiver.recv() => {
+                    match cmd {
+                        Commands::Get{key,tx  } => {
+                               let res = delegate.get(key).await;
+                               let _ = tx.send(res);
+                        }
+                        Commands::GetVersion{key,tx  } => {
+                                let _ = tx.send(delegate.get_version(key).await);
+                        }
+                        Commands::Put{key,value,precondition,tx  } => {
+                                let _ = tx.send(delegate.put(key, value, precondition).await);
+                        }
+                        Commands::Delete{key,precondition,tx  } => {
+                                let _ = tx.send(delegate.delete(key, precondition).await);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    sender: tokio::sync::mpsc::UnboundedSender<Commands>,
+}
+
+impl Client {
+    pub fn new(sender: tokio::sync::mpsc::UnboundedSender<Commands>) -> Self {
+        Self { sender }
+    }
+}
+
+#[async_trait::async_trait]
+impl MetadataStore for Client {
+    async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.sender
+            .send(Commands::Get { key, tx })
+            .map_err(|_| ReadError::Internal("Object store fetch channel ".into()))?;
+
+        rx.await.map_err(|_| {
+            ReadError::Internal("Object store fetch channel disconnected".to_string())
+        })?
+    }
+
+    async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.sender
+            .send(Commands::GetVersion { key, tx })
+            .map_err(|_| ReadError::Internal("Object store fetch channel ".into()))?;
+
+        rx.await.map_err(|_| {
+            ReadError::Internal("Object store fetch channel disconnected".to_string())
+        })?
+    }
+
+    async fn put(
+        &self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.sender
+            .send(Commands::Put {
+                key,
+                value,
+                precondition,
+                tx,
+            })
+            .map_err(|_| WriteError::Internal("Object store channel ".into()))?;
+
+        rx.await
+            .map_err(|_| WriteError::Internal("Object store channel disconnected".to_string()))?
+    }
+
+    async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.sender
+            .send(Commands::Delete {
+                key,
+                precondition,
+                tx,
+            })
+            .map_err(|_| WriteError::Internal("Object store fetch channel ".into()))?;
+
+        rx.await.map_err(|_| {
+            WriteError::Internal("Object store fetch channel disconnected".to_string())
+        })?
+    }
+}

--- a/crates/core/src/metadata_store/providers/objstore/mod.rs
+++ b/crates/core/src/metadata_store/providers/objstore/mod.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::metadata_store::providers::objstore::object_store_version_repository::ObjectStoreVersionRepository;
+use crate::metadata_store::providers::objstore::optimistic_store::OptimisticLockingMetadataStoreBuilder;
+use crate::metadata_store::providers::objstore::version_repository::VersionRepository;
+use crate::metadata_store::MetadataStore;
+use crate::{TaskCenter, TaskKind};
+use restate_types::config::MetadataStoreClient;
+use restate_types::errors::GenericError;
+
+mod glue;
+mod object_store_version_repository;
+mod optimistic_store;
+mod version_repository;
+
+pub async fn create_object_store_based_meta_store(
+    configuration: MetadataStoreClient,
+) -> Result<impl MetadataStore, GenericError> {
+    // obtain an instance of a version repository from the configuration.
+    // we use an object_store backed version repository.
+    let version_repository = Box::new(ObjectStoreVersionRepository::from_configuration(
+        configuration.clone(),
+    )?) as Box<dyn VersionRepository>;
+
+    // postpone the building of the store to the background task,
+    // the runs at the task center.
+    let store_builder = OptimisticLockingMetadataStoreBuilder {
+        version_repository,
+        configuration,
+    };
+    //
+    // setup all the glue code, the forwarding client and the event loop server.
+    //
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let server = glue::Server::new(store_builder, rx);
+    TaskCenter::spawn(
+        TaskKind::MetadataStore,
+        "metadata-store-client",
+        server.run(),
+    )
+    .expect("unable to spawn a task");
+
+    let client = glue::Client::new(tx);
+    Ok(client)
+}

--- a/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
+++ b/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
@@ -1,0 +1,413 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+use bytestring::ByteString;
+use object_store::aws::AmazonS3Builder;
+use object_store::aws::S3ConditionalPut::ETagMatch;
+use object_store::path::Path;
+use object_store::{Error, ObjectStore, PutMode, PutOptions, PutPayload, UpdateVersion};
+
+use crate::metadata_store::providers::objstore::version_repository::{
+    Tag, TaggedValue, VersionRepository, VersionRepositoryError,
+};
+use restate_types::config::{MetadataStoreClient, ObjectStoreCredentials};
+
+#[derive(Debug)]
+pub(crate) struct ObjectStoreVersionRepository {
+    object_store: Box<dyn ObjectStore>,
+}
+
+impl ObjectStoreVersionRepository {
+    pub(crate) fn from_configuration(configuration: MetadataStoreClient) -> anyhow::Result<Self> {
+        let MetadataStoreClient::ObjectStore {
+            credentials,
+            bucket,
+            ..
+        } = configuration
+        else {
+            anyhow::bail!("unexpected configuration value");
+        };
+
+        let builder = match credentials {
+            ObjectStoreCredentials::AwsEnv => AmazonS3Builder::from_env(),
+        };
+
+        let store = builder
+            .with_bucket_name(bucket)
+            .with_conditional_put(ETagMatch)
+            .build()
+            .map_err(|e| anyhow::anyhow!("Unable to build an S3 object store: {}", e))?;
+
+        Ok(Self {
+            object_store: Box::new(store),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_testing() -> Self {
+        let store = object_store::memory::InMemory::new();
+        Self {
+            object_store: Box::new(store),
+        }
+    }
+}
+
+const EXISTS_HEADER: Bytes = Bytes::from_static(b"e");
+const DELETED_HEADER: Bytes = Bytes::from_static(b"d");
+
+#[async_trait::async_trait]
+impl VersionRepository for ObjectStoreVersionRepository {
+    async fn create(&self, key: ByteString, content: Bytes) -> Result<Tag, VersionRepositoryError> {
+        let path = Path::from(key.to_string());
+
+        let opts = PutOptions {
+            mode: PutMode::Create,
+            ..Default::default()
+        };
+
+        let payload = PutPayload::from_iter([EXISTS_HEADER, content.clone()]);
+
+        match self.object_store.put_opts(&path, payload, opts).await {
+            Ok(res) => {
+                let etag = res.e_tag.ok_or_else(|| {
+                    VersionRepositoryError::UnexpectedCondition(
+                        "expecting an ETag to be present".into(),
+                    )
+                })?;
+                Ok(etag.into())
+            }
+            Err(Error::AlreadyExists { .. }) => {
+                // a file with this name already exists.
+                // but it can be a deleted marker.
+                // so let's find out what's inside
+                let get_result = self
+                    .object_store
+                    .get(&path)
+                    .await
+                    .map_err(|e| VersionRepositoryError::Network(e.into()))?;
+                let etag = get_result.meta.e_tag.as_ref().ok_or_else(|| {
+                    VersionRepositoryError::UnexpectedCondition("was expecting an etag".into())
+                })?;
+                let tag: Tag = etag.to_owned().into();
+                let bytes = get_result
+                    .bytes()
+                    .await
+                    .map_err(|e| VersionRepositoryError::Network(e.into()))?;
+                if bytes.starts_with(&EXISTS_HEADER) {
+                    return Err(VersionRepositoryError::AlreadyExists);
+                }
+                assert_eq!(bytes, DELETED_HEADER);
+                self.put_if_tag_matches(key, tag, content).await
+            }
+            Err(e) => Err(VersionRepositoryError::Network(e.into())),
+        }
+    }
+
+    async fn get(&self, key: ByteString) -> Result<TaggedValue, VersionRepositoryError> {
+        let path = Path::from(key.to_string());
+        match self.object_store.get(&path).await {
+            Ok(res) => {
+                let etag = res.meta.e_tag.as_ref().ok_or_else(|| {
+                    VersionRepositoryError::UnexpectedCondition(
+                        "expecting an ETag to be present".into(),
+                    )
+                })?;
+                let tag = etag.to_owned().into();
+                let mut buf = res
+                    .bytes()
+                    .await
+                    .map_err(|e| VersionRepositoryError::Network(e.into()))?;
+                if buf.starts_with(&DELETED_HEADER) {
+                    Err(VersionRepositoryError::NotFound)
+                } else {
+                    let bytes = buf.split_off(EXISTS_HEADER.len());
+                    Ok(TaggedValue { bytes, tag })
+                }
+            }
+            Err(Error::NotFound { .. }) => Err(VersionRepositoryError::NotFound),
+            Err(e) => Err(VersionRepositoryError::Network(e.into())),
+        }
+    }
+
+    async fn put_if_tag_matches(
+        &self,
+        key: ByteString,
+        expected: Tag,
+        new_content: Bytes,
+    ) -> Result<Tag, VersionRepositoryError> {
+        let etag = expected.as_string();
+        let update_version = UpdateVersion {
+            e_tag: Some(etag),
+            version: None,
+        };
+
+        let path = Path::from(key.to_string());
+        match self
+            .object_store
+            .put_opts(
+                &path,
+                PutPayload::from_iter([EXISTS_HEADER, new_content]),
+                PutOptions::from(PutMode::Update(update_version)),
+            )
+            .await
+        {
+            Ok(res) => {
+                let etag = res.e_tag.ok_or_else(|| {
+                    VersionRepositoryError::UnexpectedCondition("expecting an etag".into())
+                })?;
+                let tag: Tag = etag.into();
+                Ok(tag)
+            }
+            Err(Error::Precondition { .. }) => Err(VersionRepositoryError::PreconditionFailed),
+            Err(e) => Err(VersionRepositoryError::Network(e.into())),
+        }
+    }
+
+    async fn put(
+        &self,
+        key: ByteString,
+        new_content: Bytes,
+    ) -> Result<Tag, VersionRepositoryError> {
+        let path = Path::from(key.to_string());
+        match self
+            .object_store
+            .put(&path, PutPayload::from_iter([EXISTS_HEADER, new_content]))
+            .await
+        {
+            Ok(res) => {
+                let etag = res.e_tag.ok_or_else(|| {
+                    VersionRepositoryError::UnexpectedCondition("expecting an etag".into())
+                })?;
+                let tag: Tag = etag.into();
+                Ok(tag)
+            }
+            Err(e) => Err(VersionRepositoryError::Network(e.into())),
+        }
+    }
+
+    async fn delete(&self, key: ByteString) -> Result<(), VersionRepositoryError> {
+        let path = Path::from(key.to_string());
+        match self
+            .object_store
+            .put(&path, PutPayload::from_bytes(DELETED_HEADER))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => Err(VersionRepositoryError::Network(e.into())),
+        }
+    }
+
+    async fn delete_if_tag_matches(
+        &self,
+        key: ByteString,
+        expected: Tag,
+    ) -> Result<(), VersionRepositoryError> {
+        let etag = expected.as_string();
+        let update_version = UpdateVersion {
+            e_tag: Some(etag),
+            version: None,
+        };
+
+        let path = Path::from(key.to_string());
+        match self
+            .object_store
+            .put_opts(
+                &path,
+                PutPayload::from_bytes(DELETED_HEADER),
+                PutOptions::from(PutMode::Update(update_version)),
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(Error::Precondition { .. }) => Err(VersionRepositoryError::PreconditionFailed),
+            Err(e) => Err(VersionRepositoryError::Network(e.into())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metadata_store::providers::objstore::object_store_version_repository::ObjectStoreVersionRepository;
+    use crate::metadata_store::providers::objstore::version_repository::{
+        VersionRepository, VersionRepositoryError,
+    };
+    use bytes::{Buf, Bytes};
+    use bytestring::ByteString;
+    use std::sync::Arc;
+    use tokio::task::JoinSet;
+
+    const KEY_1: ByteString = ByteString::from_static("1");
+    const HELLO_WORLD: Bytes = Bytes::from_static(b"hello world");
+
+    const HELLO: Bytes = Bytes::from_static(b"hello");
+    const WORLD: Bytes = Bytes::from_static(b"world");
+
+    #[tokio::test]
+    async fn simple_usage() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        let tag = store.create(KEY_1, HELLO_WORLD).await.unwrap();
+
+        let tagged_value = store.get(KEY_1).await.unwrap();
+
+        assert_eq!(tagged_value.tag, tag);
+        assert_eq!(tagged_value.bytes, HELLO_WORLD);
+    }
+
+    #[tokio::test]
+    async fn get_non_existing_should_fail() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        match store.get(KEY_1).await {
+            Err(VersionRepositoryError::NotFound) => {
+                // ok!
+            }
+            _ => {
+                panic!("Should be NotFound");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn create_twice_should_fail() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        store.create(KEY_1, HELLO_WORLD).await.unwrap();
+
+        match store.create(KEY_1, HELLO_WORLD).await {
+            Err(VersionRepositoryError::AlreadyExists) => {
+                // ok!
+            }
+            _ => {
+                panic!("should have failed");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_should_work() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        store.create(KEY_1, HELLO_WORLD).await.unwrap();
+
+        store.delete(KEY_1).await.unwrap();
+
+        match store.get(KEY_1).await {
+            Err(VersionRepositoryError::NotFound) => {
+                // ok!
+            }
+            _ => {
+                panic!("should not be present");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn create_after_delete_should_work() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        store.create(KEY_1, HELLO_WORLD).await.unwrap();
+
+        store.delete(KEY_1).await.unwrap();
+
+        store.create(KEY_1, WORLD).await.unwrap();
+
+        let tv = store.get(KEY_1).await.unwrap();
+
+        assert_eq!(tv.bytes, WORLD);
+    }
+
+    #[tokio::test]
+    async fn conditional_put_should_work() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        let tag = store.create(KEY_1, HELLO_WORLD).await.unwrap();
+
+        store.put_if_tag_matches(KEY_1, tag, WORLD).await.unwrap();
+
+        let tv = store.get(KEY_1).await.unwrap();
+
+        assert_eq!(tv.bytes, WORLD);
+    }
+
+    #[tokio::test]
+    async fn conditional_put_should_fail() {
+        let store = ObjectStoreVersionRepository::new_for_testing();
+
+        let tag = store.create(KEY_1, HELLO_WORLD).await.unwrap();
+
+        store
+            .put_if_tag_matches(KEY_1, tag.clone(), HELLO)
+            .await
+            .unwrap();
+
+        match store.put_if_tag_matches(KEY_1, tag.clone(), WORLD).await {
+            Err(VersionRepositoryError::PreconditionFailed) => {
+                // ok!
+            }
+            _ => panic!("should have failed"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrency_test() {
+        let store = Arc::new(ObjectStoreVersionRepository::new_for_testing());
+
+        store
+            .create(KEY_1, Bytes::copy_from_slice(&0u64.to_be_bytes()))
+            .await
+            .unwrap();
+
+        //
+        // first task
+        //
+
+        let mut futures = JoinSet::new();
+
+        for _ in 0..2048 {
+            let cloned_store = store.clone();
+            futures.spawn(async move {
+                loop {
+                    let (tag, mut bytes) =
+                        cloned_store.get(KEY_1.clone()).await.unwrap().into_inner();
+
+                    let mut n = bytes.get_u64();
+                    n += 1;
+
+                    match cloned_store
+                        .put_if_tag_matches(
+                            KEY_1.clone(),
+                            tag,
+                            Bytes::copy_from_slice(&n.to_be_bytes()),
+                        )
+                        .await
+                    {
+                        Ok(_) => {
+                            break;
+                        }
+                        Err(VersionRepositoryError::PreconditionFailed) => {
+                            continue;
+                        }
+                        Err(e) => {
+                            panic!("should not happened: {}", e);
+                        }
+                    }
+                }
+            });
+        }
+
+        futures.join_all().await;
+
+        let (_, mut bytes) = store.get(KEY_1).await.unwrap().into_inner();
+
+        assert_eq!(bytes.get_u64(), 2048u64);
+    }
+}

--- a/crates/core/src/metadata_store/providers/objstore/optimistic_store.rs
+++ b/crates/core/src/metadata_store/providers/objstore/optimistic_store.rs
@@ -1,0 +1,325 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::borrow::Cow;
+
+use bytes::{BufMut, Bytes, BytesMut};
+use bytestring::ByteString;
+
+use crate::metadata_store::providers::objstore::version_repository::VersionRepositoryError::PreconditionFailed;
+use crate::metadata_store::providers::objstore::version_repository::{
+    TaggedValue, VersionRepository, VersionRepositoryError,
+};
+use crate::metadata_store::{Precondition, ReadError, VersionedValue, WriteError};
+use restate_types::config::MetadataStoreClient;
+use restate_types::Version;
+
+pub(crate) struct OptimisticLockingMetadataStoreBuilder {
+    pub(crate) version_repository: Box<dyn VersionRepository>,
+    pub(crate) configuration: MetadataStoreClient,
+}
+
+impl OptimisticLockingMetadataStoreBuilder {
+    pub(crate) async fn build(self) -> anyhow::Result<OptimisticLockingMetadataStore> {
+        let MetadataStoreClient::ObjectStore { .. } = self.configuration else {
+            anyhow::bail!("unexpected configuration value");
+        };
+        Ok(OptimisticLockingMetadataStore::new(self.version_repository))
+    }
+}
+
+pub struct OptimisticLockingMetadataStore {
+    version_repository: Box<dyn VersionRepository>,
+    arena: BytesMut,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(tag = "version", content = "value")]
+enum OnDiskValue<'a> {
+    V1(Cow<'a, VersionedValue>),
+}
+
+fn tagged_value_to_versioned_value(tagged_value: &TaggedValue) -> anyhow::Result<VersionedValue> {
+    let on_disk: OnDiskValue<'static> = ciborium::from_reader(tagged_value.bytes.as_ref())?;
+    match on_disk {
+        OnDiskValue::V1(cow) => Ok(cow.into_owned()),
+    }
+}
+
+impl OptimisticLockingMetadataStore {
+    fn new(version_repository: Box<dyn VersionRepository>) -> Self {
+        Self {
+            version_repository,
+            arena: BytesMut::with_capacity(8196),
+        }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        key: ByteString,
+    ) -> Result<Option<VersionedValue>, ReadError> {
+        match self.version_repository.get(key).await {
+            Ok(res) => {
+                let d = tagged_value_to_versioned_value(&res)
+                    .map_err(|e| ReadError::Codec(e.into()))?;
+                Ok(Some(d))
+            }
+            Err(VersionRepositoryError::NotFound) => Ok(None),
+            Err(e) => Err(ReadError::Network(e.into())),
+        }
+    }
+
+    pub(crate) async fn get_version(
+        &mut self,
+        key: ByteString,
+    ) -> Result<Option<Version>, ReadError> {
+        if let Some(res) = self.get(key).await? {
+            Ok(Some(res.version))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn serialize_versioned_value(
+        &mut self,
+        versioned_value: &VersionedValue,
+    ) -> Result<Bytes, WriteError> {
+        self.arena.clear();
+        let writer = (&mut self.arena).writer();
+
+        let on_disk = OnDiskValue::V1(Cow::Borrowed(versioned_value));
+        ciborium::into_writer(&on_disk, writer)
+            .map(|_| self.arena.split().freeze())
+            .map_err(|e| WriteError::Codec(e.into()))
+    }
+
+    pub(crate) async fn put(
+        &mut self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        let buf = self.serialize_versioned_value(&value)?;
+        match precondition {
+            Precondition::None => {
+                self.version_repository
+                    .put(key, buf)
+                    .await
+                    .map_err(|e| WriteError::Network(e.into()))?;
+                Ok(())
+            }
+            Precondition::DoesNotExist => match self.version_repository.create(key, buf).await {
+                Ok(_) => Ok(()),
+                Err(VersionRepositoryError::AlreadyExists) => {
+                    Err(WriteError::FailedPrecondition("already exists".to_string()))
+                }
+                Err(e) => Err(WriteError::Network(e.into())),
+            },
+            Precondition::MatchesVersion(version) => {
+                // we need to get the current version here, because the version provided by the API does not
+                // match the version provided by the object store (ETag vs logical version)
+                //
+                // 1. get the current logical version and the object store tag.
+                //
+                let (current_tag, current_version) =
+                    match self.version_repository.get(key.clone()).await {
+                        Ok(tagged) => {
+                            let versioned_value = tagged_value_to_versioned_value(&tagged)
+                                .map_err(|e| WriteError::Codec(e.into()))?;
+                            (tagged.tag, versioned_value.version)
+                        }
+                        Err(VersionRepositoryError::NotFound) => {
+                            return Err(WriteError::FailedPrecondition(
+                                "no current version exists".to_string(),
+                            ))
+                        }
+                        Err(e) => return Err(WriteError::Network(e.into())),
+                    };
+                //
+                // 2. check if logical version is the expected version
+                //
+                if current_version != version {
+                    return Err(WriteError::FailedPrecondition(format!(
+                        "expected {} != got {}",
+                        version, current_version
+                    )));
+                }
+                //
+                // 3. try compare and set
+                //
+                match self
+                    .version_repository
+                    .put_if_tag_matches(key, current_tag, buf)
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(PreconditionFailed) => Err(WriteError::FailedPrecondition(
+                        "failed precondition".to_string(),
+                    )),
+                    Err(e) => Err(WriteError::Network(e.into())),
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn delete(
+        &mut self,
+        key: ByteString,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        match precondition {
+            Precondition::None => match self.version_repository.delete(key).await {
+                Ok(_) => Ok(()),
+                Err(e) => Err(WriteError::Network(e.into())),
+            },
+            Precondition::DoesNotExist => Err(WriteError::Internal(
+                "This combination does not make sense".to_string(),
+            )),
+            Precondition::MatchesVersion(version) => {
+                // we need to convert a version into a tag, this mean we need to do a read first.
+                let (tag, current_version) = match self.version_repository.get(key.clone()).await {
+                    Ok(res) => {
+                        let tag = res.tag.clone();
+                        let d = tagged_value_to_versioned_value(&res)
+                            .map_err(|e| WriteError::Codec(e.into()))?;
+                        (tag, d.version)
+                    }
+                    Err(VersionRepositoryError::NotFound) => {
+                        return Err(WriteError::FailedPrecondition(
+                            "No version found".to_string(),
+                        ))
+                    }
+                    Err(e) => return Err(WriteError::Network(e.into())),
+                };
+
+                if current_version != version {
+                    return Err(WriteError::FailedPrecondition(
+                        "version mismatch".to_string(),
+                    ));
+                }
+
+                match self
+                    .version_repository
+                    .delete_if_tag_matches(key, tag)
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(PreconditionFailed) => Err(WriteError::FailedPrecondition(
+                        "failed precondition".to_string(),
+                    )),
+                    Err(e) => Err(WriteError::Network(e.into())),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metadata_store::providers::objstore::object_store_version_repository::ObjectStoreVersionRepository;
+    use crate::metadata_store::providers::objstore::optimistic_store::OptimisticLockingMetadataStore;
+    use crate::metadata_store::{Precondition, VersionedValue, WriteError};
+    use bytes::Bytes;
+    use bytestring::ByteString;
+    use restate_types::Version;
+
+    const KEY_1: ByteString = ByteString::from_static("1");
+    const HELLO: Bytes = Bytes::from_static(b"hello");
+
+    #[tokio::test]
+    async fn basic_example() {
+        let mut store = OptimisticLockingMetadataStore::new(Box::new(
+            ObjectStoreVersionRepository::new_for_testing(),
+        ));
+
+        store
+            .put(
+                KEY_1,
+                VersionedValue::new(Version::MIN.next(), HELLO),
+                Precondition::None,
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn put_if_absent() {
+        let mut store = OptimisticLockingMetadataStore::new(Box::new(
+            ObjectStoreVersionRepository::new_for_testing(),
+        ));
+
+        store
+            .put(
+                KEY_1,
+                VersionedValue::new(Version::MIN.next(), HELLO),
+                Precondition::DoesNotExist,
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn put_if_absent_should_fail() {
+        let mut store = OptimisticLockingMetadataStore::new(Box::new(
+            ObjectStoreVersionRepository::new_for_testing(),
+        ));
+
+        store
+            .put(
+                KEY_1,
+                VersionedValue::new(Version::MIN.next(), HELLO),
+                Precondition::DoesNotExist,
+            )
+            .await
+            .unwrap();
+
+        match store
+            .put(
+                KEY_1,
+                VersionedValue::new(Version::MIN.next(), HELLO),
+                Precondition::DoesNotExist,
+            )
+            .await
+        {
+            Err(WriteError::FailedPrecondition(_)) => {
+                // ok
+            }
+            _ => {
+                panic!("Expected WriteError::FailedPrecondition");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn put_if_absent_on_deleted_value() {
+        let mut store = OptimisticLockingMetadataStore::new(Box::new(
+            ObjectStoreVersionRepository::new_for_testing(),
+        ));
+
+        store
+            .put(
+                KEY_1,
+                VersionedValue::new(Version::MIN.next(), HELLO),
+                Precondition::DoesNotExist,
+            )
+            .await
+            .unwrap();
+        store.delete(KEY_1, Precondition::None).await.unwrap();
+
+        store
+            .put(
+                KEY_1,
+                VersionedValue::new(Version::MIN.next(), HELLO),
+                Precondition::DoesNotExist,
+            )
+            .await
+            .unwrap();
+    }
+}

--- a/crates/core/src/metadata_store/providers/objstore/version_repository.rs
+++ b/crates/core/src/metadata_store/providers/objstore/version_repository.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+use bytestring::ByteString;
+
+use restate_types::errors::GenericError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum VersionRepositoryError {
+    #[error("already exists")]
+    AlreadyExists,
+    #[error("precondition failed")]
+    PreconditionFailed,
+    #[error("not found")]
+    NotFound,
+    #[error("Network {0}")]
+    Network(GenericError),
+    #[error("Unexpected condition {0}")]
+    UnexpectedCondition(String),
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub(crate) struct Tag(ByteString);
+
+impl From<String> for Tag {
+    fn from(value: String) -> Self {
+        Tag(value.into())
+    }
+}
+
+impl Tag {
+    pub(crate) fn as_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaggedValue {
+    pub tag: Tag,
+    pub bytes: Bytes,
+}
+
+impl TaggedValue {
+    #[cfg(test)]
+    pub(crate) fn into_inner(self) -> (Tag, Bytes) {
+        (self.tag, self.bytes)
+    }
+}
+
+#[async_trait::async_trait]
+pub(crate) trait VersionRepository: Sync + Send + 'static {
+    async fn create(&self, key: ByteString, content: Bytes) -> Result<Tag, VersionRepositoryError>;
+
+    async fn get(&self, key: ByteString) -> Result<TaggedValue, VersionRepositoryError>;
+
+    async fn put_if_tag_matches(
+        &self,
+        key: ByteString,
+        expected: Tag,
+        new_content: Bytes,
+    ) -> Result<Tag, VersionRepositoryError>;
+
+    async fn put(&self, key: ByteString, new_content: Bytes)
+        -> Result<Tag, VersionRepositoryError>;
+
+    async fn delete(&self, key: ByteString) -> Result<(), VersionRepositoryError>;
+
+    async fn delete_if_tag_matches(
+        &self,
+        key: ByteString,
+        expected_tag: Tag,
+    ) -> Result<(), VersionRepositoryError>;
+}

--- a/crates/metadata-store/src/local/mod.rs
+++ b/crates/metadata-store/src/local/mod.rs
@@ -13,6 +13,7 @@ mod store;
 
 mod service;
 
+use restate_core::metadata_store::providers::create_object_store_based_meta_store;
 use restate_core::metadata_store::{providers::EtcdMetadataStore, MetadataStoreClient};
 use restate_types::{
     config::{MetadataStoreClient as MetadataStoreClientConfig, MetadataStoreClientOptions},
@@ -39,6 +40,10 @@ pub async fn create_client(
         }
         MetadataStoreClientConfig::Etcd { addresses } => {
             let store = EtcdMetadataStore::new(addresses, &metadata_store_client_options).await?;
+            MetadataStoreClient::new(store, backoff_policy)
+        }
+        conf @ MetadataStoreClientConfig::ObjectStore { .. } => {
+            let store = create_object_store_based_meta_store(conf).await?;
             MetadataStoreClient::new(store, backoff_policy)
         }
     };

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -494,6 +494,27 @@ pub struct MetadataStoreClientOptions {
         description = "Definition of a bootstrap metadata store"
     )
 )]
+pub enum ObjectStoreCredentials {
+    /// # Use standard AWS environment variables
+    ///
+    /// Configure the object store by setting the standard AWS env variables (prefixed with AWS_)
+    AwsEnv,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "kebab-case",
+    rename_all_fields = "kebab-case"
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schemars",
+    schemars(
+        title = "Metadata Store",
+        description = "Definition of a bootstrap metadata store"
+    )
+)]
 pub enum MetadataStoreClient {
     /// Connects to an embedded metadata store that is run by nodes that run with the MetadataStore role.
     Embedded {
@@ -505,6 +526,14 @@ pub enum MetadataStoreClient {
     Etcd {
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         addresses: Vec<String>,
+    },
+    /// Uses an object store as a metadata store.
+    ObjectStore {
+        credentials: ObjectStoreCredentials,
+
+        /// # The bucket name to use for storage
+        #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+        bucket: String,
     },
 }
 


### PR DESCRIPTION
## Object store backed Metadata store 

This PR introduces a new type of a metastore that uses `S3` (any similar) object stores that support conditional updates.

## end result 

running the following:

```bash
export AWS_REGION=eu-central-1
export AWS_ACCESS_KEY_ID=
export AWS_SECRET_ACCESS_KEY=
export AWS_SESSION_TOKEN="

export AWS_ENDPOINT=https://s3.eu-central-1.amazonaws.com

export AWS_PROVIDER_NAME=Static
export RESTATE_METADATA_STORE_CLIENT__TYPE="object-store"
export RESTATE_METADATA_STORE_CLIENT__BUCKET="XXXXXXXX"
export RESTATE_METADATA_STORE_CLIENT__CREDENTIALS__TYPE="aws-env"

cargo run --example three_nodes_and_metadata -- --nocapture
```

starts a 3 node cluster that uses an s3 bucket for a metadata storage:

```
[nix-shell:~/work/restate]$ ./source.s3.sh 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.73s
     Running `target/debug/examples/three_nodes_and_metadata --nocapture`
2024-11-27T14:38:34.545666Z  INFO restate_local_cluster_runner::cluster: Starting cluster test-cluster in /home/igal/work/restate/restate-data
2024-11-27T14:38:34.549226Z  INFO restate_local_cluster_runner::node: Started node metadata-node in /home/igal/work/restate/restate-data/metadata-node (pid 233735)
2024-11-27T14:38:35.825120Z  INFO three_nodes_and_metadata: admin node started: 2024-11-27T14:38:35.824212Z  INFO restate_node: Restate server is ready
2024-11-27T14:38:35.984871Z  INFO restate_local_cluster_runner::node: Node metadata-node admin check is healthy after 6 attempts
2024-11-27T14:38:35.989555Z  INFO restate_local_cluster_runner::node: Started node node-1 in /home/igal/work/restate/restate-data/node-1 (pid 233916)
2024-11-27T14:38:35.994266Z  INFO restate_local_cluster_runner::node: Started node node-2 in /home/igal/work/restate/restate-data/node-2 (pid 233917)
2024-11-27T14:38:35.998782Z  INFO restate_local_cluster_runner::node: Started node node-3 in /home/igal/work/restate/restate-data/node-3 (pid 233918)

```

listing the bucket yields the possible keys

```
[nix-shell:~]$ aws s3 ls s3://XXXX
2024-11-27 15:38:40       1221 bifrost_config
2024-11-27 15:38:38        950 nodes_config
2024-11-27 15:35:54        385 partition_table
2024-11-27 15:38:41        112 pp_epoch_0
2024-11-27 15:38:41        112 pp_epoch_1
2024-11-27 15:38:41        112 pp_epoch_2
2024-11-27 15:38:41        112 pp_epoch_3
2024-11-27 15:38:40        519 scheduling_plan
```

## Additional configuration keys

```
[metadata-store-client]    
type = "object-store"    
bucket = "restate-metadata"    
    
[metadata-store-client.credentials]    
type = "aws-env"  
```

## How does this work?

This is basically a client, each node runs an instance of this client, and the clients are using S3's optimistic concurrency control to move forward the different keys.



currently the only support cred type are AWS_X env variables, a followup referenced here in the conversation would be to plug in additional cred providers (unify the work done by @pcholakov )