### PR TITLE
[Bifrost] Auto provision logs metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6080,6 +6080,7 @@ dependencies = [
  "enumset",
  "futures",
  "googletest",
+ "itertools 0.13.0",
  "metrics",
  "parking_lot",
  "paste",

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info};
 use restate_metadata_store::ReadModifyWriteError;
 use restate_types::cluster_controller::SchedulingPlan;
 use restate_types::logs::metadata::{
-    DefaultProvider, LogletParams, Logs, LogsConfiguration, ProviderKind, SegmentIndex,
+    LogletParams, Logs, LogsConfiguration, ProviderConfiguration, ProviderKind, SegmentIndex,
 };
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, PARTITION_TABLE_KEY, SCHEDULING_PLAN_KEY,
@@ -183,7 +183,7 @@ enum ClusterControllerCommand {
     UpdateClusterConfiguration {
         num_partitions: NonZeroU16,
         replication_strategy: ReplicationStrategy,
-        default_provider: DefaultProvider,
+        default_provider: ProviderConfiguration,
         response_tx: oneshot::Sender<anyhow::Result<()>>,
     },
     SealAndExtendChain {
@@ -249,7 +249,7 @@ impl ClusterControllerHandle {
         &self,
         num_partitions: NonZeroU16,
         replication_strategy: ReplicationStrategy,
-        default_provider: DefaultProvider,
+        default_provider: ProviderConfiguration,
     ) -> Result<anyhow::Result<()>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -439,7 +439,7 @@ impl<T: TransportConnect> Service<T> {
         &self,
         num_partitions: u16,
         replication_strategy: ReplicationStrategy,
-        default_provider: DefaultProvider,
+        default_provider: ProviderConfiguration,
     ) -> anyhow::Result<()> {
         let logs = self
             .metadata_store_client
@@ -457,8 +457,7 @@ impl<T: TransportConnect> Service<T> {
 
                 // we can only change the default provider
                 if logs.version() != Version::INVALID
-                    && logs.configuration().default_provider.as_provider_kind()
-                        != default_provider.as_provider_kind()
+                    && logs.configuration().default_provider.kind() != default_provider.kind()
                 {
                     {
                         return Err(
@@ -786,16 +785,16 @@ impl SealAndExtendTask {
 
         let (provider, params) = match &logs.configuration().default_provider {
             #[cfg(any(test, feature = "memory-loglet"))]
-            DefaultProvider::InMemory => (
+            ProviderConfiguration::InMemory => (
                 ProviderKind::InMemory,
                 u64::from(loglet_id.next()).to_string().into(),
             ),
-            DefaultProvider::Local => (
+            ProviderConfiguration::Local => (
                 ProviderKind::Local,
                 u64::from(loglet_id.next()).to_string().into(),
             ),
             #[cfg(feature = "replicated-loglet")]
-            DefaultProvider::Replicated(config) => {
+            ProviderConfiguration::Replicated(config) => {
                 let schedule_plan = self
                     .metadata_store_client
                     .get::<SchedulingPlan>(SCHEDULING_PLAN_KEY.clone())
@@ -833,6 +832,7 @@ mod tests {
 
     use googletest::assert_that;
     use googletest::matchers::eq;
+    use restate_types::logs::metadata::ProviderKind;
     use test_log::test;
 
     use restate_bifrost::providers::memory_loglet;
@@ -843,7 +843,7 @@ mod tests {
     use restate_core::test_env::NoOpMessageHandler;
     use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
     use restate_types::cluster::cluster_state::PartitionProcessorStatus;
-    use restate_types::config::{AdminOptions, Configuration};
+    use restate_types::config::{AdminOptions, BifrostOptions, Configuration};
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::PartitionId;
     use restate_types::live::Live;
@@ -1086,8 +1086,11 @@ mod tests {
         admin_options.log_trim_threshold = 0;
         let interval_duration = Duration::from_secs(10);
         admin_options.log_trim_interval = Some(interval_duration.into());
+        let mut bifrost_options = BifrostOptions::default();
+        bifrost_options.default_provider = ProviderKind::InMemory;
         let config = Configuration {
             admin: admin_options,
+            bifrost: bifrost_options,
             ..Default::default()
         };
 
@@ -1136,6 +1139,7 @@ mod tests {
     where
         F: FnMut(TestCoreEnvBuilder<FailingConnector>) -> TestCoreEnvBuilder<FailingConnector>,
     {
+        restate_types::config::set_current_config(config);
         let mut builder = TestCoreEnvBuilder::with_incoming_only_connector();
         let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
         let bifrost = bifrost_svc.handle();
@@ -1143,7 +1147,7 @@ mod tests {
         let mut server_builder = NetworkServerBuilder::default();
 
         let svc = Service::new(
-            Live::from_value(config),
+            Configuration::updateable(),
             HealthStatus::default(),
             bifrost.clone(),
             builder.networking.clone(),

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -158,12 +158,8 @@ where
         )
         .await?;
 
-        let logs_controller = LogsController::init(
-            &configuration,
-            service.bifrost.clone(),
-            service.metadata_writer.clone(),
-        )
-        .await?;
+        let logs_controller =
+            LogsController::init(service.bifrost.clone(), service.metadata_writer.clone()).await?;
 
         let (log_trim_interval, log_trim_threshold) =
             create_log_trim_interval(&configuration.admin);

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -17,10 +17,9 @@ use tokio::time;
 use tokio::time::{Interval, MissedTickBehavior};
 use tracing::{debug, info, warn};
 
-use restate_bifrost::{Bifrost, BifrostAdmin};
-use restate_core::metadata_store::MetadataStoreClient;
+use restate_bifrost::Bifrost;
 use restate_core::network::TransportConnect;
-use restate_core::{my_node_id, Metadata, MetadataWriter};
+use restate_core::{my_node_id, Metadata};
 use restate_types::cluster::cluster_state::{AliveNode, NodeState};
 use restate_types::config::{AdminOptions, Configuration};
 use restate_types::identifiers::PartitionId;
@@ -135,8 +134,6 @@ pub enum LeaderEvent {
 
 pub struct Leader<T> {
     bifrost: Bifrost,
-    metadata_store_client: MetadataStoreClient,
-    metadata_writer: MetadataWriter,
     logs_watcher: watch::Receiver<Version>,
     partition_table_watcher: watch::Receiver<Version>,
     find_logs_tail_interval: Interval,
@@ -156,7 +153,7 @@ where
 
         let scheduler = Scheduler::init(
             &configuration,
-            service.metadata_store_client.clone(),
+            service.metadata_writer.metadata_store_client().clone(),
             service.networking.clone(),
         )
         .await?;
@@ -164,7 +161,6 @@ where
         let logs_controller = LogsController::init(
             &configuration,
             service.bifrost.clone(),
-            service.metadata_store_client.clone(),
             service.metadata_writer.clone(),
         )
         .await?;
@@ -179,8 +175,6 @@ where
         let metadata = Metadata::current();
         let mut leader = Self {
             bifrost: service.bifrost.clone(),
-            metadata_store_client: service.metadata_store_client.clone(),
-            metadata_writer: service.metadata_writer.clone(),
             logs_watcher: metadata.watch(MetadataKind::Logs),
             partition_table_watcher: metadata.watch(MetadataKind::PartitionTable),
             cluster_state_watcher: service.cluster_state_refresher.cluster_state_watcher(),
@@ -296,12 +290,6 @@ where
     }
 
     async fn trim_logs_inner(&self) -> Result<(), restate_bifrost::Error> {
-        let bifrost_admin = BifrostAdmin::new(
-            &self.bifrost,
-            &self.metadata_writer,
-            &self.metadata_store_client,
-        );
-
         let cluster_state = self.cluster_state_watcher.current();
 
         let mut persisted_lsns_per_partition: BTreeMap<
@@ -342,13 +330,13 @@ where
             if persisted_lsns.len() >= cluster_state.nodes.len() {
                 let min_persisted_lsn = persisted_lsns.into_values().min().unwrap_or(Lsn::INVALID);
                 // trim point is before the oldest record
-                let current_trim_point = bifrost_admin.get_trim_point(log_id).await?;
+                let current_trim_point = self.bifrost.get_trim_point(log_id).await?;
 
                 if min_persisted_lsn >= current_trim_point + self.log_trim_threshold {
                     debug!(
                     "Automatic trim log '{log_id}' for all records before='{min_persisted_lsn}'"
                 );
-                    bifrost_admin.trim(log_id, min_persisted_lsn).await?
+                    self.bifrost.admin().trim(log_id, min_persisted_lsn).await?
                 }
             } else {
                 warn!("Stop automatically trimming log '{log_id}' because not all nodes are running a partition processor applying this log.");

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -17,7 +17,6 @@ use restate_types::config::AdminOptions;
 use restate_types::live::LiveLoad;
 use tower::ServiceBuilder;
 
-use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::network::net_util;
 use restate_core::MetadataWriter;
 use restate_service_protocol::discovery::ServiceDiscovery;
@@ -44,7 +43,6 @@ where
 {
     pub fn new(
         metadata_writer: MetadataWriter,
-        metadata_store_client: MetadataStoreClient,
         bifrost: Bifrost,
         subscription_validator: V,
         service_discovery: ServiceDiscovery,
@@ -54,7 +52,6 @@ where
         Self {
             bifrost,
             schema_registry: SchemaRegistry::new(
-                metadata_store_client,
                 metadata_writer,
                 service_discovery,
                 subscription_validator,

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -31,6 +31,7 @@ derive_more = { workspace = true }
 enum-map = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 googletest = { workspace = true, features = ["anyhow"], optional = true }
+itertools = { workspace = true }
 metrics = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -116,7 +116,7 @@ impl Appender {
                     info!(
                         attempt = attempt,
                         segment_index = %loglet.segment_index(),
-                        "Append batch will be retried (loglet being sealed), waiting for tail to be determined"
+                        "Append batch will be retried (loglet is being sealed), waiting for tail to be determined"
                     );
                     let new_loglet = Self::wait_next_unsealed_loglet(
                         self.log_id,
@@ -131,7 +131,7 @@ impl Appender {
                 Err(AppendError::Other(err)) if err.retryable() => {
                     if let Some(retry_dur) = retry_iter.next() {
                         info!(
-                            ?err,
+                            %err,
                             attempt = attempt,
                             segment_index = %loglet.segment_index(),
                             "Failed to append this batch. Since underlying error is retryable, will retry in {:?}",
@@ -140,7 +140,7 @@ impl Appender {
                         tokio::time::sleep(retry_dur).await;
                     } else {
                         warn!(
-                            ?err,
+                            %err,
                             attempt = attempt,
                             segment_index = %loglet.segment_index(),
                             "Failed to append this batch and exhausted all attempts to retry",

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -316,6 +316,7 @@ impl<'a> BifrostAdmin<'a> {
                 .metadata_writer
                 .metadata_store_client()
                 .get_or_insert(BIFROST_CONFIG_KEY.clone(), || {
+                    debug!("Attempting to initialize logs metadata in metadata store");
                     Logs::from_configuration(&Configuration::pinned())
                 })
         })

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -11,13 +11,13 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use restate_core::metadata_store::retry_on_network_error;
 use tracing::{debug, info, instrument};
 
 use restate_core::{Metadata, MetadataKind, MetadataWriter};
 use restate_metadata_store::MetadataStoreClient;
 use restate_types::config::Configuration;
-use restate_types::logs::builder::BuilderError;
-use restate_types::logs::metadata::{LogletParams, Logs, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{Chain, LogletParams, Logs, ProviderKind, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, TailState};
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::Version;
@@ -74,6 +74,61 @@ impl<'a> BifrostAdmin<'a> {
     pub async fn trim(&self, log_id: LogId, trim_point: Lsn) -> Result<()> {
         self.bifrost.inner.fail_if_shutting_down()?;
         self.bifrost.inner.trim(log_id, trim_point).await
+    }
+
+    /// Seals a loglet under a set of conditions.
+    ///
+    /// The loglet will be sealed if and only if the following is true:
+    ///   - if segment_index is set, the tail loglet must match segment_index.
+    ///   If the intention is to create the log, then `segment_index` must be set to `None`.
+    ///
+    /// This will continue to retry sealing for seal retryable errors automatically.
+    #[instrument(level = "debug", skip(self), err)]
+    pub async fn seal_and_auto_extend_chain(
+        &self,
+        log_id: LogId,
+        segment_index: Option<SegmentIndex>,
+    ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
+        let logs = Metadata::with_current(|m| m.logs_snapshot());
+        let provider_config = &logs.configuration().default_provider;
+        let provider = self.bifrost.inner.provider_for(provider_config.kind())?;
+        // if this is a new log, we don't need to seal and we can immediately write to metadata
+        // store, otherwise, we need to seal first.
+        if logs.chain(&log_id).is_none() && segment_index.is_none() {
+            let proposed_params =
+                provider.propose_new_loglet_params(log_id, None, provider_config)?;
+            self.add_log(log_id, provider_config.kind(), proposed_params)
+                .await?;
+            return Ok(());
+        }
+
+        let segment_index = segment_index
+            .or_else(|| logs.chain(&log_id).map(|c| c.tail_index()))
+            .ok_or(Error::UnknownLogId(log_id))?;
+
+        let sealed_segment = loop {
+            let sealed_segment = self.seal(log_id, segment_index).await?;
+            if sealed_segment.tail.is_sealed() {
+                break sealed_segment;
+            }
+            debug!(%log_id, %segment_index, "Segment is not sealed yet");
+            tokio::time::sleep(Configuration::pinned().bifrost.seal_retry_interval.into()).await;
+        };
+
+        let proposed_params =
+            provider.propose_new_loglet_params(log_id, logs.chain(&log_id), provider_config)?;
+
+        self.add_segment_with_params(
+            log_id,
+            segment_index,
+            sealed_segment.tail.offset(),
+            provider_config.kind(),
+            proposed_params,
+        )
+        .await?;
+
+        Ok(())
     }
 
     /// Seals a loglet under a set of conditions.
@@ -187,34 +242,93 @@ impl<'a> BifrostAdmin<'a> {
         params: LogletParams,
     ) -> Result<()> {
         self.bifrost.inner.fail_if_shutting_down()?;
-        let logs = self
-            .metadata_store_client
-            .read_modify_write(BIFROST_CONFIG_KEY.clone(), move |logs: Option<Logs>| {
-                let logs = logs.ok_or(Error::UnknownLogId(log_id))?;
+        let retry_policy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+        let logs = retry_on_network_error(retry_policy, || {
+            self.metadata_store_client.read_modify_write(
+                BIFROST_CONFIG_KEY.clone(),
+                |logs: Option<Logs>| {
+                    let logs = logs.ok_or(Error::UnknownLogId(log_id))?;
 
-                let mut builder = logs.into_builder();
-                let mut chain_builder = builder.chain(log_id).ok_or(Error::UnknownLogId(log_id))?;
+                    let mut builder = logs.into_builder();
+                    let mut chain_builder =
+                        builder.chain(log_id).ok_or(Error::UnknownLogId(log_id))?;
 
-                if chain_builder.tail().index() != last_segment_index {
-                    // tail is not what we expected.
-                    return Err(Error::from(AdminError::SegmentMismatch {
-                        expected: last_segment_index,
-                        found: chain_builder.tail().index(),
-                    }));
-                }
+                    if chain_builder.tail().index() != last_segment_index {
+                        // tail is not what we expected.
+                        return Err(Error::from(AdminError::SegmentMismatch {
+                            expected: last_segment_index,
+                            found: chain_builder.tail().index(),
+                        }));
+                    }
 
-                match chain_builder.append_segment(base_lsn, provider, params.clone()) {
-                    Err(e) => match e {
-                        BuilderError::SegmentConflict(lsn) => {
-                            Err(Error::from(AdminError::SegmentConflict(lsn)))
-                        }
-                        _ => unreachable!("the log must exist at this point"),
-                    },
-                    Ok(_) => Ok(builder.build()),
-                }
-            })
-            .await
-            .map_err(|e| e.transpose())?;
+                    let _ = chain_builder
+                        .append_segment(base_lsn, provider, params.clone())
+                        .map_err(AdminError::from)?;
+                    Ok(builder.build())
+                },
+            )
+        })
+        .await
+        .map_err(|e| e.transpose())?;
+
+        self.metadata_writer.update(Arc::new(logs)).await?;
+        Ok(())
+    }
+
+    /// Adds a new log if it doesn't exist.
+    #[instrument(level = "debug", skip(self), err)]
+    async fn add_log(
+        &self,
+        log_id: LogId,
+        provider: ProviderKind,
+        params: LogletParams,
+    ) -> Result<()> {
+        self.bifrost.inner.fail_if_shutting_down()?;
+        let retry_policy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+        let logs = retry_on_network_error(retry_policy, || {
+            self.metadata_store_client.read_modify_write::<_, _, Error>(
+                BIFROST_CONFIG_KEY.clone(),
+                |logs: Option<Logs>| {
+                    // We assume that we'll always see a value set in metadata for BIFROST_CONFIG_KEY,
+                    // provisioning the empty logs metadata is not our responsibility.
+                    let logs = logs.ok_or(Error::LogsMetadataNotProvisioned)?;
+
+                    let mut builder = logs.into_builder();
+                    builder
+                        .add_log(log_id, Chain::new(provider, params.clone()))
+                        .map_err(AdminError::from)?;
+                    Ok(builder.build())
+                },
+            )
+        })
+        .await
+        .map_err(|e| e.transpose())?;
+
+        self.metadata_writer.update(Arc::new(logs)).await?;
+        Ok(())
+    }
+
+    /// Creates empty metadata if none exists for bifrost and publishes it to metadata
+    /// manager.
+    pub async fn init_metadata(&self) -> Result<(), Error> {
+        let retry_policy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+
+        let logs = retry_on_network_error(retry_policy, || {
+            self.metadata_store_client
+                .get_or_insert(BIFROST_CONFIG_KEY.clone(), || {
+                    Logs::from_configuration(&Configuration::pinned())
+                })
+        })
+        .await?;
 
         self.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())

--- a/crates/bifrost/src/loglet/provider.rs
+++ b/crates/bifrost/src/loglet/provider.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
 use restate_types::logs::LogId;
 
 use super::{Loglet, OperationError};
@@ -36,6 +38,19 @@ pub trait LogletProvider: Send + Sync {
         segment_index: SegmentIndex,
         params: &LogletParams,
     ) -> Result<Arc<dyn Loglet>>;
+
+    /// Returns a proposed `LogletParams` given this log_id, chain, and defaults.
+    ///
+    /// This will not perform any updates, it just statically generates a valid
+    /// configuration for a potentially new loglet.
+    ///
+    /// if `chain` is None, this means we no chain exists already for this log.
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError>;
 
     /// A hook that's called after provider is started.
     async fn post_start(&self) {}

--- a/crates/bifrost/src/loglet/provider.rs
+++ b/crates/bifrost/src/loglet/provider.rs
@@ -44,7 +44,8 @@ pub trait LogletProvider: Send + Sync {
     /// This will not perform any updates, it just statically generates a valid
     /// configuration for a potentially new loglet.
     ///
-    /// if `chain` is None, this means we no chain exists already for this log.
+    /// if `chain` is None, the provider should assume that no chain exists already
+    /// for this log.
     fn propose_new_loglet_params(
         &self,
         log_id: LogId,

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -17,8 +17,10 @@ use tracing::debug;
 
 use restate_types::config::{LocalLogletOptions, RocksDbOptions};
 use restate_types::live::BoxedLiveLoad;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::LogId;
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
+use restate_types::logs::{LogId, LogletId};
 
 use super::log_store::RocksDbLogStore;
 use super::log_store_writer::RocksDbLogWriterHandle;
@@ -103,6 +105,20 @@ impl LogletProvider for LocalLogletProvider {
         };
 
         Ok(loglet as Arc<dyn Loglet>)
+    }
+
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        _defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError> {
+        let new_segment_index = chain
+            .map(|c| c.tail_index().next())
+            .unwrap_or(SegmentIndex::OLDEST);
+        Ok(LogletParams::from(
+            LogletId::new(log_id, new_segment_index).to_string(),
+        ))
     }
 
     async fn shutdown(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -22,9 +22,11 @@ use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, info};
 
 use restate_core::ShutdownError;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
 use restate_types::logs::{
-    KeyFilter, LogId, LogletOffset, MatchKeyQuery, Record, SequenceNumber, TailState,
+    KeyFilter, LogId, LogletId, LogletOffset, MatchKeyQuery, Record, SequenceNumber, TailState,
 };
 
 use crate::loglet::util::TailOffsetWatch;
@@ -98,6 +100,20 @@ impl LogletProvider for MemoryLogletProvider {
         };
 
         Ok(loglet as Arc<dyn Loglet>)
+    }
+
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        _defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError> {
+        let new_segment_index = chain
+            .map(|c| c.tail_index().next())
+            .unwrap_or(SegmentIndex::OLDEST);
+        Ok(LogletParams::from(
+            LogletId::new(log_id, new_segment_index).to_string(),
+        ))
     }
 
     async fn shutdown(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/replicated_loglet/mod.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/mod.rs
@@ -13,6 +13,7 @@ mod log_server_manager;
 mod loglet;
 pub(crate) mod metric_definitions;
 mod network;
+mod nodeset_selector;
 mod provider;
 mod read_path;
 mod remote_sequencer;

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -16,16 +16,19 @@ use dashmap::DashMap;
 use tracing::debug;
 
 use restate_core::network::{MessageRouterBuilder, Networking, TransportConnect};
-use restate_core::{TaskCenter, TaskKind};
+use restate_core::{my_node_id, Metadata, TaskCenter, TaskKind};
 use restate_metadata_store::MetadataStoreClient;
 use restate_types::config::Configuration;
-use restate_types::logs::metadata::{LogletParams, ProviderKind, SegmentIndex};
-use restate_types::logs::{LogId, RecordCache};
+use restate_types::logs::metadata::{
+    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+};
+use restate_types::logs::{LogId, LogletId, RecordCache};
 use restate_types::replicated_loglet::ReplicatedLogletParams;
 
 use super::loglet::ReplicatedLoglet;
 use super::metric_definitions;
 use super::network::RequestPump;
+use super::nodeset_selector::{NodeSelectionError, NodeSetSelector, ObservedClusterState};
 use super::rpc_routers::{LogServersRpc, SequencersRpc};
 use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::providers::replicated_loglet::error::ReplicatedLogletError;
@@ -199,6 +202,76 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
     ) -> Result<Arc<dyn Loglet>, Error> {
         let loglet = self.get_or_create_loglet(log_id, segment_index, params)?;
         Ok(loglet as Arc<dyn Loglet>)
+    }
+
+    fn propose_new_loglet_params(
+        &self,
+        log_id: LogId,
+        chain: Option<&Chain>,
+        defaults: &ProviderConfiguration,
+    ) -> Result<LogletParams, OperationError> {
+        let ProviderConfiguration::Replicated(defaults) = defaults else {
+            panic!("ProviderConfiguration::Replicated is expected");
+        };
+
+        let new_segment_index = chain
+            .map(|c| c.tail_index().next())
+            .unwrap_or(SegmentIndex::OLDEST);
+
+        let loglet_id = LogletId::new(log_id, new_segment_index);
+
+        let mut rng = rand::thread_rng();
+
+        let replication = defaults.replication_property.clone();
+        let strategy = defaults.nodeset_selection_strategy;
+
+        // if the last loglet in the chain is of the same provider kind, we can use this to
+        // influence the nodeset selector.
+        let previous_params = chain.and_then(|chain| {
+            let tail_config = chain.tail().config;
+            match tail_config.kind {
+                ProviderKind::Replicated => Some(
+                    ReplicatedLogletParams::deserialize_from(tail_config.params.as_bytes())
+                        .expect("params serde must be infallible"),
+                ),
+                // Another kind, we don't care about its config
+                _ => None,
+            }
+        });
+
+        let preferred_nodes = previous_params
+            .map(|p| p.nodeset.clone())
+            .unwrap_or_default();
+        let nodes_config = Metadata::with_current(|m| m.nodes_config_ref());
+
+        let selection = NodeSetSelector::new(&nodes_config, &ObservedClusterState).select(
+            strategy,
+            &replication,
+            &mut rng,
+            &preferred_nodes,
+        );
+
+        match selection {
+            Ok(nodeset) => Ok(LogletParams::from(
+                ReplicatedLogletParams {
+                    loglet_id,
+                    // We choose ourselves to be the sequencer for this loglet
+                    sequencer: my_node_id(),
+                    replication,
+                    nodeset,
+                }
+                .serialize()
+                .expect("params serde must be infallible"),
+            )),
+            Err(e @ NodeSelectionError::InsufficientWriteableNodes) => {
+                debug!(
+                    ?loglet_id,
+                    "Insufficient writeable nodes to select new nodeset for replicated loglet"
+                );
+
+                Err(OperationError::terminal(e))
+            }
+        }
     }
 
     async fn shutdown(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
@@ -94,6 +94,7 @@ impl CheckSealTask {
                     loglet_id = %my_params.loglet_id,
                     status = %nodeset_checker,
                     effective_nodeset = %effective_nodeset,
+                    replication = %my_params.replication,
                     "Insufficient nodes responded to GetLogletInfo requests, we cannot determine seal status, we'll assume it's unsealed for now",
                 );
                 return Ok(CheckSealOutcome::ProbablyOpen);

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -11,7 +11,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::Context;
 use enum_map::EnumMap;
 use tracing::{debug, error, trace};
 
@@ -81,11 +80,10 @@ impl BifrostService {
     ///
     /// This requires to run within a task_center context.
     pub async fn start(self) -> anyhow::Result<()> {
-        // Perform an initial metadata sync.
-        self.inner
-            .sync_metadata()
-            .await
-            .context("Initial bifrost metadata sync has failed!")?;
+        // Make sure we have v1 metadata written to metadata store with the default
+        // configuration. If metadata is already initialized, this will make sure we have the
+        // latest version set in metadata manager.
+        self.bifrost.admin().init_metadata().await?;
 
         // initialize all enabled providers.
         if self.factories.is_empty() {

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -29,7 +29,7 @@ use restate_types::schema::Schema;
 use restate_types::{GenerationalNodeId, Version, Versioned};
 
 use crate::metadata::manager::Command;
-use crate::metadata_store::ReadError;
+use crate::metadata_store::{MetadataStoreClient, ReadError};
 use crate::network::WeakConnection;
 use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
 
@@ -335,6 +335,7 @@ struct MetadataInner {
 /// so it's safe to call update_* without checking the current version.
 #[derive(Clone)]
 pub struct MetadataWriter {
+    metadata_store_client: MetadataStoreClient,
     sender: manager::CommandSender,
     /// strictly used to set my node id. Do not use this to update metadata
     /// directly to avoid race conditions.
@@ -342,8 +343,20 @@ pub struct MetadataWriter {
 }
 
 impl MetadataWriter {
-    fn new(sender: manager::CommandSender, inner: Arc<MetadataInner>) -> Self {
-        Self { sender, inner }
+    fn new(
+        sender: manager::CommandSender,
+        metadata_store_client: MetadataStoreClient,
+        inner: Arc<MetadataInner>,
+    ) -> Self {
+        Self {
+            metadata_store_client,
+            sender,
+            inner,
+        }
+    }
+
+    pub fn metadata_store_client(&self) -> &MetadataStoreClient {
+        &self.metadata_store_client
     }
 
     // Returns when the nodes configuration update is performed.

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -258,7 +258,11 @@ impl MetadataManager {
     }
 
     pub fn writer(&self) -> MetadataWriter {
-        MetadataWriter::new(self.metadata.sender.clone(), self.metadata.inner.clone())
+        MetadataWriter::new(
+            self.metadata.sender.clone(),
+            self.metadata_store_client.clone(),
+            self.metadata.inner.clone(),
+        )
     }
 
     /// Start and wait for shutdown signal.

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::any::type_name;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -428,11 +429,18 @@ impl MetadataManager {
         let mut maybe_new_version = new_value.version();
 
         if new_value.version() > current_value.version() {
+            trace!(
+                "Updating {} from {} to {}",
+                type_name::<M>(),
+                current_value.version(),
+                new_value.version(),
+            );
             container.store(new_value);
         } else {
             /* Do nothing, current is already newer */
             trace!(
-                "Ignoring update {} because we are at {}",
+                "Ignoring update of {} to {} because we are already at {}",
+                type_name::<M>(),
                 new_value.version(),
                 current_value.version(),
             );

--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -105,7 +105,6 @@ pub trait MetadataStore {
 /// Metadata store client which allows storing [`Versioned`] values into a [`MetadataStore`].
 #[derive(Clone)]
 pub struct MetadataStoreClient {
-    // premature optimization? Maybe introduce trait object once we have multiple implementations?
     inner: Arc<dyn MetadataStore + Send + Sync>,
     backoff_policy: Option<RetryPolicy>,
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -184,7 +184,8 @@ impl Node {
             record_cache.clone(),
             &mut router_builder,
         );
-        let bifrost_svc = BifrostService::new().enable_local_loglet(&updateable_config);
+        let bifrost_svc =
+            BifrostService::new(metadata_manager.writer()).enable_local_loglet(&updateable_config);
 
         #[cfg(feature = "replicated-loglet")]
         let bifrost_svc = bifrost_svc.with_factory(replicated_loglet_factory);
@@ -271,7 +272,6 @@ impl Node {
                     metadata_manager.writer(),
                     &mut server_builder,
                     &mut router_builder,
-                    metadata_store_client.clone(),
                     worker_role
                         .as_ref()
                         .map(|worker_role| worker_role.storage_query_context().clone()),

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -14,7 +14,6 @@ use codederror::CodedError;
 use restate_admin::cluster_controller;
 use restate_admin::service::AdminService;
 use restate_bifrost::Bifrost;
-use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::NetworkServerBuilder;
 use restate_core::network::Networking;
@@ -70,7 +69,6 @@ impl<T: TransportConnect> AdminRole<T> {
         metadata_writer: MetadataWriter,
         server_builder: &mut NetworkServerBuilder,
         router_builder: &mut MessageRouterBuilder,
-        metadata_store_client: MetadataStoreClient,
         local_query_context: Option<QueryContext>,
     ) -> Result<Self, AdminRoleBuildError> {
         health_status.update(AdminStatus::StartingUp);
@@ -104,7 +102,6 @@ impl<T: TransportConnect> AdminRole<T> {
 
         let admin = AdminService::new(
             metadata_writer.clone(),
-            metadata_store_client.clone(),
             bifrost.clone(),
             config.ingress.clone(),
             service_discovery,
@@ -121,7 +118,6 @@ impl<T: TransportConnect> AdminRole<T> {
                 router_builder,
                 server_builder,
                 metadata_writer,
-                metadata_store_client,
             ))
         } else {
             None

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -233,7 +233,7 @@ pub struct CommonOptions {
 
     /// # Network error retry policy
     ///
-    /// The retry policy for node network error
+    /// The retry policy for network related errors
     pub network_error_retry_policy: RetryPolicy,
 }
 

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -213,14 +213,14 @@ mod tests {
     // Start paused makes sure the timer is immediately fired
     #[test(restate_core::test(start_paused = true))]
     pub async fn cleanup_works() {
-        let _env = TestCoreEnvBuilder::with_incoming_only_connector()
+        let env = TestCoreEnvBuilder::with_incoming_only_connector()
             .set_partition_table(PartitionTable::with_equally_sized_partitions(
                 Version::MIN,
                 1,
             ))
             .build()
             .await;
-        let bifrost = Bifrost::init_in_memory().await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
 
         let expired_invocation =
             InvocationId::from_parts(PartitionKey::MIN, InvocationUuid::mock_random());

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -637,12 +637,12 @@ mod tests {
 
     #[test(restate_core::test)]
     async fn become_leader_then_step_down() -> googletest::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(0, 0).await;
+        let env = TestCoreEnv::create_with_single_node(0, 0).await;
         let storage_options = StorageOptions::default();
         let rocksdb_options = RocksDbOptions::default();
 
         RocksDbManager::init(Constant::new(CommonOptions::default()));
-        let bifrost = Bifrost::init_in_memory().await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
 
         let partition_store_manager = PartitionStoreManager::create(
             Constant::new(storage_options.clone()).boxed(),

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -628,7 +628,7 @@ mod tests {
 
         let (truncation_tx, _truncation_rx) = mpsc::channel(1);
 
-        let bifrost = Bifrost::init_in_memory().await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer.clone()).await;
         let shuffle = Shuffle::new(metadata, outbox_reader, truncation_tx, 1, bifrost.clone());
 
         ShuffleEnv {

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1006,7 +1006,8 @@ mod tests {
 
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
-        let bifrost_svc = BifrostService::new().with_factory(memory_loglet::Factory::default());
+        let bifrost_svc = BifrostService::new(env_builder.metadata_writer.clone())
+            .with_factory(memory_loglet::Factory::default());
         let bifrost = bifrost_svc.handle();
 
         let partition_store_manager = PartitionStoreManager::create(

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -15,7 +15,7 @@ use enumset::{enum_set, EnumSet};
 use googletest::internal::test_outcome::TestAssertionFailure;
 use googletest::IntoTestResult;
 
-use restate_bifrost::{loglet::Loglet, Bifrost, BifrostAdmin};
+use restate_bifrost::{loglet::Loglet, Bifrost};
 use restate_core::metadata_store::Precondition;
 use restate_core::TaskCenter;
 use restate_core::{metadata_store::MetadataStoreClient, MetadataWriter};
@@ -90,16 +90,6 @@ pub struct TestEnv {
     pub metadata_writer: MetadataWriter,
     pub metadata_store_client: MetadataStoreClient,
     pub cluster: StartedCluster,
-}
-
-impl TestEnv {
-    pub fn bifrost_admin(&self) -> BifrostAdmin<'_> {
-        BifrostAdmin::new(
-            &self.bifrost,
-            &self.metadata_writer,
-            &self.metadata_store_client,
-        )
-    }
 }
 
 pub async fn run_in_test_env<F, O>(

--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -248,22 +248,12 @@ mod tests {
                 }
 
                 let mut sealer_handle: JoinHandle<googletest::Result<()>> = tokio::task::spawn({
-                    let (bifrost, metadata_writer, metadata_store_client) = (
-                        test_env.bifrost.clone(),
-                        test_env.metadata_writer.clone(),
-                        test_env.metadata_store_client.clone()
-                    );
+                    let bifrost = test_env.bifrost.clone();
 
                     async move {
                         let cancellation_token = cancellation_token();
 
                         let mut chain = metadata.updateable_logs_metadata().map(|logs| logs.chain(&log_id).expect("a chain to exist"));
-
-                        let bifrost_admin = restate_bifrost::BifrostAdmin::new(
-                            &bifrost,
-                            &metadata_writer,
-                            &metadata_store_client,
-                        );
 
                         let mut last_loglet_id = None;
 
@@ -280,7 +270,8 @@ mod tests {
                             eprintln!("Sealing loglet {} and creating new loglet {}", params.loglet_id, params.loglet_id.next());
                             params.loglet_id = params.loglet_id.next();
 
-                            bifrost_admin
+                            bifrost
+                                .admin()
                                 .seal_and_extend_chain(
                                     log_id,
                                     None,

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -176,7 +176,7 @@ fn spawn_environment(config: Live<Configuration>, num_logs: u16) -> (task_center
         metadata_writer.submit(Arc::new(logs));
         spawn_metadata_manager(metadata_manager).expect("metadata manager starts");
 
-        let bifrost_svc = BifrostService::new()
+        let bifrost_svc = BifrostService::new(metadata_writer)
             .enable_in_memory_loglet()
             .enable_local_loglet(&config);
         let bifrost = bifrost_svc.handle();

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -16,7 +16,7 @@ use std::fmt::{self, Display, Write};
 use cling::prelude::*;
 
 use restate_types::{
-    logs::metadata::DefaultProvider, partition_table::ReplicationStrategy,
+    logs::metadata::ProviderConfiguration, partition_table::ReplicationStrategy,
     protobuf::cluster::ClusterConfiguration,
 };
 
@@ -43,7 +43,7 @@ fn cluster_config_string(config: ClusterConfiguration) -> anyhow::Result<String>
 
     write_leaf(&mut w, 1, false, "Bifrost replication strategy", strategy)?;
 
-    let provider: DefaultProvider = config.default_provider.unwrap_or_default().try_into()?;
+    let provider: ProviderConfiguration = config.default_provider.unwrap_or_default().try_into()?;
     write_default_provider(&mut w, 1, provider)?;
 
     Ok(w)
@@ -52,19 +52,19 @@ fn cluster_config_string(config: ClusterConfiguration) -> anyhow::Result<String>
 fn write_default_provider<W: fmt::Write>(
     w: &mut W,
     depth: usize,
-    provider: DefaultProvider,
+    provider: ProviderConfiguration,
 ) -> Result<(), fmt::Error> {
     let title = "Bifrost Provider";
     match provider {
         #[cfg(any(test, feature = "memory-loglet"))]
-        DefaultProvider::InMemory => {
+        ProviderConfiguration::InMemory => {
             write_leaf(w, depth, true, title, "in-memory")?;
         }
-        DefaultProvider::Local => {
+        ProviderConfiguration::Local => {
             write_leaf(w, depth, true, title, "local")?;
         }
         #[cfg(feature = "replicated-loglet")]
-        DefaultProvider::Replicated(config) => {
+        ProviderConfiguration::Replicated(config) => {
             write_leaf(w, depth, true, title, "replicated")?;
             let depth = depth + 1;
             write_leaf(

--- a/tools/restatectl/src/commands/cluster/config/set.rs
+++ b/tools/restatectl/src/commands/cluster/config/set.rs
@@ -23,7 +23,7 @@ use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
 use restate_types::logs::metadata::{
-    DefaultProvider, NodeSetSelectionStrategy, ProviderKind, ReplicatedLogletConfig,
+    NodeSetSelectionStrategy, ProviderConfiguration, ProviderKind, ReplicatedLogletConfig,
 };
 use restate_types::partition_table::ReplicationStrategy;
 use restate_types::replicated_loglet::ReplicationProperty;
@@ -89,8 +89,8 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
 
     if let Some(provider) = set_opts.bifrost_provider {
         let default_provider = match provider {
-            ProviderKind::InMemory => DefaultProvider::InMemory,
-            ProviderKind::Local => DefaultProvider::Local,
+            ProviderKind::InMemory => ProviderConfiguration::InMemory,
+            ProviderKind::Local => ProviderConfiguration::Local,
             ProviderKind::Replicated => {
                 let config = ReplicatedLogletConfig {
                     replication_property: set_opts
@@ -101,7 +101,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
                         .nodeset_selection_strategy
                         .unwrap_or_default(),
                 };
-                DefaultProvider::Replicated(config)
+                ProviderConfiguration::Replicated(config)
             }
         };
 

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -86,6 +86,7 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
 
         let metadata_manager =
             MetadataManager::new(metadata_builder, metadata_store_client.clone());
+        let metadata_writer = metadata_manager.writer();
         let mut router_builder = MessageRouterBuilder::default();
         metadata_manager.register_in_message_router(&mut router_builder);
 
@@ -95,7 +96,8 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
             metadata_manager.run(),
         )?;
 
-        let bifrost_svc = BifrostService::new().enable_local_loglet(&Configuration::updateable());
+        let bifrost_svc =
+            BifrostService::new(metadata_writer).enable_local_loglet(&Configuration::updateable());
 
         let bifrost = bifrost_svc.handle();
         // Ensures bifrost has initial metadata synced up before starting the worker.

--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -55,6 +55,11 @@ pub async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> any
 
     c_println!("Log Configuration ({})", logs.version());
 
+    c_println!(
+        "Default Provider Config: {:?}",
+        logs.configuration().default_provider
+    );
+
     // sort by log-id for display
     let logs: BTreeMap<LogId, &Chain> = logs.iter().map(|(id, chain)| (*id, chain)).collect();
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -103,11 +103,10 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
 
     // We start the Meta service, then download the openapi schema generated
     let node_env = TestCoreEnv::create_with_single_node(1, 1).await;
-    let bifrost = Bifrost::init_in_memory().await;
+    let bifrost = Bifrost::init_in_memory(node_env.metadata_writer.clone()).await;
 
     let admin_service = AdminService::new(
         node_env.metadata_writer.clone(),
-        node_env.metadata_store_client.clone(),
         bifrost,
         Mock,
         ServiceDiscovery::new(


### PR DESCRIPTION

BifrostService will not auto provision its own metadata entry in metadata store on startup.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2458).
* __->__ #2458
* #2457
* #2451