### PR TITLE
[chore] mechanical cleanup

### DIFF
--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -154,12 +154,10 @@ pub trait LogletReadStream: Stream<Item = Result<LogEntry<LogletOffset>, Operati
 
 pub type SendableLogletReadStream = Pin<Box<dyn LogletReadStream + Send>>;
 
-#[allow(dead_code)]
-pub(crate) struct LogletCommitResolver {
+pub struct LogletCommitResolver {
     tx: oneshot::Sender<Result<LogletOffset, AppendError>>,
 }
 
-#[allow(dead_code)]
 impl LogletCommitResolver {
     pub fn sealed(self) {
         let _ = self.tx.send(Err(AppendError::Sealed));
@@ -179,20 +177,19 @@ pub struct LogletCommit {
 }
 
 impl LogletCommit {
-    pub(crate) fn sealed() -> Self {
+    pub fn sealed() -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Err(AppendError::Sealed));
         Self { rx }
     }
 
-    pub(crate) fn resolved(offset: LogletOffset) -> Self {
+    pub fn resolved(offset: LogletOffset) -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Ok(offset));
         Self { rx }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn deferred() -> (Self, LogletCommitResolver) {
+    pub fn deferred() -> (Self, LogletCommitResolver) {
         let (tx, rx) = oneshot::channel();
         (Self { rx }, LogletCommitResolver { tx })
     }

--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -15,11 +15,9 @@ pub(crate) mod metric_definitions;
 mod network;
 mod provider;
 mod read_path;
-#[allow(dead_code)]
 mod remote_sequencer;
 pub mod replication;
 mod rpc_routers;
-#[allow(dead_code)]
 pub mod sequencer;
 mod tasks;
 #[cfg(any(test, feature = "test-util"))]


### PR DESCRIPTION

- Move loglet mod to follow new file-style module as it contains type defs and logic
- Removal of dead_code attribute and cleanup of unused types/structs/vars/etc.

```
// left intentionally to make sapling+github happy
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2426).
* #2440
* #2439
* #2427
* __->__ #2426