### PR TITLE
Introduce `PartitionReplication` and remove `ReplicationStrategy`

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -299,7 +299,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         let response = GetClusterConfigurationResponse {
             cluster_configuration: Some(ClusterConfiguration {
                 num_partitions: u32::from(partition_table.num_partitions()),
-                replication_strategy: Some(partition_table.replication_strategy().into()),
+                partition_replication: partition_table.partition_replication().clone().into(),
                 bifrost_provider: Some(logs.configuration().default_provider.clone().into()),
             }),
         };
@@ -318,15 +318,9 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
 
         self.controller_handle
             .update_cluster_configuration(
-                request
-                    .replication_strategy
-                    .ok_or_else(|| {
-                        Status::invalid_argument("replication_strategy is a required field")
-                    })?
-                    .try_into()
-                    .map_err(|err| {
-                        Status::invalid_argument(format!("invalid replication_strategy: {err}"))
-                    })?,
+                request.partition_replication.try_into().map_err(|err| {
+                    Status::invalid_argument(format!("invalid partition_replication: {err}"))
+                })?,
                 request
                     .bifrost_provider
                     .ok_or_else(|| {

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -22,15 +22,17 @@ service NodeCtlSvc {
   rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse);
 
   // Provision the Restate cluster on this node.
-  rpc ProvisionCluster(ProvisionClusterRequest) returns (ProvisionClusterResponse);
+  rpc ProvisionCluster(ProvisionClusterRequest)
+      returns (ProvisionClusterResponse);
 }
 
 message ProvisionClusterRequest {
   bool dry_run = 1;
   // if unset then the configured cluster num partitions will be used
   optional uint32 num_partitions = 2;
-  // if unset then the configured cluster placement strategy will be used
-  optional restate.cluster.ReplicationStrategy placement_strategy = 3;
+  // if unset partition replication will default to `everywhere`. Otherwise
+  // it's limited to the provided replication property
+  optional restate.cluster.ReplicationProperty partition_replication = 3;
   // if unset then the configured cluster default log provider will be used
   optional restate.cluster.BifrostProvider log_provider = 4;
 }
@@ -60,8 +62,8 @@ message IdentResponse {
 }
 
 message GetMetadataRequest {
-  // If set, we'll first sync with metadata store to esnure we are returning the latest value.
-  // Otherwise, we'll return the local value on this node.
+  // If set, we'll first sync with metadata store to esnure we are returning the
+  // latest value. Otherwise, we'll return the local value on this node.
   bool sync = 1;
   restate.common.MetadataKind kind = 2;
 }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -18,7 +18,7 @@ use restate_core::network::net_util::create_tonic_channel;
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest as ProtoProvisionClusterRequest;
 use restate_types::logs::metadata::ProviderConfiguration;
-use restate_types::partition_table::ReplicationStrategy;
+use restate_types::partition_table::PartitionReplication;
 use restate_types::retries::RetryPolicy;
 use restate_types::{
     config::{Configuration, MetadataStoreClient},
@@ -759,7 +759,7 @@ impl StartedNode {
     pub async fn provision_cluster(
         &self,
         num_partitions: Option<NonZeroU16>,
-        placement_strategy: Option<ReplicationStrategy>,
+        partition_replication: PartitionReplication,
         log_provider: Option<ProviderConfiguration>,
     ) -> anyhow::Result<bool> {
         let channel = create_tonic_channel(
@@ -770,7 +770,7 @@ impl StartedNode {
         let request = ProtoProvisionClusterRequest {
             dry_run: false,
             num_partitions: num_partitions.map(|num| u32::from(num.get())),
-            placement_strategy: placement_strategy.map(Into::into),
+            partition_replication: partition_replication.into(),
             log_provider: log_provider.map(|log_provider| log_provider.into()),
         };
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -47,7 +47,7 @@ use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfigurati
 use restate_types::logs::RecordCache;
 use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, PARTITION_TABLE_KEY};
 use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
-use restate_types::partition_table::{PartitionTable, PartitionTableBuilder, ReplicationStrategy};
+use restate_types::partition_table::{PartitionReplication, PartitionTable, PartitionTableBuilder};
 use restate_types::protobuf::common::{
     AdminStatus, IngressStatus, LogServerStatus, MetadataServerStatus, NodeRpcStatus, NodeStatus,
     WorkerStatus,
@@ -544,8 +544,7 @@ impl Node {
 pub struct ClusterConfiguration {
     #[into_prost(map = "num_partitions_to_u32")]
     pub num_partitions: NonZeroU16,
-    #[prost(required)]
-    pub replication_strategy: ReplicationStrategy,
+    pub partition_replication: PartitionReplication,
     #[prost(required)]
     pub bifrost_provider: ProviderConfiguration,
 }
@@ -558,7 +557,7 @@ impl ClusterConfiguration {
     pub fn from_configuration(configuration: &Configuration) -> Self {
         ClusterConfiguration {
             num_partitions: configuration.common.bootstrap_num_partitions,
-            replication_strategy: ReplicationStrategy::default(),
+            partition_replication: configuration.admin.default_partition_replication.clone(),
             bifrost_provider: ProviderConfiguration::from_configuration(configuration),
         }
     }
@@ -633,7 +632,7 @@ fn generate_initial_metadata(
         .with_equally_sized_partitions(cluster_configuration.num_partitions.get())
         .expect("Empty partition table should not have conflicts");
     initial_partition_table_builder
-        .set_replication_strategy(cluster_configuration.replication_strategy);
+        .set_partition_replication(cluster_configuration.partition_replication.clone());
     let initial_partition_table = initial_partition_table_builder.build();
 
     let initial_logs = Logs::with_logs_configuration(LogsConfiguration::from(

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -31,7 +31,6 @@ use restate_types::config::Configuration;
 use restate_types::health::Health;
 use restate_types::logs::metadata::ProviderConfiguration;
 use restate_types::nodes_config::Role;
-use restate_types::partition_table::ReplicationStrategy;
 use restate_types::protobuf::cluster::ClusterConfiguration as ProtoClusterConfiguration;
 use restate_types::protobuf::node::Message;
 use restate_types::storage::StorageCodec;
@@ -79,11 +78,7 @@ impl NodeCtlSvcHandler {
             })
             .transpose()?
             .unwrap_or(config.common.bootstrap_num_partitions);
-        let replication_strategy = request
-            .placement_strategy
-            .map(ReplicationStrategy::try_from)
-            .transpose()?
-            .unwrap_or_default();
+        let partition_replication = request.partition_replication.try_into()?;
         let bifrost_provider = request
             .log_provider
             .map(ProviderConfiguration::try_from)
@@ -91,7 +86,7 @@ impl NodeCtlSvcHandler {
 
         Ok(ClusterConfiguration {
             num_partitions,
-            replication_strategy,
+            partition_replication,
             bifrost_provider,
         })
     }

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -77,28 +77,16 @@ message PartitionProcessorStatus {
   optional restate.common.Lsn target_tail_lsn = 11;
 }
 
-message ReplicatedProviderConfig { string replication_property = 1; }
+message ReplicationProperty { string replication_property = 1; }
 
 message BifrostProvider {
   string provider = 1;
   // only required if provider = "replicated"
-  optional ReplicatedProviderConfig replicated_config = 2;
-}
-
-enum ReplicationStrategyKind {
-  ReplicationStrategyKind_UNKNOWN = 0;
-  OnAllNodes = 1;
-  Factor = 2;
-}
-
-message ReplicationStrategy {
-  ReplicationStrategyKind kind = 1;
-  // required if kind == "Factor"
-  optional uint32 factor = 2;
+  optional ReplicationProperty replication_property = 2;
 }
 
 message ClusterConfiguration {
   uint32 num_partitions = 1;
-  ReplicationStrategy replication_strategy = 2;
+  optional ReplicationProperty partition_replication = 2;
   BifrostProvider bifrost_provider = 3;
 }

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::partition_table::ReplicationStrategy;
+use crate::partition_table::PartitionReplication;
 
 use super::QueryEngineOptions;
 use serde::{Deserialize, Serialize};
@@ -68,11 +68,12 @@ pub struct AdminOptions {
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub log_tail_update_interval: humantime::Duration,
 
-    /// # Default replication strategy
+    /// # Default partition replication strategy
     ///
-    /// The default replication strategy to be used by the cluster controller to schedule partition
+    /// The default partition replication strategy to be used by the cluster controller to place partition
     /// processors.
-    pub default_replication_strategy: ReplicationStrategy,
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub default_partition_replication: PartitionReplication,
 
     #[cfg(any(test, feature = "test-util"))]
     pub disable_cluster_controller: bool,
@@ -111,7 +112,7 @@ impl Default for AdminOptions {
             // try to trim the log every hour
             log_trim_interval: Some(Duration::from_secs(60 * 60).into()),
             log_trim_threshold: 1000,
-            default_replication_strategy: ReplicationStrategy::OnAllNodes,
+            default_partition_replication: PartitionReplication::default(),
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
             log_tail_update_interval: Duration::from_secs(5 * 60).into(),

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -160,7 +160,7 @@ impl From<ProviderConfiguration> for crate::protobuf::cluster::BifrostProvider {
             ProviderConfiguration::InMemory => result.provider = ProviderKind::InMemory.to_string(),
             ProviderConfiguration::Replicated(config) => {
                 result.provider = ProviderKind::Replicated.to_string();
-                result.replicated_config = Some(cluster::ReplicatedProviderConfig {
+                result.replication_property = Some(cluster::ReplicationProperty {
                     replication_property: config.replication_property.to_string(),
                 })
             }
@@ -180,7 +180,7 @@ impl TryFrom<crate::protobuf::cluster::BifrostProvider> for ProviderConfiguratio
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderKind::InMemory => Ok(Self::InMemory),
             ProviderKind::Replicated => {
-                let config = value.replicated_config.ok_or_else(|| {
+                let config = value.replication_property.ok_or_else(|| {
                     anyhow::anyhow!("replicate_config is required with replicated provider")
                 })?;
 

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -46,6 +46,8 @@ pub mod common {
 }
 
 pub mod cluster {
+    use crate::partition_table::PartitionReplication;
+
     include!(concat!(env!("OUT_DIR"), "/restate.cluster.rs"));
 
     impl std::fmt::Display for RunMode {
@@ -56,6 +58,46 @@ pub mod cluster {
                 RunMode::Follower => "Follower",
             };
             write!(f, "{o}")
+        }
+    }
+
+    impl From<crate::replicated_loglet::ReplicationProperty> for ReplicationProperty {
+        fn from(value: crate::replicated_loglet::ReplicationProperty) -> Self {
+            ReplicationProperty {
+                replication_property: value.to_string(),
+            }
+        }
+    }
+
+    impl TryFrom<ReplicationProperty> for crate::replicated_loglet::ReplicationProperty {
+        type Error = anyhow::Error;
+
+        fn try_from(value: ReplicationProperty) -> Result<Self, Self::Error> {
+            value.replication_property.parse()
+        }
+    }
+
+    impl TryFrom<Option<ReplicationProperty>> for PartitionReplication {
+        type Error = anyhow::Error;
+
+        fn try_from(value: Option<ReplicationProperty>) -> Result<Self, Self::Error> {
+            Ok(value
+                .map(TryFrom::try_from)
+                .transpose()?
+                .map_or(PartitionReplication::Everywhere, |p| {
+                    PartitionReplication::Limit(p)
+                }))
+        }
+    }
+
+    impl From<PartitionReplication> for Option<ReplicationProperty> {
+        fn from(value: PartitionReplication) -> Self {
+            match value {
+                PartitionReplication::Everywhere => None,
+                PartitionReplication::Limit(replication_property) => {
+                    Some(replication_property.into())
+                }
+            }
         }
     }
 }

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -21,6 +21,7 @@ use restate_local_cluster_runner::{
 };
 use restate_types::config::MetadataStoreClient;
 use restate_types::logs::metadata::{ProviderConfiguration, ReplicatedLogletConfig};
+use restate_types::partition_table::PartitionReplication;
 use restate_types::replicated_loglet::ReplicationProperty;
 use restate_types::{config::Configuration, nodes_config::Role, PlainNodeId};
 use test_log::test;
@@ -158,7 +159,7 @@ async fn replicated_loglet() -> googletest::Result<()> {
     cluster.nodes[0]
         .provision_cluster(
             None,
-            None,
+            PartitionReplication::Everywhere,
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
         )
         .await

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -16,8 +16,7 @@ use std::fmt::{self, Display, Write};
 use cling::prelude::*;
 
 use restate_types::{
-    logs::metadata::ProviderConfiguration, partition_table::ReplicationStrategy,
-    protobuf::cluster::ClusterConfiguration,
+    logs::metadata::ProviderConfiguration, protobuf::cluster::ClusterConfiguration,
 };
 
 #[derive(Run, Subcommand, Clone)]
@@ -38,10 +37,13 @@ pub fn cluster_config_string(config: &ClusterConfiguration) -> anyhow::Result<St
         "Number of partitions",
         config.num_partitions,
     )?;
-    let strategy: ReplicationStrategy =
-        config.replication_strategy.unwrap_or_default().try_into()?;
+    let strategy: &str = config
+        .partition_replication
+        .as_ref()
+        .map(|p| p.replication_property.as_str())
+        .unwrap_or("*");
 
-    write_leaf(&mut w, 1, false, "Bifrost replication strategy", strategy)?;
+    write_leaf(&mut w, 1, false, "Partition replication", strategy)?;
 
     let provider: ProviderConfiguration = config
         .bifrost_provider

--- a/tools/restatectl/src/commands/cluster/config/set.rs
+++ b/tools/restatectl/src/commands/cluster/config/set.rs
@@ -21,7 +21,6 @@ use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::ui::console::{confirm_or_exit, StyledTable};
 use restate_cli_util::{c_println, c_warn};
 use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind};
-use restate_types::partition_table::ReplicationStrategy;
 use restate_types::replicated_loglet::ReplicationProperty;
 
 use crate::commands::cluster::config::cluster_config_string;
@@ -31,16 +30,17 @@ use crate::{app::ConnectionInfo, util::grpc_channel};
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "config_set")]
 pub struct ConfigSetOpts {
-    /// Replication strategy. Possible values
-    /// are `on-all-nodes` or `factor(n)`
+    /// Partition replication strategy. If not set places
+    /// partitions replicas on all nodes.
+    /// Accepts `replication property` as a value.
     #[clap(long)]
-    replication_strategy: Option<ReplicationStrategy>,
+    partition_replication: Option<ReplicationProperty>,
 
     /// Bifrost provider kind.
     #[clap(long)]
     bifrost_provider: Option<ProviderKind>,
 
-    /// Replication property
+    /// Replication property for `replicated` bifrost provider.
     #[clap(long, required_if_eq("bifrost_provider", "replicated"))]
     replication_property: Option<ReplicationProperty>,
 }
@@ -60,9 +60,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
 
     let current_config_string = cluster_config_string(&current)?;
 
-    if let Some(replication_strategy) = set_opts.replication_strategy {
-        current.replication_strategy = Some(replication_strategy.into());
-    }
+    current.partition_replication = set_opts.partition_replication.clone().map(Into::into);
 
     if let Some(provider) = set_opts.bifrost_provider {
         let default_provider =

--- a/tools/restatectl/src/commands/cluster/provision.rs
+++ b/tools/restatectl/src/commands/cluster/provision.rs
@@ -19,7 +19,6 @@ use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest;
 use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind, ReplicatedLogletConfig};
 use restate_types::net::AdvertisedAddress;
-use restate_types::partition_table::ReplicationStrategy;
 use restate_types::replicated_loglet::ReplicationProperty;
 use std::num::NonZeroU16;
 use tonic::codec::CompressionEncoding;
@@ -36,10 +35,11 @@ pub struct ProvisionOpts {
     #[clap(long)]
     num_partitions: Option<NonZeroU16>,
 
-    /// Replication strategy. Possible values
-    /// are `on-all-nodes` or `factor(n)`
+    /// Optional partition placement strategy. By default replicates
+    /// partitions on all nodes. Accepts replication property
+    /// string as a value
     #[clap(long)]
-    replication_strategy: Option<ReplicationStrategy>,
+    partition_replication: Option<ReplicationProperty>,
 
     /// Default log provider kind
     #[clap(long)]
@@ -72,7 +72,7 @@ async fn cluster_provision(
     let request = ProvisionClusterRequest {
         dry_run: true,
         num_partitions: provision_opts.num_partitions.map(|n| u32::from(n.get())),
-        placement_strategy: provision_opts.replication_strategy.map(Into::into),
+        partition_replication: provision_opts.partition_replication.clone().map(Into::into),
         log_provider: log_provider.map(Into::into),
     };
 
@@ -115,7 +115,7 @@ async fn cluster_provision(
     let request = ProvisionClusterRequest {
         dry_run: false,
         num_partitions: Some(cluster_configuration_to_provision.num_partitions),
-        placement_strategy: cluster_configuration_to_provision.replication_strategy,
+        partition_replication: cluster_configuration_to_provision.partition_replication,
         log_provider: cluster_configuration_to_provision.bifrost_provider,
     };
 


### PR DESCRIPTION
Introduce `PartitionReplication` and remove `ReplicationStrategy`

Summary:

The idea here is that we can't use `ReplicationStategy`
because it's not location aware and instead we should describe
placement in terms of `ReplicationProperty`.

If partition replication is not set the system assume placement is `Everywhere`,
otherwise the num of copies is limited by the provided replication property.

> Right now the placement is still not location aware but this will
most probably change in the future
