### PR TITLE
Remove xxh3builder where its out-performed by default hasher

### DIFF
--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -10,8 +10,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use xxhash_rust::xxh3::Xxh3Builder;
-
 use restate_types::cluster::cluster_state::{ClusterState, NodeState, RunMode};
 use restate_types::identifiers::PartitionId;
 use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
@@ -20,10 +18,10 @@ use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
 /// information and the target scheduling plan to instruct nodes to start/stop partition processors.
 #[derive(Debug, Default, Clone)]
 pub struct ObservedClusterState {
-    pub partitions: HashMap<PartitionId, ObservedPartitionState, Xxh3Builder>,
-    pub alive_nodes: HashMap<PlainNodeId, GenerationalNodeId, Xxh3Builder>,
-    pub dead_nodes: HashSet<PlainNodeId, Xxh3Builder>,
-    pub nodes_to_partitions: HashMap<PlainNodeId, HashSet<PartitionId, Xxh3Builder>, Xxh3Builder>,
+    pub partitions: HashMap<PartitionId, ObservedPartitionState>,
+    pub alive_nodes: HashMap<PlainNodeId, GenerationalNodeId>,
+    pub dead_nodes: HashSet<PlainNodeId>,
+    pub nodes_to_partitions: HashMap<PlainNodeId, HashSet<PartitionId>>,
 }
 
 impl ObservedClusterState {
@@ -115,7 +113,7 @@ impl ObservedClusterState {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ObservedPartitionState {
-    pub partition_processors: HashMap<PlainNodeId, RunMode, Xxh3Builder>,
+    pub partition_processors: HashMap<PlainNodeId, RunMode>,
 }
 
 impl ObservedPartitionState {

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -8,12 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use rand::seq::IteratorRandom;
-use restate_types::live::Pinned;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
+
+use rand::seq::IteratorRandom;
 use tracing::debug;
-use xxhash_rust::xxh3::Xxh3Builder;
 
 use restate_core::metadata_store::{Precondition, ReadError, ReadWriteError, WriteError};
 use restate_core::network::{NetworkSender, Networking, Outgoing, TransportConnect};
@@ -22,6 +21,7 @@ use restate_core::{
     TargetVersion, TaskCenter, TaskHandle, TaskKind,
 };
 use restate_types::identifiers::PartitionId;
+use restate_types::live::Pinned;
 use restate_types::logs::LogId;
 use restate_types::metadata_store::keys::PARTITION_TABLE_KEY;
 use restate_types::net::partition_processor_manager::{
@@ -35,8 +35,6 @@ use restate_types::{NodeId, PlainNodeId, Version};
 
 use crate::cluster_controller::logs_controller;
 use crate::cluster_controller::observed_cluster_state::ObservedClusterState;
-
-type HashSet<T> = std::collections::HashSet<T, Xxh3Builder>;
 
 #[derive(Debug, thiserror::Error)]
 #[error("failed reading scheduling plan from metadata store: {0}")]

--- a/crates/core/src/partitions.rs
+++ b/crates/core/src/partitions.rs
@@ -19,7 +19,6 @@ use restate_types::net::metadata::MetadataKind;
 use restate_types::partition_table::PartitionTable;
 use tokio::sync::mpsc;
 use tracing::{debug, trace};
-use xxhash_rust::xxh3::Xxh3Builder;
 
 use restate_types::identifiers::PartitionId;
 use restate_types::{NodeId, Version};
@@ -106,7 +105,7 @@ struct PartitionToNodesRoutingTable {
     version: Version,
     /// A mapping of partition IDs to node IDs that are believed to be authoritative for that
     /// serving requests for that partition.
-    inner: HashMap<PartitionId, NodeId, Xxh3Builder>,
+    inner: HashMap<PartitionId, NodeId>,
 }
 
 /// Task to refresh the routing information, periodically or on-demand. A single
@@ -222,7 +221,7 @@ pub fn spawn_partition_routing_refresher(
 
 impl From<Pinned<PartitionTable>> for PartitionToNodesRoutingTable {
     fn from(value: Pinned<PartitionTable>) -> Self {
-        let mut inner = HashMap::<PartitionId, NodeId, Xxh3Builder>::default();
+        let mut inner = HashMap::<PartitionId, NodeId>::default();
         for (partition_id, partition) in value.partitions() {
             if let Some(leader) = partition.placement.leader() {
                 inner.insert(*partition_id, (*leader).into());

--- a/crates/log-server/src/metadata.rs
+++ b/crates/log-server/src/metadata.rs
@@ -14,7 +14,6 @@ use std::sync::{Arc, OnceLock};
 use chrono::Utc;
 use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
-use xxhash_rust::xxh3::Xxh3Builder;
 
 use restate_bifrost::loglet::util::TailOffsetWatch;
 use restate_bifrost::loglet::OperationError;
@@ -64,7 +63,7 @@ impl LogStoreMarker {
 /// Caches loglet state in memory
 #[derive(Default, Clone)]
 pub struct LogletStateMap {
-    inner: Arc<AsyncMutex<HashMap<LogletId, LogletState, Xxh3Builder>>>,
+    inner: Arc<AsyncMutex<HashMap<LogletId, LogletState>>>,
 }
 
 impl LogletStateMap {

--- a/crates/log-server/src/network.rs
+++ b/crates/log-server/src/network.rs
@@ -18,7 +18,6 @@ use anyhow::Context;
 use futures::stream::FuturesUnordered;
 use tokio_stream::StreamExt as TokioStreamExt;
 use tracing::{debug, trace};
-use xxhash_rust::xxh3::Xxh3Builder;
 
 use restate_core::cancellation_watcher;
 use restate_core::network::{Incoming, MessageRouterBuilder, MessageStream};
@@ -36,7 +35,7 @@ use crate::metadata::LogletStateMap;
 
 const DEFAULT_WRITERS_CAPACITY: usize = 128;
 
-type LogletWorkerMap = HashMap<LogletId, LogletWorkerHandle, Xxh3Builder>;
+type LogletWorkerMap = HashMap<LogletId, LogletWorkerHandle>;
 
 pub struct RequestPump {
     _configuration: Live<Configuration>,
@@ -107,8 +106,7 @@ impl RequestPump {
 
         let mut shutdown = std::pin::pin!(cancellation_watcher());
 
-        let mut loglet_workers =
-            HashMap::with_capacity_and_hasher(DEFAULT_WRITERS_CAPACITY, Xxh3Builder::default());
+        let mut loglet_workers = HashMap::with_capacity(DEFAULT_WRITERS_CAPACITY);
 
         health_status.update(LogServerStatus::Ready);
 

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -20,7 +20,6 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use smallvec::SmallVec;
-use xxhash_rust::xxh3::Xxh3Builder;
 
 use super::builder::LogsBuilder;
 use super::LogletId;
@@ -73,8 +72,7 @@ pub struct LogletRef<P> {
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct LookupIndex {
-    pub(super) replicated_loglets:
-        HashMap<LogletId, LogletRef<ReplicatedLogletParams>, Xxh3Builder>,
+    pub(super) replicated_loglets: HashMap<LogletId, LogletRef<ReplicatedLogletParams>>,
 }
 
 impl LookupIndex {
@@ -297,7 +295,7 @@ pub struct LogsConfiguration {
 #[serde(try_from = "LogsSerde", into = "LogsSerde")]
 pub struct Logs {
     pub(super) version: Version,
-    pub(super) logs: HashMap<LogId, Chain, Xxh3Builder>,
+    pub(super) logs: HashMap<LogId, Chain>,
     pub(super) lookup_index: LookupIndex,
     pub(super) config: LogsConfiguration,
 }
@@ -327,7 +325,7 @@ impl TryFrom<LogsSerde> for Logs {
     type Error = anyhow::Error;
 
     fn try_from(value: LogsSerde) -> Result<Self, Self::Error> {
-        let mut logs = HashMap::with_capacity_and_hasher(value.logs.len(), Xxh3Builder::new());
+        let mut logs = HashMap::with_capacity(value.logs.len());
         let mut lookup_index = LookupIndex::default();
 
         let mut config = value.config;

--- a/crates/types/src/logs/record_cache.rs
+++ b/crates/types/src/logs/record_cache.rs
@@ -12,7 +12,6 @@ use moka::{
     policy::EvictionPolicy,
     sync::{Cache, CacheBuilder},
 };
-use xxhash_rust::xxh3::Xxh3Builder;
 
 use super::{LogletId, LogletOffset, Record, SequenceNumber};
 
@@ -25,7 +24,7 @@ type RecordKey = (LogletId, LogletOffset);
 /// RemoteSequencers
 #[derive(Clone)]
 pub struct RecordCache {
-    inner: Option<Cache<RecordKey, Record, Xxh3Builder>>,
+    inner: Option<Cache<RecordKey, Record>>,
 }
 
 impl RecordCache {
@@ -43,7 +42,7 @@ impl RecordCache {
                     })
                     .max_capacity(memory_budget_bytes.try_into().unwrap_or(u64::MAX))
                     .eviction_policy(EvictionPolicy::lru())
-                    .build_with_hasher(Xxh3Builder::default()),
+                    .build(),
             )
         } else {
             None

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 use enumset::{EnumSet, EnumSetType};
 use serde_with::serde_as;
-use xxhash_rust::xxh3::Xxh3Builder;
+use xxhash_rust::xxh3::Xxh3DefaultBuilder;
 
 use crate::locality::NodeLocation;
 use crate::net::AdvertisedAddress;
@@ -58,8 +58,8 @@ pub struct NodesConfiguration {
     cluster_name: String,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
-    nodes: HashMap<PlainNodeId, MaybeNode, Xxh3Builder>,
-    name_lookup: HashMap<String, PlainNodeId, Xxh3Builder>,
+    nodes: HashMap<PlainNodeId, MaybeNode>,
+    name_lookup: HashMap<String, PlainNodeId, Xxh3DefaultBuilder>,
 }
 
 impl Default for NodesConfiguration {

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -19,7 +19,7 @@ use std::sync::LazyLock;
 use anyhow::Context;
 use indexmap::IndexSet;
 use regex::Regex;
-use xxhash_rust::xxh3::{self, Xxh3Builder};
+use xxhash_rust::xxh3::Xxh3;
 
 use crate::cluster::cluster_state::RunMode;
 use crate::identifiers::{PartitionId, PartitionKey};
@@ -184,7 +184,7 @@ impl FindPartition for PartitionTable {
     derive_more::From,
     derive_more::AsRef,
 )]
-pub struct PartitionPlacement(IndexSet<PlainNodeId, Xxh3Builder>);
+pub struct PartitionPlacement(IndexSet<PlainNodeId>);
 
 impl PartitionPlacement {
     pub fn iter(&self) -> impl Iterator<Item = (&PlainNodeId, RunMode)> {
@@ -244,7 +244,7 @@ impl PartitionPlacement {
     }
 
     fn hashed(&self) -> u64 {
-        let mut state = xxh3::Xxh3::new();
+        let mut state = Xxh3::new();
         self.hash(&mut state);
         state.finish()
     }

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -18,7 +18,6 @@ use crate::{GenerationalNodeId, PlainNodeId};
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use serde_with::DisplayFromStr;
-use xxhash_rust::xxh3::Xxh3Builder;
 
 /// Configuration parameters of a replicated loglet segment
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
@@ -123,7 +122,7 @@ impl NodeSet {
     }
 
     /// Creates a new nodeset that excludes the nodes not in the provided set
-    pub fn new_excluding(&self, excluded_node_ids: &HashSet<PlainNodeId, Xxh3Builder>) -> NodeSet {
+    pub fn new_excluding(&self, excluded_node_ids: &HashSet<PlainNodeId>) -> NodeSet {
         NodeSet::from(
             self.iter()
                 .copied()


### PR DESCRIPTION

I ran some benches to estimate the benefit of the currently used `Xxh3Builder` for int-keyed maps/sets and it has performed a lot worse than the default hasher. On the other hand, `Xxh3DefaultBuilder` performed a lot better but it was comparable to the default hasher which didn't make it compelling enough to use. I kept `Xxh3DefaultBuilder` (not `Xxh3Builder`) for the string-keyed map.
