### PR TITLE
Support comma-separated list of roles in restate-server

### DIFF
--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -30,7 +30,10 @@ use super::LogFormat;
 pub struct CommonOptionCliOverride {
     /// Defines the roles which this Restate node should run, by default the node
     /// starts with all roles.
-    #[clap(long, alias = "role", global = true)]
+    ///
+    /// Roles can be comma-separated list without spaces (`--roles=worker,admin,log-server`),
+    /// or a repeated option like `--roles=worker --roles=admin`.
+    #[clap(long, alias = "role", global = true, value_delimiter=',', num_args = 0..)]
     pub roles: Option<Vec<Role>>,
 
     /// Unique name for this node in the cluster. The node must not change unless

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -37,6 +37,7 @@ pub enum NodesConfigError {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[enumset(serialize_repr = "list")]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "clap", clap(rename_all = "kebab-case"))]
 pub enum Role {


### PR DESCRIPTION

Summary:

Allows restate-server to start with `--roles=admin,worker` in addition to the existing method of repeating the option `--roles=admin --roles=worker`. Note that `--role` is also a supported alias.

This also fixes the Display impl of `Role` to print the kebab-case representation of the `Role` type for a consistency.

Test Plan:

Starting restate-server with a mixture of style works as expected:
```
cargo run --bin restate-server -- --roles=log-server,admin --role=metadata-store
...
...
2024-11-19T11:24:35.488926Z INFO restate_node
  My Node ID is N0:3
    roles: admin | metadata-store | log-server
    address: http://127.0.0.1:5122/
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2319).
* #2320
* __->__ #2319