### PR TITLE
force reconfiguration of a loglet with `restatectl logs reconfigure`

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -98,15 +98,19 @@ message CreatePartitionSnapshotRequest { uint32 partition_id = 1; }
 
 message CreatePartitionSnapshotResponse { string snapshot_id = 1; }
 
-message SealAndExtendChainRequest {
-  uint32 log_id = 1;
+message ChainExtension {
   // segment_index will be automatically selected (to the index of last segment)
   // if not set.
   optional uint32 segment_index = 2;
-  restate.common.Version min_version = 3;
   // check `ProviderKind` for possible values.
   string provider = 4;
   string params = 5;
+}
+
+message SealAndExtendChainRequest {
+  uint32 log_id = 1;
+  restate.common.Version min_version = 2;
+  optional ChainExtension extension = 3;
 }
 
 message SealedSegment {

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -348,7 +348,7 @@ fn try_provisioning(
 /// Build a new segment configuration for a replicated loglet based on the observed cluster state
 /// and the previous configuration.
 #[cfg(feature = "replicated-loglet")]
-fn build_new_replicated_loglet_configuration(
+pub fn build_new_replicated_loglet_configuration(
     replicated_loglet_config: &ReplicatedLogletConfig,
     loglet_id: ReplicatedLogletId,
     nodes_config: &NodesConfiguration,

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -550,14 +550,20 @@ impl<T: TransportConnect> Scheduler<T> {
 /// Placement hints for the [`logs_controller::LogsController`] based on the current
 /// [`SchedulingPlan`].
 pub struct SchedulingPlanNodeSetSelectorHints<'a> {
-    scheduling_plan: &'a SchedulingPlan,
+    scheduling_plan: Option<&'a SchedulingPlan>,
 }
 
 impl<'a, T> From<&'a Scheduler<T>> for SchedulingPlanNodeSetSelectorHints<'a> {
     fn from(value: &'a Scheduler<T>) -> Self {
         Self {
-            scheduling_plan: &value.scheduling_plan,
+            scheduling_plan: Some(&value.scheduling_plan),
         }
+    }
+}
+
+impl<'a> From<Option<&'a SchedulingPlan>> for SchedulingPlanNodeSetSelectorHints<'a> {
+    fn from(scheduling_plan: Option<&'a SchedulingPlan>) -> Self {
+        Self { scheduling_plan }
     }
 }
 
@@ -566,7 +572,7 @@ impl<'a> logs_controller::NodeSetSelectorHints for SchedulingPlanNodeSetSelector
         let partition_id = PartitionId::from(*log_id);
 
         self.scheduling_plan
-            .get(&partition_id)
+            .and_then(|p| p.get(&partition_id))
             .and_then(|target_state| target_state.leader.map(Into::into))
     }
 }

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -25,7 +25,7 @@ mod watchdog;
 pub use appender::Appender;
 pub use background_appender::{AppenderHandle, BackgroundAppender, CommitToken, LogSender};
 pub use bifrost::Bifrost;
-pub use bifrost_admin::BifrostAdmin;
+pub use bifrost_admin::{BifrostAdmin, SealedSegment};
 pub use error::{Error, Result};
 pub use read_stream::LogReadStream;
 pub use record::{InputRecord, LogEntry};


### PR DESCRIPTION
force reconfiguration of a loglet with `restatectl logs reconfigure`

Summary:
when calling `restatectl logs reconfigure` without a `provider`
the reconfigure will instead schedule the loglet to be sealed
and then the system will reconfigure it with cluster configuration
