### PR TITLE
Harden ClusterController by not panicking on errors

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -29,7 +29,7 @@ use crate::cluster_controller::logs_controller::nodeset_selection::{
 use crate::cluster_controller::observed_cluster_state::ObservedClusterState;
 use crate::cluster_controller::scheduler;
 use restate_bifrost::{Bifrost, Error as BifrostError};
-use restate_core::metadata_store::{Precondition, ReadWriteError, WriteError};
+use restate_core::metadata_store::{Precondition, WriteError};
 use restate_core::{Metadata, MetadataWriter, ShutdownError, TaskCenterFutureExt};
 use restate_types::errors::GenericError;
 use restate_types::identifiers::PartitionId;
@@ -53,8 +53,6 @@ const FALLBACK_MAX_RETRY_DELAY: Duration = Duration::from_secs(5);
 
 #[derive(Debug, thiserror::Error)]
 pub enum LogsControllerError {
-    #[error("failed writing to the metadata store: {0}")]
-    MetadataStore(#[from] ReadWriteError),
     #[error("failed creating logs: {0}")]
     LogsBuilder(#[from] logs::builder::BuilderError),
     #[error("failed creating loglet params from loglet configuration: {0}")]


### PR DESCRIPTION
Instead of escalating errors from the ClusterController service which ultimately leads to a panic, this commit catches those errors and logs them on warning in the hope that a retry will fix the problem. The down- side is that a buggy cluster controller will never step down so that another cluster controller can take over as the leader.

This is more of a band-aid which helps tolerating failed writes to the metadata store.

This fixes #2276.