### PR TITLE
Remove inner retry mechanism from GrpcMetadataServerClient

### DIFF
--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -142,7 +142,7 @@ impl VersionedValue {
 flexbuffers_storage_encode_decode!(VersionedValue);
 
 /// Preconditions for the write operations of the [`MetadataStore`].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
 pub enum Precondition {
     /// No precondition
     None,


### PR DESCRIPTION
Instead of letting the client retry, it is now the responsibility of the
user to retry if she wants. This gives more flexibility and avoids the negative
effet of prolonged retry delays if there is a nesting of retry policies. Only
if the response let's us learn about a known leader, we will retry immediately.

This PR is based on #2581.