### PR TITLE
A more efficient serialization format for raft metadata store

### DIFF
--- a/crates/metadata-store/proto/metadata_store_svc.proto
+++ b/crates/metadata-store/proto/metadata_store_svc.proto
@@ -35,9 +35,7 @@ service MetadataStoreSvc {
   rpc Status(google.protobuf.Empty) returns (StatusResponse);
 }
 
-message GetRequest {
-  string key = 1;
-}
+message GetRequest { string key = 1; }
 
 message PutRequest {
   string key = 1;
@@ -55,17 +53,11 @@ message VersionedValue {
   bytes bytes = 2;
 }
 
-message GetResponse {
-  optional VersionedValue value = 1;
-}
+message GetResponse { optional VersionedValue value = 1; }
 
-message Version {
-  uint32 value = 1;
-}
+message Version { uint32 value = 1; }
 
-message GetVersionResponse {
-  optional Version version = 1;
-}
+message GetVersionResponse { optional Version version = 1; }
 
 enum PreconditionKind {
   PreconditionKind_UNKNOWN = 0;
@@ -80,13 +72,9 @@ message Precondition {
   optional Version version = 2;
 }
 
-message ProvisionRequest {
-  bytes nodes_configuration = 1;
-}
+message ProvisionRequest { bytes nodes_configuration = 1; }
 
-message ProvisionResponse {
-  bool newly_provisioned = 1;
-}
+message ProvisionResponse { bool newly_provisioned = 1; }
 
 message StatusResponse {
   restate.common.MetadataServerStatus status = 1;
@@ -118,3 +106,34 @@ message RaftSummary {
   uint64 first_index = 4;
   uint64 last_index = 5;
 }
+
+// Ulid is a u128, which is not supported
+// by protobuf so instead we built it out of
+// 2 uint64 which is more efficient than a
+// bytes type.
+message Ulid {
+  uint64 low = 1;
+  uint64 high = 2;
+}
+
+enum WriteRequestKind {
+  WriteRequestKind_UNKNOWN = 0;
+  Put = 1;
+  Delete = 2;
+}
+
+message WriteRequest {
+  Ulid request_id = 1;
+  WriteRequestKind kind = 2;
+  bytes key = 3;
+  Precondition precondition = 4;
+  // value is only required if WriteRequestKind is set to PUT
+  optional VersionedValue value = 7;
+}
+
+message KvEntry {
+  bytes key = 1;
+  VersionedValue value = 2;
+}
+
+message KvSnapshot { repeated KvEntry entries = 1; }

--- a/crates/metadata-store/src/grpc/mod.rs
+++ b/crates/metadata-store/src/grpc/mod.rs
@@ -15,7 +15,9 @@ tonic::include_proto!("restate.metadata_store_svc");
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("metadata_store_svc");
 
 pub mod pb_conversions {
-    use crate::grpc::{GetResponse, GetVersionResponse, PreconditionKind};
+    use crate::grpc::{
+        GetResponse, GetVersionResponse, PreconditionKind, Ulid, WriteRequest, WriteRequestKind,
+    };
     use crate::{grpc, MetadataStoreSummary};
     use restate_core::metadata_store::{Precondition, VersionedValue};
     use restate_types::Version;
@@ -170,5 +172,108 @@ pub mod pb_conversions {
                 },
             }
         }
+    }
+
+    impl From<ulid::Ulid> for Ulid {
+        fn from(value: ulid::Ulid) -> Self {
+            Self {
+                high: (value.0 >> 64) as u64,
+                low: value.0 as u64,
+            }
+        }
+    }
+
+    impl From<Ulid> for ulid::Ulid {
+        fn from(value: Ulid) -> Self {
+            Self::from((value.high as u128) << 64 | value.low as u128)
+        }
+    }
+
+    impl From<crate::WriteRequest> for WriteRequest {
+        fn from(value: crate::WriteRequest) -> Self {
+            match value.kind {
+                crate::RequestKind::Delete { key, precondition } => Self {
+                    request_id: Some(value.request_id.into()),
+                    kind: WriteRequestKind::Delete as i32,
+                    key: key.into_bytes(),
+                    precondition: Some(precondition.into()),
+                    value: None,
+                },
+                crate::RequestKind::Put {
+                    key,
+                    value: versioned_value,
+                    precondition,
+                } => Self {
+                    request_id: Some(value.request_id.into()),
+                    key: key.into_bytes(),
+                    kind: WriteRequestKind::Put as i32,
+                    precondition: Some(precondition.into()),
+                    value: Some(versioned_value.into()),
+                },
+            }
+        }
+    }
+
+    impl TryFrom<WriteRequest> for crate::WriteRequest {
+        type Error = ConversionError;
+
+        fn try_from(value: WriteRequest) -> Result<Self, Self::Error> {
+            let request_id = value
+                .request_id
+                .ok_or_else(|| ConversionError::missing_field("request_id"))?
+                .into();
+
+            let request = match WriteRequestKind::try_from(value.kind)
+                .map_err(|_| ConversionError::invalid_data("kind"))?
+            {
+                WriteRequestKind::Delete => Self {
+                    request_id,
+                    kind: crate::RequestKind::Delete {
+                        key: value
+                            .key
+                            .try_into()
+                            .map_err(|_| ConversionError::invalid_data("key"))?,
+                        precondition: value
+                            .precondition
+                            .ok_or_else(|| ConversionError::missing_field("precondition"))?
+                            .try_into()?,
+                    },
+                },
+                WriteRequestKind::Put => Self {
+                    request_id,
+                    kind: crate::RequestKind::Put {
+                        key: value
+                            .key
+                            .try_into()
+                            .map_err(|_| ConversionError::invalid_data("key"))?,
+                        value: value
+                            .value
+                            .ok_or_else(|| ConversionError::missing_field("value"))?
+                            .try_into()?,
+                        precondition: value
+                            .precondition
+                            .ok_or_else(|| ConversionError::missing_field("precondition"))?
+                            .try_into()?,
+                    },
+                },
+                _ => return Err(ConversionError::InvalidData("kind")),
+            };
+
+            Ok(request)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Ulid;
+
+    #[test]
+    fn test_ulid_encoding() {
+        let id = ulid::Ulid::new();
+        let encoded = Ulid::from(id);
+        let decoded = ulid::Ulid::from(encoded);
+
+        assert_eq!(id, decoded);
     }
 }

--- a/crates/metadata-store/src/raft/store.rs
+++ b/crates/metadata-store/src/raft/store.rs
@@ -23,7 +23,6 @@ use crate::{
 };
 use arc_swap::ArcSwapOption;
 use bytes::BytesMut;
-use flexbuffers::{DeserializationError, SerializationError};
 use futures::future::{FusedFuture, OptionFuture};
 use futures::never::Never;
 use futures::FutureExt;
@@ -64,6 +63,8 @@ use tracing::{debug, info, instrument, trace, warn, Span};
 use tracing_slog::TracingSlogDrain;
 use ulid::Ulid;
 
+use super::kv_memory_storage::{CreateSnapshotError, RestoreSnapshotError};
+
 const RAFT_INITIAL_LOG_TERM: u64 = 1;
 const RAFT_INITIAL_LOG_INDEX: u64 = 1;
 
@@ -92,9 +93,9 @@ pub enum Error {
     #[error("failed reading/writing from/to storage: {0}")]
     Storage(#[from] storage::Error),
     #[error("failed restoring the snapshot: {0}")]
-    RestoreSnapshot(#[from] DeserializationError),
+    RestoreSnapshot(#[from] RestoreSnapshotError),
     #[error("failed creating snapshot: {0}")]
-    CreateSnapshot(#[from] SerializationError),
+    CreateSnapshot(#[from] CreateSnapshotError),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
 }


### PR DESCRIPTION
A more efficient serialization format for raft metadata store

Summary:
When applicable, use protobuf instead of flexbuffers for
message types. This include (so far):
- WriteRequest
- KvSnapshot
