### PR TITLE
Adding placements to partition table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7077,6 +7077,7 @@ dependencies = [
  "http 1.2.0",
  "http-serde",
  "humantime",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "jsonptr",
  "moka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ hyper-rustls = { version = "0.27.2", default-features = false, features = [
     "logging",
 ] }
 hyper-util = { version = "0.1" }
+indexmap = "2.7"
 itertools = "0.13.0"
 jsonschema = "0.26.0"
 metrics = { version = "0.24" }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -45,6 +45,7 @@ hostname = { workspace = true }
 http = { workspace = true }
 http-serde = { workspace = true }
 humantime = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 moka = { workspace = true, features = ["sync", "logging"] }
 notify = { version = "7.0.0" }

--- a/crates/utoipa/Cargo.toml
+++ b/crates/utoipa/Cargo.toml
@@ -15,7 +15,7 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
-indexmap = { version = "2", features = ["serde"] }
+indexmap = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2"


### PR DESCRIPTION
Adding placements to partition table

Summary:
Partition table now includes the placement of each partition. PartitionPlacement, representing the set of nodes where the partition should run, with the first node in the group designated as the leader.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2464).
* #2479
* __->__ #2464