### PR TITLE
[Bifrost] Design improvements for find_tail

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -104,8 +104,7 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
         cluster_state_tx: Arc<watch::Sender<Arc<ClusterState>>>,
     ) -> Result<Option<TaskHandle<anyhow::Result<()>>>, ShutdownError> {
         let refresh = async move {
-            // todo: potentially downgrade to trace()...
-            debug!("Refreshing cluster state");
+            trace!("Refreshing cluster state");
             let last_state = Arc::clone(&cluster_state_tx.borrow());
             let metadata = Metadata::current();
             // make sure we have a partition table that equals or newer than last refresh
@@ -219,8 +218,7 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
             };
 
             // publish the new state
-            // todo: potentially downgrade to trace!
-            debug!("New cluster state is acquired, publishing");
+            trace!("New cluster state is acquired, publishing");
             cluster_state_tx.send(Arc::new(state))?;
             Ok(())
         };

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -8,10 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::time::Duration;
-
 use bytes::{Bytes, BytesMut};
-use restate_types::protobuf::cluster::ClusterConfiguration;
 use tonic::{async_trait, Request, Response, Status};
 use tracing::info;
 
@@ -22,6 +19,7 @@ use restate_types::logs::metadata::{Logs, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, NODES_CONFIG_KEY};
 use restate_types::nodes_config::NodesConfiguration;
+use restate_types::protobuf::cluster::ClusterConfiguration;
 use restate_types::storage::{StorageCodec, StorageEncode};
 use restate_types::{Version, Versioned};
 
@@ -247,9 +245,9 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 err => Status::internal(err.to_string()),
             })?;
 
-        let tail_state = tokio::time::timeout(Duration::from_secs(2), writable_loglet.find_tail())
+        let tail_state = writable_loglet
+            .find_tail()
             .await
-            .map_err(|_elapsed| Status::deadline_exceeded("Timedout finding tail"))?
             .map_err(|err| Status::internal(err.to_string()))?;
 
         let response = FindTailResponse {

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -21,7 +21,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time;
 use tokio::time::{Instant, Interval, MissedTickBehavior};
 use tonic::codec::CompressionEncoding;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use restate_metadata_server::ReadModifyWriteError;
 use restate_types::logs::metadata::{
@@ -320,7 +320,7 @@ impl<T: TransportConnect> Service<T> {
                 Ok(cluster_state) = cluster_state_watcher.next_cluster_state() => {
                     self.observed_cluster_state.update(&cluster_state);
                     // todo: potentially downgrade to trace
-                    debug!("Observed cluster state updated");
+                    trace!("Observed cluster state updated");
                     // todo quarantine this cluster controller if errors re-occur too often so that
                     //  another cluster controller can take over
                     if let Err(err) = state.update(&self) {

--- a/crates/bifrost/src/providers/replicated_loglet/log_server_manager.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/log_server_manager.rs
@@ -79,6 +79,18 @@ impl RemoteLogServerManager {
         Self { servers }
     }
 
+    pub fn try_get_tail_offset(&self, id: PlainNodeId) -> Option<TailOffsetWatch> {
+        let server = self.servers.get(&id).expect("node is in nodeset");
+
+        if let Ok(guard) = server.try_lock() {
+            if let Some(current) = guard.deref() {
+                return Some(current.local_tail().clone());
+            }
+        }
+
+        None
+    }
+
     /// Gets a log-server instance. On first time it will initialize a new connection
     /// to log server. It will make sure all following get call holds the same
     /// connection.

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use tracing::{debug, info, instrument};
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+use tracing::{debug, info, instrument, trace};
 
 use restate_core::network::{Networking, TransportConnect};
 use restate_types::logs::metadata::SegmentIndex;
@@ -58,6 +60,8 @@ pub(super) struct ReplicatedLoglet<T> {
     ///   should run a proper tail search.
     known_global_tail: TailOffsetWatch,
     sequencer: SequencerAccess<T>,
+    #[debug(skip)]
+    seal_in_progress: Mutex<()>,
 }
 
 impl<T: TransportConnect> ReplicatedLoglet<T> {
@@ -112,6 +116,7 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
             record_cache,
             known_global_tail,
             sequencer,
+            seal_in_progress: Mutex::new(()),
         }
     }
 
@@ -138,9 +143,121 @@ pub enum SequencerAccess<T> {
     Local { handle: Sequencer<T> },
 }
 
+impl<T> SequencerAccess<T> {
+    pub fn mark_as_maybe_sealed(&self) {
+        match self {
+            SequencerAccess::Remote { handle } => handle.mark_as_maybe_sealed(),
+            SequencerAccess::Local { handle } => handle.sequencer_state().mark_as_maybe_sealed(),
+        }
+    }
+
+    pub fn maybe_sealed(&self) -> bool {
+        match self {
+            SequencerAccess::Remote { handle } => handle.maybe_sealed(),
+            SequencerAccess::Local { handle } => handle.sequencer_state().maybe_sealed(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum FindTailOptions {
+    #[default]
+    Default,
+    /// Tells the loglet provider to force a check on the seal status of the loglet. Note that the
+    /// seal flag invariants still hold. If the tail is open, we are absolutely sure that the tail
+    /// LSN is committed.
+    ForceSealCheck,
+}
+
 impl<T: TransportConnect> ReplicatedLoglet<T> {
     pub fn last_known_global_tail(&self) -> TailState<LogletOffset> {
         *self.known_global_tail.get()
+    }
+
+    pub async fn find_tail_inner(
+        &self,
+        find_tail_opts: FindTailOptions,
+    ) -> Result<TailState<LogletOffset>, OperationError> {
+        let latest_tail = *self.known_global_tail.get();
+        if latest_tail.is_sealed() {
+            return Ok(latest_tail);
+        }
+        let find_tail_opts = if self.sequencer.maybe_sealed() {
+            // auto-force seal check if we have reasons to believe that it might be sealing
+            FindTailOptions::ForceSealCheck
+        } else {
+            find_tail_opts
+        };
+
+        match self.sequencer {
+            SequencerAccess::Local { ref handle } => {
+                if find_tail_opts == FindTailOptions::ForceSealCheck {
+                    if self.sequencer.maybe_sealed() {
+                        // let's fire a seal to ensure this seal is complete.
+                        self.seal().await?;
+                    } else {
+                        // We might have been sealed by external node and the sequencer is unaware. In this
+                        // case, we run a check seal task to determine if we suspect that sealing is
+                        // happening.
+                        let result = CheckSealTask::run(
+                            &self.my_params,
+                            &self.logservers_rpc.get_loglet_info,
+                            handle.sequencer_state().remote_log_servers(),
+                            &self.known_global_tail,
+                            &self.networking,
+                        )
+                        .await?;
+                        // things might have changed during this time
+                        if self.known_global_tail.get().is_sealed() {
+                            return Ok(*self.known_global_tail.get());
+                        }
+                        match result {
+                            CheckSealOutcome::Sealing => {
+                                // We are likely to be sealing...
+                                // let's fire a seal to ensure this seal is complete.
+                                self.seal().await?;
+                            }
+                            CheckSealOutcome::FullySealed => {
+                                // already fully sealed, just make sure the sequencer is drained.
+                                handle.drain().await?;
+                                // note that we can only do that if we are the sequencer because
+                                // our known_global_tail is authoritative. We have no doubt about
+                                // whether the tail needs to be repaired or not.
+                                self.known_global_tail.notify_seal();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                return Ok(*self.known_global_tail.get());
+            }
+            SequencerAccess::Remote { .. } => {
+                let task = FindTailTask::new(
+                    self.log_id,
+                    self.segment_index,
+                    self.my_params.clone(),
+                    self.networking.clone(),
+                    self.logservers_rpc.clone(),
+                    self.sequencers_rpc.clone(),
+                    self.known_global_tail.clone(),
+                    self.record_cache.clone(),
+                );
+                let tail_status = task.run(find_tail_opts).await;
+                match tail_status {
+                    FindTailResult::Open { global_tail } => {
+                        self.known_global_tail.notify_offset_update(global_tail);
+                        Ok(*self.known_global_tail.get())
+                    }
+                    FindTailResult::Sealed { global_tail } => {
+                        self.known_global_tail.notify(true, global_tail);
+                        Ok(*self.known_global_tail.get())
+                    }
+                    FindTailResult::Error(reason) => {
+                        Err(ReplicatedLogletError::FindTailFailed(reason).into())
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -152,6 +269,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         from: LogletOffset,
         to: Option<LogletOffset>,
     ) -> Result<SendableLogletReadStream, OperationError> {
+        trace!("create_read_stream() called");
         let cache = self.record_cache.clone();
         let known_global_tail = self.known_global_tail.clone();
         let my_params = self.my_params.clone();
@@ -208,60 +326,11 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
     }
 
     async fn find_tail(&self) -> Result<TailState<LogletOffset>, OperationError> {
-        match self.sequencer {
-            SequencerAccess::Local { .. } => {
-                let latest_tail = *self.known_global_tail.get();
-                if latest_tail.is_sealed() {
-                    return Ok(latest_tail);
-                }
-                // We might have been sealed by external node and the sequencer is unaware. In this
-                // case, we run a check seal task to determine if we suspect that sealing is
-                // happening.
-                let result = CheckSealTask::run(
-                    &self.my_params,
-                    &self.logservers_rpc.get_loglet_info,
-                    &self.known_global_tail,
-                    &self.networking,
-                )
-                .await?;
-                if result == CheckSealOutcome::Sealing {
-                    // We are likely to be sealing...
-                    // let's fire a seal to ensure this seal is complete.
-                    self.seal().await?;
-                }
-                return Ok(*self.known_global_tail.get());
-            }
-            SequencerAccess::Remote { .. } => {
-                let task = FindTailTask::new(
-                    self.log_id,
-                    self.segment_index,
-                    self.my_params.clone(),
-                    self.networking.clone(),
-                    self.logservers_rpc.clone(),
-                    self.sequencers_rpc.clone(),
-                    self.known_global_tail.clone(),
-                    self.record_cache.clone(),
-                );
-                let tail_status = task.run().await;
-                match tail_status {
-                    FindTailResult::Open { global_tail } => {
-                        self.known_global_tail.notify_offset_update(global_tail);
-                        Ok(*self.known_global_tail.get())
-                    }
-                    FindTailResult::Sealed { global_tail } => {
-                        self.known_global_tail.notify(true, global_tail);
-                        Ok(*self.known_global_tail.get())
-                    }
-                    FindTailResult::Error(reason) => {
-                        Err(ReplicatedLogletError::FindTailFailed(reason).into())
-                    }
-                }
-            }
-        }
+        self.find_tail_inner(FindTailOptions::default()).await
     }
 
     #[instrument(
-        level="error",
+        level="debug",
         skip_all,
         fields(
             loglet_id = %self.my_params.loglet_id,
@@ -269,6 +338,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         )
     )]
     async fn get_trim_point(&self) -> Result<Option<LogletOffset>, OperationError> {
+        trace!("get_trim_point() called");
         GetTrimPointTask::new(
             &self.my_params,
             self.logservers_rpc.clone(),
@@ -280,7 +350,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
     }
 
     #[instrument(
-        level="error",
+        level="debug",
         skip_all,
         fields(
             loglet_id = %self.my_params.loglet_id,
@@ -291,6 +361,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
     /// Trim the log to the min(trim_point, last_committed_offset)
     /// trim_point is inclusive (will be trimmed)
     async fn trim(&self, trim_point: LogletOffset) -> Result<(), OperationError> {
+        trace!("trim() called");
         let trim_point = trim_point.min(self.known_global_tail.latest_offset().prev_unchecked());
 
         TrimTask::new(
@@ -308,24 +379,53 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         Ok(())
     }
 
-    async fn seal(&self) -> Result<(), OperationError> {
-        let _ = SealTask::new(
-            self.my_params.clone(),
-            self.logservers_rpc.seal.clone(),
-            self.known_global_tail.clone(),
+    #[instrument(
+        level="error",
+        skip_all,
+        fields(
+            otel.name = "replicated_loglet: seal",
         )
-        .run(self.networking.clone())
+    )]
+    async fn seal(&self) -> Result<(), OperationError> {
+        // lock-free fast-path
+        if self.known_global_tail.get().is_sealed() {
+            return Ok(());
+        }
+        trace!("seal() called");
+
+        // Ensure that only one seal operation is in progress at a time.
+        let start = Instant::now();
+        let _guard = self.seal_in_progress.lock().await;
+        trace!("seal() lock was acquired after {:?}", start.elapsed());
+
+        if self.known_global_tail.get().is_sealed() {
+            return Ok(());
+        }
+
+        debug!("Attempting to seal loglet");
+        let _ = SealTask::run(
+            &self.my_params,
+            &self.logservers_rpc.seal,
+            &self.known_global_tail,
+            &self.networking,
+        )
         .await?;
         // If we are the sequencer, we need to wait until the sequencer is drained.
         if let SequencerAccess::Local { handle } = &self.sequencer {
             handle.drain().await?;
             self.known_global_tail.notify_seal();
         };
+        // Primarily useful for remote sequencer to enforce seal check on the next find_tail() call
+        self.sequencer.mark_as_maybe_sealed();
         // On remote sequencer, we only set our global tail to sealed when we call find_tail and it
         // returns Sealed. We should NOT:
         // - Use AppendError::Sealed to mark our sealed global_tail
-        // - Mark our global tail as sealed on successful seal() call.
-        info!(loglet_id=%self.my_params.loglet_id, "Loglet has been sealed successfully");
+        // - Mark our global tail as sealed on successful seal() call because our view of known_global_tail might
+        //   not be up-to-date at the time we sealed. We want that to happen by find_tail() after
+        //   it consults the sequencer, or by running a full find-tail algorithm directly on log
+        //   servers.
+        debug!(loglet_id=%self.my_params.loglet_id, "seal() has completed successfully in {:?}",
+            start.elapsed());
         Ok(())
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -34,6 +34,7 @@ use super::network::RequestPump;
 use super::rpc_routers::{LogServersRpc, SequencersRpc};
 use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::providers::replicated_loglet::error::ReplicatedLogletError;
+use crate::providers::replicated_loglet::loglet::FindTailOptions;
 use crate::providers::replicated_loglet::tasks::PeriodicTailChecker;
 use crate::Error;
 
@@ -177,13 +178,30 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
                     self.sequencer_rpc_routers.clone(),
                     self.record_cache.clone(),
                 );
+                let is_local_sequencer = loglet.is_sequencer_local();
                 let key_value = entry.insert(Arc::new(loglet));
+
                 let loglet = Arc::downgrade(key_value.value());
+                // the periodic tail checker depends on whether we are a sequencer node or not.
+                // For non-sequencer nodes, the period impacts the max lag of our read
+                // streams' view of tail. For sequencers, we only need this to do periodic
+                // releases/check-seals.
+                let (duration, opts) = if is_local_sequencer {
+                    (
+                        Configuration::pinned()
+                            .bifrost
+                            .replicated_loglet
+                            .sequencer_inactivity_timeout
+                            .into(),
+                        FindTailOptions::ForceSealCheck,
+                    )
+                } else {
+                    (Duration::from_secs(2), FindTailOptions::Default)
+                };
                 let _ = TaskCenter::spawn(
                     TaskKind::BifrostBackgroundLowPriority,
                     "periodic-tail-checker",
-                    // todo: configuration
-                    PeriodicTailChecker::run(loglet_id, loglet, Duration::from_secs(2)),
+                    PeriodicTailChecker::run(loglet_id, loglet, duration, opts),
                 );
                 Arc::clone(key_value.value())
             }

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -138,7 +138,7 @@ impl ReadStreamTask {
     ) -> Result<(), OperationError> {
         let mut nodes_config = networking.metadata().updateable_nodes_config();
         let my_node_id = networking.my_node_id();
-        let records_rpc_timeout = Configuration::pinned()
+        let records_rpc_timeout = *Configuration::pinned()
             .bifrost
             .replicated_loglet
             .log_server_rpc_timeout;

--- a/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
@@ -11,7 +11,7 @@
 use std::{
     ops::Deref,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -50,6 +50,16 @@ pub struct RemoteSequencer<T> {
     sequencers_rpc: SequencersRpc,
     known_global_tail: TailOffsetWatch,
     connection: Arc<Mutex<Option<RemoteSequencerConnection>>>,
+    maybe_sealed: AtomicBool,
+}
+
+impl<T> RemoteSequencer<T> {
+    pub fn mark_as_maybe_sealed(&self) {
+        self.maybe_sealed.store(true, Ordering::Relaxed)
+    }
+    pub fn maybe_sealed(&self) -> bool {
+        self.maybe_sealed.load(Ordering::Relaxed)
+    }
 }
 
 impl<T> RemoteSequencer<T>
@@ -83,6 +93,7 @@ where
             sequencers_rpc,
             known_global_tail,
             connection: Arc::default(),
+            maybe_sealed: AtomicBool::new(false),
         }
     }
 

--- a/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
@@ -26,7 +26,7 @@ type SmartString = smartstring::SmartString<smartstring::LazyCompact>;
 
 /// Possible results of f-majority checks for a subset of the NodeSet.
 /// Read variant docs for details.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FMajorityResult {
     /// The subset of nodes neither satisfies the authoritative f-majority
     /// property, nor does it contain sufficient authoritative nodes.

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -227,7 +227,8 @@ impl<T: TransportConnect> SequencerAppender<T> {
             self.sequencer_shared_state.selector.replication_property(),
         );
 
-        let store_timeout = self
+        // todo: should be exponential backoff
+        let store_timeout = *self
             .configuration
             .live_load()
             .bifrost
@@ -494,6 +495,7 @@ impl<'a, T: TransportConnect> LogServerStoreTask<'a, T> {
         match incoming.body().status {
             Status::Sealing | Status::Sealed => {
                 server.local_tail().notify_seal();
+                self.sequencer_shared_state.mark_as_maybe_sealed();
                 return Ok(StoreTaskStatus::Sealed);
             }
             _ => {

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/check_seal.rs
@@ -8,38 +8,49 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tracing::{info, instrument, trace};
+use std::collections::BTreeMap;
+
+use restate_types::retries::RetryPolicy;
+use restate_types::PlainNodeId;
+use tokio::task::JoinSet;
+use tracing::{debug, instrument, trace, Instrument};
 
 use restate_core::network::rpc_router::RpcRouter;
-use restate_core::network::{Networking, TransportConnect};
-use restate_core::{cancellation_watcher, ShutdownError};
-use restate_types::net::log_server::GetLogletInfo;
+use restate_core::network::{Incoming, Networking, TransportConnect};
+use restate_core::{ShutdownError, TaskCenterFutureExt};
+use restate_types::net::log_server::{
+    GetLogletInfo, LogServerRequestHeader, LogServerResponseHeader, LogletInfo, Status,
+};
 use restate_types::replicated_loglet::{LogNodeSetExt, ReplicatedLogletParams};
 
-use super::{FindTailOnNode, NodeTailStatus};
+use super::util::Disposition;
 use crate::loglet::util::TailOffsetWatch;
-use crate::providers::replicated_loglet::replication::NodeSetChecker;
+use crate::providers::replicated_loglet::log_server_manager::RemoteLogServerManager;
+use crate::providers::replicated_loglet::replication::{FMajorityResult, NodeSetChecker};
+use crate::providers::replicated_loglet::tasks::util::RunOnSingleNode;
 
 /// Attempts to detect if the loglet has been sealed or if there is a seal in progress by
-/// consulting nodes until it reaches f-majority, and it stops at the first sealed response
-/// from any log-server since this is a sufficient signal that a seal is on-going.
-///
-/// the goal of this operation to get a signal on sequencer node that a seal has happened (or
-/// ongoing) if we have not been receiving appends for some time.
+/// consulting nodes until it reaches f-majority. If it cannot achieve f-majority, it'll still
+/// let us know if any node is in sealing state so we can continue the original seal operation.
 ///
 /// This allows PeriodicFindTail to detect seal that was triggered externally to unblock read
-/// streams running locally that rely on the sequencer's view of known_global_tail.
+/// streams running locally
 ///
 ///
-/// Note that this task can return Open if it cannot reach out to any node, so we should not use it
+/// Note 1: This is designed to be used with the local-sequencer but in the future it may be
+/// extended to be more general purpose.
+///
+/// Note 2: This task can return Open if it cannot reach out to any node, so we should not use it
 /// for operations that rely on absolute correctness of the tail. For those, use FindTailTask
 /// instead.
-pub struct CheckSealTask {}
+pub struct CheckSealTask;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CheckSealOutcome {
+    FullySealed,
     Sealing,
     ProbablyOpen,
+    Open,
 }
 
 impl CheckSealTask {
@@ -47,16 +58,24 @@ impl CheckSealTask {
     pub async fn run<T: TransportConnect>(
         my_params: &ReplicatedLogletParams,
         get_loglet_info_rpc: &RpcRouter<GetLogletInfo>,
+        log_servers: &RemoteLogServerManager,
         known_global_tail: &TailOffsetWatch,
         networking: &Networking<T>,
     ) -> Result<CheckSealOutcome, ShutdownError> {
+        if known_global_tail.is_sealed() {
+            return Ok(CheckSealOutcome::FullySealed);
+        }
+        debug!(
+            loglet_id = %my_params.loglet_id,
+            "Checking seal status for loglet"
+        );
         // If all nodes in the nodeset is in "provisioning", we can confidently short-circuit
         // the result to LogletOffset::Oldest and the loglet is definitely unsealed.
         if my_params
             .nodeset
             .all_provisioning(&networking.metadata().nodes_config_ref())
         {
-            return Ok(CheckSealOutcome::ProbablyOpen);
+            return Ok(CheckSealOutcome::Open);
         }
         // todo: If effective nodeset is empty, should we consider that the loglet is implicitly
         // sealed?
@@ -65,59 +84,147 @@ impl CheckSealTask {
             .nodeset
             .to_effective(&networking.metadata().nodes_config_ref());
 
-        let mut nodeset_checker = NodeSetChecker::<NodeTailStatus>::new(
+        let mut nodeset_checker = NodeSetChecker::<bool>::new(
             &effective_nodeset,
             &networking.metadata().nodes_config_ref(),
             &my_params.replication,
         );
 
-        let mut nodes = effective_nodeset.shuffle_for_reads(networking.metadata().my_node_id());
+        let local_tails: BTreeMap<PlainNodeId, TailOffsetWatch> = effective_nodeset
+            .iter()
+            .filter_map(|node_id| {
+                log_servers
+                    .try_get_tail_offset(*node_id)
+                    .map(|w| (*node_id, w))
+            })
+            .collect();
 
-        let mut cancel = std::pin::pin!(cancellation_watcher());
-        trace!(
-            loglet_id = %my_params.loglet_id,
-            effective_nodeset = %effective_nodeset,
-            "Checking seal status for loglet",
-        );
+        // If some of the nodes are already sealed, we know our answer and we don't need to go through
+        // the rest of the nodes.
+        for (node_id, local_tail) in local_tails.iter() {
+            // do not use the unsealed signal as authoritative source here.
+            if local_tail.is_sealed() {
+                nodeset_checker.set_attribute(*node_id, true);
+            }
+        }
 
-        loop {
+        // You might be wondering, why don't we just check if any of the nodes are sealed and
+        // return here? Because we want to dispatch background tasks to update the seal/local-tail
+        // status for the rest of the nodeset. This aids with future runs of this task, and helps
+        // the sequencer get a fresh view if it didn't communicate with those nodes for some time.
+
+        let mut inflight_requests = JoinSet::new();
+        for node_id in effective_nodeset.iter().copied() {
+            // only create tasks for nodes that we think they are open
             if nodeset_checker
-                .check_fmajority(NodeTailStatus::is_known_unsealed)
-                .passed()
+                .get_attribute(&node_id)
+                .copied()
+                .unwrap_or(false)
             {
-                // once we reach f-majority of unsealed, we stop.
-                return Ok(CheckSealOutcome::ProbablyOpen);
+                // This node is known to be sealed, don't run a task for it.
+                continue;
             }
-
-            let Some(next_node) = nodes.pop() else {
-                info!(
-                    loglet_id = %my_params.loglet_id,
-                    status = %nodeset_checker,
-                    effective_nodeset = %effective_nodeset,
-                    replication = %my_params.replication,
-                    "Insufficient nodes responded to GetLogletInfo requests, we cannot determine seal status, we'll assume it's unsealed for now",
-                );
-                return Ok(CheckSealOutcome::ProbablyOpen);
+            let request = GetLogletInfo {
+                header: LogServerRequestHeader::new(
+                    my_params.loglet_id,
+                    known_global_tail.latest_offset(),
+                ),
             };
 
-            let task = FindTailOnNode {
-                node_id: next_node,
-                loglet_id: my_params.loglet_id,
-                get_loglet_info_rpc,
-                known_global_tail,
-            };
-            let tail_status = tokio::select! {
-                _ = &mut cancel => {
-                    return Err(ShutdownError);
+            inflight_requests.spawn({
+                let networking = networking.clone();
+                let rpc_router = get_loglet_info_rpc.clone();
+                let known_global_tail = known_global_tail.clone();
+                let local_tail = local_tails.get(&node_id).cloned();
+
+                async move {
+                    let task = RunOnSingleNode::new(
+                        node_id,
+                        request,
+                        &rpc_router,
+                        &known_global_tail,
+                        // do not retry
+                        RetryPolicy::None,
+                    );
+
+                    (
+                        node_id,
+                        task.run(on_info_response(local_tail), &networking).await,
+                    )
                 }
-                (_, tail_status) = task.run(networking) => { tail_status },
-            };
-            if tail_status.is_known_sealed() {
-                // we only need to see a single node sealed to declare that we are probably sealing (or
-                // sealed)
-                return Ok(CheckSealOutcome::Sealing);
+                .in_current_tc()
+                .in_current_span()
+            });
+        }
+
+        // Waiting for GetLogletInfo responses
+        loop {
+            // are we fully sealed? We use BestEffort here because we'd still want to consider a
+            // loglet sealed even if some nodes lost data. The check-seal wouldn't determine the
+            // known_global_tail, only whether the loglet is sealed or not and it's safe to do so.
+            // non-authoritative nodes cannot accept normal writes, only repair writes.
+            if nodeset_checker.check_fmajority(|attr| *attr) >= FMajorityResult::BestEffort {
+                // no need to detach, we don't need responses from the rest of the nodes
+                return Ok(CheckSealOutcome::FullySealed);
             }
-            nodeset_checker.merge_attribute(next_node, tail_status);
+
+            // keep grabbing results
+            let Some(response) = inflight_requests.join_next().await else {
+                // no more results, since we didn't return earlier, we know that we didn't get
+                // enough responses to determine the result authoritatively
+                break;
+            };
+            let Ok((node_id, response)) = response else {
+                // task panicked or runtime is shutting down.
+                continue;
+            };
+            let Ok(response) = response else {
+                // GetLogletInfo task failed/aborted on this node. The inner task will log the error in this case.
+                continue;
+            };
+
+            nodeset_checker.set_attribute(node_id, response.sealed);
+        }
+
+        // are we partially sealed?
+        if nodeset_checker.any(|attr| *attr) {
+            return Ok(CheckSealOutcome::Sealing);
+        }
+
+        if nodeset_checker.check_fmajority(|attr| !(*attr)) >= FMajorityResult::BestEffort {
+            return Ok(CheckSealOutcome::Open);
+        }
+
+        debug!(
+            loglet_id = %my_params.loglet_id,
+            status = %nodeset_checker,
+            effective_nodeset = %effective_nodeset,
+            replication = %my_params.replication,
+            "Insufficient nodes responded to GetLogletInfo requests, we cannot determine seal status, we'll assume it's unsealed for now",
+        );
+        return Ok(CheckSealOutcome::ProbablyOpen);
+    }
+}
+
+fn on_info_response(
+    server_local_tail: Option<TailOffsetWatch>,
+) -> impl Fn(Incoming<LogletInfo>) -> Disposition<LogServerResponseHeader> {
+    move |msg: Incoming<LogletInfo>| -> Disposition<LogServerResponseHeader> {
+        if let Status::Ok = msg.body().header.status {
+            if let Some(server_local_tail) = &server_local_tail {
+                server_local_tail.notify_offset_update(msg.body().local_tail);
+                if msg.body().header.sealed {
+                    server_local_tail.notify_seal();
+                }
+            }
+            Disposition::Return(msg.into_body().header)
+        } else {
+            trace!(
+                "GetLogletInfo request failed on node {}, status is {:?}",
+                msg.peer(),
+                msg.body().header.status
+            );
+            Disposition::Abort
         }
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/get_trim_point.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/get_trim_point.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use tokio::task::JoinSet;
-use tracing::trace;
+use tracing::{instrument, trace, Instrument, Span};
 
 use restate_core::network::{Incoming, Networking, TransportConnect};
 use restate_core::TaskCenterFutureExt;
@@ -57,6 +57,7 @@ impl<'a> GetTrimPointTask<'a> {
         }
     }
 
+    #[instrument(level = "debug", skip_all, fields(loglet_id))]
     pub async fn run<T: TransportConnect>(
         self,
         networking: Networking<T>,
@@ -114,6 +115,7 @@ impl<'a> GetTrimPointTask<'a> {
                     (node_id, task.run(on_info_response, &networking).await)
                 }
                 .in_current_tc()
+                .instrument(Span::current())
             });
         }
 

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
@@ -12,25 +12,28 @@ use std::sync::Weak;
 use std::time::Duration;
 
 use tokio::time::Instant;
+use tracing::instrument;
 use tracing::{debug, trace};
 
 use restate_core::network::TransportConnect;
 use restate_types::logs::LogletId;
 
-use crate::loglet::{Loglet, OperationError};
-use crate::providers::replicated_loglet::loglet::ReplicatedLoglet;
+use crate::loglet::OperationError;
+use crate::providers::replicated_loglet::loglet::{FindTailOptions, ReplicatedLoglet};
 
 pub struct PeriodicTailChecker {}
 
 impl PeriodicTailChecker {
+    #[instrument(level = "debug", skip_all, fields(%loglet_id))]
     pub async fn run<T: TransportConnect>(
         loglet_id: LogletId,
         loglet: Weak<ReplicatedLoglet<T>>,
         duration: Duration,
+        opts: FindTailOptions,
     ) -> anyhow::Result<()> {
         debug!(
             %loglet_id,
-            "Starting a background periodic tail checker for this loglet",
+            "Started a background periodic tail checker for this loglet",
         );
         // Optimization. Don't run the check if the tail/seal has been updated recently.
         // Unfortunately this requires a litte bit more setup in the TailOffsetWatch so we don't do
@@ -50,18 +53,16 @@ impl PeriodicTailChecker {
             );
             if loglet.known_global_tail().is_sealed() {
                 // stop the task. we are sealed already.
-                trace!(
+                debug!(
                     %loglet_id,
                     is_sequencer = ?loglet.is_sequencer_local(),
                     "Loglet has been sealed, stopping the periodic tail checker",
                 );
                 return Ok(());
             }
-            tokio::time::sleep(duration).await;
             let start = Instant::now();
-            match loglet.find_tail().await {
+            match loglet.find_tail_inner(opts).await {
                 Ok(tail) => {
-                    // todo: maybe remove this.
                     trace!(
                         %loglet_id,
                         known_global_tail = %tail.offset(),
@@ -79,15 +80,16 @@ impl PeriodicTailChecker {
                     );
                     return Ok(());
                 }
-                Err(OperationError::Other(e)) => {
+                Err(OperationError::Other(err)) => {
                     trace!(
-                        ?e,
+                        %err,
                         is_sequencer = ?loglet.is_sequencer_local(),
                         %loglet_id,
                         "Couldn't determine the tail status of the loglet. Will retry in the next period",
                     );
                 }
             }
+            tokio::time::sleep(duration).await;
         }
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
@@ -11,7 +11,7 @@
 use std::time::Duration;
 
 use tokio::task::JoinSet;
-use tracing::{trace, warn};
+use tracing::{trace, warn, Instrument, Span};
 
 use restate_core::network::{Networking, TransportConnect};
 use restate_core::{ShutdownError, TaskCenterFutureExt};
@@ -155,6 +155,7 @@ impl<T: TransportConnect> RepairTail<T> {
                     }
                 }
                 .in_current_tc()
+                .instrument(Span::current())
             });
         }
 

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
@@ -10,7 +10,7 @@
 
 use restate_core::TaskCenterFutureExt;
 use tokio::task::JoinSet;
-use tracing::{debug, trace, warn};
+use tracing::{debug, instrument, trace, warn, Instrument, Span};
 
 use restate_core::network::{Incoming, Networking, TransportConnect};
 use restate_types::config::Configuration;
@@ -68,6 +68,7 @@ impl<'a> TrimTask<'a> {
         }
     }
 
+    #[instrument(level = "error", skip_all, fields(%trim_point))]
     pub async fn run<T: TransportConnect>(
         self,
         trim_point: LogletOffset,
@@ -136,6 +137,7 @@ impl<'a> TrimTask<'a> {
                     (node_id, task.run(on_trim_response, &networking).await)
                 }
                 .in_current_tc()
+                .instrument(Span::current())
             });
         }
 

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -234,14 +234,25 @@ pub struct ReplicatedLogletOptions {
 
     /// Sequencer retry policy
     ///
-    /// Backoff introduced when sequencer fail to find a suitable spread
-    /// of log servers
+    /// Backoff introduced when sequencer fail to find a suitable spread of log servers
     pub sequencer_retry_policy: RetryPolicy,
+
+    /// Sequencer inactivity timeout
+    ///
+    /// The sequencer is allowed to consider itself quiescent if it did not commit records for this period of time.
+    /// It may use this to sends pre-emptive release/seal check requests to log-servers.
+    ///
+    /// The sequencer is also allowed to use this value as interval to send seal/release checks even if it's not quiescent.
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub sequencer_inactivity_timeout: humantime::Duration,
 
     /// Log Server RPC timeout
     ///
     /// Timeout waiting on log server response
-    pub log_server_rpc_timeout: Duration,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub log_server_rpc_timeout: humantime::Duration,
 
     /// Log Server RPC retry policy
     ///
@@ -337,11 +348,12 @@ impl Default for ReplicatedLogletOptions {
                 None,
                 Some(Duration::from_millis(5000)),
             ),
-            log_server_rpc_timeout: Duration::from_millis(5000),
+            sequencer_inactivity_timeout: Duration::from_secs(15).into(),
+            log_server_rpc_timeout: Duration::from_millis(2000).into(),
             log_server_retry_policy: RetryPolicy::exponential(
                 Duration::from_millis(250),
                 2.0,
-                Some(10),
+                Some(3),
                 Some(Duration::from_millis(2000)),
             ),
             readahead_records: NonZeroUsize::new(100).unwrap(),

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -155,6 +155,7 @@ impl Appended {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSequencerState {
     pub header: CommonRequestHeader,
+    pub force_seal_check: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION

This PR introduces a few changes resulting in significant improvements in failover time, and performance of common operation like find_tail().
The result is failover time that in the hundreds of milliseconds in the happy path and in the order of a couple of seconds in the unhappy path. `find_tail()` is
also now significantly cheaper to run if the sequencer is running, this enables parallelization of `find_tail()` runs in logs controller (and more frequent as well). The latter comment will be reflected in a separate PR.

This also includes a new implementation of the seal task that reuses the `RunOnSingleNode` utility and that doesn't continue attempts once f-majority is sealed to reduce overloading the cluster. This can be reconsidered if we observed issues.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2593).
* #2615
* #2614
* #2613
* __->__ #2593