### PR TITLE
Race condition between provision step and BifrostService::start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7989,6 +7989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use bytes::{Bytes, BytesMut};
 use restate_types::protobuf::cluster::ClusterConfiguration;
+use restate_types::replicated_loglet::ReplicationProperty;
 use tonic::{async_trait, Request, Response, Status};
 use tracing::info;
 
@@ -299,7 +300,10 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         let response = GetClusterConfigurationResponse {
             cluster_configuration: Some(ClusterConfiguration {
                 num_partitions: u32::from(partition_table.num_partitions()),
-                replication_strategy: Some(partition_table.replication_strategy().into()),
+                partition_placement_strategy: partition_table
+                    .placement_strategy()
+                    .clone()
+                    .map(Into::into),
                 bifrost_provider: Some(logs.configuration().default_provider.clone().into()),
             }),
         };
@@ -319,11 +323,9 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         self.controller_handle
             .update_cluster_configuration(
                 request
-                    .replication_strategy
-                    .ok_or_else(|| {
-                        Status::invalid_argument("replication_strategy is a required field")
-                    })?
-                    .try_into()
+                    .partition_placement_strategy
+                    .map(ReplicationProperty::try_from)
+                    .transpose()
                     .map_err(|err| {
                         Status::invalid_argument(format!("invalid replication_strategy: {err}"))
                     })?,

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -300,7 +300,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             cluster_configuration: Some(ClusterConfiguration {
                 num_partitions: u32::from(partition_table.num_partitions()),
                 replication_strategy: Some(partition_table.replication_strategy().into()),
-                default_provider: Some(logs.configuration().default_provider.clone().into()),
+                bifrost_provider: Some(logs.configuration().default_provider.clone().into()),
             }),
         };
 
@@ -328,7 +328,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                         Status::invalid_argument(format!("invalid replication_strategy: {err}"))
                     })?,
                 request
-                    .default_provider
+                    .bifrost_provider
                     .ok_or_else(|| {
                         Status::invalid_argument("default_provider is a required field")
                     })?

--- a/crates/admin/src/cluster_controller/logs_controller/nodeset_selection.rs
+++ b/crates/admin/src/cluster_controller/logs_controller/nodeset_selection.rs
@@ -15,7 +15,6 @@ use rand::prelude::IteratorRandom;
 use rand::Rng;
 use tracing::trace;
 
-use restate_types::logs::metadata::NodeSetSelectionStrategy;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::replicated_loglet::{LocationScope, NodeSet, ReplicationProperty};
 
@@ -49,15 +48,13 @@ impl<'a> NodeSetSelector<'a> {
     pub fn can_improve(
         &self,
         nodeset: &NodeSet,
-        strategy: NodeSetSelectionStrategy,
         replication_property: &ReplicationProperty,
     ) -> bool {
         let writable_nodeset = WritableNodeSet::from(self.nodes_config);
         let alive_nodeset = writable_nodeset.alive(self.cluster_state);
         let current_alive = alive_nodeset.intersect(nodeset);
 
-        let nodeset_size =
-            nodeset_size_range(&strategy, replication_property, writable_nodeset.len());
+        let nodeset_size = nodeset_size_range(replication_property, writable_nodeset.len());
 
         if current_alive.len() == nodeset_size.target_size {
             return false;
@@ -74,7 +71,6 @@ impl<'a> NodeSetSelector<'a> {
     /// requirements of the supplied selection strategy and replication, or an explicit error.
     pub fn select<R: Rng + ?Sized>(
         &self,
-        strategy: NodeSetSelectionStrategy,
         replication_property: &ReplicationProperty,
         rng: &mut R,
         preferred_nodes: &NodeSet,
@@ -88,8 +84,7 @@ impl<'a> NodeSetSelector<'a> {
         // Only consider alive, writable storage nodes.
         let alive_nodeset = writable_nodeset.alive(self.cluster_state);
 
-        let nodeset_size =
-            nodeset_size_range(&strategy, replication_property, writable_nodeset.len());
+        let nodeset_size = nodeset_size_range(replication_property, writable_nodeset.len());
 
         if writable_nodeset.len() < nodeset_size.fault_tolerant_size {
             trace!(
@@ -103,69 +98,64 @@ impl<'a> NodeSetSelector<'a> {
             return Err(NodeSelectionError::InsufficientWriteableNodes);
         }
 
-        let nodeset = match strategy {
-            NodeSetSelectionStrategy::StrictFaultTolerantGreedy => {
-                let mut nodes = preferred_nodes
+        let mut nodes = preferred_nodes
+            .iter()
+            .copied()
+            .filter(|node_id| alive_nodeset.contains(node_id))
+            .choose_multiple(rng, nodeset_size.target_size);
+
+        if nodes.len() < nodeset_size.target_size {
+            let remaining = nodeset_size.target_size - nodes.len();
+            nodes.extend(
+                alive_nodeset
                     .iter()
-                    .copied()
-                    .filter(|node_id| alive_nodeset.contains(node_id))
-                    .choose_multiple(rng, nodeset_size.target_size);
+                    .filter(|node_id| !preferred_nodes.contains(node_id))
+                    .choose_multiple(rng, remaining),
+            );
+        }
 
-                if nodes.len() < nodeset_size.target_size {
-                    let remaining = nodeset_size.target_size - nodes.len();
-                    nodes.extend(
-                        alive_nodeset
-                            .iter()
-                            .filter(|node_id| !preferred_nodes.contains(node_id))
-                            .choose_multiple(rng, remaining),
-                    );
-                }
-
-                if nodes.len() < nodeset_size.minimum_size {
-                    trace!(
+        if nodes.len() < nodeset_size.minimum_size {
+            trace!(
                         "Failed to place replicated loglet: insufficient alive nodes to meet minimum size requirement {} < {}",
                         nodes.len(),
                         nodeset_size.minimum_size,
                     );
 
-                    return Err(NodeSelectionError::InsufficientWriteableNodes);
-                }
+            return Err(NodeSelectionError::InsufficientWriteableNodes);
+        }
 
-                // last possibility is if the selected nodeset is still
-                // smaller than fault tolerant size we try to extend from the full nodeset
-                // which includes possibly dead nodes
-                if nodes.len() < nodeset_size.fault_tolerant_size {
-                    // greedy approach: Every other node that is not
-                    // already in the set.
-                    let remaining = nodeset_size.fault_tolerant_size - nodes.len();
+        // last possibility is if the selected nodeset is still
+        // smaller than fault tolerant size we try to extend from the full nodeset
+        // which includes possibly dead nodes
+        if nodes.len() < nodeset_size.fault_tolerant_size {
+            // greedy approach: Every other node that is not
+            // already in the set.
+            let remaining = nodeset_size.fault_tolerant_size - nodes.len();
 
-                    let extension = writable_nodeset
-                        .iter()
-                        .filter(|node_id| !alive_nodeset.contains(node_id))
-                        .cloned()
-                        .sorted_by(|l, r| {
-                            // sorting nodes by "preferred" nodes. Preferred nodes comes first.
-                            match (preferred_nodes.contains(l), preferred_nodes.contains(r)) {
-                                (true, true) | (false, false) => Ordering::Equal,
-                                (true, false) => Ordering::Less,
-                                (false, true) => Ordering::Greater,
-                            }
-                        })
-                        .take(remaining);
+            let extension = writable_nodeset
+                .iter()
+                .filter(|node_id| !alive_nodeset.contains(node_id))
+                .cloned()
+                .sorted_by(|l, r| {
+                    // sorting nodes by "preferred" nodes. Preferred nodes comes first.
+                    match (preferred_nodes.contains(l), preferred_nodes.contains(r)) {
+                        (true, true) | (false, false) => Ordering::Equal,
+                        (true, false) => Ordering::Less,
+                        (false, true) => Ordering::Greater,
+                    }
+                })
+                .take(remaining);
 
-                    nodes.extend(extension);
-                }
+            nodes.extend(extension);
+        }
 
-                let nodes_len = nodes.len();
-                let nodeset = NodeSet::from_iter(nodes);
-                assert_eq!(
-                    nodeset.len(),
-                    nodes_len,
-                    "We have accidentally chosen duplicate candidates during nodeset selection"
-                );
-                nodeset
-            }
-        };
+        let nodes_len = nodes.len();
+        let nodeset = NodeSet::from_iter(nodes);
+        assert_eq!(
+            nodeset.len(),
+            nodes_len,
+            "We have accidentally chosen duplicate candidates during nodeset selection"
+        );
 
         // even with all possible dead node we still can't reach the fault tolerant
         // nodeset size. This means there are not enough nodes in the cluster
@@ -200,7 +190,6 @@ struct NodeSetSizeRange {
 }
 
 fn nodeset_size_range(
-    strategy: &NodeSetSelectionStrategy,
     replication_property: &ReplicationProperty,
     writable_nodes_size: usize,
 ) -> NodeSetSizeRange {
@@ -220,15 +209,11 @@ fn nodeset_size_range(
         "The calculated minimum nodeset size can not be less than the replication factor"
     );
 
-    let (fault_tolerant_size, nodeset_target_size) = match strategy {
-        // writable_nodes_size includes any writable node (log-server) dead or alive.
-        // in the greedy strategy we take the max(fault_tolerant, writable_nodes_size) as
-        // our target size
-        NodeSetSelectionStrategy::StrictFaultTolerantGreedy => (
-            fault_tolerant_size,
-            max(fault_tolerant_size, writable_nodes_size),
-        ),
-    };
+    // writable_nodes_size includes any writable node (log-server) dead or alive.
+    // in the greedy strategy we take the max(fault_tolerant, writable_nodes_size) as
+    // our target size
+
+    let nodeset_target_size = max(fault_tolerant_size, writable_nodes_size);
 
     NodeSetSizeRange {
         minimum_size: min_copies.into(),
@@ -306,12 +291,7 @@ pub mod tests {
 
         let preferred_nodes = NodeSet::empty();
         NodeSetSelector::new(&nodes_config, &observed_state)
-            .select(
-                NodeSetSelectionStrategy::StrictFaultTolerantGreedy,
-                &replication,
-                &mut thread_rng(),
-                &preferred_nodes,
-            )
+            .select(&replication, &mut thread_rng(), &preferred_nodes)
             .unwrap(); // panics
     }
 
@@ -350,10 +330,8 @@ pub mod tests {
             ..Default::default()
         };
 
-        let strategy = NodeSetSelectionStrategy::StrictFaultTolerantGreedy;
         let preferred_nodes = NodeSet::empty();
         let selection = NodeSetSelector::new(&nodes_config, &observed_state).select(
-            strategy,
             &replication,
             &mut thread_rng(),
             &preferred_nodes,
@@ -374,10 +352,8 @@ pub mod tests {
         let replication =
             ReplicationProperty::with_scope(LocationScope::Node, 1.try_into().unwrap());
 
-        let strategy = NodeSetSelectionStrategy::StrictFaultTolerantGreedy;
         let preferred_nodes = NodeSet::empty();
         let selection = NodeSetSelector::new(&nodes.nodes_config, &nodes.observed_state).select(
-            strategy,
             &replication,
             &mut thread_rng(),
             &preferred_nodes,
@@ -407,7 +383,6 @@ pub mod tests {
 
         // initial selection - no prior preferences
         let selection = NodeSetSelector::new(&nodes.nodes_config, &nodes.observed_state).select(
-            NodeSetSelectionStrategy::StrictFaultTolerantGreedy,
             &replication,
             &mut thread_rng(),
             &NodeSet::empty(),
@@ -419,7 +394,6 @@ pub mod tests {
         nodes.kill_node(1);
 
         let selection = NodeSetSelector::new(&nodes.nodes_config, &nodes.observed_state).select(
-            NodeSetSelectionStrategy::StrictFaultTolerantGreedy,
             &replication,
             &mut thread_rng(),
             &initial_nodeset, // preferred nodes
@@ -435,7 +409,6 @@ pub mod tests {
         nodes.add_dedicated_log_server_node(4);
 
         let selection = NodeSetSelector::new(&nodes.nodes_config, &nodes.observed_state).select(
-            NodeSetSelectionStrategy::StrictFaultTolerantGreedy,
             &replication,
             &mut thread_rng(),
             &initial_nodeset, // preferred nodes
@@ -452,7 +425,6 @@ pub mod tests {
 
         // initial selection - no prior preferences
         let selection = NodeSetSelector::new(&nodes.nodes_config, &nodes.observed_state).select(
-            NodeSetSelectionStrategy::StrictFaultTolerantGreedy,
             &replication,
             &mut thread_rng(),
             &NodeSet::empty(),
@@ -485,10 +457,8 @@ pub mod tests {
         let replication =
             ReplicationProperty::with_scope(LocationScope::Node, 2.try_into().unwrap());
 
-        let strategy = NodeSetSelectionStrategy::StrictFaultTolerantGreedy;
         let preferred_nodes = NodeSet::empty();
         let selection = NodeSetSelector::new(&nodes.nodes_config, &nodes.observed_state).select(
-            strategy,
             &replication,
             &mut thread_rng(),
             &preferred_nodes,

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -223,7 +223,6 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
         let mut rng = rand::thread_rng();
 
         let replication = defaults.replication_property.clone();
-        let strategy = defaults.nodeset_selection_strategy;
 
         // if the last loglet in the chain is of the same provider kind, we can use this to
         // influence the nodeset selector.
@@ -245,7 +244,6 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
         let nodes_config = Metadata::with_current(|m| m.nodes_config_ref());
 
         let selection = NodeSetSelector::new(&nodes_config, &ObservedClusterState).select(
-            strategy,
             &replication,
             &mut rng,
             &preferred_nodes,

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -32,7 +32,7 @@ message ProvisionClusterRequest {
   // if unset then the configured cluster placement strategy will be used
   optional restate.cluster.ReplicationStrategy placement_strategy = 3;
   // if unset then the configured cluster default log provider will be used
-  optional restate.cluster.DefaultProvider log_provider = 4;
+  optional restate.cluster.BifrostProvider log_provider = 4;
 }
 
 message ProvisionClusterResponse {

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -22,7 +22,8 @@ service NodeCtlSvc {
   rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse);
 
   // Provision the Restate cluster on this node.
-  rpc ProvisionCluster(ProvisionClusterRequest) returns (ProvisionClusterResponse);
+  rpc ProvisionCluster(ProvisionClusterRequest)
+      returns (ProvisionClusterResponse);
 }
 
 message ProvisionClusterRequest {
@@ -30,7 +31,7 @@ message ProvisionClusterRequest {
   // if unset then the configured cluster num partitions will be used
   optional uint32 num_partitions = 2;
   // if unset then the configured cluster placement strategy will be used
-  optional restate.cluster.ReplicationStrategy placement_strategy = 3;
+  optional restate.cluster.ReplicationProperty partition_placement_strategy = 3;
   // if unset then the configured cluster default log provider will be used
   optional restate.cluster.BifrostProvider log_provider = 4;
 }
@@ -60,8 +61,8 @@ message IdentResponse {
 }
 
 message GetMetadataRequest {
-  // If set, we'll first sync with metadata store to esnure we are returning the latest value.
-  // Otherwise, we'll return the local value on this node.
+  // If set, we'll first sync with metadata store to esnure we are returning the
+  // latest value. Otherwise, we'll return the local value on this node.
   bool sync = 1;
   restate.common.MetadataKind kind = 2;
 }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -18,7 +18,7 @@ use restate_core::network::net_util::create_tonic_channel;
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest as ProtoProvisionClusterRequest;
 use restate_types::logs::metadata::ProviderConfiguration;
-use restate_types::partition_table::ReplicationStrategy;
+use restate_types::protobuf::cluster::ReplicationProperty;
 use restate_types::retries::RetryPolicy;
 use restate_types::{
     config::{Configuration, MetadataStoreClient},
@@ -759,7 +759,7 @@ impl StartedNode {
     pub async fn provision_cluster(
         &self,
         num_partitions: Option<NonZeroU16>,
-        placement_strategy: Option<ReplicationStrategy>,
+        partition_placement_strategy: Option<ReplicationProperty>,
         log_provider: Option<ProviderConfiguration>,
     ) -> anyhow::Result<bool> {
         let channel = create_tonic_channel(
@@ -770,7 +770,7 @@ impl StartedNode {
         let request = ProtoProvisionClusterRequest {
             dry_run: false,
             num_partitions: num_partitions.map(|num| u32::from(num.get())),
-            placement_strategy: placement_strategy.map(Into::into),
+            partition_placement_strategy: partition_placement_strategy.map(Into::into),
             log_provider: log_provider.map(|log_provider| log_provider.into()),
         };
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,6 +16,7 @@ mod roles;
 use anyhow::Context;
 use bytestring::ByteString;
 use prost_dto::IntoProst;
+use restate_types::replicated_loglet::ReplicationProperty;
 use std::num::NonZeroU16;
 use tracing::{debug, error, info, trace, warn};
 
@@ -47,7 +48,7 @@ use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfigurati
 use restate_types::logs::RecordCache;
 use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, PARTITION_TABLE_KEY};
 use restate_types::nodes_config::{LogServerConfig, NodeConfig, NodesConfiguration, Role};
-use restate_types::partition_table::{PartitionTable, PartitionTableBuilder, ReplicationStrategy};
+use restate_types::partition_table::{PartitionTable, PartitionTableBuilder};
 use restate_types::protobuf::common::{
     AdminStatus, IngressStatus, LogServerStatus, MetadataServerStatus, NodeRpcStatus, NodeStatus,
     WorkerStatus,
@@ -544,8 +545,7 @@ impl Node {
 pub struct ClusterConfiguration {
     #[into_prost(map = "num_partitions_to_u32")]
     pub num_partitions: NonZeroU16,
-    #[prost(required)]
-    pub replication_strategy: ReplicationStrategy,
+    pub partition_placement_strategy: Option<ReplicationProperty>,
     #[prost(required)]
     pub bifrost_provider: ProviderConfiguration,
 }
@@ -558,7 +558,7 @@ impl ClusterConfiguration {
     pub fn from_configuration(configuration: &Configuration) -> Self {
         ClusterConfiguration {
             num_partitions: configuration.common.bootstrap_num_partitions,
-            replication_strategy: ReplicationStrategy::default(),
+            partition_placement_strategy: configuration.admin.default_placement_strategy.clone(),
             bifrost_provider: ProviderConfiguration::from_configuration(configuration),
         }
     }
@@ -633,7 +633,7 @@ fn generate_initial_metadata(
         .with_equally_sized_partitions(cluster_configuration.num_partitions.get())
         .expect("Empty partition table should not have conflicts");
     initial_partition_table_builder
-        .set_replication_strategy(cluster_configuration.replication_strategy);
+        .set_placement_strategy(cluster_configuration.partition_placement_strategy.clone());
     let initial_partition_table = initial_partition_table_builder.build();
 
     let initial_logs = Logs::with_logs_configuration(LogsConfiguration::from(

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -547,7 +547,7 @@ pub struct ClusterConfiguration {
     #[prost(required)]
     pub replication_strategy: ReplicationStrategy,
     #[prost(required)]
-    pub default_provider: ProviderConfiguration,
+    pub bifrost_provider: ProviderConfiguration,
 }
 
 fn num_partitions_to_u32(num_partitions: NonZeroU16) -> u32 {
@@ -559,7 +559,7 @@ impl ClusterConfiguration {
         ClusterConfiguration {
             num_partitions: configuration.common.bootstrap_num_partitions,
             replication_strategy: ReplicationStrategy::default(),
-            default_provider: ProviderConfiguration::from_configuration(configuration),
+            bifrost_provider: ProviderConfiguration::from_configuration(configuration),
         }
     }
 }
@@ -637,7 +637,7 @@ fn generate_initial_metadata(
     let initial_partition_table = initial_partition_table_builder.build();
 
     let initial_logs = Logs::with_logs_configuration(LogsConfiguration::from(
-        cluster_configuration.default_provider.clone(),
+        cluster_configuration.bifrost_provider.clone(),
     ));
 
     let initial_nodes_configuration = create_initial_nodes_configuration(common_opts);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -578,11 +578,6 @@ async fn provision_cluster_metadata(
     let (initial_nodes_configuration, initial_partition_table, initial_logs) =
         generate_initial_metadata(common_opts, cluster_configuration);
 
-    let result = retry_on_network_error(common_opts.network_error_retry_policy.clone(), || {
-        metadata_store_client.provision(&initial_nodes_configuration)
-    })
-    .await?;
-
     retry_on_network_error(common_opts.network_error_retry_policy.clone(), || {
         write_initial_value_dont_fail_if_it_exists(
             metadata_store_client,
@@ -602,6 +597,12 @@ async fn provision_cluster_metadata(
     })
     .await
     .context("failed provisioning the initial logs")?;
+
+    let result = retry_on_network_error(common_opts.network_error_retry_policy.clone(), || {
+        metadata_store_client.provision(&initial_nodes_configuration)
+    })
+    .await
+    .context("failed provisioning the initial nodes configuration")?;
 
     Ok(result)
 }

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -84,7 +84,7 @@ impl NodeCtlSvcHandler {
             .map(ReplicationStrategy::try_from)
             .transpose()?
             .unwrap_or_default();
-        let default_provider = request
+        let bifrost_provider = request
             .log_provider
             .map(ProviderConfiguration::try_from)
             .unwrap_or_else(|| Ok(ProviderConfiguration::from_configuration(config)))?;
@@ -92,7 +92,7 @@ impl NodeCtlSvcHandler {
         Ok(ClusterConfiguration {
             num_partitions,
             replication_strategy,
-            default_provider,
+            bifrost_provider,
         })
     }
 }

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -102,7 +102,7 @@ impl SelectPartitions for MockPartitionSelector {
     async fn get_live_partitions(&self) -> Result<Vec<(PartitionId, Partition)>, GenericError> {
         let id = PartitionId::MIN;
         let partition_range = 0..=PartitionKey::MAX;
-        let partition = Partition::new(partition_range);
+        let partition = Partition::new(id, partition_range);
         Ok(vec![(id, partition)])
     }
 }

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -70,7 +70,7 @@ fn filter_partitions(
         .find_map(|(partition_id, partition)| {
             if partition.key_range.contains(&partition_key) {
                 let new_range = partition_key..=partition_key;
-                let new_partition = Partition::new(new_range);
+                let new_partition = Partition::new(partition_id, new_range);
                 Some((partition_id, new_partition))
             } else {
                 None

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -67,7 +67,7 @@ serde_path_to_error = { version = "0.1" }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
-smartstring = { workspace = true }
+smartstring = { workspace = true, features = ["serde"]}
 static_assertions = { workspace = true }
 strum = { workspace = true }
 sync_wrapper = { workspace = true }

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -77,28 +77,16 @@ message PartitionProcessorStatus {
   optional restate.common.Lsn target_tail_lsn = 11;
 }
 
-message ReplicatedProviderConfig { string replication_property = 1; }
+message ReplicationProperty { string replication_property = 1; }
 
 message BifrostProvider {
   string provider = 1;
   // only required if provider = "replicated"
-  optional ReplicatedProviderConfig replicated_config = 2;
-}
-
-enum ReplicationStrategyKind {
-  ReplicationStrategyKind_UNKNOWN = 0;
-  OnAllNodes = 1;
-  Factor = 2;
-}
-
-message ReplicationStrategy {
-  ReplicationStrategyKind kind = 1;
-  // required if kind == "Factor"
-  optional uint32 factor = 2;
+  optional ReplicationProperty replication_property = 2;
 }
 
 message ClusterConfiguration {
   uint32 num_partitions = 1;
-  ReplicationStrategy replication_strategy = 2;
+  optional ReplicationProperty partition_placement_strategy = 2;
   BifrostProvider bifrost_provider = 3;
 }

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -77,17 +77,7 @@ message PartitionProcessorStatus {
   optional restate.common.Lsn target_tail_lsn = 11;
 }
 
-enum NodeSetSelectionStrategyKind {
-  NodeSetSelectionStrategyKind_UNKNOWN = 0;
-  StrictFaultTolerantGreedy = 1;
-}
-
-message NodeSetSelectionStrategy { NodeSetSelectionStrategyKind kind = 1; }
-
-message ReplicatedProviderConfig {
-  string replication_property = 1;
-  NodeSetSelectionStrategy nodeset_selection_strategy = 2;
-}
+message ReplicatedProviderConfig { string replication_property = 1; }
 
 message DefaultProvider {
   string provider = 1;

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -79,7 +79,7 @@ message PartitionProcessorStatus {
 
 message ReplicatedProviderConfig { string replication_property = 1; }
 
-message DefaultProvider {
+message BifrostProvider {
   string provider = 1;
   // only required if provider = "replicated"
   optional ReplicatedProviderConfig replicated_config = 2;
@@ -100,5 +100,5 @@ message ReplicationStrategy {
 message ClusterConfiguration {
   uint32 num_partitions = 1;
   ReplicationStrategy replication_strategy = 2;
-  DefaultProvider default_provider = 3;
+  BifrostProvider bifrost_provider = 3;
 }

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::partition_table::ReplicationStrategy;
+use crate::replicated_loglet::ReplicationProperty;
 
 use super::QueryEngineOptions;
 use serde::{Deserialize, Serialize};
@@ -68,11 +68,13 @@ pub struct AdminOptions {
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub log_tail_update_interval: humantime::Duration,
 
-    /// # Default replication strategy
+    /// # Default partition placement strategy
     ///
-    /// The default replication strategy to be used by the cluster controller to schedule partition
+    /// The default partition placement strategy to be used by the cluster controller to place partition
     /// processors.
-    pub default_replication_strategy: ReplicationStrategy,
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub default_placement_strategy: Option<ReplicationProperty>,
 
     #[cfg(any(test, feature = "test-util"))]
     pub disable_cluster_controller: bool,
@@ -111,7 +113,7 @@ impl Default for AdminOptions {
             // try to trim the log every hour
             log_trim_interval: Some(Duration::from_secs(60 * 60).into()),
             log_trim_threshold: 1000,
-            default_replication_strategy: ReplicationStrategy::OnAllNodes,
+            default_placement_strategy: None,
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
             log_tail_update_interval: Duration::from_secs(5 * 60).into(),

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -160,7 +160,7 @@ impl From<ProviderConfiguration> for crate::protobuf::cluster::BifrostProvider {
             ProviderConfiguration::InMemory => result.provider = ProviderKind::InMemory.to_string(),
             ProviderConfiguration::Replicated(config) => {
                 result.provider = ProviderKind::Replicated.to_string();
-                result.replicated_config = Some(cluster::ReplicatedProviderConfig {
+                result.replication_property = Some(cluster::ReplicationProperty {
                     replication_property: config.replication_property.to_string(),
                 })
             }
@@ -180,7 +180,7 @@ impl TryFrom<crate::protobuf::cluster::BifrostProvider> for ProviderConfiguratio
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderKind::InMemory => Ok(Self::InMemory),
             ProviderKind::Replicated => {
-                let config = value.replicated_config.ok_or_else(|| {
+                let config = value.replication_property.ok_or_else(|| {
                     anyhow::anyhow!("replicate_config is required with replicated provider")
                 })?;
 

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -9,11 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{hash_map, BTreeMap, HashMap, HashSet};
-use std::fmt::Display;
 use std::num::NonZeroU8;
 use std::str::FromStr;
 
-use anyhow::Context;
 use bytestring::ByteString;
 use enum_map::Enum;
 use rand::RngCore;
@@ -25,9 +23,6 @@ use super::builder::LogsBuilder;
 use super::LogletId;
 use crate::config::Configuration;
 use crate::logs::{LogId, Lsn, SequenceNumber};
-use crate::protobuf::cluster::{
-    NodeSetSelectionStrategy as ProtoNodeSetSelectionStrategy, NodeSetSelectionStrategyKind,
-};
 use crate::replicated_loglet::{ReplicatedLogletParams, ReplicationProperty};
 use crate::{flexbuffers_storage_encode_decode, Version, Versioned};
 
@@ -117,79 +112,6 @@ impl LookupIndex {
     }
 }
 
-/// Node set selection strategy for picking cluster members to host replicated logs. Note that this
-/// concerns loglet replication configuration across storage servers during log bootstrap or cluster
-/// reconfiguration, for example when expanding capacity.
-///
-/// It is expected that the Bifrost data plane will deal with short-term server unavailability.
-/// Therefore, we can afford to aim high with our nodeset selections and optimise for maximum
-/// possible fault tolerance. It is the data plane's responsibility to achieve availability within
-/// this nodeset during periods of individual node downtime.
-///
-/// Finally, nodeset selection is orthogonal to log sequencer placement.
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Default, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[serde(rename_all = "kebab-case")]
-pub enum NodeSetSelectionStrategy {
-    /// Selects an optimal nodeset size based on the replication factor. The nodeset size is at
-    /// least `2f+1`, where `f` is the number of tolerable failures.
-    ///
-    /// It's calculated by working backwards from a replication factor of `f+1`. If there are
-    /// more nodes available in the cluster, the strategy will use them.
-    ///
-    /// This strategy will never suggest a nodeset smaller than `2f+1`, thus ensuring that there is
-    /// always plenty of fault tolerance built into the loglet. This is a safe default choice.
-    ///
-    /// Example: For a replication factor of (2) `F=f+1=2`, `f` will equal to 1, and hence
-    /// the node set size will be `2f+1 => 3`.
-    ///
-    /// For an `F=3` (and hence `f=2`), then `2f+1` => 5 nodes
-    #[default]
-    StrictFaultTolerantGreedy,
-}
-
-impl Display for NodeSetSelectionStrategy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::StrictFaultTolerantGreedy => write!(f, "strict-fault-tolerant-greedy"),
-        }
-    }
-}
-
-impl FromStr for NodeSetSelectionStrategy {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "strict-fault-tolerant-greedy" => Ok(Self::StrictFaultTolerantGreedy),
-            _ => Err("Unknown node set selection strategy"),
-        }
-    }
-}
-
-impl From<NodeSetSelectionStrategy> for ProtoNodeSetSelectionStrategy {
-    fn from(value: NodeSetSelectionStrategy) -> Self {
-        match value {
-            NodeSetSelectionStrategy::StrictFaultTolerantGreedy => Self {
-                kind: NodeSetSelectionStrategyKind::StrictFaultTolerantGreedy.into(),
-            },
-        }
-    }
-}
-
-impl TryFrom<ProtoNodeSetSelectionStrategy> for NodeSetSelectionStrategy {
-    type Error = anyhow::Error;
-
-    fn try_from(value: ProtoNodeSetSelectionStrategy) -> Result<Self, Self::Error> {
-        if value.kind == i32::from(NodeSetSelectionStrategyKind::StrictFaultTolerantGreedy) {
-            Ok(Self::StrictFaultTolerantGreedy)
-        } else {
-            anyhow::bail!("Unknown nodeset selection strategy kind")
-        }
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ProviderConfiguration {
@@ -216,7 +138,6 @@ impl ProviderConfiguration {
             ProviderKind::InMemory => ProviderConfiguration::InMemory,
             ProviderKind::Local => ProviderConfiguration::Local,
             ProviderKind::Replicated => ProviderConfiguration::Replicated(ReplicatedLogletConfig {
-                nodeset_selection_strategy: NodeSetSelectionStrategy::default(),
                 replication_property: configuration
                     .bifrost
                     .replicated_loglet
@@ -241,7 +162,6 @@ impl From<ProviderConfiguration> for crate::protobuf::cluster::DefaultProvider {
                 result.provider = ProviderKind::Replicated.to_string();
                 result.replicated_config = Some(cluster::ReplicatedProviderConfig {
                     replication_property: config.replication_property.to_string(),
-                    nodeset_selection_strategy: Some(config.nodeset_selection_strategy.into()),
                 })
             }
         };
@@ -266,10 +186,6 @@ impl TryFrom<crate::protobuf::cluster::DefaultProvider> for ProviderConfiguratio
 
                 Ok(Self::Replicated(ReplicatedLogletConfig {
                     replication_property: config.replication_property.parse()?,
-                    nodeset_selection_strategy: config
-                        .nodeset_selection_strategy
-                        .context("NodeSet selection strategy is required")?
-                        .try_into()?,
                 }))
             }
         }
@@ -279,7 +195,6 @@ impl TryFrom<crate::protobuf::cluster::DefaultProvider> for ProviderConfiguratio
 #[serde_as]
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ReplicatedLogletConfig {
-    pub nodeset_selection_strategy: NodeSetSelectionStrategy,
     #[serde_as(as = "DisplayFromStr")]
     pub replication_property: ReplicationProperty,
 }
@@ -343,7 +258,6 @@ impl TryFrom<LogsSerde> for Logs {
                         config = Some(LogsConfiguration {
                             default_provider: ProviderConfiguration::Replicated(
                                 ReplicatedLogletConfig {
-                                    nodeset_selection_strategy: NodeSetSelectionStrategy::default(),
                                     replication_property: ReplicationProperty::new(
                                         NonZeroU8::new(2).expect("2 is not 0"),
                                     ),

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -148,11 +148,11 @@ impl ProviderConfiguration {
     }
 }
 
-impl From<ProviderConfiguration> for crate::protobuf::cluster::DefaultProvider {
+impl From<ProviderConfiguration> for crate::protobuf::cluster::BifrostProvider {
     fn from(value: ProviderConfiguration) -> Self {
         use crate::protobuf::cluster;
 
-        let mut result = crate::protobuf::cluster::DefaultProvider::default();
+        let mut result = crate::protobuf::cluster::BifrostProvider::default();
 
         match value {
             ProviderConfiguration::Local => result.provider = ProviderKind::Local.to_string(),
@@ -170,9 +170,9 @@ impl From<ProviderConfiguration> for crate::protobuf::cluster::DefaultProvider {
     }
 }
 
-impl TryFrom<crate::protobuf::cluster::DefaultProvider> for ProviderConfiguration {
+impl TryFrom<crate::protobuf::cluster::BifrostProvider> for ProviderConfiguration {
     type Error = anyhow::Error;
-    fn try_from(value: crate::protobuf::cluster::DefaultProvider) -> Result<Self, Self::Error> {
+    fn try_from(value: crate::protobuf::cluster::BifrostProvider) -> Result<Self, Self::Error> {
         let provider_kind: ProviderKind = value.provider.parse()?;
 
         match provider_kind {

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -46,6 +46,7 @@ pub mod common {
 }
 
 pub mod cluster {
+
     include!(concat!(env!("OUT_DIR"), "/restate.cluster.rs"));
 
     impl std::fmt::Display for RunMode {
@@ -56,6 +57,22 @@ pub mod cluster {
                 RunMode::Follower => "Follower",
             };
             write!(f, "{o}")
+        }
+    }
+
+    impl From<crate::replicated_loglet::ReplicationProperty> for ReplicationProperty {
+        fn from(value: crate::replicated_loglet::ReplicationProperty) -> Self {
+            ReplicationProperty {
+                replication_property: value.to_string(),
+            }
+        }
+    }
+
+    impl TryFrom<ReplicationProperty> for crate::replicated_loglet::ReplicationProperty {
+        type Error = anyhow::Error;
+
+        fn try_from(value: ReplicationProperty) -> Result<Self, Self::Error> {
+            value.replication_property.parse()
         }
     }
 }

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -20,9 +20,7 @@ use restate_local_cluster_runner::{
     node::{BinarySource, Node},
 };
 use restate_types::config::MetadataStoreClient;
-use restate_types::logs::metadata::{
-    NodeSetSelectionStrategy, ProviderConfiguration, ReplicatedLogletConfig,
-};
+use restate_types::logs::metadata::{ProviderConfiguration, ReplicatedLogletConfig};
 use restate_types::replicated_loglet::ReplicationProperty;
 use restate_types::{config::Configuration, nodes_config::Role, PlainNodeId};
 use test_log::test;
@@ -155,7 +153,6 @@ async fn replicated_loglet() -> googletest::Result<()> {
 
     let replicated_loglet_config = ReplicatedLogletConfig {
         replication_property: ReplicationProperty::new(NonZeroU8::new(2).expect("to be non-zero")),
-        nodeset_selection_strategy: NodeSetSelectionStrategy::default(),
     };
 
     cluster.nodes[0]

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -16,8 +16,7 @@ use std::fmt::{self, Display, Write};
 use cling::prelude::*;
 
 use restate_types::{
-    logs::metadata::ProviderConfiguration, partition_table::ReplicationStrategy,
-    protobuf::cluster::ClusterConfiguration,
+    logs::metadata::ProviderConfiguration, protobuf::cluster::ClusterConfiguration,
 };
 
 #[derive(Run, Subcommand, Clone)]
@@ -38,10 +37,13 @@ pub fn cluster_config_string(config: &ClusterConfiguration) -> anyhow::Result<St
         "Number of partitions",
         config.num_partitions,
     )?;
-    let strategy: ReplicationStrategy =
-        config.replication_strategy.unwrap_or_default().try_into()?;
+    let strategy: &str = config
+        .partition_placement_strategy
+        .as_ref()
+        .map(|p| p.replication_property.as_str())
+        .unwrap_or("*");
 
-    write_leaf(&mut w, 1, false, "Bifrost replication strategy", strategy)?;
+    write_leaf(&mut w, 1, false, "Partition placement strategy", strategy)?;
 
     let provider: ProviderConfiguration = config
         .bifrost_provider

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -44,7 +44,7 @@ pub fn cluster_config_string(config: &ClusterConfiguration) -> anyhow::Result<St
     write_leaf(&mut w, 1, false, "Bifrost replication strategy", strategy)?;
 
     let provider: ProviderConfiguration = config
-        .default_provider
+        .bifrost_provider
         .clone()
         .unwrap_or_default()
         .try_into()?;

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -74,13 +74,6 @@ fn write_default_provider<W: fmt::Write>(
             write_leaf(
                 w,
                 depth,
-                false,
-                "Node set selection strategy",
-                config.nodeset_selection_strategy,
-            )?;
-            write_leaf(
-                w,
-                depth,
                 true,
                 "Replication property",
                 config.replication_property.to_string(),

--- a/tools/restatectl/src/commands/cluster/config/set.rs
+++ b/tools/restatectl/src/commands/cluster/config/set.rs
@@ -36,7 +36,7 @@ pub struct ConfigSetOpts {
     #[clap(long)]
     replication_strategy: Option<ReplicationStrategy>,
 
-    /// Default provider kind
+    /// Bifrost provider kind.
     #[clap(long)]
     bifrost_provider: Option<ProviderKind>,
 
@@ -77,7 +77,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
             }
         }
 
-        current.default_provider = Some(default_provider.into());
+        current.bifrost_provider = Some(default_provider.into());
     }
 
     let updated_config_string = cluster_config_string(&current)?;

--- a/tools/restatectl/src/commands/cluster/provision.rs
+++ b/tools/restatectl/src/commands/cluster/provision.rs
@@ -97,7 +97,7 @@ async fn cluster_provision(
         cluster_config_string(&cluster_configuration_to_provision)?
     );
 
-    if let Some(default_provider) = &cluster_configuration_to_provision.default_provider {
+    if let Some(default_provider) = &cluster_configuration_to_provision.bifrost_provider {
         let default_provider = ProviderConfiguration::try_from(default_provider.clone())?;
 
         match default_provider {
@@ -116,7 +116,7 @@ async fn cluster_provision(
         dry_run: false,
         num_partitions: Some(cluster_configuration_to_provision.num_partitions),
         placement_strategy: cluster_configuration_to_provision.replication_strategy,
-        log_provider: cluster_configuration_to_provision.default_provider,
+        log_provider: cluster_configuration_to_provision.bifrost_provider,
     };
 
     match client.provision_cluster(request).await {

--- a/tools/restatectl/src/commands/cluster/provision.rs
+++ b/tools/restatectl/src/commands/cluster/provision.rs
@@ -17,9 +17,7 @@ use restate_cli_util::ui::console::confirm_or_exit;
 use restate_cli_util::{c_error, c_println, c_warn};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest;
-use restate_types::logs::metadata::{
-    NodeSetSelectionStrategy, ProviderConfiguration, ProviderKind, ReplicatedLogletConfig,
-};
+use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind, ReplicatedLogletConfig};
 use restate_types::net::AdvertisedAddress;
 use restate_types::partition_table::ReplicationStrategy;
 use restate_types::replicated_loglet::ReplicationProperty;
@@ -150,7 +148,6 @@ pub fn extract_default_provider(
         ProviderKind::Replicated => {
             let config = ReplicatedLogletConfig {
                 replication_property: replication_property.clone().expect("is required"),
-                nodeset_selection_strategy: NodeSetSelectionStrategy::default(),
             };
             ProviderConfiguration::Replicated(config)
         }


### PR DESCRIPTION
Race condition between provision step and BifrostService::start

Summary:
Avoid the race conditition by simply making sure Logs and PartitionTable metadata
are initialized before NodesConfiguration

Initializing NodesConfiguration first unlocks the nodes waiting to join
the cluster which makes them race over the PartitionTable and Logs config
initialization

Fixes #2486

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2516).
* __->__ #2516
* #2514
* #2517
* #2513
* #2512