### PR TITLE
[Networking] Enable and tune h2 keep-alive on the server-end of connections

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,7 +37,7 @@ http-body = { workspace = true }
 http-body-util = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { workspace = true }
+hyper-util = { workspace = true, features = ["server-graceful", "server"] }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
 object_store = { workspace = true, features = ["aws"] }

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, info, trace, warn, Instrument, Span};
+use tracing::{debug, info, instrument, trace, warn, Instrument, Span};
 
 use restate_types::config::NetworkingOptions;
 use restate_types::net::codec::MessageBodyExt;
@@ -355,6 +355,7 @@ impl<T: TransportConnect> ConnectionManager<T> {
         self.start_connection_reactor(connection, incoming)
     }
 
+    #[instrument(skip_all)]
     fn connect_loopback(&self) -> Result<Arc<OwnedConnection>, NetworkError> {
         let (tx, rx) = mpsc::channel(self.networking_options.outbound_queue_length.into());
         let connection = OwnedConnection::new(

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -186,7 +186,7 @@ pub mod test_util {
             });
 
             // start acceptor
-            TaskCenter::spawn(TaskKind::RpcConnection, "test-connection-acceptor", {
+            TaskCenter::spawn(TaskKind::Disposable, "test-connection-acceptor", {
                 let connector = connector.clone();
                 async move {
                     while let Some(connection) = new_connections.recv().await {

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -49,7 +49,7 @@ impl TaskId {
 ///   * `OnCancel` - What to do when the task is cancelled:
 ///     - `ignore                 - Ignores the tokio task. The task will be dropped on tokio
 ///                                 runtime drop.
-///     - `abort`                 - Aborts the tokio task (default)
+///     - `abort`                 - Aborts the tokio task
 ///     - `wait`  (default)       - Wait for graceful shutdown. The task must respond
 ///                                  to cancellation_watcher() or check periodically for
 ///                                  is_cancellation_requested()
@@ -80,8 +80,9 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
-    #[strum(props(OnCancel = "abort", OnError = "log"))]
-    RpcConnection,
+    SocketHandler,
+    #[strum(props(OnError = "log"))]
+    H2Stream,
     /// A task that handles a single RPC request. The task is executed on the default runtime to
     /// decouple it from the lifetime of the originating runtime. Use this task kind if you want to
     /// make sure that the rpc response is sent even if the originating runtime is dropped.

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -100,6 +100,8 @@ impl NetworkServer {
                 health,
                 connection_manager,
             ))
+            .max_decoding_message_size(32 * 1024 * 1024)
+            .max_encoding_message_size(32 * 1024 * 1024)
             .accept_compressed(CompressionEncoding::Gzip)
             .send_compressed(CompressionEncoding::Gzip),
             restate_types::protobuf::FILE_DESCRIPTOR_SET,

--- a/crates/storage-query-postgres/src/pgwire_server.rs
+++ b/crates/storage-query-postgres/src/pgwire_server.rs
@@ -98,7 +98,7 @@ pub fn spawn_connection(
 ) {
     // fails only if we are shutting down
     let _ = TaskCenter::spawn_child(
-        TaskKind::RpcConnection,
+        TaskKind::SocketHandler,
         "postgres-query-connection",
         async move {
             let result = process_socket(incoming_socket, None, factory).await;

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -77,8 +77,8 @@ impl Default for NetworkingOptions {
             ),
             handshake_timeout: Duration::from_secs(3).into(),
             outbound_queue_length: NonZeroUsize::new(1000).expect("Non zero number"),
-            http2_keep_alive_interval: Duration::from_secs(40).into(),
-            http2_keep_alive_timeout: Duration::from_secs(20).into(),
+            http2_keep_alive_interval: Duration::from_secs(5).into(),
+            http2_keep_alive_timeout: Duration::from_secs(5).into(),
             http2_adaptive_window: true,
         }
     }


### PR DESCRIPTION

h2 keep-alive is very important to detect frozen streams, we only had this enabled on client-side of connections so we didn't always detect broken network or frozen processes. This also tunes the default such that we can detect frozen processes in 5-10s. The biggest impact comes from bifrost's remote sequencers being able to detect that their in-flight appends can/should be retried, otherwise the'll be stuck indefinitely even if the loglet has been sealed already (albeit this happens on a higher level).
- Changes the max frame size to 32MB (default is 4MB) to allow for larger batches
- Fixes a small lineage issue in tracing individual connection tasks (more to follow on the larger issue in subsequent PRs)
- Changes how shutdown is designed for connections. Connections now wait for 5 seconds for graceful sub-streams drain before dropping the connection
- Minor renames and logging
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2422).
* #2427
* #2426
* #2424
* #2423
* __->__ #2422