### PR TITLE
Enable jemalloc feature on rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7237,6 +7237,7 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "pkg-config",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -8200,8 +8201,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "git+https://github.com/restatedev/jemallocator?rev=7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0#7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",
@@ -8209,8 +8211,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
-source = "git+https://github.com/restatedev/jemallocator?rev=7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0#7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8f832b7e742e0d826fb9fed05a62e4bd747969bf" }
+rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf", "jemalloc"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8f832b7e742e0d826fb9fed05a62e4bd747969bf" }
 rstest = "0.23.0"
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
@@ -179,8 +179,7 @@ tempfile = "3.6.0"
 test-log = { version = "0.2.11", default-features = false, features = [
     "trace",
 ] }
-# tikv-jemallocator has not yet been released with musl target support, so we pin a main commit
-tikv-jemallocator = { git = "https://github.com/restatedev/jemallocator", rev = "7c32f6e3d6ad5e4e492cc08d6bdb8307acf9afa0", default-features = false }
+tikv-jemallocator = "0.6"
 thiserror = "1.0"
 tokio = { version = "1.41.1", default-features = false, features = [
     "rt-multi-thread",


### PR DESCRIPTION
We now have 0.6 of jemalloc which includes our patches, so we don't need the fork any more. And we can enable the feature on rust-rocksdb, which also uses 0.6. This feature will means that rocksdb is informed that jemalloc is present