### PR TITLE
[TaskCenter] maintain tracing lineage for child/unmanaged tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6072,6 +6072,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "criterion",
+ "crossbeam-utils",
  "dashmap",
  "derive_more",
  "enum-map",

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -23,6 +23,7 @@ restate-test-util = { workspace = true, optional = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+crossbeam-utils = { version = "0.8" }
 dashmap = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -30,7 +30,6 @@ use crate::providers::replicated_loglet::tasks::{
 };
 
 use super::error::ReplicatedLogletError;
-use super::log_server_manager::RemoteLogServerManager;
 use super::metric_definitions::{BIFROST_RECORDS_ENQUEUED_BYTES, BIFROST_RECORDS_ENQUEUED_TOTAL};
 use super::read_path::{ReadStreamTask, ReplicatedLogletReadStream};
 use super::remote_sequencer::RemoteSequencer;
@@ -72,9 +71,6 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
         record_cache: RecordCache,
     ) -> Self {
         let known_global_tail = TailOffsetWatch::new(TailState::Open(LogletOffset::OLDEST));
-        let log_server_manager =
-            RemoteLogServerManager::new(my_params.loglet_id, &my_params.nodeset);
-
         let sequencer = if networking.my_node_id() == my_params.sequencer {
             debug!(
                 loglet_id = %my_params.loglet_id,
@@ -90,7 +86,6 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
                     selector_strategy,
                     networking.clone(),
                     logservers_rpc.store.clone(),
-                    log_server_manager.clone(),
                     record_cache.clone(),
                     known_global_tail.clone(),
                 ),

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -363,6 +363,7 @@ impl ReadStreamTask {
                         %to_offset,
                         "Could not request record batch, exhausted all servers in the nodeset. Retrying.."
                     );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
                     continue 'main;
                 };
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,7 +37,7 @@ http-body = { workspace = true }
 http-body-util = { workspace = true }
 humantime = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { workspace = true }
+hyper-util = { workspace = true, features = ["server-graceful", "server"] }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
 object_store = { workspace = true, features = ["aws"] }

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 use rand::seq::SliceRandom;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, info, trace, warn, Instrument, Span};
+use tracing::{debug, info, instrument, trace, warn, Instrument, Span};
 
 use restate_types::config::NetworkingOptions;
 use restate_types::net::codec::MessageBodyExt;
@@ -355,6 +355,7 @@ impl<T: TransportConnect> ConnectionManager<T> {
         self.start_connection_reactor(connection, incoming)
     }
 
+    #[instrument(skip_all)]
     fn connect_loopback(&self) -> Result<Arc<OwnedConnection>, NetworkError> {
         let (tx, rx) = mpsc::channel(self.networking_options.outbound_queue_length.into());
         let connection = OwnedConnection::new(

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -192,7 +192,7 @@ where
 
                 let connection = graceful_shutdown.watch(builder
                     .serve_connection(io, service.clone()).into_owned())
-                    .instrument(Span::current());
+                    .in_current_span();
 
                 // TaskCenter will wait for the parent task, we don't need individual connection
                 // handlers to be managed tasks. We just need to make sure that we actually try and

--- a/crates/core/src/network/networking.rs
+++ b/crates/core/src/network/networking.rs
@@ -19,7 +19,7 @@ use restate_types::{GenerationalNodeId, NodeId};
 
 use super::{
     ConnectionManager, HasConnection, NetworkError, NetworkSendError, NetworkSender, NoConnection,
-    Outgoing, OwnedConnection, WeakConnection,
+    Outgoing, WeakConnection,
 };
 use super::{GrpcConnector, TransportConnect};
 use crate::Metadata;
@@ -99,27 +99,6 @@ impl<T: TransportConnect> Networking<T> {
         };
 
         Ok(self.connections.get_or_connect(node).await?.downgrade())
-    }
-
-    /// A connection sender is pinned to a single stream, thus guaranteeing ordered delivery of
-    /// messages.
-    pub async fn node_owned_connection(
-        &self,
-        node: impl Into<NodeId>,
-    ) -> Result<Arc<OwnedConnection>, NetworkError> {
-        let node = node.into();
-        // find latest generation if this is not generational node id
-        let node = match node.as_generational() {
-            Some(node) => node,
-            None => {
-                self.metadata
-                    .nodes_config_ref()
-                    .find_node_by_id(node)?
-                    .current_generation
-            }
-        };
-
-        self.connections.get_or_connect(node).await
     }
 }
 

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -186,7 +186,7 @@ pub mod test_util {
             });
 
             // start acceptor
-            TaskCenter::spawn(TaskKind::RpcConnection, "test-connection-acceptor", {
+            TaskCenter::spawn(TaskKind::Disposable, "test-connection-acceptor", {
                 let connector = connector.clone();
                 async move {
                     while let Some(connection) = new_connections.recv().await {

--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use restate_types::identifiers::PartitionId;
 use tokio_util::sync::CancellationToken;
-use tracing::instrument;
+use tracing::{instrument, Instrument};
 
 use crate::{Metadata, ShutdownError};
 
@@ -116,7 +116,7 @@ impl Handle {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        self.inner.spawn_child(kind, name, future)
+        self.inner.spawn_child(kind, name, future.in_current_span())
     }
 
     pub fn spawn_unmanaged<F, T>(
@@ -129,7 +129,8 @@ impl Handle {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        self.inner.spawn_unmanaged(kind, name, future)
+        self.inner
+            .spawn_unmanaged(kind, name, future.in_current_span())
     }
 
     /// Must be called within a Localset-scoped task, not from a normal spawned task.
@@ -143,7 +144,7 @@ impl Handle {
     where
         F: Future<Output = anyhow::Result<()>> + 'static,
     {
-        self.inner.spawn_local(kind, name, future)
+        self.inner.spawn_local(kind, name, future.in_current_span())
     }
 
     pub fn metadata(&self) -> Option<Metadata> {

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -49,7 +49,7 @@ impl TaskId {
 ///   * `OnCancel` - What to do when the task is cancelled:
 ///     - `ignore                 - Ignores the tokio task. The task will be dropped on tokio
 ///                                 runtime drop.
-///     - `abort`                 - Aborts the tokio task (default)
+///     - `abort`                 - Aborts the tokio task
 ///     - `wait`  (default)       - Wait for graceful shutdown. The task must respond
 ///                                  to cancellation_watcher() or check periodically for
 ///                                  is_cancellation_requested()
@@ -80,8 +80,9 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
-    #[strum(props(OnCancel = "abort", OnError = "log"))]
-    RpcConnection,
+    SocketHandler,
+    #[strum(props(OnError = "log"))]
+    H2Stream,
     /// A task that handles a single RPC request. The task is executed on the default runtime to
     /// decouple it from the lifetime of the originating runtime. Use this task kind if you want to
     /// make sure that the rpc response is sent even if the originating runtime is dropped.

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -124,7 +124,6 @@ pub enum TaskKind {
     LogletProvider,
     #[strum(props(OnCancel = "abort"))]
     Watchdog,
-    #[strum(props(OnCancel = "wait", runtime = "default"))]
     SequencerAppender,
     // -- Replicated loglet tasks
     /// Receives messages from remote sequencers on nodes with local sequencer. This is also used

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -100,6 +100,8 @@ impl NetworkServer {
                 health,
                 connection_manager,
             ))
+            .max_decoding_message_size(32 * 1024 * 1024)
+            .max_encoding_message_size(32 * 1024 * 1024)
             .accept_compressed(CompressionEncoding::Gzip)
             .send_compressed(CompressionEncoding::Gzip),
             restate_types::protobuf::FILE_DESCRIPTOR_SET,

--- a/crates/storage-query-postgres/src/pgwire_server.rs
+++ b/crates/storage-query-postgres/src/pgwire_server.rs
@@ -98,7 +98,7 @@ pub fn spawn_connection(
 ) {
     // fails only if we are shutting down
     let _ = TaskCenter::spawn_child(
-        TaskKind::RpcConnection,
+        TaskKind::SocketHandler,
         "postgres-query-connection",
         async move {
             let result = process_socket(incoming_socket, None, factory).await;

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -221,11 +221,11 @@ pub struct ReplicatedLogletOptions {
     /// Note that this will be increased to fit the biggest batch of records being enqueued.
     pub maximum_inflight_records: NonZeroUsize,
 
-    /// Sequencer backoff strategy
+    /// Sequencer retry policy
     ///
     /// Backoff introduced when sequencer fail to find a suitable spread
     /// of log servers
-    pub sequencer_backoff_strategy: RetryPolicy,
+    pub sequencer_retry_policy: RetryPolicy,
 
     /// Log Server RPC timeout
     ///
@@ -268,7 +268,7 @@ impl Default for ReplicatedLogletOptions {
         Self {
             maximum_inflight_records: NonZeroUsize::new(1000).unwrap(),
 
-            sequencer_backoff_strategy: RetryPolicy::exponential(
+            sequencer_retry_policy: RetryPolicy::exponential(
                 Duration::from_millis(250),
                 2.0,
                 None,

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -77,8 +77,8 @@ impl Default for NetworkingOptions {
             ),
             handshake_timeout: Duration::from_secs(3).into(),
             outbound_queue_length: NonZeroUsize::new(1000).expect("Non zero number"),
-            http2_keep_alive_interval: Duration::from_secs(40).into(),
-            http2_keep_alive_timeout: Duration::from_secs(20).into(),
+            http2_keep_alive_interval: Duration::from_secs(5).into(),
+            http2_keep_alive_timeout: Duration::from_secs(5).into(),
             http2_adaptive_window: true,
         }
     }

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -155,7 +155,7 @@ impl NodeSet {
         self.0.contains(node)
     }
 
-    /// returns true if this node didn't already exist in the nodeset
+    /// Returns true if this node didn't already exist in the nodeset
     pub fn insert(&mut self, node: PlainNodeId) -> bool {
         self.0.insert(node)
     }
@@ -177,6 +177,11 @@ impl NodeSet {
                 .iter()
                 .map(|node_id| nodes_config.get_log_server_storage_state(node_id))
                 .all(|storage_state| storage_state.is_provisioning())
+    }
+
+    /// Clears the nodeset, removes all nodes.
+    pub fn clear(&mut self) {
+        self.0.clear();
     }
 
     pub fn remove(&mut self, node: &PlainNodeId) -> bool {


### PR DESCRIPTION

This change ensures that when using spawn_child or spawn_unmanaged, futures carry the parent span automatically. for spawn(), it's up to the caller to `.instrument(Span::current())` their futures if similar behaviour is needed since `spawn()` is considered as a detached task.

```
# intentionally left empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2424).
* #2427
* #2426
* __->__ #2424
* #2423
* #2422