### PR TITLE
Follow up #2544

### DIFF
--- a/crates/metadata-store/src/lib.rs
+++ b/crates/metadata-store/src/lib.rs
@@ -399,7 +399,8 @@ impl WriteRequest {
     }
 
     fn decode_from_bytes(bytes: Bytes) -> Result<Self, StorageDecodeError> {
-        let result = grpc::WriteRequest::decode(bytes).unwrap();
+        let result = grpc::WriteRequest::decode(bytes)
+            .map_err(|err| StorageDecodeError::DecodeValue(err.into()))?;
         result
             .try_into()
             .map_err(|err: ConversionError| StorageDecodeError::DecodeValue(err.into()))


### PR DESCRIPTION
Follow up #2544

Summary:
Follow up to PR #2544. Avoid unrwap() when decoding a value
