### PR TITLE
[Mechanical] Upgrade prost-dto to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5508,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "prost-dto"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5145d3fa63cf018899b3fdb7595a84597ac4315a2296663d81b15d87994e8a"
+checksum = "507287d74904a170345662840a603bd5d937b39d3d6a589916cd33c9deda8ecd"
 dependencies = [
  "prost-dto-core",
  "prost-dto-derive",
@@ -5518,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "prost-dto-core"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfc357b4d026d9c61112e75827e7f01e6b7fbe38664836194b19c063ca124ba"
+checksum = "9d8c10eed0bdb7f642bf4c2dd85c289e9fc6db578a37b8689c6b166196b0d36c"
 dependencies = [
  "chrono",
  "darling",
@@ -5531,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "prost-dto-derive"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feef623adf0ea256c19bdc3fbcad12060be6b3fb5f29bd471b1eeb02b3d33f6"
+checksum = "f1ccc60758662c45ce4c5a5f9fa72f87c47bd282416c23e7b78e12c00b9fe344"
 dependencies = [
  "proc-macro2",
  "prost-dto-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ pin-project-lite = { version = "0.2" }
 prost = { version = "0.13.1" }
 prost-build = { version = "0.13.1" }
 priority-queue = "2.0.3"
-prost-dto = { version = "0.0.2" }
+prost-dto = { version = "0.0.3" }
 prost-types = { version = "0.13.1" }
 rand = "0.8.5"
 rayon = { version = "1.10" }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -15,7 +15,7 @@ mod roles;
 
 use anyhow::Context;
 use bytestring::ByteString;
-use prost_dto::IntoProto;
+use prost_dto::IntoProst;
 use std::num::NonZeroU16;
 use tracing::{debug, error, info, trace, warn};
 
@@ -540,14 +540,14 @@ impl Node {
     }
 }
 
-#[derive(Clone, Debug, IntoProto)]
-#[proto(target = "restate_types::protobuf::cluster::ClusterConfiguration")]
+#[derive(Clone, Debug, IntoProst)]
+#[prost(target = "restate_types::protobuf::cluster::ClusterConfiguration")]
 pub struct ClusterConfiguration {
-    #[into_proto(map = "num_partitions_to_u32")]
+    #[into_prost(map = "num_partitions_to_u32")]
     pub num_partitions: NonZeroU16,
-    #[proto(required)]
+    #[prost(required)]
     pub replication_strategy: ReplicationStrategy,
-    #[proto(required)]
+    #[prost(required)]
     pub default_provider: ProviderConfiguration,
 }
 

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -11,7 +11,7 @@
 use std::collections::BTreeMap;
 use std::time::Instant;
 
-use prost_dto::IntoProto;
+use prost_dto::IntoProst;
 use serde::{Deserialize, Serialize};
 
 use crate::identifiers::{LeaderEpoch, PartitionId};
@@ -21,16 +21,16 @@ use crate::{GenerationalNodeId, PlainNodeId, Version};
 
 /// A container for health information about every node and partition in the
 /// cluster.
-#[derive(Debug, Clone, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::ClusterState")]
+#[derive(Debug, Clone, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::ClusterState")]
 pub struct ClusterState {
-    #[into_proto(map = "instant_to_proto")]
+    #[into_prost(map = "instant_to_proto")]
     pub last_refreshed: Option<Instant>,
-    #[proto(required)]
+    #[prost(required)]
     pub nodes_config_version: Version,
-    #[proto(required)]
+    #[prost(required)]
     pub partition_table_version: Version,
-    #[proto(required)]
+    #[prost(required)]
     pub logs_metadata_version: Version,
     pub nodes: BTreeMap<PlainNodeId, NodeState>,
 }
@@ -74,62 +74,62 @@ fn instant_to_proto(t: Instant) -> prost_types::Duration {
     t.elapsed().try_into().unwrap()
 }
 
-#[derive(Debug, Clone, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::NodeState", oneof = "state")]
+#[derive(Debug, Clone, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::NodeState", oneof = "state")]
 pub enum NodeState {
     Alive(AliveNode),
     Dead(DeadNode),
     Suspect(SuspectNode),
 }
 
-#[derive(Debug, Clone, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::AliveNode")]
+#[derive(Debug, Clone, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::AliveNode")]
 pub struct AliveNode {
-    #[proto(required)]
+    #[prost(required)]
     pub last_heartbeat_at: MillisSinceEpoch,
-    #[proto(required)]
+    #[prost(required)]
     pub generational_node_id: GenerationalNodeId,
     pub partitions: BTreeMap<PartitionId, PartitionProcessorStatus>,
 }
 
-#[derive(Debug, Clone, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::DeadNode")]
+#[derive(Debug, Clone, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::DeadNode")]
 pub struct DeadNode {
     pub last_seen_alive: Option<MillisSinceEpoch>,
 }
 
-#[derive(Debug, Clone, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::SuspectNode")]
+#[derive(Debug, Clone, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::SuspectNode")]
 /// As the name implies, SuspectNode is both dead and alive
 /// until we receive a heartbeat
 pub struct SuspectNode {
-    #[proto(required)]
+    #[prost(required)]
     pub generational_node_id: GenerationalNodeId,
-    #[proto(required)]
+    #[prost(required)]
     pub last_attempt: MillisSinceEpoch,
 }
 
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, IntoProto, derive_more::Display,
+    Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, IntoProst, derive_more::Display,
 )]
-#[proto(target = "crate::protobuf::cluster::RunMode")]
+#[prost(target = "crate::protobuf::cluster::RunMode")]
 pub enum RunMode {
     Leader,
     Follower,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::ReplayStatus")]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::ReplayStatus")]
 pub enum ReplayStatus {
     Starting,
     Active,
     CatchingUp,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
-#[proto(target = "crate::protobuf::cluster::PartitionProcessorStatus")]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProst)]
+#[prost(target = "crate::protobuf::cluster::PartitionProcessorStatus")]
 pub struct PartitionProcessorStatus {
-    #[proto(required)]
+    #[prost(required)]
     pub updated_at: MillisSinceEpoch,
     pub planned_mode: RunMode,
     pub effective_mode: RunMode,

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use bitflags::bitflags;
-use prost_dto::{FromProto, IntoProto};
+use prost_dto::{FromProst, IntoProst};
 use serde::{Deserialize, Serialize};
 
 use super::codec::{WireDecode, WireEncode};
@@ -69,8 +69,8 @@ macro_rules! define_logserver_rpc {
     };
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, IntoProto, FromProto)]
-#[proto(target = "crate::protobuf::log_server_common::Status")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, IntoProst, FromProst)]
+#[prost(target = "crate::protobuf::log_server_common::Status")]
 #[repr(u8)]
 pub enum Status {
     /// Operation was successful
@@ -180,8 +180,8 @@ impl LogServerRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, IntoProto, FromProto)]
-#[proto(target = "crate::protobuf::log_server_common::ResponseHeader")]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProst, FromProst)]
+#[prost(target = "crate::protobuf::log_server_common::ResponseHeader")]
 pub struct LogServerResponseHeader {
     /// The position after the last locally committed record on this node
     pub local_tail: LogletOffset,
@@ -385,10 +385,10 @@ pub struct GetLogletInfo {
     pub header: LogServerRequestHeader,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, IntoProto)]
-#[proto(target = "crate::protobuf::log_server_common::LogletInfo")]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProst)]
+#[prost(target = "crate::protobuf::log_server_common::LogletInfo")]
 pub struct LogletInfo {
-    #[proto(required)]
+    #[prost(required)]
     pub header: LogServerResponseHeader,
     pub trim_point: LogletOffset,
 }
@@ -656,9 +656,9 @@ pub struct GetDigest {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, IntoProto, FromProto,
+    Debug, Clone, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, IntoProst, FromProst,
 )]
-#[proto(target = "crate::protobuf::log_server_common::DigestEntry")]
+#[prost(target = "crate::protobuf::log_server_common::DigestEntry")]
 #[display("[{from_offset}..{to_offset}] -> {status} ({})",  self.len())]
 pub struct DigestEntry {
     // inclusive
@@ -668,10 +668,10 @@ pub struct DigestEntry {
 }
 
 #[derive(
-    Debug, Clone, Eq, PartialEq, derive_more::Display, Serialize, Deserialize, IntoProto, FromProto,
+    Debug, Clone, Eq, PartialEq, derive_more::Display, Serialize, Deserialize, IntoProst, FromProst,
 )]
 #[repr(u8)]
-#[proto(target = "crate::protobuf::log_server_common::RecordStatus")]
+#[prost(target = "crate::protobuf::log_server_common::RecordStatus")]
 pub enum RecordStatus {
     #[display("T")]
     Trimmed,
@@ -697,10 +697,10 @@ impl DigestEntry {
 }
 
 /// Response to a `GetDigest` request
-#[derive(Debug, Clone, Serialize, Deserialize, IntoProto, FromProto)]
-#[proto(target = "crate::protobuf::log_server_common::Digest")]
+#[derive(Debug, Clone, Serialize, Deserialize, IntoProst, FromProst)]
+#[prost(target = "crate::protobuf::log_server_common::Digest")]
 pub struct Digest {
-    #[proto(required)]
+    #[prost(required)]
     pub header: LogServerResponseHeader,
     // If the node's local trim-point (or archival-point) overlaps with the digest range, an entry will be
     // added to include where the trim-gap ends. Otherwise, offsets for non-existing records

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -10,7 +10,7 @@
 
 use anyhow::bail;
 use enum_map::Enum;
-use prost_dto::{FromProto, IntoProto};
+use prost_dto::{FromProst, IntoProst};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use strum::EnumIter;
@@ -62,10 +62,10 @@ define_message! {
     Deserialize,
     derive_more::Display,
     strum::EnumCount,
-    IntoProto,
-    FromProto,
+    IntoProst,
+    FromProst,
 )]
-#[proto(target = "crate::protobuf::common::MetadataKind")]
+#[prost(target = "crate::protobuf::common::MetadataKind")]
 pub enum MetadataKind {
     NodesConfiguration,
     Schema,
@@ -73,7 +73,7 @@ pub enum MetadataKind {
     Logs,
 }
 
-// todo remove once prost_dto supports TryFromProto
+// todo remove once prost_dto supports TryFromProst
 impl TryFrom<crate::protobuf::common::MetadataKind> for MetadataKind {
     type Error = anyhow::Error;
 


### PR DESCRIPTION

prost-dto 0.0.3 renames IntoProto/FromProto to `IntoProst/FromProst` and all macro attributes accordingly. It also removes the auto skipping of fields, only fields marked with `#[prost(skip)]` are now skipped.
