### PR TITLE
Add /health handler to node server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6586,6 +6586,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "prost",
+ "prost-dto",
  "prost-types",
  "rand 0.9.0",
  "restate-core-derive",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ ciborium = { workspace = true}
 dashmap = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
+prost-dto = { workspace = true }
 enum-map = { workspace = true }
 enumset = { workspace = true }
 etcd-client = { workspace = true }

--- a/crates/core/src/identification.rs
+++ b/crates/core/src/identification.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::task_center::TaskCenterMonitoring;
+use crate::{Metadata, TaskCenter};
+use enumset::EnumSet;
+use restate_types::config::Configuration;
+use restate_types::health::{
+    AdminStatus, LogServerStatus, MetadataServerStatus, NodeStatus, WorkerStatus,
+};
+use restate_types::nodes_config::Role;
+use restate_types::{NodeId, Version};
+use serde_with::serde_as;
+use std::time::Duration;
+
+#[serde_as]
+#[derive(serde::Serialize, prost_dto::IntoProst)]
+#[prost(target = "crate::protobuf::node_ctl_svc::IdentResponse")]
+pub struct Identification {
+    pub status: NodeStatus,
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub node_id: Option<NodeId>,
+    pub cluster_name: String,
+    #[into_prost(map = "enum_set_to_vec", map_by_ref)]
+    pub roles: EnumSet<Role>,
+    #[prost(name=age_s)]
+    #[into_prost(map=Duration::as_secs, map_by_ref)]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub age: humantime::Duration,
+    pub admin_status: AdminStatus,
+    pub worker_status: WorkerStatus,
+    pub log_server_status: LogServerStatus,
+    pub metadata_server_status: MetadataServerStatus,
+    pub nodes_config_version: Version,
+    pub logs_version: Version,
+    pub schema_version: Version,
+    pub partition_table_version: Version,
+}
+
+fn enum_set_to_vec(roles: &EnumSet<Role>) -> Vec<String> {
+    roles.iter().map(|role| role.to_string()).collect()
+}
+
+impl Identification {
+    /// Gets the identification information for this node. It needs to be called from within the
+    /// [`TaskCenter`].
+    pub fn get() -> Self {
+        let (node_status, admin_status, worker_status, metadata_server_status, log_server_status) =
+            TaskCenter::with_current(|tc| {
+                let health = tc.health();
+                (
+                    health.current_node_status(),
+                    health.current_admin_status(),
+                    health.current_worker_status(),
+                    health.current_metadata_store_status(),
+                    health.current_log_server_status(),
+                )
+            });
+        let age = TaskCenter::with_current(|tc| tc.age());
+        let metadata = Metadata::current();
+        let configuration = Configuration::pinned();
+
+        Identification {
+            status: node_status,
+            node_id: metadata.my_node_id_opt().map(Into::into),
+            roles: *configuration.roles(),
+            cluster_name: configuration.common.cluster_name().to_owned(),
+            age: age.into(),
+            admin_status,
+            worker_status,
+            metadata_server_status,
+            log_server_status,
+            nodes_config_version: metadata.nodes_config_version(),
+            logs_version: metadata.logs_version(),
+            schema_version: metadata.schema_version(),
+            partition_table_version: metadata.partition_table_version(),
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod error;
+mod identification;
 mod metadata;
 pub mod metadata_store;
 mod metric_definitions;
@@ -40,6 +41,8 @@ pub use error::*;
 ///
 #[cfg(any(test, feature = "test-util"))]
 pub use restate_core_derive::test;
+
+pub use identification::Identification;
 
 pub use metadata::{
     Metadata, MetadataBuilder, MetadataKind, MetadataManager, MetadataWriter, SyncError,

--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -10,18 +10,16 @@
 
 use std::fmt::Write;
 
-use axum::extract::State;
-use metrics_exporter_prometheus::formatting;
-use rocksdb::statistics::{Histogram, Ticker};
-
-use restate_core::task_center::TaskCenterMonitoring;
-use restate_rocksdb::{CfName, RocksDbManager};
-
 use crate::network_server::prometheus_helpers::{
     MetricUnit, format_rocksdb_histogram_for_prometheus, format_rocksdb_property_for_prometheus,
     format_rocksdb_stat_ticker_for_prometheus,
 };
 use crate::network_server::state::NodeCtrlHandlerState;
+use axum::extract::State;
+use metrics_exporter_prometheus::formatting;
+use restate_core::task_center::TaskCenterMonitoring;
+use restate_rocksdb::{CfName, RocksDbManager};
+use rocksdb::statistics::{Histogram, Ticker};
 
 const ROCKSDB_TICKERS: &[Ticker] = &[
     Ticker::BlockCacheBytesRead,
@@ -174,6 +172,7 @@ const ROCKSDB_CF_PROPERTIES: &[(&str, MetricUnit)] = &[
 ];
 
 // -- Direct HTTP Handlers --
+
 pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String {
     let default_cf = CfName::new("default");
     let mut out = String::new();

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -103,6 +103,11 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
             "#[derive(::enum_map::Enum, ::derive_more::IsVariant, ::derive_more::Display)]",
         )
         .enum_attribute("Message.body", "#[derive(::derive_more::IsVariant)]")
+        .enum_attribute("NodeStatus", "#[derive(::serde::Serialize)]")
+        .enum_attribute("AdminStatus", "#[derive(::serde::Serialize)]")
+        .enum_attribute("LogServerStatus", "#[derive(::serde::Serialize)]")
+        .enum_attribute("WorkerStatus", "#[derive(::serde::Serialize)]")
+        .enum_attribute("MetadataServerStatus", "#[derive(::serde::Serialize)]")
         .btree_map([
             ".restate.cluster.ClusterState",
             ".restate.cluster.AliveNode",


### PR DESCRIPTION
This commit adds a very simple /health handler that returns 200 if the server is running. This allows to check whether the node server is running.

This fixes #2461.