### PR TITLE
[Locality] Set node location on cluster join

### DIFF
--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -80,7 +80,9 @@ impl<'a> NodeInit<'a> {
         info!(
             roles = %my_node_config.roles,
             address = %my_node_config.address,
-            "My Node ID is {}", my_node_config.current_generation);
+            location = %my_node_config.location,
+            "My Node ID is {}", my_node_config.current_generation
+        );
 
         self.metadata_writer
             .update(Arc::new(nodes_configuration))
@@ -202,6 +204,33 @@ impl<'a> NodeInit<'a> {
                             node_config.name,
                             "node name must match"
                         );
+
+                        // do location changes according to the following truth table
+                        let current_location = &node_config.location;
+                        let new_location = common_opts.location();
+                        match (current_location.is_empty(), new_location.is_empty()) {
+                            (true, false) => {
+                                // relatively safe and an expected change for someone enabling locality for the first time.
+                                node_config.location = common_opts.location().clone();
+                            }
+                            (false, false) if current_location != new_location => {
+                                warn!(
+                                    "Node location has changed from '{current_location}' to '{new_location}'. \
+                                    This change can be dangerous if the cluster is configured with geo-aware replication, but we'll still apply it. \
+                                    You can reverted back on the next server restart.",
+                                );
+                                node_config.location = common_opts.location().clone();
+                            }
+                            (false, false) => { /* do nothing; location didn't change */ }
+                            (true, true) => { /* do nothing; both are empty */}
+                            (false, true) => {
+                                // leave current location as is, warn about it.
+                                warn!(
+                                    "Node location was '{current_location}' in a previous configuration, and it's empty in this configuration. \
+                                    Setting the location back to empty is not permitted, location will stay as '{current_location}'",
+                                );
+                            }
+                        }
 
                         if common_opts.force_node_id.is_some_and(|configured_node_id| {
                             configured_node_id != node_config.current_generation.as_plain()

--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -15,6 +15,7 @@ use humantime::Duration;
 use serde::Serialize;
 use serde_with::{serde_as, skip_serializing_none};
 
+use crate::locality::NodeLocation;
 use crate::net::{AdvertisedAddress, BindAddress};
 use crate::nodes_config::Role;
 use crate::PlainNodeId;
@@ -40,6 +41,29 @@ pub struct CommonOptionCliOverride {
     /// it's started with empty local store. It defaults to the node hostname.
     #[clap(long, env = "RESTATE_NODE_NAME", global = true)]
     pub node_name: Option<String>,
+
+    /// Node location
+    ///
+    /// Setting the location allows Restate to form a tree-like cluster topology.
+    /// The value is written in the format of "<region>[.zone]" to assign this node
+    /// to a specific region, or to a zone within a region.
+    ///
+    /// The value of region and zone is arbitrary but whitespace and `.` are disallowed.
+    ///
+    ///
+    /// NOTE: It's _strongly_ recommended to not change the node's location string after
+    /// its initial registration. Changing the location may result in data loss or data
+    /// inconsistency if `log-server` is enabled on this node.
+    ///
+    /// When this value is not set, the node is considered to be in the _default_ location.
+    /// The _default_ location means that the node is not assigned to any specific region or zone.
+    ///
+    /// ## Examples
+    /// - `us-west` -- the node is in the `us-west` region.
+    /// - `us-west.a1` -- the node is in the `us-west` region and in the `a1` zone.
+    /// - `` -- [default] the node is in the default location
+    #[clap(long, alias = "node-location", global = true)]
+    pub location: Option<NodeLocation>,
 
     /// If set, the node insists on acquiring this node ID.
     #[clap(long, global = true)]


### PR DESCRIPTION

Location of the node is now committed to nodes configuration on cluster join. Location is also accepted as command line parameter in the format of `--location=region.zone`. The following rules apply:
- Node location is not set if it is not provided as command line parameter. (empty by default)
- Node location can be changed, but we'll print a warning.
- Node location cannot be set back to empty after setting it to a concrete value before. (warning will be printed)

The node location is now also printed in the `My Node ID` log line for visibility.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2498).
* #2500
* __->__ #2498