### PR TITLE
[Mechanical] Rename ReplicatedLogletId to LogletId

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -835,7 +835,7 @@ mod tests {
     use test_log::test;
 
     use restate_bifrost::providers::memory_loglet;
-    use restate_bifrost::{Bifrost, BifrostService};
+    use restate_bifrost::{Bifrost, BifrostService, ErrorRecoveryStrategy};
     use restate_core::network::{
         FailingConnector, Incoming, MessageHandler, MockPeerConnection, NetworkServerBuilder,
     };
@@ -875,7 +875,7 @@ mod tests {
         let _ = builder.build().await;
         bifrost_svc.start().await?;
 
-        let mut appender = bifrost.create_appender(LOG_ID)?;
+        let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::default())?;
 
         TaskCenter::spawn(TaskKind::SystemService, "cluster-controller", svc.run())?;
 
@@ -972,7 +972,7 @@ mod tests {
         let (_node_2, _node2_reactor) =
             node_2.process_with_message_handler(get_node_state_handler)?;
 
-        let mut appender = bifrost.create_appender(LOG_ID)?;
+        let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::default())?;
         for i in 1..=20 {
             let lsn = appender.append("").await?;
             assert_eq!(Lsn::from(i), lsn);
@@ -1049,7 +1049,7 @@ mod tests {
         let (_node_2, _node2_reactor) =
             node_2.process_with_message_handler(get_node_state_handler)?;
 
-        let mut appender = bifrost.create_appender(LOG_ID)?;
+        let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::default())?;
         for i in 1..=20 {
             let lsn = appender.append(format!("record{i}")).await?;
             assert_eq!(Lsn::from(i), lsn);
@@ -1112,7 +1112,7 @@ mod tests {
         })
         .await?;
 
-        let mut appender = bifrost.create_appender(LOG_ID)?;
+        let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::default())?;
         for i in 1..=5 {
             let lsn = appender.append(format!("record{i}")).await?;
             assert_eq!(Lsn::from(i), lsn);

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -12,6 +12,8 @@ default = []
 replicated-loglet = []
 memory-loglet = ["restate-types/memory-loglet"]
 test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util"]
+# enables bifrost to auto seal and extend. This is a transitional feature that will be removed soon.
+auto-extend = []
 
 [dependencies]
 restate-core = { workspace = true }

--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -26,11 +26,10 @@ use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionProcessorRp
 use restate_types::invocation::{
     InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext,
 };
-use restate_types::logs::{LogId, Record};
+use restate_types::logs::{LogId, LogletId, Record};
 use restate_types::net::codec::{serialize_message, MessageBodyExt, WireDecode};
 use restate_types::net::replicated_loglet::{Append, CommonRequestHeader};
 use restate_types::protobuf::node::Message;
-use restate_types::replicated_loglet::ReplicatedLogletId;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::GenerationalNodeId;
 use restate_wal_protocol::{Command, Destination, Envelope};
@@ -124,7 +123,7 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
         header: CommonRequestHeader {
             log_id: LogId::from(12u16),
             segment_index: 2.into(),
-            loglet_id: ReplicatedLogletId::new(12u16.into(), 4.into()),
+            loglet_id: LogletId::new(12u16.into(), 4.into()),
         },
         payloads,
     };

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -21,7 +21,7 @@ use restate_types::logs::{LogId, Lsn, Record};
 use restate_types::retries::RetryIter;
 use restate_types::storage::StorageEncode;
 
-use crate::bifrost::BifrostInner;
+use crate::bifrost::{BifrostInner, ErrorRecoveryStrategy};
 use crate::loglet::AppendError;
 use crate::loglet_wrapper::LogletWrapper;
 use crate::{Error, InputRecord, Result};
@@ -31,17 +31,25 @@ pub struct Appender {
     log_id: LogId,
     #[debug(skip)]
     pub(super) config: Live<Configuration>,
+    // todo: asoli remove
+    #[allow(unused)]
+    error_recovery_strategy: ErrorRecoveryStrategy,
     loglet_cache: Option<LogletWrapper>,
     #[debug(skip)]
     bifrost_inner: Arc<BifrostInner>,
 }
 
 impl Appender {
-    pub(crate) fn new(log_id: LogId, bifrost_inner: Arc<BifrostInner>) -> Self {
+    pub(crate) fn new(
+        log_id: LogId,
+        error_recovery_strategy: ErrorRecoveryStrategy,
+        bifrost_inner: Arc<BifrostInner>,
+    ) -> Self {
         let config = Configuration::updateable();
         Self {
             log_id,
             config,
+            error_recovery_strategy,
             loglet_cache: Default::default(),
             bifrost_inner,
         }

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -24,7 +24,7 @@ mod watchdog;
 
 pub use appender::Appender;
 pub use background_appender::{AppenderHandle, BackgroundAppender, CommitToken, LogSender};
-pub use bifrost::Bifrost;
+pub use bifrost::{Bifrost, ErrorRecoveryStrategy};
 pub use bifrost_admin::{BifrostAdmin, SealedSegment};
 pub use error::{Error, Result};
 pub use read_stream::LogReadStream;

--- a/crates/bifrost/src/providers/replicated_loglet/error.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/error.rs
@@ -13,8 +13,7 @@ use std::sync::Arc;
 use restate_core::ShutdownError;
 use restate_types::errors::MaybeRetryableError;
 use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::LogId;
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::logs::{LogId, LogletId};
 
 use crate::loglet::OperationError;
 
@@ -25,7 +24,7 @@ pub(crate) enum ReplicatedLogletError {
     #[error("cannot find the tail of the loglet: {0}")]
     FindTailFailed(String),
     #[error("could not seal loglet_id={0}, insufficient nodes available for seal")]
-    SealFailed(ReplicatedLogletId),
+    SealFailed(LogletId),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
 }

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -346,8 +346,8 @@ mod tests {
     use restate_types::config::{set_current_config, Configuration};
     use restate_types::health::HealthStatus;
     use restate_types::live::Live;
-    use restate_types::logs::Keys;
-    use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicationProperty};
+    use restate_types::logs::{Keys, LogletId};
+    use restate_types::replicated_loglet::{NodeSet, ReplicationProperty};
     use restate_types::{GenerationalNodeId, PlainNodeId};
 
     use crate::loglet::{AppendError, Loglet};
@@ -421,7 +421,7 @@ mod tests {
     // ** Single-node replicated-loglet smoke tests **
     #[test(restate_core::test(start_paused = true))]
     async fn test_append_local_sequencer_single_node() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -464,7 +464,7 @@ mod tests {
     // ** Single-node replicated-loglet seal **
     #[test(restate_core::test(start_paused = true))]
     async fn test_seal_local_sequencer_single_node() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -513,7 +513,7 @@ mod tests {
     #[test(restate_core::test(start_paused = true))]
     async fn single_node_gapless_loglet_smoke_test() -> Result<()> {
         let record_cache = RecordCache::new(1_000_000);
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -528,7 +528,7 @@ mod tests {
 
     #[test(restate_core::test(start_paused = true))]
     async fn single_node_single_loglet_readstream() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -544,7 +544,7 @@ mod tests {
 
     #[test(restate_core::test(start_paused = true))]
     async fn single_node_single_loglet_readstream_with_trims() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -567,7 +567,7 @@ mod tests {
 
     #[test(restate_core::test(start_paused = true))]
     async fn single_node_append_after_seal() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -583,7 +583,7 @@ mod tests {
 
     #[test(restate_core::test(start_paused = true))]
     async fn single_node_append_after_seal_concurrent() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),
@@ -600,7 +600,7 @@ mod tests {
 
     #[test(restate_core::test(start_paused = true))]
     async fn single_node_seal_empty() -> Result<()> {
-        let loglet_id = ReplicatedLogletId::new_unchecked(122);
+        let loglet_id = LogletId::new_unchecked(122);
         let params = ReplicatedLogletParams {
             loglet_id,
             sequencer: GenerationalNodeId::new(1, 1),

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer.rs
@@ -26,9 +26,9 @@ use restate_core::{
 };
 use restate_types::{
     config::Configuration,
-    logs::{LogletOffset, Record, RecordCache, SequenceNumber},
+    logs::{LogletId, LogletOffset, Record, RecordCache, SequenceNumber},
     net::log_server::Store,
-    replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty},
+    replicated_loglet::{NodeSet, ReplicatedLogletParams, ReplicationProperty},
     GenerationalNodeId,
 };
 
@@ -74,7 +74,7 @@ impl SequencerSharedState {
         &self.my_params
     }
 
-    pub fn loglet_id(&self) -> &ReplicatedLogletId {
+    pub fn loglet_id(&self) -> &LogletId {
         &self.my_params.loglet_id
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/digests.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/digests.rs
@@ -17,12 +17,12 @@ use tracing::{debug, trace, warn};
 use restate_core::network::rpc_router::{RpcError, RpcRouter};
 use restate_core::network::{Networking, TransportConnect};
 use restate_core::{cancellation_watcher, ShutdownError, TaskCenterFutureExt};
-use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber};
 use restate_types::net::log_server::{
     Digest, LogServerRequestHeader, RecordStatus, Status, Store, StoreFlags,
 };
 use restate_types::nodes_config::NodesConfiguration;
-use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletId, ReplicatedLogletParams};
+use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletParams};
 use restate_types::{GenerationalNodeId, PlainNodeId};
 
 use crate::loglet::util::TailOffsetWatch;
@@ -40,7 +40,7 @@ struct ReplicationFailed;
 /// Tracks digest responses and record repairs to achieve a consistent and durable
 /// state of the loglet tail.
 pub struct Digests {
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     // inclusive. The first record we need to repair.
     start_offset: LogletOffset,
     // exclusive (this should be the durable global_tail after finishing)

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -18,12 +18,10 @@ use restate_core::network::{Networking, TransportConnect};
 use restate_core::TaskCenterFutureExt;
 use restate_types::config::Configuration;
 use restate_types::logs::metadata::SegmentIndex;
-use restate_types::logs::{LogId, LogletOffset, RecordCache, SequenceNumber};
+use restate_types::logs::{LogId, LogletId, LogletOffset, RecordCache, SequenceNumber};
 use restate_types::net::log_server::{GetLogletInfo, LogServerRequestHeader, Status, WaitForTail};
 use restate_types::net::replicated_loglet::{CommonRequestHeader, GetSequencerState};
-use restate_types::replicated_loglet::{
-    EffectiveNodeSet, ReplicatedLogletId, ReplicatedLogletParams,
-};
+use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletParams};
 use restate_types::PlainNodeId;
 
 use super::{NodeTailStatus, RepairTail, RepairTailResult, SealTask};
@@ -485,7 +483,7 @@ impl<T: TransportConnect> FindTailTask<T> {
 
 pub(super) struct FindTailOnNode<'a> {
     pub(super) node_id: PlainNodeId,
-    pub(super) loglet_id: ReplicatedLogletId,
+    pub(super) loglet_id: LogletId,
     pub(super) get_loglet_info_rpc: &'a RpcRouter<GetLogletInfo>,
     pub(super) known_global_tail: &'a TailOffsetWatch,
 }
@@ -603,7 +601,7 @@ impl<'a> FindTailOnNode<'a> {
 
 struct WaitForTailOnNode {
     node_id: PlainNodeId,
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     wait_for_tail_rpc: RpcRouter<WaitForTail>,
     known_global_tail: TailOffsetWatch,
 }

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
@@ -15,7 +15,7 @@ use tokio::time::Instant;
 use tracing::{debug, trace};
 
 use restate_core::network::TransportConnect;
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::logs::LogletId;
 
 use crate::loglet::{Loglet, OperationError};
 use crate::providers::replicated_loglet::loglet::ReplicatedLoglet;
@@ -24,7 +24,7 @@ pub struct PeriodicTailChecker {}
 
 impl PeriodicTailChecker {
     pub async fn run<T: TransportConnect>(
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         loglet: Weak<ReplicatedLoglet<T>>,
         duration: Duration,
     ) -> anyhow::Result<()> {

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/seal.rs
@@ -15,11 +15,9 @@ use restate_core::network::rpc_router::{RpcError, RpcRouter};
 use restate_core::network::{Incoming, Networking, TransportConnect};
 use restate_core::{TaskCenter, TaskKind};
 use restate_types::config::Configuration;
-use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber};
 use restate_types::net::log_server::{LogServerRequestHeader, Seal, Sealed, Status};
-use restate_types::replicated_loglet::{
-    EffectiveNodeSet, NodeSet, ReplicatedLogletId, ReplicatedLogletParams,
-};
+use restate_types::replicated_loglet::{EffectiveNodeSet, NodeSet, ReplicatedLogletParams};
 use restate_types::retries::RetryPolicy;
 use restate_types::{GenerationalNodeId, PlainNodeId};
 
@@ -132,7 +130,7 @@ impl SealTask {
 
 struct SealSingleNode<T> {
     node_id: PlainNodeId,
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     sequencer: GenerationalNodeId,
     seal_router: RpcRouter<Seal>,
     networking: Networking<T>,

--- a/crates/log-server/src/grpc_svc_handler.rs
+++ b/crates/log-server/src/grpc_svc_handler.rs
@@ -11,9 +11,8 @@
 use async_trait::async_trait;
 use tonic::{Request, Response, Status};
 
-use restate_types::logs::{LogletOffset, RecordCache, SequenceNumber};
+use restate_types::logs::{LogletId, LogletOffset, RecordCache, SequenceNumber};
 use restate_types::net::log_server::{GetDigest, LogServerResponseHeader, LogletInfo};
-use restate_types::replicated_loglet::ReplicatedLogletId;
 
 use crate::logstore::LogStore;
 use crate::metadata::LogletStateMap;
@@ -51,7 +50,7 @@ where
         request: Request<GetDigestRequest>,
     ) -> Result<Response<GetDigestResponse>, Status> {
         let request = request.into_inner();
-        let loglet_id = ReplicatedLogletId::from(request.loglet_id);
+        let loglet_id = LogletId::from(request.loglet_id);
         let state = self
             .state_map
             .get_or_load(loglet_id, &self.log_store)
@@ -82,7 +81,7 @@ where
         request: Request<GetLogletInfoRequest>,
     ) -> Result<Response<GetLogletInfoResponse>, Status> {
         let request = request.into_inner();
-        let loglet_id = ReplicatedLogletId::from(request.loglet_id);
+        let loglet_id = LogletId::from(request.loglet_id);
         let state = self
             .state_map
             .get_or_load(loglet_id, &self.log_store)

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -16,9 +16,8 @@ use tracing::{debug, trace, trace_span, warn, Instrument};
 
 use restate_core::network::Incoming;
 use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskHandle, TaskKind};
-use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber};
 use restate_types::net::log_server::*;
-use restate_types::replicated_loglet::ReplicatedLogletId;
 use restate_types::GenerationalNodeId;
 
 use crate::logstore::{AsyncToken, LogStore};
@@ -93,14 +92,14 @@ impl LogletWorkerHandle {
 }
 
 pub struct LogletWorker<S> {
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     log_store: S,
     loglet_state: LogletState,
 }
 
 impl<S: LogStore> LogletWorker<S> {
     pub fn start(
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         log_store: S,
         loglet_state: LogletState,
     ) -> Result<LogletWorkerHandle, ShutdownError> {
@@ -613,7 +612,6 @@ mod tests {
     use restate_types::logs::{KeyFilter, Keys, Record, RecordCache};
     use restate_types::net::codec::MessageBodyExt;
     use restate_types::net::CURRENT_PROTOCOL_VERSION;
-    use restate_types::replicated_loglet::ReplicatedLogletId;
 
     use crate::metadata::LogletStateMap;
     use crate::rocksdb_logstore::{RocksDbLogStore, RocksDbLogStoreBuilder};
@@ -642,7 +640,7 @@ mod tests {
     async fn test_simple_store_flow() -> Result<()> {
         let log_store = setup().await?;
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
@@ -718,7 +716,7 @@ mod tests {
     async fn test_store_and_seal() -> Result<()> {
         let log_store = setup().await?;
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
@@ -878,7 +876,7 @@ mod tests {
         let log_store = setup().await?;
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
         const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
@@ -1041,7 +1039,7 @@ mod tests {
     async fn test_simple_get_records_flow() -> Result<()> {
         let log_store = setup().await?;
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
@@ -1258,7 +1256,7 @@ mod tests {
     async fn test_trim_basics() -> Result<()> {
         let log_store = setup().await?;
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
-        const LOGLET: ReplicatedLogletId = ReplicatedLogletId::new_unchecked(1);
+        const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (net_tx, mut net_rx) = mpsc::channel(10);
         let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);

--- a/crates/log-server/src/logstore.rs
+++ b/crates/log-server/src/logstore.rs
@@ -15,8 +15,8 @@ use tokio::sync::oneshot;
 
 use restate_bifrost::loglet::OperationError;
 use restate_core::ShutdownError;
+use restate_types::logs::LogletId;
 use restate_types::net::log_server::{Digest, GetDigest, GetRecords, Records, Seal, Store, Trim};
-use restate_types::replicated_loglet::ReplicatedLogletId;
 
 use crate::metadata::{LogStoreMarker, LogletState};
 
@@ -32,7 +32,7 @@ pub trait LogStore: Clone + Send + 'static {
     /// [`LogletState`] will not observe the values in this one.
     fn load_loglet_state(
         &self,
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
     ) -> impl Future<Output = Result<LogletState, OperationError>> + Send;
 
     fn enqueue_store(

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -19,8 +19,7 @@ use xxhash_rust::xxh3::Xxh3Builder;
 use restate_bifrost::loglet::util::TailOffsetWatch;
 use restate_bifrost::loglet::OperationError;
 use restate_core::ShutdownError;
-use restate_types::logs::{LogletOffset, SequenceNumber, TailState};
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber, TailState};
 use restate_types::{GenerationalNodeId, PlainNodeId};
 
 use crate::logstore::LogStore;
@@ -65,7 +64,7 @@ impl LogStoreMarker {
 /// Caches loglet state in memory
 #[derive(Default, Clone)]
 pub struct LogletStateMap {
-    inner: Arc<AsyncMutex<HashMap<ReplicatedLogletId, LogletState, Xxh3Builder>>>,
+    inner: Arc<AsyncMutex<HashMap<LogletId, LogletState, Xxh3Builder>>>,
 }
 
 impl LogletStateMap {
@@ -76,7 +75,7 @@ impl LogletStateMap {
 
     pub async fn get_or_load<S: LogStore>(
         &self,
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         log_store: &S,
     ) -> Result<LogletState, OperationError> {
         let mut guard = self.inner.lock().await;

--- a/crates/log-server/src/network.rs
+++ b/crates/log-server/src/network.rs
@@ -25,10 +25,10 @@ use restate_core::network::{Incoming, MessageRouterBuilder, MessageStream};
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::logs::LogletId;
 use restate_types::net::log_server::*;
 use restate_types::nodes_config::StorageState;
 use restate_types::protobuf::common::LogServerStatus;
-use restate_types::replicated_loglet::ReplicatedLogletId;
 
 use crate::loglet_worker::{LogletWorker, LogletWorkerHandle};
 use crate::logstore::LogStore;
@@ -36,7 +36,7 @@ use crate::metadata::LogletStateMap;
 
 const DEFAULT_WRITERS_CAPACITY: usize = 128;
 
-type LogletWorkerMap = HashMap<ReplicatedLogletId, LogletWorkerHandle, Xxh3Builder>;
+type LogletWorkerMap = HashMap<LogletId, LogletWorkerHandle, Xxh3Builder>;
 
 pub struct RequestPump {
     _configuration: Live<Configuration>,
@@ -312,7 +312,7 @@ impl RequestPump {
     }
 
     async fn find_or_create_worker<'a, S: LogStore>(
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         log_store: &S,
         state_map: &LogletStateMap,
         loglet_workers: &'a mut LogletWorkerMap,

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -20,13 +20,12 @@ use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LogServerOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber};
 use restate_types::net::log_server::{
     Digest, DigestEntry, Gap, GetDigest, GetRecords, LogServerResponseHeader, MaybeRecord,
     RecordStatus, Records, Seal, Store, Trim,
 };
 use restate_types::protobuf::common::LogServerStatus;
-use restate_types::replicated_loglet::ReplicatedLogletId;
 use restate_types::GenerationalNodeId;
 
 use super::keys::{KeyPrefixKind, MetadataKey, MARKER_KEY};
@@ -100,10 +99,7 @@ impl LogStore for RocksDbLogStore {
         Ok(())
     }
 
-    async fn load_loglet_state(
-        &self,
-        loglet_id: ReplicatedLogletId,
-    ) -> Result<LogletState, OperationError> {
+    async fn load_loglet_state(&self, loglet_id: LogletId) -> Result<LogletState, OperationError> {
         let start = Instant::now();
         let metadata_cf = self.metadata_cf();
         let data_cf = self.data_cf();
@@ -501,11 +497,10 @@ mod tests {
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
     use restate_types::live::Live;
-    use restate_types::logs::{LogletOffset, Record, RecordCache, SequenceNumber};
+    use restate_types::logs::{LogletId, LogletOffset, Record, RecordCache, SequenceNumber};
     use restate_types::net::log_server::{
         DigestEntry, GetDigest, LogServerRequestHeader, RecordStatus, Status, Store, StoreFlags,
     };
-    use restate_types::replicated_loglet::ReplicatedLogletId;
     use restate_types::{GenerationalNodeId, PlainNodeId};
 
     use super::RocksDbLogStore;
@@ -554,8 +549,8 @@ mod tests {
     async fn test_load_loglet_state() -> Result<()> {
         let log_store = setup().await?;
         // fresh/unknown loglet
-        let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
-        let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
+        let loglet_id_1 = LogletId::new_unchecked(88);
+        let loglet_id_2 = LogletId::new_unchecked(89);
         let sequencer_1 = GenerationalNodeId::new(5, 213);
         let sequencer_2 = GenerationalNodeId::new(2, 212);
 
@@ -645,8 +640,8 @@ mod tests {
     #[test(restate_core::test(start_paused = true))]
     async fn test_digest() -> Result<()> {
         let log_store = setup().await?;
-        let loglet_id_1 = ReplicatedLogletId::new_unchecked(88);
-        let loglet_id_2 = ReplicatedLogletId::new_unchecked(89);
+        let loglet_id_1 = LogletId::new_unchecked(88);
+        let loglet_id_2 = LogletId::new_unchecked(89);
         let sequencer_1 = GenerationalNodeId::new(5, 213);
         let sequencer_2 = GenerationalNodeId::new(2, 212);
 

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -33,8 +33,7 @@ use restate_core::{cancellation_watcher, ShutdownError, TaskCenter, TaskKind};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LogServerOptions;
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::{LogletOffset, Record, RecordCache, SequenceNumber};
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::logs::{LogletId, LogletOffset, Record, RecordCache, SequenceNumber};
 
 use super::keys::{DataRecordKey, KeyPrefixKind, MetadataKey};
 use super::record_format::DataRecordEncoder;
@@ -51,7 +50,7 @@ const RECORD_SIZE_GUESS: usize = 4_096; // Estimate 4KiB per record
 const INITIAL_SERDE_BUFFER_SIZE: usize = 16_384; // Initial capacity 16KiB
 
 pub struct LogStoreWriteCommand {
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     data_update: Option<DataUpdate>,
     metadata_update: Option<MetadataUpdate>,
     ack: Option<Ack>,
@@ -220,7 +219,7 @@ impl LogStoreWriter {
     fn update_metadata(
         metadata_cf: &Arc<BoundColumnFamily>,
         write_batch: &mut WriteBatch,
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         update: MetadataUpdate,
         buffer: &mut BytesMut,
     ) {
@@ -248,7 +247,7 @@ impl LogStoreWriter {
     fn trim_log_records(
         data_cf: &Arc<BoundColumnFamily>,
         write_batch: &mut WriteBatch,
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         trim_point: LogletOffset,
         buffer: &mut BytesMut,
     ) {

--- a/crates/types/src/logs/loglet.rs
+++ b/crates/types/src/logs/loglet.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use crate::logs::metadata::SegmentIndex;
+use crate::logs::LogId;
+
+/// LogletId is a helper type to generate reliably unique identifiers for individual loglets in a
+/// single chain.
+///
+/// This is not an essential type and loglet providers may choose to use their own type. This type
+/// stitches the log-id and a segment-index in a u64 number which can be displayed as
+/// `<logid>_<segment_index>`
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Eq,
+    PartialEq,
+    Hash,
+    Ord,
+    PartialOrd,
+    Clone,
+    Copy,
+    derive_more::From,
+    derive_more::Deref,
+    derive_more::Into,
+)]
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct LogletId(u64);
+
+impl LogletId {
+    /// Creates a new [`LogletId`] from a [`LogId`] and a [`SegmentIndex`]. The upper
+    /// 32 bits are the log_id and the lower are the segment_index.
+    pub fn new(log_id: LogId, segment_index: SegmentIndex) -> Self {
+        let id = u64::from(u32::from(log_id)) << 32 | u64::from(u32::from(segment_index));
+        Self(id)
+    }
+
+    /// It's your responsibility that the value has the right meaning.
+    pub const fn new_unchecked(v: u64) -> Self {
+        Self(v)
+    }
+
+    /// Creates a new [`LogletId`] by incrementing the lower 32 bits (segment index part).
+    pub fn next(&self) -> Self {
+        assert!(
+            self.0 & 0xFFFFFFFF < u64::from(u32::MAX),
+            "Segment part must not overflow into the LogId part"
+        );
+        Self(self.0 + 1)
+    }
+
+    fn log_id(&self) -> LogId {
+        LogId::new(u32::try_from(self.0 >> 32).expect("upper 32 bits should fit into u32"))
+    }
+
+    fn segment_index(&self) -> SegmentIndex {
+        SegmentIndex::from(
+            u32::try_from(self.0 & 0xFFFFFFFF).expect("lower 32 bits should fit into u32"),
+        )
+    }
+}
+
+impl Display for LogletId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}_{}", self.log_id(), self.segment_index())
+    }
+}
+
+impl FromStr for LogletId {
+    type Err = <u64 as FromStr>::Err;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains('_') {
+            let parts: Vec<&str> = s.split('_').collect();
+            let log_id: u32 = parts[0].parse()?;
+            let segment_index: u32 = parts[1].parse()?;
+            Ok(LogletId::new(
+                LogId::from(log_id),
+                SegmentIndex::from(segment_index),
+            ))
+        } else {
+            // treat the string as raw replicated log-id
+            let id: u64 = s.parse()?;
+            Ok(LogletId(id))
+        }
+    }
+}

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -17,11 +17,13 @@ use crate::identifiers::PartitionId;
 use crate::storage::StorageEncode;
 
 pub mod builder;
+mod loglet;
 pub mod metadata;
 mod record;
 mod record_cache;
 mod tail;
 
+pub use loglet::*;
 pub use record::Record;
 pub use record_cache::RecordCache;
 pub use tail::*;

--- a/crates/types/src/logs/record_cache.rs
+++ b/crates/types/src/logs/record_cache.rs
@@ -14,11 +14,10 @@ use moka::{
 };
 use xxhash_rust::xxh3::Xxh3Builder;
 
-use super::{LogletOffset, Record, SequenceNumber};
-use crate::replicated_loglet::ReplicatedLogletId;
+use super::{LogletId, LogletOffset, Record, SequenceNumber};
 
 /// Unique record key across different loglets.
-type RecordKey = (ReplicatedLogletId, LogletOffset);
+type RecordKey = (LogletId, LogletOffset);
 
 /// A a simple LRU-based record cache.
 ///
@@ -54,7 +53,7 @@ impl RecordCache {
     }
 
     /// Writes a record to cache externally
-    pub fn add(&self, loglet_id: ReplicatedLogletId, offset: LogletOffset, record: Record) {
+    pub fn add(&self, loglet_id: LogletId, offset: LogletOffset, record: Record) {
         let Some(ref inner) = self.inner else {
             return;
         };
@@ -65,7 +64,7 @@ impl RecordCache {
     /// Extend cache with records
     pub fn extend<I: AsRef<[Record]>>(
         &self,
-        loglet_id: ReplicatedLogletId,
+        loglet_id: LogletId,
         mut first_offset: LogletOffset,
         records: I,
     ) {
@@ -80,7 +79,7 @@ impl RecordCache {
     }
 
     /// Get a for given loglet id and offset.
-    pub fn get(&self, loglet_id: ReplicatedLogletId, offset: LogletOffset) -> Option<Record> {
+    pub fn get(&self, loglet_id: LogletId, offset: LogletOffset) -> Option<Record> {
         let inner = self.inner.as_ref()?;
 
         inner.get(&(loglet_id, offset))

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -17,8 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use super::codec::{WireDecode, WireEncode};
 use super::{RpcRequest, TargetName};
-use crate::logs::{KeyFilter, LogletOffset, Record, SequenceNumber, TailState};
-use crate::replicated_loglet::ReplicatedLogletId;
+use crate::logs::{KeyFilter, LogletId, LogletOffset, Record, SequenceNumber, TailState};
 use crate::time::MillisSinceEpoch;
 use crate::GenerationalNodeId;
 
@@ -166,14 +165,14 @@ define_logserver_rpc! {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogServerRequestHeader {
-    pub loglet_id: ReplicatedLogletId,
+    pub loglet_id: LogletId,
     /// If the sender has now knowledge of this value, it can safely be set to
     /// `LogletOffset::INVALID`
     pub known_global_tail: LogletOffset,
 }
 
 impl LogServerRequestHeader {
-    pub fn new(loglet_id: ReplicatedLogletId, known_global_tail: LogletOffset) -> Self {
+    pub fn new(loglet_id: LogletId, known_global_tail: LogletOffset) -> Self {
         Self {
             loglet_id,
             known_global_tail,

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -17,9 +17,8 @@ use serde::{Deserialize, Serialize};
 
 use super::TargetName;
 use crate::logs::metadata::SegmentIndex;
-use crate::logs::{LogId, LogletOffset, Record, SequenceNumber, TailState};
+use crate::logs::{LogId, LogletId, LogletOffset, Record, SequenceNumber, TailState};
 use crate::net::define_rpc;
-use crate::replicated_loglet::ReplicatedLogletId;
 
 // ----- ReplicatedLoglet Sequencer API -----
 define_rpc! {
@@ -66,7 +65,7 @@ pub struct CommonRequestHeader {
     pub log_id: LogId,
     pub segment_index: SegmentIndex,
     /// The loglet_id id globally unique
-    pub loglet_id: ReplicatedLogletId,
+    pub loglet_id: LogletId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -10,7 +10,7 @@
 
 use crate::partition::leadership::Error;
 use futures::never::Never;
-use restate_bifrost::{Bifrost, CommitToken};
+use restate_bifrost::{Bifrost, CommitToken, ErrorRecoveryStrategy};
 use restate_core::my_node_id;
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::identifiers::{PartitionId, PartitionKey};
@@ -44,6 +44,7 @@ impl SelfProposer {
         let bifrost_appender = bifrost
             .create_background_appender(
                 LogId::from(partition_id),
+                ErrorRecoveryStrategy::extend_preferred(),
                 BIFROST_QUEUE_SIZE,
                 MAX_BIFROST_APPEND_BATCH,
             )?

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -26,6 +26,7 @@ use restate_local_cluster_runner::{
 use restate_rocksdb::RocksDbManager;
 use restate_types::logs::builder::LogsBuilder;
 use restate_types::logs::metadata::{Chain, LogletParams, SegmentIndex};
+use restate_types::logs::LogletId;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::{
     config::Configuration,
@@ -33,7 +34,7 @@ use restate_types::{
     logs::{metadata::ProviderKind, LogId},
     net::{AdvertisedAddress, BindAddress},
     nodes_config::Role,
-    replicated_loglet::{ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty},
+    replicated_loglet::{ReplicatedLogletParams, ReplicationProperty},
     GenerationalNodeId, PlainNodeId,
 };
 
@@ -137,7 +138,7 @@ where
     cluster.wait_healthy(Duration::from_secs(30)).await?;
 
     let loglet_params = ReplicatedLogletParams {
-        loglet_id: ReplicatedLogletId::new(LogId::from(1u32), SegmentIndex::OLDEST),
+        loglet_id: LogletId::new(LogId::from(1u32), SegmentIndex::OLDEST),
         sequencer,
         replication,
         // node 1 is the metadata, 2..=count+1 are logservers

--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -21,7 +21,7 @@ mod tests {
 
     use futures_util::StreamExt;
     use googletest::prelude::*;
-    use restate_bifrost::loglet::AppendError;
+    use restate_bifrost::{loglet::AppendError, ErrorRecoveryStrategy};
     use restate_core::{cancellation_token, Metadata, TaskCenterFutureExt};
     use test_log::test;
 
@@ -235,6 +235,7 @@ mod tests {
                                 let offset = bifrost
                                     .append(
                                         log_id,
+                                        ErrorRecoveryStrategy::Wait,
                                         format!("appender-{appender_id}-record{i}"),
                                     )
                                     .await?;

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -14,7 +14,7 @@ use bytes::BytesMut;
 use hdrhistogram::Histogram;
 use tracing::info;
 
-use restate_bifrost::Bifrost;
+use restate_bifrost::{Bifrost, ErrorRecoveryStrategy};
 use restate_types::logs::{LogId, WithKeys};
 
 use crate::util::{print_latencies, DummyPayload};
@@ -41,7 +41,8 @@ pub async fn run(
     let blob = BytesMut::zeroed(args.payload_size).freeze();
     let mut append_latencies = Histogram::<u64>::new(3)?;
     let mut counter = 0;
-    let mut appender = bifrost.create_appender(LOG_ID)?;
+    let mut appender =
+        bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::extend_preferred())?;
     let start = Instant::now();
     loop {
         if counter >= args.num_records {

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -16,7 +16,7 @@ use futures::StreamExt;
 use hdrhistogram::Histogram;
 use tracing::info;
 
-use restate_bifrost::Bifrost;
+use restate_bifrost::{Bifrost, ErrorRecoveryStrategy};
 use restate_core::{Metadata, TaskCenter, TaskHandle, TaskKind};
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, WithKeys};
 
@@ -96,6 +96,7 @@ pub async fn run(_common_args: &Arguments, args: &WriteToReadOpts, bifrost: Bifr
                 let appender_handle = bifrost
                     .create_background_appender(
                         LOG_ID,
+                        ErrorRecoveryStrategy::extend_preferred(),
                         args.write_buffer_size,
                         args.max_batch_size,
                     )?

--- a/tools/restatectl/src/commands/log/gen_metadata.rs
+++ b/tools/restatectl/src/commands/log/gen_metadata.rs
@@ -14,10 +14,8 @@ use cling::prelude::*;
 
 use restate_types::logs::builder::LogsBuilder;
 use restate_types::logs::metadata::{Chain, LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
-use restate_types::replicated_loglet::{
-    NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty,
-};
+use restate_types::logs::{LogId, LogletId};
+use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletParams, ReplicationProperty};
 use restate_types::{GenerationalNodeId, PlainNodeId};
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
@@ -49,7 +47,7 @@ async fn generate_log_metadata(opts: &GenerateLogMetadataOpts) -> anyhow::Result
         let log_id = LogId::from(log_id);
         let segment_index = SegmentIndex::OLDEST;
         let loglet_params = ReplicatedLogletParams {
-            loglet_id: ReplicatedLogletId::new(log_id, segment_index),
+            loglet_id: LogletId::new(log_id, segment_index),
             sequencer: opts.sequencer,
             replication: ReplicationProperty::new(opts.replication_factor),
             nodeset: NodeSet::from_iter(opts.nodeset.clone()),

--- a/tools/restatectl/src/commands/log/reconfigure.rs
+++ b/tools/restatectl/src/commands/log/reconfigure.rs
@@ -21,11 +21,9 @@ use restate_admin::cluster_controller::protobuf::{
 };
 use restate_cli_util::{c_eprintln, c_println};
 use restate_types::logs::metadata::{Logs, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
+use restate_types::logs::{LogId, LogletId};
 use restate_types::protobuf::common::Version;
-use restate_types::replicated_loglet::{
-    NodeSet, ReplicatedLogletId, ReplicatedLogletParams, ReplicationProperty,
-};
+use restate_types::replicated_loglet::{NodeSet, ReplicatedLogletParams, ReplicationProperty};
 use restate_types::storage::StorageCodec;
 use restate_types::{GenerationalNodeId, PlainNodeId};
 
@@ -162,7 +160,7 @@ async fn replicated_loglet_params(
         .map(SegmentIndex::from)
         .unwrap_or(chain.tail_index());
 
-    let loglet_id = ReplicatedLogletId::new(log_id, tail_index.next());
+    let loglet_id = LogletId::new(log_id, tail_index.next());
 
     let tail_segment = chain.tail();
 

--- a/tools/restatectl/src/commands/replicated_loglet/digest.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/digest.rs
@@ -25,10 +25,10 @@ use restate_core::MetadataKind;
 use restate_log_server::protobuf::log_server_svc_client::LogServerSvcClient;
 use restate_log_server::protobuf::GetDigestRequest;
 use restate_types::logs::metadata::Logs;
-use restate_types::logs::{LogletOffset, SequenceNumber, TailState};
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber, TailState};
 use restate_types::net::log_server::RecordStatus;
 use restate_types::nodes_config::{NodesConfiguration, Role};
-use restate_types::replicated_loglet::{EffectiveNodeSet, ReplicatedLogletId};
+use restate_types::replicated_loglet::EffectiveNodeSet;
 use restate_types::storage::StorageCodec;
 use restate_types::Versioned;
 
@@ -40,7 +40,7 @@ use crate::util::grpc_connect;
 #[cling(run = "get_digest")]
 pub struct DigestOpts {
     /// The replicated loglet id
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     /// Sync metadata from metadata store first
     #[arg(long)]
     sync_metadata: bool,

--- a/tools/restatectl/src/commands/replicated_loglet/digest_util.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/digest_util.rs
@@ -13,14 +13,14 @@ use std::collections::{BTreeMap, HashMap};
 use tracing::warn;
 
 use restate_bifrost::loglet::util::TailOffsetWatch;
-use restate_types::logs::{LogletOffset, SequenceNumber};
+use restate_types::logs::{LogletId, LogletOffset, SequenceNumber};
 use restate_types::net::log_server::{Digest, LogServerResponseHeader, RecordStatus, Status};
-use restate_types::replicated_loglet::{ReplicatedLogletId, ReplicatedLogletParams};
+use restate_types::replicated_loglet::ReplicatedLogletParams;
 use restate_types::PlainNodeId;
 
 /// Tracks digest responses and record statuses
 pub struct DigestsHelper {
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     // all offsets `[start_offset..target_tail)`
     offsets: BTreeMap<LogletOffset, HashMap<PlainNodeId, RecordStatus>>,
     known_nodes: HashMap<PlainNodeId, LogServerResponseHeader>,

--- a/tools/restatectl/src/commands/replicated_loglet/info.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/info.rs
@@ -10,16 +10,16 @@
 
 use anyhow::Context;
 use cling::prelude::*;
+use tonic::codec::CompressionEncoding;
 
 use restate_cli_util::{c_indentln, c_println};
 use restate_core::network::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::network::protobuf::node_ctl_svc::GetMetadataRequest;
 use restate_core::MetadataKind;
 use restate_types::logs::metadata::Logs;
-use restate_types::replicated_loglet::ReplicatedLogletId;
+use restate_types::logs::LogletId;
 use restate_types::storage::StorageCodec;
 use restate_types::Versioned;
-use tonic::codec::CompressionEncoding;
 
 use crate::app::ConnectionInfo;
 use crate::util::grpc_connect;
@@ -28,7 +28,7 @@ use crate::util::grpc_connect;
 #[cling(run = "get_info")]
 pub struct InfoOpts {
     /// The replicated loglet id
-    loglet_id: ReplicatedLogletId,
+    loglet_id: LogletId,
     /// Sync metadata from metadata store first
     #[arg(long)]
     sync_metadata: bool,


### PR DESCRIPTION

Summary:
Moves ReplicatedLogletId to be a common helper type for all loglets that want to benefit from its internal structure. The changes are mechanical since the type now is in `restate_types::logs` instead being specific under replicated_loglet.

Test Plan: Unit tests
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2450).
* #2451
* __->__ #2450
* #2446