### PR TITLE
Fix transport connector to use the correct message limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6642,12 +6642,14 @@ dependencies = [
  "anyhow",
  "futures",
  "pin-project",
+ "pin-project-lite",
  "restate-test-util",
  "test-log",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "workspace-hack",
 ]
 

--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -104,6 +104,8 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
         cluster_state_tx: Arc<watch::Sender<Arc<ClusterState>>>,
     ) -> Result<Option<TaskHandle<anyhow::Result<()>>>, ShutdownError> {
         let refresh = async move {
+            // todo: potentially downgrade to trace()...
+            debug!("Refreshing cluster state");
             let last_state = Arc::clone(&cluster_state_tx.borrow());
             let metadata = Metadata::current();
             // make sure we have a partition table that equals or newer than last refresh
@@ -217,6 +219,8 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             };
 
             // publish the new state
+            // todo: potentially downgrade to trace!
+            debug!("New cluster state is acquired, publishing");
             cluster_state_tx.send(Arc::new(state))?;
             Ok(())
         };

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -19,13 +19,14 @@ use rand::prelude::IteratorRandom;
 use rand::thread_rng;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
-use tracing::{debug, error, info, trace, trace_span, Instrument};
+use tracing::{debug, error, info, trace_span, Instrument};
 
 use restate_bifrost::{Bifrost, Error as BifrostError};
 use restate_core::metadata_store::{Precondition, WriteError};
 use restate_core::{
     Metadata, MetadataKind, MetadataWriter, ShutdownError, TargetVersion, TaskCenterFutureExt,
 };
+use restate_futures_util::overdue::OverdueLoggingExt;
 use restate_types::errors::GenericError;
 use restate_types::identifiers::PartitionId;
 use restate_types::live::Pinned;
@@ -141,6 +142,12 @@ impl LogState {
                         segment_index: segment_index_to_seal,
                         seal_lsn,
                     }
+                } else {
+                    debug!(
+                        "Ignoring sealing because out state is at segment {} while the seal is for segment {}. Current state is LogState::Available, we are not transitioning to LogState::Sealed",
+                        segment_index,
+                        segment_index_to_seal,
+                    );
                 }
             }
             LogState::Sealing {
@@ -156,6 +163,12 @@ impl LogState {
                         segment_index: segment_index_to_seal,
                         seal_lsn,
                     }
+                } else {
+                    debug!(
+                        "Ignoring sealing because out state is at segment {} while the seal is for segment {}. Current state is LogState::Sealing",
+                        segment_index,
+                        segment_index_to_seal,
+                    );
                 }
             }
             LogState::Sealed { .. } => {}
@@ -1077,7 +1090,7 @@ impl LogsController {
             for (log_id, chain) in logs.iter() {
                 let tail_segment = chain.tail();
 
-                let writable_loglet = match bifrost.admin().writeable_loglet(*log_id).await {
+                let writeable_loglet = match bifrost.admin().writeable_loglet(*log_id).await {
                     Ok(loglet) => loglet,
                     Err(BifrostError::Shutdown(_)) => break,
                     Err(err) => {
@@ -1086,25 +1099,26 @@ impl LogsController {
                     }
                 };
 
-                if writable_loglet.segment_index() != tail_segment.index() {
+                if writeable_loglet.segment_index() != tail_segment.index() {
                     // writable segment in bifrost is probably ahead of our snapshot.
                     // then there is probably a new metadata update that will fix this
                     // for now we just ignore this segment
-                    trace!(%log_id, segment_index=%tail_segment.index(), "Segment is not tail segment, skip finding tail");
+                    debug!(%log_id, segment_index=%tail_segment.index(), "Segment is not tail segment, skip finding tail");
                     continue;
                 }
 
-                let found_tail = match writable_loglet.find_tail().await {
+                debug!(%log_id, segment_index=%writeable_loglet.segment_index(), "Attempting to find tail for loglet");
+                let found_tail = match writeable_loglet.find_tail().await {
                     Ok(tail) => tail,
                     Err(err) => {
-                        debug!(error=%err, %log_id, segment_index=%tail_segment.index(), "Failed to find tail for loglet");
+                        debug!(error=%err, %log_id, segment_index=%writeable_loglet.segment_index(), "Failed to find tail for loglet");
                         continue;
                     }
                 };
 
                 // send message
                 let update = LogTailUpdate {
-                    segment_index: writable_loglet.segment_index(),
+                    segment_index: writeable_loglet.segment_index(),
                     tail: found_tail,
                 };
 
@@ -1118,6 +1132,12 @@ impl LogsController {
 
         self.async_operations.spawn(
             find_tail
+                .log_slow_after(
+                    Duration::from_secs(3),
+                    tracing::Level::INFO,
+                    "Determining the tail status for all logs",
+                )
+                .with_overdue(Duration::from_secs(30), tracing::Level::WARN)
                 .instrument(trace_span!("scheduled-find-tail"))
                 .in_current_tc(),
         );
@@ -1204,7 +1224,7 @@ impl LogsController {
                 {
                     return match err {
                         WriteError::FailedPrecondition(err) => {
-                            debug!(
+                            info!(
                                 %err,
                                 "Detected a concurrent modification of the log chain. Fetching latest"
                             );
@@ -1241,26 +1261,26 @@ impl LogsController {
 
         self.async_operations.spawn(
             async move {
+                let start = tokio::time::Instant::now();
                 if let Some(debounce) = &mut debounce {
                     let delay = debounce.next().unwrap_or(FALLBACK_MAX_RETRY_DELAY);
-                    debug!(?delay, %log_id, %segment_index, "Wait before attempting to seal log");
+                    debug!(?delay, %log_id, %segment_index, "Wait before attempting to seal loglet");
                     tokio::time::sleep(delay).await;
                 }
 
                 match bifrost.admin().seal(log_id, segment_index).await {
                     Ok(sealed_segment) => {
-                        if sealed_segment.tail.is_sealed() {
-                            Event::SealSucceeded {
-                                log_id,
-                                segment_index,
-                                seal_lsn: sealed_segment.tail.offset(),
-                            }
-                        } else {
-                            Event::SealFailed {
-                                log_id,
-                                segment_index,
-                                debounce,
-                            }
+                        debug!(
+                            %log_id,
+                            %segment_index,
+                            "Loglet has been sealed in {:?}, stable tail is {}",
+                            start.elapsed(),
+                            sealed_segment.tail.offset(),
+                        );
+                        Event::SealSucceeded {
+                            log_id,
+                            segment_index,
+                            seal_lsn: sealed_segment.tail.offset(),
                         }
                     }
                     Err(err) => {

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -10,10 +10,11 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
-use tracing::debug;
+use tracing::{debug, info};
 
 use restate_core::metadata_store::{Precondition, ReadError, ReadWriteError, WriteError};
 use restate_core::network::{NetworkSender, Networking, Outgoing, TransportConnect};
@@ -21,6 +22,7 @@ use restate_core::{
     cancellation_watcher, Metadata, MetadataKind, MetadataWriter, ShutdownError, SyncError,
     TargetVersion, TaskCenter, TaskHandle, TaskKind,
 };
+use restate_futures_util::overdue::OverdueLoggingExt;
 use restate_types::cluster::cluster_state::RunMode;
 use restate_types::identifiers::PartitionId;
 use restate_types::locality::LocationScope;
@@ -133,7 +135,6 @@ impl<T: TransportConnect> Scheduler<T> {
             // we need to wait until both partitions and logs are created
             return Ok(());
         }
-
         let version = partition_table.version();
 
         // todo(azmy): avoid cloning the partition table every time by keeping
@@ -156,7 +157,10 @@ impl<T: TransportConnect> Scheduler<T> {
         });
 
         if let Some(partition_table) = builder.build_if_modified() {
-            debug!("Updated partition table placement: {partition_table:?}");
+            debug!(
+                "Will attempt to write partition table {} to metadata store",
+                partition_table.version()
+            );
             self.try_update_partition_table(version, partition_table)
                 .await?;
 
@@ -179,27 +183,50 @@ impl<T: TransportConnect> Scheduler<T> {
                 &partition_table,
                 Precondition::MatchesVersion(version),
             )
+            .log_slow_after(
+                Duration::from_secs(1),
+                tracing::Level::DEBUG,
+                format!("Updating partition table to version {version}"),
+            )
+            .with_overdue(Duration::from_secs(3), tracing::Level::INFO)
             .await
         {
-            Ok(_) => {}
-            Err(WriteError::FailedPrecondition(msg)) => {
-                debug!("Partition table update failed due to: {msg}");
-                // There is no need to wait for the partition table
-                // to synchronize. The update_partition_placement will
-                // get called again anyway once the partition table is updated.
-                self.sync_partition_table()?;
+            Ok(_) => {
+                debug!(
+                    "Partition table {} has been written to metadata store",
+                    partition_table.version()
+                );
+            }
+            Err(WriteError::FailedPrecondition(err)) => {
+                info!(
+                    err,
+                    "Write partition table to metadata store was rejected due to version conflict, \
+                        this is benign unless it's happening repeatedly. In such case, we might be in \
+                        a tight race with another admin node"
+                );
+                // There is no need to wait for the partition table to synchronize.
+                // The update_partition_placement will get called again anyway once
+                // the partition table is updated.
+                self.sync_partition_table(partition_table.version().next())?;
             }
             Err(err) => return Err(err.into()),
         }
 
+        let new_version = partition_table.version();
         self.metadata_writer
             .update(Arc::new(partition_table))
+            .log_slow_after(
+                Duration::from_millis(100),
+                tracing::Level::DEBUG,
+                format!("Updating partition table in metadata manager to {new_version}."),
+            )
+            .with_overdue(Duration::from_secs(2), tracing::Level::INFO)
             .await?;
         Ok(())
     }
 
     /// Synchronize partition table asynchronously
-    fn sync_partition_table(&mut self) -> Result<(), Error> {
+    fn sync_partition_table(&mut self, next_version: Version) -> Result<(), Error> {
         if self
             .inflight_sync_task
             .as_ref()
@@ -211,11 +238,11 @@ impl<T: TransportConnect> Scheduler<T> {
         let task = TaskCenter::spawn_unmanaged(
             TaskKind::Disposable,
             "scheduler-sync-partition-table",
-            async {
+            async move {
                 let cancelled = cancellation_watcher();
                 let metadata = Metadata::current();
                 tokio::select! {
-                    result = metadata.sync(MetadataKind::PartitionTable, TargetVersion::Latest) => {
+                    result = metadata.sync(MetadataKind::PartitionTable, TargetVersion::Version(next_version)) => {
                         if let Err(err) = result {
                             debug!("Failed to sync partition table metadata: {err}");
                         }

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -77,7 +77,9 @@ impl TransportConnect for GrpcConnector {
         };
 
         // Establish the connection
-        let mut client = CoreNodeSvcClient::new(channel);
+        let mut client = CoreNodeSvcClient::new(channel)
+            .max_decoding_message_size(32 * 1024 * 1024)
+            .max_encoding_message_size(32 * 1024 * 1024);
         let incoming = client.create_connection(output_stream).await?.into_inner();
         Ok(incoming.map(|x| x.map_err(ProtocolError::from)))
     }

--- a/crates/futures-util/Cargo.toml
+++ b/crates/futures-util/Cargo.toml
@@ -13,8 +13,10 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 anyhow = { workspace = true }
 futures = { workspace = true }
 pin-project = { workspace = true }
+pin-project-lite = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 restate-test-util = { workspace = true }
@@ -22,3 +24,4 @@ restate-test-util = { workspace = true }
 test-log = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-test = { workspace = true }

--- a/crates/futures-util/src/lib.rs
+++ b/crates/futures-util/src/lib.rs
@@ -9,4 +9,5 @@
 // by the Apache License, Version 2.0.
 
 pub mod command;
+pub mod overdue;
 pub mod pipe;

--- a/crates/futures-util/src/overdue.rs
+++ b/crates/futures-util/src/overdue.rs
@@ -1,0 +1,339 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Display;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+use std::time::Duration;
+
+use pin_project_lite::pin_project;
+use tokio::time::{Instant, Sleep};
+use tracing::{debug, error, info, trace, warn, Level};
+
+const MAX_REPEAT_DURATION: Duration = const { Duration::from_secs(30) };
+
+/// Adds the ability to override task-center for a future and all its children
+pub trait OverdueLoggingExt: Future + Sized {
+    /// Logs a message at the given level if the future takes longer than the given duration after
+    /// its creation. After the first log, it repeats logging with exponential backoff duration
+    /// clamped at 30 seconds.
+    fn log_slow_after<M>(
+        self,
+        after: Duration,
+        level: Level,
+        message: M,
+    ) -> WithOverdueLogging<Self, M>
+    where
+        M: Display + Send + Sync + 'static,
+    {
+        WithOverdueLogging {
+            future: self,
+            slow_level: level,
+            overdue_level: level,
+            repeat_duration_iter: ExponentialBackoff::new(after),
+            overdue_after: None,
+            is_already_overdue: false,
+            started_at: Instant::now(),
+            has_logged: false,
+            delay: tokio::time::sleep_until(Instant::now() + after),
+            message,
+        }
+    }
+}
+
+struct ExponentialBackoff {
+    current: Duration,
+}
+
+impl ExponentialBackoff {
+    /// Create a new ExponentialBackoff iterator with the given start, max, and factor.
+    fn new(start: Duration) -> Self {
+        ExponentialBackoff { current: start }
+    }
+
+    fn advance(&mut self) {
+        // Attempt to multiply by factor=2; clamp at `MAX_DURATION`
+        self.current = self
+            .current
+            .saturating_mul(2)
+            .clamp(self.current, MAX_REPEAT_DURATION);
+    }
+}
+
+impl<F: Future> OverdueLoggingExt for F {}
+
+pin_project! {
+    pub struct WithOverdueLogging<F, M> {
+        #[pin]
+        future: F,
+        slow_level: Level,
+        started_at: Instant,
+        repeat_duration_iter:ExponentialBackoff,
+
+        overdue_level: Level,
+        overdue_after: Option<Duration>,
+        is_already_overdue: bool,
+        has_logged: bool,
+
+        #[pin]
+        delay: Sleep,
+        message: M,
+    }
+}
+
+impl<F, M> WithOverdueLogging<F, M>
+where
+    F: Future,
+    M: Display + Send + Sync + 'static,
+{
+    /// Marks this future as overdue and logs at `level` from this point onwards.
+    /// Panics if duration is smaller that the slow logging duration
+    pub fn with_overdue(mut self, duration: Duration, level: Level) -> Self {
+        assert!(
+            duration >= self.repeat_duration_iter.current,
+            "log_overdue_after accepts durations that are >= initial slow duration"
+        );
+        self.overdue_after = Some(duration);
+        self.overdue_level = level;
+        self
+    }
+}
+
+impl<F: Future, M> Future for WithOverdueLogging<F, M>
+where
+    M: Display + Send + Sync + 'static,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // projecting so we can operate on futures that are not Unpinned.
+        let mut this = self.project();
+
+        let mut should_log = false;
+        // fixing (now) as one time reference that everything is calculated from to avoid drifts.
+        let now = Instant::now();
+        // Check how long we've been waiting so far.
+        let elapsed_since_start = now.saturating_duration_since(*this.started_at);
+        let (mut level, mut label) = if *this.is_already_overdue {
+            (*this.overdue_level, "overdue")
+        } else {
+            (*this.slow_level, "slow")
+        };
+
+        // are we overdue and we haven't logged overdue yet?
+        if !*this.is_already_overdue
+            && this
+                .overdue_after
+                .is_some_and(|overdue| elapsed_since_start >= overdue)
+        {
+            level = *this.overdue_level;
+            label = "overdue";
+            should_log = true;
+            *this.is_already_overdue = true;
+            this.delay
+                .as_mut()
+                .reset(now + this.repeat_duration_iter.current);
+        }
+
+        // Are we slow? If yes, should we log again?
+        if this.delay.is_elapsed() || should_log {
+            *this.has_logged = true;
+            log_message(this.message, level, elapsed_since_start, label);
+        }
+
+        // Forward the poll to the underlying pinned future.
+        match this.future.poll(cx) {
+            Poll::Ready(res) if *this.has_logged => {
+                // if we have logged, we should also say that we completed
+                // Note that we log at the last level used (i.e. overdue's level) if we are already
+                // overdue. This is to ensure that we have symmetry in logging. If we logged on a WARN
+                // level that an operation is overdue, we'd also want to see that the operation has
+                // been completed on the same level, otherwise we may never know that it did.
+                log_completion(this.message, level, elapsed_since_start);
+                return Poll::Ready(res);
+            }
+            Poll::Ready(res) => {
+                return Poll::Ready(res);
+            }
+            Poll::Pending => {}
+        }
+
+        // Wait for the delay
+        ready!(this.delay.as_mut().poll(cx));
+
+        this.repeat_duration_iter.advance();
+        let normal_next_point = now + this.repeat_duration_iter.current;
+        let new_deadline = if !*this.is_already_overdue && this.overdue_after.is_some() {
+            let overdue_at = now
+                + this
+                    .overdue_after
+                    .unwrap()
+                    .saturating_sub(elapsed_since_start);
+            // rationale here is, if we are already at the overdue point, we should have printed
+            // the overdue message above and is_already_overdue should be true.
+            // everything is calculated from a fixed `now` to make checks like these possible.
+            debug_assert!(overdue_at > now);
+            std::cmp::min(overdue_at, normal_next_point)
+        } else {
+            // we are overdue already
+            normal_next_point
+        };
+        this.delay.as_mut().reset(new_deadline);
+        // to make sure we register the waker
+        let r = this.delay.poll(cx);
+        assert!(r.is_pending());
+        Poll::Pending
+    }
+}
+
+fn log_message<M: Display>(message: &M, level: Level, elapsed: Duration, label: &str) {
+    match level {
+        Level::ERROR => error!(?elapsed, "[{label}] {message}"),
+        Level::WARN => warn!(?elapsed, "[{label}] {message}"),
+        Level::INFO => info!(?elapsed, "[{label}] {message}"),
+        Level::DEBUG => debug!(?elapsed, "[{label}] {message}"),
+        Level::TRACE => trace!(?elapsed, "[{label}] {message}"),
+    }
+}
+
+fn log_completion<M: Display>(message: &M, level: Level, elapsed: Duration) {
+    match level {
+        Level::ERROR => error!(?elapsed, "[completed] {message}"),
+        Level::WARN => warn!(?elapsed, "[completed] {message}"),
+        Level::INFO => info!(?elapsed, "[completed] {message}"),
+        Level::DEBUG => debug!(?elapsed, "[completed] {message}"),
+        Level::TRACE => trace!(?elapsed, "[completed] {message}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use tracing_test::traced_test;
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn no_log_slow() {
+        let future = tokio::time::sleep(Duration::from_millis(500)).log_slow_after(
+            Duration::from_secs(2),
+            Level::DEBUG,
+            "false op",
+        );
+        future.await;
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains("sleep operation"))
+                .count()
+            {
+                0 => Ok(()),
+                n => Err(format!("Expected no matching logs, but found {}", n)),
+            }
+        });
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn log_slow() {
+        let future = tokio::time::sleep(Duration::from_secs(2)).log_slow_after(
+            Duration::from_millis(500),
+            Level::DEBUG,
+            "sleep operation",
+        );
+        future.await;
+        logs_contain("[slow] sleep operation elapsed=500s");
+        logs_contain("[slow] sleep operation elapsed=1.5s");
+        logs_contain("[completed] sleep operation elapsed=2s");
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains("sleep operation"))
+                .count()
+            {
+                3 => Ok(()),
+                n => Err(format!("Expected 3 matching logs, but found {}", n)),
+            }
+        });
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn log_overdue_dedup() {
+        // 10 seconds of total sleep
+        let future = tokio::time::sleep(Duration::from_secs(10))
+            .log_slow_after(Duration::from_millis(500), Level::DEBUG, "sleep operation")
+            .with_overdue(Duration::from_millis(3200), Level::WARN);
+        future.await;
+
+        assert!(logs_contain("[slow] sleep operation elapsed=500ms"));
+        // 1s later
+        assert!(logs_contain("[slow] sleep operation elapsed=1.5s"));
+        // 3.2 (the overdue point) is closer than 1.5+2=3.5, so we should see overdue sooner than 4.5 elapsed time
+        assert!(logs_contain("[overdue] sleep operation elapsed=3.2s"));
+        // we use the next (unused) duration from the previous run (2s)
+        // we expect that 3.2s+2s = 5.2s is our next notification point
+        assert!(logs_contain("[overdue] sleep operation elapsed=5.2s"));
+        // back to normal, next point is 4s after 5.2s = 9.2s
+        assert!(logs_contain("[overdue] sleep operation elapsed=9.2s"));
+        // operation finishes before the next tick which is after 8s (9.2+8=17.2s)
+        assert!(logs_contain("[completed] sleep operation elapsed=10s"));
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains("sleep operation"))
+                .count()
+            {
+                6 => Ok(()),
+                n => Err(format!("Expected 6 matching logs, but found {}", n)),
+            }
+        });
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn log_overdue_normal() {
+        // 5 minutes sleep
+        let future = async {
+            tokio::time::sleep(Duration::from_millis(35900)).await;
+        }
+        .log_slow_after(Duration::from_millis(500), Level::DEBUG, "sleep operation")
+        .with_overdue(Duration::from_secs(10), Level::WARN);
+
+        future.await;
+        logs_contain("[slow] sleep operation elapsed=500ms");
+        // 1s
+        logs_contain("[slow] sleep operation elapsed=1.5s");
+        // 2s
+        logs_contain("[slow] sleep operation elapsed=3.5s");
+        // 4s
+        logs_contain("[slow] sleep operation elapsed=7.5s");
+        // over due at 10s
+        logs_contain("[overdue] sleep operation elapsed=10s");
+        // 8s
+        logs_contain("[overdue] sleep operation elapsed=18s");
+        // 16s
+        logs_contain("[overdue] sleep operation elapsed=34s");
+        logs_contain("[completed] sleep operation elapsed=35.9s");
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains("sleep operation"))
+                .count()
+            {
+                8 => Ok(()),
+                n => Err(format!("Expected 8 matching logs, but found {}", n)),
+            }
+        });
+    }
+}

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -35,7 +35,6 @@ use crate::time::MillisSinceEpoch;
 
 /// Identifying the leader epoch of a partition processor
 #[derive(
-    Debug,
     PartialEq,
     Eq,
     Ord,
@@ -46,10 +45,12 @@ use crate::time::MillisSinceEpoch;
     derive_more::From,
     derive_more::Into,
     derive_more::Display,
+    derive_more::Debug,
     serde::Serialize,
     serde::Deserialize,
 )]
 #[display("e{}", _0)]
+#[debug("e{}", _0)]
 pub struct LeaderEpoch(u64);
 impl LeaderEpoch {
     pub const INITIAL: Self = Self(1);
@@ -82,7 +83,6 @@ impl From<LeaderEpoch> for crate::protobuf::common::LeaderEpoch {
 #[derive(
     Copy,
     Clone,
-    Debug,
     PartialEq,
     Eq,
     Hash,
@@ -93,12 +93,14 @@ impl From<LeaderEpoch> for crate::protobuf::common::LeaderEpoch {
     derive_more::Into,
     derive_more::Add,
     derive_more::Display,
+    derive_more::Debug,
     derive_more::FromStr,
     serde::Serialize,
     serde::Deserialize,
 )]
 #[repr(transparent)]
 #[serde(transparent)]
+#[debug("{}", _0)]
 pub struct PartitionId(u16);
 
 impl From<PartitionId> for u32 {

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -37,16 +37,17 @@ use crate::{flexbuffers_storage_encode_decode, Version, Versioned};
     PartialEq,
     Ord,
     PartialOrd,
-    Debug,
     Hash,
     Serialize,
     Deserialize,
     derive_more::From,
     derive_more::Into,
     derive_more::Display,
+    derive_more::Debug,
 )]
 #[repr(transparent)]
 #[serde(transparent)]
+#[debug("{}", _0)]
 pub struct SegmentIndex(pub(crate) u32);
 
 impl SegmentIndex {
@@ -218,11 +219,12 @@ pub struct LogsConfiguration {
     pub default_provider: ProviderConfiguration,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(try_from = "LogsSerde", into = "LogsSerde")]
 pub struct Logs {
     pub(super) version: Version,
     pub(super) logs: HashMap<LogId, Chain>,
+    #[debug(skip)]
     pub(super) lookup_index: LookupIndex,
     pub(super) config: LogsConfiguration,
 }

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -29,7 +29,6 @@ pub use record_cache::RecordCache;
 pub use tail::*;
 
 #[derive(
-    Debug,
     Clone,
     Copy,
     Eq,
@@ -37,12 +36,14 @@ pub use tail::*;
     Hash,
     Ord,
     PartialOrd,
+    derive_more::Debug,
     derive_more::Display,
     derive_more::From,
     derive_more::Into,
     Serialize,
     Deserialize,
 )]
+#[debug("{}", _0)]
 pub struct LogId(u32);
 
 impl LogId {

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -20,7 +20,6 @@ use bytes::{Buf, BufMut, BytesMut};
 /// must be also generational and the generations must match. If you are only interested in
 /// checking the id part, then compare using `x.id() == y.id()` instead of `x == y`.
 #[derive(
-    Debug,
     PartialEq,
     Eq,
     Clone,
@@ -28,6 +27,7 @@ use bytes::{Buf, BufMut, BytesMut};
     Hash,
     derive_more::From,
     derive_more::Display,
+    derive_more::Debug,
     derive_more::IsVariant,
     serde::Serialize,
     serde::Deserialize,
@@ -38,7 +38,6 @@ pub enum NodeId {
 }
 
 #[derive(
-    Debug,
     PartialEq,
     Eq,
     PartialOrd,
@@ -48,10 +47,12 @@ pub enum NodeId {
     Hash,
     derive_more::From,
     derive_more::Display,
+    derive_more::Debug,
     serde::Serialize,
     serde::Deserialize,
 )]
 #[display("{}:{}", _0, _1)]
+#[debug("{}:{}", _0, _1)]
 pub struct GenerationalNodeId(PlainNodeId, u32);
 
 #[derive(Debug, thiserror::Error)]
@@ -120,7 +121,6 @@ impl From<u64> for GenerationalNodeId {
 }
 
 #[derive(
-    Debug,
     Default,
     PartialEq,
     Eq,
@@ -132,12 +132,14 @@ impl From<u64> for GenerationalNodeId {
     derive_more::From,
     derive_more::Into,
     derive_more::Display,
+    derive_more::Debug,
     serde::Serialize,
     serde::Deserialize,
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(transparent))]
 #[display("N{}", _0)]
+#[debug("N{}", _0)]
 pub struct PlainNodeId(u32);
 
 impl FromStr for PlainNodeId {

--- a/crates/types/src/replication/replication_property.rs
+++ b/crates/types/src/replication/replication_property.rs
@@ -34,7 +34,7 @@ static REPLICATION_PROPERTY_EXTRACTOR: LazyLock<Regex> = LazyLock::new(|| {
 pub struct ReplicationPropertyError(String);
 
 /// The replication policy for appends
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Eq, PartialEq)]
 pub struct ReplicationProperty(BTreeMap<LocationScope, u8>);
 
 impl ReplicationProperty {
@@ -148,6 +148,12 @@ impl ReplicationProperty {
             .0;
         debug_assert!(scope < LocationScope::Root);
         scope
+    }
+}
+
+impl std::fmt::Debug for ReplicationProperty {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -10,7 +10,6 @@
 
 /// A type used for versioned metadata.
 #[derive(
-    Debug,
     Clone,
     Copy,
     PartialEq,
@@ -20,11 +19,13 @@
     derive_more::Display,
     derive_more::From,
     derive_more::Into,
+    derive_more::Debug,
     derive_more::AddAssign,
     serde::Serialize,
     serde::Deserialize,
 )]
 #[display("v{}", _0)]
+#[debug("v{}", _0)]
 pub struct Version(u32);
 
 impl Version {


### PR DESCRIPTION

We currently set the networking server encode/decode limit to 32MiB, this sets the same for client channels.
A future change might make this a constant somewhere.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2580).
* __->__ #2580
* #2579
* #2570
* #2577