### PR TITLE
Add pprof heap endpoints to node api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,6 +3800,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jemalloc_pprof"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a883828bd6a4b957cd9f618886ff19e5f3ebd34e06ba0e855849e049fef32fb"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4107,6 +4124,19 @@ checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
 dependencies = [
  "byteorder",
  "crc",
+]
+
+[[package]]
+name = "mappings"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9229c438fbf1c333926e2053c4c091feabbd40a1b590ec62710fea2384af9e"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
 ]
 
 [[package]]
@@ -5236,6 +5266,19 @@ dependencies = [
  "symbolic-demangle",
  "tempfile",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pprof_util"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c568b3f8c1c37886ae07459b1946249e725c315306b03be5632f84c239f781"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "num",
+ "paste",
+ "prost",
 ]
 
 [[package]]
@@ -6508,6 +6551,7 @@ dependencies = [
  "humantime",
  "hyper 1.5.1",
  "hyper-util",
+ "jemalloc_pprof",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-tracing-context",
@@ -8238,6 +8282,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -72,6 +72,9 @@ tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemalloc_pprof = "0.6.0"
+
 [dev-dependencies]
 restate-test-util = { workspace = true }
 

--- a/crates/node/src/network_server/mod.rs
+++ b/crates/node/src/network_server/mod.rs
@@ -10,6 +10,7 @@
 
 mod grpc_svc_handler;
 mod metrics;
+mod pprof;
 mod prometheus_helpers;
 mod service;
 mod state;

--- a/crates/node/src/network_server/pprof.rs
+++ b/crates/node/src/network_server/pprof.rs
@@ -14,7 +14,7 @@ mod pprof {
                 } else {
                     Err((
                         axum::http::StatusCode::PRECONDITION_FAILED,
-                        "Heap profiling not activated: first call /debug/pprof/heap/activate\n"
+                        "Heap profiling not activated: first curl -XPUT :5122/debug/pprof/heap/activate\n"
                             .into(),
                     ))
                 }

--- a/crates/node/src/network_server/pprof.rs
+++ b/crates/node/src/network_server/pprof.rs
@@ -1,0 +1,82 @@
+#[cfg(target_os = "linux")]
+mod pprof {
+    use http::StatusCode;
+
+    pub async fn heap() -> Result<impl axum::response::IntoResponse, (StatusCode, String)> {
+        match jemalloc_pprof::PROF_CTL.as_ref() {
+            Some(prof_ctl) => {
+                let mut prof_ctl = prof_ctl.lock().await;
+                if prof_ctl.activated() {
+                    let pprof = prof_ctl
+                        .dump_pprof()
+                        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+                    Ok(pprof)
+                } else {
+                    Err((
+                        axum::http::StatusCode::PRECONDITION_FAILED,
+                        "Heap profiling not activated: first call /debug/pprof/heap/activate\n"
+                            .into(),
+                    ))
+                }
+            }
+            None => Err((
+                axum::http::StatusCode::PRECONDITION_FAILED,
+                "Heap profiling not enabled: run with MALLOC_CONF=\"prof:true\"\n".into(),
+            )),
+        }
+    }
+
+    pub async fn activate_heap() -> Result<(), (StatusCode, String)> {
+        match jemalloc_pprof::PROF_CTL.as_ref() {
+            Some(prof_ctl) => {
+                let mut prof_ctl = prof_ctl.lock().await;
+                prof_ctl
+                    .activate()
+                    .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+                Ok(())
+            }
+            None => Err((
+                axum::http::StatusCode::PRECONDITION_FAILED,
+                "Heap profiling not enabled: run with MALLOC_CONF=\"prof:true\"\n".into(),
+            )),
+        }
+    }
+
+    pub async fn deactivate_heap() -> Result<(), (StatusCode, String)> {
+        match jemalloc_pprof::PROF_CTL.as_ref() {
+            Some(prof_ctl) => {
+                let mut prof_ctl = prof_ctl.lock().await;
+                prof_ctl
+                    .deactivate()
+                    .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+                Ok(())
+            }
+            None => Err((
+                axum::http::StatusCode::PRECONDITION_FAILED,
+                "Heap profiling not enabled: run with MALLOC_CONF=\"prof:true\"\n".into(),
+            )),
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod pprof {
+    use http::StatusCode;
+
+    pub async fn heap() -> (StatusCode, String) {
+        (
+            axum::http::StatusCode::PRECONDITION_FAILED,
+            "Heap profiling is only available on Linux\n".into(),
+        )
+    }
+
+    pub async fn activate_heap() -> (StatusCode, String) {
+        heap().await
+    }
+
+    pub async fn deactivate_heap() -> (StatusCode, String) {
+        heap().await
+    }
+}
+
+pub use pprof::*;

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use axum::routing::get;
+use axum::routing::{get, on, MethodFilter};
 use tonic::codec::CompressionEncoding;
 
 use restate_core::network::protobuf::node_svc::node_svc_server::NodeSvcServer;
@@ -42,12 +42,20 @@ impl NetworkServer {
 
         let shared_state = state_builder.build().expect("should be infallible");
 
+        let post_or_put = MethodFilter::POST.or(MethodFilter::PUT);
+
         // -- HTTP service (for prometheus et al.)
         let axum_router = axum::Router::new()
             .route("/metrics", get(render_metrics))
             .route("/debug/pprof/heap", get(pprof::heap))
-            .route("/debug/pprof/heap/activate", get(pprof::activate_heap))
-            .route("/debug/pprof/heap/deactivate", get(pprof::deactivate_heap))
+            .route(
+                "/debug/pprof/heap/activate",
+                on(post_or_put, pprof::activate_heap),
+            )
+            .route(
+                "/debug/pprof/heap/deactivate",
+                on(post_or_put, pprof::deactivate_heap),
+            )
             .with_state(shared_state);
 
         let node_health = health.node_status();

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -21,6 +21,7 @@ use crate::network_server::metrics::{install_global_prometheus_recorder, render_
 use crate::network_server::state::NodeCtrlHandlerStateBuilder;
 
 use super::grpc_svc_handler::NodeSvcHandler;
+use super::pprof;
 
 pub struct NetworkServer {}
 
@@ -44,6 +45,9 @@ impl NetworkServer {
         // -- HTTP service (for prometheus et al.)
         let axum_router = axum::Router::new()
             .route("/metrics", get(render_metrics))
+            .route("/debug/pprof/heap", get(pprof::heap))
+            .route("/debug/pprof/heap/activate", get(pprof::activate_heap))
+            .route("/debug/pprof/heap/deactivate", get(pprof::deactivate_heap))
             .with_state(shared_state);
 
         let node_health = health.node_status();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -44,6 +44,12 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+// On linux, run jemalloc with profiling enabled, but inactive (so there is no performance impact)
+// If needed, profiling can be activated with :5122/debug/pprof/heap/activate, or by overriding this value with $MALLOC_CONF
+#[cfg(target_os = "linux")]
+#[export_name = "malloc_conf"]
+pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
+
 #[derive(Debug, clap::Parser)]
 #[command(author, version, about)]
 struct RestateArguments {


### PR DESCRIPTION
Provide a mechanism of obtaining pprof-format heap dumps

On linux (easiest on musl build ):
```
curl localhost:5122/debug/pprof/heap/activate
... do some work that will lead to allocations
curl localhost:5122/debug/pprof/heap > heap.pb.gz
pprof -http=:9090 ./restate-server  heap.pb.gz
```