### PR TITLE
Compile-time feature no-trace-logging to filter trace logging

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [features]
 default = []
 frame-pointer = ["pprof/frame-pointer"]
+no-trace-logging = ["tracing/max_level_debug", "tracing/release_max_level_debug"]
 
 [dependencies]
 restate-core = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 [features]
 default = ["cloud"]
 cloud = []
+no-trace-logging = ["tracing/max_level_debug", "tracing/release_max_level_debug"]
 
 [dependencies]
 restate-admin-rest-model = { workspace = true }

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -154,12 +154,10 @@ pub trait LogletReadStream: Stream<Item = Result<LogEntry<LogletOffset>, Operati
 
 pub type SendableLogletReadStream = Pin<Box<dyn LogletReadStream + Send>>;
 
-#[allow(dead_code)]
-pub(crate) struct LogletCommitResolver {
+pub struct LogletCommitResolver {
     tx: oneshot::Sender<Result<LogletOffset, AppendError>>,
 }
 
-#[allow(dead_code)]
 impl LogletCommitResolver {
     pub fn sealed(self) {
         let _ = self.tx.send(Err(AppendError::Sealed));
@@ -179,20 +177,19 @@ pub struct LogletCommit {
 }
 
 impl LogletCommit {
-    pub(crate) fn sealed() -> Self {
+    pub fn sealed() -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Err(AppendError::Sealed));
         Self { rx }
     }
 
-    pub(crate) fn resolved(offset: LogletOffset) -> Self {
+    pub fn resolved(offset: LogletOffset) -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Ok(offset));
         Self { rx }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn deferred() -> (Self, LogletCommitResolver) {
+    pub fn deferred() -> (Self, LogletCommitResolver) {
         let (tx, rx) = oneshot::channel();
         (Self { rx }, LogletCommitResolver { tx })
     }

--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -15,11 +15,9 @@ pub(crate) mod metric_definitions;
 mod network;
 mod provider;
 mod read_path;
-#[allow(dead_code)]
 mod remote_sequencer;
 pub mod replication;
 mod rpc_routers;
-#[allow(dead_code)]
 pub mod sequencer;
 mod tasks;
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -23,8 +23,7 @@ use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
 use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tracing::log::trace;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ReadError {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,7 @@ options_schema = [
 memory-loglet = ["restate-node/memory-loglet", "restate-admin/memory-loglet"]
 replicated-loglet = ["restate-node/replicated-loglet", "restate-admin/replicated-loglet"]
 crate_per_service = ["restate-tracing-instrumentation/service_per_crate"]
+no-trace-logging = ["tracing/max_level_debug", "tracing/release_max_level_debug"]
 
 [dependencies]
 restate-admin = { workspace = true }

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -13,6 +13,7 @@ replicated-loglet = [
     "restate-bifrost/replicated-loglet",
 ]
 memory-loglet = ["restate-types/memory-loglet", "restate-bifrost/memory-loglet", "restate-admin/memory-loglet"]
+no-trace-logging = ["tracing/max_level_debug", "tracing/release_max_level_debug"]
 
 [dependencies]
 restate-admin = { workspace = true, features = ["clients"] }


### PR DESCRIPTION
At the moment, this is an opt-in feature (build with `-F no-trace-logging` to enable). We might decide to filter trace logging from our docker builds after experimenting with this.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2427).
* #2440
* #2439
* __->__ #2427
* #2426