### PR TITLE
Introduces docker-debug to justfile

### DIFF
--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -30,7 +30,10 @@ use super::LogFormat;
 pub struct CommonOptionCliOverride {
     /// Defines the roles which this Restate node should run, by default the node
     /// starts with all roles.
-    #[clap(long, alias = "role", global = true)]
+    ///
+    /// Roles can be comma-separated list without spaces (`--roles=worker,admin,log-server`),
+    /// or a repeated option like `--roles=worker --roles=admin`.
+    #[clap(long, alias = "role", global = true, value_delimiter=',', num_args = 0..)]
     pub roles: Option<Vec<Role>>,
 
     /// Unique name for this node in the cluster. The node must not change unless

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -37,6 +37,7 @@ pub enum NodesConfigError {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[enumset(serialize_repr = "list")]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "clap", clap(rename_all = "kebab-case"))]
 pub enum Role {

--- a/docker/debug.Dockerfile
+++ b/docker/debug.Dockerfile
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 -  Restate Software, Inc., Restate GmbH.
+# All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS planner
+COPY . .
+RUN just chef-prepare
+
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS base
+COPY --from=planner /restate/recipe.json recipe.json
+COPY justfile justfile
+
+# avoid sharing sccache port between multiplatform builds - they share a network but not a filesystem, so it won't work
+FROM base AS base-amd64
+ARG SCCACHE_SERVER_PORT=4226
+
+FROM base AS base-arm64
+ARG SCCACHE_SERVER_PORT=4227
+
+FROM base-$TARGETARCH AS builder
+ARG SCCACHE_SERVER_PORT
+ARG TARGETARCH
+# https://github.com/mozilla/sccache/blob/main/docs/GHA.md
+ARG ACTIONS_CACHE_URL=''
+ARG ACTIONS_RUNTIME_TOKEN=''
+ARG SCCACHE_GHA_ENABLED=''
+# Overrides the behaviour of the release profile re including debug symbols, which in our repo is not to include them.
+# Should be set to 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html
+ARG CARGO_PROFILE_RELEASE_DEBUG=true
+ARG RESTATE_FEATURES=''
+# Caching layer if nothing has changed
+# Only build restate binary to avoid compiling unneeded crates
+RUN just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --bin restate-server
+COPY . .
+RUN just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=dev --bin restate-server && \
+    just notice-file && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/debug/restate-server target/restate-server
+
+# We do not need the Rust toolchain to run the server binary!
+FROM debian:bookworm-slim AS runtime
+COPY --from=builder /restate/target/restate-server /usr/local/bin
+COPY --from=builder /restate/NOTICE /NOTICE
+COPY --from=builder /restate/LICENSE /LICENSE
+# copy OS roots
+COPY --from=builder /etc/ssl /etc/ssl
+# useful for health checks
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+WORKDIR /
+ENTRYPOINT ["/usr/local/bin/restate-server"]

--- a/justfile
+++ b/justfile
@@ -137,6 +137,10 @@ docker:
     # podman builds do not work without --platform set, even though it claims to default to host arch
     docker buildx build . --platform linux/{{ _docker_arch }} --file docker/Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --build-arg RESTATE_FEATURES={{ features }} --load
 
+docker-debug:
+    # podman builds do not work without --platform set, even though it claims to default to host arch
+    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/debug.Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --build-arg RESTATE_FEATURES={{ features }} --load
+
 notice-file:
     cargo license -d -a --avoid-build-deps --avoid-dev-deps {{ _features }} | (echo "Restate Runtime\nCopyright (c) 2024 Restate Software, Inc., Restate GmbH <code@restate.dev>\n" && cat) > NOTICE
 


### PR DESCRIPTION

Summary:

This allows us to quickly build debug docker images, perhaps we can use those in CI as well in the near future.


Test Plan:

```
just docker-build
...

~ ❯❯❯ docker image ls
REPOSITORY                               TAG             IMAGE ID       CREATED          SIZE
localhost/restatedev/restate             unknown         f8bd3765f210   14 seconds ago   1.5GB
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2320).
* __->__ #2320
* #2319