### PR TITLE
[Bifrost] Let providers propose their own parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6080,6 +6080,7 @@ dependencies = [
  "enumset",
  "futures",
  "googletest",
+ "itertools 0.13.0",
  "metrics",
  "parking_lot",
  "paste",

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info};
 use restate_metadata_store::ReadModifyWriteError;
 use restate_types::cluster_controller::SchedulingPlan;
 use restate_types::logs::metadata::{
-    DefaultProvider, LogletParams, Logs, LogsConfiguration, ProviderKind, SegmentIndex,
+    LogletParams, Logs, LogsConfiguration, ProviderConfiguration, ProviderKind, SegmentIndex,
 };
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, PARTITION_TABLE_KEY, SCHEDULING_PLAN_KEY,
@@ -183,7 +183,7 @@ enum ClusterControllerCommand {
     UpdateClusterConfiguration {
         num_partitions: NonZeroU16,
         replication_strategy: ReplicationStrategy,
-        default_provider: DefaultProvider,
+        default_provider: ProviderConfiguration,
         response_tx: oneshot::Sender<anyhow::Result<()>>,
     },
     SealAndExtendChain {
@@ -249,7 +249,7 @@ impl ClusterControllerHandle {
         &self,
         num_partitions: NonZeroU16,
         replication_strategy: ReplicationStrategy,
-        default_provider: DefaultProvider,
+        default_provider: ProviderConfiguration,
     ) -> Result<anyhow::Result<()>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -439,7 +439,7 @@ impl<T: TransportConnect> Service<T> {
         &self,
         num_partitions: u16,
         replication_strategy: ReplicationStrategy,
-        default_provider: DefaultProvider,
+        default_provider: ProviderConfiguration,
     ) -> anyhow::Result<()> {
         let logs = self
             .metadata_store_client
@@ -457,8 +457,7 @@ impl<T: TransportConnect> Service<T> {
 
                 // we can only change the default provider
                 if logs.version() != Version::INVALID
-                    && logs.configuration().default_provider.as_provider_kind()
-                        != default_provider.as_provider_kind()
+                    && logs.configuration().default_provider.kind() != default_provider.kind()
                 {
                     {
                         return Err(
@@ -786,16 +785,16 @@ impl SealAndExtendTask {
 
         let (provider, params) = match &logs.configuration().default_provider {
             #[cfg(any(test, feature = "memory-loglet"))]
-            DefaultProvider::InMemory => (
+            ProviderConfiguration::InMemory => (
                 ProviderKind::InMemory,
                 u64::from(loglet_id.next()).to_string().into(),
             ),
-            DefaultProvider::Local => (
+            ProviderConfiguration::Local => (
                 ProviderKind::Local,
                 u64::from(loglet_id.next()).to_string().into(),
             ),
             #[cfg(feature = "replicated-loglet")]
-            DefaultProvider::Replicated(config) => {
+            ProviderConfiguration::Replicated(config) => {
                 let schedule_plan = self
                     .metadata_store_client
                     .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
@@ -833,6 +832,7 @@ mod tests {
 
     use googletest::assert_that;
     use googletest::matchers::eq;
+    use restate_types::logs::metadata::ProviderKind;
     use test_log::test;
 
     use restate_bifrost::providers::memory_loglet;
@@ -843,7 +843,7 @@ mod tests {
     use restate_core::test_env::NoOpMessageHandler;
     use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
     use restate_types::cluster::cluster_state::PartitionProcessorStatus;
-    use restate_types::config::{AdminOptions, Configuration};
+    use restate_types::config::{AdminOptions, BifrostOptions, Configuration};
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::PartitionId;
     use restate_types::live::Live;
@@ -1086,8 +1086,11 @@ mod tests {
         admin_options.log_trim_threshold = 0;
         let interval_duration = Duration::from_secs(10);
         admin_options.log_trim_interval = Some(interval_duration.into());
+        let mut bifrost_options = BifrostOptions::default();
+        bifrost_options.default_provider = ProviderKind::InMemory;
         let config = Configuration {
             admin: admin_options,
+            bifrost: bifrost_options,
             ..Default::default()
         };
 
@@ -1136,6 +1139,7 @@ mod tests {
     where
         F: FnMut(TestCoreEnvBuilder<FailingConnector>) -> TestCoreEnvBuilder<FailingConnector>,
     {
+        restate_types::config::set_current_config(config);
         let mut builder = TestCoreEnvBuilder::with_incoming_only_connector();
         let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
         let bifrost = bifrost_svc.handle();
@@ -1143,7 +1147,7 @@ mod tests {
         let mut server_builder = NetworkServerBuilder::default();
 
         let svc = Service::new(
-            Live::from_value(config),
+            Configuration::updateable(),
             HealthStatus::default(),
             bifrost.clone(),
             builder.networking.clone(),

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -31,6 +31,7 @@ derive_more = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 googletest = { workspace = true, features = ["anyhow"], optional = true }
+itertools = { workspace = true }
 metrics = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -116,7 +116,7 @@ impl Appender {
                     info!(
                         attempt = attempt,
                         segment_index = %loglet.segment_index(),
-                        "Append batch will be retried (loglet being sealed), waiting for tail to be determined"
+                        "Append batch will be retried (loglet is being sealed), waiting for tail to be determined"
                     );
                     let new_loglet = Self::wait_next_unsealed_loglet(
                         self.log_id,
@@ -131,7 +131,7 @@ impl Appender {
                 Err(AppendError::Other(err)) if err.retryable() => {
                     if let Some(retry_dur) = retry_iter.next() {
                         info!(
-                            ?err,
+                            %err,
                             attempt = attempt,
                             segment_index = %loglet.segment_index(),
                             "Failed to append this batch. Since underlying error is retryable, will retry in {:?}",
@@ -140,7 +140,7 @@ impl Appender {
                         tokio::time::sleep(retry_dur).await;
                     } else {
                         warn!(
-                            ?err,
+                            %err,
                             attempt = attempt,
                             segment_index = %loglet.segment_index(),
                             "Failed to append this batch and exhausted all attempts to retry",

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -11,13 +11,13 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use restate_core::metadata_store::retry_on_network_error;
 use tracing::{debug, info, instrument};
 
 use restate_core::{Metadata, MetadataKind, MetadataWriter};
 use restate_metadata_store::MetadataStoreClient;
 use restate_types::config::Configuration;
-use restate_types::logs::builder::BuilderError;
-use restate_types::logs::metadata::{LogletParams, Logs, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{Chain, LogletParams, Logs, ProviderKind, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, TailState};
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::Version;
@@ -74,6 +74,61 @@ impl<'a> BifrostAdmin<'a> {
     pub async fn trim(&self, log_id: LogId, trim_point: Lsn) -> Result<()> {
         self.bifrost.inner.fail_if_shutting_down()?;
         self.bifrost.inner.trim(log_id, trim_point).await
+    }
+
+    /// Seals a loglet under a set of conditions.
+    ///
+    /// The loglet will be sealed if and only if the following is true:
+    ///   - if segment_index is set, the tail loglet must match segment_index.
+    ///   If the intention is to create the log, then `segment_index` must be set to `None`.
+    ///
+    /// This will continue to retry sealing for seal retryable errors automatically.
+    #[instrument(level = "debug", skip(self), err)]
+    pub async fn seal_and_auto_extend_chain(
+        &self,
+        log_id: LogId,
+        segment_index: Option<SegmentIndex>,
+    ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
+        let logs = Metadata::with_current(|m| m.logs_snapshot());
+        let provider_config = &logs.configuration().default_provider;
+        let provider = self.bifrost.inner.provider_for(provider_config.kind())?;
+        // if this is a new log, we don't need to seal and we can immediately write to metadata
+        // store, otherwise, we need to seal first.
+        if logs.chain(&log_id).is_none() && segment_index.is_none() {
+            let proposed_params =
+                provider.propose_new_loglet_params(log_id, None, provider_config)?;
+            self.add_log(log_id, provider_config.kind(), proposed_params)
+                .await?;
+            return Ok(());
+        }
+
+        let segment_index = segment_index
+            .or_else(|| logs.chain(&log_id).map(|c| c.tail_index()))
+            .ok_or(Error::UnknownLogId(log_id))?;
+
+        let sealed_segment = loop {
+            let sealed_segment = self.seal(log_id, segment_index).await?;
+            if sealed_segment.tail.is_sealed() {
+                break sealed_segment;
+            }
+            debug!(%log_id, %segment_index, "Segment is not sealed yet");
+            tokio::time::sleep(Configuration::pinned().bifrost.seal_retry_interval.into()).await;
+        };
+
+        let proposed_params =
+            provider.propose_new_loglet_params(log_id, logs.chain(&log_id), provider_config)?;
+
+        self.add_segment_with_params(
+            log_id,
+            segment_index,
+            sealed_segment.tail.offset(),
+            provider_config.kind(),
+            proposed_params,
+        )
+        .await?;
+
+        Ok(())
     }
 
     /// Seals a loglet under a set of conditions.
@@ -187,34 +242,93 @@ impl<'a> BifrostAdmin<'a> {
         params: LogletParams,
     ) -> Result<()> {
         self.bifrost.inner.fail_if_shutting_down()?;
-        let logs = self
-            .metadata_store_client
-            .read_modify_write(BIFROST_CONFIG_KEY.clone(), move |logs: Option<Logs>| {
-                let logs = logs.ok_or(Error::UnknownLogId(log_id))?;
+        let retry_policy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+        let logs = retry_on_network_error(retry_policy, || {
+            self.metadata_store_client.read_modify_write(
+                BIFROST_CONFIG_KEY.clone(),
+                |logs: Option<Logs>| {
+                    let logs = logs.ok_or(Error::UnknownLogId(log_id))?;
 
-                let mut builder = logs.into_builder();
-                let mut chain_builder = builder.chain(log_id).ok_or(Error::UnknownLogId(log_id))?;
+                    let mut builder = logs.into_builder();
+                    let mut chain_builder =
+                        builder.chain(log_id).ok_or(Error::UnknownLogId(log_id))?;
 
-                if chain_builder.tail().index() != last_segment_index {
-                    // tail is not what we expected.
-                    return Err(Error::from(AdminError::SegmentMismatch {
-                        expected: last_segment_index,
-                        found: chain_builder.tail().index(),
-                    }));
-                }
+                    if chain_builder.tail().index() != last_segment_index {
+                        // tail is not what we expected.
+                        return Err(Error::from(AdminError::SegmentMismatch {
+                            expected: last_segment_index,
+                            found: chain_builder.tail().index(),
+                        }));
+                    }
 
-                match chain_builder.append_segment(base_lsn, provider, params.clone()) {
-                    Err(e) => match e {
-                        BuilderError::SegmentConflict(lsn) => {
-                            Err(Error::from(AdminError::SegmentConflict(lsn)))
-                        }
-                        _ => unreachable!("the log must exist at this point"),
-                    },
-                    Ok(_) => Ok(builder.build()),
-                }
-            })
-            .await
-            .map_err(|e| e.transpose())?;
+                    let _ = chain_builder
+                        .append_segment(base_lsn, provider, params.clone())
+                        .map_err(AdminError::from)?;
+                    Ok(builder.build())
+                },
+            )
+        })
+        .await
+        .map_err(|e| e.transpose())?;
+
+        self.metadata_writer.update(Arc::new(logs)).await?;
+        Ok(())
+    }
+
+    /// Adds a new log if it doesn't exist.
+    #[instrument(level = "debug", skip(self), err)]
+    async fn add_log(
+        &self,
+        log_id: LogId,
+        provider: ProviderKind,
+        params: LogletParams,
+    ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
+        let retry_policy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+        let logs = retry_on_network_error(retry_policy, || {
+            self.metadata_store_client.read_modify_write::<_, _, Error>(
+                BIFROST_CONFIG_KEY.clone(),
+                |logs: Option<Logs>| {
+                    // We assume that we'll always see a value set in metadata for BIFROST_CONFIG_KEY,
+                    // provisioning the empty logs metadata is not our responsibility.
+                    let logs = logs.ok_or(Error::LogsMetadataNotProvisioned)?;
+
+                    let mut builder = logs.into_builder();
+                    builder
+                        .add_log(log_id, Chain::new(provider, params.clone()))
+                        .map_err(AdminError::from)?;
+                    Ok(builder.build())
+                },
+            )
+        })
+        .await
+        .map_err(|e| e.transpose())?;
+
+        self.metadata_writer.update(Arc::new(logs)).await?;
+        Ok(())
+    }
+
+    /// Creates empty metadata if none exists for bifrost and publishes it to metadata
+    /// manager.
+    pub async fn init_metadata(&self) -> Result<(), Error> {
+        let retry_policy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+
+        let logs = retry_on_network_error(retry_policy, || {
+            self.metadata_store_client
+                .get_or_insert(BIFROST_CONFIG_KEY.clone(), || {
+                    Logs::from_configuration(&Configuration::pinned())
+                })
+        })
+        .await?;
 
         self.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())

--- a/crates/bifrost/src/loglet/provider.rs
+++ b/crates/bifrost/src/loglet/provider.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
 use restate_types::logs::LogId;
 
 use super::{Loglet, OperationError};
@@ -36,6 +38,19 @@ pub trait LogletProvider: Send + Sync {
         segment_index: SegmentIndex,
         params: &LogletParams,
     ) -> Result<Arc<dyn Loglet>>;
+
+    /// Returns a proposed `LogletParams` given this log_id, chain, and defaults.
+    ///
+    /// This will not perform any updates, it just statically generates a valid
+    /// configuration for a potentially new loglet.
+    ///
+    /// if `chain` is None, this means we no chain exists already for this log.
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError>;
 
     /// A hook that's called after provider is started.
     async fn post_start(&self) {}

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -17,8 +17,10 @@ use tracing::debug;
 
 use restate_types::config::{LocalLogletOptions, RocksDbOptions};
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
+use restate_types::logs::{LogId, LogletId};
 
 use super::log_store::RocksDbLogStore;
 use super::log_store_writer::RocksDbLogWriterHandle;
@@ -103,6 +105,20 @@ impl LogletProvider for LocalLogletProvider {
         };
 
         Ok(loglet as Arc<dyn Loglet>)
+    }
+
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        _defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError> {
+        let new_segment_index = chain
+            .map(|c| c.tail_index().next())
+            .unwrap_or(SegmentIndex::OLDEST);
+        Ok(LogletParams::from(
+            LogletId::new(log_id, new_segment_index).to_string(),
+        ))
     }
 
     async fn shutdown(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -22,9 +22,11 @@ use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, info};
 
 use restate_core::ShutdownError;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
 use restate_types::logs::{
-    KeyFilter, LogId, LogletOffset, MatchKeyQuery, Record, SequenceNumber, TailState,
+    KeyFilter, LogId, LogletId, LogletOffset, MatchKeyQuery, Record, SequenceNumber, TailState,
 };
 
 use crate::loglet::util::TailOffsetWatch;
@@ -98,6 +100,20 @@ impl LogletProvider for MemoryLogletProvider {
         };
 
         Ok(loglet as Arc<dyn Loglet>)
+    }
+
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        _defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError> {
+        let new_segment_index = chain
+            .map(|c| c.tail_index().next())
+            .unwrap_or(SegmentIndex::OLDEST);
+        Ok(LogletParams::from(
+            LogletId::new(log_id, new_segment_index).to_string(),
+        ))
     }
 
     async fn shutdown(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -13,6 +13,7 @@ mod log_server_manager;
 mod loglet;
 pub(crate) mod metric_definitions;
 mod network;
+mod nodeset_selector;
 mod provider;
 mod read_path;
 mod remote_sequencer;

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -16,16 +16,19 @@ use dashmap::DashMap;
 use tracing::debug;
 
 use restate_core::network::{MessageRouterBuilder, Networking, TransportConnect};
-use restate_core::{TaskCenter, TaskKind};
+use restate_core::{my_node_id, Metadata, TaskCenter, TaskKind};
 use restate_metadata_store::MetadataStoreClient;
 use restate_types::config::Configuration;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::{LogId, RecordCache};
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
+use restate_types::logs::{LogId, LogletId, RecordCache};
 use restate_types::replicated_loglet::ReplicatedLogletParams;
 
 use super::loglet::ReplicatedLoglet;
 use super::metric_definitions;
 use super::network::RequestPump;
+use super::nodeset_selector::{NodeSelectionError, NodeSetSelector, ObservedClusterState};
 use super::rpc_routers::{LogServersRpc, SequencersRpc};
 use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::providers::replicated_loglet::error::ReplicatedLogletError;
@@ -199,6 +202,76 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
     ) -> Result<Arc<dyn Loglet>, Error> {
         let loglet = self.get_or_create_loglet(log_id, segment_index, params)?;
         Ok(loglet as Arc<dyn Loglet>)
+    }
+
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError> {
+        let ProviderConfiguration::Replicated(defaults) = defaults else {
+            panic!("ProviderConfiguration::Replicated is expected");
+        };
+
+        let new_segment_index = chain
+            .map(|c| c.tail_index().next())
+            .unwrap_or(SegmentIndex::OLDEST);
+
+        let loglet_id = LogletId::new(log_id, new_segment_index);
+
+        let mut rng = rand::thread_rng();
+
+        let replication = defaults.replication_property.clone();
+        let strategy = defaults.nodeset_selection_strategy;
+
+        // if the last loglet in the chain is of the same provider kind, we can use this to
+        // influence the nodeset selector.
+        let previous_params = chain.and_then(|chain| {
+            let tail_config = chain.tail().config;
+            match tail_config.kind {
+                ProviderKind::Replicated => Some(
+                    ReplicatedLogletParams::deserialize_from(tail_config.params.as_bytes())
+                        .expect("params serde must be infallible"),
+                ),
+                // Another kind, we don't care about its config
+                _ => None,
+            }
+        });
+
+        let preferred_nodes = previous_params
+            .map(|p| p.nodeset.clone())
+            .unwrap_or_default();
+        let nodes_config = Metadata::with_current(|m| m.nodes_config_ref());
+
+        let selection = NodeSetSelector::new(&nodes_config, &ObservedClusterState).select(
+            strategy,
+            &replication,
+            &mut rng,
+            &preferred_nodes,
+        );
+
+        match selection {
+            Ok(nodeset) => Ok(LogletParams::from(
+                ReplicatedLogletParams {
+                    loglet_id,
+                    // We choose ourselves to be the sequencer for this loglet
+                    sequencer: my_node_id(),
+                    replication,
+                    nodeset,
+                }
+                .serialize()
+                .expect("params serde must be infallible"),
+            )),
+            Err(e @ NodeSelectionError::InsufficientWriteableNodes) => {
+                debug!(
+                    ?loglet_id,
+                    "Insufficient writeable nodes to select new nodeset for replicated loglet"
+                );
+
+                Err(OperationError::terminal(e))
+            }
+        }
     }
 
     async fn shutdown(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
@@ -94,6 +94,7 @@ impl CheckSealTask {
                     loglet_id = %my_params.loglet_id,
                     status = %nodeset_checker,
                     effective_nodeset = %effective_nodeset,
+                    replication = %my_params.replication,
                     "Insufficient nodes responded to GetLogletInfo requests, we cannot determine seal status, we'll assume it's unsealed for now",
                 );
                 return Ok(CheckSealOutcome::ProbablyOpen);

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::any::type_name;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -428,11 +429,18 @@ impl MetadataManager {
         let mut maybe_new_version = new_value.version();
 
         if new_value.version() > current_value.version() {
+            trace!(
+                "Updating {} from {} to {}",
+                type_name::<M>(),
+                current_value.version(),
+                new_value.version(),
+            );
             container.store(new_value);
         } else {
             /* Do nothing, current is already newer */
             trace!(
-                "Ignoring update {} because we are at {}",
+                "Ignoring update of {} to {} because we are already at {}",
+                type_name::<M>(),
                 new_value.version(),
                 current_value.version(),
             );

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -233,7 +233,7 @@ pub struct CommonOptions {
 
     /// # Network error retry policy
     ///
-    /// The retry policy for node network error
+    /// The retry policy for network related errors
     pub network_error_retry_policy: RetryPolicy,
 }
 

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -16,7 +16,7 @@ use std::fmt::{self, Display, Write};
 use cling::prelude::*;
 
 use restate_types::{
-    logs::metadata::DefaultProvider, partition_table::ReplicationStrategy,
+    logs::metadata::ProviderConfiguration, partition_table::ReplicationStrategy,
     protobuf::cluster::ClusterConfiguration,
 };
 
@@ -43,7 +43,7 @@ fn cluster_config_string(config: ClusterConfiguration) -> anyhow::Result<String>
 
     write_leaf(&mut w, 1, false, "Bifrost replication strategy", strategy)?;
 
-    let provider: DefaultProvider = config.default_provider.unwrap_or_default().try_into()?;
+    let provider: ProviderConfiguration = config.default_provider.unwrap_or_default().try_into()?;
     write_default_provider(&mut w, 1, provider)?;
 
     Ok(w)
@@ -52,19 +52,19 @@ fn cluster_config_string(config: ClusterConfiguration) -> anyhow::Result<String>
 fn write_default_provider<W: fmt::Write>(
     w: &mut W,
     depth: usize,
-    provider: DefaultProvider,
+    provider: ProviderConfiguration,
 ) -> Result<(), fmt::Error> {
     let title = "Bifrost Provider";
     match provider {
         #[cfg(any(test, feature = "memory-loglet"))]
-        DefaultProvider::InMemory => {
+        ProviderConfiguration::InMemory => {
             write_leaf(w, depth, true, title, "in-memory")?;
         }
-        DefaultProvider::Local => {
+        ProviderConfiguration::Local => {
             write_leaf(w, depth, true, title, "local")?;
         }
         #[cfg(feature = "replicated-loglet")]
-        DefaultProvider::Replicated(config) => {
+        ProviderConfiguration::Replicated(config) => {
             write_leaf(w, depth, true, title, "replicated")?;
             let depth = depth + 1;
             write_leaf(

--- a/tools/restatectl/src/commands/cluster/config/set.rs
+++ b/tools/restatectl/src/commands/cluster/config/set.rs
@@ -23,7 +23,7 @@ use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
 use restate_types::logs::metadata::{
-    DefaultProvider, NodeSetSelectionStrategy, ProviderKind, ReplicatedLogletConfig,
+    NodeSetSelectionStrategy, ProviderConfiguration, ProviderKind, ReplicatedLogletConfig,
 };
 use restate_types::partition_table::ReplicationStrategy;
 use restate_types::replicated_loglet::ReplicationProperty;
@@ -89,8 +89,8 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
 
     if let Some(provider) = set_opts.bifrost_provider {
         let default_provider = match provider {
-            ProviderKind::InMemory => DefaultProvider::InMemory,
-            ProviderKind::Local => DefaultProvider::Local,
+            ProviderKind::InMemory => ProviderConfiguration::InMemory,
+            ProviderKind::Local => ProviderConfiguration::Local,
             ProviderKind::Replicated => {
                 let config = ReplicatedLogletConfig {
                     replication_property: set_opts
@@ -101,7 +101,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
                         .nodeset_selection_strategy
                         .unwrap_or_default(),
                 };
-                DefaultProvider::Replicated(config)
+                ProviderConfiguration::Replicated(config)
             }
         };
 

--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -55,6 +55,11 @@ pub async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> any
 
     c_println!("Log Configuration ({})", logs.version());
 
+    c_println!(
+        "Default Provider Config: {:?}",
+        logs.configuration().default_provider
+    );
+
     // sort by log-id for display
     let logs: BTreeMap<LogId, &Chain> = logs.iter().map(|(id, chain)| (*id, chain)).collect();
 


### PR DESCRIPTION

- BifrostAdmin can now init empty logs configuration
- BifrostAdmin can now auto extend the chain
- Providers now have control over suggesting a new segment configuration
- Introduces a temporary copy of NodeSetSelector into bifrost until log-controller is removed
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2451).
* #2458
* #2457
* __->__ #2451