### PR TITLE
[TaskCenter][3/n] New TaskCenter::spawn_child

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6103,7 +6103,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "parking_lot",
- "pin-project",
+ "pin-project-lite",
  "prost",
  "prost-types",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ opentelemetry_sdk = { version = "0.24.0" }
 parking_lot = { version = "0.12" }
 paste = "1.0"
 pin-project = "1.0"
+pin-project-lite = { version = "0.2" }
 prost = { version = "0.13.1" }
 prost-build = { version = "0.13.1" }
 priority-queue = "2.0.3"

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -99,7 +99,7 @@ pub fn spawn_restate(config: Configuration) -> TaskCenter {
     restate_types::config::set_current_config(config.clone());
     let updateable_config = Configuration::updateable();
 
-    tc.block_on("benchmark", None, async {
+    tc.block_on(async {
         RocksDbManager::init(Constant::new(config.common));
 
         tc.spawn(TaskKind::SystemBoot, "restate", None, async move {

--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -19,7 +19,9 @@ use restate_core::network::rpc_router::RpcRouter;
 use restate_core::network::{
     MessageRouterBuilder, NetworkError, Networking, Outgoing, TransportConnect,
 };
-use restate_core::{Metadata, ShutdownError, TaskCenter, TaskHandle};
+use restate_core::{
+    Metadata, ShutdownError, TaskCenter, TaskCenterFutureExt, TaskHandle, TaskKind,
+};
 use restate_types::cluster::cluster_state::{
     AliveNode, ClusterState, DeadNode, NodeState, SuspectNode,
 };
@@ -28,7 +30,6 @@ use restate_types::time::MillisSinceEpoch;
 use restate_types::Version;
 
 pub struct ClusterStateRefresher<T> {
-    task_center: TaskCenter,
     metadata: Metadata,
     network_sender: Networking<T>,
     get_state_router: RpcRouter<GetNodeState>,
@@ -39,7 +40,6 @@ pub struct ClusterStateRefresher<T> {
 
 impl<T: TransportConnect> ClusterStateRefresher<T> {
     pub fn new(
-        task_center: TaskCenter,
         metadata: Metadata,
         network_sender: Networking<T>,
         router_builder: &mut MessageRouterBuilder,
@@ -57,7 +57,6 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             watch::channel(Arc::from(initial_state));
 
         Self {
-            task_center,
             metadata,
             network_sender,
             get_state_router,
@@ -97,7 +96,6 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
         }
 
         self.in_flight_refresh = Self::start_refresh_task(
-            self.task_center.clone(),
             self.get_state_router.clone(),
             self.network_sender.clone(),
             Arc::clone(&self.cluster_state_update_tx),
@@ -108,13 +106,11 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
     }
 
     fn start_refresh_task(
-        tc: TaskCenter,
         get_state_router: RpcRouter<GetNodeState>,
         network_sender: Networking<T>,
         cluster_state_tx: Arc<watch::Sender<Arc<ClusterState>>>,
         metadata: Metadata,
     ) -> Result<Option<TaskHandle<anyhow::Result<()>>>, ShutdownError> {
-        let task_center = tc.clone();
         let refresh = async move {
             let last_state = Arc::clone(&cluster_state_tx.borrow());
             // make sure we have a partition table that equals or newer than last refresh
@@ -137,13 +133,12 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             for (_, node_config) in nodes_config.iter() {
                 let node_id = node_config.current_generation;
                 let rpc_router = get_state_router.clone();
-                let tc = tc.clone();
                 let network_sender = network_sender.clone();
                 join_set
                     .build_task()
                     .name("get-nodes-state")
-                    .spawn(async move {
-                        tc.run_in_scope("get-node-state", None, async move {
+                    .spawn(
+                        async move {
                             match network_sender.node_connection(node_id).await {
                                 Ok(connection) => {
                                     let outgoing = Outgoing::new(node_id, GetNodeState::default())
@@ -161,9 +156,9 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
                                 }
                                 Err(network_error) => (node_id, Err(network_error)),
                             }
-                        })
-                        .await
-                    })
+                        }
+                        .in_current_tc_as_task(TaskKind::InPlace, "get-nodes-state"),
+                    )
                     .expect("to spawn task");
             }
             while let Some(Ok((node_id, result))) = join_set.join_next().await {
@@ -233,7 +228,7 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             Ok(())
         };
 
-        let handle = task_center.spawn_unmanaged(
+        let handle = TaskCenter::current().spawn_unmanaged(
             restate_core::TaskKind::Disposable,
             "cluster-state-refresh",
             None,

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -91,8 +91,6 @@ impl<T: PartitionProcessorPlacementHints> PartitionProcessorPlacementHints for &
 pub struct Scheduler<T> {
     scheduling_plan: SchedulingPlan,
     last_updated_scheduling_plan: Instant,
-
-    task_center: TaskCenter,
     metadata_store_client: MetadataStoreClient,
     networking: Networking<T>,
 }
@@ -104,7 +102,6 @@ pub struct Scheduler<T> {
 impl<T: TransportConnect> Scheduler<T> {
     pub async fn init(
         configuration: &Configuration,
-        task_center: TaskCenter,
         metadata_store_client: MetadataStoreClient,
         networking: Networking<T>,
     ) -> Result<Self, BuildError> {
@@ -120,7 +117,6 @@ impl<T: TransportConnect> Scheduler<T> {
         Ok(Self {
             scheduling_plan,
             last_updated_scheduling_plan: Instant::now(),
-            task_center,
             metadata_store_client,
             networking,
         })
@@ -478,10 +474,9 @@ impl<T: TransportConnect> Scheduler<T> {
                     commands,
                 };
 
-                self.task_center.spawn_child(
+                TaskCenter::spawn_child(
                     TaskKind::Disposable,
                     "send-control-processors-to-node",
-                    None,
                     {
                         let networking = self.networking.clone();
                         async move {
@@ -584,7 +579,9 @@ mod tests {
         HashSet, PartitionProcessorPlacementHints, Scheduler,
     };
     use restate_core::network::{ForwardingHandler, Incoming, MessageCollectorMockConnector};
-    use restate_core::{metadata, TaskCenterBuilder, TestCoreEnv, TestCoreEnvBuilder};
+    use restate_core::{
+        metadata, TaskCenterBuilder, TaskCenterFutureExt, TestCoreEnv, TestCoreEnvBuilder,
+    };
     use restate_types::cluster::cluster_state::{
         AliveNode, ClusterState, DeadNode, NodeState, PartitionProcessorStatus, RunMode,
     };
@@ -618,44 +615,41 @@ mod tests {
     #[test(tokio::test)]
     async fn empty_leadership_changes_dont_modify_plan() -> googletest::Result<()> {
         let test_env = TestCoreEnv::create_with_single_node(0, 0).await;
-        let tc = test_env.tc.clone();
         let metadata_store_client = test_env.metadata_store_client.clone();
         let networking = test_env.networking.clone();
 
-        test_env
-            .tc
-            .run_in_scope("test", None, async {
-                let initial_scheduling_plan = metadata_store_client
-                    .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
-                    .await
-                    .expect("scheduling plan");
-                let mut scheduler = Scheduler::init(
-                    Configuration::pinned().as_ref(),
-                    tc,
-                    metadata_store_client.clone(),
-                    networking,
+        async {
+            let initial_scheduling_plan = metadata_store_client
+                .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
+                .await
+                .expect("scheduling plan");
+            let mut scheduler = Scheduler::init(
+                Configuration::pinned().as_ref(),
+                metadata_store_client.clone(),
+                networking,
+            )
+            .await?;
+            let observed_cluster_state = ObservedClusterState::default();
+
+            scheduler
+                .on_observed_cluster_state(
+                    &observed_cluster_state,
+                    &metadata().nodes_config_ref(),
+                    NoPlacementHints,
                 )
                 .await?;
-                let observed_cluster_state = ObservedClusterState::default();
 
-                scheduler
-                    .on_observed_cluster_state(
-                        &observed_cluster_state,
-                        &metadata().nodes_config_ref(),
-                        NoPlacementHints,
-                    )
-                    .await?;
+            let scheduling_plan = metadata_store_client
+                .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
+                .await
+                .expect("scheduling plan");
 
-                let scheduling_plan = metadata_store_client
-                    .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
-                    .await
-                    .expect("scheduling plan");
+            assert_eq!(initial_scheduling_plan, scheduling_plan);
 
-                assert_eq!(initial_scheduling_plan, scheduling_plan);
-
-                Ok(())
-            })
-            .await
+            Ok(())
+        }
+        .in_tc(&test_env.tc)
+        .await
     }
 
     #[test(tokio::test(start_paused = true))]
@@ -742,78 +736,76 @@ mod tests {
             .set_scheduling_plan(initial_scheduling_plan)
             .build()
             .await;
-        let tc = env.tc.clone();
-        env.tc
-            .run_in_scope("test", None, async move {
-                let mut scheduler = Scheduler::init(
-                    Configuration::pinned().as_ref(),
-                    tc,
-                    metadata_store_client.clone(),
-                    networking,
-                )
-                .await?;
-                let mut observed_cluster_state = ObservedClusterState::default();
+        async move {
+            let mut scheduler = Scheduler::init(
+                Configuration::pinned().as_ref(),
+                metadata_store_client.clone(),
+                networking,
+            )
+            .await?;
+            let mut observed_cluster_state = ObservedClusterState::default();
 
-                for _ in 0..num_scheduling_rounds {
-                    let cluster_state = random_cluster_state(&node_ids, num_partitions);
+            for _ in 0..num_scheduling_rounds {
+                let cluster_state = random_cluster_state(&node_ids, num_partitions);
 
-                    observed_cluster_state.update(&cluster_state);
-                    scheduler
-                        .on_observed_cluster_state(
-                            &observed_cluster_state,
-                            &metadata().nodes_config_ref(),
-                            NoPlacementHints,
-                        )
-                        .await?;
-                    // collect all control messages from the network to build up the effective scheduling plan
-                    let control_messages = control_recv
-                        .as_mut()
-                        .take_until(tokio::time::sleep(Duration::from_secs(10)))
-                        .collect::<Vec<_>>()
-                        .await;
+                observed_cluster_state.update(&cluster_state);
+                scheduler
+                    .on_observed_cluster_state(
+                        &observed_cluster_state,
+                        &metadata().nodes_config_ref(),
+                        NoPlacementHints,
+                    )
+                    .await?;
+                // collect all control messages from the network to build up the effective scheduling plan
+                let control_messages = control_recv
+                    .as_mut()
+                    .take_until(tokio::time::sleep(Duration::from_secs(10)))
+                    .collect::<Vec<_>>()
+                    .await;
 
-                    let observed_cluster_state =
-                        derive_observed_cluster_state(&cluster_state, control_messages);
-                    let target_scheduling_plan = metadata_store_client
-                        .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
-                        .await?
-                        .expect("the scheduler should have created a scheduling plan");
+                let observed_cluster_state =
+                    derive_observed_cluster_state(&cluster_state, control_messages);
+                let target_scheduling_plan = metadata_store_client
+                    .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
+                    .await?
+                    .expect("the scheduler should have created a scheduling plan");
 
-                    // assert that the effective scheduling plan aligns with the target scheduling plan
-                    assert_that!(
-                        observed_cluster_state,
-                        matches_scheduling_plan(&target_scheduling_plan)
-                    );
+                // assert that the effective scheduling plan aligns with the target scheduling plan
+                assert_that!(
+                    observed_cluster_state,
+                    matches_scheduling_plan(&target_scheduling_plan)
+                );
 
-                    let alive_nodes: HashSet<_> = cluster_state
-                        .alive_nodes()
-                        .map(|node| node.generational_node_id.as_plain())
-                        .collect();
+                let alive_nodes: HashSet<_> = cluster_state
+                    .alive_nodes()
+                    .map(|node| node.generational_node_id.as_plain())
+                    .collect();
 
-                    for (_, target_state) in target_scheduling_plan.iter() {
-                        // assert that every partition has a leader which is part of the alive nodes set
-                        assert!(target_state
-                            .leader
-                            .is_some_and(|leader| alive_nodes.contains(&leader)));
+                for (_, target_state) in target_scheduling_plan.iter() {
+                    // assert that every partition has a leader which is part of the alive nodes set
+                    assert!(target_state
+                        .leader
+                        .is_some_and(|leader| alive_nodes.contains(&leader)));
 
-                        // assert that the replication strategy was respected
-                        match replication_strategy {
-                            ReplicationStrategy::OnAllNodes => {
-                                assert_eq!(target_state.node_set, alive_nodes)
-                            }
-                            ReplicationStrategy::Factor(replication_factor) => assert_eq!(
-                                target_state.node_set.len(),
-                                alive_nodes.len().min(
-                                    usize::try_from(replication_factor.get())
-                                        .expect("u32 fits into usize")
-                                )
-                            ),
+                    // assert that the replication strategy was respected
+                    match replication_strategy {
+                        ReplicationStrategy::OnAllNodes => {
+                            assert_eq!(target_state.node_set, alive_nodes)
                         }
+                        ReplicationStrategy::Factor(replication_factor) => assert_eq!(
+                            target_state.node_set.len(),
+                            alive_nodes.len().min(
+                                usize::try_from(replication_factor.get())
+                                    .expect("u32 fits into usize")
+                            )
+                        ),
                     }
                 }
-                googletest::Result::Ok(())
-            })
-            .await?;
+            }
+            googletest::Result::Ok(())
+        }
+        .in_tc(&env.tc)
+        .await?;
 
         Ok(())
     }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -58,7 +58,6 @@ pub enum Error {
 }
 
 pub struct Service<T> {
-    task_center: TaskCenter,
     metadata: Metadata,
     networking: Networking<T>,
     bifrost: Bifrost,
@@ -84,7 +83,6 @@ where
         mut configuration: Live<Configuration>,
         health_status: HealthStatus<AdminStatus>,
         bifrost: Bifrost,
-        task_center: TaskCenter,
         metadata: Metadata,
         networking: Networking<T>,
         router_builder: &mut MessageRouterBuilder,
@@ -94,12 +92,8 @@ where
     ) -> Self {
         let (command_tx, command_rx) = mpsc::channel(2);
 
-        let cluster_state_refresher = ClusterStateRefresher::new(
-            task_center.clone(),
-            metadata.clone(),
-            networking.clone(),
-            router_builder,
-        );
+        let cluster_state_refresher =
+            ClusterStateRefresher::new(metadata.clone(), networking.clone(), router_builder);
 
         let processor_manager_client =
             PartitionProcessorManagerClient::new(networking.clone(), router_builder);
@@ -125,7 +119,6 @@ where
         Service {
             configuration,
             health_status,
-            task_center,
             metadata,
             networking,
             bifrost,
@@ -230,10 +223,9 @@ impl<T: TransportConnect> Service<T> {
         let mut config_watcher = Configuration::watcher();
         let mut cluster_state_watcher = self.cluster_state_refresher.cluster_state_watcher();
 
-        self.task_center.spawn_child(
+        TaskCenter::spawn_child(
             TaskKind::SystemService,
             "cluster-controller-metadata-sync",
-            None,
             sync_cluster_controller_metadata(self.metadata.clone()),
         )?;
 
@@ -346,10 +338,9 @@ impl<T: TransportConnect> Service<T> {
                 );
 
                 let mut node_rpc_client = self.processor_manager_client.clone();
-                let _ = self.task_center.spawn_child(
+                let _ = TaskCenter::spawn_child(
                     TaskKind::Disposable,
                     "create-snapshot-response",
-                    Some(partition_id),
                     async move {
                         let _ = response_tx.send(
                             node_rpc_client
@@ -521,7 +512,6 @@ mod tests {
             Live::from_value(Configuration::default()),
             HealthStatus::default(),
             bifrost.clone(),
-            builder.tc.clone(),
             builder.metadata.clone(),
             builder.networking.clone(),
             &mut builder.router_builder,
@@ -841,7 +831,6 @@ mod tests {
             Live::from_value(config),
             HealthStatus::default(),
             bifrost.clone(),
-            builder.tc.clone(),
             builder.metadata.clone(),
             builder.networking.clone(),
             &mut builder.router_builder,

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -162,7 +162,6 @@ where
 
         let scheduler = Scheduler::init(
             &configuration,
-            service.task_center.clone(),
             service.metadata_store_client.clone(),
             service.networking.clone(),
         )

--- a/crates/bifrost/benches/append_throughput.rs
+++ b/crates/bifrost/benches/append_throughput.rs
@@ -104,7 +104,7 @@ fn write_throughput_local_loglet(c: &mut Criterion) {
         provider,
     ));
 
-    let bifrost = tc.block_on("bifrost-init", None, async {
+    let bifrost = tc.block_on(async {
         let metadata = metadata();
         let bifrost_svc = BifrostService::new(restate_core::task_center(), metadata)
             .enable_local_loglet(&Live::from_value(config));

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -44,9 +44,7 @@ pub async fn spawn_environment(
     let metadata_writer = metadata_manager.writer();
     tc.try_set_global_metadata(metadata.clone());
 
-    tc.run_in_scope_sync("db-manager-init", None, || {
-        RocksDbManager::init(Constant::new(config.common))
-    });
+    tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(config.common)));
 
     let logs = restate_types::logs::metadata::bootstrap_logs_metadata(provider, None, num_logs);
 

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -13,6 +13,7 @@ use tracing::warn;
 
 use restate_core::{
     spawn_metadata_manager, MetadataBuilder, MetadataManager, TaskCenter, TaskCenterBuilder,
+    TaskCenterFutureExt,
 };
 use restate_metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
@@ -34,25 +35,30 @@ pub async fn spawn_environment(
         .build()
         .expect("task_center builds");
 
-    restate_types::config::set_current_config(config.clone());
-    let metadata_builder = MetadataBuilder::default();
+    async {
+        restate_types::config::set_current_config(config.clone());
+        let metadata_builder = MetadataBuilder::default();
 
-    let metadata_store_client = MetadataStoreClient::new_in_memory();
-    let metadata = metadata_builder.to_metadata();
-    let metadata_manager = MetadataManager::new(metadata_builder, metadata_store_client.clone());
+        let metadata_store_client = MetadataStoreClient::new_in_memory();
+        let metadata = metadata_builder.to_metadata();
+        let metadata_manager =
+            MetadataManager::new(metadata_builder, metadata_store_client.clone());
 
-    let metadata_writer = metadata_manager.writer();
-    tc.try_set_global_metadata(metadata.clone());
+        let metadata_writer = metadata_manager.writer();
+        TaskCenter::try_set_global_metadata(metadata.clone());
 
-    tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(config.common)));
+        RocksDbManager::init(Constant::new(config.common));
 
-    let logs = restate_types::logs::metadata::bootstrap_logs_metadata(provider, None, num_logs);
+        let logs = restate_types::logs::metadata::bootstrap_logs_metadata(provider, None, num_logs);
 
-    metadata_store_client
-        .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
-        .await
-        .expect("to store bifrost config in metadata store");
-    metadata_writer.submit(Arc::new(logs));
-    spawn_metadata_manager(&tc, metadata_manager).expect("metadata manager starts");
+        metadata_store_client
+            .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
+            .await
+            .expect("to store bifrost config in metadata store");
+        metadata_writer.submit(Arc::new(logs));
+        spawn_metadata_manager(metadata_manager).expect("metadata manager starts");
+    }
+    .in_tc(&tc)
+    .await;
     tc
 }

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -20,7 +20,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt as TokioStreamExt;
 use tracing::{debug, error, trace, warn};
 
-use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
+use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskKind};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LocalLogletOptions;
 use restate_types::live::BoxedLiveLoad;
@@ -85,10 +85,9 @@ impl LogStoreWriter {
         // the backlog while we process this one.
         let (sender, receiver) = mpsc::channel(batch_size * 2);
 
-        task_center().spawn_child(
+        TaskCenter::spawn_child(
             TaskKind::LogletProvider,
             "local-loglet-writer",
-            None,
             async move {
                 debug!("Start running LogStoreWriter");
                 let opts = updateable.live_load();

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -317,7 +317,6 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
 
     async fn seal(&self) -> Result<(), OperationError> {
         let _ = SealTask::new(
-            task_center(),
             self.my_params.clone(),
             self.logservers_rpc.seal.clone(),
             self.known_global_tail.clone(),
@@ -388,7 +387,6 @@ mod tests {
         let log_server = LogServerService::create(
             HealthStatus::default(),
             config.clone(),
-            node_env.tc.clone(),
             node_env.metadata.clone(),
             node_env.metadata_store_client.clone(),
             record_cache.clone(),

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -350,7 +350,6 @@ impl<T: TransportConnect> FindTailTask<T> {
                     if nodeset_checker.any(NodeTailStatus::is_known_sealed) {
                         // run seal task then retry the find-tail check.
                         let seal_task = SealTask::new(
-                            self.task_center.clone(),
                             self.my_params.clone(),
                             self.logservers_rpc.seal.clone(),
                             self.known_global_tail.clone(),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,7 +40,7 @@ metrics = { workspace = true }
 opentelemetry = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-pin-project = { workspace = true }
+pin-project-lite = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -617,7 +617,7 @@ mod tests {
         S: Fn(&mut T, Version),
     {
         let tc = TaskCenterBuilder::default().build()?;
-        tc.block_on("test", None, async move {
+        tc.block_on(async move {
             let metadata_builder = MetadataBuilder::default();
             let metadata_store_client = MetadataStoreClient::new_in_memory();
             let metadata = metadata_builder.to_metadata();
@@ -689,7 +689,7 @@ mod tests {
         I: Fn(&mut T),
     {
         let tc = TaskCenterBuilder::default().build()?;
-        tc.block_on("test", None, async move {
+        tc.block_on(async move {
             let metadata_builder = MetadataBuilder::default();
             let metadata_store_client = MetadataStoreClient::new_in_memory();
 

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -73,6 +73,30 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    pub fn try_with_current<F, R>(f: F) -> Option<R>
+    where
+        F: Fn(&Metadata) -> R,
+    {
+        TaskCenter::with_metadata(|m| f(m))
+    }
+
+    pub fn try_current() -> Option<Metadata> {
+        TaskCenter::with_current(|tc| tc.metadata())
+    }
+
+    #[track_caller]
+    pub fn with_current<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Metadata) -> R,
+    {
+        TaskCenter::with_metadata(|m| f(m)).expect("called outside task-center scope")
+    }
+
+    #[track_caller]
+    pub fn current() -> Metadata {
+        TaskCenter::with_current(|tc| tc.metadata()).expect("called outside task-center scope")
+    }
+
     #[inline(always)]
     pub fn nodes_config_snapshot(&self) -> Arc<NodesConfiguration> {
         self.inner.nodes_config.load_full()

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -386,11 +386,8 @@ impl Default for VersionWatch {
     }
 }
 
-pub fn spawn_metadata_manager(
-    tc: &TaskCenter,
-    metadata_manager: MetadataManager,
-) -> Result<TaskId, ShutdownError> {
-    tc.spawn(
+pub fn spawn_metadata_manager(metadata_manager: MetadataManager) -> Result<TaskId, ShutdownError> {
+    TaskCenter::current().spawn(
         TaskKind::MetadataBackgroundSync,
         "metadata-manager",
         None,

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -41,8 +41,8 @@ use super::{Handler, MessageRouter};
 use crate::metadata::Urgency;
 use crate::network::handshake::{negotiate_protocol_version, wait_for_hello};
 use crate::network::{Incoming, PeerMetadataVersion};
-use crate::Metadata;
-use crate::{cancellation_watcher, current_task_id, task_center, TaskId, TaskKind};
+use crate::{cancellation_watcher, current_task_id, TaskId, TaskKind};
+use crate::{Metadata, TaskCenter};
 
 struct ConnectionManagerInner {
     router: MessageRouter,
@@ -451,10 +451,9 @@ impl<T: TransportConnect> ConnectionManager<T> {
         );
         let router = guard.router.clone();
 
-        let task_id = task_center().spawn_child(
+        let task_id = TaskCenter::spawn_child(
             TaskKind::ConnectionReactor,
             "network-connection-reactor",
-            None,
             run_reactor(
                 self.inner.clone(),
                 connection.clone(),

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -14,7 +14,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::{cancellation_watcher, task_center, ShutdownError, TaskCenter, TaskKind};
 use http::Uri;
 use hyper::body::{Body, Incoming};
 use hyper::rt::{Read, Write};
@@ -28,6 +27,8 @@ use tracing::{debug, info, instrument, Span};
 use restate_types::config::{MetadataStoreClientOptions, NetworkingOptions};
 use restate_types::errors::GenericError;
 use restate_types::net::{AdvertisedAddress, BindAddress};
+
+use crate::{cancellation_watcher, ShutdownError, TaskCenter, TaskKind};
 
 pub fn create_tonic_channel_from_advertised_address<T: CommonClientConnectionOptions>(
     address: AdvertisedAddress,
@@ -161,8 +162,6 @@ where
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     let mut shutdown = std::pin::pin!(cancellation_watcher());
-    let tc = task_center();
-    let executor = TaskCenterExecutor::new(tc.clone(), server_name);
     loop {
         tokio::select! {
             biased;
@@ -174,10 +173,10 @@ where
                 let io = TokioIo::new(stream);
                 debug!(?remote_addr, "Accepting incoming connection");
 
-                tc.spawn_child(TaskKind::RpcConnection, server_name, None, handle_connection(
+                TaskCenter::spawn_child(TaskKind::RpcConnection, server_name, handle_connection(
+                    server_name,
                     io,
                     service.clone(),
-                    executor.clone(),
                     remote_addr,
                 ))?;
             }
@@ -188,9 +187,9 @@ where
 }
 
 async fn handle_connection<S, B, I, A>(
+    server_name: &'static str,
     io: I,
     service: S,
-    executor: TaskCenterExecutor,
     remote_addr: A,
 ) -> anyhow::Result<()>
 where
@@ -206,6 +205,9 @@ where
     I: Read + Write + Unpin + 'static,
     A: Send + Debug,
 {
+    // todo (asoli): Use TaskCenter's Handle Api when it's introduced to replace the nesting of
+    // run_in_scope_sync and TaskCenter::spawn_child.
+    let executor = TaskCenterExecutor::new(TaskCenter::current(), server_name);
     let builder = hyper_util::server::conn::auto::Builder::new(executor);
     let connection = builder.serve_connection(io, service);
 
@@ -246,13 +248,13 @@ where
 {
     fn execute(&self, fut: F) {
         // ignore shutdown error
-        let _ =
-            self.task_center
-                .spawn_child(TaskKind::RpcConnection, self.name, None, async move {
-                    // ignore the future output
-                    let _ = fut.await;
-                    Ok(())
-                });
+        self.task_center.run_in_scope_sync(|| {
+            let _ = TaskCenter::spawn_child(TaskKind::RpcConnection, self.name, async move {
+                // ignore the future output
+                let _ = fut.await;
+                Ok(())
+            });
+        });
     }
 }
 

--- a/crates/core/src/task_center/extensions.rs
+++ b/crates/core/src/task_center/extensions.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2023 - 2025  Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use pin_project_lite::pin_project;
+use tokio::task::futures::TaskLocalFuture;
+use tokio_util::sync::CancellationToken;
+
+use crate::task_center::TaskContext;
+use crate::Metadata;
+
+use super::{
+    GlobalOverrides, TaskCenter, TaskId, TaskKind, CURRENT_TASK_CENTER, OVERRIDES, TASK_CONTEXT,
+};
+
+type TaskCenterFuture<F> =
+    TaskLocalFuture<TaskCenter, TaskLocalFuture<GlobalOverrides, TaskLocalFuture<TaskContext, F>>>;
+
+/// Adds the ability to override task-center for a future and all its children
+pub trait TaskCenterFutureExt: Sized {
+    /// Ensures that a future will run within a task-center context. This will inherit the current
+    /// task context (if there is one). Otherwise, it'll run in the context of the root task (task-id=0).
+    fn in_tc(self, task_center: &TaskCenter) -> WithTaskCenter<Self>;
+
+    /// Lets task-center treat this future as a pseudo-task. It gets its own TaskId and an
+    /// independent cancellation token. However, task-center will not spawn this as a task nor
+    /// manage its lifecycle.
+    fn in_tc_as_task(
+        self,
+        task_center: &TaskCenter,
+        kind: TaskKind,
+        name: &'static str,
+    ) -> WithTaskCenter<Self>;
+
+    /// Ensures that a future will run within the task-center in current scope. This will inherit the current
+    /// task context (if there is one). Otherwise, it'll run in the context of the root task (task-id=0).
+    ///
+    /// This is useful when running dispatching a future as a task on an external runtime/thread,
+    /// or when running a future on tokio's JoinSet without representing those tokio tasks as
+    /// task-center tasks. However, in the latter case, it's preferred to use
+    /// [`Self::in_current_ts_as_task`] instead.
+    fn in_current_tc(self) -> WithTaskCenter<Self>;
+
+    /// Attaches current task-center and lets it treat the future as a pseudo-task. It gets its own TaskId and an
+    /// independent cancellation token. However, task-center will not spawn this as a task nor
+    /// manage its lifecycle.
+    fn in_current_tc_as_task(self, kind: TaskKind, name: &'static str) -> WithTaskCenter<Self>;
+}
+
+pin_project! {
+    pub struct WithTaskCenter<F> {
+        #[pin]
+        inner_fut: TaskCenterFuture<F>,
+    }
+}
+
+impl<F, O> TaskCenterFutureExt for F
+where
+    F: Future<Output = O>,
+{
+    fn in_tc(self, task_center: &TaskCenter) -> WithTaskCenter<Self> {
+        let ctx = task_center.with_task_context(Clone::clone);
+
+        let inner = CURRENT_TASK_CENTER.scope(
+            task_center.clone(),
+            OVERRIDES.scope(
+                OVERRIDES.try_with(Clone::clone).unwrap_or_default(),
+                TASK_CONTEXT.scope(ctx, self),
+            ),
+        );
+        WithTaskCenter { inner_fut: inner }
+    }
+
+    fn in_tc_as_task(
+        self,
+        task_center: &TaskCenter,
+        kind: TaskKind,
+        name: &'static str,
+    ) -> WithTaskCenter<Self> {
+        let ctx = task_center.with_task_context(move |parent| TaskContext {
+            id: TaskId::default(),
+            name,
+            kind,
+            cancellation_token: CancellationToken::new(),
+            partition_id: parent.partition_id,
+        });
+
+        let inner = CURRENT_TASK_CENTER.scope(
+            task_center.clone(),
+            OVERRIDES.scope(
+                OVERRIDES.try_with(Clone::clone).unwrap_or_default(),
+                TASK_CONTEXT.scope(ctx, self),
+            ),
+        );
+        WithTaskCenter { inner_fut: inner }
+    }
+
+    /// Ensures that a future will run within a task-center context. This will inherit the current
+    /// task context (if there is one). Otherwise, it'll run in the context of the root task (task-id=0).
+    fn in_current_tc(self) -> WithTaskCenter<Self> {
+        TaskCenter::with_current(|tc| self.in_tc(tc))
+    }
+
+    fn in_current_tc_as_task(self, kind: TaskKind, name: &'static str) -> WithTaskCenter<Self> {
+        TaskCenter::with_current(|tc| self.in_tc_as_task(tc, kind, name))
+    }
+}
+
+impl<T: Future> Future for WithTaskCenter<T> {
+    type Output = T::Output;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        ctx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        this.inner_fut.poll(ctx)
+    }
+}
+
+/// Adds the ability to override Metadata for a future and all its children
+pub trait MetadataFutureExt: Sized {
+    /// Attaches restate's Metadata as an override on a future and all children futures or
+    /// task-center tasks spawned from it.
+    fn with_metadata(self, metadata: &Metadata) -> WithMetadata<Self>;
+}
+
+pin_project! {
+    pub struct WithMetadata<F> {
+        #[pin]
+        inner_fut: TaskLocalFuture<GlobalOverrides, F>,
+    }
+}
+
+impl<F, O> MetadataFutureExt for F
+where
+    F: Future<Output = O>,
+{
+    fn with_metadata(self, metadata: &Metadata) -> WithMetadata<Self> {
+        let current_overrides = OVERRIDES.try_with(Clone::clone).unwrap_or_default();
+        // temporary mute until overrides include more fields
+        #[allow(clippy::needless_update)]
+        let overrides = GlobalOverrides {
+            metadata: Some(metadata.clone()),
+            ..current_overrides
+        };
+        let inner = OVERRIDES.scope(overrides, self);
+        WithMetadata { inner_fut: inner }
+    }
+}
+
+impl<T: Future> Future for WithMetadata<T> {
+    type Output = T::Output;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        ctx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        this.inner_fut.poll(ctx)
+    }
+}

--- a/crates/core/src/task_center/mod.rs
+++ b/crates/core/src/task_center/mod.rs
@@ -9,22 +9,25 @@
 // by the Apache License, Version 2.0.
 
 mod builder;
+mod extensions;
 mod runtime;
 mod task;
 mod task_kind;
 
 pub use builder::*;
+pub use extensions::*;
 pub use runtime::*;
 pub use task::*;
 pub use task_kind::*;
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
-use futures::{Future, FutureExt};
+use futures::FutureExt;
 use metrics::{counter, gauge};
 use parking_lot::Mutex;
 use tokio::runtime::RuntimeMetrics;
@@ -46,9 +49,18 @@ const EXIT_CODE_FAILURE: i32 = 1;
 
 task_local! {
     // Current task center
-    static CURRENT_TASK_CENTER: TaskCenter;
+    pub(self) static CURRENT_TASK_CENTER: TaskCenter;
     // Tasks provide access to their context
-    static CONTEXT: TaskContext;
+    static TASK_CONTEXT: TaskContext;
+
+    /// Access to a task-level global overrides.
+    static OVERRIDES: GlobalOverrides;
+}
+
+#[derive(Default, Clone)]
+struct GlobalOverrides {
+    metadata: Option<Metadata>,
+    //config: Arc<Configuration>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -75,6 +87,13 @@ impl TaskCenter {
         ingress_runtime: Option<tokio::runtime::Runtime>,
     ) -> Self {
         metric_definitions::describe_metrics();
+        let root_task_context = TaskContext {
+            id: TaskId::ROOT,
+            name: "::",
+            kind: TaskKind::InPlace,
+            cancellation_token: CancellationToken::new(),
+            partition_id: None,
+        };
         Self {
             inner: Arc::new(TaskCenterInner {
                 start_time: Instant::now(),
@@ -88,8 +107,37 @@ impl TaskCenter {
                 managed_tasks: Mutex::new(HashMap::new()),
                 global_metadata: OnceLock::new(),
                 managed_runtimes: Mutex::new(HashMap::with_capacity(64)),
+                root_task_context,
             }),
         }
+    }
+
+    pub fn try_current() -> Option<TaskCenter> {
+        Self::try_with_current(Clone::clone)
+    }
+
+    pub fn try_with_current<F, R>(f: F) -> Option<R>
+    where
+        F: FnOnce(&TaskCenter) -> R,
+    {
+        CURRENT_TASK_CENTER.try_with(|tc| f(tc)).ok()
+    }
+
+    /// Get the current task center. Use this to spawn tasks on the current task center.
+    /// This must be called from within a task-center task.
+    #[track_caller]
+    pub fn current() -> TaskCenter {
+        Self::with_current(Clone::clone)
+    }
+
+    #[track_caller]
+    pub fn with_current<F, R>(f: F) -> R
+    where
+        F: FnOnce(&TaskCenter) -> R,
+    {
+        CURRENT_TASK_CENTER
+            .try_with(|tc| f(tc))
+            .expect("called outside task-center task")
     }
 
     pub fn default_runtime_metrics(&self) -> RuntimeMetrics {
@@ -137,10 +185,6 @@ impl TaskCenter {
         self.inner.current_exit_code.load(Ordering::Relaxed)
     }
 
-    pub fn metadata(&self) -> Option<&Metadata> {
-        self.inner.global_metadata.get()
-    }
-
     fn submit_runtime_metrics(runtime: &'static str, stats: RuntimeMetrics) {
         gauge!("restate.tokio.num_workers", "runtime" => runtime).set(stats.num_workers() as f64);
         gauge!("restate.tokio.blocking_threads", "runtime" => runtime)
@@ -173,15 +217,40 @@ impl TaskCenter {
         }
     }
 
-    /// Clone the currently set METADATA (and if Some()). Otherwise falls back to global metadata.
+    pub(crate) fn metadata(&self) -> Option<Metadata> {
+        match OVERRIDES.try_with(|overrides| overrides.metadata.clone()) {
+            Ok(Some(o)) => Some(o),
+            // No metadata override, use task-center-level metadata
+            _ => self.inner.global_metadata.get().cloned(),
+        }
+    }
+
     #[track_caller]
-    fn clone_metadata(&self) -> Option<Metadata> {
-        CONTEXT
-            .try_with(|m| m.metadata.clone())
+    /// Attempt to access task-level overridden metadata first, if we don't have an override,
+    /// fallback to task-center's level metadata.
+    pub(crate) fn with_metadata<F, R>(f: F) -> Option<R>
+    where
+        F: FnOnce(&Metadata) -> R,
+    {
+        OVERRIDES
+            .try_with(|overrides| match &overrides.metadata {
+                Some(m) => Some(f(m)),
+                // No metadata override, use task-center-level metadata
+                None => CURRENT_TASK_CENTER.with(|tc| tc.inner.global_metadata.get().map(f)),
+            })
             .ok()
             .flatten()
-            .or_else(|| self.inner.global_metadata.get().cloned())
     }
+
+    fn with_task_context<F, R>(&self, f: F) -> R
+    where
+        F: Fn(&TaskContext) -> R,
+    {
+        TASK_CONTEXT
+            .try_with(|ctx| f(ctx))
+            .unwrap_or_else(|_| f(&self.inner.root_task_context))
+    }
+
     /// Triggers a shutdown of the system. All running tasks will be asked gracefully
     /// to cancel but we will only wait for tasks with a TaskKind that has the property
     /// "OnCancel" set to "wait".
@@ -231,14 +300,12 @@ impl TaskCenter {
     {
         let inner = self.inner.clone();
         let id = TaskId::default();
-        let metadata = self.clone_metadata();
         let context = TaskContext {
             id,
             name,
             kind,
             partition_id,
             cancellation_token: cancel.clone(),
-            metadata,
         };
         let task = Arc::new(Task {
             context: context.clone(),
@@ -323,14 +390,12 @@ impl TaskCenter {
 
         let cancel = CancellationToken::new();
         let id = TaskId::default();
-        let metadata = self.clone_metadata();
         let context = TaskContext {
             id,
             name,
             kind,
             partition_id,
             cancellation_token: cancel.clone(),
-            metadata,
         };
 
         let fut = unmanaged_wrapper(self.clone(), context, future);
@@ -374,8 +439,7 @@ impl TaskCenter {
             kind,
             cancellation_token: cancellation_token.clone(),
             // We must be within task-context already. let's get inherit partition_id
-            partition_id: CONTEXT.with(|c| c.partition_id),
-            metadata: Some(metadata()),
+            partition_id: self.with_task_context(|c| c.partition_id),
         };
 
         let task = Arc::new(Task {
@@ -458,7 +522,6 @@ impl TaskCenter {
             kind: root_task_kind,
             cancellation_token: cancel.clone(),
             partition_id,
-            metadata: Some(metadata()),
         };
 
         let (result_tx, result_rx) = oneshot::channel();
@@ -513,17 +576,15 @@ impl TaskCenter {
             return Err(ShutdownError);
         }
 
-        let parent_id =
-            current_task_id().expect("spawn_child called outside of a task-center task");
-        // From this point onwards, we unwrap() directly with the assumption that we are in task-center
-        // context and that the previous (expect) guards against reaching this point if we are
-        // outside task-center.
-        let parent_kind = current_task_kind().unwrap();
-        let parent_name = CONTEXT.try_with(|ctx| ctx.name).unwrap();
+        let (parent_id, parent_name, parent_kind, cancel) = self.with_task_context(|ctx| {
+            (
+                ctx.id,
+                ctx.name,
+                ctx.kind,
+                ctx.cancellation_token.child_token(),
+            )
+        });
 
-        let cancel = CONTEXT
-            .try_with(|ctx| ctx.cancellation_token.child_token())
-            .unwrap();
         let result = self.spawn_inner(kind, name, partition_id, cancel, future);
 
         trace!(
@@ -540,17 +601,17 @@ impl TaskCenter {
     pub fn spawn_blocking_unmanaged<F, O>(
         &self,
         name: &'static str,
-        partition_id: Option<PartitionId>,
         future: F,
     ) -> tokio::task::JoinHandle<O>
     where
         F: Future<Output = O> + Send + 'static,
         O: Send + 'static,
     {
-        let tc = self.clone();
+        let rt_handle = self.inner.default_runtime_handle.clone();
+        let future = future.in_tc_as_task(self, TaskKind::InPlace, name);
         self.inner
             .default_runtime_handle
-            .spawn_blocking(move || tc.block_on(name, partition_id, future))
+            .spawn_blocking(move || rt_handle.block_on(future))
     }
 
     /// Cancelling the child will not cancel the parent. Note that parent task will not
@@ -566,9 +627,7 @@ impl TaskCenter {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        let cancel = CONTEXT
-            .try_with(|ctx| ctx.cancellation_token.child_token())
-            .expect("spawning inside task-center context");
+        let cancel = self.with_task_context(|ctx| ctx.cancellation_token.child_token());
         self.spawn_inner(kind, name, partition_id, cancel, future)
     }
 
@@ -644,18 +703,13 @@ impl TaskCenter {
 
     /// Sets the current task_center but doesn't create a task. Use this when you need to run a
     /// future within task_center scope.
-    pub fn block_on<F, O>(
-        &self,
-        name: &'static str,
-        partition_id: Option<PartitionId>,
-        future: F,
-    ) -> O
+    pub fn block_on<F, O>(&self, future: F) -> O
     where
         F: Future<Output = O>,
     {
         self.inner
             .default_runtime_handle
-            .block_on(self.run_in_scope(name, partition_id, future))
+            .block_on(future.in_tc(self))
     }
 
     /// Sets the current task_center but doesn't create a task. Use this when you need to run a
@@ -669,46 +723,38 @@ impl TaskCenter {
     where
         F: Future<Output = O>,
     {
-        let cancel = CancellationToken::new();
+        let cancellation_token = CancellationToken::new();
         let id = TaskId::default();
-        let metadata = self.clone_metadata();
-        let context = TaskContext {
+        let ctx = TaskContext {
             id,
             name,
             kind: TaskKind::InPlace,
-            cancellation_token: cancel.clone(),
+            cancellation_token: cancellation_token.clone(),
             partition_id,
-            metadata,
         };
 
         CURRENT_TASK_CENTER
-            .scope(self.clone(), CONTEXT.scope(context, future))
+            .scope(
+                self.clone(),
+                OVERRIDES.scope(
+                    OVERRIDES.try_with(Clone::clone).unwrap_or_default(),
+                    TASK_CONTEXT.scope(ctx, future),
+                ),
+            )
             .await
     }
 
     /// Sets the current task_center but doesn't create a task. Use this when you need to run a
     /// closure within task_center scope.
-    pub fn run_in_scope_sync<F, O>(
-        &self,
-        name: &'static str,
-        partition_id: Option<PartitionId>,
-        f: F,
-    ) -> O
+    pub fn run_in_scope_sync<F, O>(&self, f: F) -> O
     where
         F: FnOnce() -> O,
     {
-        let cancel = CancellationToken::new();
-        let id = TaskId::default();
-        let metadata = self.clone_metadata();
-        let context = TaskContext {
-            id,
-            name,
-            kind: TaskKind::InPlace,
-            partition_id,
-            cancellation_token: cancel.clone(),
-            metadata,
-        };
-        CURRENT_TASK_CENTER.sync_scope(self.clone(), || CONTEXT.sync_scope(context, f))
+        CURRENT_TASK_CENTER.sync_scope(self.clone(), || {
+            OVERRIDES.sync_scope(OVERRIDES.try_with(Clone::clone).unwrap_or_default(), || {
+                TASK_CONTEXT.sync_scope(self.with_task_context(Clone::clone), f)
+            })
+        })
     }
 
     /// Take control over the running task from task-center. This returns None if the task was not
@@ -835,10 +881,11 @@ struct TaskCenterInner {
     current_exit_code: AtomicI32,
     managed_tasks: Mutex<HashMap<TaskId, Arc<Task>>>,
     global_metadata: OnceLock<Metadata>,
+    root_task_context: TaskContext,
 }
 
 /// This wrapper function runs in a newly-spawned task. It initializes the
-/// task-local variables and calls the payload function.
+/// task-local variables and wraps the inner future.
 async fn wrapper<F>(task_center: TaskCenter, context: TaskContext, future: F)
 where
     F: Future<Output = anyhow::Result<()>> + 'static,
@@ -849,12 +896,16 @@ where
     let result = CURRENT_TASK_CENTER
         .scope(
             task_center.clone(),
-            CONTEXT.scope(context, {
-                // We use AssertUnwindSafe here so that the wrapped function
-                // doesn't need to be UnwindSafe. We should not do anything after
-                // unwinding that'd risk us being in unwind-unsafe behavior.
-                AssertUnwindSafe(future).catch_unwind()
-            }),
+            OVERRIDES.scope(
+                OVERRIDES.try_with(Clone::clone).unwrap_or_default(),
+                TASK_CONTEXT.scope(
+                    context,
+                    // We use AssertUnwindSafe here so that the wrapped function
+                    // doesn't need to be UnwindSafe. We should not do anything after
+                    // unwinding that'd risk us being in unwind-unsafe behavior.
+                    AssertUnwindSafe(future).catch_unwind(),
+                ),
+            ),
         )
         .await;
     task_center.on_finish(id, result).await;
@@ -868,29 +919,21 @@ where
     trace!(kind = ?context.kind, name = ?context.name, "Starting task {}", context.id);
 
     CURRENT_TASK_CENTER
-        .scope(task_center.clone(), CONTEXT.scope(context, future))
+        .scope(
+            task_center.clone(),
+            OVERRIDES.scope(
+                OVERRIDES.try_with(Clone::clone).unwrap_or_default(),
+                TASK_CONTEXT.scope(context, future),
+            ),
+        )
         .await
-}
-
-/// The current task-center task kind. This returns None if we are not in the scope
-/// of a task-center task.
-pub fn current_task_kind() -> Option<TaskKind> {
-    CONTEXT.try_with(|ctx| ctx.kind).ok()
-}
-
-/// The current task-center task Id. This returns None if we are not in the scope
-/// of a task-center task.
-pub fn current_task_id() -> Option<TaskId> {
-    CONTEXT.try_with(|ctx| ctx.id).ok()
 }
 
 /// Access to global metadata handle. This is available in task-center tasks only!
 #[track_caller]
 pub fn metadata() -> Metadata {
-    CONTEXT
-        .try_with(|ctx| ctx.metadata.clone())
-        .expect("metadata() called outside task-center scope")
-        .expect("metadata() called before global metadata was set")
+    // todo: migrate call-sites
+    Metadata::current()
 }
 
 #[track_caller]
@@ -898,32 +941,41 @@ pub fn with_metadata<F, R>(f: F) -> R
 where
     F: FnOnce(&Metadata) -> R,
 {
-    CURRENT_TASK_CENTER.with(|tc| {
-        f(tc.metadata()
-            .expect("metadata must be set. Is global metadata set?"))
-    })
+    Metadata::with_current(f)
 }
 
 /// Access to this node id. This is available in task-center tasks only!
 #[track_caller]
 pub fn my_node_id() -> GenerationalNodeId {
-    CONTEXT
-        .try_with(|ctx| ctx.metadata.as_ref().map(|m| m.my_node_id()))
-        .expect("my_node_id() called outside task-center scope")
-        .expect("my_node_id() called before global metadata was set")
+    // todo: migrate call-sites
+    Metadata::with_current(|m| m.my_node_id())
+}
+
+/// The current task-center task Id. This returns None if we are not in the scope
+/// of a task-center task.
+pub fn current_task_id() -> Option<TaskId> {
+    TASK_CONTEXT
+        .try_with(|ctx| Some(ctx.id))
+        .unwrap_or(TaskCenter::try_with_current(|tc| {
+            tc.inner.root_task_context.id
+        }))
 }
 
 /// The current partition Id associated to the running task-center task.
 pub fn current_task_partition_id() -> Option<PartitionId> {
-    CONTEXT.try_with(|ctx| ctx.partition_id).ok().flatten()
+    TASK_CONTEXT
+        .try_with(|ctx| Some(ctx.partition_id))
+        .unwrap_or(TaskCenter::try_with_current(|tc| {
+            tc.inner.root_task_context.partition_id
+        }))
+        .flatten()
 }
 
 /// Get the current task center. Use this to spawn tasks on the current task center.
 /// This must be called from within a task-center task.
 pub fn task_center() -> TaskCenter {
-    CURRENT_TASK_CENTER
-        .try_with(|t| t.clone())
-        .expect("task_center() called in a task-center task")
+    // migrate call-sites
+    TaskCenter::current()
 }
 
 /// A Future that can be used to check if the current task has been requested to
@@ -939,7 +991,7 @@ pub async fn cancellation_watcher() {
 /// cancel_task() call, or if it's a child and the parent is being cancelled by a
 /// cancel_task() call, this cancellation token will be set to cancelled.
 pub fn cancellation_token() -> CancellationToken {
-    let res = CONTEXT.try_with(|ctx| ctx.cancellation_token.clone());
+    let res = TASK_CONTEXT.try_with(|ctx| ctx.cancellation_token.clone());
 
     if cfg!(any(test, feature = "test-util")) {
         // allow in tests to call from non-task-center tasks.
@@ -951,7 +1003,7 @@ pub fn cancellation_token() -> CancellationToken {
 
 /// Has the current task been requested to cancel?
 pub fn is_cancellation_requested() -> bool {
-    CONTEXT
+    TASK_CONTEXT
         .try_with(|ctx| ctx.cancellation_token.is_cancelled())
         .unwrap_or_else(|_| {
             if cfg!(any(test, feature = "test-util")) {
@@ -966,7 +1018,6 @@ mod tests {
     use super::*;
 
     use googletest::prelude::*;
-    use restate_test_util::assert_eq;
     use restate_types::config::CommonOptionsBuilder;
     use tracing_test::traced_test;
 
@@ -986,7 +1037,6 @@ mod tests {
         tc.spawn(TaskKind::RoleRunner, "worker-role", None, async {
             info!("Hello async");
             tokio::time::sleep(Duration::from_secs(10)).await;
-            assert_eq!(TaskKind::RoleRunner, current_task_kind().unwrap());
             info!("Bye async");
             Ok(())
         })

--- a/crates/core/src/task_center/task.rs
+++ b/crates/core/src/task_center/task.rs
@@ -18,7 +18,7 @@ use tokio_util::sync::CancellationToken;
 use restate_types::identifiers::PartitionId;
 
 use super::{TaskId, TaskKind};
-use crate::{Metadata, ShutdownError};
+use crate::ShutdownError;
 
 #[derive(Clone)]
 pub(super) struct TaskContext {
@@ -31,8 +31,6 @@ pub(super) struct TaskContext {
     /// Tasks associated with a specific partition ID will have this set. This allows
     /// for cancellation of tasks associated with that partition.
     pub(super) partition_id: Option<PartitionId>,
-    /// Access to a locally-cached metadata view.
-    pub(super) metadata: Option<Metadata>,
 }
 
 pub(super) struct Task<R = ()> {

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use strum::EnumProperty;
 
-static NEXT_TASK_ID: AtomicU64 = const { AtomicU64::new(0) };
+static NEXT_TASK_ID: AtomicU64 = const { AtomicU64::new(1) };
 
 #[derive(
     Clone,
@@ -36,6 +36,8 @@ impl Default for TaskId {
 }
 
 impl TaskId {
+    pub const ROOT: TaskId = TaskId(0);
+
     pub fn new() -> Self {
         Default::default()
     }

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -95,6 +95,8 @@ pub enum TaskKind {
     SystemService,
     #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     Ingress,
+    /// Kafka ingestion related task
+    Kafka,
     PartitionProcessor,
     /// Longer-running, low-priority tasks that is responsible for the export, and potentially
     /// upload to remote storage, of partition store snapshots.

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -33,7 +33,7 @@ use crate::network::{
     ConnectionManager, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder,
     NetworkError, Networking, ProtocolError, TransportConnect,
 };
-use crate::{spawn_metadata_manager, MetadataBuilder, TaskId};
+use crate::{spawn_metadata_manager, MetadataBuilder, TaskCenterFutureExt, TaskId};
 use crate::{Metadata, MetadataManager, MetadataWriter};
 use crate::{TaskCenter, TaskCenterBuilder};
 
@@ -103,7 +103,7 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
         let partition_table = PartitionTable::with_equally_sized_partitions(Version::MIN, 10);
         let scheduling_plan =
             SchedulingPlan::from(&partition_table, ReplicationStrategy::OnAllNodes);
-        tc.try_set_global_metadata(metadata.clone());
+        tc.try_set_global_metadata_inner(metadata.clone());
 
         // Use memory-loglet as a default if in test-mode
         #[cfg(any(test, feature = "test-util"))]
@@ -167,78 +167,79 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
     }
 
     pub async fn build(mut self) -> TestCoreEnv<T> {
-        self.metadata_manager
-            .register_in_message_router(&mut self.router_builder);
-        self.networking
-            .connection_manager()
-            .set_message_router(self.router_builder.build());
+        let tc = self.tc;
+        async {
+            self.metadata_manager
+                .register_in_message_router(&mut self.router_builder);
+            self.networking
+                .connection_manager()
+                .set_message_router(self.router_builder.build());
 
-        let metadata_manager_task = spawn_metadata_manager(&self.tc, self.metadata_manager)
-            .expect("metadata manager should start");
+            let metadata_manager_task = spawn_metadata_manager(self.metadata_manager)
+                .expect("metadata manager should start");
 
-        self.metadata_store_client
-            .put(
-                NODES_CONFIG_KEY.clone(),
-                &self.nodes_config,
-                Precondition::None,
-            )
-            .await
-            .expect("to store nodes config in metadata store");
-        self.metadata_writer
-            .submit(Arc::new(self.nodes_config.clone()));
+            self.metadata_store_client
+                .put(
+                    NODES_CONFIG_KEY.clone(),
+                    &self.nodes_config,
+                    Precondition::None,
+                )
+                .await
+                .expect("to store nodes config in metadata store");
+            self.metadata_writer
+                .submit(Arc::new(self.nodes_config.clone()));
 
-        let logs = bootstrap_logs_metadata(
-            self.provider_kind,
-            None,
-            self.partition_table.num_partitions(),
-        );
-        self.metadata_store_client
-            .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
-            .await
-            .expect("to store bifrost config in metadata store");
-        self.metadata_writer.submit(Arc::new(logs));
+            let logs = bootstrap_logs_metadata(
+                self.provider_kind,
+                None,
+                self.partition_table.num_partitions(),
+            );
+            self.metadata_store_client
+                .put(BIFROST_CONFIG_KEY.clone(), &logs, Precondition::None)
+                .await
+                .expect("to store bifrost config in metadata store");
+            self.metadata_writer.submit(Arc::new(logs));
 
-        self.metadata_store_client
-            .put(
-                PARTITION_TABLE_KEY.clone(),
-                &self.partition_table,
-                Precondition::None,
-            )
-            .await
-            .expect("to store partition table in metadata store");
-        self.metadata_writer.submit(Arc::new(self.partition_table));
+            self.metadata_store_client
+                .put(
+                    PARTITION_TABLE_KEY.clone(),
+                    &self.partition_table,
+                    Precondition::None,
+                )
+                .await
+                .expect("to store partition table in metadata store");
+            self.metadata_writer.submit(Arc::new(self.partition_table));
 
-        self.metadata_store_client
-            .put(
-                SCHEDULING_PLAN_KEY.clone(),
-                &self.scheduling_plan,
-                Precondition::None,
-            )
-            .await
-            .expect("sot store scheduling plan in metadata store");
+            self.metadata_store_client
+                .put(
+                    SCHEDULING_PLAN_KEY.clone(),
+                    &self.scheduling_plan,
+                    Precondition::None,
+                )
+                .await
+                .expect("sot store scheduling plan in metadata store");
 
-        self.tc
-            .run_in_scope("test-env", None, async {
-                let _ = self
-                    .metadata
-                    .wait_for_version(
-                        MetadataKind::NodesConfiguration,
-                        self.nodes_config.version(),
-                    )
-                    .await
-                    .unwrap();
-            })
-            .await;
-        self.metadata_writer.set_my_node_id(self.my_node_id);
+            let _ = self
+                .metadata
+                .wait_for_version(
+                    MetadataKind::NodesConfiguration,
+                    self.nodes_config.version(),
+                )
+                .await
+                .unwrap();
+            self.metadata_writer.set_my_node_id(self.my_node_id);
 
-        TestCoreEnv {
-            tc: self.tc,
-            metadata: self.metadata,
-            metadata_manager_task,
-            metadata_writer: self.metadata_writer,
-            networking: self.networking,
-            metadata_store_client: self.metadata_store_client,
+            TestCoreEnv {
+                tc: TaskCenter::current(),
+                metadata: self.metadata,
+                metadata_manager_task,
+                metadata_writer: self.metadata_writer,
+                networking: self.networking,
+                metadata_store_client: self.metadata_store_client,
+            }
         }
+        .in_tc(&tc)
+        .await
     }
 }
 

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -37,7 +37,7 @@ hyper-util = { workspace = true, features = ["http1", "http2", "server", "tokio"
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
-pin-project-lite = "0.2.13"
+pin-project-lite = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -287,7 +287,7 @@ impl ConsumerTask {
                             consumer_group_id.clone()
                         );
 
-                        if let Ok(task_id) = self.task_center.spawn_child(TaskKind::Ingress, "partition-queue", None, task) {
+                        if let Ok(task_id) = TaskCenter::spawn_child(TaskKind::Ingress, "partition-queue", task) {
                             e.insert(task_id);
                         } else {
                             break Ok(());

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -191,7 +191,7 @@ impl Service {
 
 mod task_orchestrator {
     use crate::consumer_task;
-    use restate_core::task_center;
+    use restate_core::{TaskCenterFutureExt, TaskKind};
     use restate_timer_queue::TimerQueue;
     use restate_types::identifiers::SubscriptionId;
     use restate_types::retries::{RetryIter, RetryPolicy};
@@ -344,12 +344,10 @@ mod task_orchestrator {
             let task_id = self
                 .tasks
                 .spawn({
-                    let tc = task_center();
                     let consumer_task_clone = consumer_task_clone.clone();
-                    async move {
-                        tc.run_in_scope("kafka-consumer-task", None, consumer_task_clone.run(rx))
-                            .await
-                    }
+                    consumer_task_clone
+                        .run(rx)
+                        .in_current_tc_as_task(TaskKind::Kafka, "kafka-consumer-task")
                 })
                 .id();
 

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -93,7 +93,6 @@ impl LogletWorkerHandle {
 }
 
 pub struct LogletWorker<S> {
-    task_center: TaskCenter,
     loglet_id: ReplicatedLogletId,
     log_store: S,
     loglet_state: LogletState,
@@ -101,13 +100,11 @@ pub struct LogletWorker<S> {
 
 impl<S: LogStore> LogletWorker<S> {
     pub fn start(
-        task_center: TaskCenter,
         loglet_id: ReplicatedLogletId,
         log_store: S,
         loglet_state: LogletState,
     ) -> Result<LogletWorkerHandle, ShutdownError> {
         let writer = Self {
-            task_center: task_center.clone(),
             loglet_id,
             log_store,
             loglet_state,
@@ -121,7 +118,8 @@ impl<S: LogStore> LogletWorker<S> {
         let (trim_tx, trim_rx) = mpsc::unbounded_channel();
         let (wait_for_tail_tx, wait_for_tail_rx) = mpsc::unbounded_channel();
         let (get_digest_tx, get_digest_rx) = mpsc::unbounded_channel();
-        let tc_handle = task_center.spawn_unmanaged(
+        // todo
+        let tc_handle = TaskCenter::current().spawn_unmanaged(
             TaskKind::LogletWriter,
             "loglet-worker",
             None,
@@ -423,7 +421,7 @@ impl<S: LogStore> LogletWorker<S> {
     fn process_wait_for_tail(&mut self, msg: Incoming<WaitForTail>) {
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
-        let _ = self.task_center.spawn(
+        let _ = TaskCenter::current().spawn(
             TaskKind::Disposable,
             "logserver-tail-monitor",
             None,
@@ -465,7 +463,7 @@ impl<S: LogStore> LogletWorker<S> {
         let log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
-        let _ = self.task_center.spawn(
+        let _ = TaskCenter::current().spawn(
             TaskKind::Disposable,
             "logserver-get-records",
             None,
@@ -500,7 +498,7 @@ impl<S: LogStore> LogletWorker<S> {
         let log_store = self.log_store.clone();
         let loglet_state = self.loglet_state.clone();
         // fails on shutdown, in this case, we ignore the request
-        let _ = self.task_center.spawn(
+        let _ = TaskCenter::current().spawn(
             TaskKind::Disposable,
             "logserver-get-digest",
             None,
@@ -538,8 +536,8 @@ impl<S: LogStore> LogletWorker<S> {
         // fails on shutdown, in this case, we ignore the request
         let mut loglet_state = self.loglet_state.clone();
         let log_store = self.log_store.clone();
-        let _ = self
-            .task_center
+        let _ =
+            TaskCenter::current()
             .spawn(TaskKind::Disposable, "logserver-trim", None, async move {
                 let loglet_id = msg.body().header.loglet_id;
                 let new_trim_point = msg.body().trim_point;
@@ -616,7 +614,7 @@ mod tests {
     use test_log::test;
 
     use restate_core::network::OwnedConnection;
-    use restate_core::{MetadataBuilder, TaskCenter, TaskCenterBuilder};
+    use restate_core::{MetadataBuilder, TaskCenter, TaskCenterBuilder, TaskCenterFutureExt};
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
     use restate_types::live::Live;
@@ -636,498 +634,738 @@ mod tests {
         let tc = TaskCenterBuilder::default_for_tests().build()?;
         let config = Live::from_value(Configuration::default());
         let common_rocks_opts = config.clone().map(|c| &c.common);
-        let log_store = tc
-            .run_in_scope("test-setup", None, async {
-                RocksDbManager::init(common_rocks_opts);
-                let metadata_builder = MetadataBuilder::default();
-                assert!(tc.try_set_global_metadata(metadata_builder.to_metadata()));
-                // create logstore.
-                let builder = RocksDbLogStoreBuilder::create(
-                    config.clone().map(|c| &c.log_server).boxed(),
-                    config.map(|c| &c.log_server.rocksdb).boxed(),
-                    RecordCache::new(1_000_000),
-                )
-                .await?;
-                let log_store = builder.start(&tc, Default::default()).await?;
-                Result::Ok(log_store)
-            })
+        let log_store = async {
+            RocksDbManager::init(common_rocks_opts);
+            let metadata_builder = MetadataBuilder::default();
+            assert!(TaskCenter::try_set_global_metadata(
+                metadata_builder.to_metadata()
+            ));
+            // create logstore.
+            let builder = RocksDbLogStoreBuilder::create(
+                config.clone().map(|c| &c.log_server).boxed(),
+                config.map(|c| &c.log_server.rocksdb).boxed(),
+                RecordCache::new(1_000_000),
+            )
             .await?;
+            let log_store = builder.start(Default::default()).await?;
+            Result::Ok(log_store)
+        }
+        .in_tc(&tc)
+        .await?;
         Ok((tc, log_store))
     }
 
     #[test(tokio::test(start_paused = true))]
     async fn test_simple_store_flow() -> Result<()> {
-        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-
         let (tc, log_store) = setup().await?;
-        let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        async {
+            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+            let loglet_state_map = LogletStateMap::default();
+            let (net_tx, mut net_rx) = mpsc::channel(10);
+            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-        let worker = LogletWorker::start(tc.clone(), LOGLET, log_store, loglet_state)?;
+            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-        let payloads: Arc<[Record]> = vec![
-            Record::from("a sample record"),
-            Record::from("another record"),
-        ]
-        .into();
+            let payloads: Arc<[Record]> = vec![
+                Record::from("a sample record"),
+                Record::from("another record"),
+            ]
+            .into();
 
-        // offsets 1, 2
-        let msg1 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::OLDEST,
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
+            // offsets 1, 2
+            let msg1 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::OLDEST,
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
 
-        // offsets 3, 4
-        let msg2 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::new(3),
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
+            // offsets 3, 4
+            let msg2 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::new(3),
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
-        let msg1_id = msg1.msg_id();
-        let msg2_id = msg2.msg_id();
+            let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
+            let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+            let msg1_id = msg1.msg_id();
+            let msg2_id = msg2.msg_id();
 
-        // pipelined writes
-        worker.enqueue_store(msg1).unwrap();
-        worker.enqueue_store(msg2).unwrap();
-        // wait for response (in test-env, it's safe to assume that responses will arrive in order)
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg1_id));
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+            // pipelined writes
+            worker.enqueue_store(msg1).unwrap();
+            worker.enqueue_store(msg2).unwrap();
+            // wait for response (in test-env, it's safe to assume that responses will arrive in order)
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg1_id));
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
-        // response 2
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg2_id));
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(5)));
+            // response 2
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg2_id));
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(5)));
 
-        tc.shutdown_node("test completed", 0).await;
-        RocksDbManager::get().shutdown().await;
+            tc.shutdown_node("test completed", 0).await;
+            RocksDbManager::get().shutdown().await;
 
-        Ok(())
+            Ok(())
+        }
+        .in_tc(&tc)
+        .await
     }
 
     #[test(tokio::test(start_paused = true))]
     async fn test_store_and_seal() -> Result<()> {
-        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-
         let (tc, log_store) = setup().await?;
-        let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        async {
+            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+            let loglet_state_map = LogletStateMap::default();
+            let (net_tx, mut net_rx) = mpsc::channel(10);
+            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-        let worker = LogletWorker::start(tc.clone(), LOGLET, log_store, loglet_state)?;
+            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-        let payloads: Arc<[Record]> = vec![
-            Record::from("a sample record"),
-            Record::from("another record"),
-        ]
-        .into();
+            let payloads: Arc<[Record]> = vec![
+                Record::from("a sample record"),
+                Record::from("another record"),
+            ]
+            .into();
 
-        // offsets 1, 2
-        let msg1 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::OLDEST,
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
+            // offsets 1, 2
+            let msg1 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::OLDEST,
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
 
-        let seal1 = Seal {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            sequencer: SEQUENCER,
-        };
+            let seal1 = Seal {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                sequencer: SEQUENCER,
+            };
 
-        let seal2 = Seal {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            sequencer: SEQUENCER,
-        };
+            let seal2 = Seal {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                sequencer: SEQUENCER,
+            };
 
-        // offsets 3, 4
-        let msg2 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::new(3),
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
+            // offsets 3, 4
+            let msg2 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::new(3),
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
-        let seal2 = Incoming::for_testing(connection.downgrade(), seal2, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
-        let msg1_id = msg1.msg_id();
-        let seal1_id = seal1.msg_id();
-        let seal2_id = seal2.msg_id();
-        let msg2_id = msg2.msg_id();
+            let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
+            let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
+            let seal2 = Incoming::for_testing(connection.downgrade(), seal2, None);
+            let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+            let msg1_id = msg1.msg_id();
+            let seal1_id = seal1.msg_id();
+            let seal2_id = seal2.msg_id();
+            let msg2_id = msg2.msg_id();
 
-        worker.enqueue_store(msg1).unwrap();
-        // first store is successful
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg1_id));
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
-        worker.enqueue_seal(seal1).unwrap();
-        // should latch onto existing seal
-        worker.enqueue_seal(seal2).unwrap();
-        // seal takes precedence, but it gets processed in the background. This store is likely to
-        // observe Status::Sealing
-        worker.enqueue_store(msg2).unwrap();
-        // sealing
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg2_id));
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Sealing));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
-        // seal responses can come at any order, but we'll consume waiters queue before we process
-        // store messages.
-        // sealed
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
-        let sealed: Sealed = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(sealed.status, eq(Status::Ok));
-        assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
+            worker.enqueue_store(msg1).unwrap();
+            // first store is successful
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg1_id));
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+            worker.enqueue_seal(seal1).unwrap();
+            // should latch onto existing seal
+            worker.enqueue_seal(seal2).unwrap();
+            // seal takes precedence, but it gets processed in the background. This store is likely to
+            // observe Status::Sealing
+            worker.enqueue_store(msg2).unwrap();
+            // sealing
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg2_id));
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Sealing));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+            // seal responses can come at any order, but we'll consume waiters queue before we process
+            // store messages.
+            // sealed
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
+            let sealed: Sealed = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(sealed.status, eq(Status::Ok));
+            assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
 
-        // sealed2
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
-        let sealed: Sealed = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(sealed.status, eq(Status::Ok));
-        assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
+            // sealed2
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
+            let sealed: Sealed = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(sealed.status, eq(Status::Ok));
+            assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
 
-        // try another store
-        let msg3 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(3)),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::new(3),
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
-        let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
-        let msg3_id = msg3.msg_id();
-        worker.enqueue_store(msg3).unwrap();
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg3_id));
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Sealed));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+            // try another store
+            let msg3 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(3)),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::new(3),
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
+            let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
+            let msg3_id = msg3.msg_id();
+            worker.enqueue_store(msg3).unwrap();
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg3_id));
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Sealed));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
-        // GetLogletInfo
-        // offsets 3, 4
-        let msg = GetLogletInfo {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-        };
-        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
-        let msg_id = msg.msg_id();
-        worker.enqueue_get_loglet_info(msg).unwrap();
+            // GetLogletInfo
+            // offsets 3, 4
+            let msg = GetLogletInfo {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            };
+            let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+            let msg_id = msg.msg_id();
+            worker.enqueue_get_loglet_info(msg).unwrap();
 
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg_id));
-        let info: LogletInfo = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(info.status, eq(Status::Ok));
-        assert_that!(info.local_tail, eq(LogletOffset::new(3)));
-        assert_that!(info.trim_point, eq(LogletOffset::INVALID));
-        assert_that!(info.sealed, eq(true));
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg_id));
+            let info: LogletInfo = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(info.status, eq(Status::Ok));
+            assert_that!(info.local_tail, eq(LogletOffset::new(3)));
+            assert_that!(info.trim_point, eq(LogletOffset::INVALID));
+            assert_that!(info.sealed, eq(true));
 
-        tc.shutdown_node("test completed", 0).await;
-        RocksDbManager::get().shutdown().await;
-
-        Ok(())
+            tc.shutdown_node("test completed", 0).await;
+            RocksDbManager::get().shutdown().await;
+            Ok(())
+        }
+        .in_tc(&tc)
+        .await
     }
 
     #[test(tokio::test(start_paused = true))]
     async fn test_repair_store() -> Result<()> {
-        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-
         let (tc, log_store) = setup().await?;
-        let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        async {
+            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+            const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
+            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+            let loglet_state_map = LogletStateMap::default();
+            let (net_tx, mut net_rx) = mpsc::channel(10);
+            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-        let (peer_net_tx, mut peer_net_rx) = mpsc::channel(10);
-        let repair_connection =
-            OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, peer_net_tx);
+            let (peer_net_tx, mut peer_net_rx) = mpsc::channel(10);
+            let repair_connection =
+                OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, peer_net_tx);
 
-        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-        let worker = LogletWorker::start(tc.clone(), LOGLET, log_store, loglet_state)?;
+            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-        let payloads: Arc<[Record]> = vec![
-            Record::from("a sample record"),
-            Record::from("another record"),
-        ]
-        .into();
+            let payloads: Arc<[Record]> = vec![
+                Record::from("a sample record"),
+                Record::from("another record"),
+            ]
+            .into();
 
-        // offsets 1, 2
-        let msg1 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::OLDEST,
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
+            // offsets 1, 2
+            let msg1 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::OLDEST,
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
 
-        // offsets 10, 11
-        let msg2 = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::new(10),
-            flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
-        };
+            // offsets 10, 11
+            let msg2 = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::new(10),
+                flags: StoreFlags::empty(),
+                payloads: payloads.clone(),
+            };
 
-        let seal1 = Seal {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            sequencer: SEQUENCER,
-        };
+            let seal1 = Seal {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                sequencer: SEQUENCER,
+            };
 
-        // 5, 6
-        let repair_message_before_local_tail = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::new(5),
-            flags: StoreFlags::IgnoreSeal,
-            payloads: payloads.clone(),
-        };
+            // 5, 6
+            let repair_message_before_local_tail = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::new(5),
+                flags: StoreFlags::IgnoreSeal,
+                payloads: payloads.clone(),
+            };
 
-        // 16, 17
-        let repair_message_after_local_tail = Store {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(16)),
-            timeout_at: None,
-            sequencer: SEQUENCER,
-            known_archived: LogletOffset::INVALID,
-            first_offset: LogletOffset::new(16),
-            flags: StoreFlags::IgnoreSeal,
-            payloads: payloads.clone(),
-        };
+            // 16, 17
+            let repair_message_after_local_tail = Store {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(16)),
+                timeout_at: None,
+                sequencer: SEQUENCER,
+                known_archived: LogletOffset::INVALID,
+                first_offset: LogletOffset::new(16),
+                flags: StoreFlags::IgnoreSeal,
+                payloads: payloads.clone(),
+            };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
-        let repair1 = Incoming::for_testing(
-            repair_connection.downgrade(),
-            repair_message_before_local_tail,
-            None,
-        );
-        let repair2 = Incoming::for_testing(
-            repair_connection.downgrade(),
-            repair_message_after_local_tail,
-            None,
-        );
-        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
+            let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
+            let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+            let repair1 = Incoming::for_testing(
+                repair_connection.downgrade(),
+                repair_message_before_local_tail,
+                None,
+            );
+            let repair2 = Incoming::for_testing(
+                repair_connection.downgrade(),
+                repair_message_after_local_tail,
+                None,
+            );
+            let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
 
-        worker.enqueue_store(msg1).unwrap();
-        worker.enqueue_store(msg2).unwrap();
-        // first store is successful
-        let response = net_rx.recv().await.unwrap();
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.sealed, eq(false));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+            worker.enqueue_store(msg1).unwrap();
+            worker.enqueue_store(msg2).unwrap();
+            // first store is successful
+            let response = net_rx.recv().await.unwrap();
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.sealed, eq(false));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
-        // 10, 11
-        let response = net_rx.recv().await.unwrap();
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.sealed, eq(false));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
+            // 10, 11
+            let response = net_rx.recv().await.unwrap();
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.sealed, eq(false));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
 
-        worker.enqueue_seal(seal1).unwrap();
-        // seal responses can come at any order, but we'll consume waiters queue before we process
-        // store messages.
-        // sealed
-        let response = net_rx.recv().await.unwrap();
-        let sealed: Sealed = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(sealed.status, eq(Status::Ok));
-        assert_that!(sealed.local_tail, eq(LogletOffset::new(12)));
+            worker.enqueue_seal(seal1).unwrap();
+            // seal responses can come at any order, but we'll consume waiters queue before we process
+            // store messages.
+            // sealed
+            let response = net_rx.recv().await.unwrap();
+            let sealed: Sealed = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(sealed.status, eq(Status::Ok));
+            assert_that!(sealed.local_tail, eq(LogletOffset::new(12)));
 
-        // repair store (before local tail, local tail won't move)
-        worker.enqueue_store(repair1).unwrap();
-        let response = peer_net_rx.recv().await.unwrap();
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
+            // repair store (before local tail, local tail won't move)
+            worker.enqueue_store(repair1).unwrap();
+            let response = peer_net_rx.recv().await.unwrap();
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
 
-        worker.enqueue_store(repair2).unwrap();
-        let response = peer_net_rx.recv().await.unwrap();
-        let stored: Stored = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(18)));
+            worker.enqueue_store(repair2).unwrap();
+            let response = peer_net_rx.recv().await.unwrap();
+            let stored: Stored = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(stored.status, eq(Status::Ok));
+            assert_that!(stored.local_tail, eq(LogletOffset::new(18)));
 
-        // GetLogletInfo
-        // offsets 3, 4
-        let msg = GetLogletInfo {
-            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-        };
-        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
-        let msg_id = msg.msg_id();
-        worker.enqueue_get_loglet_info(msg).unwrap();
+            // GetLogletInfo
+            // offsets 3, 4
+            let msg = GetLogletInfo {
+                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            };
+            let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+            let msg_id = msg.msg_id();
+            worker.enqueue_get_loglet_info(msg).unwrap();
 
-        let response = net_rx.recv().await.unwrap();
-        let header = response.header.unwrap();
-        assert_that!(header.in_response_to(), eq(msg_id));
-        let info: LogletInfo = response
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(info.status, eq(Status::Ok));
-        assert_that!(info.local_tail, eq(LogletOffset::new(18)));
-        assert_that!(info.trim_point, eq(LogletOffset::INVALID));
-        assert_that!(info.sealed, eq(true));
-
-        tc.shutdown_node("test completed", 0).await;
-        RocksDbManager::get().shutdown().await;
-
-        Ok(())
+            let response = net_rx.recv().await.unwrap();
+            let header = response.header.unwrap();
+            assert_that!(header.in_response_to(), eq(msg_id));
+            let info: LogletInfo = response
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(info.status, eq(Status::Ok));
+            assert_that!(info.local_tail, eq(LogletOffset::new(18)));
+            assert_that!(info.trim_point, eq(LogletOffset::INVALID));
+            assert_that!(info.sealed, eq(true));
+            tc.shutdown_node("test completed", 0).await;
+            RocksDbManager::get().shutdown().await;
+            Ok(())
+        }
+        .in_tc(&tc)
+        .await
     }
 
     #[test(tokio::test(start_paused = true))]
     async fn test_simple_get_records_flow() -> Result<()> {
-        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-
         let (tc, log_store) = setup().await?;
-        let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        async {
+            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+            let loglet_state_map = LogletStateMap::default();
+            let (net_tx, mut net_rx) = mpsc::channel(10);
+            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-        let worker = LogletWorker::start(tc.clone(), LOGLET, log_store, loglet_state)?;
+            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-        // Populate the log-store with some records (..,2,..,5,..,10, 11)
-        // Note: dots mean we don't have records at those globally committed offsets.
-        worker
-            .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
-                Store {
-                    // faking that offset=1 is released
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(2)),
-                    timeout_at: None,
-                    sequencer: SEQUENCER,
-                    known_archived: LogletOffset::INVALID,
-                    first_offset: LogletOffset::new(2),
-                    flags: StoreFlags::empty(),
-                    payloads: vec![Record::from("record2")].into(),
-                },
-                None,
-            ))
-            .unwrap();
+            // Populate the log-store with some records (..,2,..,5,..,10, 11)
+            // Note: dots mean we don't have records at those globally committed offsets.
+            worker
+                .enqueue_store(Incoming::for_testing(
+                    connection.downgrade(),
+                    Store {
+                        // faking that offset=1 is released
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(2)),
+                        timeout_at: None,
+                        sequencer: SEQUENCER,
+                        known_archived: LogletOffset::INVALID,
+                        first_offset: LogletOffset::new(2),
+                        flags: StoreFlags::empty(),
+                        payloads: vec![Record::from("record2")].into(),
+                    },
+                    None,
+                ))
+                .unwrap();
 
-        worker
-            .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
-                Store {
-                    // faking that offset=4 is released
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(5)),
-                    timeout_at: None,
-                    sequencer: SEQUENCER,
-                    known_archived: LogletOffset::INVALID,
-                    first_offset: LogletOffset::new(5),
-                    flags: StoreFlags::empty(),
-                    payloads: vec![Record::from(("record5", Keys::Single(11)))].into(),
-                },
-                None,
-            ))
-            .unwrap();
+            worker
+                .enqueue_store(Incoming::for_testing(
+                    connection.downgrade(),
+                    Store {
+                        // faking that offset=4 is released
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(5)),
+                        timeout_at: None,
+                        sequencer: SEQUENCER,
+                        known_archived: LogletOffset::INVALID,
+                        first_offset: LogletOffset::new(5),
+                        flags: StoreFlags::empty(),
+                        payloads: vec![Record::from(("record5", Keys::Single(11)))].into(),
+                    },
+                    None,
+                ))
+                .unwrap();
 
-        worker
-            .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
-                Store {
-                    // faking that offset=9 is released
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                    timeout_at: None,
-                    sequencer: SEQUENCER,
-                    known_archived: LogletOffset::INVALID,
-                    first_offset: LogletOffset::new(10),
-                    flags: StoreFlags::empty(),
-                    payloads: vec![Record::from("record10"), Record::from("record11")].into(),
-                },
-                None,
-            ))
-            .unwrap();
+            worker
+                .enqueue_store(Incoming::for_testing(
+                    connection.downgrade(),
+                    Store {
+                        // faking that offset=9 is released
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                        timeout_at: None,
+                        sequencer: SEQUENCER,
+                        known_archived: LogletOffset::INVALID,
+                        first_offset: LogletOffset::new(10),
+                        flags: StoreFlags::empty(),
+                        payloads: vec![Record::from("record10"), Record::from("record11")].into(),
+                    },
+                    None,
+                ))
+                .unwrap();
 
-        // Wait for stores to complete.
-        for _ in 0..3 {
+            // Wait for stores to complete.
+            for _ in 0..3 {
+                let stored: Stored = net_rx
+                    .recv()
+                    .await
+                    .unwrap()
+                    .body
+                    .unwrap()
+                    .try_decode(connection.protocol_version())?;
+                assert_that!(stored.status, eq(Status::Ok));
+            }
+
+            // We expect to see [2, 5]. No trim gaps, no filtered gaps.
+            worker
+                .enqueue_get_records(Incoming::for_testing(
+                    connection.downgrade(),
+                    GetRecords {
+                        // faking that offset=9 is released
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                        filter: KeyFilter::Any,
+                        // no memory limits
+                        total_limit_in_bytes: None,
+                        from_offset: LogletOffset::new(1),
+                        to_offset: LogletOffset::new(7),
+                    },
+                    None,
+                ))
+                .unwrap();
+
+            let mut records: Records = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(records.status, eq(Status::Ok));
+            assert_that!(records.local_tail, eq(LogletOffset::new(12)));
+            assert_that!(records.sealed, eq(false));
+            assert_that!(records.next_offset, eq(LogletOffset::new(8)));
+            assert_that!(records.records.len(), eq(2));
+            // pop in reverse order
+            for i in [5, 2] {
+                let (offset, record) = records.records.pop().unwrap();
+                assert_that!(offset, eq(LogletOffset::from(i)));
+                assert_that!(record.is_data(), eq(true));
+                let data = record.try_unwrap_data().unwrap();
+                let original: String = data.decode().unwrap();
+                assert_that!(original, eq(format!("record{}", i)));
+            }
+
+            // We expect to see [2, FILTERED(5), 10, 11]. No trim gaps.
+            worker
+                .enqueue_get_records(Incoming::for_testing(
+                    connection.downgrade(),
+                    GetRecords {
+                        // INVALID can be used when we don't have a reasonable value to pass in.
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                        // no memory limits
+                        total_limit_in_bytes: None,
+                        filter: KeyFilter::Within(0..=5),
+                        from_offset: LogletOffset::new(1),
+                        // to a point beyond local tail
+                        to_offset: LogletOffset::new(100),
+                    },
+                    None,
+                ))
+                .unwrap();
+
+            let mut records: Records = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(records.status, eq(Status::Ok));
+            assert_that!(records.local_tail, eq(LogletOffset::new(12)));
+            assert_that!(records.next_offset, eq(LogletOffset::new(12)));
+            assert_that!(records.sealed, eq(false));
+            assert_that!(records.records.len(), eq(4));
+            // pop() returns records in reverse order
+            for i in [11, 10, 5, 2] {
+                let (offset, record) = records.records.pop().unwrap();
+                assert_that!(offset, eq(LogletOffset::from(i)));
+                if i == 5 {
+                    // this one is filtered
+                    assert_that!(record.is_filtered_gap(), eq(true));
+                    let gap = record.try_unwrap_filtered_gap().unwrap();
+                    assert_that!(gap.to, eq(LogletOffset::new(5)));
+                } else {
+                    assert_that!(record.is_data(), eq(true));
+                    let data = record.try_unwrap_data().unwrap();
+                    let original: String = data.decode().unwrap();
+                    assert_that!(original, eq(format!("record{}", i)));
+                }
+            }
+
+            // Apply memory limits (2 bytes) should always see the first real record.
+            // We expect to see [FILTERED(5), 10]. (11 is not returend due to budget)
+            worker
+                .enqueue_get_records(Incoming::for_testing(
+                    connection.downgrade(),
+                    GetRecords {
+                        // INVALID can be used when we don't have a reasonable value to pass in.
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                        // no memory limits
+                        total_limit_in_bytes: Some(2),
+                        filter: KeyFilter::Within(0..=5),
+                        from_offset: LogletOffset::new(4),
+                        // to a point beyond local tail
+                        to_offset: LogletOffset::new(100),
+                    },
+                    None,
+                ))
+                .unwrap();
+
+            let mut records: Records = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(records.status, eq(Status::Ok));
+            assert_that!(records.local_tail, eq(LogletOffset::new(12)));
+            assert_that!(records.next_offset, eq(LogletOffset::new(11)));
+            assert_that!(records.sealed, eq(false));
+            assert_that!(records.records.len(), eq(2));
+            // pop() returns records in reverse order
+            for i in [10, 5] {
+                let (offset, record) = records.records.pop().unwrap();
+                assert_that!(offset, eq(LogletOffset::from(i)));
+                if i == 5 {
+                    // this one is filtered
+                    assert_that!(record.is_filtered_gap(), eq(true));
+                    let gap = record.try_unwrap_filtered_gap().unwrap();
+                    assert_that!(gap.to, eq(LogletOffset::new(5)));
+                } else {
+                    assert_that!(record.is_data(), eq(true));
+                    let data = record.try_unwrap_data().unwrap();
+                    let original: String = data.decode().unwrap();
+                    assert_that!(original, eq(format!("record{}", i)));
+                }
+            }
+
+            tc.shutdown_node("test completed", 0).await;
+            RocksDbManager::get().shutdown().await;
+
+            Ok(())
+        }
+        .in_tc(&tc)
+        .await
+    }
+
+    #[test(tokio::test(start_paused = true))]
+    async fn test_trim_basics() -> Result<()> {
+        let (tc, log_store) = setup().await?;
+        async {
+            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+            let loglet_state_map = LogletStateMap::default();
+            let (net_tx, mut net_rx) = mpsc::channel(10);
+            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+
+            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+            let worker = LogletWorker::start(LOGLET, log_store.clone(), loglet_state.clone())?;
+
+            assert_that!(loglet_state.trim_point(), eq(LogletOffset::INVALID));
+            assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::OLDEST));
+            // The loglet has no knowledge of global commits, it shouldn't accept trims.
+            worker
+                .enqueue_trim(Incoming::for_testing(
+                    connection.downgrade(),
+                    Trim {
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::OLDEST),
+                        trim_point: LogletOffset::OLDEST,
+                    },
+                    None,
+                ))
+                .unwrap();
+
+            let trimmed: Trimmed = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(trimmed.status, eq(Status::Malformed));
+            assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
+            assert_that!(trimmed.sealed, eq(false));
+
+            // The loglet has knowledge of global tail of 10, it should accept trims up to 9 but it
+            // won't move trim point beyond its local tail.
+            worker
+                .enqueue_trim(Incoming::for_testing(
+                    connection.downgrade(),
+                    Trim {
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                        trim_point: LogletOffset::new(9),
+                    },
+                    None,
+                ))
+                .unwrap();
+
+            let trimmed: Trimmed = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(trimmed.status, eq(Status::Ok));
+            assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
+            assert_that!(trimmed.sealed, eq(false));
+
+            // let's store some records at offsets (5, 6)
+            worker
+                .enqueue_store(Incoming::for_testing(
+                    connection.downgrade(),
+                    Store {
+                        // faking that offset=9 is released
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                        timeout_at: None,
+                        sequencer: SEQUENCER,
+                        known_archived: LogletOffset::INVALID,
+                        first_offset: LogletOffset::new(5),
+                        flags: StoreFlags::empty(),
+                        payloads: vec![Record::from("record5"), Record::from("record6")].into(),
+                    },
+                    None,
+                ))
+                .unwrap();
             let stored: Stored = net_rx
                 .recv()
                 .await
@@ -1136,372 +1374,144 @@ mod tests {
                 .unwrap()
                 .try_decode(connection.protocol_version())?;
             assert_that!(stored.status, eq(Status::Ok));
-        }
+            assert_that!(stored.local_tail, eq(LogletOffset::new(7)));
 
-        // We expect to see [2, 5]. No trim gaps, no filtered gaps.
-        worker
-            .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
-                GetRecords {
-                    // faking that offset=9 is released
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                    filter: KeyFilter::Any,
-                    // no memory limits
-                    total_limit_in_bytes: None,
-                    from_offset: LogletOffset::new(1),
-                    to_offset: LogletOffset::new(7),
-                },
-                None,
-            ))
-            .unwrap();
+            // trim to 5
+            worker
+                .enqueue_trim(Incoming::for_testing(
+                    connection.downgrade(),
+                    Trim {
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                        trim_point: LogletOffset::new(5),
+                    },
+                    None,
+                ))
+                .unwrap();
 
-        let mut records: Records = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(records.status, eq(Status::Ok));
-        assert_that!(records.local_tail, eq(LogletOffset::new(12)));
-        assert_that!(records.sealed, eq(false));
-        assert_that!(records.next_offset, eq(LogletOffset::new(8)));
-        assert_that!(records.records.len(), eq(2));
-        // pop in reverse order
-        for i in [5, 2] {
-            let (offset, record) = records.records.pop().unwrap();
-            assert_that!(offset, eq(LogletOffset::from(i)));
-            assert_that!(record.is_data(), eq(true));
-            let data = record.try_unwrap_data().unwrap();
-            let original: String = data.decode().unwrap();
-            assert_that!(original, eq(format!("record{}", i)));
-        }
+            let trimmed: Trimmed = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(trimmed.status, eq(Status::Ok));
+            assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
+            assert_that!(trimmed.sealed, eq(false));
 
-        // We expect to see [2, FILTERED(5), 10, 11]. No trim gaps.
-        worker
-            .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
-                GetRecords {
-                    // INVALID can be used when we don't have a reasonable value to pass in.
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                    // no memory limits
-                    total_limit_in_bytes: None,
-                    filter: KeyFilter::Within(0..=5),
-                    from_offset: LogletOffset::new(1),
-                    // to a point beyond local tail
-                    to_offset: LogletOffset::new(100),
-                },
-                None,
-            ))
-            .unwrap();
+            // Attempt to read. We expect to see a trim gap (1->5, 6 (data-record))
+            worker
+                .enqueue_get_records(Incoming::for_testing(
+                    connection.downgrade(),
+                    GetRecords {
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                        total_limit_in_bytes: None,
+                        filter: KeyFilter::Any,
+                        from_offset: LogletOffset::OLDEST,
+                        // to a point beyond local tail
+                        to_offset: LogletOffset::new(100),
+                    },
+                    None,
+                ))
+                .unwrap();
 
-        let mut records: Records = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(records.status, eq(Status::Ok));
-        assert_that!(records.local_tail, eq(LogletOffset::new(12)));
-        assert_that!(records.next_offset, eq(LogletOffset::new(12)));
-        assert_that!(records.sealed, eq(false));
-        assert_that!(records.records.len(), eq(4));
-        // pop() returns records in reverse order
-        for i in [11, 10, 5, 2] {
-            let (offset, record) = records.records.pop().unwrap();
-            assert_that!(offset, eq(LogletOffset::from(i)));
-            if i == 5 {
-                // this one is filtered
-                assert_that!(record.is_filtered_gap(), eq(true));
-                let gap = record.try_unwrap_filtered_gap().unwrap();
-                assert_that!(gap.to, eq(LogletOffset::new(5)));
-            } else {
-                assert_that!(record.is_data(), eq(true));
-                let data = record.try_unwrap_data().unwrap();
-                let original: String = data.decode().unwrap();
-                assert_that!(original, eq(format!("record{}", i)));
+            let mut records: Records = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(records.status, eq(Status::Ok));
+            assert_that!(records.local_tail, eq(LogletOffset::new(7)));
+            assert_that!(records.next_offset, eq(LogletOffset::new(7)));
+            assert_that!(records.sealed, eq(false));
+            assert_that!(records.records.len(), eq(2));
+            // pop() returns records in reverse order
+            for i in [6, 1] {
+                let (offset, record) = records.records.pop().unwrap();
+                assert_that!(offset, eq(LogletOffset::from(i)));
+                if i == 1 {
+                    // this one is a trim gap
+                    assert_that!(record.is_trim_gap(), eq(true));
+                    let gap = record.try_unwrap_trim_gap().unwrap();
+                    assert_that!(gap.to, eq(LogletOffset::new(5)));
+                } else {
+                    assert_that!(record.is_data(), eq(true));
+                    let data = record.try_unwrap_data().unwrap();
+                    let original: String = data.decode().unwrap();
+                    assert_that!(original, eq(format!("record{}", i)));
+                }
             }
-        }
 
-        // Apply memory limits (2 bytes) should always see the first real record.
-        // We expect to see [FILTERED(5), 10]. (11 is not returend due to budget)
-        worker
-            .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
-                GetRecords {
-                    // INVALID can be used when we don't have a reasonable value to pass in.
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                    // no memory limits
-                    total_limit_in_bytes: Some(2),
-                    filter: KeyFilter::Within(0..=5),
-                    from_offset: LogletOffset::new(4),
-                    // to a point beyond local tail
-                    to_offset: LogletOffset::new(100),
-                },
-                None,
-            ))
-            .unwrap();
+            // trim everything
+            worker
+                .enqueue_trim(Incoming::for_testing(
+                    connection.downgrade(),
+                    Trim {
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                        trim_point: LogletOffset::new(9),
+                    },
+                    None,
+                ))
+                .unwrap();
 
-        let mut records: Records = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(records.status, eq(Status::Ok));
-        assert_that!(records.local_tail, eq(LogletOffset::new(12)));
-        assert_that!(records.next_offset, eq(LogletOffset::new(11)));
-        assert_that!(records.sealed, eq(false));
-        assert_that!(records.records.len(), eq(2));
-        // pop() returns records in reverse order
-        for i in [10, 5] {
+            let trimmed: Trimmed = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(trimmed.status, eq(Status::Ok));
+            assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
+            assert_that!(trimmed.sealed, eq(false));
+
+            // Attempt to read again. We expect to see a trim gap (1->6)
+            worker
+                .enqueue_get_records(Incoming::for_testing(
+                    connection.downgrade(),
+                    GetRecords {
+                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                        total_limit_in_bytes: None,
+                        filter: KeyFilter::Any,
+                        from_offset: LogletOffset::OLDEST,
+                        // to a point beyond local tail
+                        to_offset: LogletOffset::new(100),
+                    },
+                    None,
+                ))
+                .unwrap();
+
+            let mut records: Records = net_rx
+                .recv()
+                .await
+                .unwrap()
+                .body
+                .unwrap()
+                .try_decode(connection.protocol_version())?;
+            assert_that!(records.status, eq(Status::Ok));
+            assert_that!(records.local_tail, eq(LogletOffset::new(7)));
+            assert_that!(records.next_offset, eq(LogletOffset::new(7)));
+            assert_that!(records.sealed, eq(false));
+            assert_that!(records.records.len(), eq(1));
             let (offset, record) = records.records.pop().unwrap();
-            assert_that!(offset, eq(LogletOffset::from(i)));
-            if i == 5 {
-                // this one is filtered
-                assert_that!(record.is_filtered_gap(), eq(true));
-                let gap = record.try_unwrap_filtered_gap().unwrap();
-                assert_that!(gap.to, eq(LogletOffset::new(5)));
-            } else {
-                assert_that!(record.is_data(), eq(true));
-                let data = record.try_unwrap_data().unwrap();
-                let original: String = data.decode().unwrap();
-                assert_that!(original, eq(format!("record{}", i)));
-            }
+            assert_that!(offset, eq(LogletOffset::from(1)));
+            assert_that!(record.is_trim_gap(), eq(true));
+            let gap = record.try_unwrap_trim_gap().unwrap();
+            assert_that!(gap.to, eq(LogletOffset::new(6)));
+
+            // Make sure that we can load the local-tail correctly when loading the loglet_state
+            let loglet_state_map = LogletStateMap::default();
+            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+            assert_that!(loglet_state.trim_point(), eq(LogletOffset::new(6)));
+            assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::new(7)));
+
+            tc.shutdown_node("test completed", 0).await;
+            RocksDbManager::get().shutdown().await;
+            Ok(())
         }
-
-        tc.shutdown_node("test completed", 0).await;
-        RocksDbManager::get().shutdown().await;
-
-        Ok(())
-    }
-
-    #[test(tokio::test(start_paused = true))]
-    async fn test_trim_basics() -> Result<()> {
-        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-
-        let (tc, log_store) = setup().await?;
-        let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
-
-        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-        let worker =
-            LogletWorker::start(tc.clone(), LOGLET, log_store.clone(), loglet_state.clone())?;
-
-        assert_that!(loglet_state.trim_point(), eq(LogletOffset::INVALID));
-        assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::OLDEST));
-        // The loglet has no knowledge of global commits, it shouldn't accept trims.
-        worker
-            .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
-                Trim {
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::OLDEST),
-                    trim_point: LogletOffset::OLDEST,
-                },
-                None,
-            ))
-            .unwrap();
-
-        let trimmed: Trimmed = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(trimmed.status, eq(Status::Malformed));
-        assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
-        assert_that!(trimmed.sealed, eq(false));
-
-        // The loglet has knowledge of global tail of 10, it should accept trims up to 9 but it
-        // won't move trim point beyond its local tail.
-        worker
-            .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
-                Trim {
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                    trim_point: LogletOffset::new(9),
-                },
-                None,
-            ))
-            .unwrap();
-
-        let trimmed: Trimmed = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(trimmed.status, eq(Status::Ok));
-        assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
-        assert_that!(trimmed.sealed, eq(false));
-
-        // let's store some records at offsets (5, 6)
-        worker
-            .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
-                Store {
-                    // faking that offset=9 is released
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                    timeout_at: None,
-                    sequencer: SEQUENCER,
-                    known_archived: LogletOffset::INVALID,
-                    first_offset: LogletOffset::new(5),
-                    flags: StoreFlags::empty(),
-                    payloads: vec![Record::from("record5"), Record::from("record6")].into(),
-                },
-                None,
-            ))
-            .unwrap();
-        let stored: Stored = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(stored.status, eq(Status::Ok));
-        assert_that!(stored.local_tail, eq(LogletOffset::new(7)));
-
-        // trim to 5
-        worker
-            .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
-                Trim {
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                    trim_point: LogletOffset::new(5),
-                },
-                None,
-            ))
-            .unwrap();
-
-        let trimmed: Trimmed = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(trimmed.status, eq(Status::Ok));
-        assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
-        assert_that!(trimmed.sealed, eq(false));
-
-        // Attempt to read. We expect to see a trim gap (1->5, 6 (data-record))
-        worker
-            .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
-                GetRecords {
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                    total_limit_in_bytes: None,
-                    filter: KeyFilter::Any,
-                    from_offset: LogletOffset::OLDEST,
-                    // to a point beyond local tail
-                    to_offset: LogletOffset::new(100),
-                },
-                None,
-            ))
-            .unwrap();
-
-        let mut records: Records = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(records.status, eq(Status::Ok));
-        assert_that!(records.local_tail, eq(LogletOffset::new(7)));
-        assert_that!(records.next_offset, eq(LogletOffset::new(7)));
-        assert_that!(records.sealed, eq(false));
-        assert_that!(records.records.len(), eq(2));
-        // pop() returns records in reverse order
-        for i in [6, 1] {
-            let (offset, record) = records.records.pop().unwrap();
-            assert_that!(offset, eq(LogletOffset::from(i)));
-            if i == 1 {
-                // this one is a trim gap
-                assert_that!(record.is_trim_gap(), eq(true));
-                let gap = record.try_unwrap_trim_gap().unwrap();
-                assert_that!(gap.to, eq(LogletOffset::new(5)));
-            } else {
-                assert_that!(record.is_data(), eq(true));
-                let data = record.try_unwrap_data().unwrap();
-                let original: String = data.decode().unwrap();
-                assert_that!(original, eq(format!("record{}", i)));
-            }
-        }
-
-        // trim everything
-        worker
-            .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
-                Trim {
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                    trim_point: LogletOffset::new(9),
-                },
-                None,
-            ))
-            .unwrap();
-
-        let trimmed: Trimmed = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(trimmed.status, eq(Status::Ok));
-        assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
-        assert_that!(trimmed.sealed, eq(false));
-
-        // Attempt to read again. We expect to see a trim gap (1->6)
-        worker
-            .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
-                GetRecords {
-                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                    total_limit_in_bytes: None,
-                    filter: KeyFilter::Any,
-                    from_offset: LogletOffset::OLDEST,
-                    // to a point beyond local tail
-                    to_offset: LogletOffset::new(100),
-                },
-                None,
-            ))
-            .unwrap();
-
-        let mut records: Records = net_rx
-            .recv()
-            .await
-            .unwrap()
-            .body
-            .unwrap()
-            .try_decode(connection.protocol_version())?;
-        assert_that!(records.status, eq(Status::Ok));
-        assert_that!(records.local_tail, eq(LogletOffset::new(7)));
-        assert_that!(records.next_offset, eq(LogletOffset::new(7)));
-        assert_that!(records.sealed, eq(false));
-        assert_that!(records.records.len(), eq(1));
-        let (offset, record) = records.records.pop().unwrap();
-        assert_that!(offset, eq(LogletOffset::from(1)));
-        assert_that!(record.is_trim_gap(), eq(true));
-        let gap = record.try_unwrap_trim_gap().unwrap();
-        assert_that!(gap.to, eq(LogletOffset::new(6)));
-
-        // Make sure that we can load the local-tail correctly when loading the loglet_state
-        let loglet_state_map = LogletStateMap::default();
-        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-        assert_that!(loglet_state.trim_point(), eq(LogletOffset::new(6)));
-        assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::new(7)));
-
-        tc.shutdown_node("test completed", 0).await;
-        RocksDbManager::get().shutdown().await;
-
-        Ok(())
+        .in_tc(&tc)
+        .await
     }
 }

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -16,7 +16,7 @@ use restate_types::protobuf::common::LogServerStatus;
 use rocksdb::{DBCompressionType, SliceTransform};
 use static_assertions::const_assert;
 
-use restate_core::{ShutdownError, TaskCenter};
+use restate_core::ShutdownError;
 use restate_rocksdb::{CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager};
 use restate_types::config::{LogServerOptions, RocksDbOptions};
 use restate_types::live::BoxedLiveLoad;
@@ -81,7 +81,6 @@ impl RocksDbLogStoreBuilder {
 
     pub async fn start(
         self,
-        task_center: &TaskCenter,
         health_status: HealthStatus<LogServerStatus>,
     ) -> Result<RocksDbLogStore, ShutdownError> {
         let RocksDbLogStoreBuilder {
@@ -96,7 +95,7 @@ impl RocksDbLogStoreBuilder {
             record_cache,
             health_status.clone(),
         )
-        .start(task_center)?;
+        .start()?;
 
         Ok(RocksDbLogStore {
             health_status,

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -95,7 +95,7 @@ impl LogStoreWriter {
     }
 
     /// Must be called from task_center context
-    pub fn start(mut self, tc: &TaskCenter) -> Result<RocksDbLogWriterHandle, ShutdownError> {
+    pub fn start(mut self) -> Result<RocksDbLogWriterHandle, ShutdownError> {
         // big enough to allow a second full batch to queue up while the existing one is being processed
         let batch_size = std::cmp::max(
             1,
@@ -107,10 +107,9 @@ impl LogStoreWriter {
         // the backlog while we process this one.
         let (sender, receiver) = mpsc::channel(batch_size * 2);
 
-        tc.spawn_child(
+        TaskCenter::spawn_child(
             TaskKind::SystemService,
             "log-server-rocksdb-writer",
-            None,
             async move {
                 debug!("Start running LogStoreWriter");
                 let mut opts = self.updateable_options.clone();

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -331,9 +331,7 @@ async fn create_test_environment(
 
     let task_center = &env.tc;
 
-    task_center.run_in_scope_sync("db-manager-init", None, || {
-        RocksDbManager::init(config.clone().map(|c| &c.common))
-    });
+    task_center.run_in_scope_sync(|| RocksDbManager::init(config.clone().map(|c| &c.common)));
 
     let client = start_metadata_store(
         config.pinned().common.metadata_store_client.clone(),

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -21,7 +21,9 @@ use restate_core::network::protobuf::node_svc::{
 };
 use restate_core::network::ConnectionManager;
 use restate_core::network::{ProtocolError, TransportConnect};
-use restate_core::{metadata, MetadataKind, TargetVersion, TaskCenter};
+use restate_core::{
+    metadata, MetadataKind, TargetVersion, TaskCenter, TaskCenterFutureExt, TaskKind,
+};
 use restate_types::health::Health;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::node::Message;
@@ -61,7 +63,7 @@ impl<T: TransportConnect> NodeSvc for NodeSvcHandler<T> {
         let metadata_server_status = self.health.current_metadata_server_status();
         let log_server_status = self.health.current_log_server_status();
         let age_s = self.task_center.age().as_secs();
-        self.task_center.run_in_scope_sync("get_ident", None, || {
+        self.task_center.run_in_scope_sync(|| {
             let metadata = metadata();
             Ok(Response::new(IdentResponse {
                 status: node_status.into(),
@@ -98,12 +100,9 @@ impl<T: TransportConnect> NodeSvc for NodeSvcHandler<T> {
         let incoming = request.into_inner();
         let transformed = incoming.map(|x| x.map_err(ProtocolError::from));
         let output_stream = self
-            .task_center
-            .run_in_scope(
-                "accept-connection",
-                None,
-                self.connections.accept_incoming_connection(transformed),
-            )
+            .connections
+            .accept_incoming_connection(transformed)
+            .in_current_tc_as_task(TaskKind::InPlace, "accept-connection")
             .await?;
 
         // For uniformity with outbound connections, we map all responses to Ok, we never rely on

--- a/crates/node/src/roles/base.rs
+++ b/crates/node/src/roles/base.rs
@@ -14,9 +14,8 @@ use futures::StreamExt;
 use restate_core::{
     cancellation_watcher,
     network::{Incoming, MessageRouterBuilder, MessageStream, NetworkError},
-    task_center,
     worker_api::ProcessorsManagerHandle,
-    ShutdownError, TaskKind,
+    ShutdownError, TaskCenter, TaskKind,
 };
 use restate_types::net::node::{GetNodeState, NodeStateResponse};
 
@@ -39,8 +38,7 @@ impl BaseRole {
     }
 
     pub fn start(self) -> anyhow::Result<()> {
-        let tc = task_center();
-        tc.spawn_child(TaskKind::RoleRunner, "base-role-service", None, async {
+        TaskCenter::spawn_child(TaskKind::RoleRunner, "base-role-service", async {
             let cancelled = cancellation_watcher();
 
             tokio::select! {

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -47,10 +47,8 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
         .expect("task_center builds");
 
     let worker_options = WorkerOptions::default();
-    tc.run_in_scope_sync("db-manager-init", None, || {
-        RocksDbManager::init(Constant::new(CommonOptions::default()))
-    });
-    let rocksdb = tc.block_on("test-setup", None, async {
+    tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+    let rocksdb = tc.block_on(async {
         //
         // setup
         //

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -52,9 +52,7 @@ async fn storage_test_environment_with_manager() -> (PartitionStoreManager, Part
         .ingress_runtime_handle(tokio::runtime::Handle::current())
         .build()
         .expect("task_center builds");
-    tc.run_in_scope_sync("db-manager-init", None, || {
-        RocksDbManager::init(Constant::new(CommonOptions::default()))
-    });
+    tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
     let worker_options = Live::from_value(WorkerOptions::default());
     let manager = PartitionStoreManager::create(
         worker_options.clone().map(|c| &c.storage),

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -51,7 +51,7 @@ aws-smithy-async = {version = "1.2.1", default-features = false}
 aws-smithy-runtime = {version = "1.6.2", default-features = false}
 aws-smithy-runtime-api = {version = "1.7.1", default-features = false}
 aws-smithy-types = { version = "1.2.0", default-features = false}
-pin-project-lite = "0.2.13"
+pin-project-lite = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -161,9 +161,8 @@ impl MockQueryEngine {
             + 'static,
     ) -> Self {
         // Prepare Rocksdb
-        task_center().run_in_scope_sync("db-manager-init", None, || {
-            RocksDbManager::init(Constant::new(CommonOptions::default()))
-        });
+        task_center()
+            .run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
         let worker_options = Live::from_value(WorkerOptions::default());
         let manager = PartitionStoreManager::create(
             worker_options.clone().map(|c| &c.storage),

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -640,9 +640,7 @@ mod tests {
         let storage_options = StorageOptions::default();
         let rocksdb_options = RocksDbOptions::default();
 
-        tc.run_in_scope_sync("db-manager-init", None, || {
-            RocksDbManager::init(Constant::new(CommonOptions::default()))
-        });
+        tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
 
         let bifrost = tc
             .run_in_scope(

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -460,7 +460,9 @@ mod tests {
 
     use restate_bifrost::{Bifrost, LogEntry};
     use restate_core::network::FailingConnector;
-    use restate_core::{TaskKind, TestCoreEnv, TestCoreEnvBuilder};
+    use restate_core::{
+        TaskCenter, TaskCenterFutureExt, TaskKind, TestCoreEnv, TestCoreEnvBuilder,
+    };
     use restate_storage_api::outbox_table::OutboxMessage;
     use restate_storage_api::StorageError;
     use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionId};
@@ -686,14 +688,9 @@ mod tests {
         let shuffle_env = create_shuffle_env(outbox_reader).await;
         let tc = shuffle_env.env.tc.clone();
 
-        tc.run_in_scope("test", None, async {
+        async {
             let partition_id = shuffle_env.shuffle.metadata.partition_id;
-            tc.spawn_child(
-                TaskKind::Shuffle,
-                "shuffle",
-                None,
-                shuffle_env.shuffle.run(),
-            )?;
+            TaskCenter::spawn_child(TaskKind::Shuffle, "shuffle", shuffle_env.shuffle.run())?;
             let reader = shuffle_env.bifrost.create_reader(
                 LogId::from(partition_id),
                 KeyFilter::Any,
@@ -706,7 +703,8 @@ mod tests {
             assert_received_invoke_commands(messages, expected_messages);
 
             Ok::<(), anyhow::Error>(())
-        })
+        }
+        .in_tc(&tc)
         .await
     }
 
@@ -732,14 +730,9 @@ mod tests {
         let shuffle_env = create_shuffle_env(outbox_reader).await;
         let tc = shuffle_env.env.tc.clone();
 
-        tc.run_in_scope("test", None, async {
+        async {
             let partition_id = shuffle_env.shuffle.metadata.partition_id;
-            tc.spawn_child(
-                TaskKind::Shuffle,
-                "shuffle",
-                None,
-                shuffle_env.shuffle.run(),
-            )?;
+            TaskCenter::spawn_child(TaskKind::Shuffle, "shuffle", shuffle_env.shuffle.run())?;
             let reader = shuffle_env.bifrost.create_reader(
                 LogId::from(partition_id),
                 KeyFilter::Any,
@@ -752,7 +745,8 @@ mod tests {
             assert_received_invoke_commands(messages, expected_messages);
 
             Ok::<(), anyhow::Error>(())
-        })
+        }
+        .in_tc(&tc)
         .await
     }
 
@@ -775,64 +769,63 @@ mod tests {
         let tc = shuffle_env.env.tc.clone();
         let total_restarts = Arc::new(AtomicUsize::new(0));
 
-        let shuffle_task_id = tc
-            .run_in_scope("test", None, async {
-                let partition_id = shuffle_env.shuffle.metadata.partition_id;
-                let reader = shuffle_env.bifrost.create_reader(
-                    LogId::from(partition_id),
-                    KeyFilter::Any,
-                    Lsn::INVALID,
-                    Lsn::MAX,
-                )?;
-                let total_restarts = Arc::clone(&total_restarts);
+        let shuffle_task_id = async {
+            let partition_id = shuffle_env.shuffle.metadata.partition_id;
+            let reader = shuffle_env.bifrost.create_reader(
+                LogId::from(partition_id),
+                KeyFilter::Any,
+                Lsn::INVALID,
+                Lsn::MAX,
+            )?;
+            let total_restarts = Arc::clone(&total_restarts);
 
-                let shuffle_task =
-                    tc.spawn_child(TaskKind::Shuffle, "shuffle", None, async move {
-                        let mut shuffle = shuffle_env.shuffle;
-                        let metadata = shuffle.metadata;
-                        let truncation_tx = shuffle.truncation_tx.clone();
-                        let mut processed_range = 0;
-                        let mut num_restarts = 0;
+            let shuffle_task = TaskCenter::spawn_child(TaskKind::Shuffle, "shuffle", async move {
+                let mut shuffle = shuffle_env.shuffle;
+                let metadata = shuffle.metadata;
+                let truncation_tx = shuffle.truncation_tx.clone();
+                let mut processed_range = 0;
+                let mut num_restarts = 0;
 
-                        // restart shuffle on failures and update failing outbox reader
-                        while shuffle.run().await.is_err() {
-                            num_restarts += 1;
-                            // update the failing outbox reader to make a bit more progress and delete some of the delivered records
-                            {
-                                let outbox_reader = Arc::get_mut(&mut outbox_reader)
-                                    .expect("only one reference should exist");
+                // restart shuffle on failures and update failing outbox reader
+                while shuffle.run().await.is_err() {
+                    num_restarts += 1;
+                    // update the failing outbox reader to make a bit more progress and delete some of the delivered records
+                    {
+                        let outbox_reader = Arc::get_mut(&mut outbox_reader)
+                            .expect("only one reference should exist");
 
-                                // leave the first entry to generate some holes
-                                for idx in (processed_range + 1)..outbox_reader.fail_index {
-                                    outbox_reader.records[usize::try_from(idx)
-                                        .expect("index should fit in usize")] = None;
-                                }
-
-                                processed_range = outbox_reader.fail_index;
-                                outbox_reader.fail_index += 10;
-                            }
-
-                            shuffle = Shuffle::new(
-                                metadata,
-                                Arc::clone(&outbox_reader),
-                                truncation_tx.clone(),
-                                1,
-                                shuffle_env.bifrost.clone(),
-                            );
+                        // leave the first entry to generate some holes
+                        for idx in (processed_range + 1)..outbox_reader.fail_index {
+                            outbox_reader.records
+                                [usize::try_from(idx).expect("index should fit in usize")] = None;
                         }
 
-                        total_restarts.store(num_restarts, Ordering::Relaxed);
+                        processed_range = outbox_reader.fail_index;
+                        outbox_reader.fail_index += 10;
+                    }
 
-                        Ok(())
-                    })?;
+                    shuffle = Shuffle::new(
+                        metadata,
+                        Arc::clone(&outbox_reader),
+                        truncation_tx.clone(),
+                        1,
+                        shuffle_env.bifrost.clone(),
+                    );
+                }
 
-                let messages = collect_invoke_commands_until(reader, last_invocation_id).await?;
+                total_restarts.store(num_restarts, Ordering::Relaxed);
 
-                assert_received_invoke_commands(messages, expected_messages);
+                Ok(())
+            })?;
 
-                Ok::<_, anyhow::Error>(shuffle_task)
-            })
-            .await?;
+            let messages = collect_invoke_commands_until(reader, last_invocation_id).await?;
+
+            assert_received_invoke_commands(messages, expected_messages);
+
+            Ok::<_, anyhow::Error>(shuffle_task)
+        }
+        .in_tc(&tc)
+        .await?;
 
         let shuffle_task = tc.cancel_task(shuffle_task_id).expect("should exist");
         shuffle_task.await?;

--- a/crates/worker/src/partition_processor_manager/message_handler.rs
+++ b/crates/worker/src/partition_processor_manager/message_handler.rs
@@ -10,7 +10,7 @@
 
 use restate_core::network::{Incoming, MessageHandler};
 use restate_core::worker_api::ProcessorsManagerHandle;
-use restate_core::{task_center, TaskKind};
+use restate_core::{TaskCenter, TaskKind};
 use restate_types::net::partition_processor_manager::{
     CreateSnapshotRequest, CreateSnapshotResponse, SnapshotError,
 };
@@ -36,49 +36,47 @@ impl MessageHandler for PartitionProcessorManagerMessageHandler {
 
     async fn on_message(&self, msg: Incoming<Self::MessageType>) {
         let processors_manager_handle = self.processors_manager_handle.clone();
-        task_center()
-            .spawn_child(
-                TaskKind::Disposable,
-                "create-snapshot-request-rpc",
-                None,
-                async move {
-                    let create_snapshot_result = processors_manager_handle
-                        .create_snapshot(msg.body().partition_id)
-                        .await;
+        TaskCenter::spawn_child(
+            TaskKind::Disposable,
+            "create-snapshot-request-rpc",
+            async move {
+                let create_snapshot_result = processors_manager_handle
+                    .create_snapshot(msg.body().partition_id)
+                    .await;
 
-                    match create_snapshot_result.as_ref() {
-                        Ok(snapshot) => {
-                            debug!(
-                                partition_id = %msg.body().partition_id,
-                                %snapshot,
-                                "Create snapshot successfully completed",
-                            );
-                            msg.to_rpc_response(CreateSnapshotResponse {
-                                result: Ok(snapshot.snapshot_id),
-                            })
-                        }
-                        Err(err) => {
-                            warn!(
-                                partition_id = %msg.body().partition_id,
-                                "Create snapshot failed: {}",
-                                err
-                            );
-                            msg.to_rpc_response(CreateSnapshotResponse {
-                                result: Err(SnapshotError::SnapshotCreationFailed(err.to_string())),
-                            })
-                        }
+                match create_snapshot_result.as_ref() {
+                    Ok(snapshot) => {
+                        debug!(
+                            partition_id = %msg.body().partition_id,
+                            %snapshot,
+                            "Create snapshot successfully completed",
+                        );
+                        msg.to_rpc_response(CreateSnapshotResponse {
+                            result: Ok(snapshot.snapshot_id),
+                        })
                     }
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        warn!(result = ?create_snapshot_result, "Failed to send response: {}", e);
-                        anyhow::anyhow!("Failed to send response to create snapshot request: {}", e)
-                    })
-                },
-            )
-            .map_err(|e| {
-                warn!("Failed to spawn request handler: {}", e);
-            })
-            .ok();
+                    Err(err) => {
+                        warn!(
+                            partition_id = %msg.body().partition_id,
+                            "Create snapshot failed: {}",
+                            err
+                        );
+                        msg.to_rpc_response(CreateSnapshotResponse {
+                            result: Err(SnapshotError::SnapshotCreationFailed(err.to_string())),
+                        })
+                    }
+                }
+                .send()
+                .await
+                .map_err(|e| {
+                    warn!(result = ?create_snapshot_result, "Failed to send response: {}", e);
+                    anyhow::anyhow!("Failed to send response to create snapshot request: {}", e)
+                })
+            },
+        )
+        .map_err(|e| {
+            warn!("Failed to spawn request handler: {}", e);
+        })
+        .ok();
     }
 }

--- a/crates/worker/src/partition_processor_manager/mod.rs
+++ b/crates/worker/src/partition_processor_manager/mod.rs
@@ -651,7 +651,6 @@ impl PartitionProcessorManager {
                     // where doing otherwise appears to starve the Tokio event loop, causing very slow startup.
                     let handle = self.task_center.spawn_blocking_unmanaged(
                         "starting-partition-processor",
-                        Some(partition_id),
                         starting_task.run(),
                     );
 
@@ -955,11 +954,9 @@ mod tests {
             TestCoreEnvBuilder::with_incoming_only_connector().set_nodes_config(nodes_config);
         let health_status = HealthStatus::default();
 
-        env_builder
-            .tc
-            .run_in_scope_sync("db-manager-init", None, || {
-                RocksDbManager::init(Constant::new(CommonOptions::default()));
-            });
+        env_builder.tc.run_in_scope_sync(|| {
+            RocksDbManager::init(Constant::new(CommonOptions::default()));
+        });
 
         let bifrost_svc = BifrostService::new(env_builder.tc.clone(), env_builder.metadata.clone())
             .with_factory(memory_loglet::Factory::default());

--- a/crates/worker/src/partition_processor_manager/mod.rs
+++ b/crates/worker/src/partition_processor_manager/mod.rs
@@ -229,12 +229,7 @@ impl PartitionProcessorManager {
             self.partition_store_manager.clone(),
             persisted_lsns_tx,
         );
-        self.task_center.spawn_child(
-            TaskKind::Watchdog,
-            "persisted-lsn-watchdog",
-            None,
-            watchdog.run(),
-        )?;
+        TaskCenter::spawn_child(TaskKind::Watchdog, "persisted-lsn-watchdog", watchdog.run())?;
 
         let mut logs_version_watcher = self.metadata.watch(MetadataKind::Logs);
         let mut partition_table_version_watcher = self.metadata.watch(MetadataKind::PartitionTable);

--- a/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
+++ b/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
@@ -178,9 +178,9 @@ mod tests {
         let storage_options = StorageOptions::default();
         let rocksdb_options = RocksDbOptions::default();
 
-        node_env.tc.run_in_scope_sync("db-manager-init", None, || {
-            RocksDbManager::init(Constant::new(CommonOptions::default()))
-        });
+        node_env
+            .tc
+            .run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
 
         let all_partition_keys = RangeInclusive::new(0, PartitionKey::MAX);
         let partition_store_manager = PartitionStoreManager::create(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
         .options(Configuration::pinned().common.clone())
         .build()
         .expect("task_center builds");
-    tc.block_on("main", None, {
+    tc.block_on({
         let tc = tc.clone();
         async move {
             // Apply tracing config globally

--- a/tools/bifrost-benchpress/Cargo.toml
+++ b/tools/bifrost-benchpress/Cargo.toml
@@ -26,7 +26,7 @@ restate-metadata-store = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-test-util = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
-restate-types = { workspace = true, features = ["test-util"] }
+restate-types = { workspace = true, features = ["test-util", "clap"] }
 
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -157,7 +157,7 @@ fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (TaskCenter,
             MetadataManager::new(metadata_builder, metadata_store_client.clone());
 
         let metadata_writer = metadata_manager.writer();
-        task_center.try_set_global_metadata(metadata.clone());
+        TaskCenter::try_set_global_metadata(metadata.clone());
 
         RocksDbManager::init(config.clone().map(|c| &c.common));
 
@@ -172,7 +172,7 @@ fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (TaskCenter,
             .await
             .expect("to store bifrost config in metadata store");
         metadata_writer.submit(Arc::new(logs));
-        spawn_metadata_manager(&task_center, metadata_manager).expect("metadata manager starts");
+        spawn_metadata_manager(metadata_manager).expect("metadata manager starts");
 
         let bifrost_svc = BifrostService::new(task_center, metadata)
             .enable_in_memory_loglet()

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -92,7 +92,7 @@ fn main() -> anyhow::Result<()> {
     let (tc, bifrost) = spawn_environment(Configuration::updateable(), 1);
     let task_center = tc.clone();
     let args = cli_args.clone();
-    tc.block_on("benchpress", None, async move {
+    tc.block_on(async move {
         let tracing_guard = init_tracing_and_logging(&config.common, "Bifrost benchpress")
             .expect("failed to configure logging and tracing!");
 
@@ -149,7 +149,7 @@ fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (TaskCenter,
         .expect("task_center builds");
 
     let task_center = tc.clone();
-    let bifrost = tc.block_on("spawn", None, async move {
+    let bifrost = tc.block_on(async move {
         let metadata_builder = MetadataBuilder::default();
         let metadata_store_client = MetadataStoreClient::new_in_memory();
         let metadata = metadata_builder.to_metadata();

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -17,7 +17,7 @@ use hdrhistogram::Histogram;
 use tracing::info;
 
 use restate_bifrost::Bifrost;
-use restate_core::{TaskCenter, TaskHandle, TaskKind};
+use restate_core::{Metadata, TaskCenter, TaskHandle, TaskKind};
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, WithKeys};
 
 use crate::util::{print_latencies, DummyPayload};
@@ -140,7 +140,7 @@ pub async fn run(
 
     println!(
         "Log Chain: {:#?}",
-        tc.metadata().unwrap().logs_ref().chain(&LOG_ID).unwrap()
+        Metadata::current().logs_ref().chain(&LOG_ID).unwrap()
     );
     println!("Payload size per record: {} bytes", args.payload_size);
     println!();

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 use cling::{Collect, Run};
 use tracing::debug;
 
+use restate_core::TaskCenter;
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
 use restate_types::live::Live;
@@ -57,32 +58,28 @@ async fn get_value_remote(opts: &GetValueOpts) -> anyhow::Result<Option<GenericM
 }
 
 async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericMetadataValue>> {
-    run_in_task_center(
-        opts.metadata.config_file.as_ref(),
-        |config, task_center| async move {
-            let rocksdb_manager =
-                RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
-            debug!("RocksDB Initialized");
+    run_in_task_center(opts.metadata.config_file.as_ref(), |config| async move {
+        let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+        debug!("RocksDB Initialized");
 
-            let metadata_store_client = metadata_store::start_metadata_store(
-                config.common.metadata_store_client.clone(),
-                Live::from_value(config.metadata_store.clone()).boxed(),
-                Live::from_value(config.metadata_store.clone())
-                    .map(|c| &c.rocksdb)
-                    .boxed(),
-                &task_center,
-            )
-            .await?;
-            debug!("Metadata store client created");
+        let metadata_store_client = metadata_store::start_metadata_store(
+            config.common.metadata_store_client.clone(),
+            Live::from_value(config.metadata_store.clone()).boxed(),
+            Live::from_value(config.metadata_store.clone())
+                .map(|c| &c.rocksdb)
+                .boxed(),
+            &TaskCenter::current(),
+        )
+        .await?;
+        debug!("Metadata store client created");
 
-            let value: Option<GenericMetadataValue> = metadata_store_client
-                .get(ByteString::from(opts.key.as_str()))
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))?;
+        let value: Option<GenericMetadataValue> = metadata_store_client
+            .get(ByteString::from(opts.key.as_str()))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))?;
 
-            rocksdb_manager.shutdown().await;
-            anyhow::Ok(value)
-        },
-    )
+        rocksdb_manager.shutdown().await;
+        anyhow::Ok(value)
+    })
     .await
 }


### PR DESCRIPTION

- Improvements to the future extensions (fixing root task context propagation)
- A round of removals of explicit task-center reference passing
- `try_set_global_metadata` is now an associated function

## Example

Before:
```rust
  task_center().spawn_child(
      TaskKind::RpcServer,
      "metadata-store-grpc",
      None,
      async move {
          net_util::run_hyper_server(
              &bind_address,
              service,
              "metadata-store-grpc",
              || health_status.update(MetadataServerStatus::Ready),
              || health_status.update(MetadataServerStatus::Unknown),
          )
          .await?;
          Ok(())
      },
  )?;
```

After:
```rust
  TaskCenter::spawn_child(TaskKind::RpcServer, "metadata-store-grpc", async move {
      net_util::run_hyper_server(
          &bind_address,
          service,
          "metadata-store-grpc",
          || health_status.update(MetadataServerStatus::Ready),
          || health_status.update(MetadataServerStatus::Unknown),
      )
      .await?;
      Ok(())
  })?;
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2343).
* #2355 (2 commits)
* #2352
* #2344
* __->__ #2343
* #2339