### PR TITLE
Improve error messages

### DIFF
--- a/crates/service-client/src/lib.rs
+++ b/crates/service-client/src/lib.rs
@@ -152,9 +152,9 @@ impl ServiceClient {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ServiceClientError {
-    #[error(transparent)]
+    #[error("HTTP client error: {0}")]
     Http(#[from] http::HttpError),
-    #[error(transparent)]
+    #[error("Lambda client error: {0}")]
     Lambda(#[from] lambda::LambdaError),
     #[error(transparent)]
     IdentityV1(#[from] <request_identity::v1::Signer<'static, 'static> as SignRequest>::Error),


### PR DESCRIPTION
* Add response headers to bad discovery response. Fix https://github.com/restatedev/restate/issues/2369
* Improve connect error in ServiceClient