### PR TITLE
Option to disable `LogsController`

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -60,13 +60,13 @@ pub enum Error {
 /// Placement hints for the [`Scheduler`]. The hints can specify which nodes should be chosen for
 /// the partition processor placement and on which node the leader should run.
 pub trait PartitionProcessorPlacementHints {
-    fn preferred_nodes(&self, partition_id: &PartitionId) -> impl Iterator<Item = &PlainNodeId>;
+    fn preferred_nodes(&self, partition_id: &PartitionId) -> impl Iterator<Item = PlainNodeId>;
 
     fn preferred_leader(&self, partition_id: &PartitionId) -> Option<PlainNodeId>;
 }
 
 impl<T: PartitionProcessorPlacementHints> PartitionProcessorPlacementHints for &T {
-    fn preferred_nodes(&self, partition_id: &PartitionId) -> impl Iterator<Item = &PlainNodeId> {
+    fn preferred_nodes(&self, partition_id: &PartitionId) -> impl Iterator<Item = PlainNodeId> {
         (*self).preferred_nodes(partition_id)
     }
 
@@ -290,8 +290,7 @@ impl<T: TransportConnect> Scheduler<T> {
                     // todo: Implement cleverer strategies
                     // randomly choose from the preferred workers nodes first
                     let new_nodes = preferred_worker_nodes
-                        .filter(|node_id| !target_state.node_set.contains(**node_id))
-                        .cloned()
+                        .filter(|node_id| !target_state.node_set.contains(*node_id))
                         .choose_multiple(
                             &mut rng,
                             replication_factor - target_state.node_set.len(),
@@ -314,7 +313,7 @@ impl<T: TransportConnect> Scheduler<T> {
                     }
                 } else if target_state.node_set.len() > replication_factor {
                     let preferred_worker_nodes: HashSet<PlainNodeId> =
-                        preferred_worker_nodes.cloned().collect();
+                        preferred_worker_nodes.collect();
 
                     // first remove the not preferred nodes
                     for node_id in target_state
@@ -588,7 +587,7 @@ mod tests {
         fn preferred_nodes(
             &self,
             _partition_id: &PartitionId,
-        ) -> impl Iterator<Item = &PlainNodeId> {
+        ) -> impl Iterator<Item = PlainNodeId> {
             iter::empty()
         }
 

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -161,8 +161,12 @@ where
 
         let scheduler = Scheduler::new(service.metadata_writer.clone(), service.networking.clone());
 
-        let logs_controller =
-            LogsController::new(service.bifrost.clone(), service.metadata_writer.clone())?;
+        let logs_controller = if configuration.admin.disable_logs_controller {
+            info!("Logs controller is disabled");
+            LogsController::disabled()
+        } else {
+            LogsController::enabled(service.bifrost.clone(), service.metadata_writer.clone())?
+        };
 
         let (log_trim_interval, log_trim_threshold) =
             create_log_trim_interval(&configuration.admin);

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -77,6 +77,11 @@ pub struct AdminOptions {
 
     #[cfg(any(test, feature = "test-util"))]
     pub disable_cluster_controller: bool,
+
+    /// # Disable logs controller
+    ///
+    /// Default: false
+    pub disable_logs_controller: bool,
 }
 
 impl AdminOptions {
@@ -116,6 +121,7 @@ impl Default for AdminOptions {
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
             log_tail_update_interval: Duration::from_secs(5 * 60).into(),
+            disable_logs_controller: false,
         }
     }
 }


### PR DESCRIPTION
Option to disable `LogsController`

Summary:
Support disabling logs controller via a configuration flag

Instead of checking the flag everywhere. If flag is set, logs
controller is replaced with a `no-op` logs controller.
