### PR TITLE
Handle stale metadata version when starting a CC leader

### DIFF
--- a/crates/admin/src/cluster_controller/mod.rs
+++ b/crates/admin/src/cluster_controller/mod.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod cluster_controller_state;
 pub mod cluster_state_refresher;
 pub mod grpc_svc_handler;
 mod logs_controller;

--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -52,6 +52,11 @@ impl ObservedClusterState {
                     self.alive_nodes
                         .insert(*node_id, alive_node.generational_node_id);
                 }
+                NodeState::Suspect(maybe_node) => {
+                    self.dead_nodes.remove(node_id);
+                    self.alive_nodes
+                        .insert(*node_id, maybe_node.generational_node_id);
+                }
                 NodeState::Dead(_) => {
                     self.alive_nodes.remove(node_id);
                     self.dead_nodes.insert(*node_id);

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -29,13 +29,20 @@ message NodeState {
   oneof state {
     AliveNode alive = 1;
     DeadNode dead = 2;
+    SuspectNode suspect = 3;
   }
+}
+
+message SuspectNode {
+  restate.common.NodeId generational_node_id = 1;
+  google.protobuf.Timestamp last_attempt = 2;
 }
 
 message AliveNode {
   restate.common.NodeId generational_node_id = 1;
   google.protobuf.Timestamp last_heartbeat_at = 2;
-  // partition id is u16 but protobuf doesn't support u16. This must be a value that's safe to convert to u16
+  // partition id is u16 but protobuf doesn't support u16. This must be a value
+  // that's safe to convert to u16
   map<uint32, PartitionProcessorStatus> partitions = 3;
 }
 


### PR DESCRIPTION
Handle stale metadata version when starting a CC leader

Summary:
In some situation, when a Cluster Controller leader is starting again
some or all of the nodes in the cluster can have an outdated version of
the metadata that has the new leader generational id

This causes some of the "get state" requests to fail, which causes the CC
to think the nodes are dead and does an unnecessary reschedule of PPs

To avoid this, we introduces a third state "Suspect" node. Which is
dead and alive until we can be sure
