### PR TITLE
Intorduce `--production` flag and profile

### DIFF
--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -55,6 +55,15 @@ use crate::errors::GenericError;
 use crate::live::Live;
 use crate::nodes_config::Role;
 
+/// Overrides production profile
+pub static PRODUCTION_PROFILE_DEFAULTS: LazyLock<Configuration> = LazyLock::new(|| {
+    let mut default = Configuration::default();
+
+    default.common.allow_bootstrap = false;
+
+    default
+});
+
 #[cfg(any(test, feature = "test-util"))]
 enum TempOrPath {
     Temp(tempfile::TempDir),


### PR DESCRIPTION
Intorduce `--production` flag and profile

Summary:
Support a `--production` flag that when enabled, overrides the
default configuration with a production ready values

So far the `--production` flag:
- disables `allow-bootstrap`
- sets the default provider to `replicated`

Fixes #2410
