### PR TITLE
[WIP] Implement Cancel restart/Kill restart feature

### DIFF
--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -31,6 +31,10 @@ pub enum DeletionMode {
     Kill,
     #[serde(alias = "purge")]
     Purge,
+    #[serde(alias = "kill-and-restart")]
+    KillAndRestart,
+    #[serde(alias = "cancel-and-restart")]
+    CancelAndRestart,
 }
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct DeleteInvocationParams {
@@ -90,6 +94,12 @@ pub async fn delete_invocation<V>(
             Command::TerminateInvocation(InvocationTermination::kill(invocation_id))
         }
         DeletionMode::Purge => Command::PurgeInvocation(PurgeInvocationRequest { invocation_id }),
+        DeletionMode::CancelAndRestart => {
+            Command::TerminateInvocation(InvocationTermination::cancel_and_restart(invocation_id))
+        }
+        DeletionMode::KillAndRestart => {
+            Command::TerminateInvocation(InvocationTermination::kill_and_restart(invocation_id))
+        }
     };
 
     let partition_key = invocation_id.partition_key();

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -92,6 +92,7 @@ fn invoked_status(invocation_target: InvocationTarget) -> InvocationStatus {
         source: Source::Ingress(*RPC_REQUEST_ID),
         completion_retention_duration: Duration::ZERO,
         idempotency_key: None,
+        restart_when_completed: false,
     })
 }
 
@@ -105,6 +106,7 @@ fn killed_status(invocation_target: InvocationTarget) -> InvocationStatus {
         source: Source::Ingress(*RPC_REQUEST_ID),
         completion_retention_duration: Duration::ZERO,
         idempotency_key: None,
+        restart_when_completed: false,
     })
 }
 
@@ -119,6 +121,7 @@ fn suspended_status(invocation_target: InvocationTarget) -> InvocationStatus {
             source: Source::Ingress(*RPC_REQUEST_ID),
             completion_retention_duration: Duration::ZERO,
             idempotency_key: None,
+            restart_when_completed: false,
         },
         waiting_for_completed_entries: HashSet::default(),
     }

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -153,6 +153,7 @@ message InvocationStatusV2 {
   uint32 journal_length = 14;
   optional string deployment_id = 15;
   optional dev.restate.service.protocol.ServiceProtocolVersion service_protocol_version = 16;
+  bool restart_when_completed = 23;
 
   // Suspended
   repeated uint32 waiting_for_completed_entries = 17;
@@ -519,12 +520,27 @@ message OutboxMessage {
     ResponseResult response_result = 3;
   }
 
+  // TODO remove this in Restate 1.3
   message OutboxKill {
     InvocationId invocation_id = 1;
   }
 
+  // TODO remove this in Restate 1.3
   message OutboxCancel {
     InvocationId invocation_id = 1;
+  }
+
+  message OutboxTermination {
+    enum TerminationFlavor {
+      UNKNOWN = 0;
+      KILL = 1;
+      KILL_AND_RESTART = 2;
+      CANCEL = 3;
+      CANCEL_AND_RESTART = 4;
+    }
+
+    InvocationId invocation_id = 1;
+    TerminationFlavor flavor = 2;
   }
 
   message AttachInvocationRequest {
@@ -543,6 +559,7 @@ message OutboxMessage {
     OutboxKill kill = 4;
     OutboxCancel cancel = 5;
     AttachInvocationRequest attach_invocation_request = 6;
+    OutboxTermination termination = 7;
   }
 
 }

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -473,6 +473,9 @@ pub struct InFlightInvocationMetadata {
     /// If zero, the invocation completion will not be retained.
     pub completion_retention_duration: Duration,
     pub idempotency_key: Option<ByteString>,
+
+    /// When the invocation completes, restart it.
+    pub restart_when_completed: bool,
 }
 
 impl InFlightInvocationMetadata {
@@ -496,6 +499,7 @@ impl InFlightInvocationMetadata {
                 completion_retention_duration: pre_flight_invocation_metadata
                     .completion_retention_duration,
                 idempotency_key: pre_flight_invocation_metadata.idempotency_key,
+                restart_when_completed: false,
             },
             InvocationInput {
                 argument: pre_flight_invocation_metadata.argument,
@@ -624,6 +628,7 @@ mod test_util {
                 source: Source::Ingress(PartitionProcessorRpcRequestId::default()),
                 completion_retention_duration: Duration::ZERO,
                 idempotency_key: None,
+                restart_when_completed: false,
             }
         }
     }

--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -14,7 +14,7 @@ use restate_types::identifiers::{EntryIndex, InvocationId, JournalEntryId, Parti
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::{CompletionResult, EntryType};
 use std::future::Future;
-use std::ops::RangeInclusive;
+use std::ops::{Range, RangeInclusive};
 
 /// Different types of journal entries persisted by the runtime
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,5 +78,13 @@ pub trait JournalTable: ReadOnlyJournalTable {
         &mut self,
         invocation_id: &InvocationId,
         journal_length: EntryIndex,
+    ) -> impl Future<Output = ()> + Send {
+        self.delete_journal_range(invocation_id, 0..journal_length)
+    }
+
+    fn delete_journal_range(
+        &mut self,
+        invocation_id: &InvocationId,
+        journal_range: Range<EntryIndex>,
     ) -> impl Future<Output = ()> + Send;
 }

--- a/crates/types/src/invocation.rs
+++ b/crates/types/src/invocation.rs
@@ -773,15 +773,35 @@ impl InvocationTermination {
             flavor: TerminationFlavor::Cancel,
         }
     }
+
+    pub const fn kill_and_restart(invocation_id: InvocationId) -> Self {
+        Self {
+            invocation_id,
+            flavor: TerminationFlavor::KillAndRestart,
+        }
+    }
+
+    pub const fn cancel_and_restart(invocation_id: InvocationId) -> Self {
+        Self {
+            invocation_id,
+            flavor: TerminationFlavor::CancelAndRestart,
+        }
+    }
 }
 
-/// Flavor of the termination. Can be kill (hard stop) or graceful cancel.
+/// Flavor of the termination.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TerminationFlavor {
     /// hard termination, no clean up
     Kill,
+    /// hard termination with restart afterward using same input
+    #[serde(alias = "kill-and-restart")]
+    KillAndRestart,
     /// graceful termination allowing the invocation to clean up
     Cancel,
+    /// graceful termination allowing the invocation to clean up with restart afterward using same input
+    #[serde(alias = "cancel-and-restart")]
+    CancelAndRestart,
 }
 
 /// Message to purge an invocation.

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -178,7 +178,7 @@ async fn terminate_scheduled_invocation(
 #[case(ExperimentalFeature::InvocationStatusKilled.into(), TerminationFlavor::KillAndRestart)]
 #[case(EnumSet::empty(), TerminationFlavor::KillAndRestart)]
 #[case(EnumSet::empty(), TerminationFlavor::CancelAndRestart)]
-#[tokio::test]
+#[restate_core::test]
 async fn terminate_and_restart_scheduled_invocation_has_no_effect(
     #[case] experimental_features: EnumSet<ExperimentalFeature>,
     #[case] termination_flavor: TerminationFlavor,
@@ -229,7 +229,7 @@ async fn terminate_and_restart_scheduled_invocation_has_no_effect(
 #[case(ExperimentalFeature::InvocationStatusKilled.into(), TerminationFlavor::KillAndRestart)]
 #[case(EnumSet::empty(), TerminationFlavor::KillAndRestart)]
 #[case(EnumSet::empty(), TerminationFlavor::CancelAndRestart)]
-#[tokio::test]
+#[restate_core::test]
 async fn terminate_and_restart_inboxed_invocation_has_no_effect(
     #[case] experimental_features: EnumSet<ExperimentalFeature>,
     #[case] termination_flavor: TerminationFlavor,
@@ -287,7 +287,7 @@ async fn terminate_and_restart_inboxed_invocation_has_no_effect(
     Ok(())
 }
 
-#[tokio::test]
+#[restate_core::test]
 async fn kill_and_restart_when_invoked() -> anyhow::Result<()> {
     let mut test_env = TestEnv::create_with_experimental_features(
         ExperimentalFeature::InvocationStatusKilled.into(),
@@ -375,7 +375,7 @@ async fn kill_and_restart_when_invoked() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[restate_core::test]
 async fn kill_and_restart_when_suspended() -> anyhow::Result<()> {
     let mut test_env = TestEnv::create_with_experimental_features(
         ExperimentalFeature::InvocationStatusKilled.into(),

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -11,6 +11,7 @@
 use bytes::Bytes;
 use bytestring::ByteString;
 use googletest::prelude::*;
+use restate_storage_api::invocation_status_table::InvocationStatus;
 use restate_storage_api::timer_table::{TimerKey, TimerKeyKind};
 use restate_types::errors::codes;
 use restate_types::identifiers::EntryIndex;
@@ -150,6 +151,18 @@ pub mod outbox {
             ))
         )
     }
+}
+
+pub fn invoked() -> impl Matcher<ActualT = InvocationStatus> {
+    pat!(InvocationStatus::Invoked { .. })
+}
+
+pub fn suspended() -> impl Matcher<ActualT = InvocationStatus> {
+    pat!(InvocationStatus::Suspended { .. })
+}
+
+pub fn killed() -> impl Matcher<ActualT = InvocationStatus> {
+    pat!(InvocationStatus::Killed { .. })
 }
 
 pub fn completion(


### PR DESCRIPTION
Fix #895. Depends on https://github.com/restatedev/restate/pull/2335

The fundamental commit where semantics are implements is this one: https://github.com/restatedev/restate/commit/0edc593d5117a16aba429722c96149e3c3bd1e32

Essentially the behavior is the following:

* Cancel and Kill behaviors are left untouched
* If the "restart" option is enabled when cancelling/killing, at the end of the invocation the state machine will simply reset the in flight invocation status, removing the pinned deployment id and resetting the journal (except the first entry, that is the input entry)

This commit exposes the feature both in Admin API and in CLI