### PR TITLE
[4/n] Promote ReplicationProperty to replication module

### DIFF
--- a/crates/types/src/locality/location_scope.rs
+++ b/crates/types/src/locality/location_scope.rs
@@ -38,6 +38,7 @@ pub enum NodeLocationScope {
     Region,
 
     // Special; Includes all lower-level scopes.
+    #[strum(disabled)]
     Root,
 }
 

--- a/crates/types/src/replicated_loglet/mod.rs
+++ b/crates/types/src/replicated_loglet/mod.rs
@@ -10,13 +10,12 @@
 
 mod log_nodeset;
 mod params;
-mod replication_property;
 mod spread;
 
 pub use log_nodeset::*;
 pub use params::*;
-pub use replication_property::*;
 pub use spread::*;
 
 // re-export to avoid mass-refactoring
-pub use super::replication::NodeSet;
+pub use super::locality::NodeLocationScope as LocationScope;
+pub use super::replication::{NodeSet, ReplicationProperty, ReplicationPropertyError};

--- a/crates/types/src/replication/mod.rs
+++ b/crates/types/src/replication/mod.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod nodeset;
+mod nodeset;
+mod replication_property;
 
-pub use nodeset::NodeSet;
+pub use nodeset::*;
+pub use replication_property::*;


### PR DESCRIPTION

ReplicationProperty is no longer tied to replicated loglet, partition_table also uses it to define partition_replication. This PR promotes it and merges NodeLocationScope with LocationScope.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2526).
* #2541
* #2539
* #2537
* #2530
* __->__ #2526