### PR TITLE
Add support for immediate seal-and-extend to the LogsController

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -194,16 +194,15 @@ impl LogState {
             }
             LogState::Available { segment_index, .. }
             | LogState::Sealing { segment_index, .. }
-            | LogState::Sealed { segment_index, .. }
-                if *segment_index < new_segment_index =>
-            {
-                *self = LogState::Available {
-                    configuration: Some(new_configuration),
-                    segment_index: new_segment_index,
+            | LogState::Sealed { segment_index, .. } => {
+                if *segment_index < new_segment_index {
+                    *self = LogState::Available {
+                        configuration: Some(new_configuration),
+                        segment_index: new_segment_index,
+                    }
+                } else {
+                    debug!(segment_index = %new_segment_index, "Ignoring setting segment to available because it's outdated.");
                 }
-            }
-            _ => {
-                panic!("Trying to transition LogState to Available with a segment that should be sealed.");
             }
         }
     }


### PR DESCRIPTION
If the LogsController finds a suitable configuration for the next segment when sealing a loglet, then it will try to seal_and_extend with this configuration immediately instead of first sealing and then deciding on the new configuration.