### PR TITLE
Split debuginfo out in release builds and upload to polarsignals

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      parca:
+        description: 'split out debug symbols and upload to polar signals'
+        required: false
+        default: false
+        type: boolean
       features:
         description: 'features to enable in the build'
         required: false
@@ -46,6 +51,11 @@ on:
         required: false
         default: false
         type: boolean
+      parca:
+        description: 'upload debug symbols to polar signals'
+        required: false
+        default: false
+        type: boolean
       pushToDockerHub:
         description: 'push image to DockerHub'
         required: false
@@ -61,7 +71,7 @@ env:
 jobs:
   build-and-push-image:
     runs-on: warp-ubuntu-latest-x64-16x
-    timeout-minutes: ${{ inputs.debug && 140 || 70 }}
+    timeout-minutes: ${{ (inputs.debug || inputs.parca) && 140 || 70 }}
 
     steps:
       - name: Checkout repository
@@ -155,8 +165,11 @@ jobs:
           platforms: ${{ github.ref == 'refs/heads/main' && 'linux/arm64,linux/amd64' || (inputs.platforms || 'linux/arm64,linux/amd64') }}
           network: host
           build-args: |
-            CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug }}
+            CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug || inputs.parca }}
+            UPLOAD_DEBUGINFO=${{ inputs.parca }}
             RESTATE_FEATURES=${{ inputs.features || '' }}
+          secrets: |
+            parca=${{ secrets.PARCA_TOKEN }}
           cache-from: type=gha,url=http://127.0.0.1:49160/
           cache-to: type=gha,url=http://127.0.0.1:49160/,mode=max
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     secrets: inherit
     with:
       pushToDockerHub: true
+      parca: true
 
   release-helm:
     name: Release helm chart

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+ARG UPLOAD_DEBUGINFO=false
+
 FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS planner
 COPY . .
 RUN just chef-prepare
@@ -44,14 +46,23 @@ RUN --mount=type=cache,target=/var/cache/sccache \
     just notice-file && \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server
 
+FROM builder AS upload-false
+
+FROM builder AS upload-true
+RUN objcopy --only-keep-debug target/restate-server target/restate-server.debug
+RUN objcopy --strip-debug target/restate-server
+RUN --mount=type=secret,id=parca parca-debuginfo upload --store-address=grpc.polarsignals.com:443 --bearer-token-file=/run/secrets/parca target/restate-server.debug
+
+FROM upload-$UPLOAD_DEBUGINFO AS upload
+
 # We do not need the Rust toolchain to run the server binary!
 FROM debian:bookworm-slim AS runtime
-COPY --from=builder /restate/target/restate-server /usr/local/bin
-COPY --from=builder /restate/NOTICE /NOTICE
-COPY --from=builder /restate/LICENSE /LICENSE
+RUN apt-get update && apt-get install --no-install-recommends -y curl && rm -rf /var/lib/apt/lists/*
+COPY --from=upload /restate/target/restate-server /usr/local/bin
+COPY --from=upload /restate/NOTICE /NOTICE
+COPY --from=upload /restate/LICENSE /LICENSE
 # copy OS roots
-COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=upload /etc/ssl /etc/ssl
 # useful for health checks
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/restate-server"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,12 +57,12 @@ FROM upload-$UPLOAD_DEBUGINFO AS upload
 
 # We do not need the Rust toolchain to run the server binary!
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update && apt-get install --no-install-recommends -y curl && rm -rf /var/lib/apt/lists/*
-COPY --from=upload /restate/target/restate-server /usr/local/bin
-COPY --from=upload /restate/NOTICE /NOTICE
-COPY --from=upload /restate/LICENSE /LICENSE
-# copy OS roots
-COPY --from=upload /etc/ssl /etc/ssl
 # useful for health checks
+RUN apt-get update && apt-get install --no-install-recommends -y curl && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /restate/NOTICE /NOTICE
+COPY --from=builder /restate/LICENSE /LICENSE
+# copy OS roots
+COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=upload /restate/target/restate-server /usr/local/bin
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/restate-server"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,8 +49,8 @@ RUN --mount=type=cache,target=/var/cache/sccache \
 FROM builder AS upload-false
 
 FROM builder AS upload-true
-RUN objcopy --only-keep-debug target/restate-server target/restate-server.debug
-RUN objcopy --strip-debug target/restate-server
+RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --only-keep-debug target/restate-server target/restate-server.debug
+RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy  --strip-debug target/restate-server
 RUN --mount=type=secret,id=parca parca-debuginfo upload --store-address=grpc.polarsignals.com:443 --bearer-token-file=/run/secrets/parca target/restate-server.debug
 
 FROM upload-$UPLOAD_DEBUGINFO AS upload


### PR DESCRIPTION
We will benefit both when uploading heaps/profiles to polar signals, but we also have our own debuginfod endpoint so tools like perf will be able to magically find the debug symbols for a given binary