### PR TITLE
Add a mechanism for converting SQL schemas based on negotiated version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,8 +407,7 @@ dependencies = [
 [[package]]
 name = "arrow_convert"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5584435cad2be1ac9505b33052599e77c176d6520502204853ded2c05b2e8b"
+source = "git+https://github.com/jackkleeman/arrow-convert?rev=9878358dd38cf4a2a6c8367541be3cd374fbb2c6#9878358dd38cf4a2a6c8367541be3cd374fbb2c6"
 dependencies = [
  "arrow",
  "arrow_convert_derive",
@@ -420,8 +419,7 @@ dependencies = [
 [[package]]
 name = "arrow_convert_derive"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41ef3794174d2ebdc75c9601d06dc3badafd2539541bdd0eda185192e0c6fe4"
+source = "git+https://github.com/jackkleeman/arrow-convert?rev=9878358dd38cf4a2a6c8367541be3cd374fbb2c6#9878358dd38cf4a2a6c8367541be3cd374fbb2c6"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ restate-types = { workspace = true }
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
 arrow = { version = "53.1.0", features = ["ipc", "prettyprint", "json"] }
-arrow_convert = { version = "0.7.2" }
+arrow_convert = {git = "https://github.com/jackkleeman/arrow-convert", rev = "9878358dd38cf4a2a6c8367541be3cd374fbb2c6"}
 axum = { workspace = true, default-features = false, features = ["http1", "http2", "query", "tokio"] }
 bytes = { workspace = true }
 base62 = { version = "2.0.2" }

--- a/cli/src/clients/admin_client.rs
+++ b/cli/src/clients/admin_client.rs
@@ -186,10 +186,13 @@ impl AdminClient {
             .request(method, path)
             .timeout(self.request_timeout);
 
-        match self.bearer_token.as_deref() {
+        let request_builder = match self.bearer_token.as_deref() {
             Some(token) => request_builder.bearer_auth(token),
             None => request_builder,
-        }
+        };
+
+        let (api_version_header, api_version) = self.admin_api_version.into();
+        request_builder.header(api_version_header, api_version)
     }
 
     /// Prepare a request builder that encodes the body as JSON.

--- a/cli/src/clients/admin_client.rs
+++ b/cli/src/clients/admin_client.rs
@@ -27,8 +27,8 @@ use crate::clients::AdminClientInterface;
 use super::errors::ApiError;
 
 /// Min/max supported admin API versions
-pub const MIN_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V1;
-pub const MAX_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V1;
+pub const MIN_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V2;
+pub const MAX_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V2;
 
 #[derive(Error, Debug)]
 #[error(transparent)]

--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -763,7 +763,7 @@ impl arrow_convert::field::ArrowField for RestateDateTime {
 }
 
 impl arrow_convert::deserialize::ArrowDeserialize for RestateDateTime {
-    type ArrayType = TimestampMillisecondArray;
+    type ArrayType = arrow::array::TimestampMillisecondArray;
 
     #[inline]
     fn arrow_deserialize(v: Option<i64>) -> Option<Self> {
@@ -771,42 +771,6 @@ impl arrow_convert::deserialize::ArrowDeserialize for RestateDateTime {
             arrow::datatypes::TimestampMillisecondType,
         >(v?)?;
         Some(RestateDateTime(Local.from_utc_datetime(&timestamp)))
-    }
-}
-
-// This newtype is necessary to implement ArrowArray, which is implemented for TimestampNanosecond but not TimestampMillisecond for some reason
-#[repr(transparent)]
-struct TimestampMillisecondArray(arrow::array::TimestampMillisecondArray);
-
-impl TimestampMillisecondArray {
-    fn from_ref(v: &arrow::array::TimestampMillisecondArray) -> &Self {
-        // SAFETY: transmuting a single-element newtype struct with repr(transparent) is safe
-        unsafe { std::mem::transmute(v) }
-    }
-}
-
-impl arrow_convert::deserialize::ArrowArray for TimestampMillisecondArray {
-    type BaseArrayType = arrow::array::TimestampMillisecondArray;
-    #[inline]
-    fn iter_from_array_ref(
-        b: &dyn Array,
-    ) -> <Self as arrow_convert::deserialize::ArrowArrayIterable>::Iter<'_> {
-        let b = b.as_any().downcast_ref::<Self::BaseArrayType>().unwrap();
-        <Self as arrow_convert::deserialize::ArrowArrayIterable>::iter(
-            TimestampMillisecondArray::from_ref(b),
-        )
-    }
-}
-
-impl arrow_convert::deserialize::ArrowArrayIterable for TimestampMillisecondArray {
-    type Item<'a> = Option<
-        <arrow::datatypes::TimestampMillisecondType as arrow::array::ArrowPrimitiveType>::Native,
-    >;
-
-    type Iter<'a> = arrow::array::PrimitiveIter<'a, arrow::datatypes::TimestampMillisecondType>;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        IntoIterator::into_iter(&self.0)
     }
 }
 

--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -756,7 +756,7 @@ impl arrow_convert::field::ArrowField for RestateDateTime {
     #[inline]
     fn data_type() -> arrow::datatypes::DataType {
         arrow::datatypes::DataType::Timestamp(
-            arrow::datatypes::TimeUnit::Microsecond,
+            arrow::datatypes::TimeUnit::Millisecond,
             Some(TIMEZONE_UTC.clone()),
         )
     }

--- a/cli/src/clients/datafusion_helpers.rs
+++ b/cli/src/clients/datafusion_helpers.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use arrow::array::{Array, ArrayAccessor, AsArray, StringArray};
-use arrow::datatypes::{ArrowTemporalType, Date64Type};
+use arrow::datatypes::ArrowTemporalType;
 use arrow::record_batch::RecordBatch;
 use arrow_convert::{ArrowDeserialize, ArrowField};
 use bytes::Bytes;
@@ -111,10 +111,17 @@ fn value_as_u64_opt(batch: &RecordBatch, col: usize, row: usize) -> Option<u64> 
 }
 
 fn value_as_dt_opt(batch: &RecordBatch, col: usize, row: usize) -> Option<chrono::DateTime<Local>> {
-    batch
-        .column(col)
-        .as_primitive::<arrow::datatypes::Date64Type>()
-        .value_as_local_datetime_opt(row)
+    let col = batch.column(col);
+    match col.data_type() {
+        arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, _) => col
+            .as_primitive::<arrow::datatypes::TimestampMillisecondType>()
+            .value_as_local_datetime_opt(row),
+        // older versions of restate used Date64 instead of TimestampMillisecond
+        arrow::datatypes::DataType::Date64 => col
+            .as_primitive::<arrow::datatypes::Date64Type>()
+            .value_as_local_datetime_opt(row),
+        _ => panic!("Column is not a timestamp"),
+    }
 }
 
 #[derive(ValueEnum, Copy, Clone, Eq, Hash, PartialEq, Debug, Default)]
@@ -515,11 +522,7 @@ pub async fn get_service_status(
                     .column(2)
                     .as_primitive::<arrow::datatypes::Int64Type>()
                     .value(i);
-                let oldest_at = batch
-                    .column(3)
-                    .as_primitive::<arrow::datatypes::Date64Type>()
-                    .value_as_local_datetime_opt(i)
-                    .unwrap();
+                let oldest_at = value_as_dt_opt(&batch, 3, i).unwrap();
 
                 let oldest_invocation = batch.column(4).as_string::<i32>().value_string(i);
 
@@ -744,23 +747,66 @@ impl From<RestateDateTime> for DateTime<Local> {
     }
 }
 
+pub static TIMEZONE_UTC: std::sync::LazyLock<std::sync::Arc<str>> =
+    std::sync::LazyLock::new(|| std::sync::Arc::from("+00:00"));
+
 impl arrow_convert::field::ArrowField for RestateDateTime {
     type Type = Self;
 
     #[inline]
     fn data_type() -> arrow::datatypes::DataType {
-        arrow::datatypes::DataType::Date64
+        arrow::datatypes::DataType::Timestamp(
+            arrow::datatypes::TimeUnit::Microsecond,
+            Some(TIMEZONE_UTC.clone()),
+        )
     }
 }
 
 impl arrow_convert::deserialize::ArrowDeserialize for RestateDateTime {
-    type ArrayType = arrow::array::Date64Array;
+    type ArrayType = TimestampMillisecondArray;
 
     #[inline]
     fn arrow_deserialize(v: Option<i64>) -> Option<Self> {
-        v.and_then(arrow::temporal_conversions::as_datetime::<Date64Type>)
-            .map(|naive| Local.from_utc_datetime(&naive))
-            .map(RestateDateTime)
+        let timestamp = arrow::temporal_conversions::as_datetime::<
+            arrow::datatypes::TimestampMillisecondType,
+        >(v?)?;
+        Some(RestateDateTime(Local.from_utc_datetime(&timestamp)))
+    }
+}
+
+// This newtype is necessary to implement ArrowArray, which is implemented for TimestampNanosecond but not TimestampMillisecond for some reason
+#[repr(transparent)]
+struct TimestampMillisecondArray(arrow::array::TimestampMillisecondArray);
+
+impl TimestampMillisecondArray {
+    fn from_ref(v: &arrow::array::TimestampMillisecondArray) -> &Self {
+        // SAFETY: transmuting a single-element newtype struct with repr(transparent) is safe
+        unsafe { std::mem::transmute(v) }
+    }
+}
+
+impl arrow_convert::deserialize::ArrowArray for TimestampMillisecondArray {
+    type BaseArrayType = arrow::array::TimestampMillisecondArray;
+    #[inline]
+    fn iter_from_array_ref(
+        b: &dyn Array,
+    ) -> <Self as arrow_convert::deserialize::ArrowArrayIterable>::Iter<'_> {
+        let b = b.as_any().downcast_ref::<Self::BaseArrayType>().unwrap();
+        <Self as arrow_convert::deserialize::ArrowArrayIterable>::iter(
+            TimestampMillisecondArray::from_ref(b),
+        )
+    }
+}
+
+impl arrow_convert::deserialize::ArrowArrayIterable for TimestampMillisecondArray {
+    type Item<'a> = Option<
+        <arrow::datatypes::TimestampMillisecondType as arrow::array::ArrowPrimitiveType>::Native,
+    >;
+
+    type Iter<'a> = arrow::array::PrimitiveIter<'a, arrow::datatypes::TimestampMillisecondType>;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        IntoIterator::into_iter(&self.0)
     }
 }
 

--- a/cli/src/clients/datafusion_http_client.rs
+++ b/cli/src/clients/datafusion_http_client.rs
@@ -63,7 +63,7 @@ impl DataFusionHttpClient {
     fn prepare(&self) -> Result<reqwest::RequestBuilder, Error> {
         Ok(self
             .inner
-            .prepare(reqwest::Method::POST, self.inner.base_url.join("/query")?))
+            .prepare(reqwest::Method::POST, self.inner.versioned_url(["query"])))
     }
 
     pub async fn run_query(&self, query: String) -> Result<SqlResponse, Error> {

--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -219,7 +219,7 @@ pub async fn run_register(State(env): State<CliEnv>, discover_opts: &Register) -
 
     // Is this an existing deployment?
     let existing_deployment = match client
-        .get_deployment(&dry_run_result.id)
+        .get_deployment(&dry_run_result.id.to_string())
         .await?
         .into_body()
         .await

--- a/cli/src/commands/services/describe.rs
+++ b/cli/src/commands/services/describe.rs
@@ -53,7 +53,7 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     table.add_kv_row("Deployment ID:", service.deployment_id);
 
     let deployment = client
-        .get_deployment(&service.deployment_id)
+        .get_deployment(&service.deployment_id.to_string())
         .await?
         .into_body()
         .await?;

--- a/crates/admin-rest-model/src/converters.rs
+++ b/crates/admin-rest-model/src/converters.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_types::schema::service::{HandlerMetadata, HandlerMetadataType, ServiceMetadata};
+
+use crate::{
+    deployments::{DetailedDeploymentResponse, RegisterDeploymentResponse},
+    services::ListServicesResponse,
+    version::AdminApiVersion,
+};
+
+pub fn convert_register_deployment_response(
+    version: AdminApiVersion,
+    resp: RegisterDeploymentResponse,
+) -> RegisterDeploymentResponse {
+    match version {
+        AdminApiVersion::V1 => convert_register_deployment_response_v1(resp),
+        _ => resp,
+    }
+}
+
+fn convert_register_deployment_response_v1(
+    resp: RegisterDeploymentResponse,
+) -> RegisterDeploymentResponse {
+    RegisterDeploymentResponse {
+        services: resp
+            .services
+            .into_iter()
+            .map(convert_service_metadata_v1)
+            .collect(),
+        ..resp
+    }
+}
+
+pub fn convert_detailed_deployment_response(
+    version: AdminApiVersion,
+    resp: DetailedDeploymentResponse,
+) -> DetailedDeploymentResponse {
+    match version {
+        AdminApiVersion::V1 => convert_detailed_deployment_response_v1(resp),
+        _ => resp,
+    }
+}
+
+fn convert_detailed_deployment_response_v1(
+    resp: DetailedDeploymentResponse,
+) -> DetailedDeploymentResponse {
+    DetailedDeploymentResponse {
+        services: resp
+            .services
+            .into_iter()
+            .map(convert_service_metadata_v1)
+            .collect(),
+        ..resp
+    }
+}
+
+pub fn convert_list_services_response(
+    version: AdminApiVersion,
+    resp: ListServicesResponse,
+) -> ListServicesResponse {
+    match version {
+        AdminApiVersion::V1 => convert_list_services_response_v1(resp),
+        _ => resp,
+    }
+}
+
+fn convert_list_services_response_v1(resp: ListServicesResponse) -> ListServicesResponse {
+    ListServicesResponse {
+        services: resp
+            .services
+            .into_iter()
+            .map(convert_service_metadata_v1)
+            .collect(),
+    }
+}
+
+pub fn convert_service_metadata(
+    version: AdminApiVersion,
+    service_metadata: ServiceMetadata,
+) -> ServiceMetadata {
+    match version {
+        AdminApiVersion::V1 => convert_service_metadata_v1(service_metadata),
+        _ => service_metadata,
+    }
+}
+
+fn convert_service_metadata_v1(service_metadata: ServiceMetadata) -> ServiceMetadata {
+    ServiceMetadata {
+        handlers: service_metadata
+            .handlers
+            .into_iter()
+            .map(convert_handler_metadata_v1)
+            .collect(),
+        ..service_metadata
+    }
+}
+
+fn convert_handler_metadata_v1(handler_metadata: HandlerMetadata) -> HandlerMetadata {
+    HandlerMetadata {
+        // pre 1.2, we provided Shared instead of None when the handler is in a Service
+        ty: handler_metadata.ty.or(Some(HandlerMetadataType::Shared)),
+        ..handler_metadata
+    }
+}

--- a/crates/admin-rest-model/src/lib.rs
+++ b/crates/admin-rest-model/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub mod converters;
 pub mod deployments;
 pub mod handlers;
 pub mod services;

--- a/crates/admin-rest-model/src/version.rs
+++ b/crates/admin-rest-model/src/version.rs
@@ -26,40 +26,16 @@ pub enum AdminApiVersion {
     V2 = 2,
 }
 
-impl From<AdminApiVersion> for (http::HeaderName, http::HeaderValue) {
-    fn from(value: AdminApiVersion) -> Self {
-        (
-            AdminApiVersion::HEADER_NAME,
-            http::HeaderValue::from(value.as_repr()),
-        )
-    }
-}
-
 impl AdminApiVersion {
-    const HEADER_NAME: http::HeaderName =
-        http::HeaderName::from_static("x-restate-admin-api-version");
-
     pub fn as_repr(&self) -> u16 {
         *self as u16
     }
 
-    pub fn from_headers(headers: &http::HeaderMap) -> Self {
-        let is_cli = matches!(headers.get(http::header::USER_AGENT), Some(value) if value.as_bytes().starts_with(b"restate-cli"));
-
-        match headers.get(Self::HEADER_NAME) {
-            Some(value) => match value.to_str() {
-                Ok(value) => match value.parse::<u16>() {
-                    Ok(value) => match Self::try_from(value) {
-                        Ok(value) => value,
-                        Err(_) => Self::Unknown,
-                    },
-                    Err(_) => Self::Unknown,
-                },
-                Err(_) => Self::Unknown,
-            },
-            // CLI didn't used to send the version header, but if we know its the CLI, then we can treat that as V1
-            None if is_cli => Self::V1,
-            None => Self::Unknown,
+    pub const fn as_path_segment(&self) -> Option<&str> {
+        match self {
+            AdminApiVersion::Unknown => None,
+            AdminApiVersion::V1 => Some("v1"),
+            AdminApiVersion::V2 => Some("v2"),
         }
     }
 

--- a/crates/admin-rest-model/src/version.rs
+++ b/crates/admin-rest-model/src/version.rs
@@ -23,11 +23,44 @@ use std::ops::RangeInclusive;
 pub enum AdminApiVersion {
     Unknown = 0,
     V1 = 1,
+    V2 = 2,
+}
+
+impl From<AdminApiVersion> for (http::HeaderName, http::HeaderValue) {
+    fn from(value: AdminApiVersion) -> Self {
+        (
+            AdminApiVersion::HEADER_NAME,
+            http::HeaderValue::from(value.as_repr()),
+        )
+    }
 }
 
 impl AdminApiVersion {
+    const HEADER_NAME: http::HeaderName =
+        http::HeaderName::from_static("x-restate-admin-api-version");
+
     pub fn as_repr(&self) -> u16 {
         *self as u16
+    }
+
+    pub fn from_headers(headers: &http::HeaderMap) -> Self {
+        let is_cli = matches!(headers.get(http::header::USER_AGENT), Some(value) if value.as_bytes().starts_with(b"restate-cli"));
+
+        match headers.get(Self::HEADER_NAME) {
+            Some(value) => match value.to_str() {
+                Ok(value) => match value.parse::<u16>() {
+                    Ok(value) => match Self::try_from(value) {
+                        Ok(value) => value,
+                        Err(_) => Self::Unknown,
+                    },
+                    Err(_) => Self::Unknown,
+                },
+                Err(_) => Self::Unknown,
+            },
+            // CLI didn't used to send the version header, but if we know its the CLI, then we can treat that as V1
+            None if is_cli => Self::V1,
+            None => Self::Unknown,
+        }
     }
 
     pub fn choose_max_supported_version(

--- a/crates/admin/src/rest_api/version.rs
+++ b/crates/admin/src/rest_api/version.rs
@@ -14,7 +14,7 @@ use restate_admin_rest_model::version::{AdminApiVersion, VersionInformation};
 
 /// Min/max supported admin api versions by the server
 pub const MIN_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V1;
-pub const MAX_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V1;
+pub const MAX_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V2;
 
 /// Version information endpoint
 #[openapi(

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use axum::error_handling::HandleErrorLayer;
 use http::StatusCode;
+use restate_admin_rest_model::version::AdminApiVersion;
 use restate_bifrost::Bifrost;
 use restate_types::config::AdminOptions;
 use restate_types::live::LiveLoad;
@@ -83,16 +84,28 @@ where
         let router = router.merge(crate::web_ui::web_ui_router());
 
         // Merge meta API router
-        let router = router.merge(rest_api::create_router(rest_state)).layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(|_| async {
-                    StatusCode::TOO_MANY_REQUESTS
-                }))
-                .layer(tower::load_shed::LoadShedLayer::new())
-                .layer(tower::limit::GlobalConcurrencyLimitLayer::new(
-                    opts.concurrent_api_requests_limit(),
-                )),
-        );
+        let router = router.merge(rest_api::create_router(rest_state));
+
+        let router = axum::Router::new()
+            .merge(with_unknown_api_version_middleware(router.clone()))
+            .nest(
+                "/v1",
+                with_api_version_middleware(router.clone(), AdminApiVersion::V1),
+            )
+            .nest(
+                "/v2",
+                with_api_version_middleware(router, AdminApiVersion::V2),
+            )
+            .layer(
+                ServiceBuilder::new()
+                    .layer(HandleErrorLayer::new(|_| async {
+                        StatusCode::TOO_MANY_REQUESTS
+                    }))
+                    .layer(tower::load_shed::LoadShedLayer::new())
+                    .layer(tower::limit::GlobalConcurrencyLimitLayer::new(
+                        opts.concurrent_api_requests_limit(),
+                    )),
+            );
 
         let service = hyper_util::service::TowerToHyperService::new(router.into_service());
 
@@ -106,4 +119,30 @@ where
         .await
         .map_err(Into::into)
     }
+}
+
+fn with_unknown_api_version_middleware(router: axum::Router) -> axum::Router {
+    router.layer(axum::middleware::from_fn(
+        move |mut request: axum::extract::Request, next: axum::middleware::Next| {
+    let is_cli = matches!(request.headers().get(http::header::USER_AGENT), Some(value) if value.as_bytes().starts_with(b"restate-cli"));
+
+    if is_cli {
+        // If the CLI is using an unversioned API url, it must be be pre 1.2, so api version v1
+        request.extensions_mut().insert(AdminApiVersion::V1);
+    } else {
+        request.extensions_mut().insert(AdminApiVersion::Unknown);
+    }
+
+    next.run(request)
+
+    }))
+}
+
+fn with_api_version_middleware(router: axum::Router, version: AdminApiVersion) -> axum::Router {
+    router.layer(axum::middleware::from_fn(
+        move |mut request: axum::extract::Request, next: axum::middleware::Next| {
+            request.extensions_mut().insert(version);
+            next.run(request)
+        },
+    ))
 }

--- a/crates/admin/src/storage_query/convert.rs
+++ b/crates/admin/src/storage_query/convert.rs
@@ -1,0 +1,261 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use datafusion::{
+    arrow::{
+        array::{
+            Array, ArrayRef, AsArray, BinaryArray, GenericByteArray, RecordBatch, StringArray,
+        },
+        buffer::{OffsetBuffer, ScalarBuffer},
+        datatypes::{ByteArrayType, DataType, Field, FieldRef, Schema, SchemaRef},
+        error::ArrowError,
+    },
+    error::DataFusionError,
+    execution::{RecordBatchStream, SendableRecordBatchStream},
+};
+use futures::{Stream, StreamExt};
+
+pub(super) const V1_CONVERTER: JoinConverter<LargeConverter, FullCountConverter> =
+    JoinConverter::new(LargeConverter, FullCountConverter);
+
+pub(super) struct ConvertRecordBatchStream<C> {
+    converter: C,
+    inner: SendableRecordBatchStream,
+    converted_schema: SchemaRef,
+    done: bool,
+}
+
+impl<C: Converter> ConvertRecordBatchStream<C> {
+    pub(super) fn new(converter: C, inner: SendableRecordBatchStream) -> Self {
+        let converted_schema = converter.convert_schema(inner.schema());
+
+        Self {
+            converter,
+            inner,
+            converted_schema,
+            done: false,
+        }
+    }
+}
+
+impl<C: Converter> RecordBatchStream for ConvertRecordBatchStream<C> {
+    fn schema(&self) -> SchemaRef {
+        self.converted_schema.clone()
+    }
+}
+
+impl<C: Converter> Stream for ConvertRecordBatchStream<C> {
+    type Item = Result<RecordBatch, DataFusionError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        let record_batch = ready!(self.inner.poll_next_unpin(cx));
+
+        Poll::Ready(match record_batch {
+            Some(record_batch) => Some(match record_batch {
+                Ok(record_batch) => Ok(self
+                    .converter
+                    .convert_record_batch(&self.converted_schema, record_batch)?),
+                Err(err) => {
+                    self.done = true;
+                    Err(err)
+                }
+            }),
+            None => None,
+        })
+    }
+}
+
+pub(super) trait Converter: Unpin {
+    fn convert_schema(&self, schema: SchemaRef) -> SchemaRef {
+        let fields = Vec::from_iter(schema.fields().iter().cloned());
+        let fields = self.convert_fields(fields);
+        SchemaRef::new(Schema::new_with_metadata(fields, schema.metadata().clone()))
+    }
+
+    fn convert_record_batch(
+        &self,
+        converted_schema: &SchemaRef,
+        record_batch: RecordBatch,
+    ) -> Result<RecordBatch, ArrowError> {
+        let columns = Vec::from_iter(record_batch.columns().iter().cloned());
+        let columns = self.convert_columns(converted_schema, columns)?;
+
+        RecordBatch::try_new(converted_schema.clone(), columns)
+    }
+
+    fn convert_columns(
+        &self,
+        converted_schema: &SchemaRef,
+        columns: Vec<ArrayRef>,
+    ) -> Result<Vec<ArrayRef>, ArrowError>;
+
+    fn convert_fields(&self, fields: Vec<FieldRef>) -> Vec<FieldRef>;
+}
+
+pub(super) struct NoopConverter;
+
+impl Converter for NoopConverter {
+    #[inline]
+    fn convert_schema(&self, schema: SchemaRef) -> SchemaRef {
+        schema
+    }
+
+    #[inline]
+    fn convert_record_batch(
+        &self,
+        _: &SchemaRef,
+        record_batch: RecordBatch,
+    ) -> Result<RecordBatch, ArrowError> {
+        Ok(record_batch)
+    }
+
+    fn convert_columns(
+        &self,
+        _: &SchemaRef,
+        _: Vec<ArrayRef>,
+    ) -> Result<Vec<ArrayRef>, ArrowError> {
+        unreachable!()
+    }
+
+    fn convert_fields(&self, _: Vec<FieldRef>) -> Vec<FieldRef> {
+        unreachable!()
+    }
+}
+
+pub(super) struct JoinConverter<Before, After> {
+    before: Before,
+    after: After,
+}
+
+impl<Before, After> JoinConverter<Before, After> {
+    const fn new(before: Before, after: After) -> Self {
+        Self { before, after }
+    }
+}
+
+impl<Before: Converter, After: Converter> Converter for JoinConverter<Before, After> {
+    fn convert_columns(
+        &self,
+        converted_schema: &SchemaRef,
+        columns: Vec<ArrayRef>,
+    ) -> Result<Vec<ArrayRef>, ArrowError> {
+        self.after.convert_columns(
+            converted_schema,
+            self.before.convert_columns(converted_schema, columns)?,
+        )
+    }
+
+    fn convert_fields(&self, fields: Vec<FieldRef>) -> Vec<FieldRef> {
+        self.after
+            .convert_fields(self.before.convert_fields(fields))
+    }
+}
+
+// Prior to 1.2, we always converted LargeUtf8 to Utf8
+pub(super) struct LargeConverter;
+
+impl Converter for LargeConverter {
+    fn convert_columns(
+        &self,
+        _converted_schema: &SchemaRef,
+        columns: Vec<ArrayRef>,
+    ) -> Result<Vec<ArrayRef>, ArrowError> {
+        columns
+            .into_iter()
+            .map(|column| {
+                Ok(match column.data_type() {
+                    DataType::LargeBinary => {
+                        let col: BinaryArray = convert_array_offset(column.as_binary::<i64>())?;
+                        ArrayRef::from(Box::new(col) as Box<dyn Array>)
+                    }
+                    DataType::LargeUtf8 => {
+                        let col: StringArray = convert_array_offset(column.as_string::<i64>())?;
+                        ArrayRef::from(Box::new(col) as Box<dyn Array>)
+                    }
+                    _ => column,
+                })
+            })
+            .collect()
+    }
+
+    fn convert_fields(&self, fields: Vec<FieldRef>) -> Vec<FieldRef> {
+        fields
+            .into_iter()
+            .map(|field| {
+                let data_type = match field.data_type() {
+                    // Represent binary as base64
+                    DataType::LargeBinary => DataType::Binary,
+                    DataType::LargeUtf8 => DataType::Utf8,
+                    other => other.clone(),
+                };
+                FieldRef::new(Field::new(field.name(), data_type, field.is_nullable()))
+            })
+            .collect()
+    }
+}
+
+fn convert_array_offset<Before: ByteArrayType, After: ByteArrayType>(
+    array: &GenericByteArray<Before>,
+) -> Result<GenericByteArray<After>, ArrowError>
+where
+    After::Offset: TryFrom<Before::Offset>,
+{
+    let offsets = array
+        .offsets()
+        .iter()
+        .map(|&o| After::Offset::try_from(o))
+        .collect::<Result<ScalarBuffer<After::Offset>, _>>()
+        .map_err(|_| ArrowError::CastError("offset conversion failed".into()))?;
+    GenericByteArray::<After>::try_new(
+        OffsetBuffer::new(offsets),
+        array.values().clone(),
+        array.nulls().cloned(),
+    )
+}
+
+// Prior to 1.2, we used a datafusion version which incorrectly considered the results of 'COUNT' statements to be nullable
+// This is relevant for a single field name, `full_count` which is used in `inv ls`.
+pub(super) struct FullCountConverter;
+
+impl Converter for FullCountConverter {
+    fn convert_columns(
+        &self,
+        _converted_schema: &SchemaRef,
+        columns: Vec<ArrayRef>,
+    ) -> Result<Vec<ArrayRef>, ArrowError> {
+        // this is a schema-only conversion
+        Ok(columns)
+    }
+
+    fn convert_fields(&self, fields: Vec<FieldRef>) -> Vec<FieldRef> {
+        fields
+            .into_iter()
+            .map(|field| {
+                if field.name().as_str() == "full_count"
+                    && field.data_type().eq(&DataType::Int64)
+                    && !field.is_nullable()
+                {
+                    FieldRef::new(Field::clone(&field).with_nullable(true))
+                } else {
+                    field
+                }
+            })
+            .collect()
+    }
+}

--- a/crates/admin/src/storage_query/convert.rs
+++ b/crates/admin/src/storage_query/convert.rs
@@ -146,7 +146,7 @@ impl<Before: Converter, After: Converter> Converter for JoinConverter<Before, Af
     }
 }
 
-// Prior to 1.2, we always converted LargeUtf8 to Utf8
+// Prior to 1.2, we always converted LargeUtf8 to Utf8 and LargeBinary to Binary.
 pub(super) struct LargeConverter;
 
 impl Converter for LargeConverter {

--- a/crates/admin/src/storage_query/mod.rs
+++ b/crates/admin/src/storage_query/mod.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod convert;
 mod error;
 mod query;
 

--- a/crates/admin/src/storage_query/query.rs
+++ b/crates/admin/src/storage_query/query.rs
@@ -34,7 +34,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_with::serde_as;
 
-use super::convert::{ConvertRecordBatchStream, NoopConverter, V1_CONVERTER};
+use super::convert::{ConvertRecordBatchStream, V1_CONVERTER};
 use super::error::StorageQueryError;
 use crate::state::QueryServiceState;
 
@@ -71,10 +71,8 @@ pub async fn query(
             V1_CONVERTER,
             record_batch_stream,
         )),
-        AdminApiVersion::Unknown | AdminApiVersion::V2 => Box::pin(ConvertRecordBatchStream::new(
-            NoopConverter,
-            record_batch_stream,
-        )),
+        // treat 'unknown' as latest, users can specify 1 if they want to maintain old behaviour
+        AdminApiVersion::Unknown | AdminApiVersion::V2 => record_batch_stream,
     };
 
     let (result_stream, content_type) = match headers.get(http::header::ACCEPT) {

--- a/crates/storage-query-datafusion/src/deployment/schema.rs
+++ b/crates/storage-query-datafusion/src/deployment/schema.rs
@@ -25,7 +25,7 @@ define_table!(sys_deployment(
     endpoint: DataType::LargeUtf8,
 
     /// Timestamp indicating the deployment registration time.
-    created_at: DataType::Date64,
+    created_at: TimestampMillisecond,
 
     /// Minimum supported protocol version.
     min_service_protocol_version: DataType::UInt32,

--- a/crates/storage-query-datafusion/src/inbox/schema.rs
+++ b/crates/storage-query-datafusion/src/inbox/schema.rs
@@ -32,5 +32,5 @@ define_table!(sys_inbox(
 
     /// Timestamp indicating the start of this invocation.
     /// DEPRECATED: you should not use this field anymore, but join with the sys_invocation table
-    created_at: DataType::Date64,
+    created_at: TimestampMillisecond,
 ));

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -30,7 +30,7 @@ define_table!(sys_invocation_state(
     retry_count: DataType::UInt64,
 
     /// Timestamp indicating the start of the most recent attempt of this invocation.
-    last_start_at: DataType::Date64,
+    last_start_at: TimestampMillisecond,
 
     // The deployment that was selected in the last invocation attempt. This is
     // guaranteed to be set unlike in `sys_status` table which require that the
@@ -44,7 +44,7 @@ define_table!(sys_invocation_state(
     last_attempt_server: DataType::LargeUtf8,
 
     /// Timestamp indicating the start of the next attempt of this invocation.
-    next_retry_at: DataType::Date64,
+    next_retry_at: TimestampMillisecond,
 
     /// An error message describing the most recent failed attempt of this invocation, if any.
     last_failure: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -85,21 +85,21 @@ define_table!(sys_invocation_status(
     journal_size: DataType::UInt32,
 
     /// Timestamp indicating the start of this invocation.
-    created_at: DataType::Date64,
+    created_at: TimestampMillisecond,
 
     /// Timestamp indicating the last invocation status transition. For example, last time the
     /// status changed from `invoked` to `suspended`.
-    modified_at: DataType::Date64,
+    modified_at: TimestampMillisecond,
 
     /// Timestamp indicating when the invocation was inboxed, if ever.
-    inboxed_at: DataType::Date64,
+    inboxed_at: TimestampMillisecond,
 
     /// Timestamp indicating when the invocation was scheduled, if ever.
-    scheduled_at: DataType::Date64,
+    scheduled_at: TimestampMillisecond,
 
     /// Timestamp indicating when the invocation first transitioned to running, if ever.
-    running_at: DataType::Date64,
+    running_at: TimestampMillisecond,
 
     /// Timestamp indicating when the invocation was completed, if ever.
-    completed_at: DataType::Date64,
+    completed_at: TimestampMillisecond,
 ));

--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -44,7 +44,7 @@ define_table!(sys_journal(
     invoked_target: DataType::LargeUtf8,
 
     /// If this entry represents a sleep, indicates wakeup time.
-    sleep_wakeup_at: DataType::Date64,
+    sleep_wakeup_at: TimestampMillisecond,
 
     /// If this entry is a promise related entry (GetPromise, PeekPromise, CompletePromise), indicates the promise name.
     promise_name: DataType::LargeUtf8,

--- a/deny.toml
+++ b/deny.toml
@@ -171,6 +171,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/restatedev/rust-rocksdb.git",
     "https://github.com/apache/arrow-rs.git",
+    "https://github.com/jackkleeman/arrow-convert",
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
Currently there are 2 ways that old CLIs will break against 1.2
1. COUNT(*) queries no longer return nullable values. The old CLI expects that they do for a particular field.
2. We no longer convert LargeUtf8 and LargeBinary to their non large equivalents. The old CLI expects that we do.

And i want to introduce a new way, by encoding our timestamp data correctly instead of as date64. 

To cover these 3 breaking changes, I have added a mechanism to convert schemas on the fly based on negotiated version. CLI clients will start providing their negotiated version as a header `x-restate-admin-api-version`. CLI user-agent clients that don't do so will be presumed to be on version 1. Other clients that don't do so will be presumed to be happy with the latest version. This is still a slight breaking change if someone is depending on certain schema types, but they can provide `x-restate-admin-api-version: 1` to maintain the current behaviour.

NB: this PR does not cover newer CLIs talking to older restate clusters. In my opinion we should move the CLI to use JSON for the sql operations, which is itself a somewhat breaking change as json is only present from 1.1.3, but once thats sorted, these conversions become mostly irrelevant for new CLIs.