### PR TITLE
Remove unnecessary spawn_blocking_unmanaged from task-center

### DIFF
--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -150,19 +150,6 @@ impl Handle {
         self.inner.metadata()
     }
 
-    /// Spawn a potentially thread-blocking future on a dedicated thread pool
-    pub fn spawn_blocking_unmanaged<F, O>(
-        &self,
-        name: &'static str,
-        future: F,
-    ) -> tokio::task::JoinHandle<O>
-    where
-        F: Future<Output = O> + Send + 'static,
-        O: Send + 'static,
-    {
-        self.inner.spawn_blocking_unmanaged(name, future)
-    }
-
     /// Take control over the running task from task-center. This returns None if the task was not
     /// found, completed, or has been cancelled.
     pub fn take_task(&self, task_id: TaskId) -> Option<TaskHandle<()>> {

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -654,16 +654,9 @@ impl PartitionProcessorManager {
                     let starting_task = self
                         .start_partition_processor_task(partition_id, partition_key_range.clone());
 
-                    // We spawn the partition processors start tasks on the blocking thread pool due to a macOS issue
-                    // where doing otherwise appears to starve the Tokio event loop, causing very slow startup.
-                    let handle = TaskCenter::spawn_blocking_unmanaged(
-                        "starting-partition-processor",
-                        starting_task.run(),
-                    );
-
                     self.asynchronous_operations.spawn(
                         async move {
-                            let result = handle.await.expect("task must not panic");
+                            let result = starting_task.run();
                             AsynchronousEvent {
                                 partition_id,
                                 inner: EventKind::Started(result),

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -64,9 +64,7 @@ impl SpawnPartitionProcessorTask {
             partition_id=%self.partition_id,
         )
     )]
-    pub async fn run(
-        self,
-    ) -> anyhow::Result<(StartedProcessor, RuntimeTaskHandle<anyhow::Result<()>>)> {
+    pub fn run(self) -> anyhow::Result<(StartedProcessor, RuntimeTaskHandle<anyhow::Result<()>>)> {
         let Self {
             task_name,
             partition_id,
@@ -119,16 +117,15 @@ impl SpawnPartitionProcessorTask {
             {
                 let options = options.clone();
                 let key_range = key_range.clone();
-                let partition_store = partition_store_manager
-                    .open_partition_store(
-                        partition_id,
-                        key_range,
-                        OpenMode::CreateIfMissing,
-                        &options.storage.rocksdb,
-                    )
-                    .await?;
-
                 move || async move {
+                    let partition_store = partition_store_manager
+                        .open_partition_store(
+                            partition_id,
+                            key_range,
+                            OpenMode::CreateIfMissing,
+                            &options.storage.rocksdb,
+                        )
+                        .await?;
                     TaskCenter::spawn_child(
                         TaskKind::SystemService,
                         invoker_name,


### PR DESCRIPTION
The actual reason why we were blocking tokio was that we were opening the partition_store inline (on the caller's thread), this quickly saturates all workers in default tokio threads (in joinset)

The fix is to move opening the partition store into the newly created runtime. A longer-term fix to address the slow creation of column-families is to batch open them instead of doing so one by one. Rocksdb has a long-standing issue with  column-family creation performance, but this requires that we expose `rocksdb_create_column_families()` from C binding to rust.