### PR TITLE
Classify Unknown statuses as retryable 

### DIFF
--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use tracing::{debug, info, instrument};
 
-use restate_core::metadata_store::retry_on_network_error;
+use restate_core::metadata_store::retry_on_retryable_error;
 use restate_core::{Metadata, MetadataKind};
 use restate_types::config::Configuration;
 use restate_types::logs::metadata::{Chain, LogletParams, Logs, ProviderKind, SegmentIndex};
@@ -222,7 +222,7 @@ impl<'a> BifrostAdmin<'a> {
             .common
             .network_error_retry_policy
             .clone();
-        let logs = retry_on_network_error(retry_policy, || {
+        let logs = retry_on_retryable_error(retry_policy, || {
             self.inner
                 .metadata_writer
                 .metadata_store_client()
@@ -267,7 +267,7 @@ impl<'a> BifrostAdmin<'a> {
             .common
             .network_error_retry_policy
             .clone();
-        let logs = retry_on_network_error(retry_policy, || {
+        let logs = retry_on_retryable_error(retry_policy, || {
             self.inner
                 .metadata_writer
                 .metadata_store_client()
@@ -301,7 +301,7 @@ impl<'a> BifrostAdmin<'a> {
             .network_error_retry_policy
             .clone();
 
-        let logs = retry_on_network_error(retry_policy, || {
+        let logs = retry_on_retryable_error(retry_policy, || {
             self.inner
                 .metadata_writer
                 .metadata_store_client()

--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -27,9 +27,9 @@ use crate::network::net_util::CommonClientConnectionOptions;
 impl From<EtcdError> for ReadError {
     fn from(value: EtcdError) -> Self {
         match value {
-            err @ EtcdError::IoError(_) => Self::Network(err.into()),
-            err @ EtcdError::TransportError(_) => Self::Network(err.into()),
-            any => Self::Store(any.into()),
+            err @ EtcdError::IoError(_) => Self::retryable(err),
+            err @ EtcdError::TransportError(_) => Self::retryable(err),
+            any => Self::terminal(any),
         }
     }
 }
@@ -37,9 +37,9 @@ impl From<EtcdError> for ReadError {
 impl From<EtcdError> for WriteError {
     fn from(value: EtcdError) -> Self {
         match value {
-            err @ EtcdError::IoError(_) => Self::Network(err.into()),
-            err @ EtcdError::TransportError(_) => Self::Network(err.into()),
-            any => Self::Store(any.into()),
+            err @ EtcdError::IoError(_) => Self::retryable(err),
+            err @ EtcdError::TransportError(_) => Self::retryable(err),
+            any => Self::terminal(any),
         }
     }
 }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -182,7 +182,7 @@ impl Node {
         let mut nodes = Vec::with_capacity(usize::try_from(size).expect("u32 to fit into usize"));
 
         base_config.common.allow_bootstrap = false;
-        base_config.metadata_store.kind = MetadataStoreKind::Raft;
+        base_config.metadata_server.kind = MetadataStoreKind::Raft;
 
         for node_id in 1..=size {
             let mut effective_config = base_config.clone();

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -18,7 +18,7 @@ use restate_core::network::net_util::create_tonic_channel;
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest as ProtoProvisionClusterRequest;
 use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvcClient;
-use restate_types::config::MetadataStoreKind;
+use restate_types::config::{MetadataServerKind, RaftOptions};
 use restate_types::logs::metadata::ProviderConfiguration;
 use restate_types::partition_table::PartitionReplication;
 use restate_types::protobuf::common::MetadataServerStatus;
@@ -182,7 +182,7 @@ impl Node {
         let mut nodes = Vec::with_capacity(usize::try_from(size).expect("u32 to fit into usize"));
 
         base_config.common.allow_bootstrap = false;
-        base_config.metadata_server.kind = MetadataStoreKind::Raft;
+        base_config.metadata_server.kind = MetadataServerKind::Raft(RaftOptions::default());
 
         for node_id in 1..=size {
             let mut effective_config = base_config.clone();

--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -288,14 +288,16 @@ struct NoKnownMetadataServer;
 
 fn map_status_to_read_error(status: Status) -> ReadError {
     match &status.code() {
-        Code::Unavailable => ReadError::retryable(status),
+        // Transport errors manifest as unknown statuses, hence mark them as retryable
+        Code::Unavailable | Code::Unknown => ReadError::retryable(status),
         _ => ReadError::terminal(status),
     }
 }
 
 fn map_status_to_write_error(status: Status) -> WriteError {
     match &status.code() {
-        Code::Unavailable => WriteError::retryable(status),
+        // Transport errors manifest as unknown statuses, hence mark them as retryable
+        Code::Unavailable | Code::Unknown => WriteError::retryable(status),
         Code::FailedPrecondition => WriteError::FailedPrecondition(status.message().to_string()),
         _ => WriteError::terminal(status),
     }
@@ -303,7 +305,8 @@ fn map_status_to_write_error(status: Status) -> WriteError {
 
 fn map_status_to_provision_error(status: Status) -> ProvisionError {
     match &status.code() {
-        Code::Unavailable => ProvisionError::retryable(status),
+        // Transport errors manifest as unknown statuses, hence mark them as retryable
+        Code::Unavailable | Code::Unknown => ProvisionError::retryable(status),
         _ => ProvisionError::terminal(status),
     }
 }

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -29,7 +29,7 @@ pub use restate_core::metadata_store::{
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataWriter, ShutdownError};
 use restate_types::config::{
-    Configuration, MetadataServerOptions, MetadataStoreKind, RocksDbOptions,
+    Configuration, MetadataServerKind, MetadataServerOptions, RocksDbOptions,
 };
 use restate_types::errors::GenericError;
 use restate_types::health::HealthStatus;
@@ -238,7 +238,7 @@ pub async fn create_metadata_server(
     server_builder: &mut NetworkServerBuilder,
 ) -> anyhow::Result<BoxedMetadataStoreService> {
     match metadata_server_options.kind {
-        MetadataStoreKind::Local => local::create_server(
+        MetadataServerKind::Local => local::create_server(
             metadata_server_options,
             rocksdb_options,
             health_status,
@@ -247,7 +247,7 @@ pub async fn create_metadata_server(
         .await
         .map_err(anyhow::Error::from)
         .map(|store| store.boxed()),
-        MetadataStoreKind::Raft => raft::create_server(
+        MetadataServerKind::Raft { .. } => raft::create_server(
             rocksdb_options,
             health_status,
             metadata_writer,

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -29,7 +29,7 @@ pub use restate_core::metadata_store::{
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataWriter, ShutdownError};
 use restate_types::config::{
-    Configuration, MetadataStoreKind, MetadataStoreOptions, RocksDbOptions,
+    Configuration, MetadataServerOptions, MetadataStoreKind, RocksDbOptions,
 };
 use restate_types::errors::GenericError;
 use restate_types::health::HealthStatus;
@@ -231,15 +231,15 @@ where
 }
 
 pub async fn create_metadata_server(
-    metadata_store_options: &MetadataStoreOptions,
+    metadata_server_options: &MetadataServerOptions,
     rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
     health_status: HealthStatus<MetadataServerStatus>,
     metadata_writer: Option<MetadataWriter>,
     server_builder: &mut NetworkServerBuilder,
 ) -> anyhow::Result<BoxedMetadataStoreService> {
-    match metadata_store_options.kind {
+    match metadata_server_options.kind {
         MetadataStoreKind::Local => local::create_server(
-            metadata_store_options,
+            metadata_server_options,
             rocksdb_options,
             health_status,
             server_builder,

--- a/crates/metadata-server/src/local/mod.rs
+++ b/crates/metadata-server/src/local/mod.rs
@@ -13,7 +13,7 @@ use restate_core::metadata_store::providers::create_object_store_based_meta_stor
 use restate_core::metadata_store::{providers::EtcdMetadataStore, MetadataStoreClient};
 use restate_core::network::NetworkServerBuilder;
 use restate_rocksdb::RocksError;
-use restate_types::config::{MetadataStoreOptions, RocksDbOptions};
+use restate_types::config::{MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::protobuf::common::MetadataServerStatus;
@@ -57,13 +57,14 @@ pub async fn create_client(
 }
 
 pub(crate) async fn create_server(
-    metadata_store_options: &MetadataStoreOptions,
+    metadata_server_options: &MetadataServerOptions,
     rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
     health_status: HealthStatus<MetadataServerStatus>,
     server_builder: &mut NetworkServerBuilder,
 ) -> Result<MetadataServerRunner<LocalMetadataServer>, RocksError> {
     let store =
-        LocalMetadataServer::create(metadata_store_options, rocksdb_options, health_status).await?;
+        LocalMetadataServer::create(metadata_server_options, rocksdb_options, health_status)
+            .await?;
     Ok(MetadataServerRunner::new(store, server_builder))
 }
 

--- a/crates/metadata-server/src/local/store.rs
+++ b/crates/metadata-server/src/local/store.rs
@@ -21,7 +21,7 @@ use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
 };
-use restate_types::config::{Configuration, MetadataStoreOptions, RocksDbOptions};
+use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
@@ -56,7 +56,7 @@ pub struct LocalMetadataServer {
 
 impl LocalMetadataServer {
     pub async fn create(
-        options: &MetadataStoreOptions,
+        options: &MetadataServerOptions,
         updateable_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
         health_status: HealthStatus<MetadataServerStatus>,
     ) -> Result<Self, RocksError> {

--- a/crates/metadata-server/src/raft/storage.rs
+++ b/crates/metadata-server/src/raft/storage.rs
@@ -20,7 +20,7 @@ use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
 };
-use restate_types::config::{data_dir, MetadataStoreOptions, RocksDbOptions};
+use restate_types::config::{data_dir, MetadataServerOptions, RocksDbOptions};
 use restate_types::errors::GenericError;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::nodes_config::NodesConfiguration;
@@ -101,7 +101,7 @@ pub struct RocksDbStorage {
 
 impl RocksDbStorage {
     pub async fn create(
-        options: &MetadataStoreOptions,
+        options: &MetadataServerOptions,
         rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
     ) -> Result<Self, BuildError> {
         let db_name = DbName::new(DB_NAME);
@@ -822,14 +822,14 @@ mod tests {
     use raft::{Error as RaftError, GetEntriesContext, Storage, StorageError};
     use raft_proto::eraftpb::{ConfState, Entry, Snapshot};
     use restate_rocksdb::RocksDbManager;
-    use restate_types::config::{CommonOptions, MetadataStoreOptions, RocksDbOptions};
+    use restate_types::config::{CommonOptions, MetadataServerOptions, RocksDbOptions};
     use restate_types::live::Constant;
 
     #[test_log::test(restate_core::test)]
     async fn initial_values() -> googletest::Result<()> {
         RocksDbManager::init(Constant::new(CommonOptions::default()));
         let storage = RocksDbStorage::create(
-            &MetadataStoreOptions::default(),
+            &MetadataServerOptions::default(),
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;
@@ -846,7 +846,7 @@ mod tests {
     async fn append_entries() -> googletest::Result<()> {
         RocksDbManager::init(Constant::new(CommonOptions::default()));
         let mut storage = RocksDbStorage::create(
-            &MetadataStoreOptions::default(),
+            &MetadataServerOptions::default(),
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;
@@ -881,7 +881,7 @@ mod tests {
     async fn apply_snapshot() -> googletest::Result<()> {
         RocksDbManager::init(Constant::new(CommonOptions::default()));
         let mut storage = RocksDbStorage::create(
-            &MetadataStoreOptions::default(),
+            &MetadataServerOptions::default(),
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;
@@ -932,7 +932,7 @@ mod tests {
 
         // re-create storage to check that the information is persisted
         let storage = RocksDbStorage::create(
-            &MetadataStoreOptions::default(),
+            &MetadataServerOptions::default(),
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;
@@ -962,7 +962,7 @@ mod tests {
     async fn trim() -> googletest::Result<()> {
         RocksDbManager::init(Constant::new(CommonOptions::default()));
         let mut storage = RocksDbStorage::create(
-            &MetadataStoreOptions::default(),
+            &MetadataServerOptions::default(),
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;
@@ -1025,7 +1025,7 @@ mod tests {
     async fn overwrite_entries() -> googletest::Result<()> {
         RocksDbManager::init(Constant::new(CommonOptions::default()));
         let mut storage = RocksDbStorage::create(
-            &MetadataStoreOptions::default(),
+            &MetadataServerOptions::default(),
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;

--- a/crates/metadata-server/src/raft/store.rs
+++ b/crates/metadata-server/src/raft/store.rs
@@ -162,7 +162,7 @@ impl RaftMetadataServer {
         let (status_tx, _status_rx) = watch::channel(MetadataStoreSummary::default());
 
         let mut metadata_store_options =
-            Configuration::updateable().map(|configuration| &configuration.metadata_store);
+            Configuration::updateable().map(|configuration| &configuration.metadata_server);
         let mut storage =
             RocksDbStorage::create(metadata_store_options.live_load(), rocksdb_options).await?;
 

--- a/crates/metadata-server/src/util.rs
+++ b/crates/metadata-server/src/util.rs
@@ -8,10 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::config::MetadataStoreOptions;
+use restate_types::config::MetadataServerOptions;
 use rocksdb::DBCompressionType;
 
-pub fn db_options(_options: &MetadataStoreOptions) -> rocksdb::Options {
+pub fn db_options(_options: &MetadataServerOptions) -> rocksdb::Options {
     rocksdb::Options::default()
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -160,10 +160,10 @@ impl Node {
         let metadata_store_role = if config.has_role(Role::MetadataServer) {
             Some(
                 restate_metadata_server::create_metadata_server(
-                    &config.metadata_store,
+                    &config.metadata_server,
                     updateable_config
                         .clone()
-                        .map(|config| &config.metadata_store.rocksdb)
+                        .map(|config| &config.metadata_server.rocksdb)
                         .boxed(),
                     health.metadata_server_status(),
                     Some(metadata_writer),

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -21,16 +21,16 @@ use super::{data_dir, CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
 
 /// # Metadata store options
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(
     feature = "schemars",
-    schemars(rename = "MetadataStoreOptions", default)
+    schemars(rename = "MetadataServerOptions", default)
 )]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", default)]
 #[builder(default)]
-pub struct MetadataStoreOptions {
-    /// # Limit number of in-flight requests
+pub struct MetadataServerOptions {
+    /// Limit number of in-flight requests
     ///
     /// Number of in-flight metadata store requests.
     request_queue_length: NonZeroUsize,
@@ -49,19 +49,20 @@ pub struct MetadataStoreOptions {
     /// (See `rocksdb-total-memtables-ratio` in common).
     rocksdb_memory_ratio: f32,
 
-    /// # RocksDB options for metadata store's RocksDB instance
+    /// RocksDB options for metadata store's RocksDB instance
     ///
     /// The RocksDB options which will be used to configure the metadata store's RocksDB instance.
+    #[serde(flatten)]
     pub rocksdb: RocksDbOptions,
 
-    /// # Type of metadata store to start
+    /// Type of metadata store to start
     ///
     /// The type of metadata store to start when running the metadata store role.
     #[serde(flatten)]
     pub kind: MetadataStoreKind,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
@@ -75,7 +76,7 @@ pub enum MetadataStoreKind {
     Raft,
 }
 
-impl MetadataStoreOptions {
+impl MetadataServerOptions {
     pub fn apply_common(&mut self, common: &CommonOptions) {
         self.rocksdb.apply_common(&common.rocksdb);
 
@@ -112,7 +113,7 @@ impl MetadataStoreOptions {
     }
 }
 
-impl Default for MetadataStoreOptions {
+impl Default for MetadataServerOptions {
     fn default() -> Self {
         let rocksdb = RocksDbOptionsBuilder::default()
             .rocksdb_disable_wal(Some(false))

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -16,7 +16,7 @@ use serde_with::serde_as;
 use restate_serde_util::NonZeroByteCount;
 
 #[serde_as]
-#[derive(Debug, Clone, Default, Serialize, Deserialize, derive_builder::Builder)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, derive_builder::Builder, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(rename = "RocksDbOptions", default))]
 #[serde(rename_all = "kebab-case")]
@@ -102,7 +102,7 @@ pub struct RocksDbOptions {
 
 /// Verbosity of the LOG.
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, Hash, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, Default, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[repr(i32)]
@@ -207,7 +207,7 @@ impl RocksDbOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(rename = "RocksbStatistics"))]
 #[serde(rename_all = "kebab-case")]

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -18,6 +18,8 @@ use std::fmt::Formatter;
 /// if you don't know the actual error type or if it is not important.
 pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+pub type BoxedMaybeRetryableError = Box<dyn MaybeRetryableError + Send + Sync>;
+
 /// Tells whether an error should be retried by upper layers or not.
 pub trait MaybeRetryableError: std::error::Error + 'static {
     /// Signal upper layers whether this error should be retried or not.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -89,8 +89,8 @@ enum WipeMode {
     Worker,
     /// Wipe the local rocksdb-based loglet.
     LocalLoglet,
-    /// Wipe the local rocksdb-based metadata-store.
-    LocalMetadataStore,
+    /// Wipe the rocksdb-based metadata-server.
+    MetadataServer,
     /// Wipe all
     All,
 }
@@ -104,8 +104,8 @@ impl WipeMode {
             Some(WipeMode::LocalLoglet) => {
                 restate_fs_util::remove_dir_all_if_exists(config.bifrost.local.data_dir()).await?
             }
-            Some(WipeMode::LocalMetadataStore) => {
-                restate_fs_util::remove_dir_all_if_exists(config.metadata_store.data_dir()).await?
+            Some(WipeMode::MetadataServer) => {
+                restate_fs_util::remove_dir_all_if_exists(config.metadata_server.data_dir()).await?
             }
             Some(WipeMode::All) => restate_fs_util::remove_dir_all_if_exists(node_dir()).await?,
             _ => {}

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -74,10 +74,10 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
         let metadata = metadata_builder.to_metadata();
         TaskCenter::try_set_global_metadata(metadata.clone());
 
-        let metadata_store_client = metadata_store::start_metadata_store(
+        let metadata_store_client = metadata_store::start_metadata_server(
             config.common.metadata_store_client.clone(),
-            &config.metadata_store,
-            Live::from_value(config.metadata_store.clone())
+            &config.metadata_server,
+            Live::from_value(config.metadata_server.clone())
                 .map(|c| &c.rocksdb)
                 .boxed(),
         )

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -61,10 +61,10 @@ async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericM
         let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
         debug!("RocksDB Initialized");
 
-        let metadata_store_client = metadata_store::start_metadata_store(
+        let metadata_store_client = metadata_store::start_metadata_server(
             config.common.metadata_store_client.clone(),
-            &config.metadata_store,
-            Live::from_value(config.metadata_store.clone())
+            &config.metadata_server,
+            Live::from_value(config.metadata_server.clone())
                 .map(|c| &c.rocksdb)
                 .boxed(),
         )

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -24,7 +24,7 @@ use restate_types::Version;
 use crate::commands::metadata::{
     create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
 };
-use crate::environment::metadata_store::start_metadata_store;
+use crate::environment::metadata_store::start_metadata_server;
 use crate::environment::task_center::run_in_task_center;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
@@ -84,10 +84,10 @@ async fn patch_value_direct(
         let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
         debug!("RocksDB Initialized");
 
-        let metadata_store_client = start_metadata_store(
+        let metadata_store_client = start_metadata_server(
             config.common.metadata_store_client.clone(),
-            &config.metadata_store,
-            Live::from_value(config.metadata_store.clone())
+            &config.metadata_server,
+            Live::from_value(config.metadata_server.clone())
                 .map(|c| &c.rocksdb)
                 .boxed(),
         )

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -15,15 +15,15 @@ use restate_core::network::NetworkServerBuilder;
 use restate_core::{TaskCenter, TaskKind};
 use restate_metadata_server::MetadataServer;
 use restate_types::config;
-use restate_types::config::{MetadataStoreClientOptions, MetadataStoreOptions, RocksDbOptions};
+use restate_types::config::{MetadataServerOptions, MetadataStoreClientOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 use restate_types::protobuf::common::NodeRpcStatus;
 
-pub async fn start_metadata_store(
+pub async fn start_metadata_server(
     mut metadata_store_client_options: MetadataStoreClientOptions,
-    opts: &MetadataStoreOptions,
+    opts: &MetadataServerOptions,
     updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
 ) -> anyhow::Result<MetadataStoreClient> {
     let mut server_builder = NetworkServerBuilder::default();


### PR DESCRIPTION
Transport errors result in a Status error with an Unknown code. Since a transport
error is a retryable error, this commit updates the classification in the
GrpcMetadataServerClient accordingly.