### PR TITLE
Side quest: Optimize ReadOnlyInvocationStatusTable#all_invoked_or_killed_invocations

### DIFF
--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -161,6 +161,12 @@ message InvocationStatusV2 {
   ResponseResult result = 18;
 }
 
+// Slimmer version of InvocationStatusV2
+message InvocationV2Lite {
+  InvocationStatusV2.Status status = 1;
+  InvocationTarget invocation_target = 2;
+}
+
 // TODO remove this after 1.1
 message InvocationStatus {
 

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -351,6 +351,25 @@ impl InvocationStatus {
 
 protobuf_storage_encode_decode!(InvocationStatus, crate::storage::v1::InvocationStatusV2);
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InvocationStatusDiscriminants {
+    Scheduled,
+    Inboxed,
+    Invoked,
+    Suspended,
+    Killed,
+    Completed,
+}
+
+/// Lite status of an invocation.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct InvocationLite {
+    pub status: InvocationStatusDiscriminants,
+    pub invocation_target: InvocationTarget,
+}
+
+protobuf_storage_encode_decode!(InvocationLite, crate::storage::v1::InvocationV2Lite);
+
 /// Wrapper used by the table implementation only for the migration, don't use it!
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct InvocationStatusV1(pub InvocationStatus);


### PR DESCRIPTION
This avoids loading the full InvocationStatus in memory, only to read invocation target and status. Depends on https://github.com/restatedev/restate/pull/2335, only the last commit is relevant to this PR