### PR TITLE
Temporary band aid: Harden NodeCtlSvcHandler::GetMetadata

### DIFF
--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -84,7 +84,10 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
     ) -> Result<Response<GetMetadataResponse>, Status> {
         let request = request.into_inner();
         let metadata = Metadata::current();
-        let kind = request.kind.into();
+        let kind = request
+            .kind()
+            .try_into()
+            .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         if request.sync {
             metadata
                 .sync(kind, TargetVersion::Latest)

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -8,11 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-
+use anyhow::bail;
 use enum_map::Enum;
 use prost_dto::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use strum::EnumIter;
 
 use crate::logs::metadata::Logs;
@@ -71,6 +71,23 @@ pub enum MetadataKind {
     Schema,
     PartitionTable,
     Logs,
+}
+
+// todo remove once prost_dto supports TryFromProto
+impl TryFrom<crate::protobuf::node::MetadataKind> for MetadataKind {
+    type Error = anyhow::Error;
+
+    fn try_from(value: crate::protobuf::node::MetadataKind) -> Result<Self, Self::Error> {
+        match value {
+            crate::protobuf::node::MetadataKind::Unknown => bail!("unknown metadata kind"),
+            crate::protobuf::node::MetadataKind::NodesConfiguration => {
+                Ok(MetadataKind::NodesConfiguration)
+            }
+            crate::protobuf::node::MetadataKind::Schema => Ok(MetadataKind::Schema),
+            crate::protobuf::node::MetadataKind::PartitionTable => Ok(MetadataKind::PartitionTable),
+            crate::protobuf::node::MetadataKind::Logs => Ok(MetadataKind::Logs),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, derive_more::From)]


### PR DESCRIPTION
Make the conversion of metadata kind failable to tolerate invalid GetMetadataRequests.

This fixes #2465.