### PR TITLE
Add attach/get output to openapi and reorganize tags to improve UI visualization

### DIFF
--- a/crates/types/src/schema/openapi.rs
+++ b/crates/types/src/schema/openapi.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::identifiers::ServiceRevision;
-use crate::invocation::ServiceType;
+use crate::invocation::{InvocationTargetType, ServiceType, WorkflowHandlerType};
 use crate::schema::invocation_target::{InputValidationRule, OutputContentTypeRule};
 use crate::schema::service::HandlerSchemas;
 use restate_utoipa::openapi::path::{Operation, Parameter, ParameterIn};
@@ -21,7 +21,10 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServiceOpenAPI {
-    paths: Paths,
+    rpc_paths: Paths,
+    send_paths: Paths,
+    attach_paths: Paths,
+    get_output_paths: Paths,
     components: Components,
 }
 
@@ -39,15 +42,22 @@ impl ServiceOpenAPI {
             format!("/{service_name}/")
         };
 
-        let mut parameters: Vec<RefOr<Parameter>> = vec![];
+        let mut call_parameters: Vec<RefOr<Parameter>> = vec![];
+        let mut attach_get_output_parameters: Vec<RefOr<Parameter>> = vec![];
         if service_type.is_keyed() {
-            parameters.push(parameters_ref(KEY_PARAMETER_REF_NAME).into());
+            call_parameters.push(parameters_ref(KEY_PARAMETER_REF_NAME).into());
+            attach_get_output_parameters.push(parameters_ref(KEY_PARAMETER_REF_NAME).into());
         }
         if service_type != ServiceType::Workflow {
-            parameters.push(parameters_ref(IDEMPOTENCY_KEY_PARAMETER_REF_NAME).into());
+            call_parameters.push(parameters_ref(IDEMPOTENCY_KEY_HEADER_PARAMETER_REF_NAME).into());
+            attach_get_output_parameters
+                .push(parameters_ref(IDEMPOTENCY_KEY_PATH_PARAMETER_REF_NAME).into());
         }
 
-        let mut paths = Paths::builder();
+        let mut rpc_paths = Paths::builder();
+        let mut send_paths = Paths::builder();
+        let mut attach_paths = Paths::builder();
+        let mut get_output_paths = Paths::builder();
         for (handler_name, handler_schemas) in handlers {
             let operation_id = handler_name;
 
@@ -78,15 +88,15 @@ impl ServiceOpenAPI {
                                     )
                                 }),
                         ))
-                        .parameters(Some(parameters.clone()))
+                        .parameters(Some(call_parameters.clone()))
                         .tag(service_name.to_string())
                         .request_body(request_body.clone())
-                        .response("200", response)
-                        .response("default", responses_ref(ERROR_RESPONSE_REF_NAME))
+                        .response("200", response.clone())
+                        .response("default", responses_ref(GENERIC_ERROR_RESPONSE_REF_NAME))
                         .build(),
                 )
                 .build();
-            paths = paths.path(format!("{root_path}{handler_name}"), call_item);
+            rpc_paths = rpc_paths.path(format!("{root_path}{handler_name}"), call_item);
 
             let send_item = PathItem::builder()
                 .summary(Some(format!("Send to {service_name}/{handler_name}")))
@@ -103,21 +113,158 @@ impl ServiceOpenAPI {
                                     format!("Send request to {service_name} handler {handler_name}")
                                 }),
                         ))
-                        .parameters(Some(parameters.clone()))
+                        .parameters(Some(call_parameters.clone()))
                         .parameter(parameters_ref(DELAY_PARAMETER_REF_NAME))
                         .tag(service_name.to_string())
                         .request_body(request_body)
                         .response("200", responses_ref(SEND_RESPONSE_REF_NAME))
                         .response("202", responses_ref(SEND_RESPONSE_REF_NAME))
-                        .response("default", responses_ref(ERROR_RESPONSE_REF_NAME))
+                        .response("default", responses_ref(GENERIC_ERROR_RESPONSE_REF_NAME))
                         .build(),
                 )
                 .build();
-            paths = paths.path(format!("{root_path}{handler_name}/send"), send_item);
+            send_paths = send_paths.path(format!("{root_path}{handler_name}/send"), send_item);
+
+            if service_type == ServiceType::Workflow {
+                // We add attach/get output only for workflow run
+                if handler_schemas.target_meta.target_ty
+                    == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow)
+                {
+                    let attach_item = PathItem::builder()
+                        .summary(Some(format!("Attach to {service_name} workflow")))
+                        .operation(
+                            HttpMethod::Get,
+                            Operation::builder()
+                                .operation_id(Some(format!("{operation_id}Attach")))
+                                .description(Some(
+                                    handler_schemas
+                                        .documentation
+                                        .as_ref()
+                                        .cloned()
+                                        .unwrap_or_else(|| {
+                                            format!(
+                                                "Attach to the running instance of {service_name}/{handler_name} workflow and wait to finish"
+                                            )
+                                        }),
+                                ))
+                                .parameters(Some(attach_get_output_parameters.clone()))
+                                .tag(service_name.to_string())
+                                .response("200", response.clone())
+                                .response("404", responses_ref(INVOCATION_NOT_FOUND_ERROR_RESPONSE_REF_NAME))
+                                .response("default", responses_ref(GENERIC_ERROR_RESPONSE_REF_NAME))
+                                .build(),
+                        )
+                        .build();
+                    attach_paths = attach_paths.path(
+                        format!("/restate/workflow/{service_name}/{{key}}/attach"),
+                        attach_item,
+                    );
+
+                    let output_item = PathItem::builder()
+                        .summary(Some(format!("Get output of {service_name} workflow")))
+                        .operation(
+                            HttpMethod::Get,
+                            Operation::builder()
+                                .operation_id(Some(format!("{operation_id}Output")))
+                                .description(Some(
+                                    handler_schemas
+                                        .documentation
+                                        .as_ref()
+                                        .cloned()
+                                        .unwrap_or_else(|| {
+                                            format!(
+                                                "Get output of the {service_name}/{handler_name} workflow"
+                                            )
+                                        }),
+                                ))
+                                .parameters(Some(attach_get_output_parameters.clone()))
+                                .tag(service_name.to_string())
+                                .response("200", response)
+                                .response("404", responses_ref(INVOCATION_NOT_FOUND_ERROR_RESPONSE_REF_NAME))
+                                .response("470", responses_ref(INVOCATION_NOT_READY_RESPONSE_REF_NAME))
+                                .response("default", responses_ref(GENERIC_ERROR_RESPONSE_REF_NAME))
+                                .build(),
+                        )
+                        .build();
+                    get_output_paths = get_output_paths.path(
+                        format!("/restate/workflow/{service_name}/{{key}}/output"),
+                        output_item,
+                    );
+                }
+            } else {
+                // We add attach/get output for each individual handler with idempotency key
+                let attach_item = PathItem::builder()
+                    .summary(Some(format!("Attach to {service_name}/{handler_name} invocation using idempotency key")))
+                    .operation(
+                        HttpMethod::Get,
+                        Operation::builder()
+                            .operation_id(Some(format!("{operation_id}Attach")))
+                            .description(Some(
+                                handler_schemas
+                                    .documentation
+                                    .as_ref()
+                                    .cloned()
+                                    .unwrap_or_else(|| {
+                                        format!(
+                                            "Attach to a running instance of {service_name}/{handler_name} using the idempotency key and wait to finish"
+                                        )
+                                    }),
+                            ))
+                            .parameters(Some(attach_get_output_parameters.clone()))
+                            .tag(service_name.to_string())
+                            .response("200", response.clone())
+                            .response("404", responses_ref(INVOCATION_NOT_FOUND_ERROR_RESPONSE_REF_NAME))
+                            .response("default", responses_ref(GENERIC_ERROR_RESPONSE_REF_NAME))
+                            .build(),
+                    )
+                    .build();
+                attach_paths = attach_paths.path(
+                    format!(
+                        "/restate/invocation{root_path}{handler_name}/{{idempotencyKey}}/attach"
+                    ),
+                    attach_item,
+                );
+
+                let output_item = PathItem::builder()
+                    .summary(Some(format!("Get output of {service_name}/{handler_name} invocation using idempotency key")))
+                    .operation(
+                        HttpMethod::Get,
+                        Operation::builder()
+                            .operation_id(Some(format!("{operation_id}Output")))
+                            .description(Some(
+                                handler_schemas
+                                    .documentation
+                                    .as_ref()
+                                    .cloned()
+                                    .unwrap_or_else(|| {
+                                        format!(
+                                            "Get output of a running instance of {service_name}/{handler_name} using idempotency key"
+                                        )
+                                    }),
+                            ))
+                            .parameters(Some(attach_get_output_parameters.clone()))
+                            .tag(service_name.to_string())
+                            .response("200", response)
+                            .response("404", responses_ref(INVOCATION_NOT_FOUND_ERROR_RESPONSE_REF_NAME))
+                            .response("470", responses_ref(INVOCATION_NOT_READY_RESPONSE_REF_NAME))
+                            .response("default", responses_ref(GENERIC_ERROR_RESPONSE_REF_NAME))
+                            .build(),
+                    )
+                    .build();
+                get_output_paths = get_output_paths.path(
+                    format!(
+                        "/restate/invocation{root_path}{handler_name}/{{idempotencyKey}}/output"
+                    ),
+                    output_item,
+                );
+            }
         }
 
         ServiceOpenAPI {
-            paths: paths.build(),
+            rpc_paths: rpc_paths.build(),
+            send_paths: send_paths.build(),
+            attach_paths: attach_paths.build(),
+            get_output_paths: get_output_paths.build(),
             components: Components::builder()
                 .schemas_from_iter(schemas_collector.into_iter().map(|(schema_name, schema)| {
                     let ref_refix = format!("#/components/schemas/{schema_name}");
@@ -135,9 +282,19 @@ impl ServiceOpenAPI {
         revision: ServiceRevision,
     ) -> Value {
         let mut components = restate_components();
+
+        // Make sure Restate components appear last in the list
+        let mut restate_components_schemas = components.schemas.clone();
+        components.schemas.clear();
         components
             .schemas
             .append(&mut self.components.schemas.clone());
+        components.schemas.append(&mut restate_components_schemas);
+
+        let mut paths = self.rpc_paths.clone();
+        paths.merge(self.send_paths.clone());
+        paths.merge(self.attach_paths.clone());
+        paths.merge(self.get_output_paths.clone());
 
         // TODO how to add servers?! :(
         serde_json::to_value(
@@ -149,18 +306,19 @@ impl ServiceOpenAPI {
                         .description(documentation)
                         .build(),
                 )
-                .paths(self.paths.clone())
+                .paths(paths)
                 .components(Some(components))
                 .build(),
         )
         .expect("Mapping OpenAPI to JSON should never fail")
     }
 
-    // We need these for back-compat
-
     pub fn empty() -> Self {
         Self {
-            paths: Default::default(),
+            rpc_paths: Default::default(),
+            send_paths: Default::default(),
+            attach_paths: Default::default(),
+            get_output_paths: Default::default(),
             components: Default::default(),
         }
     }
@@ -299,16 +457,40 @@ fn restate_components() -> Components {
         .parameter(DELAY_PARAMETER_REF_NAME, delay_parameter())
         .parameter(KEY_PARAMETER_REF_NAME, key_parameter())
         .parameter(
-            IDEMPOTENCY_KEY_PARAMETER_REF_NAME,
-            idempotency_key_parameter(),
+            IDEMPOTENCY_KEY_HEADER_PARAMETER_REF_NAME,
+            idempotency_key_header_parameter(),
         )
-        .response(ERROR_RESPONSE_REF_NAME, error_response())
+        .parameter(
+            IDEMPOTENCY_KEY_PATH_PARAMETER_REF_NAME,
+            idempotency_key_path_parameter(),
+        )
+        .response(GENERIC_ERROR_RESPONSE_REF_NAME, generic_error_response())
+        .response(
+            INVOCATION_NOT_FOUND_ERROR_RESPONSE_REF_NAME,
+            invocation_not_found_error_response(),
+        )
+        .response(
+            INVOCATION_NOT_READY_RESPONSE_REF_NAME,
+            invocation_not_ready_error_response(),
+        )
         .response(SEND_RESPONSE_REF_NAME, send_response())
+        .schema(
+            GENERIC_ERROR_RESPONSE_REF_NAME,
+            Schema::new(error_response_json_schema()),
+        )
         .build()
 }
 
 fn parameters_ref(name: &str) -> Ref {
     Ref::new(format!("#/components/parameters/{name}"))
+}
+
+fn schemas_ref(name: &str) -> Ref {
+    Ref::new(format!("#/components/schemas/{name}"))
+}
+
+fn responses_ref(name: &str) -> Ref {
+    Ref::new(format!("#/components/responses/{name}"))
 }
 
 const DELAY_PARAMETER_REF_NAME: &str = "delay";
@@ -337,9 +519,9 @@ fn key_parameter() -> Parameter {
         .build()
 }
 
-const IDEMPOTENCY_KEY_PARAMETER_REF_NAME: &str = "idempotencyKey";
+const IDEMPOTENCY_KEY_HEADER_PARAMETER_REF_NAME: &str = "idempotencyKeyHeader";
 
-fn idempotency_key_parameter() -> Parameter {
+fn idempotency_key_header_parameter() -> Parameter {
     Parameter::builder()
         .name("idempotency-key")
         .parameter_in(ParameterIn::Header)
@@ -351,48 +533,33 @@ fn idempotency_key_parameter() -> Parameter {
         .build()
 }
 
-fn responses_ref(name: &str) -> Ref {
-    Ref::new(format!("#/components/responses/{name}"))
+const IDEMPOTENCY_KEY_PATH_PARAMETER_REF_NAME: &str = "idempotencyKeyPath";
+
+fn idempotency_key_path_parameter() -> Parameter {
+    Parameter::builder()
+        .name("idempotencyKey")
+        .parameter_in(ParameterIn::Path)
+        .schema(Some(
+            string_json_schema()
+        ))
+        .required(Required::True)
+        .description(Some("Idempotency key used to execute the original request, for more details checkout the [idempotency key documentation](https://docs.restate.dev/invoke/http#invoke-a-handler-idempotently)."))
+        .build()
 }
 
-const ERROR_RESPONSE_REF_NAME: &str = "Error";
+const GENERIC_ERROR_RESPONSE_REF_NAME: &str = "GenericError";
 
-fn error_response() -> Response {
+fn generic_error_response() -> Response {
     Response::builder()
         .description("Error response")
         .content(
             "application/json",
             ContentBuilder::new()
-                .schema(Some(Schema::new(error_response_json_schema())))
+                .schema(Some(schemas_ref(RESTATE_ERROR_SCHEMA_REF_NAME)))
                 .example(Some(error_response_example()))
                 .build(),
         )
         .build()
-}
-
-// Ideally we code generate this
-fn error_response_json_schema() -> Value {
-    json!({
-        "type": "object",
-        "title": "Error",
-        "description": "Generic error used by Restate to propagate Terminal errors/exceptions back to callers",
-        "properties": {
-            "code": {
-                "type": "number",
-                "title": "error code"
-            },
-            "message": {
-                "type": "string",
-                "title": "Error message"
-            },
-            "description": {
-                "type": "string",
-                "title": "Verbose error description"
-            }
-        },
-        "required": ["message"],
-        "additionalProperties": false
-    })
 }
 
 // Ideally we code generate this
@@ -401,6 +568,50 @@ fn error_response_example() -> Value {
         "code": 500,
         "message": "Internal server error",
         "description": "Very bad error happened"
+    })
+}
+
+const INVOCATION_NOT_FOUND_ERROR_RESPONSE_REF_NAME: &str = "InvocationNotFoundError";
+
+fn invocation_not_found_error_response() -> Response {
+    Response::builder()
+        .description("Invocation not found")
+        .content(
+            "application/json",
+            ContentBuilder::new()
+                .schema(Some(schemas_ref(RESTATE_ERROR_SCHEMA_REF_NAME)))
+                .example(Some(invocation_not_found_error_response_example()))
+                .build(),
+        )
+        .build()
+}
+
+fn invocation_not_found_error_response_example() -> Value {
+    json!({
+        "code": 404,
+        "message": "Not found"
+    })
+}
+
+const INVOCATION_NOT_READY_RESPONSE_REF_NAME: &str = "InvocationNotReadyError";
+
+fn invocation_not_ready_error_response() -> Response {
+    Response::builder()
+        .description("Invocation still running, output is not ready yet")
+        .content(
+            "application/json",
+            ContentBuilder::new()
+                .schema(Some(schemas_ref(RESTATE_ERROR_SCHEMA_REF_NAME)))
+                .example(Some(invocation_not_ready_error_response_example()))
+                .build(),
+        )
+        .build()
+}
+
+fn invocation_not_ready_error_response_example() -> Value {
+    json!({
+        "code": 470,
+        "message": "Not ready"
     })
 }
 
@@ -452,6 +663,33 @@ fn send_response_example() -> Value {
 
 fn string_json_schema() -> Schema {
     Schema::new(json!({"type": "string"}))
+}
+
+const RESTATE_ERROR_SCHEMA_REF_NAME: &str = "RestateError";
+
+// Ideally we code generate this
+fn error_response_json_schema() -> Value {
+    json!({
+        "type": "object",
+        "title": "RestateError",
+        "description": "Generic error used by Restate to propagate Terminal errors/exceptions back to callers",
+        "properties": {
+            "code": {
+                "type": "number",
+                "title": "error code"
+            },
+            "message": {
+                "type": "string",
+                "title": "Error message"
+            },
+            "description": {
+                "type": "string",
+                "title": "Verbose error description"
+            }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    })
 }
 
 // We need to normalize all the $refs in the schema to append the ref_prefix


### PR DESCRIPTION
Example of output operation:

![image](https://github.com/user-attachments/assets/ee07fd58-4cac-4a0e-9070-981ce2ad3f25)

Fix #2356