### PR TITLE
Avoid reordering events due to split partition queues

### DIFF
--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -8,25 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::fmt;
-use std::sync::Arc;
+use std::fmt::{self, Display};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use base64::Engine;
 use bytes::Bytes;
 use metrics::counter;
 use opentelemetry::trace::TraceContextExt;
 use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
-use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
+use rdkafka::consumer::{Consumer, ConsumerContext, Rebalance, StreamConsumer};
 use rdkafka::error::KafkaError;
 use rdkafka::message::BorrowedMessage;
-use rdkafka::{ClientConfig, Message};
+use rdkafka::topic_partition_list::TopicPartitionListElem;
+use rdkafka::{ClientConfig, ClientContext, Message};
 use tokio::sync::oneshot;
-use tracing::{debug, info, info_span, Instrument};
+use tracing::{debug, info, info_span, warn, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use restate_core::{cancellation_watcher, TaskCenter, TaskId, TaskKind};
+use restate_core::{TaskCenter, TaskId, TaskKind};
 use restate_ingress_dispatcher::{
     DeduplicationId, DispatchIngressRequest, IngressDispatcher, IngressDispatcherRequest,
 };
@@ -52,11 +52,11 @@ pub enum Error {
     },
     #[error("ingress dispatcher channel is closed")]
     IngressDispatcherClosed,
-    #[error("topic {0} partition {1} queue split didn't succeed")]
-    TopicPartitionSplit(String, i32),
+    #[error("received a message on the main partition queue for topic {0} partition {1} despite partitioned queues")]
+    UnexpectedMainQueueMessage(String, i32),
 }
 
-type MessageConsumer = StreamConsumer<DefaultConsumerContext>;
+type MessageConsumer = StreamConsumer<RebalanceContext>;
 
 #[derive(Debug, Hash)]
 pub struct KafkaDeduplicationId {
@@ -232,91 +232,199 @@ impl ConsumerTask {
             self.topics, self.client_config
         );
 
-        let consumer: Arc<MessageConsumer> = Arc::new(self.client_config.create()?);
+        let rebalance_context = RebalanceContext {
+            task_center: self.task_center.clone(),
+            consumer: OnceLock::new(),
+            topic_partition_tasks: Mutex::new(HashMap::new()),
+            sender: self.sender.clone(),
+            consumer_group_id,
+        };
+        let consumer: Arc<MessageConsumer> =
+            Arc::new(self.client_config.create_with_context(rebalance_context)?);
+        _ = consumer.context().consumer.set(Arc::downgrade(&consumer));
+        let consumer = ConsumerDrop(consumer);
+
         let topics: Vec<&str> = self.topics.iter().map(|x| &**x).collect();
         consumer.subscribe(&topics)?;
 
-        let mut topic_partition_tasks: HashMap<(String, i32), TaskId> = Default::default();
-
-        let result = loop {
+        // we have to poll the main consumer for callbacks to be processed, but we expect to only see messages on the partitioned queues
+        loop {
             tokio::select! {
                 res = consumer.recv() => {
-                    let msg = match res {
-                       Ok(msg) => msg,
-                        Err(e) => break Err(e.into())
+                    break match res {
+                        // We shouldn't see any messages on the main consumer loop
+                        Ok(msg) => Err(Error::UnexpectedMainQueueMessage(msg.topic().into(), msg.partition())),
+                        Err(e) => Err(e.into()),
                     };
-                    let topic = msg.topic().to_owned();
-                    let partition = msg.partition();
-                    let offset = msg.offset();
-
-                    // If we didn't split the queue, let's do it and start the topic partition consumer
-                     if let Entry::Vacant(e) = topic_partition_tasks.entry((topic.clone(), partition)) {
-                        let topic_partition_consumer = match consumer
-                            .split_partition_queue(&topic, partition) {
-                            Some(q) => q,
-                            None => break Err(Error::TopicPartitionSplit(topic.clone(), partition))
-                        };
-
-                        let task = topic_partition_queue_consumption_loop(
-                            self.sender.clone(),
-                            topic.clone(), partition,
-                            topic_partition_consumer,
-                            Arc::clone(&consumer),
-                            consumer_group_id.clone()
-                        );
-
-                        if let Ok(task_id) = self.task_center.spawn_child(TaskKind::Ingress, "partition-queue", None, task) {
-                            e.insert(task_id);
-                        } else {
-                            break Ok(());
-                        }
-                    }
-
-                    // We got this message, let's send it through
-                    if let Err(e) = self.sender.send(&consumer_group_id, msg).await {
-                        break Err(e)
-                    }
-
-                    // This method tells rdkafka that we have processed this message,
-                    // so its offset can be safely committed.
-                    // rdkafka periodically commits these offsets asynchronously, with a period configurable
-                    // with auto.commit.interval.ms
-                    if let Err(e) = consumer.store_offset(&topic, partition, offset) {
-                        break Err(e.into())
-                    }
                 }
                 _ = &mut rx => {
                     break Ok(());
                 }
             }
-        };
-        for task_id in topic_partition_tasks.into_values() {
-            self.task_center.cancel_task(task_id);
         }
-        result
+    }
+}
+
+struct ConsumerDrop(Arc<MessageConsumer>);
+
+impl std::ops::Deref for ConsumerDrop {
+    type Target = Arc<MessageConsumer>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for ConsumerDrop {
+    fn drop(&mut self) {
+        debug!(
+            "Stopping consumer with id {}",
+            self.context().consumer_group_id
+        );
+
+        let task_center = &self.context().task_center;
+        self
+            .context()
+            .topic_partition_tasks
+            .lock()
+            .unwrap()
+            .drain()
+            .for_each(|(partition, task_id)| {
+                debug!("Stopping partitioned consumer for partition {partition} due to the consumer stopping");
+                task_center
+                    .cancel_task(task_id)
+                    .map(|handle| handle.abort());
+            });
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct TopicPartition(String, i32);
+
+impl<'a> From<TopicPartitionListElem<'a>> for TopicPartition {
+    fn from(value: TopicPartitionListElem<'a>) -> Self {
+        Self(value.topic().into(), value.partition())
+    }
+}
+
+impl Display for TopicPartition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.0, self.1)
+    }
+}
+
+struct RebalanceContext {
+    task_center: TaskCenter,
+    consumer: OnceLock<Weak<MessageConsumer>>,
+    topic_partition_tasks: Mutex<HashMap<TopicPartition, TaskId>>,
+    sender: MessageSender,
+    consumer_group_id: String,
+}
+
+impl ClientContext for RebalanceContext {}
+
+// This callback is called synchronously with the poll of the main queue, so we don't want to block here.
+// Once the pre balance steps finish assign() will be called. If we have not split at this point,
+// then queues will be created defaulting to forward to the main loop - which we don't want.
+// However, if we have split the partition before assign is called, the queue will be created
+// with a flag RD_KAFKA_Q_F_FWD_APP and this flag will ensure that the queue will not be sent to the
+// main loop. Therefore its critical that the splits happen synchronously before the pre_rebalance ends.
+//
+// On non-cooperative rebalance during assign all the existing partitions are revoked,
+// and their queues are destroyed. Split partition queues will stop working in this case. We should ensure
+// that they are not polled again after the assign. Then there will be a further rebalance callback after the revoke
+// and we will set up new split partition streams before the assign.
+impl ConsumerContext for RebalanceContext {
+    fn pre_rebalance<'a>(&self, rebalance: &Rebalance<'a>) {
+        let mut topic_partition_tasks = self.topic_partition_tasks.lock().unwrap();
+        let consumer = self
+            .consumer
+            .get()
+            .expect("consumer must have been set in context at rebalance time");
+
+        // if the consumer has been dropped, we don't need to maintain tasks any more
+        let Some(consumer) = consumer.upgrade() else {
+            return;
+        };
+
+        match rebalance {
+            Rebalance::Assign(partitions) => {
+                for partition in partitions.elements() {
+                    let partition: TopicPartition = partition.into();
+
+                    if let Some(task_id) = topic_partition_tasks.remove(&partition) {
+                        warn!("Kafka informed us of an assigned partition {partition} which we already consider assigned, cancelling the existing partitioned consumer");
+                        self.task_center
+                            .cancel_task(task_id)
+                            .map(|handle| handle.abort());
+                    }
+
+                    match consumer.split_partition_queue(&partition.0, partition.1) {
+                        Some(queue) => {
+                            let task = topic_partition_queue_consumption_loop(
+                                self.sender.clone(),
+                                partition.clone(),
+                                queue,
+                                Arc::clone(&consumer),
+                                self.consumer_group_id.clone(),
+                            );
+
+                            if let Ok(task_id) = self.task_center.spawn_child(
+                                TaskKind::Ingress,
+                                "partition-queue",
+                                None,
+                                task,
+                            ) {
+                                topic_partition_tasks.insert(partition, task_id);
+                            } else {
+                                // shutting down
+                                return;
+                            }
+                        }
+                        None => {
+                            warn!("Invalid partition {partition} given to us in rebalance, ignoring it");
+                            continue;
+                        }
+                    }
+                }
+            }
+            Rebalance::Revoke(partitions) => {
+                for partition in partitions.elements() {
+                    let partition = partition.into();
+                    match topic_partition_tasks.remove(&partition)
+                {
+                    Some(task_id) => {
+                        debug!("Stopping partitioned consumer for partition {partition} due to rebalance");
+                        // The partitioned queue will not be polled again.
+                        // It might be mid-poll right now, but if so its result will not be sent anywhere.
+                        self.task_center.cancel_task(task_id).map(|handle| handle.abort());
+                    }
+                    None => warn!("Kafka informed us of a revoked partition {partition} which we had no consumer task for"),
+                }
+                }
+            }
+            Rebalance::Error(_) => {}
+        }
     }
 }
 
 async fn topic_partition_queue_consumption_loop(
     sender: MessageSender,
-    topic: String,
-    partition: i32,
-    topic_partition_consumer: StreamPartitionQueue<DefaultConsumerContext>,
+    partition: TopicPartition,
+    topic_partition_consumer: StreamPartitionQueue<impl ConsumerContext>,
     consumer: Arc<MessageConsumer>,
     consumer_group_id: String,
 ) -> Result<(), anyhow::Error> {
-    let mut shutdown = std::pin::pin!(cancellation_watcher());
+    debug!("Starting partitioned consumer for partition {partition}");
 
+    // this future will be aborted when the partition is no longer needed
     loop {
         tokio::select! {
             res = topic_partition_consumer.recv() => {
                 let msg = res?;
                 let offset = msg.offset();
                 sender.send(&consumer_group_id, msg).await?;
-                consumer.store_offset(&topic, partition, offset)?;
-            }
-            _ = &mut shutdown => {
-                return Ok(())
+                consumer.store_offset(&partition.0, partition.1, offset)?;
             }
         }
     }

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -241,7 +241,6 @@ mod task_orchestrator {
         ) {
             match result {
                 Ok((id, Ok(_))) => {
-                    warn!("Consumer unexpectedly closed");
                     self.start_retry_timer(id);
                 }
                 Ok((id, Err(e))) => {
@@ -259,6 +258,7 @@ mod task_orchestrator {
             let subscription_id = if let Some(subscription_id) =
                 self.running_tasks_to_subscriptions.remove(&task_id)
             {
+                warn!("Consumer unexpectedly closed");
                 subscription_id
             } else {
                 // No need to do anything, as it's a correct closure


### PR DESCRIPTION
Great care is required when splitting queues to avoid losing ordering. We rely on ordering for dedupe so reordering -> dropped kafka messages.