### PR TITLE
Return effective trim point LSN on successful trim request

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -24,7 +24,7 @@ service ClusterCtrlSvc {
 
   rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
 
-  rpc TrimLog(TrimLogRequest) returns (google.protobuf.Empty);
+  rpc TrimLog(TrimLogRequest) returns (TrimLogResponse);
 
   rpc CreatePartitionSnapshot(CreatePartitionSnapshotRequest)
       returns (CreatePartitionSnapshotResponse);
@@ -92,6 +92,11 @@ message ListNodesResponse {
 message TrimLogRequest {
   uint32 log_id = 1;
   uint64 trim_point = 2;
+}
+
+message TrimLogResponse {
+  uint32 log_id = 1;
+  optional uint64 trim_point = 2;
 }
 
 message CreatePartitionSnapshotRequest { uint32 partition_id = 1; }

--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -96,6 +96,7 @@ message TrimLogRequest {
 
 message TrimLogResponse {
   uint32 log_id = 1;
+  // the underlying log's actual trim point as reported by the loglet provider
   optional uint64 trim_point = 2;
 }
 

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -170,7 +170,7 @@ enum ClusterControllerCommand {
     TrimLog {
         log_id: LogId,
         trim_point: Lsn,
-        response_tx: oneshot::Sender<anyhow::Result<()>>,
+        response_tx: oneshot::Sender<anyhow::Result<Option<Lsn>>>,
     },
     CreateSnapshot {
         partition_id: PartitionId,
@@ -209,7 +209,7 @@ impl ClusterControllerHandle {
         &self,
         log_id: LogId,
         trim_point: Lsn,
-    ) -> Result<Result<(), anyhow::Error>, ShutdownError> {
+    ) -> Result<Result<Option<Lsn>, anyhow::Error>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let _ = self
@@ -575,7 +575,7 @@ impl<T: TransportConnect> Service<T> {
                 info!(
                     ?log_id,
                     trim_point_inclusive = ?trim_point,
-                    "Manual trim log command received");
+                    "Trim log command received");
                 let result = self.bifrost.admin().trim(log_id, trim_point).await;
                 let _ = response_tx.send(result.map_err(Into::into));
             }

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -329,8 +329,9 @@ where
                 let current_trim_point = self.bifrost.get_trim_point(log_id).await?;
 
                 if min_persisted_lsn >= current_trim_point + self.log_trim_threshold {
-                    debug!("Automatic trim log '{log_id}' for all records before='{min_persisted_lsn}'");
-                    self.bifrost.admin().trim(log_id, min_persisted_lsn).await?;
+                    debug!("Automatic trim log '{log_id}' for records up to {min_persisted_lsn}");
+                    let trim_point = self.bifrost.admin().trim(log_id, min_persisted_lsn).await?;
+                    debug!("Trimmed log '{log_id}' to '{trim_point:?}'");
                 }
             } else {
                 warn!("Stop automatically trimming log '{log_id}' because not all nodes are running a partition processor applying this log.");

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -329,10 +329,8 @@ where
                 let current_trim_point = self.bifrost.get_trim_point(log_id).await?;
 
                 if min_persisted_lsn >= current_trim_point + self.log_trim_threshold {
-                    debug!(
-                    "Automatic trim log '{log_id}' for all records before='{min_persisted_lsn}'"
-                );
-                    self.bifrost.admin().trim(log_id, min_persisted_lsn).await?
+                    debug!("Automatic trim log '{log_id}' for all records before='{min_persisted_lsn}'");
+                    self.bifrost.admin().trim(log_id, min_persisted_lsn).await?;
                 }
             } else {
                 warn!("Stop automatically trimming log '{log_id}' because not all nodes are running a partition processor applying this log.");

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -46,7 +46,7 @@ impl<'a> BifrostAdmin<'a> {
     /// Set `trim_point` to the value returned from `find_tail()` or `Lsn::MAX` to
     /// trim all records of the log.
     #[instrument(level = "debug", skip(self), err)]
-    pub async fn trim(&self, log_id: LogId, trim_point: Lsn) -> Result<()> {
+    pub async fn trim(&self, log_id: LogId, trim_point: Lsn) -> Result<Option<Lsn>> {
         self.bifrost.inner.fail_if_shutting_down()?;
         self.bifrost.inner.trim(log_id, trim_point).await
     }

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -135,7 +135,7 @@ pub trait Loglet: Send + Sync + std::fmt::Debug {
     /// Passing `Offset::INVALID` is a no-op. (success)
     /// Passing `Offset::OLDEST` trims the first record in the loglet (if exists).
     ///
-    /// Returns the new trim point offset if a trim was performed by this call, or `None` otherwise.
+    /// Returns the trim point offset regardless of whether a trim was performed by this call.
     async fn trim(&self, trim_point: LogletOffset) -> Result<Option<LogletOffset>, OperationError>;
 
     /// Seal the loglet. This operation is idempotent.

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -127,14 +127,16 @@ pub trait Loglet: Send + Sync + std::fmt::Debug {
     async fn get_trim_point(&self) -> Result<Option<LogletOffset>, OperationError>;
 
     /// Trim the loglet prefix up to and including the `trim_point`.
-    /// If trim_point equal or higher than the loglet tail, the loglet trims its data until the tail.
+    /// If trim_point equal or higher than the loglet tail, the loglet trims its data up to the tail.
     ///
-    /// It's acceptable to pass `trim_point` beyond the tail of the loglet (Offset::MAX is legal).
-    /// The behaviour in this case is equivalent to trim(find_tail() - 1).
+    /// It's acceptable to pass `trim_point` beyond the tail of the loglet (i.e. `Offset::MAX` is legal).
+    /// The behaviour in this case is equivalent to `trim(find_tail() - 1)`.
     ///
     /// Passing `Offset::INVALID` is a no-op. (success)
     /// Passing `Offset::OLDEST` trims the first record in the loglet (if exists).
-    async fn trim(&self, trim_point: LogletOffset) -> Result<(), OperationError>;
+    ///
+    /// Returns the new trim point offset if a trim was performed by this call, or `None` otherwise.
+    async fn trim(&self, trim_point: LogletOffset) -> Result<Option<LogletOffset>, OperationError>;
 
     /// Seal the loglet. This operation is idempotent.
     ///

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -193,11 +193,11 @@ impl LogletWrapper {
     /// `trim_point`: inclusive LSN up to which to trim the loglet; if the LSN is beyond the
     /// loglet's end, it will be trimmed in full.
     ///
-    /// Returns the effective trim point of the loglet after a trim was performed, `None` otherwise.
+    /// Returns the trim point of the loglet regardless of whether the call caused it to change.
     pub async fn trim(&self, trim_point: Lsn) -> Result<Option<Lsn>, OperationError> {
         // trimming to INVALID is no-op
         if trim_point == Lsn::INVALID {
-            return Ok(None);
+            return self.get_trim_point().await;
         }
         // saturate to the loglet max possible offset.
         let trim_point = trim_point.min(Lsn::new(LogletOffset::MAX.into()));

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -216,9 +216,10 @@ impl Loglet for LocalLoglet {
         }
     }
 
-    /// Trim the log to the minimum of new_trim_point and last_committed_offset
-    /// new_trim_point is inclusive (will be trimmed)
-    async fn trim(&self, new_trim_point: LogletOffset) -> Result<(), OperationError> {
+    async fn trim(
+        &self,
+        new_trim_point: LogletOffset,
+    ) -> Result<Option<LogletOffset>, OperationError> {
         let effective_trim_point = new_trim_point.min(LogletOffset::new(
             self.last_committed_offset.load(Ordering::Relaxed),
         ));
@@ -233,7 +234,7 @@ impl Loglet for LocalLoglet {
 
         if current_trim_point >= effective_trim_point {
             // nothing to do since we have already trimmed beyond new_trim_point
-            return Ok(());
+            return Ok(None);
         }
 
         counter!(BIFROST_LOCAL_TRIM).increment(1);
@@ -255,7 +256,7 @@ impl Loglet for LocalLoglet {
             "Loglet trim operation enqueued"
         );
 
-        Ok(())
+        Ok(Some(effective_trim_point))
     }
 
     async fn seal(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -224,7 +224,7 @@ impl Loglet for LocalLoglet {
             self.last_committed_offset.load(Ordering::Relaxed),
         ));
 
-        // the lock is needed to prevent concurrent trim operations from over taking each other :-(
+        // The lock is needed to prevent concurrent trim operations from over taking each other :-(
         // The problem is that the LogStoreWriter is not the component holding the ground truth
         // but the LocalLoglet is. The bad thing that could happen is that we might not trim earlier
         // parts in case two trim operations get reordered and we crash before applying the second.
@@ -234,7 +234,7 @@ impl Loglet for LocalLoglet {
 
         if current_trim_point >= effective_trim_point {
             // nothing to do since we have already trimmed beyond new_trim_point
-            return Ok(None);
+            return Ok(Some(current_trim_point));
         }
 
         counter!(BIFROST_LOCAL_TRIM).increment(1);

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -386,24 +386,27 @@ impl Loglet for MemoryLoglet {
         }
     }
 
-    async fn trim(&self, new_trim_point: LogletOffset) -> Result<(), OperationError> {
+    async fn trim(
+        &self,
+        requested_trim_point: LogletOffset,
+    ) -> Result<Option<LogletOffset>, OperationError> {
         let mut log = self.log.lock().unwrap();
-        let actual_trim_point = new_trim_point.min(LogletOffset::new(
+        let requested_trim_point = requested_trim_point.min(LogletOffset::new(
             self.last_committed_offset.load(Ordering::Relaxed),
         ));
 
         let current_trim_point = LogletOffset::new(self.trim_point_offset.load(Ordering::Relaxed));
 
-        if current_trim_point >= actual_trim_point {
-            return Ok(());
+        if current_trim_point >= requested_trim_point {
+            return Ok(Some(current_trim_point));
         }
 
-        let trim_point_index = self.saturating_offset_to_index(actual_trim_point);
+        let trim_point_index = self.saturating_offset_to_index(requested_trim_point);
         self.trim_point_offset
-            .store(*actual_trim_point, Ordering::Relaxed);
+            .store(*requested_trim_point, Ordering::Relaxed);
         log.drain(0..=trim_point_index);
 
-        Ok(())
+        Ok(Some(requested_trim_point))
     }
 
     async fn seal(&self) -> Result<(), OperationError> {

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -394,9 +394,11 @@ impl Loglet for MemoryLoglet {
         let requested_trim_point = requested_trim_point.min(LogletOffset::new(
             self.last_committed_offset.load(Ordering::Relaxed),
         ));
+        if requested_trim_point == LogletOffset::INVALID {
+            return Ok(None);
+        }
 
         let current_trim_point = LogletOffset::new(self.trim_point_offset.load(Ordering::Relaxed));
-
         if current_trim_point >= requested_trim_point {
             return Ok(Some(current_trim_point));
         }

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -314,7 +314,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         .await?;
 
         info!(
-            loglet_id=%self.my_params.loglet_id,
+            loglet_id = %self.my_params.loglet_id,
             ?requested_trim_point,
             ?trim_point,
             "Loglet trim task completed successfully"
@@ -340,7 +340,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         // returns Sealed. We should NOT:
         // - Use AppendError::Sealed to mark our sealed global_tail
         // - Mark our global tail as sealed on successful seal() call.
-        info!(loglet_id=%self.my_params.loglet_id, "Loglet has been sealed successfully");
+        info!(loglet_id = %self.my_params.loglet_id, "Loglet has been sealed successfully");
         Ok(())
     }
 }

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -26,7 +26,7 @@ use crate::metadata::LogletState;
 /// A loglet worker
 ///
 /// The design of the store flow assumes that sequencer will send records in the order we can
-/// accept then (per-connection) to reduce complexity on the log-server side. This means that
+/// accept them (per-connection) to reduce complexity on the log-server side. This means that
 /// the log-server does not need to re-order or buffer records in memory.
 /// Records will be rejected if:
 ///   1) Record offset > local tail

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -119,7 +119,7 @@ impl From<Lsn> for crate::protobuf::common::Lsn {
 
 impl SequenceNumber for Lsn {
     /// The maximum possible sequence number, this is useful when creating a read stream
-    /// with an open ended tail.
+    /// with an open-ended tail.
     const MAX: Self = Lsn(u64::MAX);
     /// 0 is not a valid sequence number. This sequence number represents invalid position
     /// in the log, or that the log has been that has been trimmed.

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -547,6 +547,8 @@ pub struct Trim {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Trimmed {
     pub header: LogServerResponseHeader,
+    /// The effective trim point.
+    pub trim_point: LogletOffset,
 }
 
 impl Deref for Trimmed {
@@ -567,17 +569,24 @@ impl Trimmed {
     pub fn empty() -> Self {
         Self {
             header: LogServerResponseHeader::empty(),
+            trim_point: LogletOffset::INVALID,
         }
     }
 
     pub fn new(tail_state: TailState<LogletOffset>, known_global_tail: LogletOffset) -> Self {
         Self {
             header: LogServerResponseHeader::new(tail_state, known_global_tail),
+            trim_point: LogletOffset::INVALID,
         }
     }
 
     pub fn with_status(mut self, status: Status) -> Self {
         self.header.status = status;
+        self
+    }
+
+    pub fn with_trim_point(mut self, trim_point: LogletOffset) -> Self {
+        self.trim_point = trim_point;
         self
     }
 }

--- a/tools/restatectl/src/commands/log/trim_log.rs
+++ b/tools/restatectl/src/commands/log/trim_log.rs
@@ -48,13 +48,24 @@ async fn trim_log(connection: &ConnectionInfo, opts: &TrimLogOpts) -> anyhow::Re
         log_id: opts.log_id,
         trim_point: opts.trim_point,
     };
-    client
+    let response = client
         .trim_log(trim_request)
         .await
         .with_context(|| "failed to submit trim request")?
         .into_inner();
 
-    c_println!("Submitted");
+    match response.trim_point {
+        Some(trim_point) => {
+            c_println!(
+                "Log id {} successfully trimmed to LSN {}",
+                opts.log_id,
+                trim_point
+            );
+        }
+        None => {
+            c_println!("Log trim request was a no-op");
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This change enables `restatectl` reporting of the effective trim point as well as positive validation in places like the upcoming trim-gap handling test  (https://github.com/restatedev/restate/pull/2463).

It's mostly just plumbing and a couple of opportunistic cleanups.

@tillrohrmann - making you the primary reviewer since you've been quite engaged with this!

cc: @AhmedSoliman for visibility - I've slightly updated the Bifrost log server `Trimmed` response RPC to support the updated semantics.