### PR TITLE
Calculate and verify CRC32 checksums for snapshot SST files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7120,6 +7120,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "codederror",
+ "crc32fast",
  "derive_builder",
  "derive_more",
  "enumset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ chrono-humanize = { version = "0.2.3" }
 clap = { version = "4", default-features = false }
 clap-verbosity-flag = { version = "2.0.1" }
 cling = { version = "0.1", default-features = false, features = ["derive"] }
+crc32fast = "1.4.2"
 criterion = "0.5"
 crossterm = { version = "0.27.0" }
 dashmap = { version = "6" }

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -59,8 +59,26 @@ pub struct PartitionSnapshotMetadata {
     pub db_comparator_name: String,
 
     /// The RocksDB SST files comprising the snapshot.
-    #[serde_as(as = "Vec<SnapshotSstFile>")]
-    pub files: Vec<LiveFile>,
+    pub files: Vec<ExtendedFileMetadata>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExtendedFileMetadata {
+    #[serde(flatten)]
+    #[serde(with = "SnapshotSstFile")]
+    pub live_file: LiveFile,
+
+    /// CRC32 checksum of the file contents.
+    pub crc32: u32,
+}
+
+impl From<&LiveFile> for ExtendedFileMetadata {
+    fn from(live_file: &LiveFile) -> Self {
+        Self {
+            live_file: live_file.clone(),
+            crc32: 0,
+        }
+    }
 }
 
 /// A locally-stored partition snapshot.

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -43,7 +43,7 @@ pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_stor
         key_range: key_range.clone(),
         min_applied_lsn: snapshot.min_applied_lsn,
         db_comparator_name: snapshot.db_comparator_name.clone(),
-        files: snapshot.files.clone(),
+        files: snapshot.files.iter().map(|f| f.into()).collect(),
     };
     let metadata_json = serde_json::to_string_pretty(&snapshot_meta).unwrap();
 
@@ -58,7 +58,11 @@ pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_stor
         base_dir: snapshots_dir.path().into(),
         min_applied_lsn: snapshot_meta.min_applied_lsn,
         db_comparator_name: snapshot_meta.db_comparator_name.clone(),
-        files: snapshot_meta.files.clone(),
+        files: snapshot_meta
+            .files
+            .iter()
+            .map(|f| f.live_file.clone())
+            .collect(),
         key_range,
     };
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -51,6 +51,7 @@ aws-credential-types = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
+crc32fast = { workspace = true}
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -64,8 +64,9 @@ impl SnapshotPartitionTask {
 
         let metadata = self.metadata(&snapshot, SystemTime::now());
 
-        self.snapshot_repository
-            .put(&metadata, snapshot.base_dir)
+        let metadata = self
+            .snapshot_repository
+            .put(metadata, snapshot.base_dir)
             .await
             .map_err(|e| SnapshotError::RepositoryIo(self.partition_id, e))?;
 
@@ -87,7 +88,7 @@ impl SnapshotPartitionTask {
             key_range: snapshot.key_range.clone(),
             min_applied_lsn: snapshot.min_applied_lsn,
             db_comparator_name: snapshot.db_comparator_name.clone(),
-            files: snapshot.files.clone(),
+            files: snapshot.files.iter().map(|f| f.into()).collect(),
         }
     }
 }


### PR DESCRIPTION
I'd like to ensure that we can detect corruption either in-place, or during download, of snapshot data files.

So far this is just a draft; I'd love some input on these points:

- I picked CRC32 because that's what RocksDB uses for its SST files - but open to suggestions! If we stay with CRC, what would be a good way to represent it in the serialized JSON? Numeric / hex?
- I am computing the checksums on the fly but I believe we can read them from the SSTs themselves; it seems like it would be just as involved, if not more, to open the exported snapshot as a read-only database, for the sake of reading the checksums though - I feel like we can burn a few CPU cycles on this since we have the data in memory during upload/download anyway?
- I'm a bit shaky on serde usage - I am having to use a wrapper to extend the RocksDB type, as well as a separate remote type to customize the serialization formatting of certain fields; are there opportunities to streamline this? Thoughts on where I've put the checksum in the metadata?