### PR TITLE
[TaskCenter] New API and migration

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -18,7 +18,7 @@ use futures_util::{future, TryFutureExt};
 use http::header::CONTENT_TYPE;
 use http::Uri;
 use pprof::flamegraph::Options;
-use restate_core::{TaskCenter, TaskCenterBuilder, TaskKind};
+use restate_core::{task_center, TaskCenter, TaskCenterBuilder, TaskKind};
 use restate_node::Node;
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::{

--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -228,10 +228,9 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             Ok(())
         };
 
-        let handle = TaskCenter::current().spawn_unmanaged(
+        let handle = TaskCenter::spawn_unmanaged(
             restate_core::TaskKind::Disposable,
             "cluster-state-refresh",
-            None,
             refresh,
         )?;
 

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -485,8 +485,7 @@ mod tests {
         FailingConnector, Incoming, MessageHandler, MockPeerConnection, NetworkServerBuilder,
     };
     use restate_core::{
-        NoOpMessageHandler, TaskCenter, TaskCenterFutureExt, TaskKind, TestCoreEnv,
-        TestCoreEnvBuilder,
+        NoOpMessageHandler, TaskCenter, TaskKind, TestCoreEnv2, TestCoreEnvBuilder2,
     };
     use restate_types::cluster::cluster_state::PartitionProcessorStatus;
     use restate_types::config::{AdminOptions, Configuration};
@@ -500,53 +499,42 @@ mod tests {
     use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
     use restate_types::{GenerationalNodeId, Version};
 
-    #[test(tokio::test)]
+    #[test(restate_core::test)]
     async fn manual_log_trim() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
-        let mut builder = TestCoreEnvBuilder::with_incoming_only_connector();
-        let tc = builder.tc.clone();
-        async {
-            let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
-            let bifrost = bifrost_svc.handle();
+        let mut builder = TestCoreEnvBuilder2::with_incoming_only_connector();
+        let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
+        let bifrost = bifrost_svc.handle();
 
-            let svc = Service::new(
-                Live::from_value(Configuration::default()),
-                HealthStatus::default(),
-                bifrost.clone(),
-                builder.metadata.clone(),
-                builder.networking.clone(),
-                &mut builder.router_builder,
-                &mut NetworkServerBuilder::default(),
-                builder.metadata_writer.clone(),
-                builder.metadata_store_client.clone(),
-            );
-            let svc_handle = svc.handle();
+        let svc = Service::new(
+            Live::from_value(Configuration::default()),
+            HealthStatus::default(),
+            bifrost.clone(),
+            builder.metadata.clone(),
+            builder.networking.clone(),
+            &mut builder.router_builder,
+            &mut NetworkServerBuilder::default(),
+            builder.metadata_writer.clone(),
+            builder.metadata_store_client.clone(),
+        );
+        let svc_handle = svc.handle();
 
-            let _ = builder.build().await;
-            bifrost_svc.start().await?;
+        let _ = builder.build().await;
+        bifrost_svc.start().await?;
 
-            let mut appender = bifrost.create_appender(LOG_ID)?;
+        let mut appender = bifrost.create_appender(LOG_ID)?;
 
-            TaskCenter::current().spawn(
-                TaskKind::SystemService,
-                "cluster-controller",
-                None,
-                svc.run(),
-            )?;
+        TaskCenter::spawn(TaskKind::SystemService, "cluster-controller", svc.run())?;
 
-            for _ in 1..=5 {
-                appender.append("").await?;
-            }
-
-            svc_handle.trim_log(LOG_ID, Lsn::from(3)).await??;
-
-            let record = bifrost.read(LOG_ID, Lsn::OLDEST).await?.unwrap();
-            assert_that!(record.sequence_number(), eq(Lsn::OLDEST));
-            assert_that!(record.trim_gap_to_sequence_number(), eq(Some(Lsn::new(3))));
-            Ok::<(), anyhow::Error>(())
+        for _ in 1..=5 {
+            appender.append("").await?;
         }
-        .in_tc(&tc)
-        .await?;
+
+        svc_handle.trim_log(LOG_ID, Lsn::from(3)).await??;
+
+        let record = bifrost.read(LOG_ID, Lsn::OLDEST).await?.unwrap();
+        assert_that!(record.sequence_number(), eq(Lsn::OLDEST));
+        assert_that!(record.trim_gap_to_sequence_number(), eq(Some(Lsn::new(3))));
 
         Ok(())
     }
@@ -584,7 +572,7 @@ mod tests {
         }
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn auto_log_trim() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
@@ -612,63 +600,58 @@ mod tests {
                 .add_message_handler(NoOpMessageHandler::<ControlProcessors>::default())
         })
         .await?;
-        let tc = node_env.tc.clone();
 
-        async move {
-            // simulate a connection from node 2 so we can have a connection between the two
-            // nodes
-            let node_2 = MockPeerConnection::connect(
-                GenerationalNodeId::new(2, 2),
-                node_env.metadata.nodes_config_version(),
-                node_env
-                    .metadata
-                    .nodes_config_ref()
-                    .cluster_name()
-                    .to_owned(),
-                node_env.networking.connection_manager(),
-                10,
-            )
-            .await?;
-            // let node2 receive messages and use the same message handler as node1
-            let (_node_2, _node2_reactor) = node_2
-                .process_with_message_handler(&TaskCenter::current(), get_node_state_handler)?;
+        // simulate a connection from node 2 so we can have a connection between the two
+        // nodes
+        let node_2 = MockPeerConnection::connect(
+            GenerationalNodeId::new(2, 2),
+            node_env.metadata.nodes_config_version(),
+            node_env
+                .metadata
+                .nodes_config_ref()
+                .cluster_name()
+                .to_owned(),
+            node_env.networking.connection_manager(),
+            10,
+        )
+        .await?;
+        // let node2 receive messages and use the same message handler as node1
+        let (_node_2, _node2_reactor) =
+            node_2.process_with_message_handler(get_node_state_handler)?;
 
-            let mut appender = bifrost.create_appender(LOG_ID)?;
-            for i in 1..=20 {
-                let lsn = appender.append("").await?;
-                assert_eq!(Lsn::from(i), lsn);
-            }
-
-            tokio::time::sleep(interval_duration * 10).await;
-
-            assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
-
-            // report persisted lsn back to cluster controller
-            persisted_lsn.store(6, Ordering::Relaxed);
-
-            tokio::time::sleep(interval_duration * 10).await;
-            // we delete 1-6.
-            assert_eq!(Lsn::from(6), bifrost.get_trim_point(LOG_ID).await?);
-
-            // increase by 4 more, this should not overcome the threshold
-            persisted_lsn.store(10, Ordering::Relaxed);
-
-            tokio::time::sleep(interval_duration * 10).await;
-            assert_eq!(Lsn::from(6), bifrost.get_trim_point(LOG_ID).await?);
-
-            // now we have reached the min threshold wrt to the last trim point
-            persisted_lsn.store(11, Ordering::Relaxed);
-
-            tokio::time::sleep(interval_duration * 10).await;
-            assert_eq!(Lsn::from(11), bifrost.get_trim_point(LOG_ID).await?);
-
-            Ok::<(), anyhow::Error>(())
+        let mut appender = bifrost.create_appender(LOG_ID)?;
+        for i in 1..=20 {
+            let lsn = appender.append("").await?;
+            assert_eq!(Lsn::from(i), lsn);
         }
-        .in_tc(&tc)
-        .await
+
+        tokio::time::sleep(interval_duration * 10).await;
+
+        assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
+
+        // report persisted lsn back to cluster controller
+        persisted_lsn.store(6, Ordering::Relaxed);
+
+        tokio::time::sleep(interval_duration * 10).await;
+        // we delete 1-6.
+        assert_eq!(Lsn::from(6), bifrost.get_trim_point(LOG_ID).await?);
+
+        // increase by 4 more, this should not overcome the threshold
+        persisted_lsn.store(10, Ordering::Relaxed);
+
+        tokio::time::sleep(interval_duration * 10).await;
+        assert_eq!(Lsn::from(6), bifrost.get_trim_point(LOG_ID).await?);
+
+        // now we have reached the min threshold wrt to the last trim point
+        persisted_lsn.store(11, Ordering::Relaxed);
+
+        tokio::time::sleep(interval_duration * 10).await;
+        assert_eq!(Lsn::from(11), bifrost.get_trim_point(LOG_ID).await?);
+
+        Ok(())
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn auto_log_trim_zero_threshold() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
         let mut admin_options = AdminOptions::default();
@@ -695,58 +678,53 @@ mod tests {
         })
         .await?;
 
-        let tc = node_env.tc.clone();
-        async move {
-            // simulate a connection from node 2 so we can have a connection between the two
-            // nodes
-            let node_2 = MockPeerConnection::connect(
-                GenerationalNodeId::new(2, 2),
-                node_env.metadata.nodes_config_version(),
-                node_env
-                    .metadata
-                    .nodes_config_ref()
-                    .cluster_name()
-                    .to_owned(),
-                node_env.networking.connection_manager(),
-                10,
-            )
-            .await?;
-            // let node2 receive messages and use the same message handler as node1
-            let (_node_2, _node2_reactor) =
-                node_2.process_with_message_handler(&node_env.tc, get_node_state_handler)?;
+        // simulate a connection from node 2 so we can have a connection between the two
+        // nodes
+        let node_2 = MockPeerConnection::connect(
+            GenerationalNodeId::new(2, 2),
+            node_env.metadata.nodes_config_version(),
+            node_env
+                .metadata
+                .nodes_config_ref()
+                .cluster_name()
+                .to_owned(),
+            node_env.networking.connection_manager(),
+            10,
+        )
+        .await?;
+        // let node2 receive messages and use the same message handler as node1
+        let (_node_2, _node2_reactor) =
+            node_2.process_with_message_handler(get_node_state_handler)?;
 
-            let mut appender = bifrost.create_appender(LOG_ID)?;
-            for i in 1..=20 {
-                let lsn = appender.append(format!("record{}", i)).await?;
-                assert_eq!(Lsn::from(i), lsn);
-            }
-            tokio::time::sleep(interval_duration * 10).await;
-            assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
-
-            // report persisted lsn back to cluster controller
-            persisted_lsn.store(3, Ordering::Relaxed);
-
-            tokio::time::sleep(interval_duration * 10).await;
-            // everything before the persisted_lsn.
-            assert_eq!(bifrost.get_trim_point(LOG_ID).await?, Lsn::from(3));
-            // we should be able to after the last persisted lsn
-            let v = bifrost.read(LOG_ID, Lsn::from(4)).await?.unwrap();
-            assert_that!(v.sequence_number(), eq(Lsn::new(4)));
-            assert!(v.is_data_record());
-            assert_that!(v.decode_unchecked::<String>(), eq("record4".to_owned()));
-
-            persisted_lsn.store(20, Ordering::Relaxed);
-
-            tokio::time::sleep(interval_duration * 10).await;
-            assert_eq!(Lsn::from(20), bifrost.get_trim_point(LOG_ID).await?);
-
-            Ok::<(), anyhow::Error>(())
+        let mut appender = bifrost.create_appender(LOG_ID)?;
+        for i in 1..=20 {
+            let lsn = appender.append(format!("record{}", i)).await?;
+            assert_eq!(Lsn::from(i), lsn);
         }
-        .in_tc(&tc)
-        .await
+        tokio::time::sleep(interval_duration * 10).await;
+        assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
+
+        // report persisted lsn back to cluster controller
+        persisted_lsn.store(3, Ordering::Relaxed);
+
+        tokio::time::sleep(interval_duration * 10).await;
+        // everything before the persisted_lsn.
+        assert_eq!(bifrost.get_trim_point(LOG_ID).await?, Lsn::from(3));
+        // we should be able to after the last persisted lsn
+        let v = bifrost.read(LOG_ID, Lsn::from(4)).await?.unwrap();
+        assert_that!(v.sequence_number(), eq(Lsn::new(4)));
+        assert!(v.is_data_record());
+        assert_that!(v.decode_unchecked::<String>(), eq("record4".to_owned()));
+
+        persisted_lsn.store(20, Ordering::Relaxed);
+
+        tokio::time::sleep(interval_duration * 10).await;
+        assert_eq!(Lsn::from(20), bifrost.get_trim_point(LOG_ID).await?);
+
+        Ok(())
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn do_not_trim_if_not_all_nodes_report_persisted_lsn() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
@@ -762,7 +740,7 @@ mod tests {
         let persisted_lsn = Arc::new(AtomicU64::new(0));
         let archived_lsn = Arc::new(AtomicU64::new(0));
 
-        let (node_env, bifrost) = create_test_env(config, |builder| {
+        let (_node_env, bifrost) = create_test_env(config, |builder| {
             let black_list = builder
                 .nodes_config
                 .iter()
@@ -781,24 +759,18 @@ mod tests {
         })
         .await?;
 
-        async move {
-            let mut appender = bifrost.create_appender(LOG_ID)?;
-            for i in 1..=5 {
-                let lsn = appender.append(format!("record{}", i)).await?;
-                assert_eq!(Lsn::from(i), lsn);
-            }
-
-            // report persisted lsn back to cluster controller for a subset of the nodes
-            persisted_lsn.store(5, Ordering::Relaxed);
-
-            tokio::time::sleep(interval_duration * 10).await;
-            // no trimming should have happened because one node did not report the persisted lsn
-            assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
-
-            Ok::<(), anyhow::Error>(())
+        let mut appender = bifrost.create_appender(LOG_ID)?;
+        for i in 1..=5 {
+            let lsn = appender.append(format!("record{}", i)).await?;
+            assert_eq!(Lsn::from(i), lsn);
         }
-        .in_tc(&node_env.tc)
-        .await?;
+
+        // report persisted lsn back to cluster controller for a subset of the nodes
+        persisted_lsn.store(5, Ordering::Relaxed);
+
+        tokio::time::sleep(interval_duration * 10).await;
+        // no trimming should have happened because one node did not report the persisted lsn
+        assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
         Ok(())
     }
@@ -806,59 +778,49 @@ mod tests {
     async fn create_test_env<F>(
         config: Configuration,
         mut modify_builder: F,
-    ) -> anyhow::Result<(TestCoreEnv<FailingConnector>, Bifrost)>
+    ) -> anyhow::Result<(TestCoreEnv2<FailingConnector>, Bifrost)>
     where
-        F: FnMut(TestCoreEnvBuilder<FailingConnector>) -> TestCoreEnvBuilder<FailingConnector>,
+        F: FnMut(TestCoreEnvBuilder2<FailingConnector>) -> TestCoreEnvBuilder2<FailingConnector>,
     {
-        let mut builder = TestCoreEnvBuilder::with_incoming_only_connector();
-        let tc = builder.tc.clone();
-        async {
-            let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
-            let bifrost = bifrost_svc.handle();
+        let mut builder = TestCoreEnvBuilder2::with_incoming_only_connector();
+        let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
+        let bifrost = bifrost_svc.handle();
 
-            let mut server_builder = NetworkServerBuilder::default();
+        let mut server_builder = NetworkServerBuilder::default();
 
-            let svc = Service::new(
-                Live::from_value(config),
-                HealthStatus::default(),
-                bifrost.clone(),
-                builder.metadata.clone(),
-                builder.networking.clone(),
-                &mut builder.router_builder,
-                &mut server_builder,
-                builder.metadata_writer.clone(),
-                builder.metadata_store_client.clone(),
-            );
+        let svc = Service::new(
+            Live::from_value(config),
+            HealthStatus::default(),
+            bifrost.clone(),
+            builder.metadata.clone(),
+            builder.networking.clone(),
+            &mut builder.router_builder,
+            &mut server_builder,
+            builder.metadata_writer.clone(),
+            builder.metadata_store_client.clone(),
+        );
 
-            let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
-            nodes_config.upsert_node(NodeConfig::new(
-                "node-1".to_owned(),
-                GenerationalNodeId::new(1, 1),
-                AdvertisedAddress::Uds("foobar".into()),
-                Role::Worker.into(),
-                LogServerConfig::default(),
-            ));
-            nodes_config.upsert_node(NodeConfig::new(
-                "node-2".to_owned(),
-                GenerationalNodeId::new(2, 2),
-                AdvertisedAddress::Uds("bar".into()),
-                Role::Worker.into(),
-                LogServerConfig::default(),
-            ));
-            let builder = modify_builder(builder.set_nodes_config(nodes_config));
+        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        nodes_config.upsert_node(NodeConfig::new(
+            "node-1".to_owned(),
+            GenerationalNodeId::new(1, 1),
+            AdvertisedAddress::Uds("foobar".into()),
+            Role::Worker.into(),
+            LogServerConfig::default(),
+        ));
+        nodes_config.upsert_node(NodeConfig::new(
+            "node-2".to_owned(),
+            GenerationalNodeId::new(2, 2),
+            AdvertisedAddress::Uds("bar".into()),
+            Role::Worker.into(),
+            LogServerConfig::default(),
+        ));
+        let builder = modify_builder(builder.set_nodes_config(nodes_config));
 
-            let node_env = builder.build().await;
-            bifrost_svc.start().await?;
+        let node_env = builder.build().await;
+        bifrost_svc.start().await?;
 
-            node_env.tc.spawn(
-                TaskKind::SystemService,
-                "cluster-controller",
-                None,
-                svc.run(),
-            )?;
-            Ok((node_env, bifrost))
-        }
-        .in_tc(&tc)
-        .await
+        TaskCenter::spawn(TaskKind::SystemService, "cluster-controller", svc.run())?;
+        Ok((node_env, bifrost))
     }
 }

--- a/crates/bifrost/benches/util.rs
+++ b/crates/bifrost/benches/util.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use tracing::warn;
 
 use restate_core::{
-    spawn_metadata_manager, MetadataBuilder, MetadataManager, TaskCenter, TaskCenterBuilder,
-    TaskCenterFutureExt,
+    spawn_metadata_manager, task_center, MetadataBuilder, MetadataManager, TaskCenter,
+    TaskCenterBuilder, TaskCenterFutureExt,
 };
 use restate_metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
@@ -26,14 +26,15 @@ pub async fn spawn_environment(
     config: Configuration,
     num_logs: u16,
     provider: ProviderKind,
-) -> TaskCenter {
+) -> task_center::Handle {
     if rlimit::increase_nofile_limit(u64::MAX).is_err() {
         warn!("Failed to increase the number of open file descriptors limit.");
     }
     let tc = TaskCenterBuilder::default()
         .options(config.common.clone())
         .build()
-        .expect("task_center builds");
+        .expect("task_center builds")
+        .to_handle();
 
     async {
         restate_types::config::set_current_config(config.clone());

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -17,7 +17,6 @@ use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{trace, warn};
 
 use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskHandle};
-use restate_types::identifiers::PartitionId;
 use restate_types::storage::StorageEncode;
 
 use crate::error::EnqueueError;
@@ -58,17 +57,12 @@ where
     /// Start the background appender as a TaskCenter background task. Note that the task will not
     /// automatically react to TaskCenter's shutdown signal, it gives control over the shutdown
     /// behaviour to the owner of [`AppenderHandle`] to drain or drop when appropriate.
-    pub fn start(
-        self,
-        name: &'static str,
-        partition_id: Option<PartitionId>,
-    ) -> Result<AppenderHandle<T>, ShutdownError> {
+    pub fn start(self, name: &'static str) -> Result<AppenderHandle<T>, ShutdownError> {
         let (tx, rx) = tokio::sync::mpsc::channel(self.queue_capacity);
 
-        let handle = TaskCenter::current().spawn_unmanaged(
+        let handle = TaskCenter::spawn_unmanaged(
             restate_core::TaskKind::BifrostAppender,
             name,
-            partition_id,
             self.run(rx),
         )?;
 

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -881,7 +881,7 @@ mod tests {
         // create an appender
         let stop_signal = Arc::new(AtomicBool::default());
         let append_counter = Arc::new(AtomicUsize::new(0));
-        let _ = TaskCenter::current().spawn(TaskKind::TestRunner, "append-records", None, {
+        let _ = TaskCenter::spawn(TaskKind::TestRunner, "append-records", {
             let append_counter = append_counter.clone();
             let stop_signal = stop_signal.clone();
             let bifrost = bifrost.clone();

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -123,7 +123,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
     assert!(loglet.read_opt(Lsn::new(end)).await?.is_none());
 
     let handle1: TaskHandle<googletest::Result<()>> =
-        TaskCenter::current().spawn_unmanaged(TaskKind::TestRunner, "read", None, {
+        TaskCenter::spawn_unmanaged(TaskKind::TestRunner, "read", {
             let loglet = loglet.clone();
             async move {
                 // read future record 4
@@ -140,7 +140,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
 
     // Waiting for 10
     let handle2: TaskHandle<googletest::Result<()>> =
-        TaskCenter::current().spawn_unmanaged(TaskKind::TestRunner, "read", None, {
+        TaskCenter::spawn_unmanaged(TaskKind::TestRunner, "read", {
             let loglet = loglet.clone();
             async move {
                 // read future record 10

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -403,25 +403,19 @@ impl Loglet for MemoryLoglet {
 mod tests {
     use super::*;
 
-    use restate_core::TestCoreEnvBuilder;
+    use restate_core::TestCoreEnvBuilder2;
 
     macro_rules! run_test {
         ($test:ident) => {
             paste::paste! {
-                #[tokio::test(start_paused = true)]
+                #[restate_core::test(start_paused = true)]
                 async fn [<memory_loglet_  $test>]() -> googletest::Result<()> {
-                let node_env = TestCoreEnvBuilder::with_incoming_only_connector()
-                    .set_provider_kind(ProviderKind::InMemory)
-                    .build()
-                    .await;
-                node_env
-                    .tc
-                    .run_in_scope("test", None, async {
-                        let loglet = MemoryLoglet::new(LogletParams::from("112".to_string()));
-                        crate::loglet::loglet_tests::$test(loglet).await
-                    })
-                    .await?;
-                Ok(())
+                    let _node_env = TestCoreEnvBuilder2::with_incoming_only_connector()
+                        .set_provider_kind(ProviderKind::InMemory)
+                        .build()
+                        .await;
+                    let loglet = MemoryLoglet::new(LogletParams::from("112".to_string()));
+                    crate::loglet::loglet_tests::$test(loglet).await
                 }
             }
         };

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use tracing::{info, trace};
 
 use restate_core::network::{NetworkError, Networking, TransportConnect};
-use restate_core::{task_center, ShutdownError, TaskHandle, TaskKind};
+use restate_core::{ShutdownError, TaskCenter, TaskHandle, TaskKind};
 use restate_types::config::Configuration;
 use restate_types::logs::{KeyFilter, LogletOffset, MatchKeyQuery, RecordCache, SequenceNumber};
 use restate_types::net::log_server::{GetRecords, LogServerRequestHeader, MaybeRecord};
@@ -122,10 +122,9 @@ impl ReadStreamTask {
             stats: Stats::default(),
             move_beyond_global_tail,
         };
-        let handle = task_center().spawn_unmanaged(
+        let handle = TaskCenter::spawn_unmanaged(
             TaskKind::ReplicatedLogletReadStream,
             "replicatedloglet-read-stream",
-            None,
             task.run(networking),
         )?;
 

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/mod.rs
@@ -21,7 +21,7 @@ use tracing::{debug, instrument, trace};
 
 use restate_core::{
     network::{rpc_router::RpcRouter, Networking, TransportConnect},
-    task_center, ShutdownError, TaskKind,
+    ShutdownError, TaskCenter, TaskKind,
 };
 use restate_types::{
     config::Configuration,
@@ -269,7 +269,7 @@ impl<T: TransportConnect> Sequencer<T> {
 
         let fut = self.in_flight.track_future(appender.run());
 
-        task_center().spawn(TaskKind::SequencerAppender, "sequencer-appender", None, fut)?;
+        TaskCenter::spawn(TaskKind::SequencerAppender, "sequencer-appender", fut)?;
 
         Ok(loglet_commit)
     }

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -158,10 +158,9 @@ impl BifrostService {
             .map_err(|_| anyhow::anyhow!("bifrost must be initialized only once"))?;
 
         // We spawn the watchdog as a background long-running task
-        TaskCenter::current().spawn(
+        TaskCenter::spawn(
             TaskKind::BifrostBackgroundHighPriority,
             "bifrost-watchdog",
-            None,
             self.watchdog.run(),
         )?;
 

--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -54,10 +54,9 @@ impl Watchdog {
         match cmd {
             WatchdogCommand::ScheduleMetadataSync => {
                 let bifrost = self.inner.clone();
-                let _ = TaskCenter::current().spawn(
+                let _ = TaskCenter::spawn(
                     TaskKind::MetadataBackgroundSync,
                     "bifrost-metadata-sync",
-                    None,
                     async move {
                         bifrost
                             .sync_metadata()
@@ -70,10 +69,9 @@ impl Watchdog {
             WatchdogCommand::WatchProvider(provider) => {
                 self.live_providers.push(provider.clone());
                 // TODO: Convert to a managed background task
-                let _ = TaskCenter::current().spawn(
+                let _ = TaskCenter::spawn(
                     TaskKind::BifrostBackgroundHighPriority,
                     "bifrost-provider-on-start",
-                    None,
                     async move {
                         provider.post_start().await;
                         Ok(())

--- a/crates/core/derive/src/tc_test.rs
+++ b/crates/core/derive/src/tc_test.rs
@@ -463,8 +463,8 @@ fn parse_knobs(mut input: ItemFn, config: FinalConfig) -> TokenStream {
                 .build()
                 .expect("Failed building task-center");
 
-            let ret = rt.block_on(#body_ident.in_tc(&task_center));
-            rt.block_on(task_center.shutdown_node("completed", 0));
+            let ret = rt.block_on(#body_ident.in_tc(&task_center.handle()));
+            rt.block_on(task_center.to_handle().shutdown_node("completed", 0));
             ret
         }
     };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -46,8 +46,8 @@ pub use metadata::{
 };
 pub use task_center::{
     cancellation_token, cancellation_watcher, is_cancellation_requested, my_node_id, AsyncRuntime,
-    MetadataFutureExt, RuntimeError, TaskCenter, TaskCenterBuildError, TaskCenterBuilder,
-    TaskCenterFutureExt, TaskContext, TaskHandle, TaskId, TaskKind,
+    MetadataFutureExt, RuntimeError, RuntimeRootTaskHandle, TaskCenter, TaskCenterBuildError,
+    TaskCenterBuilder, TaskCenterFutureExt, TaskContext, TaskHandle, TaskId, TaskKind,
 };
 
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod metadata_store;
 mod metric_definitions;
 pub mod network;
 pub mod partitions;
-mod task_center;
+pub mod task_center;
 pub mod worker_api;
 pub use error::*;
 
@@ -44,7 +44,11 @@ pub use metadata::{
     spawn_metadata_manager, Metadata, MetadataBuilder, MetadataKind, MetadataManager,
     MetadataWriter, SyncError, TargetVersion,
 };
-pub use task_center::*;
+pub use task_center::{
+    cancellation_token, cancellation_watcher, is_cancellation_requested, my_node_id, AsyncRuntime,
+    MetadataFutureExt, RuntimeError, TaskCenter, TaskCenterBuildError, TaskCenterBuilder,
+    TaskCenterFutureExt, TaskContext, TaskHandle, TaskId, TaskKind,
+};
 
 #[cfg(any(test, feature = "test-util"))]
 mod test_env;

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -611,7 +611,7 @@ mod tests {
         F: Fn(&Metadata) -> Version,
         S: Fn(&mut T, Version),
     {
-        let tc = TaskCenterBuilder::default().build()?;
+        let tc = TaskCenterBuilder::default().build()?.to_handle();
         tc.block_on(async move {
             let metadata_builder = MetadataBuilder::default();
             let metadata_store_client = MetadataStoreClient::new_in_memory();
@@ -682,7 +682,7 @@ mod tests {
         F: Fn(&Metadata) -> Version,
         I: Fn(&mut T),
     {
-        let tc = TaskCenterBuilder::default().build()?;
+        let tc = TaskCenterBuilder::default().build()?.to_handle();
         tc.block_on(async move {
             let metadata_builder = MetadataBuilder::default();
             let metadata_store_client = MetadataStoreClient::new_in_memory();

--- a/crates/core/src/metadata/mod.rs
+++ b/crates/core/src/metadata/mod.rs
@@ -387,10 +387,9 @@ impl Default for VersionWatch {
 }
 
 pub fn spawn_metadata_manager(metadata_manager: MetadataManager) -> Result<TaskId, ShutdownError> {
-    TaskCenter::current().spawn(
+    TaskCenter::spawn(
         TaskKind::MetadataBackgroundSync,
         "metadata-manager",
-        None,
         metadata_manager.run(),
     )
 }

--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -22,7 +22,7 @@ use restate_types::net::RpcRequest;
 use restate_types::protobuf::node::Header;
 use restate_types::{GenerationalNodeId, NodeId, Version};
 
-use crate::with_metadata;
+use crate::Metadata;
 
 use super::connection::OwnedConnection;
 use super::metric_definitions::CONNECTION_SEND_DURATION;
@@ -425,7 +425,7 @@ impl<M: Targeted + WireEncode> Outgoing<M, HasConnection> {
             NetworkError::ConnectionClosed(connection.peer())
         );
 
-        with_metadata(|metadata| {
+        Metadata::with_current(|metadata| {
             permit.send(self, metadata);
         });
         CONNECTION_SEND_DURATION.record(send_start.elapsed());
@@ -443,7 +443,7 @@ impl<M: Targeted + WireEncode> Outgoing<M, HasConnection> {
             Err(e) => return Err(NetworkSendError::new(self, e)),
         };
 
-        with_metadata(|metadata| {
+        Metadata::with_current(|metadata| {
             permit.send(self, metadata);
         });
         CONNECTION_SEND_DURATION.record(send_start.elapsed());
@@ -459,7 +459,7 @@ impl<M: Targeted + WireEncode> Outgoing<M, HasConnection> {
         let connection = bail_on_error!(self, self.try_upgrade());
         let permit = bail_on_error!(self, connection.try_reserve());
 
-        with_metadata(|metadata| {
+        Metadata::with_current(|metadata| {
             permit.send(self, metadata);
         });
 

--- a/crates/core/src/task_center/builder.rs
+++ b/crates/core/src/task_center/builder.rs
@@ -14,7 +14,7 @@ use tracing::error;
 
 use restate_types::config::CommonOptions;
 
-use super::TaskCenter;
+use super::{OwnedHandle, TaskCenterInner};
 
 static WORKER_ID: AtomicUsize = const { AtomicUsize::new(0) };
 
@@ -78,7 +78,7 @@ impl TaskCenterBuilder {
             .pause_time(true)
     }
 
-    pub fn build(mut self) -> Result<TaskCenter, TaskCenterBuildError> {
+    pub fn build(mut self) -> Result<OwnedHandle, TaskCenterBuildError> {
         let options = self.options.unwrap_or_default();
         if self.default_runtime_handle.is_none() {
             let mut default_runtime_builder = tokio_builder("worker", &options);
@@ -97,13 +97,13 @@ impl TaskCenterBuilder {
         if cfg!(any(test, feature = "test-util")) {
             eprintln!("!!!! Runnning with test-util enabled !!!!");
         }
-        Ok(TaskCenter::new(
+        Ok(OwnedHandle::new(TaskCenterInner::new(
             self.default_runtime_handle.unwrap(),
             self.ingress_runtime_handle.unwrap(),
             self.default_runtime,
             self.ingress_runtime,
             self.pause_time,
-        ))
+        )))
     }
 }
 

--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -1,0 +1,236 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::future::Future;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use restate_types::identifiers::PartitionId;
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+
+use crate::{Metadata, ShutdownError};
+
+use super::{
+    RuntimeError, RuntimeRootTaskHandle, TaskCenterInner, TaskContext, TaskHandle, TaskId, TaskKind,
+};
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("TaskCenter({})", inner.id)]
+pub struct Handle {
+    pub(super) inner: Arc<TaskCenterInner>,
+}
+
+static_assertions::assert_impl_all!(Handle: Send, Sync, Clone);
+
+impl Handle {
+    pub(super) fn new(inner: &Arc<TaskCenterInner>) -> Self {
+        Self {
+            inner: Arc::clone(inner),
+        }
+    }
+
+    pub(crate) fn with_task_context<F, R>(&self, f: F) -> R
+    where
+        F: Fn(&TaskContext) -> R,
+    {
+        self.inner.with_task_context(f)
+    }
+
+    /// Attempt to access task-level overridden metadata first, if we don't have an override,
+    /// fallback to task-center's level metadata.
+    pub(crate) fn with_metadata<F, R>(&self, f: F) -> Option<R>
+    where
+        F: FnOnce(&Metadata) -> R,
+    {
+        self.inner.with_metadata(f)
+    }
+
+    /// Attempt to set the global metadata handle. This should be called once
+    /// at the startup of the node.
+    pub fn try_set_global_metadata(&self, metadata: Metadata) -> bool {
+        self.inner.try_set_global_metadata(metadata)
+    }
+
+    /// Sets the current task_center but doesn't create a task. Use this when you need to run a
+    /// closure within task_center scope.
+    pub fn run_sync<F, O>(&self, f: F) -> O
+    where
+        F: FnOnce() -> O,
+    {
+        self.inner.run_sync(f)
+    }
+
+    /// Sets the current task_center but doesn't create a task. Use this when you need to run a
+    /// future within task_center scope.
+    pub fn block_on<F, O>(&self, future: F) -> O
+    where
+        F: Future<Output = O>,
+    {
+        self.inner.block_on(future)
+    }
+
+    pub fn start_runtime<F>(
+        &self,
+        root_task_kind: TaskKind,
+        runtime_name: &'static str,
+        partition_id: Option<PartitionId>,
+        root_future: impl FnOnce() -> F + Send + 'static,
+    ) -> Result<RuntimeRootTaskHandle<anyhow::Result<()>>, RuntimeError>
+    where
+        F: Future<Output = anyhow::Result<()>> + 'static,
+    {
+        self.inner
+            .start_runtime(root_task_kind, runtime_name, partition_id, root_future)
+    }
+
+    /// Launch a new task
+    pub fn spawn<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        future: F,
+    ) -> Result<TaskId, ShutdownError>
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        self.inner.spawn(kind, name, future)
+    }
+
+    /// Spawn a new task that is a child of the current task. The child task will be cancelled if the parent
+    /// task is cancelled. At the moment, the parent task will not automatically wait for children tasks to
+    /// finish before completion, but this might change in the future if the need for that arises.
+    pub fn spawn_child<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        future: F,
+    ) -> Result<TaskId, ShutdownError>
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        self.inner.spawn_child(kind, name, future)
+    }
+
+    pub fn spawn_unmanaged<F, T>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        future: F,
+    ) -> Result<TaskHandle<T>, ShutdownError>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.inner.spawn_unmanaged(kind, name, future)
+    }
+
+    /// Must be called within a Localset-scoped task, not from a normal spawned task.
+    /// If ran from a non-localset task, this will panic.
+    pub fn spawn_local<F>(
+        &self,
+        kind: TaskKind,
+        name: &'static str,
+        future: F,
+    ) -> Result<TaskId, ShutdownError>
+    where
+        F: Future<Output = anyhow::Result<()>> + 'static,
+    {
+        self.inner.spawn_local(kind, name, future)
+    }
+
+    pub fn metadata(&self) -> Option<Metadata> {
+        self.inner.metadata()
+    }
+
+    /// Spawn a potentially thread-blocking future on a dedicated thread pool
+    pub fn spawn_blocking_unmanaged<F, O>(
+        &self,
+        name: &'static str,
+        future: F,
+    ) -> tokio::task::JoinHandle<O>
+    where
+        F: Future<Output = O> + Send + 'static,
+        O: Send + 'static,
+    {
+        self.inner.spawn_blocking_unmanaged(name, future)
+    }
+
+    /// Take control over the running task from task-center. This returns None if the task was not
+    /// found, completed, or has been cancelled.
+    pub fn take_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {
+        self.inner.take_task(task_id)
+    }
+
+    /// Request cancellation of a task. This returns the join handle if the task was found and was
+    /// not already cancelled or completed. The returned task will not be awaited by task-center on
+    /// shutdown, and it's the responsibility of the caller to join or abort.
+    pub fn cancel_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {
+        self.inner.cancel_task(task_id)
+    }
+
+    /// Signal and wait for tasks to stop.
+    ///
+    ///
+    /// You can select which tasks to cancel. Any None arguments are ignored.
+    /// For example, to shut down all MetadataBackgroundSync tasks:
+    ///
+    ///   cancel_tasks(Some(TaskKind::MetadataBackgroundSync), None)
+    ///
+    /// Or to shut down all tasks for a particular partition ID:
+    ///
+    ///   cancel_tasks(None, Some(partition_id))
+    ///
+    pub async fn cancel_tasks(&self, kind: Option<TaskKind>, partition_id: Option<PartitionId>) {
+        self.inner.cancel_tasks(kind, partition_id).await
+    }
+
+    pub fn shutdown_managed_runtimes(&self) {
+        self.inner.shutdown_managed_runtimes()
+    }
+
+    /// Triggers a shutdown of the system. All running tasks will be asked gracefully
+    /// to cancel but we will only wait for tasks with a TaskKind that has the property
+    /// "OnCancel" set to "wait".
+    #[instrument(level = "error", skip(self, exit_code))]
+    pub async fn shutdown_node(&self, reason: &str, exit_code: i32) {
+        self.inner.shutdown_node(reason, exit_code).await;
+    }
+
+    /// Use to monitor an on-going shutdown when requested
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.inner.global_cancel_token.clone()
+    }
+}
+
+// Shutsdown
+pub struct OwnedHandle {
+    inner: Arc<TaskCenterInner>,
+}
+
+impl OwnedHandle {
+    pub(super) fn new(inner: TaskCenterInner) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub fn handle(&self) -> Handle {
+        Handle::new(&self.inner)
+    }
+
+    pub fn to_handle(self) -> Handle {
+        Handle { inner: self.inner }
+    }
+    /// The exit code that the process should exit with.
+    pub fn exit_code(&self) -> i32 {
+        self.inner.current_exit_code.load(Ordering::Relaxed)
+    }
+}

--- a/crates/core/src/task_center/mod.rs
+++ b/crates/core/src/task_center/mod.rs
@@ -234,6 +234,13 @@ impl TaskCenter {
         Self::current().cancel_tasks(kind, partition_id).await
     }
 
+    /// Triggers a shutdown of the system. All running tasks will be asked gracefully
+    /// to cancel but we will only wait for tasks with a TaskKind that has the property
+    /// "OnCancel" set to "wait".
+    pub async fn shutdown_node(reason: &str, exit_code: i32) {
+        Self::current().shutdown_node(reason, exit_code).await
+    }
+
     #[track_caller]
     pub fn shutdown_managed_runtimes() {
         Self::with_current(|tc| tc.shutdown_managed_runtimes())

--- a/crates/core/src/task_center/monitoring.rs
+++ b/crates/core/src/task_center/monitoring.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use metrics::gauge;
+use tokio::runtime::RuntimeMetrics;
+
+use super::Handle;
+
+pub trait TaskCenterMonitoring {
+    fn default_runtime_metrics(&self) -> RuntimeMetrics;
+
+    fn ingress_runtime_metrics(&self) -> RuntimeMetrics;
+
+    fn managed_runtime_metrics(&self) -> Vec<(&'static str, RuntimeMetrics)>;
+
+    /// How long has the task-center been running?
+    fn age(&self) -> Duration;
+
+    /// Submit telemetry for all runtimes to metrics recorder
+    fn submit_metrics(&self);
+}
+
+impl TaskCenterMonitoring for Handle {
+    fn default_runtime_metrics(&self) -> RuntimeMetrics {
+        self.inner.default_runtime_handle.metrics()
+    }
+
+    fn ingress_runtime_metrics(&self) -> RuntimeMetrics {
+        self.inner.ingress_runtime_handle.metrics()
+    }
+
+    fn managed_runtime_metrics(&self) -> Vec<(&'static str, RuntimeMetrics)> {
+        let guard = self.inner.managed_runtimes.lock();
+        guard.iter().map(|(k, v)| (*k, v.metrics())).collect()
+    }
+
+    /// How long has the task-center been running?
+    fn age(&self) -> Duration {
+        self.inner.start_time.elapsed()
+    }
+
+    /// Submit telemetry for all runtimes to metrics recorder
+    fn submit_metrics(&self) {
+        submit_runtime_metrics("default", self.default_runtime_metrics());
+        submit_runtime_metrics("ingress", self.ingress_runtime_metrics());
+
+        // Partition processor runtimes
+        let processor_runtimes = self.managed_runtime_metrics();
+        for (task_name, metrics) in processor_runtimes {
+            submit_runtime_metrics(task_name, metrics);
+        }
+    }
+}
+
+fn submit_runtime_metrics(runtime: &'static str, stats: RuntimeMetrics) {
+    gauge!("restate.tokio.num_workers", "runtime" => runtime).set(stats.num_workers() as f64);
+    gauge!("restate.tokio.blocking_threads", "runtime" => runtime)
+        .set(stats.num_blocking_threads() as f64);
+    gauge!("restate.tokio.blocking_queue_depth", "runtime" => runtime)
+        .set(stats.blocking_queue_depth() as f64);
+    gauge!("restate.tokio.num_alive_tasks", "runtime" => runtime)
+        .set(stats.num_alive_tasks() as f64);
+    gauge!("restate.tokio.io_driver_ready_count", "runtime" => runtime)
+        .set(stats.io_driver_ready_count() as f64);
+    gauge!("restate.tokio.remote_schedule_count", "runtime" => runtime)
+        .set(stats.remote_schedule_count() as f64);
+    // per worker stats
+    for idx in 0..stats.num_workers() {
+        gauge!("restate.tokio.worker_overflow_count", "runtime" => runtime, "worker" =>
+            idx.to_string())
+        .set(stats.worker_overflow_count(idx) as f64);
+        gauge!("restate.tokio.worker_poll_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_poll_count(idx) as f64);
+        gauge!("restate.tokio.worker_park_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_park_count(idx) as f64);
+        gauge!("restate.tokio.worker_noop_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_noop_count(idx) as f64);
+        gauge!("restate.tokio.worker_steal_count", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_steal_count(idx) as f64);
+        gauge!("restate.tokio.worker_total_busy_duration_seconds", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_total_busy_duration(idx).as_secs_f64());
+        gauge!("restate.tokio.worker_mean_poll_time", "runtime" => runtime, "worker" => idx.to_string())
+            .set(stats.worker_mean_poll_time(idx).as_secs_f64());
+    }
+}

--- a/crates/ingress-http/src/handler/tests.rs
+++ b/crates/ingress-http/src/handler/tests.rs
@@ -25,7 +25,7 @@ use tracing_test::traced_test;
 use restate_core::network::partition_processor_rpc_client::{
     AttachInvocationResponse, GetInvocationOutputResponse,
 };
-use restate_core::TestCoreEnv;
+use restate_core::TestCoreEnv2;
 use restate_test_util::{assert, assert_eq};
 use restate_types::identifiers::{IdempotencyId, InvocationId, ServiceId, WithInvocationId};
 use restate_types::invocation::{
@@ -48,7 +48,7 @@ use super::Handler;
 use crate::handler::responses::X_RESTATE_ID;
 use crate::MockRequestDispatcher;
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn call_service() {
     let greeting_req = GreetingRequest {
@@ -105,7 +105,7 @@ async fn call_service() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn call_service_with_get() {
     let req = hyper::Request::builder()
@@ -165,7 +165,7 @@ async fn call_service_with_get() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn call_virtual_object() {
     let greeting_req = GreetingRequest {
@@ -220,7 +220,7 @@ async fn call_virtual_object() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn send_service() {
     let greeting_req = GreetingRequest {
@@ -265,7 +265,7 @@ async fn send_service() {
     let _: SendResponse = serde_json::from_slice(&response_bytes).unwrap();
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn send_with_delay_service() {
     let greeting_req = GreetingRequest {
@@ -312,7 +312,7 @@ async fn send_with_delay_service() {
     let _: SendResponse = serde_json::from_slice(&response_bytes).unwrap();
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn send_virtual_object() {
     let greeting_req = GreetingRequest {
@@ -358,7 +358,7 @@ async fn send_virtual_object() {
     let _: SendResponse = serde_json::from_slice(&response_bytes).unwrap();
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn idempotency_key_parsing() {
     let greeting_req = GreetingRequest {
@@ -423,7 +423,7 @@ async fn idempotency_key_parsing() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn idempotency_key_and_send() {
     let greeting_req = GreetingRequest {
@@ -478,7 +478,7 @@ async fn idempotency_key_and_send() {
     let _: SendResponse = serde_json::from_slice(&response_bytes).unwrap();
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn idempotency_key_and_send_with_different_invocation_id() {
     let greeting_req = GreetingRequest {
@@ -539,7 +539,7 @@ async fn idempotency_key_and_send_with_different_invocation_id() {
     assert_eq!(send_response.invocation_id, expected_invocation_id);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn attach_with_invocation_id() {
     let invocation_id = InvocationId::mock_random();
@@ -594,7 +594,7 @@ async fn attach_with_invocation_id() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn attach_with_idempotency_id_to_unkeyed_service() {
     let mock_schemas = MockSchemas::default().with_service_and_target(
@@ -650,7 +650,7 @@ async fn attach_with_idempotency_id_to_unkeyed_service() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn attach_with_idempotency_id_to_keyed_service() {
     let mock_schemas = MockSchemas::default().with_service_and_target(
@@ -713,7 +713,7 @@ async fn attach_with_idempotency_id_to_keyed_service() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn get_output_with_invocation_id() {
     let invocation_id = InvocationId::mock_random();
@@ -768,7 +768,7 @@ async fn get_output_with_invocation_id() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn get_output_with_workflow_key() {
     let service_id = ServiceId::new("MyWorkflow", "my-key");
@@ -830,7 +830,7 @@ async fn get_output_with_workflow_key() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn bad_path_service() {
     let response = handle(
@@ -861,7 +861,7 @@ async fn bad_path_service() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn bad_path_virtual_object() {
     let response = handle(
@@ -892,7 +892,7 @@ async fn bad_path_virtual_object() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn unknown_service() {
     let response = handle(
@@ -907,7 +907,7 @@ async fn unknown_service() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn unknown_handler() {
     let response = handle(
@@ -920,7 +920,7 @@ async fn unknown_handler() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn private_service() {
     let response = handle_with_schemas_and_dispatcher(
@@ -941,7 +941,7 @@ async fn private_service() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn invalid_input() {
     let response = handle_with_schemas_and_dispatcher(
@@ -970,7 +970,7 @@ async fn invalid_input() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn set_custom_content_type_on_response() {
     let mock_schemas = MockSchemas::default().with_service_and_target(
@@ -1018,7 +1018,7 @@ async fn set_custom_content_type_on_response() {
     );
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn set_custom_content_type_on_empty_response() {
     let mock_schemas = MockSchemas::default().with_service_and_target(
@@ -1069,7 +1069,7 @@ async fn set_custom_content_type_on_empty_response() {
     );
 }
 
-#[tokio::test]
+#[restate_core::test]
 #[traced_test]
 async fn health() {
     let req = hyper::Request::builder()
@@ -1135,17 +1135,13 @@ where
     <B as http_body::Body>::Error: std::error::Error + Send + Sync + 'static,
     <B as http_body::Body>::Data: Send + Sync + 'static,
 {
-    let node_env = TestCoreEnv::create_with_single_node(1, 1).await;
+    let _env = TestCoreEnv2::create_with_single_node(1, 1).await;
 
     req.extensions_mut()
         .insert(ConnectInfo::new("0.0.0.0:0".parse().unwrap()));
     req.extensions_mut().insert(opentelemetry::Context::new());
 
-    let handler_fut = node_env.tc.run_in_scope(
-        "ingress",
-        None,
-        Handler::new(Live::from_value(schemas), Arc::new(dispatcher)).oneshot(req),
-    );
+    let handler_fut = Handler::new(Live::from_value(schemas), Arc::new(dispatcher)).oneshot(req);
 
     handler_fut.await.unwrap()
 }

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -349,8 +349,6 @@ mod tests {
         TaskCenter::spawn(TaskKind::SystemService, "ingress", ingress.run()).unwrap();
 
         // Wait server to start
-        let address = start_signal.await.unwrap();
-
-        address
+        start_signal.await.unwrap()
     }
 }

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -213,21 +213,14 @@ impl MessageSender {
 
 #[derive(Clone)]
 pub struct ConsumerTask {
-    task_center: TaskCenter,
     client_config: ClientConfig,
     topics: Vec<String>,
     sender: MessageSender,
 }
 
 impl ConsumerTask {
-    pub fn new(
-        task_center: TaskCenter,
-        client_config: ClientConfig,
-        topics: Vec<String>,
-        sender: MessageSender,
-    ) -> Self {
+    pub fn new(client_config: ClientConfig, topics: Vec<String>, sender: MessageSender) -> Self {
         Self {
-            task_center,
             client_config,
             topics,
             sender,
@@ -313,7 +306,7 @@ impl ConsumerTask {
             }
         };
         for task_id in topic_partition_tasks.into_values() {
-            self.task_center.cancel_task(task_id);
+            TaskCenter::cancel_task(task_id);
         }
         result
     }

--- a/crates/ingress-kafka/src/dispatcher.rs
+++ b/crates/ingress-kafka/src/dispatcher.rs
@@ -11,7 +11,7 @@
 use crate::consumer_task::KafkaDeduplicationId;
 use bytes::Bytes;
 use restate_bifrost::Bifrost;
-use restate_core::metadata;
+use restate_core::{my_node_id, Metadata};
 use restate_storage_api::deduplication_table::DedupInformation;
 use restate_types::identifiers::{
     partitioner, InvocationId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
@@ -190,7 +190,7 @@ impl DispatchKafkaEvent for KafkaIngressDispatcher {
         let envelope = wrap_service_invocation_in_envelope(
             partition_key,
             inner,
-            metadata().my_node_id(),
+            my_node_id(),
             deduplication_id.to_string(),
             deduplication_index,
         );
@@ -215,7 +215,7 @@ fn wrap_service_invocation_in_envelope(
     let header = Header {
         source: Source::Ingress {
             node_id: from_node_id,
-            nodes_config_version: metadata().nodes_config_version(),
+            nodes_config_version: Metadata::with_current(|m| m.nodes_config_version()),
         },
         dest: Destination::Processor {
             partition_key,

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -17,7 +17,7 @@ use crate::subscription_controller::task_orchestrator::TaskOrchestrator;
 use anyhow::Context;
 use rdkafka::error::KafkaError;
 use restate_bifrost::Bifrost;
-use restate_core::{cancellation_watcher, task_center};
+use restate_core::cancellation_watcher;
 use restate_types::config::IngressOptions;
 use restate_types::identifiers::SubscriptionId;
 use restate_types::live::LiveLoad;
@@ -142,7 +142,6 @@ impl Service {
 
         // Create the consumer task
         let consumer_task = consumer_task::ConsumerTask::new(
-            task_center(),
             client_config,
             vec![topic.to_string()],
             MessageSender::new(

--- a/crates/log-server/src/lib.rs
+++ b/crates/log-server/src/lib.rs
@@ -21,14 +21,3 @@ mod service;
 
 pub use error::LogServerBuildError;
 pub use service::LogServerService;
-
-#[cfg(test)]
-pub(crate) fn setup_panic_handler() {
-    // Make sure that panics exits the process.
-    let orig_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panic_info| {
-        // invoke the default handler and exit the process
-        orig_hook(panic_info);
-        std::process::exit(1);
-    }));
-}

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -606,7 +606,7 @@ mod tests {
     use test_log::test;
 
     use restate_core::network::OwnedConnection;
-    use restate_core::{MetadataBuilder, TaskCenter, TaskCenterBuilder, TaskCenterFutureExt};
+    use restate_core::{MetadataBuilder, TaskCenter};
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
     use restate_types::live::Live;
@@ -617,747 +617,493 @@ mod tests {
 
     use crate::metadata::LogletStateMap;
     use crate::rocksdb_logstore::{RocksDbLogStore, RocksDbLogStoreBuilder};
-    use crate::setup_panic_handler;
 
     use super::LogletWorker;
 
-    async fn setup() -> Result<(TaskCenter, RocksDbLogStore)> {
-        setup_panic_handler();
-        let tc = TaskCenterBuilder::default_for_tests().build()?;
+    async fn setup() -> Result<RocksDbLogStore> {
         let config = Live::from_value(Configuration::default());
         let common_rocks_opts = config.clone().map(|c| &c.common);
-        let log_store = async {
-            RocksDbManager::init(common_rocks_opts);
-            let metadata_builder = MetadataBuilder::default();
-            assert!(TaskCenter::try_set_global_metadata(
-                metadata_builder.to_metadata()
-            ));
-            // create logstore.
-            let builder = RocksDbLogStoreBuilder::create(
-                config.clone().map(|c| &c.log_server).boxed(),
-                config.map(|c| &c.log_server.rocksdb).boxed(),
-                RecordCache::new(1_000_000),
-            )
-            .await?;
-            let log_store = builder.start(Default::default()).await?;
-            Result::Ok(log_store)
-        }
-        .in_tc(&tc)
+        RocksDbManager::init(common_rocks_opts);
+        let metadata_builder = MetadataBuilder::default();
+        assert!(TaskCenter::try_set_global_metadata(
+            metadata_builder.to_metadata()
+        ));
+        // create logstore.
+        let builder = RocksDbLogStoreBuilder::create(
+            config.clone().map(|c| &c.log_server).boxed(),
+            config.map(|c| &c.log_server.rocksdb).boxed(),
+            RecordCache::new(1_000_000),
+        )
         .await?;
-        Ok((tc, log_store))
+        Ok(builder.start(Default::default()).await?)
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn test_simple_store_flow() -> Result<()> {
-        let (tc, log_store) = setup().await?;
-        async {
-            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-            let loglet_state_map = LogletStateMap::default();
-            let (net_tx, mut net_rx) = mpsc::channel(10);
-            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let log_store = setup().await?;
+        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        let loglet_state_map = LogletStateMap::default();
+        let (net_tx, mut net_rx) = mpsc::channel(10);
+        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
+        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+        let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-            let payloads: Arc<[Record]> = vec![
-                Record::from("a sample record"),
-                Record::from("another record"),
-            ]
-            .into();
+        let payloads: Arc<[Record]> = vec![
+            Record::from("a sample record"),
+            Record::from("another record"),
+        ]
+        .into();
 
-            // offsets 1, 2
-            let msg1 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::OLDEST,
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
+        // offsets 1, 2
+        let msg1 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::OLDEST,
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
 
-            // offsets 3, 4
-            let msg2 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::new(3),
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
+        // offsets 3, 4
+        let msg2 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::new(3),
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
 
-            let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-            let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
-            let msg1_id = msg1.msg_id();
-            let msg2_id = msg2.msg_id();
+        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
+        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1_id = msg1.msg_id();
+        let msg2_id = msg2.msg_id();
 
-            // pipelined writes
-            worker.enqueue_store(msg1).unwrap();
-            worker.enqueue_store(msg2).unwrap();
-            // wait for response (in test-env, it's safe to assume that responses will arrive in order)
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg1_id));
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+        // pipelined writes
+        worker.enqueue_store(msg1).unwrap();
+        worker.enqueue_store(msg2).unwrap();
+        // wait for response (in test-env, it's safe to assume that responses will arrive in order)
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg1_id));
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
-            // response 2
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg2_id));
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(5)));
+        // response 2
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg2_id));
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(5)));
 
-            tc.shutdown_node("test completed", 0).await;
-            RocksDbManager::get().shutdown().await;
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
 
-            Ok(())
-        }
-        .in_tc(&tc)
-        .await
+        Ok(())
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn test_store_and_seal() -> Result<()> {
-        let (tc, log_store) = setup().await?;
-        async {
-            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-            let loglet_state_map = LogletStateMap::default();
-            let (net_tx, mut net_rx) = mpsc::channel(10);
-            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let log_store = setup().await?;
+        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        let loglet_state_map = LogletStateMap::default();
+        let (net_tx, mut net_rx) = mpsc::channel(10);
+        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
+        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+        let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-            let payloads: Arc<[Record]> = vec![
-                Record::from("a sample record"),
-                Record::from("another record"),
-            ]
-            .into();
+        let payloads: Arc<[Record]> = vec![
+            Record::from("a sample record"),
+            Record::from("another record"),
+        ]
+        .into();
 
-            // offsets 1, 2
-            let msg1 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::OLDEST,
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
+        // offsets 1, 2
+        let msg1 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::OLDEST,
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
 
-            let seal1 = Seal {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                sequencer: SEQUENCER,
-            };
+        let seal1 = Seal {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            sequencer: SEQUENCER,
+        };
 
-            let seal2 = Seal {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                sequencer: SEQUENCER,
-            };
+        let seal2 = Seal {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            sequencer: SEQUENCER,
+        };
 
-            // offsets 3, 4
-            let msg2 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::new(3),
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
+        // offsets 3, 4
+        let msg2 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::new(3),
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
 
-            let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-            let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
-            let seal2 = Incoming::for_testing(connection.downgrade(), seal2, None);
-            let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
-            let msg1_id = msg1.msg_id();
-            let seal1_id = seal1.msg_id();
-            let seal2_id = seal2.msg_id();
-            let msg2_id = msg2.msg_id();
+        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
+        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
+        let seal2 = Incoming::for_testing(connection.downgrade(), seal2, None);
+        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1_id = msg1.msg_id();
+        let seal1_id = seal1.msg_id();
+        let seal2_id = seal2.msg_id();
+        let msg2_id = msg2.msg_id();
 
-            worker.enqueue_store(msg1).unwrap();
-            // first store is successful
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg1_id));
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
-            worker.enqueue_seal(seal1).unwrap();
-            // should latch onto existing seal
-            worker.enqueue_seal(seal2).unwrap();
-            // seal takes precedence, but it gets processed in the background. This store is likely to
-            // observe Status::Sealing
-            worker.enqueue_store(msg2).unwrap();
-            // sealing
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg2_id));
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Sealing));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
-            // seal responses can come at any order, but we'll consume waiters queue before we process
-            // store messages.
-            // sealed
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
-            let sealed: Sealed = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(sealed.status, eq(Status::Ok));
-            assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
+        worker.enqueue_store(msg1).unwrap();
+        // first store is successful
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg1_id));
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+        worker.enqueue_seal(seal1).unwrap();
+        // should latch onto existing seal
+        worker.enqueue_seal(seal2).unwrap();
+        // seal takes precedence, but it gets processed in the background. This store is likely to
+        // observe Status::Sealing
+        worker.enqueue_store(msg2).unwrap();
+        // sealing
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg2_id));
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Sealing));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+        // seal responses can come at any order, but we'll consume waiters queue before we process
+        // store messages.
+        // sealed
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
+        let sealed: Sealed = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(sealed.status, eq(Status::Ok));
+        assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
 
-            // sealed2
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
-            let sealed: Sealed = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(sealed.status, eq(Status::Ok));
-            assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
+        // sealed2
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
+        let sealed: Sealed = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(sealed.status, eq(Status::Ok));
+        assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
 
-            // try another store
-            let msg3 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(3)),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::new(3),
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
-            let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
-            let msg3_id = msg3.msg_id();
-            worker.enqueue_store(msg3).unwrap();
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg3_id));
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Sealed));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+        // try another store
+        let msg3 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(3)),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::new(3),
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
+        let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
+        let msg3_id = msg3.msg_id();
+        worker.enqueue_store(msg3).unwrap();
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg3_id));
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Sealed));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
-            // GetLogletInfo
-            // offsets 3, 4
-            let msg = GetLogletInfo {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            };
-            let msg = Incoming::for_testing(connection.downgrade(), msg, None);
-            let msg_id = msg.msg_id();
-            worker.enqueue_get_loglet_info(msg).unwrap();
+        // GetLogletInfo
+        // offsets 3, 4
+        let msg = GetLogletInfo {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+        };
+        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+        let msg_id = msg.msg_id();
+        worker.enqueue_get_loglet_info(msg).unwrap();
 
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg_id));
-            let info: LogletInfo = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(info.status, eq(Status::Ok));
-            assert_that!(info.local_tail, eq(LogletOffset::new(3)));
-            assert_that!(info.trim_point, eq(LogletOffset::INVALID));
-            assert_that!(info.sealed, eq(true));
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg_id));
+        let info: LogletInfo = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(info.status, eq(Status::Ok));
+        assert_that!(info.local_tail, eq(LogletOffset::new(3)));
+        assert_that!(info.trim_point, eq(LogletOffset::INVALID));
+        assert_that!(info.sealed, eq(true));
 
-            tc.shutdown_node("test completed", 0).await;
-            RocksDbManager::get().shutdown().await;
-            Ok(())
-        }
-        .in_tc(&tc)
-        .await
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn test_repair_store() -> Result<()> {
-        let (tc, log_store) = setup().await?;
-        async {
-            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-            const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
-            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-            let loglet_state_map = LogletStateMap::default();
-            let (net_tx, mut net_rx) = mpsc::channel(10);
-            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let log_store = setup().await?;
+        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+        const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        let loglet_state_map = LogletStateMap::default();
+        let (net_tx, mut net_rx) = mpsc::channel(10);
+        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-            let (peer_net_tx, mut peer_net_rx) = mpsc::channel(10);
-            let repair_connection =
-                OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, peer_net_tx);
+        let (peer_net_tx, mut peer_net_rx) = mpsc::channel(10);
+        let repair_connection =
+            OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, peer_net_tx);
 
-            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
+        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+        let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-            let payloads: Arc<[Record]> = vec![
-                Record::from("a sample record"),
-                Record::from("another record"),
-            ]
-            .into();
+        let payloads: Arc<[Record]> = vec![
+            Record::from("a sample record"),
+            Record::from("another record"),
+        ]
+        .into();
 
-            // offsets 1, 2
-            let msg1 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::OLDEST,
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
+        // offsets 1, 2
+        let msg1 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::OLDEST,
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
 
-            // offsets 10, 11
-            let msg2 = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::new(10),
-                flags: StoreFlags::empty(),
-                payloads: payloads.clone(),
-            };
+        // offsets 10, 11
+        let msg2 = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::new(10),
+            flags: StoreFlags::empty(),
+            payloads: payloads.clone(),
+        };
 
-            let seal1 = Seal {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                sequencer: SEQUENCER,
-            };
+        let seal1 = Seal {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+            sequencer: SEQUENCER,
+        };
 
-            // 5, 6
-            let repair_message_before_local_tail = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::new(5),
-                flags: StoreFlags::IgnoreSeal,
-                payloads: payloads.clone(),
-            };
+        // 5, 6
+        let repair_message_before_local_tail = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::new(5),
+            flags: StoreFlags::IgnoreSeal,
+            payloads: payloads.clone(),
+        };
 
-            // 16, 17
-            let repair_message_after_local_tail = Store {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(16)),
-                timeout_at: None,
-                sequencer: SEQUENCER,
-                known_archived: LogletOffset::INVALID,
-                first_offset: LogletOffset::new(16),
-                flags: StoreFlags::IgnoreSeal,
-                payloads: payloads.clone(),
-            };
+        // 16, 17
+        let repair_message_after_local_tail = Store {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(16)),
+            timeout_at: None,
+            sequencer: SEQUENCER,
+            known_archived: LogletOffset::INVALID,
+            first_offset: LogletOffset::new(16),
+            flags: StoreFlags::IgnoreSeal,
+            payloads: payloads.clone(),
+        };
 
-            let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-            let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
-            let repair1 = Incoming::for_testing(
-                repair_connection.downgrade(),
-                repair_message_before_local_tail,
-                None,
-            );
-            let repair2 = Incoming::for_testing(
-                repair_connection.downgrade(),
-                repair_message_after_local_tail,
-                None,
-            );
-            let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
+        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
+        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let repair1 = Incoming::for_testing(
+            repair_connection.downgrade(),
+            repair_message_before_local_tail,
+            None,
+        );
+        let repair2 = Incoming::for_testing(
+            repair_connection.downgrade(),
+            repair_message_after_local_tail,
+            None,
+        );
+        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
 
-            worker.enqueue_store(msg1).unwrap();
-            worker.enqueue_store(msg2).unwrap();
-            // first store is successful
-            let response = net_rx.recv().await.unwrap();
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.sealed, eq(false));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
+        worker.enqueue_store(msg1).unwrap();
+        worker.enqueue_store(msg2).unwrap();
+        // first store is successful
+        let response = net_rx.recv().await.unwrap();
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.sealed, eq(false));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
-            // 10, 11
-            let response = net_rx.recv().await.unwrap();
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.sealed, eq(false));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
+        // 10, 11
+        let response = net_rx.recv().await.unwrap();
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.sealed, eq(false));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
 
-            worker.enqueue_seal(seal1).unwrap();
-            // seal responses can come at any order, but we'll consume waiters queue before we process
-            // store messages.
-            // sealed
-            let response = net_rx.recv().await.unwrap();
-            let sealed: Sealed = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(sealed.status, eq(Status::Ok));
-            assert_that!(sealed.local_tail, eq(LogletOffset::new(12)));
+        worker.enqueue_seal(seal1).unwrap();
+        // seal responses can come at any order, but we'll consume waiters queue before we process
+        // store messages.
+        // sealed
+        let response = net_rx.recv().await.unwrap();
+        let sealed: Sealed = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(sealed.status, eq(Status::Ok));
+        assert_that!(sealed.local_tail, eq(LogletOffset::new(12)));
 
-            // repair store (before local tail, local tail won't move)
-            worker.enqueue_store(repair1).unwrap();
-            let response = peer_net_rx.recv().await.unwrap();
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
+        // repair store (before local tail, local tail won't move)
+        worker.enqueue_store(repair1).unwrap();
+        let response = peer_net_rx.recv().await.unwrap();
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
 
-            worker.enqueue_store(repair2).unwrap();
-            let response = peer_net_rx.recv().await.unwrap();
-            let stored: Stored = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(18)));
+        worker.enqueue_store(repair2).unwrap();
+        let response = peer_net_rx.recv().await.unwrap();
+        let stored: Stored = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(18)));
 
-            // GetLogletInfo
-            // offsets 3, 4
-            let msg = GetLogletInfo {
-                header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-            };
-            let msg = Incoming::for_testing(connection.downgrade(), msg, None);
-            let msg_id = msg.msg_id();
-            worker.enqueue_get_loglet_info(msg).unwrap();
+        // GetLogletInfo
+        // offsets 3, 4
+        let msg = GetLogletInfo {
+            header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+        };
+        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+        let msg_id = msg.msg_id();
+        worker.enqueue_get_loglet_info(msg).unwrap();
 
-            let response = net_rx.recv().await.unwrap();
-            let header = response.header.unwrap();
-            assert_that!(header.in_response_to(), eq(msg_id));
-            let info: LogletInfo = response
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(info.status, eq(Status::Ok));
-            assert_that!(info.local_tail, eq(LogletOffset::new(18)));
-            assert_that!(info.trim_point, eq(LogletOffset::INVALID));
-            assert_that!(info.sealed, eq(true));
-            tc.shutdown_node("test completed", 0).await;
-            RocksDbManager::get().shutdown().await;
-            Ok(())
-        }
-        .in_tc(&tc)
-        .await
+        let response = net_rx.recv().await.unwrap();
+        let header = response.header.unwrap();
+        assert_that!(header.in_response_to(), eq(msg_id));
+        let info: LogletInfo = response
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(info.status, eq(Status::Ok));
+        assert_that!(info.local_tail, eq(LogletOffset::new(18)));
+        assert_that!(info.trim_point, eq(LogletOffset::INVALID));
+        assert_that!(info.sealed, eq(true));
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
     }
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn test_simple_get_records_flow() -> Result<()> {
-        let (tc, log_store) = setup().await?;
-        async {
-            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-            let loglet_state_map = LogletStateMap::default();
-            let (net_tx, mut net_rx) = mpsc::channel(10);
-            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let log_store = setup().await?;
+        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        let loglet_state_map = LogletStateMap::default();
+        let (net_tx, mut net_rx) = mpsc::channel(10);
+        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
 
-            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-            let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
+        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+        let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
 
-            // Populate the log-store with some records (..,2,..,5,..,10, 11)
-            // Note: dots mean we don't have records at those globally committed offsets.
-            worker
-                .enqueue_store(Incoming::for_testing(
-                    connection.downgrade(),
-                    Store {
-                        // faking that offset=1 is released
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(2)),
-                        timeout_at: None,
-                        sequencer: SEQUENCER,
-                        known_archived: LogletOffset::INVALID,
-                        first_offset: LogletOffset::new(2),
-                        flags: StoreFlags::empty(),
-                        payloads: vec![Record::from("record2")].into(),
-                    },
-                    None,
-                ))
-                .unwrap();
+        // Populate the log-store with some records (..,2,..,5,..,10, 11)
+        // Note: dots mean we don't have records at those globally committed offsets.
+        worker
+            .enqueue_store(Incoming::for_testing(
+                connection.downgrade(),
+                Store {
+                    // faking that offset=1 is released
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(2)),
+                    timeout_at: None,
+                    sequencer: SEQUENCER,
+                    known_archived: LogletOffset::INVALID,
+                    first_offset: LogletOffset::new(2),
+                    flags: StoreFlags::empty(),
+                    payloads: vec![Record::from("record2")].into(),
+                },
+                None,
+            ))
+            .unwrap();
 
-            worker
-                .enqueue_store(Incoming::for_testing(
-                    connection.downgrade(),
-                    Store {
-                        // faking that offset=4 is released
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(5)),
-                        timeout_at: None,
-                        sequencer: SEQUENCER,
-                        known_archived: LogletOffset::INVALID,
-                        first_offset: LogletOffset::new(5),
-                        flags: StoreFlags::empty(),
-                        payloads: vec![Record::from(("record5", Keys::Single(11)))].into(),
-                    },
-                    None,
-                ))
-                .unwrap();
+        worker
+            .enqueue_store(Incoming::for_testing(
+                connection.downgrade(),
+                Store {
+                    // faking that offset=4 is released
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(5)),
+                    timeout_at: None,
+                    sequencer: SEQUENCER,
+                    known_archived: LogletOffset::INVALID,
+                    first_offset: LogletOffset::new(5),
+                    flags: StoreFlags::empty(),
+                    payloads: vec![Record::from(("record5", Keys::Single(11)))].into(),
+                },
+                None,
+            ))
+            .unwrap();
 
-            worker
-                .enqueue_store(Incoming::for_testing(
-                    connection.downgrade(),
-                    Store {
-                        // faking that offset=9 is released
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                        timeout_at: None,
-                        sequencer: SEQUENCER,
-                        known_archived: LogletOffset::INVALID,
-                        first_offset: LogletOffset::new(10),
-                        flags: StoreFlags::empty(),
-                        payloads: vec![Record::from("record10"), Record::from("record11")].into(),
-                    },
-                    None,
-                ))
-                .unwrap();
+        worker
+            .enqueue_store(Incoming::for_testing(
+                connection.downgrade(),
+                Store {
+                    // faking that offset=9 is released
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                    timeout_at: None,
+                    sequencer: SEQUENCER,
+                    known_archived: LogletOffset::INVALID,
+                    first_offset: LogletOffset::new(10),
+                    flags: StoreFlags::empty(),
+                    payloads: vec![Record::from("record10"), Record::from("record11")].into(),
+                },
+                None,
+            ))
+            .unwrap();
 
-            // Wait for stores to complete.
-            for _ in 0..3 {
-                let stored: Stored = net_rx
-                    .recv()
-                    .await
-                    .unwrap()
-                    .body
-                    .unwrap()
-                    .try_decode(connection.protocol_version())?;
-                assert_that!(stored.status, eq(Status::Ok));
-            }
-
-            // We expect to see [2, 5]. No trim gaps, no filtered gaps.
-            worker
-                .enqueue_get_records(Incoming::for_testing(
-                    connection.downgrade(),
-                    GetRecords {
-                        // faking that offset=9 is released
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                        filter: KeyFilter::Any,
-                        // no memory limits
-                        total_limit_in_bytes: None,
-                        from_offset: LogletOffset::new(1),
-                        to_offset: LogletOffset::new(7),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let mut records: Records = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(records.status, eq(Status::Ok));
-            assert_that!(records.local_tail, eq(LogletOffset::new(12)));
-            assert_that!(records.sealed, eq(false));
-            assert_that!(records.next_offset, eq(LogletOffset::new(8)));
-            assert_that!(records.records.len(), eq(2));
-            // pop in reverse order
-            for i in [5, 2] {
-                let (offset, record) = records.records.pop().unwrap();
-                assert_that!(offset, eq(LogletOffset::from(i)));
-                assert_that!(record.is_data(), eq(true));
-                let data = record.try_unwrap_data().unwrap();
-                let original: String = data.decode().unwrap();
-                assert_that!(original, eq(format!("record{}", i)));
-            }
-
-            // We expect to see [2, FILTERED(5), 10, 11]. No trim gaps.
-            worker
-                .enqueue_get_records(Incoming::for_testing(
-                    connection.downgrade(),
-                    GetRecords {
-                        // INVALID can be used when we don't have a reasonable value to pass in.
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                        // no memory limits
-                        total_limit_in_bytes: None,
-                        filter: KeyFilter::Within(0..=5),
-                        from_offset: LogletOffset::new(1),
-                        // to a point beyond local tail
-                        to_offset: LogletOffset::new(100),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let mut records: Records = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(records.status, eq(Status::Ok));
-            assert_that!(records.local_tail, eq(LogletOffset::new(12)));
-            assert_that!(records.next_offset, eq(LogletOffset::new(12)));
-            assert_that!(records.sealed, eq(false));
-            assert_that!(records.records.len(), eq(4));
-            // pop() returns records in reverse order
-            for i in [11, 10, 5, 2] {
-                let (offset, record) = records.records.pop().unwrap();
-                assert_that!(offset, eq(LogletOffset::from(i)));
-                if i == 5 {
-                    // this one is filtered
-                    assert_that!(record.is_filtered_gap(), eq(true));
-                    let gap = record.try_unwrap_filtered_gap().unwrap();
-                    assert_that!(gap.to, eq(LogletOffset::new(5)));
-                } else {
-                    assert_that!(record.is_data(), eq(true));
-                    let data = record.try_unwrap_data().unwrap();
-                    let original: String = data.decode().unwrap();
-                    assert_that!(original, eq(format!("record{}", i)));
-                }
-            }
-
-            // Apply memory limits (2 bytes) should always see the first real record.
-            // We expect to see [FILTERED(5), 10]. (11 is not returend due to budget)
-            worker
-                .enqueue_get_records(Incoming::for_testing(
-                    connection.downgrade(),
-                    GetRecords {
-                        // INVALID can be used when we don't have a reasonable value to pass in.
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                        // no memory limits
-                        total_limit_in_bytes: Some(2),
-                        filter: KeyFilter::Within(0..=5),
-                        from_offset: LogletOffset::new(4),
-                        // to a point beyond local tail
-                        to_offset: LogletOffset::new(100),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let mut records: Records = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(records.status, eq(Status::Ok));
-            assert_that!(records.local_tail, eq(LogletOffset::new(12)));
-            assert_that!(records.next_offset, eq(LogletOffset::new(11)));
-            assert_that!(records.sealed, eq(false));
-            assert_that!(records.records.len(), eq(2));
-            // pop() returns records in reverse order
-            for i in [10, 5] {
-                let (offset, record) = records.records.pop().unwrap();
-                assert_that!(offset, eq(LogletOffset::from(i)));
-                if i == 5 {
-                    // this one is filtered
-                    assert_that!(record.is_filtered_gap(), eq(true));
-                    let gap = record.try_unwrap_filtered_gap().unwrap();
-                    assert_that!(gap.to, eq(LogletOffset::new(5)));
-                } else {
-                    assert_that!(record.is_data(), eq(true));
-                    let data = record.try_unwrap_data().unwrap();
-                    let original: String = data.decode().unwrap();
-                    assert_that!(original, eq(format!("record{}", i)));
-                }
-            }
-
-            tc.shutdown_node("test completed", 0).await;
-            RocksDbManager::get().shutdown().await;
-
-            Ok(())
-        }
-        .in_tc(&tc)
-        .await
-    }
-
-    #[test(tokio::test(start_paused = true))]
-    async fn test_trim_basics() -> Result<()> {
-        let (tc, log_store) = setup().await?;
-        async {
-            const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-            const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
-            let loglet_state_map = LogletStateMap::default();
-            let (net_tx, mut net_rx) = mpsc::channel(10);
-            let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
-
-            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-            let worker = LogletWorker::start(LOGLET, log_store.clone(), loglet_state.clone())?;
-
-            assert_that!(loglet_state.trim_point(), eq(LogletOffset::INVALID));
-            assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::OLDEST));
-            // The loglet has no knowledge of global commits, it shouldn't accept trims.
-            worker
-                .enqueue_trim(Incoming::for_testing(
-                    connection.downgrade(),
-                    Trim {
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::OLDEST),
-                        trim_point: LogletOffset::OLDEST,
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let trimmed: Trimmed = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(trimmed.status, eq(Status::Malformed));
-            assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
-            assert_that!(trimmed.sealed, eq(false));
-
-            // The loglet has knowledge of global tail of 10, it should accept trims up to 9 but it
-            // won't move trim point beyond its local tail.
-            worker
-                .enqueue_trim(Incoming::for_testing(
-                    connection.downgrade(),
-                    Trim {
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                        trim_point: LogletOffset::new(9),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let trimmed: Trimmed = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(trimmed.status, eq(Status::Ok));
-            assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
-            assert_that!(trimmed.sealed, eq(false));
-
-            // let's store some records at offsets (5, 6)
-            worker
-                .enqueue_store(Incoming::for_testing(
-                    connection.downgrade(),
-                    Store {
-                        // faking that offset=9 is released
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                        timeout_at: None,
-                        sequencer: SEQUENCER,
-                        known_archived: LogletOffset::INVALID,
-                        first_offset: LogletOffset::new(5),
-                        flags: StoreFlags::empty(),
-                        payloads: vec![Record::from("record5"), Record::from("record6")].into(),
-                    },
-                    None,
-                ))
-                .unwrap();
+        // Wait for stores to complete.
+        for _ in 0..3 {
             let stored: Stored = net_rx
                 .recv()
                 .await
@@ -1366,144 +1112,369 @@ mod tests {
                 .unwrap()
                 .try_decode(connection.protocol_version())?;
             assert_that!(stored.status, eq(Status::Ok));
-            assert_that!(stored.local_tail, eq(LogletOffset::new(7)));
-
-            // trim to 5
-            worker
-                .enqueue_trim(Incoming::for_testing(
-                    connection.downgrade(),
-                    Trim {
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                        trim_point: LogletOffset::new(5),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let trimmed: Trimmed = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(trimmed.status, eq(Status::Ok));
-            assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
-            assert_that!(trimmed.sealed, eq(false));
-
-            // Attempt to read. We expect to see a trim gap (1->5, 6 (data-record))
-            worker
-                .enqueue_get_records(Incoming::for_testing(
-                    connection.downgrade(),
-                    GetRecords {
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                        total_limit_in_bytes: None,
-                        filter: KeyFilter::Any,
-                        from_offset: LogletOffset::OLDEST,
-                        // to a point beyond local tail
-                        to_offset: LogletOffset::new(100),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let mut records: Records = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(records.status, eq(Status::Ok));
-            assert_that!(records.local_tail, eq(LogletOffset::new(7)));
-            assert_that!(records.next_offset, eq(LogletOffset::new(7)));
-            assert_that!(records.sealed, eq(false));
-            assert_that!(records.records.len(), eq(2));
-            // pop() returns records in reverse order
-            for i in [6, 1] {
-                let (offset, record) = records.records.pop().unwrap();
-                assert_that!(offset, eq(LogletOffset::from(i)));
-                if i == 1 {
-                    // this one is a trim gap
-                    assert_that!(record.is_trim_gap(), eq(true));
-                    let gap = record.try_unwrap_trim_gap().unwrap();
-                    assert_that!(gap.to, eq(LogletOffset::new(5)));
-                } else {
-                    assert_that!(record.is_data(), eq(true));
-                    let data = record.try_unwrap_data().unwrap();
-                    let original: String = data.decode().unwrap();
-                    assert_that!(original, eq(format!("record{}", i)));
-                }
-            }
-
-            // trim everything
-            worker
-                .enqueue_trim(Incoming::for_testing(
-                    connection.downgrade(),
-                    Trim {
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
-                        trim_point: LogletOffset::new(9),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let trimmed: Trimmed = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(trimmed.status, eq(Status::Ok));
-            assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
-            assert_that!(trimmed.sealed, eq(false));
-
-            // Attempt to read again. We expect to see a trim gap (1->6)
-            worker
-                .enqueue_get_records(Incoming::for_testing(
-                    connection.downgrade(),
-                    GetRecords {
-                        header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
-                        total_limit_in_bytes: None,
-                        filter: KeyFilter::Any,
-                        from_offset: LogletOffset::OLDEST,
-                        // to a point beyond local tail
-                        to_offset: LogletOffset::new(100),
-                    },
-                    None,
-                ))
-                .unwrap();
-
-            let mut records: Records = net_rx
-                .recv()
-                .await
-                .unwrap()
-                .body
-                .unwrap()
-                .try_decode(connection.protocol_version())?;
-            assert_that!(records.status, eq(Status::Ok));
-            assert_that!(records.local_tail, eq(LogletOffset::new(7)));
-            assert_that!(records.next_offset, eq(LogletOffset::new(7)));
-            assert_that!(records.sealed, eq(false));
-            assert_that!(records.records.len(), eq(1));
-            let (offset, record) = records.records.pop().unwrap();
-            assert_that!(offset, eq(LogletOffset::from(1)));
-            assert_that!(record.is_trim_gap(), eq(true));
-            let gap = record.try_unwrap_trim_gap().unwrap();
-            assert_that!(gap.to, eq(LogletOffset::new(6)));
-
-            // Make sure that we can load the local-tail correctly when loading the loglet_state
-            let loglet_state_map = LogletStateMap::default();
-            let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
-            assert_that!(loglet_state.trim_point(), eq(LogletOffset::new(6)));
-            assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::new(7)));
-
-            tc.shutdown_node("test completed", 0).await;
-            RocksDbManager::get().shutdown().await;
-            Ok(())
         }
-        .in_tc(&tc)
-        .await
+
+        // We expect to see [2, 5]. No trim gaps, no filtered gaps.
+        worker
+            .enqueue_get_records(Incoming::for_testing(
+                connection.downgrade(),
+                GetRecords {
+                    // faking that offset=9 is released
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                    filter: KeyFilter::Any,
+                    // no memory limits
+                    total_limit_in_bytes: None,
+                    from_offset: LogletOffset::new(1),
+                    to_offset: LogletOffset::new(7),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let mut records: Records = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(records.status, eq(Status::Ok));
+        assert_that!(records.local_tail, eq(LogletOffset::new(12)));
+        assert_that!(records.sealed, eq(false));
+        assert_that!(records.next_offset, eq(LogletOffset::new(8)));
+        assert_that!(records.records.len(), eq(2));
+        // pop in reverse order
+        for i in [5, 2] {
+            let (offset, record) = records.records.pop().unwrap();
+            assert_that!(offset, eq(LogletOffset::from(i)));
+            assert_that!(record.is_data(), eq(true));
+            let data = record.try_unwrap_data().unwrap();
+            let original: String = data.decode().unwrap();
+            assert_that!(original, eq(format!("record{}", i)));
+        }
+
+        // We expect to see [2, FILTERED(5), 10, 11]. No trim gaps.
+        worker
+            .enqueue_get_records(Incoming::for_testing(
+                connection.downgrade(),
+                GetRecords {
+                    // INVALID can be used when we don't have a reasonable value to pass in.
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                    // no memory limits
+                    total_limit_in_bytes: None,
+                    filter: KeyFilter::Within(0..=5),
+                    from_offset: LogletOffset::new(1),
+                    // to a point beyond local tail
+                    to_offset: LogletOffset::new(100),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let mut records: Records = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(records.status, eq(Status::Ok));
+        assert_that!(records.local_tail, eq(LogletOffset::new(12)));
+        assert_that!(records.next_offset, eq(LogletOffset::new(12)));
+        assert_that!(records.sealed, eq(false));
+        assert_that!(records.records.len(), eq(4));
+        // pop() returns records in reverse order
+        for i in [11, 10, 5, 2] {
+            let (offset, record) = records.records.pop().unwrap();
+            assert_that!(offset, eq(LogletOffset::from(i)));
+            if i == 5 {
+                // this one is filtered
+                assert_that!(record.is_filtered_gap(), eq(true));
+                let gap = record.try_unwrap_filtered_gap().unwrap();
+                assert_that!(gap.to, eq(LogletOffset::new(5)));
+            } else {
+                assert_that!(record.is_data(), eq(true));
+                let data = record.try_unwrap_data().unwrap();
+                let original: String = data.decode().unwrap();
+                assert_that!(original, eq(format!("record{}", i)));
+            }
+        }
+
+        // Apply memory limits (2 bytes) should always see the first real record.
+        // We expect to see [FILTERED(5), 10]. (11 is not returend due to budget)
+        worker
+            .enqueue_get_records(Incoming::for_testing(
+                connection.downgrade(),
+                GetRecords {
+                    // INVALID can be used when we don't have a reasonable value to pass in.
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                    // no memory limits
+                    total_limit_in_bytes: Some(2),
+                    filter: KeyFilter::Within(0..=5),
+                    from_offset: LogletOffset::new(4),
+                    // to a point beyond local tail
+                    to_offset: LogletOffset::new(100),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let mut records: Records = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(records.status, eq(Status::Ok));
+        assert_that!(records.local_tail, eq(LogletOffset::new(12)));
+        assert_that!(records.next_offset, eq(LogletOffset::new(11)));
+        assert_that!(records.sealed, eq(false));
+        assert_that!(records.records.len(), eq(2));
+        // pop() returns records in reverse order
+        for i in [10, 5] {
+            let (offset, record) = records.records.pop().unwrap();
+            assert_that!(offset, eq(LogletOffset::from(i)));
+            if i == 5 {
+                // this one is filtered
+                assert_that!(record.is_filtered_gap(), eq(true));
+                let gap = record.try_unwrap_filtered_gap().unwrap();
+                assert_that!(gap.to, eq(LogletOffset::new(5)));
+            } else {
+                assert_that!(record.is_data(), eq(true));
+                let data = record.try_unwrap_data().unwrap();
+                let original: String = data.decode().unwrap();
+                assert_that!(original, eq(format!("record{}", i)));
+            }
+        }
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+
+        Ok(())
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn test_trim_basics() -> Result<()> {
+        let log_store = setup().await?;
+        const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        let loglet_state_map = LogletStateMap::default();
+        let (net_tx, mut net_rx) = mpsc::channel(10);
+        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+
+        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+        let worker = LogletWorker::start(LOGLET, log_store.clone(), loglet_state.clone())?;
+
+        assert_that!(loglet_state.trim_point(), eq(LogletOffset::INVALID));
+        assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::OLDEST));
+        // The loglet has no knowledge of global commits, it shouldn't accept trims.
+        worker
+            .enqueue_trim(Incoming::for_testing(
+                connection.downgrade(),
+                Trim {
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::OLDEST),
+                    trim_point: LogletOffset::OLDEST,
+                },
+                None,
+            ))
+            .unwrap();
+
+        let trimmed: Trimmed = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(trimmed.status, eq(Status::Malformed));
+        assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
+        assert_that!(trimmed.sealed, eq(false));
+
+        // The loglet has knowledge of global tail of 10, it should accept trims up to 9 but it
+        // won't move trim point beyond its local tail.
+        worker
+            .enqueue_trim(Incoming::for_testing(
+                connection.downgrade(),
+                Trim {
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                    trim_point: LogletOffset::new(9),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let trimmed: Trimmed = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(trimmed.status, eq(Status::Ok));
+        assert_that!(trimmed.local_tail, eq(LogletOffset::OLDEST));
+        assert_that!(trimmed.sealed, eq(false));
+
+        // let's store some records at offsets (5, 6)
+        worker
+            .enqueue_store(Incoming::for_testing(
+                connection.downgrade(),
+                Store {
+                    // faking that offset=9 is released
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                    timeout_at: None,
+                    sequencer: SEQUENCER,
+                    known_archived: LogletOffset::INVALID,
+                    first_offset: LogletOffset::new(5),
+                    flags: StoreFlags::empty(),
+                    payloads: vec![Record::from("record5"), Record::from("record6")].into(),
+                },
+                None,
+            ))
+            .unwrap();
+        let stored: Stored = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(stored.status, eq(Status::Ok));
+        assert_that!(stored.local_tail, eq(LogletOffset::new(7)));
+
+        // trim to 5
+        worker
+            .enqueue_trim(Incoming::for_testing(
+                connection.downgrade(),
+                Trim {
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                    trim_point: LogletOffset::new(5),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let trimmed: Trimmed = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(trimmed.status, eq(Status::Ok));
+        assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
+        assert_that!(trimmed.sealed, eq(false));
+
+        // Attempt to read. We expect to see a trim gap (1->5, 6 (data-record))
+        worker
+            .enqueue_get_records(Incoming::for_testing(
+                connection.downgrade(),
+                GetRecords {
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                    total_limit_in_bytes: None,
+                    filter: KeyFilter::Any,
+                    from_offset: LogletOffset::OLDEST,
+                    // to a point beyond local tail
+                    to_offset: LogletOffset::new(100),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let mut records: Records = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(records.status, eq(Status::Ok));
+        assert_that!(records.local_tail, eq(LogletOffset::new(7)));
+        assert_that!(records.next_offset, eq(LogletOffset::new(7)));
+        assert_that!(records.sealed, eq(false));
+        assert_that!(records.records.len(), eq(2));
+        // pop() returns records in reverse order
+        for i in [6, 1] {
+            let (offset, record) = records.records.pop().unwrap();
+            assert_that!(offset, eq(LogletOffset::from(i)));
+            if i == 1 {
+                // this one is a trim gap
+                assert_that!(record.is_trim_gap(), eq(true));
+                let gap = record.try_unwrap_trim_gap().unwrap();
+                assert_that!(gap.to, eq(LogletOffset::new(5)));
+            } else {
+                assert_that!(record.is_data(), eq(true));
+                let data = record.try_unwrap_data().unwrap();
+                let original: String = data.decode().unwrap();
+                assert_that!(original, eq(format!("record{}", i)));
+            }
+        }
+
+        // trim everything
+        worker
+            .enqueue_trim(Incoming::for_testing(
+                connection.downgrade(),
+                Trim {
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
+                    trim_point: LogletOffset::new(9),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let trimmed: Trimmed = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(trimmed.status, eq(Status::Ok));
+        assert_that!(trimmed.local_tail, eq(LogletOffset::new(7)));
+        assert_that!(trimmed.sealed, eq(false));
+
+        // Attempt to read again. We expect to see a trim gap (1->6)
+        worker
+            .enqueue_get_records(Incoming::for_testing(
+                connection.downgrade(),
+                GetRecords {
+                    header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
+                    total_limit_in_bytes: None,
+                    filter: KeyFilter::Any,
+                    from_offset: LogletOffset::OLDEST,
+                    // to a point beyond local tail
+                    to_offset: LogletOffset::new(100),
+                },
+                None,
+            ))
+            .unwrap();
+
+        let mut records: Records = net_rx
+            .recv()
+            .await
+            .unwrap()
+            .body
+            .unwrap()
+            .try_decode(connection.protocol_version())?;
+        assert_that!(records.status, eq(Status::Ok));
+        assert_that!(records.local_tail, eq(LogletOffset::new(7)));
+        assert_that!(records.next_offset, eq(LogletOffset::new(7)));
+        assert_that!(records.sealed, eq(false));
+        assert_that!(records.records.len(), eq(1));
+        let (offset, record) = records.records.pop().unwrap();
+        assert_that!(offset, eq(LogletOffset::from(1)));
+        assert_that!(record.is_trim_gap(), eq(true));
+        let gap = record.try_unwrap_trim_gap().unwrap();
+        assert_that!(gap.to, eq(LogletOffset::new(6)));
+
+        // Make sure that we can load the local-tail correctly when loading the loglet_state
+        let loglet_state_map = LogletStateMap::default();
+        let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
+        assert_that!(loglet_state.trim_point(), eq(LogletOffset::new(6)));
+        assert_that!(loglet_state.local_tail().offset(), eq(LogletOffset::new(7)));
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
     }
 }

--- a/crates/metadata-store/src/local/tests.rs
+++ b/crates/metadata-store/src/local/tests.rs
@@ -331,7 +331,7 @@ async fn create_test_environment(
 
     let task_center = &env.tc;
 
-    task_center.run_in_scope_sync(|| RocksDbManager::init(config.clone().map(|c| &c.common)));
+    task_center.run_sync(|| RocksDbManager::init(config.clone().map(|c| &c.common)));
 
     let client = start_metadata_store(
         config.pinned().common.metadata_store_client.clone(),

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = []
-memory-loglet = ["restate-bifrost/memory-loglet"]
+memory-loglet = ["restate-bifrost/memory-loglet", "restate-admin/memory-loglet"]
 replicated-loglet = ["restate-bifrost/replicated-loglet"]
 options_schema = [
     "dep:schemars",

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -335,7 +335,7 @@ impl Node {
         spawn_metadata_manager(self.metadata_manager)?;
 
         // Start partition routing information refresher
-        spawn_partition_routing_refresher(&tc, self.partition_routing_refresher)?;
+        spawn_partition_routing_refresher(self.partition_routing_refresher)?;
 
         let nodes_config =
             Self::upsert_node_config(&self.metadata_store_client, &config.common).await?;

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -63,7 +63,7 @@ impl<T: TransportConnect> NodeSvc for NodeSvcHandler<T> {
         let metadata_server_status = self.health.current_metadata_server_status();
         let log_server_status = self.health.current_log_server_status();
         let age_s = self.task_center.age().as_secs();
-        self.task_center.run_in_scope_sync(|| {
+        self.task_center.run_sync(|| {
             let metadata = metadata();
             Ok(Response::new(IdentResponse {
                 status: node_status.into(),

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -11,7 +11,6 @@
 use bytes::BytesMut;
 use enumset::EnumSet;
 use futures::stream::BoxStream;
-use restate_types::storage::StorageCodec;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 
@@ -21,15 +20,15 @@ use restate_core::network::protobuf::node_svc::{
 };
 use restate_core::network::ConnectionManager;
 use restate_core::network::{ProtocolError, TransportConnect};
-use restate_core::{
-    metadata, MetadataKind, TargetVersion, TaskCenter, TaskCenterFutureExt, TaskKind,
-};
+use restate_core::task_center::TaskCenterMonitoring;
+use restate_core::{task_center, Metadata, MetadataKind, TargetVersion};
 use restate_types::health::Health;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::node::Message;
+use restate_types::storage::StorageCodec;
 
 pub struct NodeSvcHandler<T> {
-    task_center: TaskCenter,
+    task_center: task_center::Handle,
     cluster_name: String,
     roles: EnumSet<Role>,
     health: Health,
@@ -38,7 +37,7 @@ pub struct NodeSvcHandler<T> {
 
 impl<T: TransportConnect> NodeSvcHandler<T> {
     pub fn new(
-        task_center: TaskCenter,
+        task_center: task_center::Handle,
         cluster_name: String,
         roles: EnumSet<Role>,
         health: Health,
@@ -63,24 +62,22 @@ impl<T: TransportConnect> NodeSvc for NodeSvcHandler<T> {
         let metadata_server_status = self.health.current_metadata_server_status();
         let log_server_status = self.health.current_log_server_status();
         let age_s = self.task_center.age().as_secs();
-        self.task_center.run_sync(|| {
-            let metadata = metadata();
-            Ok(Response::new(IdentResponse {
-                status: node_status.into(),
-                node_id: Some(metadata.my_node_id().into()),
-                roles: self.roles.iter().map(|r| r.to_string()).collect(),
-                cluster_name: self.cluster_name.clone(),
-                age_s,
-                admin_status: admin_status.into(),
-                worker_status: worker_status.into(),
-                metadata_server_status: metadata_server_status.into(),
-                log_server_status: log_server_status.into(),
-                nodes_config_version: metadata.nodes_config_version().into(),
-                logs_version: metadata.logs_version().into(),
-                schema_version: metadata.schema_version().into(),
-                partition_table_version: metadata.partition_table_version().into(),
-            }))
-        })
+        let metadata = Metadata::current();
+        Ok(Response::new(IdentResponse {
+            status: node_status.into(),
+            node_id: Some(metadata.my_node_id().into()),
+            roles: self.roles.iter().map(|r| r.to_string()).collect(),
+            cluster_name: self.cluster_name.clone(),
+            age_s,
+            admin_status: admin_status.into(),
+            worker_status: worker_status.into(),
+            metadata_server_status: metadata_server_status.into(),
+            log_server_status: log_server_status.into(),
+            nodes_config_version: metadata.nodes_config_version().into(),
+            logs_version: metadata.logs_version().into(),
+            schema_version: metadata.schema_version().into(),
+            partition_table_version: metadata.partition_table_version().into(),
+        }))
     }
 
     type CreateConnectionStream = BoxStream<'static, Result<Message, Status>>;
@@ -102,7 +99,6 @@ impl<T: TransportConnect> NodeSvc for NodeSvcHandler<T> {
         let output_stream = self
             .connections
             .accept_incoming_connection(transformed)
-            .in_current_tc_as_task(TaskKind::InPlace, "accept-connection")
             .await?;
 
         // For uniformity with outbound connections, we map all responses to Ok, we never rely on
@@ -116,7 +112,7 @@ impl<T: TransportConnect> NodeSvc for NodeSvcHandler<T> {
         request: Request<GetMetadataRequest>,
     ) -> Result<Response<GetMetadataResponse>, Status> {
         let request = request.into_inner();
-        let metadata = metadata();
+        let metadata = Metadata::current();
         let kind = request.kind.into();
         if request.sync {
             metadata

--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -18,6 +18,7 @@ use metrics_util::layers::Layer;
 use metrics_util::MetricKindMask;
 use rocksdb::statistics::{Histogram, Ticker};
 
+use restate_core::task_center::TaskCenterMonitoring;
 use restate_rocksdb::{CfName, RocksDbManager};
 use restate_types::config::CommonOptions;
 

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -13,7 +13,7 @@ use tonic::codec::CompressionEncoding;
 
 use restate_core::network::protobuf::node_svc::node_svc_server::NodeSvcServer;
 use restate_core::network::{ConnectionManager, NetworkServerBuilder, TransportConnect};
-use restate_core::task_center;
+use restate_core::TaskCenter;
 use restate_types::config::CommonOptions;
 use restate_types::health::Health;
 
@@ -31,10 +31,9 @@ impl NetworkServer {
         mut server_builder: NetworkServerBuilder,
         options: CommonOptions,
     ) -> Result<(), anyhow::Error> {
-        let tc = task_center();
         // Configure Metric Exporter
         let mut state_builder = NodeCtrlHandlerStateBuilder::default();
-        state_builder.task_center(tc.clone());
+        state_builder.task_center(TaskCenter::current());
 
         if !options.disable_prometheus {
             state_builder.prometheus_handle(Some(install_global_prometheus_recorder(&options)));
@@ -51,7 +50,7 @@ impl NetworkServer {
 
         server_builder.register_grpc_service(
             NodeSvcServer::new(NodeSvcHandler::new(
-                tc,
+                TaskCenter::current(),
                 options.cluster_name().to_owned(),
                 options.roles,
                 health,

--- a/crates/node/src/network_server/state.rs
+++ b/crates/node/src/network_server/state.rs
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use metrics_exporter_prometheus::PrometheusHandle;
-use restate_core::TaskCenter;
+use restate_core::task_center;
 
 #[derive(Clone, derive_builder::Builder)]
 pub struct NodeCtrlHandlerState {
     #[builder(default)]
     pub prometheus_handle: Option<PrometheusHandle>,
-    pub task_center: TaskCenter,
+    pub task_center: task_center::Handle,
 }

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -87,7 +87,7 @@ impl<T: TransportConnect> AdminRole<T> {
         } else {
             let remote_scanner_manager = RemoteScannerManager::new(
                 create_remote_scanner_service(networking.clone(), router_builder),
-                create_partition_locator(partition_routing),
+                create_partition_locator(partition_routing, metadata.clone()),
             );
 
             // need to create a remote query context since we are not co-located with a worker role

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -62,12 +62,11 @@ impl<T: TransportConnect> AdminRole<T> {
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         health_status: HealthStatus<AdminStatus>,
-        task_center: TaskCenter,
         bifrost: Bifrost,
         updateable_config: Live<Configuration>,
-        metadata: Metadata,
         partition_routing: PartitionRouting,
         networking: Networking<T>,
+        metadata: Metadata,
         metadata_writer: MetadataWriter,
         server_builder: &mut NetworkServerBuilder,
         router_builder: &mut MessageRouterBuilder,
@@ -87,18 +86,14 @@ impl<T: TransportConnect> AdminRole<T> {
             query_context
         } else {
             let remote_scanner_manager = RemoteScannerManager::new(
-                create_remote_scanner_service(
-                    networking.clone(),
-                    task_center.clone(),
-                    router_builder,
-                ),
-                create_partition_locator(partition_routing, metadata.clone()),
+                create_remote_scanner_service(networking.clone(), router_builder),
+                create_partition_locator(partition_routing),
             );
 
             // need to create a remote query context since we are not co-located with a worker role
             QueryContext::create(
                 &config.admin.query_engine,
-                SelectPartitionsFromMetadata::new(metadata.clone()),
+                SelectPartitionsFromMetadata,
                 None,
                 Option::<EmptyInvokerStatusHandle>::None,
                 metadata.updateable_schema(),
@@ -122,7 +117,6 @@ impl<T: TransportConnect> AdminRole<T> {
                 updateable_config.clone(),
                 health_status,
                 bifrost,
-                metadata,
                 networking,
                 router_builder,
                 server_builder,

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -39,7 +39,7 @@ static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -47,7 +47,7 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
         .expect("task_center builds");
 
     let worker_options = WorkerOptions::default();
-    tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+    tc.run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
     let rocksdb = tc.block_on(async {
         //
         // setup

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -44,7 +44,8 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
     let tc = TaskCenterBuilder::default()
         .default_runtime_handle(rt.handle().clone())
         .build()
-        .expect("task_center builds");
+        .expect("task_center builds")
+        .to_handle();
 
     let worker_options = WorkerOptions::default();
     tc.run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));

--- a/crates/partition-store/src/tests/idempotency_table_test/mod.rs
+++ b/crates/partition-store/src/tests/idempotency_table_test/mod.rs
@@ -31,7 +31,7 @@ const IDEMPOTENCY_ID_2: IdempotencyId =
 const IDEMPOTENCY_ID_3: IdempotencyId =
     IdempotencyId::unkeyed(10, "my-component", "my-handler-2", "my-key");
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_idempotency_key() {
     let mut rocksdb = storage_test_environment().await;
 

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -174,7 +174,7 @@ async fn verify_all_svc_with_status_invoked<T: InvocationStatusTable>(txn: &mut 
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_invocation_status() {
     let mut rocksdb = storage_test_environment().await;
     let mut txn = rocksdb.transaction();
@@ -184,7 +184,7 @@ async fn test_invocation_status() {
     verify_all_svc_with_status_invoked(&mut txn).await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_migration() {
     let mut rocksdb = storage_test_environment().await;
 

--- a/crates/partition-store/src/tests/journal_table_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_table_test/mod.rs
@@ -129,7 +129,7 @@ async fn verify_journal_deleted<T: JournalTable>(txn: &mut T) {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn journal_tests() {
     let mut rocksdb = storage_test_environment().await;
 

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -17,7 +17,6 @@ use futures::Stream;
 use tokio_stream::StreamExt;
 
 use crate::{OpenMode, PartitionStore, PartitionStoreManager};
-use restate_core::TaskCenterBuilder;
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::StorageError;
 use restate_types::config::{CommonOptions, WorkerOptions};
@@ -47,12 +46,7 @@ async fn storage_test_environment_with_manager() -> (PartitionStoreManager, Part
     //
     // create a rocksdb storage from options
     //
-    let tc = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .ingress_runtime_handle(tokio::runtime::Handle::current())
-        .build()
-        .expect("task_center builds");
-    tc.run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+    RocksDbManager::init(Constant::new(CommonOptions::default()));
     let worker_options = Live::from_value(WorkerOptions::default());
     let manager = PartitionStoreManager::create(
         worker_options.clone().map(|c| &c.storage),
@@ -75,7 +69,7 @@ async fn storage_test_environment_with_manager() -> (PartitionStoreManager, Part
     (manager, store)
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_read_write() {
     let (manager, store) = storage_test_environment_with_manager().await;
 

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -52,7 +52,7 @@ async fn storage_test_environment_with_manager() -> (PartitionStoreManager, Part
         .ingress_runtime_handle(tokio::runtime::Handle::current())
         .build()
         .expect("task_center builds");
-    tc.run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+    tc.run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
     let worker_options = Live::from_value(WorkerOptions::default());
     let manager = PartitionStoreManager::create(
         worker_options.clone().map(|c| &c.storage),

--- a/crates/partition-store/src/tests/promise_table_test/mod.rs
+++ b/crates/partition-store/src/tests/promise_table_test/mod.rs
@@ -34,7 +34,7 @@ const PROMISE_COMPLETED: Promise = Promise {
     state: PromiseState::Completed(EntryResult::Success(Bytes::from_static(b"{}"))),
 };
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_promise_table() {
     let mut rocksdb = storage_test_environment().await;
 

--- a/crates/partition-store/src/tests/state_table_test/mod.rs
+++ b/crates/partition-store/src/tests/state_table_test/mod.rs
@@ -111,7 +111,7 @@ pub(crate) async fn run_tests(mut rocksdb: PartitionStore) {
     verify_prefix_scan_after_delete(&mut txn).await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_all() {
     let mut rocksdb = storage_test_environment().await;
 

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -18,7 +18,7 @@ use rocksdb::{BlockBasedOptions, Cache, LogLevel, WriteBufferManager};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
-use restate_core::{cancellation_watcher, task_center, ShutdownError, TaskKind};
+use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskKind};
 use restate_serde_util::ByteCount;
 use restate_types::config::{
     CommonOptions, Configuration, RocksDbLogLevel, RocksDbOptions, StatisticsLevel,
@@ -121,14 +121,12 @@ impl RocksDbManager {
 
         DB_MANAGER.set(manager).expect("DBManager initialized once");
         // Start db monitoring.
-        task_center()
-            .spawn(
-                TaskKind::SystemService,
-                "db-manager",
-                None,
-                DbWatchdog::run(Self::get(), watchdog_rx, base_opts),
-            )
-            .expect("run db watchdog");
+        TaskCenter::spawn(
+            TaskKind::SystemService,
+            "db-manager",
+            DbWatchdog::run(Self::get(), watchdog_rx, base_opts),
+        )
+        .expect("run db watchdog");
 
         Self::get()
     }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -323,25 +323,13 @@ impl AsRef<SessionContext> for QueryContext {
 
 /// Newtype to add debug implementation which is required for [`SelectPartitions`].
 #[derive(Clone, derive_more::Debug)]
-pub struct SelectPartitionsFromMetadata {
-    #[debug(skip)]
-    metadata: Metadata,
-}
-
-impl SelectPartitionsFromMetadata {
-    pub fn new(metadata: Metadata) -> Self {
-        Self { metadata }
-    }
-}
+pub struct SelectPartitionsFromMetadata;
 
 #[async_trait]
 impl SelectPartitions for SelectPartitionsFromMetadata {
     async fn get_live_partitions(&self) -> Result<Vec<PartitionId>, GenericError> {
-        Ok(self
-            .metadata
-            .partition_table_ref()
-            .partition_ids()
-            .cloned()
-            .collect())
+        Ok(Metadata::with_current(|m| {
+            m.partition_table_ref().partition_ids().cloned().collect()
+        }))
     }
 }

--- a/crates/storage-query-datafusion/src/idempotency/tests.rs
+++ b/crates/storage-query-datafusion/src/idempotency/tests.rs
@@ -16,20 +16,13 @@ use datafusion::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use googletest::all;
 use googletest::prelude::{assert_that, eq};
-use restate_core::TaskCenterBuilder;
 use restate_storage_api::idempotency_table::{IdempotencyMetadata, IdempotencyTable};
 use restate_storage_api::Transaction;
 use restate_types::identifiers::{IdempotencyId, InvocationId};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_idempotency_key() {
-    let tc = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .build()
-        .expect("task_center builds");
-    let mut engine = tc
-        .run_in_scope("mock-query-engine", None, MockQueryEngine::create())
-        .await;
+    let mut engine = MockQueryEngine::create().await;
 
     let mut tx = engine.partition_store().transaction();
     let invocation_id_1 = InvocationId::mock_random();

--- a/crates/storage-query-datafusion/src/inbox/tests.rs
+++ b/crates/storage-query-datafusion/src/inbox/tests.rs
@@ -15,21 +15,14 @@ use datafusion::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use googletest::all;
 use googletest::prelude::{assert_that, eq};
-use restate_core::TaskCenterBuilder;
 use restate_storage_api::inbox_table::{InboxEntry, InboxTable};
 use restate_storage_api::Transaction;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::InvocationTarget;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_inbox() {
-    let tc = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .build()
-        .expect("task_center builds");
-    let mut engine = tc
-        .run_in_scope("mock-query-engine", None, MockQueryEngine::create())
-        .await;
+    let mut engine = MockQueryEngine::create().await;
 
     let mut tx = engine.partition_store().transaction();
     let invocation_target = InvocationTarget::mock_virtual_object();

--- a/crates/storage-query-datafusion/src/journal/tests.rs
+++ b/crates/storage-query-datafusion/src/journal/tests.rs
@@ -17,7 +17,6 @@ use futures::StreamExt;
 use googletest::all;
 use googletest::prelude::{assert_that, eq};
 use prost::Message;
-use restate_core::TaskCenterBuilder;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_api::journal_table::{JournalEntry, JournalTable};
 use restate_storage_api::Transaction;
@@ -29,15 +28,9 @@ use restate_types::journal::enriched::{
 use restate_types::journal::{Entry, EntryType, InputEntry};
 use restate_types::service_protocol;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_entries() {
-    let tc = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .build()
-        .expect("task_center builds");
-    let mut engine = tc
-        .run_in_scope("mock-query-engine", None, MockQueryEngine::create())
-        .await;
+    let mut engine = MockQueryEngine::create().await;
 
     let mut tx = engine.partition_store().transaction();
     let journal_invocation_id = InvocationId::mock_random();
@@ -131,15 +124,9 @@ async fn get_entries() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn select_count_star() {
-    let tc = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .build()
-        .expect("task_center builds");
-    let mut engine = tc
-        .run_in_scope("mock-query-engine", None, MockQueryEngine::create())
-        .await;
+    let mut engine = MockQueryEngine::create().await;
 
     let mut tx = engine.partition_store().transaction();
     let journal_invocation_id = InvocationId::mock_random();

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -19,7 +19,6 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
 use googletest::matcher::{Matcher, MatcherResult};
-use restate_core::task_center;
 use restate_invoker_api::status_handle::test_util::MockStatusHandle;
 use restate_invoker_api::StatusHandle;
 use restate_partition_store::{OpenMode, PartitionStore, PartitionStoreManager};
@@ -161,7 +160,7 @@ impl MockQueryEngine {
             + 'static,
     ) -> Self {
         // Prepare Rocksdb
-        task_center().run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+        RocksDbManager::init(Constant::new(CommonOptions::default()));
         let worker_options = Live::from_value(WorkerOptions::default());
         let manager = PartitionStoreManager::create(
             worker_options.clone().map(|c| &c.storage),

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -161,8 +161,7 @@ impl MockQueryEngine {
             + 'static,
     ) -> Self {
         // Prepare Rocksdb
-        task_center()
-            .run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+        task_center().run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
         let worker_options = Live::from_value(WorkerOptions::default());
         let manager = PartitionStoreManager::create(
             worker_options.clone().map(|c| &c.storage),

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -162,7 +162,7 @@ impl MockQueryEngine {
     ) -> Self {
         // Prepare Rocksdb
         task_center()
-            .run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+            .run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
         let worker_options = Live::from_value(WorkerOptions::default());
         let manager = PartitionStoreManager::create(
             worker_options.clone().map(|c| &c.storage),

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -16,8 +16,8 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, bail};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::SendableRecordBatchStream;
+use restate_core::my_node_id;
 use restate_core::partitions::PartitionRouting;
-use restate_core::Metadata;
 use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::NodeId;
 
@@ -79,17 +79,10 @@ pub trait PartitionLocator: Send + Sync + 'static {
 #[derive(Clone)]
 struct MetadataAwarePartitionLocator {
     partition_routing: PartitionRouting,
-    metadata: Metadata,
 }
 
-pub fn create_partition_locator(
-    partition_routing: PartitionRouting,
-    metadata: Metadata,
-) -> Arc<dyn PartitionLocator> {
-    Arc::new(MetadataAwarePartitionLocator {
-        partition_routing,
-        metadata,
-    })
+pub fn create_partition_locator(partition_routing: PartitionRouting) -> Arc<dyn PartitionLocator> {
+    Arc::new(MetadataAwarePartitionLocator { partition_routing })
 }
 
 impl PartitionLocator for MetadataAwarePartitionLocator {
@@ -97,7 +90,7 @@ impl PartitionLocator for MetadataAwarePartitionLocator {
         &self,
         partition_id: PartitionId,
     ) -> anyhow::Result<PartitionLocation> {
-        let my_node_id = self.metadata.my_node_id();
+        let my_node_id = my_node_id();
         match self.partition_routing.get_node_by_partition(partition_id) {
             None => {
                 self.partition_routing.request_refresh();

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -16,8 +16,8 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, bail};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::SendableRecordBatchStream;
-use restate_core::my_node_id;
 use restate_core::partitions::PartitionRouting;
+use restate_core::Metadata;
 use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::NodeId;
 
@@ -79,10 +79,17 @@ pub trait PartitionLocator: Send + Sync + 'static {
 #[derive(Clone)]
 struct MetadataAwarePartitionLocator {
     partition_routing: PartitionRouting,
+    metadata: Metadata,
 }
 
-pub fn create_partition_locator(partition_routing: PartitionRouting) -> Arc<dyn PartitionLocator> {
-    Arc::new(MetadataAwarePartitionLocator { partition_routing })
+pub fn create_partition_locator(
+    partition_routing: PartitionRouting,
+    metadata: Metadata,
+) -> Arc<dyn PartitionLocator> {
+    Arc::new(MetadataAwarePartitionLocator {
+        partition_routing,
+        metadata,
+    })
 }
 
 impl PartitionLocator for MetadataAwarePartitionLocator {
@@ -90,7 +97,7 @@ impl PartitionLocator for MetadataAwarePartitionLocator {
         &self,
         partition_id: PartitionId,
     ) -> anyhow::Result<PartitionLocation> {
-        let my_node_id = my_node_id();
+        let my_node_id = self.metadata.my_node_id();
         match self.partition_routing.get_node_by_partition(partition_id) {
             None => {
                 self.partition_routing.request_refresh();

--- a/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
@@ -105,8 +105,6 @@ impl RemoteQueryScannerServer {
         let mut scanners: HashMap<ScannerId, Scanner> = Default::default();
         let mut interval = time::interval(expire_old_scanners_after);
 
-        let node_id = my_node_id();
-
         loop {
             tokio::select! {
                         biased;
@@ -119,7 +117,7 @@ impl RemoteQueryScannerServer {
                         },
                         Some(scan_req) = open_stream.next() => {
                             next_scanner_id += 1;
-                            let scanner_id = ScannerId(node_id, next_scanner_id);
+                            let scanner_id = ScannerId(my_node_id(), next_scanner_id);
                             Self::on_open(scanner_id, scan_req, &mut scanners, query_context.clone()).await;
                         },
                         Some(next_req) = next_stream.next() => {

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -8,14 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::mocks::*;
-use crate::row;
+use std::time::{Duration, SystemTime};
+
 use datafusion::arrow::array::{LargeStringArray, UInt64Array};
 use datafusion::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use googletest::all;
 use googletest::prelude::{assert_that, eq};
-use restate_core::TaskCenterBuilder;
+
 use restate_invoker_api::status_handle::test_util::MockStatusHandle;
 use restate_invoker_api::status_handle::InvocationStatusReportInner;
 use restate_invoker_api::{InvocationErrorReport, InvocationStatusReport};
@@ -29,46 +29,39 @@ use restate_types::identifiers::PartitionId;
 use restate_types::identifiers::{DeploymentId, InvocationId};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal::EntryType;
-use std::time::{Duration, SystemTime};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+use crate::mocks::*;
+use crate::row;
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_sys_invocation() {
     let invocation_id = InvocationId::mock_random();
     let invocation_target = InvocationTarget::service("MySvc", "MyMethod");
     let invocation_error = InvocationError::internal("my error");
 
-    let tc = TaskCenterBuilder::default()
-        .default_runtime_handle(tokio::runtime::Handle::current())
-        .build()
-        .expect("task_center builds");
-    let mut engine = tc
-        .run_in_scope(
-            "mock-query-engine",
-            None,
-            MockQueryEngine::create_with(
-                MockStatusHandle::default().with(InvocationStatusReport::new(
-                    invocation_id,
-                    (PartitionId::MIN, LeaderEpoch::INITIAL),
-                    InvocationStatusReportInner {
-                        in_flight: false,
-                        start_count: 1,
-                        last_start_at: SystemTime::now() - Duration::from_secs(10),
-                        last_retry_attempt_failure: Some(InvocationErrorReport {
-                            err: invocation_error.clone(),
-                            doc_error_code: None,
-                            related_entry_index: Some(1),
-                            related_entry_name: Some("my-side-effect".to_string()),
-                            related_entry_type: Some(EntryType::Run),
-                        }),
-                        next_retry_at: Some(SystemTime::now() + Duration::from_secs(10)),
-                        last_attempt_deployment_id: Some(DeploymentId::new()),
-                        last_attempt_server: Some("restate-sdk-java/0.8.0".to_owned()),
-                    },
-                )),
-                MockSchemas::default(),
-            ),
-        )
-        .await;
+    let mut engine = MockQueryEngine::create_with(
+        MockStatusHandle::default().with(InvocationStatusReport::new(
+            invocation_id,
+            (PartitionId::MIN, LeaderEpoch::INITIAL),
+            InvocationStatusReportInner {
+                in_flight: false,
+                start_count: 1,
+                last_start_at: SystemTime::now() - Duration::from_secs(10),
+                last_retry_attempt_failure: Some(InvocationErrorReport {
+                    err: invocation_error.clone(),
+                    doc_error_code: None,
+                    related_entry_index: Some(1),
+                    related_entry_name: Some("my-side-effect".to_string()),
+                    related_entry_type: Some(EntryType::Run),
+                }),
+                next_retry_at: Some(SystemTime::now() + Duration::from_secs(10)),
+                last_attempt_deployment_id: Some(DeploymentId::new()),
+                last_attempt_server: Some("restate-sdk-java/0.8.0".to_owned()),
+            },
+        )),
+        MockSchemas::default(),
+    )
+    .await;
 
     let mut tx = engine.partition_store().transaction();
     tx.put_invocation_status(

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -218,6 +218,7 @@ pub struct LogletConfig {
 }
 
 impl LogletConfig {
+    #[cfg(any(test, feature = "memory-loglet"))]
     pub fn for_testing() -> Self {
         Self {
             kind: ProviderKind::InMemory,

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -218,7 +218,6 @@ pub struct LogletConfig {
 }
 
 impl LogletConfig {
-    #[cfg(any(test, feature = "test-util"))]
     pub fn for_testing() -> Self {
         Self {
             kind: ProviderKind::InMemory,

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -150,7 +150,7 @@ impl Worker {
 
         let remote_scanner_manager = RemoteScannerManager::new(
             create_remote_scanner_service(networking, router_builder),
-            create_partition_locator(partition_routing),
+            create_partition_locator(partition_routing, metadata.clone()),
         );
         let schema = metadata.updateable_schema();
         let storage_query_context = QueryContext::create(

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -29,7 +29,7 @@ use restate_core::network::Networking;
 use restate_core::network::TransportConnect;
 use restate_core::partitions::PartitionRouting;
 use restate_core::worker_api::ProcessorsManagerHandle;
-use restate_core::{task_center, Metadata, TaskKind};
+use restate_core::{Metadata, TaskKind};
 use restate_ingress_kafka::Service as IngressKafkaService;
 use restate_invoker_impl::InvokerHandle as InvokerChannelServiceHandle;
 use restate_metadata_store::MetadataStoreClient;
@@ -149,7 +149,7 @@ impl Worker {
         router_builder.add_message_handler(partition_processor_manager.message_handler());
 
         let remote_scanner_manager = RemoteScannerManager::new(
-            create_remote_scanner_service(networking, task_center(), router_builder),
+            create_remote_scanner_service(networking, router_builder),
             create_partition_locator(partition_routing, metadata.clone()),
         );
         let schema = metadata.updateable_schema();

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -150,12 +150,12 @@ impl Worker {
 
         let remote_scanner_manager = RemoteScannerManager::new(
             create_remote_scanner_service(networking, router_builder),
-            create_partition_locator(partition_routing, metadata.clone()),
+            create_partition_locator(partition_routing),
         );
         let schema = metadata.updateable_schema();
         let storage_query_context = QueryContext::create(
             &config.admin.query_engine,
-            SelectPartitionsFromMetadata::new(metadata),
+            SelectPartitionsFromMetadata,
             Some(partition_store_manager.clone()),
             Some(partition_processor_manager.invokers_status_reader()),
             schema,

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -257,22 +257,20 @@ mod tests {
             ),
         ]);
 
-        TaskCenter::current()
-            .spawn(
-                TaskKind::Cleaner,
-                "cleaner",
-                Some(PartitionId::MIN),
-                Cleaner::new(
-                    PartitionId::MIN,
-                    LeaderEpoch::INITIAL,
-                    mock_storage,
-                    bifrost.clone(),
-                    RangeInclusive::new(PartitionKey::MIN, PartitionKey::MAX),
-                    Duration::from_secs(1),
-                )
-                .run(),
+        TaskCenter::spawn(
+            TaskKind::Cleaner,
+            "cleaner",
+            Cleaner::new(
+                PartitionId::MIN,
+                LeaderEpoch::INITIAL,
+                mock_storage,
+                bifrost.clone(),
+                RangeInclusive::new(PartitionKey::MIN, PartitionKey::MAX),
+                Duration::from_secs(1),
             )
-            .unwrap();
+            .run(),
+        )
+        .unwrap();
 
         // By yielding once we let the cleaner task run, and perform the cleanup
         tokio::task::yield_now().await;

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -23,7 +23,7 @@ use tracing::{debug, instrument, warn};
 
 use restate_bifrost::Bifrost;
 use restate_core::network::Reciprocal;
-use restate_core::{metadata, my_node_id, ShutdownError, TaskCenter, TaskKind};
+use restate_core::{my_node_id, ShutdownError, TaskCenter, TaskKind};
 use restate_errors::NotRunningError;
 use restate_invoker_api::InvokeInputJournal;
 use restate_partition_store::PartitionStore;
@@ -227,7 +227,6 @@ where
             self.partition_processor_metadata.partition_id,
             EpochSequenceNumber::new(leader_epoch),
             &self.bifrost,
-            metadata(),
         )?;
 
         self_proposer

--- a/crates/worker/src/partition/state_machine/tests/delayed_send.rs
+++ b/crates/worker/src/partition/state_machine/tests/delayed_send.rs
@@ -16,7 +16,7 @@ use restate_types::time::MillisSinceEpoch;
 use std::time::{Duration, SystemTime};
 use test_log::test;
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn send_with_delay() {
     let mut test_env = TestEnv::create().await;
 
@@ -74,7 +74,7 @@ async fn send_with_delay() {
     test_env.shutdown().await;
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn send_with_delay_to_locked_virtual_object() {
     let mut test_env = TestEnv::create().await;
 
@@ -152,7 +152,7 @@ async fn send_with_delay_to_locked_virtual_object() {
     test_env.shutdown().await;
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn send_with_delay_and_idempotency_key() {
     let mut test_env = TestEnv::create().await;
 

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn start_and_complete_idempotent_invocation(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 
@@ -133,7 +133,7 @@ async fn start_and_complete_idempotent_invocation(#[case] disable_idempotency_ta
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn start_and_complete_idempotent_invocation_neo_table(
     #[case] disable_idempotency_table: bool,
 ) {
@@ -245,7 +245,7 @@ async fn start_and_complete_idempotent_invocation_neo_table(
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn complete_already_completed_invocation(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 
@@ -304,7 +304,7 @@ async fn complete_already_completed_invocation(#[case] disable_idempotency_table
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn attach_with_service_invocation_command_while_executing(
     #[case] disable_idempotency_table: bool,
 ) {
@@ -403,7 +403,7 @@ async fn attach_with_service_invocation_command_while_executing(
 #[case(true, false)]
 #[case(false, true)]
 #[case(false, false)]
-#[tokio::test]
+#[restate_core::test]
 async fn attach_with_send_service_invocation(
     #[case] disable_idempotency_table: bool,
     #[case] use_same_request_id: bool,
@@ -526,7 +526,7 @@ async fn attach_with_send_service_invocation(
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn attach_inboxed_with_send_service_invocation(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 
@@ -622,7 +622,7 @@ async fn attach_inboxed_with_send_service_invocation(#[case] disable_idempotency
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn attach_command(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 
@@ -715,7 +715,7 @@ async fn attach_command(#[case] disable_idempotency_table: bool) {
     test_env.shutdown().await;
 }
 
-#[tokio::test]
+#[restate_core::test]
 async fn attach_command_without_blocking_inflight() {
     let mut test_env = TestEnv::create().await;
 
@@ -775,7 +775,7 @@ async fn attach_command_without_blocking_inflight() {
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn purge_completed_idempotent_invocation(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -22,7 +22,7 @@ use restate_types::journal::enriched::EnrichedEntryHeader;
 use restate_types::service_protocol;
 use test_log::test;
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn kill_inboxed_invocation() -> anyhow::Result<()> {
     let mut test_env = TestEnv::create().await;
 
@@ -108,7 +108,7 @@ async fn kill_inboxed_invocation() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn kill_call_tree() -> anyhow::Result<()> {
     let mut test_env = TestEnv::create().await;
 
@@ -218,7 +218,7 @@ async fn kill_call_tree() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn cancel_invoked_invocation() -> Result<(), Error> {
     let mut test_env = TestEnv::create().await;
 
@@ -331,7 +331,7 @@ async fn cancel_invoked_invocation() -> Result<(), Error> {
     Ok(())
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn cancel_suspended_invocation() -> Result<(), Error> {
     let mut test_env = TestEnv::create().await;
 
@@ -448,7 +448,7 @@ async fn cancel_suspended_invocation() -> Result<(), Error> {
     Ok(())
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn cancel_invocation_entry_referring_to_previous_entry() {
     let mut test_env = TestEnv::create().await;
 

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn start_workflow_method(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 
@@ -186,7 +186,7 @@ async fn start_workflow_method(#[case] disable_idempotency_table: bool) {
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn attach_by_workflow_key(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 
@@ -324,7 +324,7 @@ async fn attach_by_workflow_key(#[case] disable_idempotency_table: bool) {
 #[rstest]
 #[case(true)]
 #[case(false)]
-#[tokio::test]
+#[restate_core::test]
 async fn purge_completed_workflow(#[case] disable_idempotency_table: bool) {
     let mut test_env = TestEnv::create_with_options(disable_idempotency_table).await;
 

--- a/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
+++ b/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
@@ -180,7 +180,7 @@ mod tests {
 
         node_env
             .tc
-            .run_in_scope_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+            .run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
 
         let all_partition_keys = RangeInclusive::new(0, PartitionKey::MAX);
         let partition_store_manager = PartitionStoreManager::create(

--- a/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
+++ b/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
@@ -156,7 +156,7 @@ impl PersistedLogLsnWatchdog {
 #[cfg(test)]
 mod tests {
     use crate::partition_processor_manager::persisted_lsn_watchdog::PersistedLogLsnWatchdog;
-    use restate_core::{TaskKind, TestCoreEnv};
+    use restate_core::{TaskCenter, TaskKind, TestCoreEnv2};
     use restate_partition_store::{OpenMode, PartitionStoreManager};
     use restate_rocksdb::RocksDbManager;
     use restate_storage_api::fsm_table::FsmTable;
@@ -172,15 +172,13 @@ mod tests {
     use tokio::sync::watch;
     use tokio::time::Instant;
 
-    #[test(tokio::test(start_paused = true))]
+    #[test(restate_core::test(start_paused = true))]
     async fn persisted_log_lsn_watchdog_detects_applied_lsns() -> anyhow::Result<()> {
-        let node_env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let _node_env = TestCoreEnv2::create_with_single_node(1, 1).await;
         let storage_options = StorageOptions::default();
         let rocksdb_options = RocksDbOptions::default();
 
-        node_env
-            .tc
-            .run_sync(|| RocksDbManager::init(Constant::new(CommonOptions::default())));
+        RocksDbManager::init(Constant::new(CommonOptions::default()));
 
         let all_partition_keys = RangeInclusive::new(0, PartitionKey::MAX);
         let partition_store_manager = PartitionStoreManager::create(
@@ -210,12 +208,7 @@ mod tests {
 
         let now = Instant::now();
 
-        node_env.tc.spawn(
-            TaskKind::Watchdog,
-            "persiste-log-lsn-test",
-            None,
-            watchdog.run(),
-        )?;
+        TaskCenter::spawn(TaskKind::Watchdog, "persiste-log-lsn-test", watchdog.run())?;
 
         assert!(
             tokio::time::timeout(Duration::from_secs(1), watch_rx.changed())
@@ -261,6 +254,8 @@ mod tests {
             watch_rx.borrow().get(&PartitionId::MIN),
             Some(&next_persisted_lsn)
         );
+
+        RocksDbManager::get().shutdown().await;
 
         Ok(())
     }

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -283,10 +283,9 @@ impl ProcessorState {
     ) {
         match self {
             ProcessorState::Starting { .. } => {
-                let _ = TaskCenter::current().spawn(
+                let _ = TaskCenter::spawn(
                     TaskKind::Disposable,
                     "partition-processor-rpc",
-                    None,
                     async move {
                         partition_processor_rpc
                             .into_outgoing(Err(PartitionProcessorRpcError::Starting))
@@ -304,10 +303,9 @@ impl ProcessorState {
                 {
                     match err {
                         TrySendError::Full(req) => {
-                            let _ = TaskCenter::current().spawn(
+                            let _ = TaskCenter::spawn(
                                 TaskKind::Disposable,
                                 "partition-processor-rpc",
-                                None,
                                 async move {
                                     req.into_outgoing(Err(PartitionProcessorRpcError::Busy))
                                         .send()
@@ -317,10 +315,9 @@ impl ProcessorState {
                             );
                         }
                         TrySendError::Closed(req) => {
-                            let _ = TaskCenter::current().spawn(
+                            let _ = TaskCenter::spawn(
                                 TaskKind::Disposable,
                                 "partition-processor-rpc",
-                                None,
                                 async move {
                                     req.into_outgoing(Err(PartitionProcessorRpcError::NotLeader(
                                         partition_id,
@@ -335,10 +332,9 @@ impl ProcessorState {
                 }
             }
             ProcessorState::Stopping { .. } => {
-                let _ = TaskCenter::current().spawn(
+                let _ = TaskCenter::spawn(
                     TaskKind::Disposable,
                     "partition-processor-rpc",
-                    None,
                     async move {
                         partition_processor_rpc
                             .into_outgoing(Err(PartitionProcessorRpcError::Stopping))

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -69,6 +69,7 @@ restate-bifrost = { workspace = true, features = ["test-util"] }
 restate-core = { workspace = true, features = ["test-util"] }
 restate-local-cluster-runner = { workspace = true }
 restate-test-util = { workspace = true }
+restate-types = { workspace = true, features = ["test-util"] }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -24,7 +24,7 @@ use test_log::test;
 
 mod common;
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn node_id_mismatch() -> googletest::Result<()> {
     let base_config = Configuration::default();
 
@@ -72,7 +72,7 @@ async fn node_id_mismatch() -> googletest::Result<()> {
     Ok(())
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn cluster_name_mismatch() -> googletest::Result<()> {
     let base_config = Configuration::default();
 
@@ -115,7 +115,7 @@ async fn cluster_name_mismatch() -> googletest::Result<()> {
     Ok(())
 }
 
-#[test(tokio::test)]
+#[test(restate_core::test)]
 async fn replicated_loglet() -> googletest::Result<()> {
     let mut base_config = Configuration::default();
     base_config.bifrost.default_provider = ProviderKind::Replicated;

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -15,7 +15,6 @@ use hdrhistogram::Histogram;
 use tracing::info;
 
 use restate_bifrost::Bifrost;
-use restate_core::TaskCenter;
 use restate_types::logs::{LogId, WithKeys};
 
 use crate::util::{print_latencies, DummyPayload};
@@ -37,7 +36,6 @@ pub struct AppendLatencyOpts {
 pub async fn run(
     _common_args: &Arguments,
     args: &AppendLatencyOpts,
-    _tc: TaskCenter,
     bifrost: Bifrost,
 ) -> anyhow::Result<()> {
     let blob = BytesMut::zeroed(args.payload_size).freeze();

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -80,7 +80,6 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
             Live::from_value(config.metadata_store.clone())
                 .map(|c| &c.rocksdb)
                 .boxed(),
-            &TaskCenter::current(),
         )
         .await?;
         debug!("Metadata store client created");
@@ -90,10 +89,9 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
         let mut router_builder = MessageRouterBuilder::default();
         metadata_manager.register_in_message_router(&mut router_builder);
 
-        TaskCenter::current().spawn(
+        TaskCenter::spawn(
             TaskKind::SystemService,
             "metadata-manager",
-            None,
             metadata_manager.run(),
         )?;
 

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -13,7 +13,6 @@ use clap::Parser;
 use cling::{Collect, Run};
 use tracing::debug;
 
-use restate_core::TaskCenter;
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
 use restate_types::live::Live;
@@ -68,7 +67,6 @@ async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericM
             Live::from_value(config.metadata_store.clone())
                 .map(|c| &c.rocksdb)
                 .boxed(),
-            &TaskCenter::current(),
         )
         .await?;
         debug!("Metadata store client created");

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -15,7 +15,6 @@ use json_patch::Patch;
 use tracing::debug;
 
 use restate_core::metadata_store::{MetadataStoreClient, Precondition};
-use restate_core::TaskCenter;
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
 use restate_types::live::Live;
@@ -90,7 +89,6 @@ async fn patch_value_direct(
             Live::from_value(config.metadata_store.clone())
                 .map(|c| &c.rocksdb)
                 .boxed(),
-            &TaskCenter::current(),
         )
         .await?;
         debug!("Metadata store client created");

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -22,7 +22,6 @@ pub async fn start_metadata_store(
     metadata_store_client_options: MetadataStoreClientOptions,
     opts: BoxedLiveLoad<MetadataStoreOptions>,
     updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
-    task_center: &TaskCenter,
 ) -> anyhow::Result<MetadataStoreClient> {
     let health_status = HealthStatus::default();
     let service = LocalMetadataStoreService::from_options(
@@ -31,10 +30,9 @@ pub async fn start_metadata_store(
         updateables_rocksdb_options,
     );
 
-    task_center.spawn(
+    TaskCenter::spawn(
         TaskKind::MetadataStore,
         "local-metadata-store",
-        None,
         async move {
             service.run().await?;
             Ok(())

--- a/tools/restatectl/src/environment/task_center.rs
+++ b/tools/restatectl/src/environment/task_center.rs
@@ -57,7 +57,7 @@ where
         .build()
         .expect("task_center builds");
 
-    let result = task_center.run_in_scope_sync(|| fn_body(config)).await;
+    let result = task_center.run_sync(|| fn_body(config)).await;
 
     task_center.shutdown_node("finished", 0).await;
     result

--- a/tools/restatectl/src/environment/task_center.rs
+++ b/tools/restatectl/src/environment/task_center.rs
@@ -55,7 +55,8 @@ where
         .ingress_runtime_handle(tokio::runtime::Handle::current())
         .options(config.common.clone())
         .build()
-        .expect("task_center builds");
+        .expect("task_center builds")
+        .to_handle();
 
     let result = task_center.run_sync(|| fn_body(config)).await;
 


### PR DESCRIPTION

This changes the remaining bits of the API and refactors most of the code to make use of it.

What's new:
- `TaskCenter` is now simply an zero-size struct with associated functions.
- `restate_core::task_center::Handle` provides a way to pass a concrete task-center value around
- `restate_core::task_center::OwnedHandle` is mostly unused at the moment, but it's meant to be a future mechanism for auto-drop (guard) task-center ownership. Primarily to be used in main fn.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2357).
* #2359
* #2358
* __->__ #2357 (8 commits)