### PR TITLE
Attach version and member information to Raft configuration changes 

### DIFF
--- a/crates/metadata-store/proto/metadata_store_svc.proto
+++ b/crates/metadata-store/proto/metadata_store_svc.proto
@@ -85,8 +85,8 @@ message StatusResponse {
 }
 
 message MetadataStoreConfiguration {
-  uint32 id = 1;
-  repeated MemberId members = 2;
+  restate.common.Version version = 1;
+  map<uint32, uint64> members = 2;
 }
 
 message MemberId {
@@ -136,4 +136,7 @@ message KvEntry {
   VersionedValue value = 2;
 }
 
-message KvSnapshot { repeated KvEntry entries = 1; }
+message MetadataStoreSnapshot {
+  MetadataStoreConfiguration configuration = 1;
+  repeated KvEntry entries = 2;
+}

--- a/crates/metadata-store/src/lib.rs
+++ b/crates/metadata-store/src/lib.rs
@@ -45,6 +45,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
 use tokio::sync::{mpsc, oneshot, watch};
+use tonic::codec::CompressionEncoding;
 use tonic::Status;
 use tracing::debug;
 use ulid::Ulid;
@@ -205,7 +206,9 @@ where
                 store.request_sender(),
                 store.provision_sender(),
                 store.status_watch(),
-            )),
+            ))
+            .accept_compressed(CompressionEncoding::Gzip)
+            .send_compressed(CompressionEncoding::Gzip),
             grpc::FILE_DESCRIPTOR_SET,
         );
 

--- a/crates/metadata-store/src/lib.rs
+++ b/crates/metadata-store/src/lib.rs
@@ -41,6 +41,7 @@ use restate_types::nodes_config::{
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -584,7 +585,7 @@ pub struct MemberId {
 }
 
 impl MemberId {
-    fn new(node_id: PlainNodeId, storage_id: StorageId) -> Self {
+    pub fn new(node_id: PlainNodeId, storage_id: StorageId) -> Self {
         MemberId {
             node_id,
             storage_id,
@@ -643,8 +644,18 @@ impl SnapshotSummary {
 #[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
 #[prost(target = "crate::grpc::MetadataStoreConfiguration")]
 struct MetadataStoreConfiguration {
-    id: u32,
-    members: Vec<MemberId>,
+    #[prost(required)]
+    version: Version,
+    members: HashMap<PlainNodeId, StorageId>,
+}
+
+impl Default for MetadataStoreConfiguration {
+    fn default() -> Self {
+        MetadataStoreConfiguration {
+            version: Version::INVALID,
+            members: HashMap::default(),
+        }
+    }
 }
 
 /// Ensures that the initial nodes configuration contains the current node and has the right

--- a/crates/metadata-store/src/network/networking.rs
+++ b/crates/metadata-store/src/network/networking.rs
@@ -21,6 +21,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
+use tonic::codec::CompressionEncoding;
 use tonic::metadata::MetadataValue;
 use tonic::IntoStreamingRequest;
 use tracing::{debug, trace};
@@ -152,7 +153,8 @@ where
                 let channel = net_util::create_tonic_channel(address.clone(), networking_options);
 
                 async move {
-                    let mut network_client = crate::network::grpc_svc::metadata_store_network_svc_client::MetadataStoreNetworkSvcClient::new(channel);
+                    let mut network_client = grpc_svc::metadata_store_network_svc_client::MetadataStoreNetworkSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip)
+                        .send_compressed(CompressionEncoding::Gzip);
                     let (outgoing_tx, outgoing_rx) = mpsc::channel(128);
 
                     let mut request = ReceiverStream::new(outgoing_rx).into_streaming_request();

--- a/crates/metadata-store/src/raft/mod.rs
+++ b/crates/metadata-store/src/raft/mod.rs
@@ -25,6 +25,7 @@ use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::protobuf::common::MetadataServerStatus;
 pub use store::RaftMetadataStore;
+use tonic::codec::CompressionEncoding;
 
 pub(crate) async fn create_store(
     rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
@@ -38,7 +39,9 @@ pub(crate) async fn create_store(
         MetadataStoreNetworkSvcServer::new(MetadataStoreNetworkHandler::new(
             store.connection_manager(),
             Some(store.join_cluster_handle()),
-        )),
+        ))
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(CompressionEncoding::Gzip),
         network::FILE_DESCRIPTOR_SET,
     );
 

--- a/crates/metadata-store/src/raft/store.rs
+++ b/crates/metadata-store/src/raft/store.rs
@@ -62,6 +62,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time;
 use tokio::time::MissedTickBehavior;
+use tonic::codec::CompressionEncoding;
 use tracing::{debug, info, instrument, trace, warn, Span};
 use tracing_slog::TracingSlogDrain;
 use ulid::Ulid;
@@ -1473,7 +1474,9 @@ impl Standby {
 
         let channel = create_tonic_channel(address, &Configuration::pinned().networking);
 
-        let mut client = MetadataStoreNetworkSvcClient::new(channel);
+        let mut client = MetadataStoreNetworkSvcClient::new(channel)
+            .accept_compressed(CompressionEncoding::Gzip)
+            .send_compressed(CompressionEncoding::Gzip);
 
         if let Err(status) = client
             .join_cluster(crate::network::grpc_svc::JoinClusterRequest {

--- a/crates/metadata-store/src/raft/store.rs
+++ b/crates/metadata-store/src/raft/store.rs
@@ -1113,9 +1113,12 @@ impl Member {
         let previous_version = new_nodes_configuration.version();
 
         for (node_id, node_config) in new_nodes_configuration.iter_mut() {
-            if !self.is_member_plain_node_id(node_id) {
+            if self.is_member_plain_node_id(node_id) {
+                // Should be a no-op since we currently use Member also to tell nodes to try join
+                // the cluster. This needs to change once we support removing nodes from the
+                // metadata store cluster.
                 node_config.metadata_server_config.metadata_server_state =
-                    MetadataServerState::Standby;
+                    MetadataServerState::Member;
             }
         }
 

--- a/tools/restatectl/src/commands/cluster/provision.rs
+++ b/tools/restatectl/src/commands/cluster/provision.rs
@@ -65,7 +65,9 @@ async fn cluster_provision(
         .unwrap_or_else(|| connection_info.cluster_controller.clone());
     let channel = grpc_channel(node_address.clone());
 
-    let mut client = NodeCtlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
+    let mut client = NodeCtlSvcClient::new(channel)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(CompressionEncoding::Gzip);
 
     let log_provider = provision_opts.bifrost_provider.map(|bifrost_provider| {
         extract_default_provider(


### PR DESCRIPTION
This commit adds version and member information to Raft configuration changes
so that we can check for members that have lost their disks and improve
observability.

This PR is based on #2544.