### PR TITLE
Introduces NodeLocation as part of the locality module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 # Tracing files
 **/*.trace
 **/flamegraph.svg
+.sl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,6 +7111,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "smallvec",
+ "smartstring",
  "static_assertions",
  "strum",
  "syn 2.0.90",

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -1278,6 +1278,7 @@ pub mod tests {
     use std::num::NonZeroU8;
 
     use enumset::{enum_set, EnumSet};
+    use restate_types::locality::NodeLocation;
     use restate_types::logs::metadata::{
         LogsConfiguration, NodeSetSelectionStrategy, ProviderConfiguration, ReplicatedLogletConfig,
     };
@@ -1465,6 +1466,7 @@ pub mod tests {
         NodeConfig::new(
             format!("node-{id}"),
             PlainNodeId::from(id).with_generation(1),
+            NodeLocation::default(),
             format!("https://node-{id}").parse().unwrap(),
             roles,
             LogServerConfig { storage_state },

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -537,7 +537,6 @@ mod tests {
     use http::Uri;
     use rand::prelude::ThreadRng;
     use rand::Rng;
-    use restate_types::metadata_store::keys::PARTITION_TABLE_KEY;
     use std::collections::BTreeMap;
     use std::iter;
     use std::num::NonZero;
@@ -557,6 +556,8 @@ mod tests {
         AliveNode, ClusterState, DeadNode, NodeState, PartitionProcessorStatus, RunMode,
     };
     use restate_types::identifiers::PartitionId;
+    use restate_types::locality::NodeLocation;
+    use restate_types::metadata_store::keys::PARTITION_TABLE_KEY;
     use restate_types::net::codec::WireDecode;
     use restate_types::net::partition_processor_manager::{ControlProcessors, ProcessorCommand};
     use restate_types::net::{AdvertisedAddress, TargetName};
@@ -646,6 +647,7 @@ mod tests {
             let node_config = NodeConfig::new(
                 format!("{node_id}"),
                 *node_id,
+                NodeLocation::default(),
                 AdvertisedAddress::Http(Uri::default()),
                 Role::Worker.into(),
                 LogServerConfig::default(),

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -741,6 +741,7 @@ mod tests {
 
     use googletest::assert_that;
     use googletest::matchers::eq;
+    use restate_types::locality::NodeLocation;
     use restate_types::logs::metadata::ProviderKind;
     use test_log::test;
 
@@ -1070,6 +1071,7 @@ mod tests {
         nodes_config.upsert_node(NodeConfig::new(
             "node-1".to_owned(),
             GenerationalNodeId::new(1, 1),
+            NodeLocation::default(),
             AdvertisedAddress::Uds("foobar".into()),
             Role::Worker.into(),
             LogServerConfig::default(),
@@ -1077,6 +1079,7 @@ mod tests {
         nodes_config.upsert_node(NodeConfig::new(
             "node-2".to_owned(),
             GenerationalNodeId::new(2, 2),
+            NodeLocation::default(),
             AdvertisedAddress::Uds("bar".into()),
             Role::Worker.into(),
             LogServerConfig::default(),

--- a/crates/bifrost/src/providers/replicated_loglet/test_util.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/test_util.rs
@@ -21,6 +21,7 @@ pub fn generate_logserver_node(
     NodeConfig::new(
         format!("node-{id}"),
         GenerationalNodeId::new(id.into(), 1),
+        format!("region-{id}").parse().unwrap(),
         format!("unix:/tmp/my_socket-{id}").parse().unwrap(),
         Role::LogServer.into(),
         LogServerConfig { storage_state },

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -581,6 +581,7 @@ mod tests {
     use super::*;
 
     use googletest::prelude::*;
+    use restate_types::locality::NodeLocation;
     use test_log::test;
 
     use restate_test_util::assert_eq;
@@ -753,6 +754,7 @@ mod tests {
         let my_node = NodeConfig::new(
             "MyNode-1".to_owned(),
             node_id,
+            NodeLocation::default(),
             address,
             roles,
             LogServerConfig::default(),

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -760,6 +760,7 @@ mod tests {
     use super::*;
 
     use googletest::prelude::*;
+    use restate_types::locality::NodeLocation;
     use test_log::test;
     use tokio::sync::mpsc;
 
@@ -990,6 +991,7 @@ mod tests {
         let node_config = NodeConfig::new(
             "42".to_owned(),
             node_id,
+            NodeLocation::default(),
             AdvertisedAddress::Uds("foobar1".into()),
             Role::Worker.into(),
             LogServerConfig::default(),

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use futures::Stream;
 
 use restate_types::config::NetworkingOptions;
+use restate_types::locality::NodeLocation;
 use restate_types::logs::metadata::{bootstrap_logs_metadata, ProviderKind};
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY,
@@ -250,6 +251,7 @@ pub fn create_mock_nodes_config(node_id: u32, generation: u32) -> NodesConfigura
     let my_node = NodeConfig::new(
         format!("MyNode-{node_id}"),
         node_id,
+        NodeLocation::default(),
         address,
         roles,
         LogServerConfig::default(),

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -251,6 +251,7 @@ impl<'a> NodeInit<'a> {
                         NodeConfig::new(
                             common_opts.node_name().to_owned(),
                             my_node_id,
+                            common_opts.location().clone(),
                             common_opts.advertised_address.clone(),
                             common_opts.roles,
                             LogServerConfig::default(),

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -615,6 +615,7 @@ fn create_initial_nodes_configuration(common_opts: &CommonOptions) -> NodesConfi
             .force_node_id
             .map(|force_node_id| force_node_id.with_generation(1))
             .unwrap_or(GenerationalNodeId::INITIAL_NODE_ID),
+        common_opts.location().clone(),
         common_opts.advertised_address.clone(),
         common_opts.roles,
         LogServerConfig::default(),

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -67,6 +67,7 @@ serde_path_to_error = { version = "0.1" }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
+smartstring = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -21,6 +21,7 @@ use serde_with::serde_as;
 use restate_serde_util::{NonZeroByteCount, SerdeableHeaderHashMap};
 
 use super::{AwsOptions, HttpOptions, PerfStatsLevel, RocksDbOptions};
+use crate::locality::NodeLocation;
 use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::retries::RetryPolicy;
@@ -50,6 +51,31 @@ pub struct CommonOptions {
     /// Unique name for this node in the cluster. The node must not change unless
     /// it's started with empty local store. It defaults to the node's hostname.
     node_name: Option<String>,
+
+    /// # Node Location
+    ///
+    /// Setting the location allows Restate to form a tree-like cluster topology.
+    /// The value is written in the format of "<region>[.zone]" to assign this node
+    /// to a specific region, or to a zone within a region.
+    ///
+    /// The value of region and zone is arbitrary but whitespace and `.` are disallowed.
+    ///
+    ///
+    /// NOTE: It's _strongly_ recommended to not change the node's location string after
+    /// its initial registration. Changing the location may result in data loss or data
+    /// inconsistency if `log-server` is enabled on this node.
+    ///
+    /// When this value is not set, the node is considered to be in the _default_ location.
+    /// The _default_ location means that the node is not assigned to any specific region or zone.
+    ///
+    /// ## Examples
+    /// - `us-west` -- the node is in the `us-west` region.
+    /// - `us-west.a1` -- the node is in the `us-west` region and in the `a1` zone.
+    /// - `` -- [default] the node is in the default location
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    #[builder(setter(strip_option))]
+    location: Option<NodeLocation>,
 
     /// If set, the node insists on acquiring this node ID.
     pub force_node_id: Option<PlainNodeId>,
@@ -260,6 +286,13 @@ impl CommonOptions {
         self.node_name.as_ref().unwrap_or(&HOSTNAME)
     }
 
+    /// The node location as defined in the configuration file, or the default configuration if
+    /// unset.
+    pub fn location(&self) -> &NodeLocation {
+        static DEFAULT_LOCATION: NodeLocation = NodeLocation::new();
+        self.location.as_ref().unwrap_or(&DEFAULT_LOCATION)
+    }
+
     #[cfg(feature = "unsafe-mutable-config")]
     pub fn set_node_name(&mut self, node_name: impl Into<String>) {
         self.node_name = Some(node_name.into())
@@ -349,6 +382,7 @@ impl Default for CommonOptions {
             //   see "roles_compat_test" test below.
             roles: EnumSet::all() - Role::HttpIngress,
             node_name: None,
+            location: None,
             force_node_id: None,
             cluster_name: "localcluster".to_owned(),
             // boot strap the cluster by default. This is very likely to change in the future to be

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod identifiers;
 pub mod invocation;
 pub mod journal;
 pub mod live;
+pub mod locality;
 pub mod logs;
 pub mod message;
 pub mod metadata_store;

--- a/crates/types/src/locality/location_scope.rs
+++ b/crates/types/src/locality/location_scope.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// [`NodeLocationScope`] specifies the location of a node in the cluster. The location
+/// is expressed by a set of hierarchical scopes. Restate assumes the cluster topology
+/// to be a tree-like structure.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    strum::EnumIter,
+    strum::Display,
+    strum::EnumString,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(ascii_case_insensitive)]
+#[repr(u8)]
+pub enum NodeLocationScope {
+    /// Special; Indicating the smallest scope (an individual node)
+    Node = 0,
+
+    // Actual scopes representing the location of a node
+    Zone,
+    Region,
+
+    // Special; Includes all lower-level scopes.
+    Root,
+}
+
+impl NodeLocationScope {
+    /// Returns None if self is already the largest scope, i.e. `Root`
+    pub const fn next_greater_scope(self) -> Option<Self> {
+        // we know `self + 1` won't overflow
+        let next = (self as u8) + 1;
+        Self::from_u8(next)
+    }
+
+    /// Returns None if self is already the smallest scope, i.e. `Node`
+    pub const fn next_smaller_scope(self) -> Option<Self> {
+        if matches!(self, Self::Node) {
+            None
+        } else {
+            Self::from_u8(self as u8 - 1)
+        }
+    }
+
+    pub const fn is_special(self) -> bool {
+        matches!(self, NodeLocationScope::Root | NodeLocationScope::Node)
+    }
+
+    // Returns the number of non-special scopes.
+    pub const fn num_scopes() -> usize {
+        NodeLocationScope::Root as usize - 1
+    }
+
+    #[inline]
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Node),
+            1 => Some(Self::Zone),
+            2 => Some(Self::Region),
+            3 => Some(Self::Root),
+            _ => None,
+        }
+    }
+}

--- a/crates/types/src/locality/mod.rs
+++ b/crates/types/src/locality/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod location_scope;
+mod node_location;
+
+pub use location_scope::NodeLocationScope;
+pub use node_location::NodeLocation;

--- a/crates/types/src/locality/node_location.rs
+++ b/crates/types/src/locality/node_location.rs
@@ -1,0 +1,541 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::str::FromStr;
+
+use itertools::Itertools;
+
+use crate::PlainNodeId;
+
+use super::NodeLocationScope;
+
+type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
+
+#[derive(thiserror::Error, Debug)]
+#[error("Invalid node location string: {0}")]
+pub struct InvalidNodeLocationError(String);
+
+/// Delimiter for location scopes in a location string (e.g. `us-east2.use2-az3`)
+pub(super) const SCOPE_DELIMITER: &str = ".";
+
+/// Delimiter for node-id after location string (e.g. `us-east2.use2-az3:N4`)
+const NODE_DELIMITER: &str = ":";
+
+/// Stores location information of non-special scopes in range (Node, Root) exclusively.
+///
+/// Identifies some domain, by giving a path from [`NodeLocationScope::Root`] to the domain.
+///
+/// It's a vector of labels for scopes from biggest to smallest. For instance,
+/// {"us-east-2", "use2-az3"} identifies zone "use2-az3" in region "us-east-2".
+///
+/// The vector always starts at the biggest possible (non-Root) scope, but doesn't
+/// necessarily go all the way to the smallest (non-Node) scope.
+/// E.g. {"us-east-2"} is valid and it identifies region "us-east-2" but doesn't
+/// specify the zone.
+///
+/// To construct NodeLocation, use our `FromStr` implementation, a la `"region1.zone".parse()` style.
+///
+/// Technical details: this is a home-made smallvec-like structure to avoid heap-allocations and to
+/// improve cache-friendlyness. It's a fixed-size array of labels, where each label is a highly-likely
+/// stack-inlined `SmartString`.
+#[derive(
+    Clone, Default, PartialEq, Eq, serde_with::DeserializeFromStr, serde_with::SerializeDisplay,
+)]
+pub struct NodeLocation {
+    /// Internal storage for labels of all scopes, the order of scopes in the array
+    /// is the reverse order of their type value: largest scope (i.e. Region) gets
+    /// stored at index 0, and so on...
+    labels: [SmartString; NodeLocationScope::num_scopes()],
+    /// number of (non-empty) scope labels specified
+    num_defined_scopes: u8,
+}
+
+impl NodeLocation {
+    /// Creates a new empty NodeLocation
+    pub const fn new() -> Self {
+        Self {
+            labels: [const { SmartString::new_const() }; NodeLocationScope::num_scopes()],
+            num_defined_scopes: 0,
+        }
+    }
+    ///  Given a scope specified in `scope`, returns a domain string that
+    ///  identifies the location of the node. The domain string will include the
+    ///  name for the specified scope as well as names for all parent scopes.
+    ///  E.g. a possible output for scope `Region` is "us-east1".
+    ///
+    ///  If `node_id` is `None` and scope [`NodeLocationScope::Node`] is treated differently:
+    ///  it's equivalent to `Zone`; i.e. the returned string will identify a zone,
+    ///  not the node. If `node_id` is given, and `scope` is [`NodeLocationScope::Node`],
+    ///  the returned string will be identify a node, e.g. "us-east-2.use2-az3:N4"
+    ///  or ":N4" if no location was supplied.
+    ///
+    ///  ## Panics
+    ///  if `scope` is [`NodeLocationScope::Root`]
+    pub fn domain_string(&self, scope: NodeLocationScope, node_id: Option<PlainNodeId>) -> String {
+        debug_assert!(scope != NodeLocationScope::Root);
+        if self.is_empty() && node_id.is_none() {
+            return String::new();
+        }
+        let effective_scopes = effective_scopes(scope);
+
+        let mut result = self
+            .labels
+            .iter()
+            .take(self.num_defined_scopes.into())
+            .take(effective_scopes)
+            .join(SCOPE_DELIMITER);
+
+        if scope == NodeLocationScope::Node {
+            if let Some(node_id) = node_id {
+                result += NODE_DELIMITER;
+                result += &node_id.to_string();
+            }
+        }
+
+        result
+    }
+
+    /// Node location label at the given `scope`.
+    ///
+    /// Note that on special scopes (Root, Node), the label is an empty string.
+    pub fn label_at(&self, scope: NodeLocationScope) -> &str {
+        static EMPTY_LABEL: &str = "";
+        if scope.is_special() {
+            return EMPTY_LABEL;
+        }
+
+        &self.labels[scope_to_index(scope)]
+    }
+
+    /// Returns true if a label is assigned at this scope
+    pub fn is_scope_defined(&self, scope: NodeLocationScope) -> bool {
+        !scope.is_special() && scope_to_index(scope) < self.num_defined_scopes as usize
+    }
+
+    /// Returns true if no labels are assigned
+    pub fn is_empty(&self) -> bool {
+        self.num_defined_scopes == 0
+    }
+
+    /// The number of scopes with assigned labels
+    pub fn num_defined_scopes(&self) -> usize {
+        self.num_defined_scopes.into()
+    }
+
+    /// Returns the smallest (narrowest) defined location scope
+    pub fn smallest_defined_scope(&self) -> NodeLocationScope {
+        if self.num_defined_scopes == 0 {
+            return NodeLocationScope::Root;
+        }
+
+        NodeLocationScope::from_u8(NodeLocationScope::Root as u8 - self.num_defined_scopes).unwrap()
+    }
+
+    /// Checks if this location is a prefix match for the input. In other words, the input location
+    /// `prefix` must be a prefix of (or equal to) this location.
+    pub fn matches_prefix(&self, prefix: &str) -> bool {
+        let prefix = prefix.trim();
+        if prefix.is_empty() || prefix == SCOPE_DELIMITER {
+            return true;
+        }
+        // Unconditionally adding scope delimiter to our location at the end to ensure we don't
+        // perform partial matching with input prefix.
+        //
+        // If input prefix is `region.us-east`, we don't want this to match `region.us-east1`. We
+        // only consider this a prefix match if the zone matches. For this to work, we add `.`
+        // suffix to the input `prefix` and unconditionally add `.` to our own value.
+        //
+        // The previous case will be prefix=`region.us-east.` which is not a prefix of
+        // `region.us-east1.`
+        let domain_str = self.domain_string(NodeLocationScope::Node, None) + SCOPE_DELIMITER;
+        if prefix.ends_with(SCOPE_DELIMITER) {
+            domain_str.starts_with(prefix)
+        } else {
+            domain_str.starts_with(&format!("{}{}", prefix, SCOPE_DELIMITER))
+        }
+    }
+
+    /// Checks if this location shares the same domain with the input location at the given scope.
+    /// For instance, if self is "us-east2" the input location is "us-east2.use2-az3" and the scope is `Zone`,
+    /// then the function returns `false` because while we share the region, we don't share the zone.
+    /// It returns `true` if the same check was done at `Region` instead.
+    ///
+    /// This is a little more efficient that `matches_prefix` if the location has been already
+    /// parsed.
+    ///
+    /// * Input scope [`NodeLocationScope::Root`] always yields `true` since Root is always shared.
+    /// * Input scope [`NodeLocationScope::Node`] always yields `false` since Node is implicit and is never shared.
+    pub fn shares_domain_with(&self, location: &NodeLocation, scope: NodeLocationScope) -> bool {
+        if scope == NodeLocationScope::Root {
+            return true;
+        }
+        if scope == NodeLocationScope::Node {
+            return false;
+        }
+
+        let effective_scopes = effective_scopes(scope);
+
+        // compare up-to the effective scopes of the input `scope`
+        self.labels
+            .iter()
+            .take(effective_scopes)
+            .eq(location.labels.iter().take(effective_scopes))
+    }
+}
+impl std::fmt::Display for NodeLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.domain_string(NodeLocationScope::Node, None))
+    }
+}
+
+impl std::fmt::Debug for NodeLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl FromStr for NodeLocation {
+    type Err = InvalidNodeLocationError;
+    ///  Fills the NodeLocation from the given location string in which labels
+    ///  of each location scope are specified.
+    ///
+    ///  Definition:
+    ///  Location Domain: a string that identifies the location of a node, it
+    ///                   consists of labels of all location scopes, separated by
+    ///                   [`DELIMITER`].
+    ///  Label:           part of the location domain string that belongs to
+    ///                   one location scope.
+    ///
+    ///  Notes: the location domain string must have all [`NodeLocationScope::num_scopes()`] separated by
+    ///         [`DELIMITER`]. The left most scope must be the biggest scope defined [`NodeLocationScope::MAX`].
+    ///         An empty label is allowed, meaning that location for the scope and
+    ///         all subscopes are not specified.
+    ///
+    ///  Legit domain string examples:
+    ///                "us-east2.use2-az3", "us-east2", "us-east2.", ".", ""
+    ///  Invalid examples:
+    ///                "us-east2...", ".use2-az3"
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // remove leading and trailing whitespaces
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let tokens: Vec<&str> = s
+            .split(SCOPE_DELIMITER)
+            .map(|token| validate_token(s, token))
+            .try_collect()?;
+
+        if tokens.len() > NodeLocationScope::num_scopes() {
+            return Err(InvalidNodeLocationError(format!(
+                "Wrong number of scopes in location string '{}'. Got {}, maximum {}",
+                s,
+                tokens.len(),
+                NodeLocationScope::num_scopes(),
+            )));
+        }
+
+        let mut n_tokens: usize = 0;
+        let mut labels = [const { SmartString::new_const() }; NodeLocationScope::num_scopes()];
+        let mut tokens = tokens.into_iter();
+
+        while n_tokens < NodeLocationScope::num_scopes() {
+            match tokens.next() {
+                None => break,
+                Some("") => break,
+                Some(token) => labels[n_tokens] = token.into(),
+            }
+
+            n_tokens += 1;
+        }
+
+        // if any of the remaining tokens are empty string, then we fail.
+        if tokens.any(|s| !s.is_empty()) {
+            return Err(InvalidNodeLocationError(format!(
+                "Non-empty label exists after an empty label in location string: '{}'",
+                s,
+            )));
+        }
+
+        Ok(Self {
+            labels,
+            num_defined_scopes: n_tokens as u8,
+        })
+    }
+}
+
+/// Converts a non-special scope into the label-index.
+///
+/// **Requires scope to be non-special**
+const fn scope_to_index(scope: NodeLocationScope) -> usize {
+    assert!(!scope.is_special());
+    // 0 - Node -- excluded
+    // 1 - Zone
+    // 2 - Region
+    // 3 - Root -- excluded
+    // num_scopes = 2
+    //
+    // zone = 2 - 1 == labels[1]
+    // region = 2 - 2 == labels[0]
+    NodeLocationScope::num_scopes() - (scope as usize)
+}
+
+/// How many scopes actual (non-special) scopes are equal or greater than this scope.
+///
+/// For instance, for a Node scope, we have 2 greater "non-special" scopes (Zone, Region),
+/// for Region, it's "1", and for Root, it's 0.
+const fn effective_scopes(scope: NodeLocationScope) -> usize {
+    match scope {
+        NodeLocationScope::Root => 0,
+        NodeLocationScope::Node => NodeLocationScope::num_scopes(),
+        scope => scope_to_index(scope) + 1,
+    }
+}
+
+fn validate_token<'a>(input: &'a str, token: &'a str) -> Result<&'a str, InvalidNodeLocationError> {
+    if token.contains(" ") || token.contains(":") {
+        return Err(InvalidNodeLocationError(format!(
+            "Illegal character(s) in location string: '{}', in label '{}'",
+            input, token
+        )));
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod tests {
+    // write tests for NodeLocation string parsing
+    use super::*;
+    use googletest::prelude::*;
+
+    #[test]
+    fn node_location_parsing_simple() {
+        // valid case 1
+        let location = NodeLocation::from_str("us-east2.use2-az3").unwrap();
+        assert_that!(
+            location.smallest_defined_scope(),
+            eq(NodeLocationScope::Zone)
+        );
+        assert_that!(location.label_at(NodeLocationScope::Region), eq("us-east2"));
+        assert_that!(location.label_at(NodeLocationScope::Zone), eq("use2-az3"));
+        assert_that!(location.label_at(NodeLocationScope::Node), eq(""));
+        assert_that!(location.label_at(NodeLocationScope::Root), eq(""));
+        assert_that!(location.num_defined_scopes(), eq(2));
+        assert_that!(
+            location.domain_string(NodeLocationScope::Region, None),
+            eq("us-east2")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Zone, None),
+            eq("us-east2.use2-az3")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, None),
+            eq("us-east2.use2-az3")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, Some(PlainNodeId::new(4))),
+            eq("us-east2.use2-az3:N4")
+        );
+        // node-id is ignored unless we are printing the Node scope.
+        assert_that!(
+            location.domain_string(NodeLocationScope::Zone, Some(PlainNodeId::new(4))),
+            eq("us-east2.use2-az3")
+        );
+
+        assert_that!(location.to_string(), eq("us-east2.use2-az3"));
+
+        // valid case 2
+        let location = NodeLocation::from_str("us-east2.").unwrap();
+        assert_that!(
+            location.smallest_defined_scope(),
+            eq(NodeLocationScope::Region)
+        );
+        assert_that!(location.label_at(NodeLocationScope::Region), eq("us-east2"));
+        assert_that!(location.label_at(NodeLocationScope::Zone), eq(""));
+        assert_that!(location.label_at(NodeLocationScope::Node), eq(""));
+        assert_that!(location.num_defined_scopes(), eq(1));
+        assert_that!(
+            location.domain_string(NodeLocationScope::Region, None),
+            eq("us-east2")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Zone, None),
+            eq("us-east2")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, None),
+            eq("us-east2")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, Some(PlainNodeId::new(4))),
+            eq("us-east2:N4")
+        );
+
+        assert_that!(location.to_string(), eq("us-east2"));
+        assert_that!(location, eq(NodeLocation::from_str("us-east2").unwrap()));
+
+        // valid case 3
+        let location = NodeLocation::from_str("us-east1").unwrap();
+        assert_that!(location.label_at(NodeLocationScope::Region), eq("us-east1"));
+        assert_that!(location.label_at(NodeLocationScope::Zone), eq(""));
+        assert_that!(location.label_at(NodeLocationScope::Node), eq(""));
+        assert_that!(location.num_defined_scopes(), eq(1));
+        assert_that!(
+            location.domain_string(NodeLocationScope::Region, None),
+            eq("us-east1")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, None),
+            eq("us-east1")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, Some(5.into())),
+            eq("us-east1:N5")
+        );
+    }
+
+    #[test]
+    fn node_location_parsing_with_empty_labels() {
+        // valid case 1 -- empty str
+        let location = NodeLocation::from_str("").unwrap();
+        assert_that!(
+            location.smallest_defined_scope(),
+            eq(NodeLocationScope::Root)
+        );
+        assert_that!(location.label_at(NodeLocationScope::Region), eq(""));
+        assert_that!(location.label_at(NodeLocationScope::Zone), eq(""));
+        assert_that!(location.label_at(NodeLocationScope::Node), eq(""));
+        assert_that!(location.num_defined_scopes(), eq(0));
+        assert_that!(
+            location.domain_string(NodeLocationScope::Region, None),
+            eq("")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, None),
+            eq("")
+        );
+        assert_that!(
+            location.domain_string(NodeLocationScope::Node, Some(5.into())),
+            eq(":N5")
+        );
+
+        assert_that!(location, eq(NodeLocation::from_str(".").unwrap()));
+        assert_that!(location, eq(NodeLocation::from_str(" ").unwrap()));
+        assert_that!(location, eq(NodeLocation::from_str("   ").unwrap()));
+
+        // valid case 1 -- region only
+    }
+
+    #[test]
+    fn node_location_parsing_invalid() {
+        // invalid case 1 -- empty region, but zone is set
+        assert!(NodeLocation::from_str(".az1").is_err());
+
+        // invalid case 2 -- too many tokens
+        assert!(NodeLocation::from_str("region1.zone1.cluster5").is_err());
+
+        // invalid case 3 -- too many tokens
+        assert!(NodeLocation::from_str("region1..").is_err());
+
+        // invalid case 4 -- too many tokens
+        assert!(NodeLocation::from_str("region1..as").is_err());
+
+        // invalid case 5 -- illegal characters
+        assert!(NodeLocation::from_str(":").is_err());
+        assert!(NodeLocation::from_str("my region").is_err());
+        assert!(NodeLocation::from_str("region.my zone").is_err());
+        assert!(NodeLocation::from_str("region.my:zone").is_err());
+    }
+
+    #[test]
+    fn node_location_matching() {
+        let location = NodeLocation::from_str("us-east2.use2-az3").unwrap();
+        assert_that!(location.matches_prefix(""), eq(true));
+        assert_that!(location.matches_prefix("."), eq(true));
+        assert_that!(location.matches_prefix("us-east2"), eq(true));
+        assert_that!(location.matches_prefix("us-east2."), eq(true));
+        assert_that!(location.matches_prefix("us-east"), eq(false));
+        assert_that!(location.matches_prefix("us-east2.use2"), eq(false));
+        assert_that!(location.matches_prefix("us-east2.use2-az3"), eq(true));
+        assert_that!(location.matches_prefix("us-east2.use2-az3."), eq(true));
+
+        let location2 = NodeLocation::from_str("us-east2.use2").unwrap();
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Root),
+            eq(true)
+        );
+
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Region),
+            eq(true)
+        );
+
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Zone),
+            eq(false)
+        );
+
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Node),
+            eq(false)
+        );
+
+        // even identical locations can't match on node scope
+        assert_that!(
+            location.shares_domain_with(&location, NodeLocationScope::Node),
+            eq(false)
+        );
+
+        // validates the same behaviour when locations are of different lengths
+        //
+        let location2 = NodeLocation::from_str("us-east2").unwrap();
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Root),
+            eq(true)
+        );
+
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Region),
+            eq(true)
+        );
+
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Zone),
+            eq(false)
+        );
+
+        assert_that!(
+            location.shares_domain_with(&location2, NodeLocationScope::Node),
+            eq(false)
+        );
+        // same if the check is flipped over
+        assert_that!(
+            location2.shares_domain_with(&location, NodeLocationScope::Root),
+            eq(true)
+        );
+
+        assert_that!(
+            location2.shares_domain_with(&location, NodeLocationScope::Region),
+            eq(true)
+        );
+
+        assert_that!(
+            location2.shares_domain_with(&location, NodeLocationScope::Zone),
+            eq(false)
+        );
+
+        assert_that!(
+            location2.shares_domain_with(&location, NodeLocationScope::Node),
+            eq(false)
+        );
+    }
+}

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -974,6 +974,7 @@ mod tests {
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::live::{Constant, Live};
+    use restate_types::locality::NodeLocation;
     use restate_types::net::partition_processor_manager::{
         ControlProcessor, ControlProcessors, ProcessorCommand,
     };
@@ -994,6 +995,7 @@ mod tests {
         let node_config = NodeConfig::new(
             "42".to_owned(),
             node_id,
+            NodeLocation::default(),
             AdvertisedAddress::Uds("foobar1".into()),
             Role::Worker | Role::Admin,
             LogServerConfig::default(),


### PR DESCRIPTION

This introduces a new configuration option to specify the node location in the following format `region.zone`. The location is optional and details are documented in the configuration key and parsing details are covered by tests.

More details in code comments.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2480).
* #2498
* __->__ #2480