### PR TITLE
Implement partition store restore-from-snapshot

### DIFF
--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -189,13 +189,9 @@ impl PartitionStoreManager {
             "Importing partition store snapshot"
         );
 
-        if let Err(e) = self
-            .rocksdb
+        self.rocksdb
             .import_cf(cf_name.clone(), opts, import_metadata)
-            .await
-        {
-            return Err(e);
-        }
+            .await?;
 
         assert!(self.rocksdb.inner().cf_handle(&cf_name).is_some());
         let partition_store = PartitionStore::new(

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -166,7 +166,17 @@ impl PartitionStoreManager {
             return Err(RocksError::ColumnFamilyExists);
         }
 
-        // todo(pavel): validate that the snapshot key range fully covers the partition key range
+        if snapshot.key_range.start() > partition_key_range.start()
+            || snapshot.key_range.end() < partition_key_range.end()
+        {
+            warn!(
+                %partition_id,
+                snapshot_range = ?snapshot.key_range,
+                partition_range = ?partition_key_range,
+                "The snapshot key range does not fully cover the partition key range"
+            );
+            return Err(RocksError::SnapshotKeyRangeMismatch);
+        }
 
         let mut import_metadata = ExportImportFilesMetaData::default();
         import_metadata.set_db_comparator_name(snapshot.db_comparator_name.as_str());

--- a/crates/rocksdb/src/error.rs
+++ b/crates/rocksdb/src/error.rs
@@ -30,6 +30,9 @@ pub enum RocksError {
     #[error("already exists")]
     #[code(unknown)]
     ColumnFamilyExists,
+    #[error("invalid key range for partition")]
+    #[code(unknown)]
+    SnapshotKeyRangeMismatch,
     #[error(transparent)]
     #[code(unknown)]
     Other(#[from] rocksdb::Error),

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -46,6 +46,8 @@ pub trait RocksAccess {
         default_cf_options: rocksdb::Options,
         cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
     ) -> Result<(), RocksError>;
+    /// Create a column family from a snapshot. The data files referenced by
+    /// `metadata` will be moved into the RocksDB data directory.
     fn import_cf(
         &self,
         name: CfName,
@@ -163,7 +165,7 @@ impl RocksAccess for rocksdb::DB {
         let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
 
         let mut import_opts = ImportColumnFamilyOptions::default();
-        import_opts.set_move_files(false); // keep the snapshot files intact
+        import_opts.set_move_files(true);
 
         Ok(Self::create_column_family_with_import(
             self,

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -72,7 +72,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 ulid = { workspace = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -68,6 +68,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 strum = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -159,6 +159,7 @@ impl Worker {
             SnapshotRepository::create_if_configured(
                 snapshots_options,
                 config.common.base_dir().join("pp-snapshots"),
+                config.common.cluster_name().to_owned(),
             )
             .await
             .map_err(BuildError::SnapshotRepository)?,

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -156,9 +156,12 @@ impl Worker {
             partition_store_manager.clone(),
             router_builder,
             bifrost,
-            SnapshotRepository::create_if_configured(snapshots_options)
-                .await
-                .map_err(BuildError::SnapshotRepository)?,
+            SnapshotRepository::create_if_configured(
+                snapshots_options,
+                config.common.base_dir().join("pp-snapshots"),
+            )
+            .await
+            .map_err(BuildError::SnapshotRepository)?,
         );
 
         // handle RPCs

--- a/crates/worker/src/partition/snapshots/repository.rs
+++ b/crates/worker/src/partition/snapshots/repository.rs
@@ -648,15 +648,9 @@ mod tests {
         );
 
         let opts = SnapshotsOptions {
-            destination: Some(destination.clone()),
+            destination: Some(destination),
             ..SnapshotsOptions::default()
         };
-
-        eprintln!("Destination: {}", destination);
-
-        let destination = Url::parse(destination.as_str())?;
-        let path = destination.path().to_string();
-        let object_store = super::create_object_store_client(destination).await?;
 
         let repository = SnapshotRepository::create_if_configured(&opts)
             .await?

--- a/crates/worker/src/partition/snapshots/repository.rs
+++ b/crates/worker/src/partition/snapshots/repository.rs
@@ -648,9 +648,15 @@ mod tests {
         );
 
         let opts = SnapshotsOptions {
-            destination: Some(destination),
+            destination: Some(destination.clone()),
             ..SnapshotsOptions::default()
         };
+
+        eprintln!("Destination: {}", destination);
+
+        let destination = Url::parse(destination.as_str())?;
+        let path = destination.path().to_string();
+        let object_store = super::create_object_store_client(destination).await?;
 
         let repository = SnapshotRepository::create_if_configured(&opts)
             .await?

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -875,6 +875,7 @@ impl PartitionProcessorManager {
             self.updateable_config.clone(),
             self.bifrost.clone(),
             self.partition_store_manager.clone(),
+            self.snapshot_repository.clone(),
         )
     }
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -11,7 +11,7 @@
 use std::ops::RangeInclusive;
 
 use tokio::sync::{mpsc, watch};
-use tracing::instrument;
+use tracing::{debug, info, instrument};
 
 use restate_bifrost::Bifrost;
 use restate_core::{Metadata, RuntimeTaskHandle, TaskCenter, TaskKind};
@@ -26,6 +26,7 @@ use restate_types::schema::Schema;
 
 use crate::invoker_integration::EntryEnricher;
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
+use crate::partition::snapshots::SnapshotRepository;
 use crate::partition_processor_manager::processor_state::StartedProcessor;
 use crate::PartitionProcessorBuilder;
 
@@ -36,6 +37,7 @@ pub struct SpawnPartitionProcessorTask {
     configuration: Live<Configuration>,
     bifrost: Bifrost,
     partition_store_manager: PartitionStoreManager,
+    snapshot_repository: Option<SnapshotRepository>,
 }
 
 impl SpawnPartitionProcessorTask {
@@ -47,6 +49,7 @@ impl SpawnPartitionProcessorTask {
         configuration: Live<Configuration>,
         bifrost: Bifrost,
         partition_store_manager: PartitionStoreManager,
+        snapshot_repository: Option<SnapshotRepository>,
     ) -> Self {
         Self {
             task_name,
@@ -55,6 +58,7 @@ impl SpawnPartitionProcessorTask {
             configuration,
             bifrost,
             partition_store_manager,
+            snapshot_repository,
         }
     }
 
@@ -72,6 +76,7 @@ impl SpawnPartitionProcessorTask {
             configuration,
             bifrost,
             partition_store_manager,
+            snapshot_repository,
         } = self;
 
         let config = configuration.pinned();
@@ -117,15 +122,66 @@ impl SpawnPartitionProcessorTask {
             {
                 let options = options.clone();
                 let key_range = key_range.clone();
+
                 move || async move {
-                    let partition_store = partition_store_manager
-                        .open_partition_store(
-                            partition_id,
-                            key_range,
-                            OpenMode::CreateIfMissing,
-                            &options.storage.rocksdb,
-                        )
-                        .await?;
+                    let partition_store = if !partition_store_manager
+                        .has_partition_store(pp_builder.partition_id)
+                        .await
+                    {
+                        let snapshot = if snapshot_repository.is_none() {
+                            debug!(
+                                partition_id = %partition_id,
+                                "No snapshot repository configured",
+                            );
+                            None
+                        } else {
+                            debug!(
+                                partition_id = %partition_id,
+                                "Looking for partition snapshot from which to bootstrap partition store",
+                            );
+                            snapshot_repository.expect("is some").get_latest(partition_id).await?
+                        };
+
+
+                        if let Some(snapshot) = snapshot {
+                            info!(
+                                partition_id = %partition_id,
+                                "Found snapshot to bootstrap partition, restoring it",
+                            );
+
+                            partition_store_manager
+                                .open_partition_store_from_snapshot(
+                                    partition_id,
+                                    key_range.clone(),
+                                    snapshot,
+                                    &options.storage.rocksdb,
+                                )
+                                .await?
+                        } else {
+                            info!(
+                                    partition_id = %partition_id,
+                                    "No snapshot found to bootstrap partition, creating new store",
+                                );
+                            partition_store_manager
+                                .open_partition_store(
+                                    partition_id,
+                                    key_range,
+                                    OpenMode::CreateIfMissing,
+                                    &options.storage.rocksdb,
+                                )
+                                .await?
+                        }
+                    } else {
+                        partition_store_manager
+                            .open_partition_store(
+                                partition_id,
+                                key_range,
+                                OpenMode::OpenExisting,
+                                &options.storage.rocksdb,
+                            )
+                            .await?
+                    };
+
                     TaskCenter::spawn_child(
                         TaskKind::SystemService,
                         invoker_name,


### PR DESCRIPTION
With this change, Partition Processor startup now checks the snapshot repository
 for a partition snapshot before creating a blank store database. If a recent
 snapshot is available, we will restore that instead of replaying the log from
 the beginning.

This PR builds on https://github.com/restatedev/restate/pull/2310

Closes: https://github.com/restatedev/restate/issues/2000

---

## Testing

Created snapshot by running `restatectl create-snapshot -p 0`, then dropped the partition CF with `rocksdb_ldb drop_column_family --db=./restate-data/.../db data-0`.

Running `restate-server` correctly restores the most recent available snapshot:

```
2024-11-27T18:43:40.042527Z TRACE restate_worker::partition_processor_manager::spawn_processor_task: Looking for snapshot to bootstrap partition store
2024-11-27T18:43:40.042670Z DEBUG on_asynchronous_event: restate_worker::partition_processor_manager: Partition processor was successfully created. target_run_mode=Leader partition_id=0 event=Started
2024-11-27T18:43:40.044494Z  INFO get_latest: aws_config::profile::credentials: constructed abstract provider from config file chain=ProfileChain { base: Sso { sso_session_name: Some("restate"), sso_region: "eu-central-1", sso_start_url: "https://d-99671f0c4b.awsapps.com/start", sso_account_id: Some("663487780041"), sso_role_name: Some("EngineerAccess") }, chain: [] } partition_id=0
2024-11-27T18:43:40.048798Z DEBUG on_asynchronous_event: restate_worker::partition_processor_manager::processor_state: Instruct partition processor to run as leader. leader_epoch=e56 partition_id=0 event=NewLeaderEpoch
2024-11-27T18:43:40.948928Z  INFO get_latest: aws_config::profile::credentials: loaded base credentials creds=Credentials { provider_name: "SSO", access_key_id: "ASIAZU6XUCTE3QRJBHL4", secret_access_key: "** redacted **", expires_after: "2024-11-28T02:43:39Z" } partition_id=0
2024-11-27T18:43:41.494631Z TRACE get_latest: restate_worker::partition::snapshots::repository: Latest snapshot metadata: LatestSnapshot { version: V1, partition_id: PartitionId(0), cluster_name: "localcluster", node_name: "Pavels-MacBook-Pro.local", created_at: Timestamp(SystemTime { tv_sec: 1732731695, tv_nsec: 510557000 }), snapshot_id: snap_14QnEfyWDrRj0GBbOz0XFiV, min_applied_lsn: Lsn(1212), path: "lsn_00000000000000001212-snap_14QnEfyWDrRj0GBbOz0XFiV" } partition_id=0
2024-11-27T18:43:42.390392Z  INFO get_latest: aws_config::profile::credentials: loaded base credentials creds=Credentials { provider_name: "SSO", access_key_id: "ASIAZU6XUCTE5UO2I244", secret_access_key: "** redacted **", expires_after: "2024-11-28T02:43:41Z" } partition_id=0
2024-11-27T18:43:42.556935Z DEBUG get_latest: restate_worker::partition::snapshots::repository: Getting snapshot data snapshot_id=snap_14QnEfyWDrRj0GBbOz0XFiV path="/Users/pavel/restate/restate/restate-data/snap_14QnEfyWDrRj0GBbOz0XFiV-OClIZB" partition_id=0
2024-11-27T18:43:43.400784Z  INFO aws_config::profile::credentials: loaded base credentials creds=Credentials { provider_name: "SSO", access_key_id: "ASIAZU6XUCTEW7NOHHGS", secret_access_key: "** redacted **", expires_after: "2024-11-28T02:43:42Z" }
2024-11-27T18:43:43.402483Z  INFO aws_config::profile::credentials: loaded base credentials creds=Credentials { provider_name: "SSO", access_key_id: "ASIAZU6XUCTEYPZHMLQY", secret_access_key: "** redacted **", expires_after: "2024-11-28T02:43:42Z" }
2024-11-27T18:43:43.607012Z TRACE restate_worker::partition::snapshots::repository: Downloaded snapshot data file to "/Users/pavel/restate/restate/restate-data/snap_14QnEfyWDrRj0GBbOz0XFiV-OClIZB/000398.sst" key=test-cluster-snapshots/0/lsn_00000000000000001212-snap_14QnEfyWDrRj0GBbOz0XFiV/000398.sst size=1144
2024-11-27T18:43:43.803874Z TRACE restate_worker::partition::snapshots::repository: Downloaded snapshot data file to "/Users/pavel/restate/restate/restate-data/snap_14QnEfyWDrRj0GBbOz0XFiV-OClIZB/000405.sst" key=test-cluster-snapshots/0/lsn_00000000000000001212-snap_14QnEfyWDrRj0GBbOz0XFiV/000405.sst size=1269
2024-11-27T18:43:43.804296Z  INFO get_latest: restate_worker::partition::snapshots::repository: Downloaded partition snapshot snapshot_id=snap_14QnEfyWDrRj0GBbOz0XFiV path="/Users/pavel/restate/restate/restate-data/snap_14QnEfyWDrRj0GBbOz0XFiV-OClIZB" partition_id=0
2024-11-27T18:43:43.804403Z TRACE restate_worker::partition_processor_manager::spawn_processor_task: Restoring partition snapshot partition_id=0
2024-11-27T18:43:43.804912Z  INFO restate_partition_store::partition_store_manager: Importing partition store snapshot partition_id=0 min_lsn=1212 path="/Users/pavel/restate/restate/restate-data/snap_14QnEfyWDrRj0GBbOz0XFiV-OClIZB"
2024-11-27T18:43:43.821260Z  INFO run: restate_worker::partition: Starting the partition processor. partition_id=0
2024-11-27T18:43:43.821502Z DEBUG run: restate_worker::partition: PartitionProcessor creating log reader last_applied_lsn=1212 current_log_tail=1220 partition_id=0
2024-11-27T18:43:43.821548Z DEBUG run: restate_worker::partition: Replaying the log from lsn=1213, log tail lsn=1220 partition_id=0
2024-11-27T18:43:43.821653Z  INFO run: restate_worker::partition: PartitionProcessor starting event loop. partition_id=0
```