### PR TITLE
Streamline restatectl connection to cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7578,6 +7578,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tempfile",
+ "thiserror 2.0.11",
  "tokio",
  "tonic",
  "tracing",

--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -22,8 +22,6 @@ service ClusterCtrlSvc {
 
   rpc DescribeLog(DescribeLogRequest) returns (DescribeLogResponse);
 
-  rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
-
   rpc TrimLog(TrimLogRequest) returns (google.protobuf.Empty);
 
   rpc CreatePartitionSnapshot(CreatePartitionSnapshotRequest)
@@ -80,13 +78,6 @@ message DescribeLogResponse {
   uint64 trim_point = 4;
   // Serialized restate_types::nodes_config::NodesConfiguration
   bytes nodes_configuration = 7;
-}
-
-message ListNodesRequest {}
-
-message ListNodesResponse {
-  // Serialized restate_types::nodes_config::NodesConfiguration
-  bytes nodes_configuration = 1;
 }
 
 message TrimLogRequest {

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -29,9 +29,8 @@ use crate::cluster_controller::protobuf::cluster_ctrl_svc_server::ClusterCtrlSvc
 use crate::cluster_controller::protobuf::{
     ClusterStateRequest, ClusterStateResponse, CreatePartitionSnapshotRequest,
     CreatePartitionSnapshotResponse, DescribeLogRequest, DescribeLogResponse, FindTailRequest,
-    FindTailResponse, ListLogsRequest, ListLogsResponse, ListNodesRequest, ListNodesResponse,
-    SealAndExtendChainRequest, SealAndExtendChainResponse, SealedSegment, TailState,
-    TrimLogRequest,
+    FindTailResponse, ListLogsRequest, ListLogsResponse, SealAndExtendChainRequest,
+    SealAndExtendChainResponse, SealedSegment, TailState, TrimLogRequest,
 };
 
 use super::protobuf::{
@@ -139,27 +138,6 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             tail_state: 0, // TailState_UNKNOWN
             tail_offset: Lsn::INVALID.as_u64(),
             trim_point: trim_point.as_u64(),
-            nodes_configuration: serialize_value(nodes_config),
-        }))
-    }
-
-    async fn list_nodes(
-        &self,
-        _request: Request<ListNodesRequest>,
-    ) -> Result<Response<ListNodesResponse>, Status> {
-        let nodes_config = self
-            .metadata_writer
-            .metadata_store_client()
-            .get::<NodesConfiguration>(NODES_CONFIG_KEY.clone())
-            .await
-            .map_err(|error| {
-                Status::unknown(format!(
-                    "Failed to get nodes configuration metadata: {error:?}"
-                ))
-            })?
-            .ok_or(Status::not_found("Missing nodes configuration"))?;
-
-        Ok(Response::new(ListNodesResponse {
             nodes_configuration: serialize_value(nodes_config),
         }))
     }

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -78,7 +78,8 @@ message GetMetadataResponse {
 
 message ClusterHealthResponse {
   string cluster_name = 1;
-  // Some value if the cluster has been configured to use the embedded metadata store
+  // Some value if the cluster has been configured to use the embedded metadata
+  // store
   optional EmbeddedMetadataClusterHealth metadata_cluster_health = 2;
 }
 

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -47,6 +47,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport", "prost"] }
 tracing = { workspace = true }

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -8,13 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::str::FromStr;
-
 use cling::prelude::*;
 
 use restate_cli_util::CliContext;
 use restate_cli_util::CommonOpts;
-use restate_types::net::AdvertisedAddress;
 
 use crate::commands::cluster::overview::ClusterStatusOpts;
 use crate::commands::cluster::Cluster;
@@ -24,6 +21,7 @@ use crate::commands::node::Nodes;
 use crate::commands::partition::Partitions;
 use crate::commands::replicated_loglet::ReplicatedLoglet;
 use crate::commands::snapshot::Snapshot;
+use crate::connection::ConnectionInfo;
 
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]
@@ -35,20 +33,6 @@ pub struct CliApp {
     pub connection: ConnectionInfo,
     #[clap(subcommand)]
     pub cmd: Command,
-}
-
-#[derive(Parser, Collect, Debug, Clone)]
-pub struct ConnectionInfo {
-    // todo: rename this to be a node address for reusability across commands
-    /// Cluster Controller address
-    #[clap(
-        long,
-        value_hint = clap::ValueHint::Url,
-        default_value_t = AdvertisedAddress::from_str("http://localhost:5122/").unwrap(),
-        env = "RESTATE_CLUSTER_CONTROLLER_ADDRESS",
-        global = true
-    )]
-    pub cluster_controller: AdvertisedAddress,
 }
 
 #[derive(Run, Subcommand, Clone)]

--- a/tools/restatectl/src/commands/cluster/overview.rs
+++ b/tools/restatectl/src/commands/cluster/overview.rs
@@ -13,10 +13,10 @@ use cling::{Collect, Run};
 
 use restate_cli_util::c_println;
 
-use crate::app::ConnectionInfo;
 use crate::commands::log::list_logs::{list_logs, ListLogsOpts};
 use crate::commands::node::list_nodes::{list_nodes, ListNodesOpts};
 use crate::commands::partition::list::{list_partitions, ListPartitionsOpts};
+use crate::connection::ConnectionInfo;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "cluster_status")]

--- a/tools/restatectl/src/commands/cluster/provision.rs
+++ b/tools/restatectl/src/commands/cluster/provision.rs
@@ -8,8 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::app::ConnectionInfo;
 use crate::commands::cluster::config::cluster_config_string;
+use crate::connection::ConnectionInfo;
 use crate::util::grpc_channel;
 use clap::Parser;
 use cling::{Collect, Run};
@@ -18,8 +18,8 @@ use restate_cli_util::{c_error, c_println, c_warn};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest;
 use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind, ReplicatedLogletConfig};
-use restate_types::net::AdvertisedAddress;
 use restate_types::replication::ReplicationProperty;
+use std::cmp::Ordering;
 use std::num::NonZeroU16;
 use tonic::codec::CompressionEncoding;
 use tonic::Code;
@@ -27,10 +27,6 @@ use tonic::Code;
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "cluster_provision")]
 pub struct ProvisionOpts {
-    /// Address of the node that should be provisioned
-    #[clap(long)]
-    address: Option<AdvertisedAddress>,
-
     /// Number of partitions
     #[clap(long)]
     num_partitions: Option<NonZeroU16>,
@@ -56,14 +52,24 @@ pub struct ProvisionOpts {
 }
 
 async fn cluster_provision(
-    connection_info: &ConnectionInfo,
+    connection: &ConnectionInfo,
     provision_opts: &ProvisionOpts,
 ) -> anyhow::Result<()> {
-    let node_address = provision_opts
-        .address
-        .clone()
-        .unwrap_or_else(|| connection_info.cluster_controller.clone());
-    let channel = grpc_channel(node_address.clone());
+    let address = match connection.addresses.len().cmp(&1) {
+        Ordering::Greater => {
+            let address = &connection.addresses[0];
+            c_println!(
+                "Cluster provisioning must be performed on a single node. Using {address} for provisioning.",
+            );
+            address
+        }
+        Ordering::Equal => &connection.addresses[0],
+        Ordering::Less => {
+            anyhow::bail!("At least one address must be specified to provision");
+        }
+    };
+
+    let channel = grpc_channel(address.clone());
 
     let mut client = NodeCtlSvcClient::new(channel)
         .accept_compressed(CompressionEncoding::Gzip)

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -20,6 +20,7 @@ use restate_types::live::Live;
 use crate::commands::metadata::{
     create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
 };
+use crate::connection::ConnectionInfo;
 use crate::environment::metadata_store;
 use crate::environment::task_center::run_in_task_center;
 
@@ -35,9 +36,9 @@ pub struct GetValueOpts {
     key: String,
 }
 
-async fn get_value(opts: &GetValueOpts) -> anyhow::Result<()> {
+async fn get_value(connection: &ConnectionInfo, opts: &GetValueOpts) -> anyhow::Result<()> {
     let value = match opts.metadata.access_mode {
-        MetadataAccessMode::Remote => get_value_remote(opts).await?,
+        MetadataAccessMode::Remote => get_value_remote(connection, opts).await?,
         MetadataAccessMode::Direct => get_value_direct(opts).await?,
     };
 
@@ -47,8 +48,11 @@ async fn get_value(opts: &GetValueOpts) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn get_value_remote(opts: &GetValueOpts) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let metadata_store_client = create_metadata_store_client(&opts.metadata).await?;
+async fn get_value_remote(
+    connection: &ConnectionInfo,
+    opts: &GetValueOpts,
+) -> anyhow::Result<Option<GenericMetadataValue>> {
+    let metadata_store_client = create_metadata_store_client(connection, &opts.metadata).await?;
 
     metadata_store_client
         .get(ByteString::from(opts.key.as_str()))

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -8,21 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::Context;
-use cling::prelude::*;
-use std::path::PathBuf;
-use std::str::FromStr;
-
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_metadata_server::create_client;
-use restate_types::config::MetadataStoreClientOptions;
-use restate_types::net::AdvertisedAddress;
-use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
-
 mod get;
 mod patch;
 mod put;
 mod status;
+
+use std::path::PathBuf;
+
+use cling::prelude::*;
+use restate_types::nodes_config::Role;
+
+use restate_core::metadata_store::MetadataStoreClient;
+use restate_metadata_server::create_client;
+use restate_types::config::MetadataStoreClientOptions;
+use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
+
+use crate::connection::ConnectionInfo;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Metadata {
@@ -39,15 +40,14 @@ pub enum Metadata {
 #[derive(Args, Clone, Debug)]
 #[clap()]
 pub struct MetadataCommonOpts {
-    /// Metadata store server addresses
+    /// Etcd store server addresses
     #[arg(
         short,
-        long = "addresses",
-        default_values = &["http://127.0.0.1:5122"],
-        env = "RESTATE_METADATA_ADDRESSES",
-        value_delimiter = ','
+        long = "etcd",
+        value_delimiter = ',',
+        required_if_eq("remote_service_type", "etcd")
     )]
-    addresses: Vec<String>,
+    etcd: Vec<String>,
 
     /// Metadata store access mode
     #[arg(long, default_value_t)]
@@ -109,20 +109,20 @@ impl Versioned for GenericMetadataValue {
 }
 
 pub async fn create_metadata_store_client(
+    connection: &ConnectionInfo,
     opts: &MetadataCommonOpts,
 ) -> anyhow::Result<MetadataStoreClient> {
     let client = match opts.remote_service_type {
-        RemoteServiceType::Restate => restate_types::config::MetadataStoreClient::Embedded {
-            addresses: opts
-                .addresses
-                .iter()
-                .map(|address| {
-                    AdvertisedAddress::from_str(address).context("failed to parse address")
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        },
+        RemoteServiceType::Restate => {
+            let nodes = connection.get_nodes_configuration().await?;
+            let addresses = nodes
+                .iter_role(Role::MetadataServer)
+                .map(|(_, node)| node.address.clone())
+                .collect();
+            restate_types::config::MetadataStoreClient::Embedded { addresses }
+        }
         RemoteServiceType::Etcd => restate_types::config::MetadataStoreClient::Etcd {
-            addresses: opts.addresses.clone(),
+            addresses: opts.etcd.clone(),
         },
     };
 

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -17,6 +17,7 @@ use serde_json::Value;
 
 use crate::commands::metadata::patch::{patch_value, PatchValueOpts};
 use crate::commands::metadata::MetadataCommonOpts;
+use crate::connection::ConnectionInfo;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]
@@ -41,7 +42,7 @@ pub struct PutValueOpts {
     dry_run: bool,
 }
 
-async fn put_value(opts: &PutValueOpts) -> anyhow::Result<()> {
+async fn put_value(connection: &ConnectionInfo, opts: &PutValueOpts) -> anyhow::Result<()> {
     let opts = opts.clone();
 
     let doc_body = opts.doc.contents()?;
@@ -69,5 +70,5 @@ async fn put_value(opts: &PutValueOpts) -> anyhow::Result<()> {
         dry_run: opts.dry_run,
     };
 
-    patch_value(&patch_opts).await
+    patch_value(connection, &patch_opts).await
 }

--- a/tools/restatectl/src/commands/replicated_loglet/info.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/info.rs
@@ -9,41 +9,22 @@
 // by the Apache License, Version 2.0.
 
 use cling::prelude::*;
-use tonic::codec::CompressionEncoding;
 
 use restate_cli_util::{c_indentln, c_println};
-use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
-use restate_core::protobuf::node_ctl_svc::GetMetadataRequest;
-use restate_core::MetadataKind;
-use restate_types::logs::metadata::Logs;
 use restate_types::logs::LogletId;
-use restate_types::storage::StorageCodec;
 use restate_types::Versioned;
 
-use crate::app::ConnectionInfo;
-use crate::util::grpc_channel;
+use crate::connection::ConnectionInfo;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "get_info")]
 pub struct InfoOpts {
     /// The replicated loglet id
     loglet_id: LogletId,
-    /// Sync metadata from metadata store first
-    #[arg(long)]
-    sync_metadata: bool,
 }
 
 async fn get_info(connection: &ConnectionInfo, opts: &InfoOpts) -> anyhow::Result<()> {
-    let channel = grpc_channel(connection.cluster_controller.clone());
-    let mut client = NodeCtlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
-
-    let req = GetMetadataRequest {
-        kind: MetadataKind::Logs.into(),
-        sync: opts.sync_metadata,
-    };
-    let mut response = client.get_metadata(req).await?.into_inner();
-
-    let logs = StorageCodec::decode::<Logs, _>(&mut response.encoded)?;
+    let logs = connection.get_logs().await?;
     c_println!("Log Configuration ({})", logs.version());
 
     let Some(loglet_ref) = logs.get_replicated_loglet(&opts.loglet_id) else {

--- a/tools/restatectl/src/connection.rs
+++ b/tools/restatectl/src/connection.rs
@@ -1,0 +1,353 @@
+// Copyright (c) 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{cmp::Ordering, collections::HashMap, fmt::Display, future::Future, sync::Arc};
+
+use cling::{prelude::Parser, Collect};
+use itertools::{Either, Itertools};
+use rand::{seq::SliceRandom, thread_rng};
+use tokio::sync::{Mutex, MutexGuard};
+use tonic::{codec::CompressionEncoding, transport::Channel, Response, Status};
+use tracing::debug;
+
+use restate_core::protobuf::node_ctl_svc::{
+    node_ctl_svc_client::NodeCtlSvcClient, GetMetadataRequest, IdentResponse,
+};
+use restate_types::{
+    logs::metadata::Logs,
+    net::AdvertisedAddress,
+    nodes_config::{NodesConfiguration, Role},
+    protobuf::common::{MetadataKind, NodeStatus},
+    storage::{StorageCodec, StorageDecode, StorageDecodeError},
+    Version, Versioned,
+};
+
+use crate::util::grpc_channel;
+
+#[derive(Clone, Parser, Collect, Debug)]
+pub struct ConnectionInfo {
+    /// Specify the nodes addresses. This option can be used multiple times.
+    #[clap(
+        long,
+        value_hint = clap::ValueHint::Url,
+        default_value = "http://localhost:5122/",
+        env = "RESTATE_ADDRESSES",
+        global = true,
+        value_delimiter = ',',
+    )]
+    pub addresses: Vec<AdvertisedAddress>,
+
+    /// Ask nodes to sync its metadata with the metadata store
+    /// first before responding to metadata requests
+    #[arg(long)]
+    pub sync_metadata: bool,
+
+    #[clap(skip)]
+    nodes_configuration: Arc<Mutex<Option<NodesConfiguration>>>,
+
+    #[clap(skip)]
+    logs: Arc<Mutex<Option<Logs>>>,
+
+    #[clap(skip)]
+    cache: Arc<Mutex<HashMap<AdvertisedAddress, Channel>>>,
+}
+
+impl ConnectionInfo {
+    /// Gets NodesConfiguration object. This function tries all provided addresses and makes sure
+    /// nodes configuration is cached.
+    pub async fn get_nodes_configuration(&self) -> Result<NodesConfiguration, ConnectionInfoError> {
+        if self.addresses.is_empty() {
+            return Err(ConnectionInfoError::NoAvailableNodes(NoRoleError(None)));
+        }
+
+        let guard = self.nodes_configuration.lock().await;
+
+        // get nodes configuration will always use the addresses seed
+        // provided via the cmdline
+        self.get_latest_metadata(
+            self.addresses.iter(),
+            self.addresses.len(),
+            MetadataKind::NodesConfiguration,
+            guard,
+            |ident| Version::from(ident.nodes_config_version),
+        )
+        .await
+    }
+
+    /// Gets Logs object.
+    ///
+    /// This function will try multiple nodes learned from nodes_configuration
+    /// to get the best guess of the latest logs version is.
+    pub async fn get_logs(&self) -> Result<Logs, ConnectionInfoError> {
+        let nodes_config = self.get_nodes_configuration().await?;
+
+        let guard = self.logs.lock().await;
+
+        let mut nodes_addresses = nodes_config
+            .iter()
+            .map(|(_, node)| &node.address)
+            .collect::<Vec<_>>();
+
+        nodes_addresses.shuffle(&mut thread_rng());
+
+        let cluster_size = nodes_addresses.len();
+        let cached = self.cache.lock().await.keys().cloned().collect::<Vec<_>>();
+
+        assert!(!cached.is_empty(), "must have cached connections");
+
+        let try_nodes = cached
+            .iter()
+            .chain(
+                nodes_addresses
+                    .into_iter()
+                    .filter(|address| !cached.contains(address)),
+            )
+            .collect::<Vec<_>>();
+
+        // To be sure we landed on the best guess of the latest version of the logs
+        // we need to ask multiple nodes in the nodes config.
+        // We make sure cached nodes has higher precedence + 50% of node set size trimmed to
+        // a total of 50% + 1 nodes.
+
+        self.get_latest_metadata(
+            try_nodes.into_iter(),
+            (cluster_size / 2) + 1,
+            MetadataKind::Logs,
+            guard,
+            |ident| Version::from(ident.logs_version),
+        )
+        .await
+    }
+
+    /// Gets Metadata object. On successful responses, [`get_latest_metadata`] will only try `try_best_of`
+    /// of the provided addresses, or until all nodes are exhausted.
+    async fn get_latest_metadata<T, M>(
+        &self,
+        addresses: impl Iterator<Item = &AdvertisedAddress>,
+        mut try_best_of: usize,
+        kind: MetadataKind,
+        mut guard: MutexGuard<'_, Option<T>>,
+        version_map: M,
+    ) -> Result<T, ConnectionInfoError>
+    where
+        T: StorageDecode + Versioned + Clone,
+        M: Fn(&IdentResponse) -> Version,
+    {
+        if let Some(meta) = &*guard {
+            return Ok(meta.clone());
+        }
+
+        let mut latest_meta: Option<T> = None;
+        let mut answer = false;
+        let mut errors = NodesErrors::default();
+        let mut cache = self.cache.lock().await;
+
+        let request = GetMetadataRequest {
+            kind: kind.into(),
+            sync: self.sync_metadata,
+        };
+
+        for address in addresses {
+            let channel = cache.entry(address.clone()).or_insert_with(|| {
+                debug!("connecting to {address}");
+                grpc_channel(address.clone())
+            });
+
+            let mut client = NodeCtlSvcClient::new(channel.clone())
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+
+            let response = match client.get_ident(()).await {
+                Ok(response) => response.into_inner(),
+                Err(status) => {
+                    errors.error(address.clone(), status);
+                    continue;
+                }
+            };
+
+            // node is reachable and has answered
+            answer = true;
+            if response.status != NodeStatus::Alive as i32 {
+                // node did not join the cluster yet.
+                continue;
+            }
+
+            if version_map(&response)
+                <= latest_meta
+                    .as_ref()
+                    .map(|c| c.version())
+                    .unwrap_or(Version::INVALID)
+            {
+                // has older version than we have.
+                continue;
+            }
+
+            let mut response = match client.get_metadata(request).await {
+                Ok(response) => response.into_inner(),
+                Err(status) => {
+                    errors.error(address.clone(), status);
+                    continue;
+                }
+            };
+
+            let meta = StorageCodec::decode::<T, _>(&mut response.encoded)
+                .map_err(|err| ConnectionInfoError::DecoderError(address.clone(), err))?;
+
+            if meta.version()
+                > latest_meta
+                    .as_ref()
+                    .map(|c| c.version())
+                    .unwrap_or(Version::INVALID)
+            {
+                latest_meta = Some(meta);
+            }
+
+            try_best_of -= 1;
+            if try_best_of == 0 {
+                break;
+            }
+        }
+
+        if !answer {
+            // all nodes have returned error
+            return Err(ConnectionInfoError::NodesErrors(errors));
+        }
+
+        *guard = latest_meta.clone();
+        latest_meta.ok_or(ConnectionInfoError::MissingMetadata)
+    }
+
+    /// Attempts to contact each node in the cluster that matches the specified role
+    /// (or all nodes if `None` is provided). The function returns upon receiving the
+    /// first successful response from a node. If an error occurs, the next matching
+    /// node is tried.
+    ///
+    /// The provided closure is responsible for executing the request using the given
+    /// channel to the node and returning the result of the response.
+    ///
+    /// Returns an error if:
+    /// - No nodes match the requested role.
+    /// - All nodes return an error.
+    pub async fn try_each<F, T, Fut>(
+        &self,
+        role: Option<Role>,
+        mut closure: F,
+    ) -> Result<Response<T>, ConnectionInfoError>
+    where
+        F: FnMut(Channel) -> Fut,
+        Fut: Future<Output = Result<Response<T>, Status>>,
+    {
+        let nodes_config = self.get_nodes_configuration().await?;
+        let mut channels = self.cache.lock().await;
+
+        let iterator = match role {
+            Some(role) => Either::Left(nodes_config.iter_role(role)),
+            None => Either::Right(nodes_config.iter()),
+        }
+        .sorted_by(|a, b| {
+            // nodes for which we already have open channels get higher precedence.
+            match (
+                channels.contains_key(&a.1.address),
+                channels.contains_key(&b.1.address),
+            ) {
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                (_, _) => a.0.cmp(&b.0),
+            }
+        });
+
+        let mut errors = NodesErrors::default();
+
+        for (_, node) in iterator {
+            // avoid creating new channels on each iteration. Instead cheaply copy the channels
+            let channel = channels
+                .entry(node.address.clone())
+                .or_insert_with(|| grpc_channel(node.address.clone()));
+
+            let result = closure(channel.clone()).await;
+            match result {
+                Ok(response) => return Ok(response),
+                Err(status) => {
+                    errors.error(node.address.clone(), status);
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Err(ConnectionInfoError::NoAvailableNodes(NoRoleError(role)))
+        } else {
+            Err(ConnectionInfoError::NodesErrors(errors))
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConnectionInfoError {
+    #[error("Could not retrieve cluster metadata. Has the cluster been provisioned yet?")]
+    MissingMetadata,
+
+    #[error("Failed to decode metadata from node {0}: {1}")]
+    DecoderError(AdvertisedAddress, StorageDecodeError),
+
+    #[error(transparent)]
+    NodesErrors(NodesErrors),
+
+    #[error(transparent)]
+    NoAvailableNodes(NoRoleError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub struct NoRoleError(Option<Role>);
+
+impl Display for NoRoleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(role) => {
+                write!(f, "No available {role} nodes to satisfy the request")?;
+            }
+            None => {
+                write!(f, "No available nodes to satisfy the request")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct NodesErrors {
+    node_status: Vec<(AdvertisedAddress, Status)>,
+}
+
+impl NodesErrors {
+    fn error(&mut self, node: AdvertisedAddress, status: Status) {
+        self.node_status.push((node, status));
+    }
+
+    fn is_empty(&self) -> bool {
+        self.node_status.is_empty()
+    }
+}
+
+impl Display for NodesErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Encountered multiple errors:")?;
+        for (address, status) in &self.node_status {
+            writeln!(f, " - {address} -> {status}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for NodesErrors {
+    fn description(&self) -> &str {
+        "aggregated nodes error"
+    }
+}

--- a/tools/restatectl/src/lib.rs
+++ b/tools/restatectl/src/lib.rs
@@ -13,4 +13,5 @@ pub(crate) mod commands;
 pub(crate) mod util;
 pub use app::CliApp;
 mod build_info;
+pub(crate) mod connection;
 pub(crate) mod environment;


### PR DESCRIPTION
Streamline restatectl connection to cluster

Summary:
Make it easier and cleaner to run the restatectl command
by accepting the restate nodes addresses via a unified argument `--address`

- Support passing multiple addresses
- The command will try to fetch the nodes configuration from the first reachable node
- All other subcommands can then use the connection info to use the nodes configuration directly
  or to connect to a specific node role
