### PR TITLE
add perl to local dev env

### DIFF
--- a/docs/dev/local-development.md
+++ b/docs/dev/local-development.md
@@ -21,7 +21,7 @@ Optionally, you can install [just](https://github.com/casey/just) to make use of
 To setup these on Fedora, run:
 
 ```shell
-sudo dnf install clang lld lldb libcxx cmake openssl-devel rocksdb-devel protobuf-compiler protobuf-devel just liburing-devel
+sudo dnf install clang lld lldb libcxx cmake openssl-devel rocksdb-devel protobuf-compiler protobuf-devel just liburing-devel perl
 ```
 
 On MacOS, you can use [homebrew](https://brew.sh)


### PR DESCRIPTION
I had this issue 

``` shell   
Compiling restate-fs-util v1.1.4 (/home/ahmedradwan/Documents/learning/repos/restate/crates/fs-util)
error: failed to run custom build command for openssl-sys v0.9.103

Caused by:
  process didn't exit successfully: /home/ahmedradwan/Documents/learning/repos/restate/target/debug/build/openssl-sys-037951741050b993/build-script-main (exit status: 101)
  --- stdout
  cargo:rustc-check-cfg=cfg(osslconf, values("OPENSSL_NO_OCB", "OPENSSL_NO_SM4", "OPENSSL_NO_SEED", "OPENSSL_NO_CHACHA", "OPENSSL_NO_CAST", "OPENSSL_NO_IDEA", "OPENSSL_NO_CAMELLIA", "OPENSSL_NO_RC4", "OPENSSL_NO_BF", "OPENSSL_NO_PSK", "OPENSSL_NO_DEPRECATED_3_0", "OPENSSL_NO_SCRYPT", "OPENSSL_NO_SM3", "OPENSSL_NO_RMD160", "OPENSSL_NO_EC2M", "OPENSSL_NO_OCSP", "OPENSSL_NO_CMS", "OPENSSL_NO_COMP", "OPENSSL_NO_SOCK", "OPENSSL_NO_STDIO"))
  cargo:rustc-check-cfg=cfg(openssl)
  cargo:rustc-check-cfg=cfg(libressl)
  cargo:rustc-check-cfg=cfg(boringssl)
  cargo:rustc-check-cfg=cfg(libressl250)
  cargo:rustc-check-cfg=cfg(libressl251)
  cargo:rustc-check-cfg=cfg(libressl252)
  cargo:rustc-check-cfg=cfg(libressl261)
  cargo:rustc-check-cfg=cfg(libressl270)
  cargo:rustc-check-cfg=cfg(libressl271)
  cargo:rustc-check-cfg=cfg(libressl273)
  cargo:rustc-check-cfg=cfg(libressl280)
  cargo:rustc-check-cfg=cfg(libressl281)
  cargo:rustc-check-cfg=cfg(libressl291)
  cargo:rustc-check-cfg=cfg(libressl310)
  cargo:rustc-check-cfg=cfg(libressl321)
  cargo:rustc-check-cfg=cfg(libressl332)
  cargo:rustc-check-cfg=cfg(libressl340)
  cargo:rustc-check-cfg=cfg(libressl350)
  cargo:rustc-check-cfg=cfg(libressl360)
  cargo:rustc-check-cfg=cfg(libressl361)
  cargo:rustc-check-cfg=cfg(libressl370)
  cargo:rustc-check-cfg=cfg(libressl380)
  cargo:rustc-check-cfg=cfg(libressl381)
  cargo:rustc-check-cfg=cfg(libressl382)
  cargo:rustc-check-cfg=cfg(libressl390)
  cargo:rustc-check-cfg=cfg(libressl400)
  cargo:rustc-check-cfg=cfg(ossl101)
  cargo:rustc-check-cfg=cfg(ossl102)
  cargo:rustc-check-cfg=cfg(ossl102f)
  cargo:rustc-check-cfg=cfg(ossl102h)
  cargo:rustc-check-cfg=cfg(ossl110)
  cargo:rustc-check-cfg=cfg(ossl110f)
  cargo:rustc-check-cfg=cfg(ossl110g)
  cargo:rustc-check-cfg=cfg(ossl110h)
  cargo:rustc-check-cfg=cfg(ossl111)
  cargo:rustc-check-cfg=cfg(ossl111b)
  cargo:rustc-check-cfg=cfg(ossl111c)
  cargo:rustc-check-cfg=cfg(ossl111d)
  cargo:rustc-check-cfg=cfg(ossl300)
  cargo:rustc-check-cfg=cfg(ossl310)
  cargo:rustc-check-cfg=cfg(ossl320)
  cargo:rustc-check-cfg=cfg(ossl330)
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_NO_VENDOR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_NO_VENDOR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
  OPENSSL_NO_VENDOR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_CONFIG_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_CONFIG_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_CONFIG_DIR
  OPENSSL_CONFIG_DIR unset
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
  CC_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
  CC_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
  AR_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
  AR_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_AR
  HOST_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
  ARFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
  ARFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_ARFLAGS
  HOST_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  cargo:rerun-if-env-changed=RANLIB_x86_64-unknown-linux-gnu
  RANLIB_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=RANLIB_x86_64_unknown_linux_gnu
  RANLIB_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_RANLIB
  HOST_RANLIB = None
  cargo:rerun-if-env-changed=RANLIB
  RANLIB = None
  cargo:rerun-if-env-changed=RANLIBFLAGS_x86_64-unknown-linux-gnu
  RANLIBFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=RANLIBFLAGS_x86_64_unknown_linux_gnu
  RANLIBFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_RANLIBFLAGS
  HOST_RANLIBFLAGS = None
  cargo:rerun-if-env-changed=RANLIBFLAGS
  RANLIBFLAGS = None
  running cd "/home/ahmedradwan/Documents/learning/repos/restate/target/debug/build/openssl-sys-f4e3fe373e386fe3/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/home/ahmedradwan/Documents/learning/repos/restate/target/debug/build/openssl-sys-f4e3fe373e386fe3/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64"

  --- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC entries checked: /usr/local/lib64/perl5/5.40 /usr/local/share/perl5/5.40 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.
  thread 'main' panicked at /home/ahmedradwan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-src-300.3.1+3.3.1/src/lib.rs:621:9:



  Error configuring OpenSSL build:
      Command: cd "/home/ahmedradwan/Documents/learning/repos/restate/target/debug/build/openssl-sys-f4e3fe373e386fe3/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/home/ahmedradwan/Documents/learning/repos/restate/target/debug/build/openssl-sys-f4e3fe373e386fe3/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64"
      Exit status: exit status: 2


      
  note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

which was solved by installing perl on my system (fedora 41)