### PR TITLE
Enable metadata-api by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
     name: Create docker image
     uses: ./.github/workflows/docker.yml
     with:
+      features: 'metadata-api'
       uploadImageAsTarball: true
       platforms: linux/amd64
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,6 +20,7 @@ jobs:
       pushToDockerHub: true
       parca: true
       buildIndividually: true
+      releaseBuild: true
 
   docker-cli:
     name: Push CLI Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: ""
         type: string
+      releaseBuild:
+        description: "prevent non-release features from being included in build"
+        required: false
+        default: false
+        type: boolean
       pushToDockerHub:
         description: "push image to DockerHub"
         required: false
@@ -166,6 +171,14 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Check for non-release features in release builds
+        if: ${{ inputs.releaseBuild }}
+        run: |
+           if [[ "${{ inputs.features }}" =~ "metadata-api" ]]; then
+             echo "Release builds should not contain non-release only features: ${{ inputs.features }}"
+             exit 1
+           fi
+
       - name: Build${{(inputs.uploadImageAsTarball != true || github.ref == 'refs/heads/main') && ' and push ' || ' '}}Docker image
         id: build
         uses: docker/build-push-action@v6
@@ -186,7 +199,7 @@ jobs:
             CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug || inputs.parca }}
             BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
             UPLOAD_DEBUGINFO=${{ inputs.parca }}
-            RESTATE_FEATURES=${{ inputs.features || '' }}
+            RESTATE_FEATURES=${{ inputs.features || releaseBuild && '' || 'metadata-api' }}
           secrets: |
             parca=${{ secrets.PARCA_TOKEN }}
           cache-from: type=gha,url=http://127.0.0.1:49160/

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [features]
-default = ["replicated-loglet", "serve-web-ui"]
+default = ["replicated-loglet", "serve-web-ui", "metadata-api"]
 clients = []
 options_schema = ["restate-service-client/options_schema"]
 memory-loglet = ["restate-bifrost/memory-loglet"]

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [features]
-default = ["replicated-loglet", "serve-web-ui", "metadata-api"]
+default = ["replicated-loglet", "serve-web-ui"]
 clients = []
 options_schema = ["restate-service-client/options_schema"]
 memory-loglet = ["restate-bifrost/memory-loglet"]


### PR DESCRIPTION
Trivial change: enables the HTTP metadata access API by default; this will enable us to run the Jepsen metadata workload against regular Docker builds from main or PR branches.

I double checked that the OpenAPI schema definition is unchanged with the inclusion of this.