### PR TITLE
Add LogId, database name, and column family name to Partitioon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7989,6 +7989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -102,7 +102,7 @@ impl SelectPartitions for MockPartitionSelector {
     async fn get_live_partitions(&self) -> Result<Vec<(PartitionId, Partition)>, GenericError> {
         let id = PartitionId::MIN;
         let partition_range = 0..=PartitionKey::MAX;
-        let partition = Partition::new(partition_range);
+        let partition = Partition::new(id, partition_range);
         Ok(vec![(id, partition)])
     }
 }

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -70,7 +70,7 @@ fn filter_partitions(
         .find_map(|(partition_id, partition)| {
             if partition.key_range.contains(&partition_key) {
                 let new_range = partition_key..=partition_key;
-                let new_partition = Partition::new(new_range);
+                let new_partition = Partition::new(partition_id, new_range);
                 Some((partition_id, new_partition))
             } else {
                 None

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -67,7 +67,7 @@ serde_path_to_error = { version = "0.1" }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
-smartstring = { workspace = true }
+smartstring = { workspace = true, features = ["serde"]}
 static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }


### PR DESCRIPTION
Add LogId, database name, and column family name to Partitioon

Summary:
Extend the Partition to inlcude more partition related attributes.
This now include:
- Log Id
- Database Name
- Column Family Name

So far these values are defaults and there is no way to change them
but this will probably change in the future

This PR only adds those fields to the partition structure but the rest
of the system still not using it. This should happen in a
follow up PR.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2512).
* #2516
* #2514
* #2517
* #2513
* __->__ #2512