### PR TITLE
Move metadata types to restate_types

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -17,12 +17,13 @@ use std::time::Duration;
 use futures::never::Never;
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
+use restate_types::metadata::Precondition;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tracing::{debug, error, trace, trace_span, Instrument};
 
 use restate_bifrost::{Bifrost, Error as BifrostError};
-use restate_core::metadata_store::{Precondition, WriteError};
+use restate_core::metadata_store::WriteError;
 use restate_core::{Metadata, MetadataWriter, ShutdownError, TaskCenterFutureExt};
 use restate_types::errors::GenericError;
 use restate_types::identifiers::PartitionId;

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -13,9 +13,10 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
+use restate_types::metadata::Precondition;
 use tracing::debug;
 
-use restate_core::metadata_store::{Precondition, ReadError, ReadWriteError, WriteError};
+use restate_core::metadata_store::{ReadError, ReadWriteError, WriteError};
 use restate_core::network::{NetworkSender, Networking, Outgoing, TransportConnect};
 use restate_core::{
     cancellation_watcher, Metadata, MetadataKind, MetadataWriter, ShutdownError, SyncError,

--- a/crates/admin/src/metadata_api/mod.rs
+++ b/crates/admin/src/metadata_api/mod.rs
@@ -24,9 +24,13 @@ use axum::{
 use bytestring::ByteString;
 use http::{header::ToStrError, HeaderMap, StatusCode};
 
-use restate_core::metadata_store::{MetadataStore, VersionedValue};
-use restate_metadata_server::{MetadataStoreClient, Precondition, ReadError, WriteError};
-use restate_types::{metadata_store::keys, Version};
+use restate_core::metadata_store::MetadataStore;
+use restate_metadata_server::{MetadataStoreClient, ReadError, WriteError};
+use restate_types::{
+    metadata::{Precondition, VersionedValue},
+    metadata_store::keys,
+    Version,
+};
 
 /// ETag header.
 const HEADER_ETAG: &str = "ETag";

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -803,7 +803,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                restate_types::metadata::Precondition::MatchesVersion(old_version),
             )
             .await?;
 

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -738,7 +738,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                restate_types::metadata::Precondition::MatchesVersion(old_version),
             )
             .await?;
 
@@ -936,7 +936,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                restate_types::metadata::Precondition::MatchesVersion(old_version),
             )
             .await?;
 

--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -14,14 +14,15 @@ mod test_util;
 #[cfg(any(test, feature = "test-util"))]
 use crate::metadata_store::test_util::InMemoryMetadataStore;
 use async_trait::async_trait;
-use bytes::{Bytes, BytesMut};
+use bytes::BytesMut;
 use bytestring::ByteString;
 use restate_types::errors::GenericError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::retries::RetryPolicy;
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode, StorageEncodeError};
-use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
+use restate_types::{Version, Versioned};
 use std::future::Future;
 use std::sync::Arc;
 use tracing::{debug, trace};
@@ -76,31 +77,6 @@ impl MetadataStoreClientError for ProvisionError {
             | ProvisionError::NotSupported(_) => false,
         }
     }
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct VersionedValue {
-    pub version: Version,
-    pub value: Bytes,
-}
-
-impl VersionedValue {
-    pub fn new(version: Version, value: Bytes) -> Self {
-        Self { version, value }
-    }
-}
-
-flexbuffers_storage_encode_decode!(VersionedValue);
-
-/// Preconditions for the write operations of the [`MetadataStore`].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum Precondition {
-    /// No precondition
-    None,
-    /// Key-value pair must not exist for the write operation to succeed.
-    DoesNotExist,
-    /// Key-value pair must have the provided [`Version`] for the write operation to succeed.
-    MatchesVersion(Version),
 }
 
 /// Metadata store abstraction. The metadata store implementations need to support linearizable

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -17,6 +17,7 @@ use futures::Stream;
 use restate_types::config::NetworkingOptions;
 use restate_types::locality::NodeLocation;
 use restate_types::logs::metadata::{bootstrap_logs_metadata, ProviderKind};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY,
 };
@@ -30,7 +31,7 @@ use restate_types::partition_table::PartitionTable;
 use restate_types::protobuf::node::Message;
 use restate_types::{GenerationalNodeId, Version};
 
-use crate::metadata_store::{MetadataStoreClient, Precondition};
+use crate::metadata_store::MetadataStoreClient;
 use crate::network::{
     ConnectionManager, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder,
     NetworkError, Networking, ProtocolError, TransportConnect,

--- a/crates/metadata-server/build.rs
+++ b/crates/metadata-server/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
+        .extern_path(".restate.metadata", "::restate_types::protobuf::metadata")
         .compile_protos(
             &["./proto/metadata_server_svc.proto"],
             &["proto", "../types/protobuf"],

--- a/crates/metadata-server/proto/metadata_server_svc.proto
+++ b/crates/metadata-server/proto/metadata_server_svc.proto
@@ -11,6 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "restate/common.proto";
+import "restate/metadata.proto";
 
 package restate.metadata_server_svc;
 
@@ -39,73 +40,24 @@ message GetRequest { string key = 1; }
 
 message PutRequest {
   string key = 1;
-  VersionedValue value = 2;
-  Precondition precondition = 3;
+  restate.metadata.VersionedValue value = 2;
+  restate.metadata.Precondition precondition = 3;
 }
 
 message DeleteRequest {
   string key = 1;
-  Precondition precondition = 2;
+  restate.metadata.Precondition precondition = 2;
 }
 
-message VersionedValue {
-  Version version = 1;
-  bytes bytes = 2;
-}
+message GetResponse { optional restate.metadata.VersionedValue value = 1; }
 
-message GetResponse { optional VersionedValue value = 1; }
-
-message Version { uint32 value = 1; }
-
-message GetVersionResponse { optional Version version = 1; }
-
-enum PreconditionKind {
-  PreconditionKind_UNKNOWN = 0;
-  NONE = 1;
-  DOES_NOT_EXIST = 2;
-  MATCHES_VERSION = 3;
-}
-
-message Precondition {
-  PreconditionKind kind = 1;
-  // needs to be set in case of PreconditionKind::MATCHES_VERSION
-  optional Version version = 2;
-}
+message GetVersionResponse { optional restate.common.Version version = 1; }
 
 message ProvisionRequest { bytes nodes_configuration = 1; }
 
 message ProvisionResponse { bool newly_provisioned = 1; }
 
-message StatusResponse {
-  restate.common.MetadataServerStatus status = 1;
-  optional MetadataServerConfiguration configuration = 2;
-  optional MemberId leader = 3;
-  optional SnapshotSummary snapshot = 4;
-  optional RaftSummary raft = 5;
-}
-
-message MetadataServerConfiguration {
-  restate.common.Version version = 1;
-  map<uint32, uint64> members = 2;
-}
-
-message MemberId {
-  uint32 node_id = 1;
-  uint64 storage_id = 2;
-}
-
-message SnapshotSummary {
-  uint64 index = 1;
-  uint64 size = 2;
-}
-
-message RaftSummary {
-  uint64 term = 1;
-  uint64 applied = 2;
-  uint64 committed = 3;
-  uint64 first_index = 4;
-  uint64 last_index = 5;
-}
+message StatusResponse { restate.metadata.MetadataStoreSummary summary = 1; }
 
 // Ulid is a u128, which is not supported
 // by protobuf so instead we built it out of
@@ -126,17 +78,17 @@ message WriteRequest {
   Ulid request_id = 1;
   WriteRequestKind kind = 2;
   bytes key = 3;
-  Precondition precondition = 4;
+  restate.metadata.Precondition precondition = 4;
   // value is only required if WriteRequestKind is set to PUT
-  optional VersionedValue value = 7;
+  optional restate.metadata.VersionedValue value = 7;
 }
 
 message KvEntry {
   bytes key = 1;
-  VersionedValue value = 2;
+  restate.metadata.VersionedValue value = 2;
 }
 
 message MetadataServerSnapshot {
-  MetadataServerConfiguration configuration = 1;
+  restate.metadata.MetadataServerConfiguration configuration = 1;
   repeated KvEntry entries = 2;
 }

--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use crate::grpc::metadata_server_svc_client::MetadataServerSvcClient;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc::{DeleteRequest, GetRequest, ProvisionRequest, PutRequest};
 use crate::KnownLeader;
 use async_trait::async_trait;
@@ -18,12 +17,14 @@ use bytestring::ByteString;
 use parking_lot::Mutex;
 use rand::prelude::IteratorRandom;
 use restate_core::metadata_store::{
-    retry_on_network_error, MetadataStore, MetadataStoreClientError, Precondition, ProvisionError,
-    ReadError, VersionedValue, WriteError,
+    retry_on_network_error, MetadataStore, MetadataStoreClientError, ProvisionError, ReadError,
+    WriteError,
 };
 use restate_core::network::net_util::create_tonic_channel;
 use restate_core::{cancellation_watcher, Metadata, TaskCenter, TaskKind};
 use restate_types::config::{Configuration, MetadataStoreClientOptions};
+use restate_types::errors::ConversionError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::net::metadata::MetadataKind;
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration, Role};

--- a/crates/metadata-server/src/grpc/mod.rs
+++ b/crates/metadata-server/src/grpc/mod.rs
@@ -15,30 +15,10 @@ tonic::include_proto!("restate.metadata_server_svc");
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("metadata_server_svc");
 
 pub mod pb_conversions {
-    use crate::grpc::{
-        GetResponse, GetVersionResponse, PreconditionKind, Ulid, WriteRequest, WriteRequestKind,
-    };
-    use crate::{grpc, MetadataStoreSummary};
-    use restate_core::metadata_store::{Precondition, VersionedValue};
+    use crate::grpc::{GetResponse, GetVersionResponse, Ulid, WriteRequest, WriteRequestKind};
+    use restate_types::errors::ConversionError;
+    use restate_types::metadata::VersionedValue;
     use restate_types::Version;
-
-    #[derive(Debug, thiserror::Error)]
-    pub enum ConversionError {
-        #[error("missing field '{0}'")]
-        MissingField(&'static str),
-        #[error("invalid data '{0}'")]
-        InvalidData(&'static str),
-    }
-
-    impl ConversionError {
-        pub fn missing_field(field: &'static str) -> Self {
-            ConversionError::MissingField(field)
-        }
-
-        pub fn invalid_data(field: &'static str) -> Self {
-            ConversionError::InvalidData(field)
-        }
-    }
 
     impl TryFrom<GetResponse> for Option<VersionedValue> {
         type Error = ConversionError;
@@ -52,125 +32,9 @@ pub mod pb_conversions {
         }
     }
 
-    impl TryFrom<grpc::VersionedValue> for VersionedValue {
-        type Error = ConversionError;
-
-        fn try_from(value: grpc::VersionedValue) -> Result<Self, Self::Error> {
-            let version = value
-                .version
-                .ok_or_else(|| ConversionError::missing_field("version"))?;
-            Ok(VersionedValue::new(version.into(), value.bytes))
-        }
-    }
-
     impl From<GetVersionResponse> for Option<Version> {
         fn from(value: GetVersionResponse) -> Self {
             value.version.map(Into::into)
-        }
-    }
-
-    impl From<VersionedValue> for grpc::VersionedValue {
-        fn from(value: VersionedValue) -> Self {
-            grpc::VersionedValue {
-                version: Some(value.version.into()),
-                bytes: value.value,
-            }
-        }
-    }
-
-    impl From<grpc::Version> for Version {
-        fn from(value: grpc::Version) -> Self {
-            Version::from(value.value)
-        }
-    }
-
-    impl From<Version> for grpc::Version {
-        fn from(value: Version) -> Self {
-            grpc::Version {
-                value: value.into(),
-            }
-        }
-    }
-
-    impl From<Precondition> for grpc::Precondition {
-        fn from(value: Precondition) -> Self {
-            match value {
-                Precondition::None => grpc::Precondition {
-                    kind: PreconditionKind::None.into(),
-                    version: None,
-                },
-                Precondition::DoesNotExist => grpc::Precondition {
-                    kind: PreconditionKind::DoesNotExist.into(),
-                    version: None,
-                },
-                Precondition::MatchesVersion(version) => grpc::Precondition {
-                    kind: PreconditionKind::MatchesVersion.into(),
-                    version: Some(version.into()),
-                },
-            }
-        }
-    }
-
-    impl TryFrom<grpc::Precondition> for Precondition {
-        type Error = ConversionError;
-
-        fn try_from(value: grpc::Precondition) -> Result<Self, Self::Error> {
-            match value.kind() {
-                PreconditionKind::Unknown => {
-                    Err(ConversionError::invalid_data("unknown precondition kind"))
-                }
-                PreconditionKind::None => Ok(Precondition::None),
-                PreconditionKind::DoesNotExist => Ok(Precondition::DoesNotExist),
-                PreconditionKind::MatchesVersion => Ok(Precondition::MatchesVersion(
-                    value
-                        .version
-                        .ok_or_else(|| ConversionError::missing_field("version"))?
-                        .into(),
-                )),
-            }
-        }
-    }
-
-    impl From<MetadataStoreSummary> for grpc::StatusResponse {
-        fn from(value: MetadataStoreSummary) -> Self {
-            match value {
-                MetadataStoreSummary::Starting => grpc::StatusResponse {
-                    status: restate_types::protobuf::common::MetadataServerStatus::StartingUp
-                        .into(),
-                    configuration: None,
-                    leader: None,
-                    raft: None,
-                    snapshot: None,
-                },
-                MetadataStoreSummary::Provisioning => grpc::StatusResponse {
-                    status:
-                        restate_types::protobuf::common::MetadataServerStatus::AwaitingProvisioning
-                            .into(),
-                    configuration: None,
-                    leader: None,
-                    raft: None,
-                    snapshot: None,
-                },
-                MetadataStoreSummary::Standby => grpc::StatusResponse {
-                    status: restate_types::protobuf::common::MetadataServerStatus::Standby.into(),
-                    configuration: None,
-                    leader: None,
-                    raft: None,
-                    snapshot: None,
-                },
-                MetadataStoreSummary::Member {
-                    configuration,
-                    leader,
-                    raft,
-                    snapshot,
-                } => grpc::StatusResponse {
-                    status: restate_types::protobuf::common::MetadataServerStatus::Member.into(),
-                    configuration: Some(grpc::MetadataServerConfiguration::from(configuration)),
-                    leader: leader.map(grpc::MemberId::from),
-                    raft: Some(grpc::RaftSummary::from(raft)),
-                    snapshot: snapshot.map(grpc::SnapshotSummary::from),
-                },
-            }
         }
     }
 

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -19,21 +19,22 @@ use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
-use grpc::pb_conversions::ConversionError;
 use prost::Message;
 use raft_proto::eraftpb::Snapshot;
-use restate_core::metadata_store::VersionedValue;
 pub use restate_core::metadata_store::{
-    MetadataStoreClient, Precondition, ReadError, ReadModifyWriteError, WriteError,
+    MetadataStoreClient, ReadError, ReadModifyWriteError, WriteError,
 };
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataWriter, ShutdownError};
 use restate_types::config::{
     Configuration, MetadataStoreKind, MetadataStoreOptions, RocksDbOptions,
 };
-use restate_types::errors::GenericError;
+use restate_types::errors::{ConversionError, GenericError};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::{
+    MetadataStoreSummary, Precondition, SnapshotSummary, VersionedValue,
+};
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
@@ -41,8 +42,6 @@ use restate_types::nodes_config::{
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
-use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
 use std::future::Future;
 use tokio::sync::{mpsc, oneshot, watch};
 use tonic::codec::CompressionEncoding;
@@ -566,97 +565,15 @@ impl JoinClusterHandle {
     }
 }
 
-/// Identifier to detect the loss of a disk.
-type StorageId = u64;
-
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    Hash,
-    PartialEq,
-    serde::Serialize,
-    serde::Deserialize,
-    prost_dto::IntoProst,
-    prost_dto::FromProst,
-)]
-#[prost(target = "crate::grpc::MemberId")]
-pub struct MemberId {
-    node_id: PlainNodeId,
-    storage_id: StorageId,
+trait SnapshotSummaryExt {
+    fn from_snapshot(snapshot: &Snapshot) -> Self;
 }
 
-impl MemberId {
-    pub fn new(node_id: PlainNodeId, storage_id: StorageId) -> Self {
-        MemberId {
-            node_id,
-            storage_id,
-        }
-    }
-}
-
-impl Display for MemberId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{:x}", self.node_id, self.storage_id & 0x0ffff)
-    }
-}
-
-/// Status summary of the metadata store.
-#[derive(Clone, Debug, Default)]
-enum MetadataStoreSummary {
-    #[default]
-    Starting,
-    Provisioning,
-    Standby,
-    Member {
-        leader: Option<MemberId>,
-        configuration: MetadataServerConfiguration,
-        raft: RaftSummary,
-        snapshot: Option<SnapshotSummary>,
-    },
-}
-
-#[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
-#[prost(target = "crate::grpc::RaftSummary")]
-struct RaftSummary {
-    term: u64,
-    committed: u64,
-    applied: u64,
-    first_index: u64,
-    last_index: u64,
-}
-
-#[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
-#[prost(target = "crate::grpc::SnapshotSummary")]
-struct SnapshotSummary {
-    index: u64,
-    // size in bytes
-    size: u64,
-}
-
-impl SnapshotSummary {
+impl SnapshotSummaryExt for SnapshotSummary {
     fn from_snapshot(snapshot: &Snapshot) -> Self {
         SnapshotSummary {
             size: u64::try_from(snapshot.get_data().len()).expect("snapshot size to fit into u64"),
             index: snapshot.get_metadata().get_index(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
-#[prost(target = "crate::grpc::MetadataServerConfiguration")]
-struct MetadataServerConfiguration {
-    #[prost(required)]
-    version: Version,
-    members: HashMap<PlainNodeId, StorageId>,
-}
-
-impl Default for MetadataServerConfiguration {
-    fn default() -> Self {
-        MetadataServerConfiguration {
-            version: Version::INVALID,
-            members: HashMap::default(),
         }
     }
 }

--- a/crates/metadata-server/src/local/store.rs
+++ b/crates/metadata-server/src/local/store.rs
@@ -16,7 +16,7 @@ use bytes::BytesMut;
 use bytestring::ByteString;
 use futures::FutureExt;
 use restate_core::cancellation_watcher;
-use restate_core::metadata_store::{serialize_value, Precondition, VersionedValue};
+use restate_core::metadata_store::serialize_value;
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
@@ -24,6 +24,7 @@ use restate_rocksdb::{
 use restate_types::config::{Configuration, MetadataStoreOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration};
 use restate_types::protobuf::common::MetadataServerStatus;

--- a/crates/metadata-server/src/raft/kv_memory_storage.rs
+++ b/crates/metadata-server/src/raft/kv_memory_storage.rs
@@ -8,15 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc::MetadataServerSnapshot;
 use crate::{
     grpc, Callback, PreconditionViolation, ReadOnlyRequest, ReadOnlyRequestKind, RequestError,
     RequestKind, WriteRequest,
 };
 use bytestring::ByteString;
-use restate_core::metadata_store::{Precondition, VersionedValue};
 use restate_core::MetadataWriter;
+use restate_types::errors::ConversionError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;

--- a/crates/metadata-server/src/raft/mod.rs
+++ b/crates/metadata-server/src/raft/mod.rs
@@ -14,7 +14,7 @@ mod store;
 
 use crate::network::{MetadataServerNetworkSvcServer, MetadataStoreNetworkHandler, NetworkMessage};
 use crate::raft::store::BuildError;
-use crate::{network, MemberId, MetadataServerRunner};
+use crate::{network, MetadataServerRunner};
 use anyhow::Context;
 use bytes::{Buf, BufMut};
 use protobuf::Message as ProtobufMessage;
@@ -23,6 +23,7 @@ use restate_core::MetadataWriter;
 use restate_types::config::RocksDbOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::MemberId;
 use restate_types::protobuf::common::MetadataServerStatus;
 pub use store::RaftMetadataServer;
 use tonic::codec::CompressionEncoding;

--- a/crates/metadata-server/src/raft/storage.rs
+++ b/crates/metadata-server/src/raft/storage.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::raft::RaftConfiguration;
-use crate::{util, StorageId};
+use crate::util;
 use bytes::{BufMut, BytesMut};
 use flexbuffers::{DeserializationError, SerializationError};
 use protobuf::{Message, ProtobufError};
@@ -23,6 +23,7 @@ use restate_rocksdb::{
 use restate_types::config::{data_dir, MetadataStoreOptions, RocksDbOptions};
 use restate_types::errors::GenericError;
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::StorageId;
 use restate_types::nodes_config::NodesConfiguration;
 use rocksdb::{BoundColumnFamily, DBPinnableSlice, ReadOptions, WriteBatch, WriteOptions, DB};
 use std::array::TryFromSliceError;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -25,9 +25,7 @@ use crate::network_server::NetworkServer;
 use crate::roles::{AdminRole, BaseRole, IngressRole, WorkerRole};
 use codederror::CodedError;
 use restate_bifrost::BifrostService;
-use restate_core::metadata_store::{
-    retry_on_network_error, Precondition, ReadWriteError, WriteError,
-};
+use restate_core::metadata_store::{retry_on_network_error, ReadWriteError, WriteError};
 use restate_core::network::{
     GrpcConnector, MessageRouterBuilder, NetworkServerBuilder, Networking,
 };
@@ -46,6 +44,7 @@ use restate_types::live::Live;
 use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfiguration};
 #[cfg(feature = "replicated-loglet")]
 use restate_types::logs::RecordCache;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, PARTITION_TABLE_KEY};
 use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, NodeConfig, NodesConfiguration, Role,

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -225,7 +225,9 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
                     debug!("Failed retrieving metadata server status from '{node_id}': {err}");
                     continue;
                 }
-            };
+            }
+            .summary
+            .expect("summary must be set");
 
             if let Some(configuration) = response.configuration {
                 if let Some(max_configuration) = max_metadata_cluster_configuration {

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -116,6 +116,7 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
                 "./protobuf/restate/cluster.proto",
                 "./protobuf/restate/log_server_common.proto",
                 "./protobuf/restate/node.proto",
+                "./protobuf/restate/metadata.proto",
             ],
             &["protobuf"],
         )?;

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -316,3 +316,21 @@ pub enum ThreadJoinError {
     #[error("thread terminated unexpectedly")]
     UnexpectedTermination,
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConversionError {
+    #[error("missing field '{0}'")]
+    MissingField(&'static str),
+    #[error("invalid data '{0}'")]
+    InvalidData(&'static str),
+}
+
+impl ConversionError {
+    pub fn missing_field(field: &'static str) -> Self {
+        ConversionError::MissingField(field)
+    }
+
+    pub fn invalid_data(field: &'static str) -> Self {
+        ConversionError::InvalidData(field)
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -34,6 +34,7 @@ pub mod live;
 pub mod locality;
 pub mod logs;
 pub mod message;
+pub mod metadata;
 pub mod metadata_store;
 pub mod net;
 pub mod nodes_config;

--- a/crates/types/src/metadata.rs
+++ b/crates/types/src/metadata.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+use bytes::Bytes;
+use prost::{DecodeError, Message};
+
+use crate::errors::ConversionError;
+use crate::protobuf::common::MetadataServerStatus;
+use crate::protobuf::metadata as protobuf;
+use crate::{flexbuffers_storage_encode_decode, PlainNodeId, Version};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VersionedValue {
+    pub version: Version,
+    pub value: Bytes,
+}
+
+impl VersionedValue {
+    pub fn new(version: Version, value: Bytes) -> Self {
+        Self { version, value }
+    }
+}
+
+flexbuffers_storage_encode_decode!(VersionedValue);
+
+impl From<VersionedValue> for protobuf::VersionedValue {
+    fn from(value: VersionedValue) -> protobuf::VersionedValue {
+        protobuf::VersionedValue {
+            version: Some(value.version.into()),
+            bytes: value.value,
+        }
+    }
+}
+
+impl TryFrom<protobuf::VersionedValue> for VersionedValue {
+    type Error = ConversionError;
+
+    fn try_from(value: protobuf::VersionedValue) -> Result<Self, Self::Error> {
+        let version = value
+            .version
+            .ok_or_else(|| ConversionError::missing_field("version"))?;
+        Ok(VersionedValue::new(version.into(), value.bytes))
+    }
+}
+
+/// Preconditions for the write operations of the [`MetadataStore`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Precondition {
+    /// No precondition
+    None,
+    /// Key-value pair must not exist for the write operation to succeed.
+    DoesNotExist,
+    /// Key-value pair must have the provided [`Version`] for the write operation to succeed.
+    MatchesVersion(Version),
+}
+
+impl From<Precondition> for protobuf::Precondition {
+    fn from(value: Precondition) -> Self {
+        match value {
+            Precondition::None => protobuf::Precondition {
+                kind: protobuf::PreconditionKind::None.into(),
+                version: None,
+            },
+            Precondition::DoesNotExist => protobuf::Precondition {
+                kind: protobuf::PreconditionKind::DoesNotExist.into(),
+                version: None,
+            },
+            Precondition::MatchesVersion(version) => protobuf::Precondition {
+                kind: protobuf::PreconditionKind::MatchesVersion.into(),
+                version: Some(version.into()),
+            },
+        }
+    }
+}
+
+impl TryFrom<protobuf::Precondition> for Precondition {
+    type Error = ConversionError;
+
+    fn try_from(value: protobuf::Precondition) -> Result<Self, Self::Error> {
+        match value.kind() {
+            protobuf::PreconditionKind::Unknown => {
+                Err(ConversionError::invalid_data("unknown precondition kind"))
+            }
+            protobuf::PreconditionKind::None => Ok(Precondition::None),
+            protobuf::PreconditionKind::DoesNotExist => Ok(Precondition::DoesNotExist),
+            protobuf::PreconditionKind::MatchesVersion => Ok(Precondition::MatchesVersion(
+                value
+                    .version
+                    .ok_or_else(|| ConversionError::missing_field("version"))?
+                    .into(),
+            )),
+        }
+    }
+}
+
+/// Identifier to detect the loss of a disk.
+pub type StorageId = u64;
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    prost_dto::IntoProst,
+    prost_dto::FromProst,
+)]
+#[prost(target = "crate::protobuf::metadata::MemberId")]
+pub struct MemberId {
+    pub node_id: PlainNodeId,
+    pub storage_id: StorageId,
+}
+
+impl MemberId {
+    pub fn new(node_id: PlainNodeId, storage_id: StorageId) -> Self {
+        MemberId {
+            node_id,
+            storage_id,
+        }
+    }
+}
+
+impl Display for MemberId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{:x}", self.node_id, self.storage_id & 0x0ffff)
+    }
+}
+
+/// Status summary of the metadata store.
+#[derive(Clone, Debug, Default)]
+pub enum MetadataStoreSummary {
+    #[default]
+    Starting,
+    Provisioning,
+    Standby,
+    Member {
+        leader: Option<MemberId>,
+        configuration: MetadataServerConfiguration,
+        raft: RaftSummary,
+        snapshot: Option<SnapshotSummary>,
+    },
+}
+
+impl From<MetadataStoreSummary> for protobuf::MetadataStoreSummary {
+    fn from(value: MetadataStoreSummary) -> Self {
+        match value {
+            MetadataStoreSummary::Starting => protobuf::MetadataStoreSummary {
+                status: MetadataServerStatus::StartingUp.into(),
+                configuration: None,
+                leader: None,
+                raft: None,
+                snapshot: None,
+            },
+            MetadataStoreSummary::Provisioning => protobuf::MetadataStoreSummary {
+                status: MetadataServerStatus::AwaitingProvisioning.into(),
+                configuration: None,
+                leader: None,
+                raft: None,
+                snapshot: None,
+            },
+            MetadataStoreSummary::Standby => protobuf::MetadataStoreSummary {
+                status: MetadataServerStatus::Standby.into(),
+                configuration: None,
+                leader: None,
+                raft: None,
+                snapshot: None,
+            },
+            MetadataStoreSummary::Member {
+                configuration,
+                leader,
+                raft,
+                snapshot,
+            } => protobuf::MetadataStoreSummary {
+                status: MetadataServerStatus::Member.into(),
+                configuration: Some(protobuf::MetadataServerConfiguration::from(configuration)),
+                leader: leader.map(protobuf::MemberId::from),
+                raft: Some(protobuf::RaftSummary::from(raft)),
+                snapshot: snapshot.map(protobuf::SnapshotSummary::from),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
+#[prost(target = "crate::protobuf::metadata::RaftSummary")]
+pub struct RaftSummary {
+    pub term: u64,
+    pub committed: u64,
+    pub applied: u64,
+    pub first_index: u64,
+    pub last_index: u64,
+}
+
+#[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
+#[prost(target = "crate::protobuf::metadata::SnapshotSummary")]
+pub struct SnapshotSummary {
+    pub index: u64,
+    // size in bytes
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, prost_dto::IntoProst, prost_dto::FromProst)]
+#[prost(target = "crate::protobuf::metadata::MetadataServerConfiguration")]
+pub struct MetadataServerConfiguration {
+    #[prost(required)]
+    pub version: Version,
+    pub members: HashMap<PlainNodeId, StorageId>,
+}
+
+impl Default for MetadataServerConfiguration {
+    fn default() -> Self {
+        MetadataServerConfiguration {
+            version: Version::INVALID,
+            members: HashMap::default(),
+        }
+    }
+}
+
+impl MetadataServerConfiguration {
+    pub fn encode_to_vec(self) -> Vec<u8> {
+        protobuf::MetadataServerConfiguration::from(self).encode_to_vec()
+    }
+
+    pub fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        protobuf::MetadataServerConfiguration::decode(buf).map(Self::from)
+    }
+}

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -260,3 +260,7 @@ pub mod log_server_common {
         }
     }
 }
+
+pub mod metadata {
+    include!(concat!(env!("OUT_DIR"), "/restate.metadata.rs"));
+}

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -16,7 +16,6 @@ use googletest::internal::test_outcome::TestAssertionFailure;
 use googletest::IntoTestResult;
 
 use restate_bifrost::{loglet::Loglet, Bifrost};
-use restate_core::metadata_store::Precondition;
 use restate_core::TaskCenter;
 use restate_core::{metadata_store::MetadataStoreClient, MetadataWriter};
 use restate_local_cluster_runner::{
@@ -27,6 +26,7 @@ use restate_rocksdb::RocksDbManager;
 use restate_types::logs::builder::LogsBuilder;
 use restate_types::logs::metadata::{Chain, LogletParams, SegmentIndex};
 use restate_types::logs::LogletId;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::{
     config::Configuration,

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use codederror::CodedError;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use restate_core::task_center::TaskCenterMonitoring;
+use restate_types::metadata::Precondition;
 use tracing::trace;
 
 use bifrost_benchpress::util::{print_prometheus_stats, print_rocksdb_stats};
@@ -25,7 +26,7 @@ use restate_core::{
     TaskCenterBuilder,
 };
 use restate_errors::fmt::RestateCode;
-use restate_metadata_server::{MetadataStoreClient, Precondition};
+use restate_metadata_server::MetadataStoreClient;
 use restate_rocksdb::RocksDbManager;
 use restate_tracing_instrumentation::init_tracing_and_logging;
 use restate_types::config::{

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -12,10 +12,11 @@ use bytestring::ByteString;
 use clap::Parser;
 use cling::{Collect, Run};
 use json_patch::Patch;
+use restate_types::metadata::Precondition;
 use serde_json::Value;
 use tracing::debug;
 
-use restate_core::metadata_store::{MetadataStoreClient, Precondition};
+use restate_core::metadata_store::MetadataStoreClient;
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
 use restate_types::live::Live;

--- a/tools/restatectl/src/commands/metadata/status.rs
+++ b/tools/restatectl/src/commands/metadata/status.rs
@@ -19,7 +19,7 @@ use restate_cli_util::ui::console::StyledTable;
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::GetMetadataRequest;
 use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvcClient;
-use restate_metadata_server::MemberId;
+use restate_types::metadata::MemberId;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::{NodesConfiguration, Role};
 use restate_types::protobuf::common::MetadataServerStatus;
@@ -76,7 +76,9 @@ async fn status(connection: &ConnectionInfo) -> anyhow::Result<()> {
                     unreachable_nodes.insert(node_id, err.to_string());
                     continue;
                 }
-            };
+            }
+            .summary
+            .expect("summary must be set");
 
             metadata_nodes_table.add_row(vec![
                 Cell::new(node_id),


### PR DESCRIPTION
Move metadata types to restate_types

Summary:
Moving all common metadata types that is used over grpc
to their own module under restate_types. This will make it
possible to reuse them for other grpc service (like NodeCtlSvc)
