### PR TITLE
[sql] Extract a partition key from the filters

### DIFF
--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -21,6 +21,7 @@ use restate_types::identifiers::{IdempotencyId, PartitionKey};
 use super::row::append_idempotency_row;
 use super::schema::SysIdempotencyBuilder;
 use crate::context::{QueryContext, SelectPartitions};
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
@@ -41,6 +42,9 @@ pub(crate) fn register_self(
         partition_selector,
         SysIdempotencyBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_service_key("service_key")
+            .with_invocation_id("invocation_id"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -21,6 +21,7 @@ use restate_types::identifiers::PartitionKey;
 use crate::context::{QueryContext, SelectPartitions};
 use crate::inbox::row::append_inbox_row;
 use crate::inbox::schema::SysInboxBuilder;
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
@@ -37,10 +38,14 @@ pub(crate) fn register_self(
             InboxScanner,
         )) as Arc<dyn ScanPartition>
     });
+
     let table = PartitionedTableProvider::new(
         partition_selector,
         SysInboxBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_partition_scanner),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_service_key("service_key")
+            .with_invocation_id("id"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -26,6 +26,7 @@ use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
 use crate::context::{QueryContext, SelectPartitions};
 use crate::invocation_state::row::append_invocation_state_row;
 use crate::invocation_state::schema::SysInvocationStateBuilder;
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 use crate::table_util::Builder;
 
@@ -55,6 +56,7 @@ pub(crate) fn register_self(
         partition_selector,
         SysInvocationStateBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_partition_scanner),
+        FirstMatchingPartitionKeyExtractor::default().with_invocation_id("id"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(status_table))
 }

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -23,6 +23,7 @@ use restate_types::identifiers::{InvocationId, PartitionKey};
 use crate::context::{QueryContext, SelectPartitions};
 use crate::invocation_status::row::append_invocation_status_row;
 use crate::invocation_status::schema::SysInvocationStatusBuilder;
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
@@ -43,6 +44,9 @@ pub(crate) fn register_self(
         partition_selector,
         SysInvocationStatusBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_service_key("target_service_key")
+            .with_invocation_id("id"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(status_table))
 }

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -20,6 +20,7 @@ use restate_types::identifiers::{JournalEntryId, PartitionKey};
 use crate::context::{QueryContext, SelectPartitions};
 use crate::journal::row::append_journal_row;
 use crate::journal::schema::SysJournalBuilder;
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
@@ -40,6 +41,7 @@ pub(crate) fn register_self(
         partition_selector,
         SysJournalBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default().with_invocation_id("id"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(journal_table))
 }

--- a/crates/storage-query-datafusion/src/keyed_service_status/table.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/table.rs
@@ -23,6 +23,7 @@ use restate_types::identifiers::{PartitionKey, ServiceId};
 use crate::context::{QueryContext, SelectPartitions};
 use crate::keyed_service_status::row::append_virtual_object_status_row;
 use crate::keyed_service_status::schema::SysKeyedServiceStatusBuilder;
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 const NAME: &str = "sys_keyed_service_status";
@@ -43,6 +44,9 @@ pub(crate) fn register_self(
         partition_selector,
         SysKeyedServiceStatusBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_service_key("service_key")
+            .with_invocation_id("invocation_id"),
     );
 
     ctx.register_partitioned_table(NAME, Arc::new(status_table))

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -42,6 +42,7 @@ use datafusion::error::DataFusionError;
 pub(crate) mod mocks;
 
 pub mod empty_invoker_status_handle;
+mod partition_filter;
 pub mod remote_query_scanner_client;
 pub mod remote_query_scanner_manager;
 #[cfg(test)]

--- a/crates/storage-query-datafusion/src/partition_filter.rs
+++ b/crates/storage-query-datafusion/src/partition_filter.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use datafusion::common::ScalarValue;
+use datafusion::logical_expr::{col, BinaryExpr, Expr, Operator};
+use restate_types::identifiers::partitioner::HashPartitioner;
+use restate_types::identifiers::{InvocationId, PartitionKey, WithPartitionKey};
+use std::str::FromStr;
+
+pub trait PartitionKeyExtractor: Send + Sync + 'static {
+    fn try_extract(&self, filters: &[Expr]) -> anyhow::Result<Option<PartitionKey>>;
+}
+
+pub struct FirstMatchingPartitionKeyExtractor {
+    extractors: Vec<Box<dyn PartitionKeyExtractor>>,
+}
+
+impl Default for FirstMatchingPartitionKeyExtractor {
+    fn default() -> Self {
+        let extractors =
+            vec![Box::new(IdentityPartitionKeyExtractor::new()) as Box<dyn PartitionKeyExtractor>];
+        Self { extractors }
+    }
+}
+
+impl FirstMatchingPartitionKeyExtractor {
+    pub fn with_service_key(self, column_name: impl Into<String>) -> Self {
+        let e = MatchingColumnExtractor::new(column_name, |column_value: &str| {
+            let key = HashPartitioner::compute_partition_key(column_value);
+            Ok(key)
+        });
+        self.append(e)
+    }
+
+    pub fn with_invocation_id(self, column_name: impl Into<String>) -> Self {
+        let e = MatchingColumnExtractor::new(column_name, |column_value: &str| {
+            let invocation_id =
+                InvocationId::from_str(column_value).context("non valid invocation id")?;
+            Ok(invocation_id.partition_key())
+        });
+        self.append(e)
+    }
+
+    pub fn append(mut self, extractor: impl PartitionKeyExtractor) -> Self {
+        self.extractors.push(Box::new(extractor));
+        self
+    }
+}
+
+impl PartitionKeyExtractor for FirstMatchingPartitionKeyExtractor {
+    fn try_extract(&self, filters: &[Expr]) -> anyhow::Result<Option<PartitionKey>> {
+        for extractor in &self.extractors {
+            if let Some(partition_key) = extractor.try_extract(filters)? {
+                return Ok(Some(partition_key));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+pub(crate) struct MatchingColumnExtractor<F> {
+    column: Expr,
+    extractor: F,
+}
+
+impl<F> MatchingColumnExtractor<F> {
+    pub(crate) fn new(column_name: impl Into<String>, extractor: F) -> Self {
+        let column = col(column_name.into());
+        Self { column, extractor }
+    }
+}
+
+impl<F> PartitionKeyExtractor for MatchingColumnExtractor<F>
+where
+    F: Fn(&str) -> anyhow::Result<PartitionKey> + Send + Sync + 'static,
+{
+    /// find an expression in the form of `$column_name = "..."`.
+    /// Then use the provided extractor to convert the textual value to a
+    /// partition_key
+    fn try_extract(&self, filters: &[Expr]) -> anyhow::Result<Option<PartitionKey>> {
+        for filter in filters {
+            if let Expr::BinaryExpr(BinaryExpr { op, left, right }) = filter {
+                if *op == Operator::Eq && **left == self.column {
+                    if let Expr::Literal(ScalarValue::LargeUtf8(Some(value))) = &**right {
+                        let f = &self.extractor;
+                        let pk = f(value)?;
+                        return Ok(Some(pk));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+struct IdentityPartitionKeyExtractor(Expr);
+
+impl IdentityPartitionKeyExtractor {
+    fn new() -> Self {
+        Self(col("partition_key"))
+    }
+}
+
+impl PartitionKeyExtractor for IdentityPartitionKeyExtractor {
+    fn try_extract(&self, filters: &[Expr]) -> anyhow::Result<Option<PartitionKey>> {
+        for filter in filters {
+            if let Expr::BinaryExpr(BinaryExpr { op, left, right }) = filter {
+                if *op == Operator::Eq && **left == self.0 {
+                    if let Expr::Literal(ScalarValue::UInt64(Some(value))) = &**right {
+                        return Ok(Some(*value as PartitionKey));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::partition_filter::{FirstMatchingPartitionKeyExtractor, PartitionKeyExtractor};
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::{col, Expr};
+    use restate_types::identifiers::{InvocationId, ServiceId, WithPartitionKey};
+    use restate_types::invocation::{InvocationTarget, VirtualObjectHandlerType};
+
+    #[test]
+    fn test_service_key() {
+        let extractor =
+            FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key");
+
+        let service_id = ServiceId::new("greeter", "key-1");
+        let expected_key = service_id.partition_key();
+
+        let got_key = extractor
+            .try_extract(&[col("service_key").eq(utf8_lit("key-1"))])
+            .expect("extract")
+            .expect("to find a value");
+
+        assert_eq!(expected_key, got_key);
+    }
+
+    #[test]
+    fn test_invocation_id() {
+        let extractor = FirstMatchingPartitionKeyExtractor::default().with_invocation_id("id");
+
+        let invocation_target = InvocationTarget::virtual_object(
+            "counter",
+            "key-2",
+            "count",
+            VirtualObjectHandlerType::Exclusive,
+        );
+        let invocation_id = InvocationId::generate(&invocation_target, None);
+        let expected_key = invocation_id.partition_key();
+        let column_value = invocation_id.to_string();
+
+        let got_key = extractor
+            .try_extract(&[col("id").eq(utf8_lit(column_value))])
+            .expect("extract")
+            .expect("to find a value");
+
+        assert_eq!(expected_key, got_key);
+    }
+
+    fn utf8_lit(value: impl Into<String>) -> Expr {
+        Expr::Literal(ScalarValue::LargeUtf8(Some(value.into())))
+    }
+}

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -21,6 +21,7 @@ use restate_types::identifiers::PartitionKey;
 use super::row::append_promise_row;
 use super::schema::SysPromiseBuilder;
 use crate::context::{QueryContext, SelectPartitions};
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
@@ -41,6 +42,7 @@ pub(crate) fn register_self(
         partition_selector,
         SysPromiseBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -20,6 +20,7 @@ use restate_storage_api::state_table::ReadOnlyStateTable;
 use restate_types::identifiers::{PartitionKey, ServiceId};
 
 use crate::context::{QueryContext, SelectPartitions};
+use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::state::row::append_state_row;
 use crate::state::schema::StateBuilder;
@@ -42,6 +43,7 @@ pub(crate) fn register_self(
         partition_selector,
         StateBuilder::schema(),
         ctx.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }


### PR DESCRIPTION
This PR adds a simple partition pruning, based on the passed filters. With this PR, we are able to prune partitions based on either an invocation_id or a service_key (these columns named differently in different tables) and also a partition_key.
In addition to pruning the partitions, we also set the scan to be more precise based on the partition_key.