### PR TITLE
Don't store the OpenAPI contract anymore, rather just cache it

### DIFF
--- a/crates/types/src/schema/openapi.rs
+++ b/crates/types/src/schema/openapi.rs
@@ -154,10 +154,6 @@ impl ServiceOpenAPI {
             components: Default::default(),
         }
     }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.paths.paths.is_empty()
-    }
 }
 
 fn request_schema_name(operation_id: &str) -> String {


### PR DESCRIPTION
For now we put this cache inside the `ServiceSchemas` data structure, but in future we should move it somewhere else (perhaps in `Schemas`)