### PR TITLE
Handle config file replacement by some editors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,6 +2780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4501,15 +4510,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify-debouncer-mini"
-version = "0.5.0"
+name = "notify-debouncer-full"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa5a66d07ed97dce782be94dcf5ab4d1b457f4243f7566c7557f15cabc8c799"
+checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
 dependencies = [
+ "file-id",
  "log",
  "notify",
  "notify-types",
- "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -7069,7 +7079,7 @@ dependencies = [
  "jsonptr",
  "moka",
  "notify",
- "notify-debouncer-mini",
+ "notify-debouncer-full",
  "num-traits",
  "opentelemetry",
  "parking_lot",
@@ -9571,6 +9581,7 @@ dependencies = [
  "arrow-ipc",
  "axum",
  "axum-core",
+ "bitflags 2.6.0",
  "bytes",
  "bzip2-sys",
  "cc",

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -48,7 +48,7 @@ humantime = { workspace = true }
 itertools = { workspace = true }
 moka = { workspace = true, features = ["sync", "logging"] }
 notify = { version = "7.0.0" }
-notify-debouncer-mini = { version = "0.5.0" }
+notify-debouncer-full = { version = "0.4" }
 num-traits = { version = "0.2.17" }
 opentelemetry = { workspace = true }
 parking_lot = { workspace = true }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -224,6 +224,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
 crossterm = { version = "0.28" }
 hyper-rustls-754bda37e0fb3874 = { package = "hyper-rustls", version = "0.27", default-features = false, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -238,6 +239,7 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "unprefixed_mall
 tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
 crossterm = { version = "0.28" }
 hyper-rustls-754bda37e0fb3874 = { package = "hyper-rustls", version = "0.27", default-features = false, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -252,6 +254,7 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "unprefixed_mall
 tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.aarch64-apple-darwin.dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
 crossterm = { version = "0.28" }
 hyper-rustls-754bda37e0fb3874 = { package = "hyper-rustls", version = "0.27", default-features = false, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -266,6 +269,7 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "unprefixed_mall
 tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
 crossterm = { version = "0.28" }
 hyper-rustls-754bda37e0fb3874 = { package = "hyper-rustls", version = "0.27", default-features = false, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }


### PR DESCRIPTION
Handle config file replacement by some editors

Summary:
We are switching mainly to notify-debounce-full to fix an issue
with detecting file changes. This also gave us better control over
the file watch and allows us to handle config file replacement.

Also Some editors replace the file on save like what vim does.
