### PR TITLE
Async Logger and remove reload handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6966,6 +6966,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-appender",
+ "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -8703,6 +8705,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ tower = "0.4"
 tower-http = { version = "0.5.2", default-features = false }
 tracing = "0.1"
 tracing-opentelemetry = { version = "0.28.0" }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "parking_lot"] }
 tracing-test = { version = "0.2.5" }
 ulid = { version = "1.1.0" }
 url = { version = "2.5" }

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -103,7 +103,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
     }
 
     #[tracing::instrument(
-        level="error",
+        level="debug",
         skip(self),
         fields(
             loglet_id=%self.sequencer_shared_state.loglet_id(),

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -39,6 +39,8 @@ thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+tracing-appender = { version = "0.2.3" }
+tracing-core = { version = "0.1" }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
 

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// mod multi_service_tracer;
 mod exporter;
 mod pretty;
 
@@ -27,15 +26,14 @@ use pretty::Pretty;
 use tonic::codegen::http::HeaderMap;
 use tonic::metadata::MetadataMap;
 use tonic::transport::ClientTlsConfig;
-use tracing::{info, warn, Level};
+use tracing::{warn, Level};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::filter::{Filtered, ParseError};
 use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::reload::Handle;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer, Registry};
+use tracing_subscriber::{EnvFilter, Layer};
 
 use restate_types::config::{CommonOptions, LogFormat};
 #[cfg(feature = "console-subscriber")]
@@ -118,7 +116,7 @@ fn build_services_tracing(common_opts: &CommonOptions) -> Result<(), Error> {
     Ok(())
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, dead_code)]
 fn build_runtime_tracing_layer<S>(
     common_opts: &CommonOptions,
     service_name: String,
@@ -216,37 +214,6 @@ where
     ))
 }
 
-#[allow(clippy::type_complexity)]
-fn build_logging_layer<S>(
-    common_opts: &CommonOptions,
-) -> Result<Box<dyn Layer<S> + Send + Sync>, Error>
-where
-    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
-{
-    let k = match common_opts.log_format {
-        LogFormat::Pretty => tracing_subscriber::fmt::layer()
-            .event_format::<Pretty<SystemTime>>(Pretty::default())
-            .fmt_fields(PrettyFields)
-            .with_writer(
-                // Write WARN and ERR to stderr, everything else to stdout
-                std::io::stderr
-                    .with_max_level(Level::WARN)
-                    .or_else(std::io::stdout),
-            )
-            .with_ansi(!common_opts.log_disable_ansi_codes)
-            .boxed(),
-        LogFormat::Compact => tracing_subscriber::fmt::layer()
-            .compact()
-            .with_ansi(!common_opts.log_disable_ansi_codes)
-            .boxed(),
-        LogFormat::Json => tracing_subscriber::fmt::layer()
-            .json()
-            .with_ansi(!common_opts.log_disable_ansi_codes)
-            .boxed(),
-    };
-    Ok(k)
-}
-
 /// Instruments the process with logging and tracing. The method returns [`TracingGuard`] which
 /// unregisters the tracing when being shut down or dropped.
 ///
@@ -255,14 +222,10 @@ where
 /// panic if it is executed outside of a Tokio runtime.
 pub fn init_tracing_and_logging(
     common_opts: &CommonOptions,
-    service_name: impl Display,
+    _service_name: impl Display,
 ) -> Result<TracingGuard, Error> {
     let layers = tracing_subscriber::registry();
-
-    let filter = EnvFilter::try_new(&common_opts.log_filter)?;
-    let (filter, reload_handle) = tracing_subscriber::reload::Layer::new(filter);
     // Logging layer
-    let layers = layers.with(build_logging_layer(common_opts)?.with_filter(filter));
     // Enables auto extraction of selected span labels in emitted metrics.
     // allowed labels are defined in restate_node_ctrl::metrics::ALLOWED_LABELS.
     //
@@ -293,26 +256,53 @@ pub fn init_tracing_and_logging(
         )
     };
 
+    // User-Service Tracing Layer
     build_services_tracing(common_opts)?;
 
-    // Tracing layer
-    let layers = layers.with(build_runtime_tracing_layer(
-        common_opts,
-        service_name.to_string(),
-    )?);
+    // Runtime Distributed Tracing layer
+    // **
+    // TEMPORARILY DISABLED DUE TO SIGNIFICANT LOCK CONTENTION
+    // **
+    // let layers = layers.with(build_runtime_tracing_layer(
+    //     common_opts,
+    //     service_name.to_string(),
+    // )?);
+
+    // Logging Layer
+    let (stdout_writer, _stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
+    let (stderr_writer, _stderr_guard) = tracing_appender::non_blocking(std::io::stderr());
+    let log_filter = EnvFilter::try_new(&common_opts.log_filter)?;
+    // Write WARN and ERR to stderr, everything else to stdout
+    let log_writer = stderr_writer
+        .with_max_level(Level::WARN)
+        .or_else(stdout_writer);
+    let log_layer = tracing_subscriber::fmt::layer()
+        .with_writer(log_writer)
+        .with_ansi(!common_opts.log_disable_ansi_codes);
+
+    let log_layer = match common_opts.log_format {
+        LogFormat::Pretty => log_layer
+            .event_format::<Pretty<SystemTime>>(Pretty::default())
+            .fmt_fields(PrettyFields)
+            .boxed(),
+        LogFormat::Compact => log_layer.compact().boxed(),
+        LogFormat::Json => log_layer.json().boxed(),
+    };
+    let layers = layers.with(log_layer.with_filter(log_filter));
 
     layers.init();
 
     Ok(TracingGuard {
         is_dropped: false,
-        reload_handle,
+        _stdout_guard,
+        _stderr_guard,
     })
 }
 
-#[derive(Debug)]
 pub struct TracingGuard {
     is_dropped: bool,
-    reload_handle: Handle<EnvFilter, Registry>,
+    _stdout_guard: tracing_appender::non_blocking::WorkerGuard,
+    _stderr_guard: tracing_appender::non_blocking::WorkerGuard,
 }
 
 impl TracingGuard {
@@ -326,18 +316,14 @@ impl TracingGuard {
         self.is_dropped = true;
     }
 
-    pub fn reload_log_filter(&self, common_opts: &CommonOptions) {
-        info!("Setting log filter to '{}'", common_opts.log_filter);
-        let _ = &self.reload_handle.modify(|f| {
-            let new_filter = EnvFilter::try_new(&common_opts.log_filter);
-            match new_filter {
-                Ok(new_filter) => {
-                    *f = new_filter;
-                }
-                // don't use logging here, tracing will panic!
-                Err(e) => eprintln!("Failed to reload log filter: '{e}'"),
-            }
-        });
+    pub fn on_config_update(&self) {
+        // can boost tracing performance by up to ~20% dependending on how many subscribers are
+        // enabled.
+        //
+        // Note: This isn't a realfix for the slow-start of tracing, but it helps if there was an
+        // incidental config update. The intent if for this to be removed when tracing callsite's
+        // builder's lock contention problem is resolved for us.
+        tracing_core::callsite::rebuild_interest_cache();
     }
 
     /// Shuts down the tracing instrumentation by running [`shutdown`] on a blocking Tokio thread.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -252,8 +252,7 @@ fn main() {
                         }
                     },
                     _ = config_update_watcher.changed() => {
-                        let config = Configuration::pinned();
-                        tracing_guard.reload_log_filter(&config.common);
+                        tracing_guard.on_config_update();
                     },
                     _ = signal::sigusr1_dump_config() => {},
                     _ = signal::sighusr2_compact() => {},


### PR DESCRIPTION

- NOTE: Disables hot-reload of log-filters, this is due to a RwLock contention, albeit it gets less severe after cold start, it's still a major hurdle to achieving max throughput.
- Removes lock contention on the underlying RwLock, this brings significant (~4.5x) throughput gain on darwin.
- NonBlocking writer will drop log lines if underlying pipe is full, this makes tokio less likely to block on stderr locks or if the underlying storage (if logging to a file) needs a flush.
- Kept rebuilding the interest index in tracing_core when configuration is updated, this improves performance by up to 20% for a warm system. There is an underlying issue in tracing-core that'll hopefully be addressed in 0.2 when it's released.
- Disables distributed tracing feature due to a severe lock contention on Linux, the contention limits the system throughput by a factor of 8 under cold-start conditions.
- Reduces the level of a spammy span in sequencer
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2399).
* #2404
* #2401
* #2400
* __->__ #2399