### PR TITLE
Added warning with body for deployment registration failures

### DIFF
--- a/crates/service-protocol/src/discovery.rs
+++ b/crates/service-protocol/src/discovery.rs
@@ -410,6 +410,17 @@ impl ServiceDiscovery {
                     .into_parts();
 
                 if !parts.status.is_success() {
+                    let body_message = body
+                        .collect()
+                        .await
+                        .map(|b| {
+                            String::from_utf8_lossy(b.to_bytes().to_vec().as_slice()).to_string()
+                        })
+                        .unwrap_or_else(|err| format!("Failed to read body {}", err));
+                    warn!(
+                        "Bad status code '{}' when discovering deployment at address '{}'. Response : {:?}",
+                        parts.status, address, body_message
+                    );
                     return Err(DiscoveryError::BadStatusCode(parts));
                 }
 


### PR DESCRIPTION
Deployment registration operations are not very frequent, but when they fail troubleshooting them could be annoying. This PR adds additional logging to the server providing context about the unexpected response 