### PR TITLE
Metadata HTTP API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,9 +910,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -933,7 +933,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5950,7 +5950,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-util",
@@ -6183,7 +6183,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tempfile",
  "termcolor",
  "thiserror 2.0.6",
@@ -6692,7 +6692,7 @@ dependencies = [
  "serde_with",
  "static_assertions",
  "strum",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tempfile",
  "thiserror 2.0.6",
  "tokio",
@@ -7110,7 +7110,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "syn 2.0.90",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tempfile",
  "test-log",
  "thiserror 2.0.6",
@@ -8186,12 +8186,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -8719,14 +8713,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -9669,7 +9663,7 @@ dependencies = [
  "strum",
  "syn 1.0.109",
  "syn 2.0.90",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
  "time",
@@ -9681,7 +9675,7 @@ dependencies = [
  "toml_edit 0.22.22",
  "tonic",
  "tower 0.4.13",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-http 0.5.2",
  "tracing",
  "tracing-core",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -14,6 +14,7 @@ options_schema = ["restate-service-client/options_schema"]
 memory-loglet = ["restate-bifrost/memory-loglet"]
 replicated-loglet = ["restate-bifrost/replicated-loglet"]
 serve-web-ui = ["restate-web-ui", "mime_guess"]
+metadata-api = []
 
 [dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/crates/admin/src/lib.rs
+++ b/crates/admin/src/lib.rs
@@ -10,6 +10,8 @@
 
 pub mod cluster_controller;
 mod error;
+#[cfg(feature = "metadata-api")]
+mod metadata_api;
 mod rest_api;
 mod schema_registry;
 pub mod service;

--- a/crates/admin/src/metadata_api/mod.rs
+++ b/crates/admin/src/metadata_api/mod.rs
@@ -1,0 +1,291 @@
+// Copyright (c) 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{Arc, LazyLock},
+};
+
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    response::{AppendHeaders, IntoResponse, Response},
+    routing::{delete, get, head, put},
+    Router,
+};
+use bytestring::ByteString;
+use http::{header::ToStrError, HeaderMap, StatusCode};
+
+use restate_core::metadata_store::{MetadataStore, VersionedValue};
+use restate_metadata_store::{MetadataStoreClient, Precondition, ReadError, WriteError};
+use restate_types::{metadata_store::keys, Version};
+
+/// ETag header.
+const HEADER_ETAG: &str = "ETag";
+
+/// If-Match header. Possible values are
+/// - *: no precondition
+/// - does-not-exist: key must not exist
+/// - <version>: Match given etag
+const HEADER_IF_MATCH: &str = "If-Match";
+
+static PROTECTED_KEYS: LazyLock<HashSet<ByteString>> = LazyLock::new(|| {
+    [
+        keys::PARTITION_TABLE_KEY.clone(),
+        keys::BIFROST_CONFIG_KEY.clone(),
+        keys::NODES_CONFIG_KEY.clone(),
+        keys::SCHEMA_INFORMATION_KEY.clone(),
+    ]
+    .into()
+});
+
+fn is_protected(key: &ByteString) -> bool {
+    PROTECTED_KEYS.contains(key) || key.starts_with(keys::PARTITION_PROCESSOR_EPOCH_PREFIX)
+}
+
+#[derive(Clone, derive_more::Deref)]
+struct MetadataStoreState {
+    inner: Arc<dyn MetadataStore + Send + Sync>,
+}
+
+pub fn router(metadata_store_client: &MetadataStoreClient) -> Router {
+    let state = MetadataStoreState {
+        inner: metadata_store_client.inner(),
+    };
+
+    Router::new()
+        .route("/metadata/:key", get(get_key))
+        .route("/metadata/:key", head(get_key_version))
+        .route("/metadata/:key", put(put_key))
+        .route("/metadata/:key", delete(delete_key))
+        .with_state(state)
+}
+
+/// Deletes a key from the metadata store
+///
+/// Requires `If-Match` header
+async fn delete_key(
+    Path(key): Path<String>,
+    State(store): State<MetadataStoreState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, StoreApiError> {
+    let key = key.into();
+
+    if is_protected(&key) {
+        return Err(StoreApiError::ProtectedKey);
+    }
+
+    // todo(azmy): implement both PreconditionHeader and VersionHeader
+    // as extractors after updating axium to version > 0.8
+    let precondition: IfMatch = headers
+        .get(HEADER_IF_MATCH)
+        .ok_or(IfMatchError::MissingPrecondition)?
+        .to_str()?
+        .parse()?;
+
+    store.delete(key, precondition.into()).await?;
+    Ok(())
+}
+
+/// Puts a key/value pair
+///
+/// Requires `If-Match` header
+/// Required `ETag` header
+async fn put_key(
+    Path(key): Path<String>,
+    State(store): State<MetadataStoreState>,
+    headers: HeaderMap,
+    value: Bytes,
+) -> Result<impl IntoResponse, StoreApiError> {
+    // todo(azmy): implement both PreconditionHeader and VersionHeader
+    // as extractors after updating axium to version > 0.8
+    let key = key.into();
+
+    if is_protected(&key) {
+        return Err(StoreApiError::ProtectedKey);
+    }
+
+    let precondition: IfMatch = headers
+        .get(HEADER_IF_MATCH)
+        .ok_or(IfMatchError::MissingPrecondition)?
+        .to_str()?
+        .parse()?;
+
+    let version: ETagHeader = headers
+        .get(HEADER_ETAG)
+        .ok_or(ETagError::MissingETag)?
+        .to_str()?
+        .parse()?;
+
+    let versioned = VersionedValue {
+        version: version.into(),
+        value,
+    };
+
+    store.put(key, versioned, precondition.into()).await?;
+    Ok(())
+}
+
+/// Gets a key from the metadata store
+async fn get_key(
+    Path(key): Path<String>,
+    State(store): State<MetadataStoreState>,
+) -> Result<impl IntoResponse, StoreApiError> {
+    let value = store
+        .get(key.into())
+        .await?
+        .ok_or(StoreApiError::NotFound)?;
+
+    Ok(VersionedValueResponse::from(value))
+}
+
+/// Gets a key version from the metadata store
+async fn get_key_version(
+    Path(key): Path<String>,
+    State(store): State<MetadataStoreState>,
+) -> Result<impl IntoResponse, HeadError> {
+    let version = store
+        .get_version(key.into())
+        .await
+        .map_err(StoreApiError::from)?
+        .ok_or(StoreApiError::NotFound)?;
+
+    Ok(AppendHeaders([(
+        HEADER_ETAG,
+        u32::from(version).to_string(),
+    )]))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum StoreApiError {
+    #[error(transparent)]
+    ReadError(#[from] ReadError),
+    #[error(transparent)]
+    WriteError(#[from] WriteError),
+    #[error("Key not found")]
+    NotFound,
+
+    #[error(transparent)]
+    ToStrError(#[from] ToStrError),
+    #[error(transparent)]
+    PreconditionError(#[from] IfMatchError),
+    #[error(transparent)]
+    VersionError(#[from] ETagError),
+    #[error("Key is protected")]
+    ProtectedKey,
+}
+
+impl StoreApiError {
+    fn code(&self) -> StatusCode {
+        match self {
+            Self::NotFound => StatusCode::NOT_FOUND,
+            Self::WriteError(WriteError::FailedPrecondition(_)) => StatusCode::PRECONDITION_FAILED,
+            Self::ProtectedKey => StatusCode::UNAUTHORIZED,
+            Self::ReadError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::WriteError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::ToStrError(_) | Self::PreconditionError(_) | Self::VersionError(_) => {
+                StatusCode::BAD_REQUEST
+            }
+        }
+    }
+}
+
+impl IntoResponse for StoreApiError {
+    fn into_response(self) -> Response {
+        (self.code(), self.to_string()).into_response()
+    }
+}
+
+// We can't return a body as a response to Head requests
+#[derive(derive_more::From)]
+struct HeadError(StoreApiError);
+
+impl IntoResponse for HeadError {
+    fn into_response(self) -> Response {
+        self.0.code().into_response()
+    }
+}
+
+#[derive(derive_more::From)]
+struct VersionedValueResponse(VersionedValue);
+
+impl IntoResponse for VersionedValueResponse {
+    fn into_response(self) -> Response {
+        (
+            AppendHeaders([(HEADER_ETAG, u32::from(self.0.version).to_string())]),
+            self.0.value,
+        )
+            .into_response()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum IfMatchError {
+    #[error("Missing If-Match header")]
+    MissingPrecondition,
+    #[error("Invalid If-Match header")]
+    InvalidPrecondition,
+}
+
+struct IfMatch(Precondition);
+
+impl FromStr for IfMatch {
+    type Err = IfMatchError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = match s.to_lowercase().as_str() {
+            "*" => Precondition::None,
+            "does-not-exist" => Precondition::DoesNotExist,
+            version => {
+                let version: u32 = version
+                    .parse()
+                    .map_err(|_| IfMatchError::InvalidPrecondition)?;
+
+                Precondition::MatchesVersion(version.into())
+            }
+        };
+
+        Ok(Self(inner))
+    }
+}
+
+impl From<IfMatch> for Precondition {
+    fn from(value: IfMatch) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ETagError {
+    #[error("Missing ETag header")]
+    MissingETag,
+
+    #[error("Invalid ETag header")]
+    InvalidETag,
+}
+
+struct ETagHeader(Version);
+
+impl FromStr for ETagHeader {
+    type Err = ETagError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version: u32 = s.parse().map_err(|_| ETagError::InvalidETag)?;
+
+        Ok(ETagHeader(version.into()))
+    }
+}
+
+impl From<ETagHeader> for Version {
+    fn from(value: ETagHeader) -> Self {
+        value.0
+    }
+}

--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -232,6 +232,10 @@ impl MetadataStoreClient {
         }
     }
 
+    pub fn inner(&self) -> Arc<dyn MetadataStore + Send + Sync> {
+        Arc::clone(&self.inner)
+    }
+
     #[cfg(any(test, feature = "test-util"))]
     pub fn new_in_memory() -> Self {
         MetadataStoreClient::new(

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,7 @@ memory-loglet = ["restate-node/memory-loglet", "restate-admin/memory-loglet"]
 replicated-loglet = ["restate-node/replicated-loglet", "restate-admin/replicated-loglet"]
 crate_per_service = ["restate-tracing-instrumentation/service_per_crate"]
 no-trace-logging = ["tracing/max_level_debug", "tracing/release_max_level_debug"]
+metadata-api = ["restate-admin/metadata-api"]
 
 [dependencies]
 restate-admin = { workspace = true }


### PR DESCRIPTION
Metadata HTTP API

Summary:
An interface that exposes Metadata via a REST API.
Is mainly used for testing and not enabled by default

Only enabled with `metadata-api` build flag

Usage:
The API is served by the admin port under `/metadata/<key>`
GET, and HEAD operations always populates the `ETag` header
if a value is found.

PUT and DELETE operations both require a `If-Match` header.
If the precondition is not met, the operation fails with (412 Precondition Failed)

PUT operation requires a header `ETag` which sets the version
of the new value
