### PR TITLE
Avoid unnecessary metadata read in cluster controller

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -23,7 +23,6 @@ use restate_core::{
 };
 use restate_types::cluster::cluster_state::RunMode;
 use restate_types::identifiers::PartitionId;
-use restate_types::live::Pinned;
 use restate_types::locality::LocationScope;
 use restate_types::logs::LogId;
 use restate_types::metadata_store::keys::PARTITION_TABLE_KEY;
@@ -485,11 +484,11 @@ impl<T: TransportConnect> Scheduler<T> {
 /// Placement hints for the [`logs_controller::LogsController`] based on the current
 /// [`SchedulingPlan`].
 pub struct PartitionTableNodeSetSelectorHints {
-    partition_table: Pinned<PartitionTable>,
+    partition_table: Arc<PartitionTable>,
 }
 
-impl From<Pinned<PartitionTable>> for PartitionTableNodeSetSelectorHints {
-    fn from(value: Pinned<PartitionTable>) -> Self {
+impl From<Arc<PartitionTable>> for PartitionTableNodeSetSelectorHints {
+    fn from(value: Arc<PartitionTable>) -> Self {
         Self {
             partition_table: value,
         }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -739,7 +739,7 @@ impl SealAndExtendTask {
                     &self.observed_cluster_state,
                     previous_params.as_ref(),
                     Metadata::with_current(|m| {
-                        PartitionTableNodeSetSelectorHints::from(m.partition_table_ref())
+                        PartitionTableNodeSetSelectorHints::from(m.partition_table_snapshot())
                     })
                     .preferred_sequencer(&self.log_id),
                 )

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -201,7 +201,7 @@ where
             &nodes_config,
             observed_cluster_state,
             Metadata::with_current(|m| {
-                PartitionTableNodeSetSelectorHints::from(m.partition_table_ref())
+                PartitionTableNodeSetSelectorHints::from(m.partition_table_snapshot())
             }),
         )?;
 


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2564).
* #2570
* #2566
* __->__ #2564