### PR TITLE
Move MetadataKind from node.proto to common.proto

### DIFF
--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -11,7 +11,6 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "restate/common.proto";
-import "restate/node.proto";
 
 package restate.node_ctl_svc;
 
@@ -45,7 +44,7 @@ message GetMetadataRequest {
   // If set, we'll first sync with metadata store to esnure we are returning the latest value.
   // Otherwise, we'll return the local value on this node.
   bool sync = 1;
-  restate.node.MetadataKind kind = 2;
+  restate.common.MetadataKind kind = 2;
 }
 
 message GetMetadataResponse {

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -132,3 +132,11 @@ enum IngressStatus {
   IngressStatus_READY = 1;
   IngressStatus_STARTING_UP = 2;
 }
+
+enum MetadataKind {
+  MetadataKind_UNKNOWN = 0;
+  NODES_CONFIGURATION = 1;
+  SCHEMA = 2;
+  PARTITION_TABLE = 3;
+  LOGS = 4;
+}

--- a/crates/types/protobuf/restate/node.proto
+++ b/crates/types/protobuf/restate/node.proto
@@ -81,13 +81,3 @@ message Message {
     BinaryMessage encoded = 5;
   }
 }
-
-// # Common node types
-
-enum MetadataKind {
-  MetadataKind_UNKNOWN = 0;
-  NODES_CONFIGURATION = 1;
-  SCHEMA = 2;
-  PARTITION_TABLE = 3;
-  LOGS = 4;
-}

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -65,7 +65,7 @@ define_message! {
     IntoProto,
     FromProto,
 )]
-#[proto(target = "crate::protobuf::node::MetadataKind")]
+#[proto(target = "crate::protobuf::common::MetadataKind")]
 pub enum MetadataKind {
     NodesConfiguration,
     Schema,
@@ -74,18 +74,20 @@ pub enum MetadataKind {
 }
 
 // todo remove once prost_dto supports TryFromProto
-impl TryFrom<crate::protobuf::node::MetadataKind> for MetadataKind {
+impl TryFrom<crate::protobuf::common::MetadataKind> for MetadataKind {
     type Error = anyhow::Error;
 
-    fn try_from(value: crate::protobuf::node::MetadataKind) -> Result<Self, Self::Error> {
+    fn try_from(value: crate::protobuf::common::MetadataKind) -> Result<Self, Self::Error> {
         match value {
-            crate::protobuf::node::MetadataKind::Unknown => bail!("unknown metadata kind"),
-            crate::protobuf::node::MetadataKind::NodesConfiguration => {
+            crate::protobuf::common::MetadataKind::Unknown => bail!("unknown metadata kind"),
+            crate::protobuf::common::MetadataKind::NodesConfiguration => {
                 Ok(MetadataKind::NodesConfiguration)
             }
-            crate::protobuf::node::MetadataKind::Schema => Ok(MetadataKind::Schema),
-            crate::protobuf::node::MetadataKind::PartitionTable => Ok(MetadataKind::PartitionTable),
-            crate::protobuf::node::MetadataKind::Logs => Ok(MetadataKind::Logs),
+            crate::protobuf::common::MetadataKind::Schema => Ok(MetadataKind::Schema),
+            crate::protobuf::common::MetadataKind::PartitionTable => {
+                Ok(MetadataKind::PartitionTable)
+            }
+            crate::protobuf::common::MetadataKind::Logs => Ok(MetadataKind::Logs),
         }
     }
 }


### PR DESCRIPTION
Move MetadataKind from node.proto to common.proto. With this change, users of the node_ctl_svc.proto only
need to import the common.proto