### PR TITLE
Move the stacktrace we get from the SDK to the bottom

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -156,16 +156,16 @@ pub(crate) enum InvokerError {
 }
 
 impl InvokerError {
-    pub(crate) fn error_details(&self) -> Option<&str> {
+    pub(crate) fn error_stacktrace(&self) -> Option<&str> {
         match self {
             InvokerError::Sdk(s) => {
                 s.error
-                    .description()
+                    .stacktrace()
                     .and_then(|s| if s.is_empty() { None } else { Some(s) })
             }
             InvokerError::SdkV2(s) => {
                 s.error
-                    .description()
+                    .stacktrace()
                     .and_then(|s| if s.is_empty() { None } else { Some(s) })
             }
             _ => None,
@@ -215,8 +215,8 @@ impl InvokerError {
                     e.message()
                 );
                 let mut err = InvocationError::new(e.code(), msg);
-                if let Some(desc) = e.description() {
-                    err = err.with_description(desc);
+                if let Some(desc) = e.stacktrace() {
+                    err = err.with_stacktrace(desc);
                 }
                 err
             }

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -292,7 +292,7 @@ impl fmt::Display for SdkInvocationError {
         if self.error.code() == codes::JOURNAL_MISMATCH {
             writeln!(
                 f,
-                "Detected journal mismatch. Either the code was updated without registering a new service deployment, or some code within the handler is non-deterministic."
+                "Detected journal mismatch. Either some code within the handler is non-deterministic, or the code was updated without registering a new service deployment."
             )?;
         } else {
             writeln!(
@@ -385,7 +385,7 @@ impl fmt::Display for SdkInvocationErrorV2 {
         if self.error.code() == codes::JOURNAL_MISMATCH {
             writeln!(
                 f,
-                "Detected journal mismatch. Either the code was updated without registering a new service deployment, or some code within the handler is non-deterministic."
+                "Detected journal mismatch. Either some code within the handler is non-deterministic, or the code was updated without registering a new service deployment."
             )?;
         } else {
             writeln!(

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -155,6 +155,103 @@ pub(crate) enum InvokerError {
     ServiceUnavailable(http::StatusCode),
 }
 
+impl InvokerError {
+    pub(crate) fn error_details(&self) -> Option<&str> {
+        match self {
+            InvokerError::Sdk(s) => {
+                s.error
+                    .description()
+                    .and_then(|s| if s.is_empty() { None } else { Some(s) })
+            }
+            InvokerError::SdkV2(s) => {
+                s.error
+                    .description()
+                    .and_then(|s| if s.is_empty() { None } else { Some(s) })
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn is_transient(&self) -> bool {
+        true
+    }
+
+    pub(crate) fn should_bump_start_message_retry_count_since_last_stored_entry(&self) -> bool {
+        !matches!(
+            self,
+            InvokerError::JournalReader(_)
+                | InvokerError::StateReader(_)
+                | InvokerError::NoDeploymentForService
+                | InvokerError::BadNegotiatedServiceProtocolVersion(_)
+                | InvokerError::UnknownDeployment(_)
+                | InvokerError::ResumeWithWrongServiceProtocolVersion(_)
+                | InvokerError::IncompatibleServiceEndpoint(_, _)
+        )
+    }
+
+    pub(crate) fn next_retry_interval_override(&self) -> Option<Duration> {
+        match self {
+            InvokerError::Sdk(SdkInvocationError {
+                next_retry_interval_override,
+                ..
+            }) => *next_retry_interval_override,
+            InvokerError::SdkV2(SdkInvocationErrorV2 {
+                next_retry_interval_override,
+                ..
+            }) => *next_retry_interval_override,
+            _ => None,
+        }
+    }
+
+    pub(crate) fn into_invocation_error(self) -> InvocationError {
+        match self {
+            InvokerError::Sdk(sdk_error) => sdk_error.error,
+            InvokerError::SdkV2(sdk_error) => sdk_error.error,
+            InvokerError::EntryEnrichment(entry_index, entry_type, e) => {
+                let msg = format!(
+                    "Error when processing entry {} of type {}: {}",
+                    entry_index,
+                    entry_type,
+                    e.message()
+                );
+                let mut err = InvocationError::new(e.code(), msg);
+                if let Some(desc) = e.description() {
+                    err = err.with_description(desc);
+                }
+                err
+            }
+            e => InvocationError::internal(e),
+        }
+    }
+
+    pub(crate) fn into_invocation_error_report(mut self) -> InvocationErrorReport {
+        let doc_error_code = codederror::CodedError::code(&self);
+        let maybe_related_entry = match self {
+            InvokerError::Sdk(SdkInvocationError {
+                ref mut related_entry,
+                ..
+            }) => related_entry.take(),
+            InvokerError::SdkV2(SdkInvocationErrorV2 {
+                related_command: ref mut related_entry,
+                ..
+            }) => related_entry
+                .take()
+                .map(InvocationErrorRelatedCommandV2::best_effort_into_v1),
+            _ => None,
+        }
+        .unwrap_or_default();
+        let err = self.into_invocation_error();
+
+        InvocationErrorReport {
+            doc_error_code,
+            err,
+            related_entry_index: maybe_related_entry.related_entry_index,
+            related_entry_name: maybe_related_entry.related_entry_name,
+            related_entry_type: maybe_related_entry.related_entry_type,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error, codederror::CodedError)]
 #[code(restate_errors::RT0017)]
 pub(crate) enum CommandPreconditionError {
@@ -203,13 +300,18 @@ impl fmt::Display for SdkInvocationError {
                 "Got a (transient) error from the service while processing invocation."
             )?;
         }
-        writeln!(f, "{}", self.error)?;
+
+        // We don't use the default formatting of error, as we want to display the stacktrace at the bottom
+        writeln!(f, "[{}] {}.", self.error.code(), self.error.message())?;
 
         if let Some(related_entry) = &self.related_entry {
             if related_entry.entry_was_commited {
-                write!(f, "This error originated after executing {related_entry}")?;
+                write!(f, "> This error originated after executing {related_entry}")?;
             } else {
-                write!(f, "This error originated while processing {related_entry}")?;
+                write!(
+                    f,
+                    "> This error originated while processing {related_entry}"
+                )?;
             }
         }
         Ok(())
@@ -291,7 +393,10 @@ impl fmt::Display for SdkInvocationErrorV2 {
                 "Got a (transient) error from the service while processing invocation."
             )?;
         }
-        writeln!(f, "{}", self.error)?;
+
+        // We don't use the default formatting of error, as we wanna display the stacktrace at the bottom
+        writeln!(f, "[{}] {}.", self.error.code(), self.error.message())?;
+
         if let Some(related_command) = &self.related_command {
             if related_command.command_was_commited {
                 write!(f, "This error originated after executing {related_command}")?;
@@ -399,86 +504,5 @@ fn specialized_restate_error_code_for_invocation_error(
         codes::JOURNAL_MISMATCH => &restate_errors::RT0016,
         codes::PROTOCOL_VIOLATION => &restate_errors::RT0012,
         _ => &restate_errors::RT0007,
-    }
-}
-
-impl InvokerError {
-    pub(crate) fn is_transient(&self) -> bool {
-        true
-    }
-
-    pub(crate) fn should_bump_start_message_retry_count_since_last_stored_entry(&self) -> bool {
-        !matches!(
-            self,
-            InvokerError::JournalReader(_)
-                | InvokerError::StateReader(_)
-                | InvokerError::NoDeploymentForService
-                | InvokerError::BadNegotiatedServiceProtocolVersion(_)
-                | InvokerError::UnknownDeployment(_)
-                | InvokerError::ResumeWithWrongServiceProtocolVersion(_)
-                | InvokerError::IncompatibleServiceEndpoint(_, _)
-        )
-    }
-
-    pub(crate) fn next_retry_interval_override(&self) -> Option<Duration> {
-        match self {
-            InvokerError::Sdk(SdkInvocationError {
-                next_retry_interval_override,
-                ..
-            }) => *next_retry_interval_override,
-            InvokerError::SdkV2(SdkInvocationErrorV2 {
-                next_retry_interval_override,
-                ..
-            }) => *next_retry_interval_override,
-            _ => None,
-        }
-    }
-
-    pub(crate) fn into_invocation_error(self) -> InvocationError {
-        match self {
-            InvokerError::Sdk(sdk_error) => sdk_error.error,
-            InvokerError::SdkV2(sdk_error) => sdk_error.error,
-            InvokerError::EntryEnrichment(entry_index, entry_type, e) => {
-                let msg = format!(
-                    "Error when processing entry {} of type {}: {}",
-                    entry_index,
-                    entry_type,
-                    e.message()
-                );
-                let mut err = InvocationError::new(e.code(), msg);
-                if let Some(desc) = e.description() {
-                    err = err.with_description(desc);
-                }
-                err
-            }
-            e => InvocationError::internal(e),
-        }
-    }
-
-    pub(crate) fn into_invocation_error_report(mut self) -> InvocationErrorReport {
-        let doc_error_code = codederror::CodedError::code(&self);
-        let maybe_related_entry = match self {
-            InvokerError::Sdk(SdkInvocationError {
-                ref mut related_entry,
-                ..
-            }) => related_entry.take(),
-            InvokerError::SdkV2(SdkInvocationErrorV2 {
-                related_command: ref mut related_entry,
-                ..
-            }) => related_entry
-                .take()
-                .map(InvocationErrorRelatedCommandV2::best_effort_into_v1),
-            _ => None,
-        }
-        .unwrap_or_default();
-        let err = self.into_invocation_error();
-
-        InvocationErrorReport {
-            doc_error_code,
-            err,
-            related_entry_index: maybe_related_entry.related_entry_index,
-            related_entry_name: maybe_related_entry.related_entry_name,
-            related_entry_type: maybe_related_entry.related_entry_type,
-        }
     }
 }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1109,14 +1109,14 @@ where
                     "transient" => "true"
                 )
                 .increment(1);
-                if let Some(error_details) = error.error_details() {
+                if let Some(error_stacktrace) = error.error_stacktrace() {
                     // The error details is treated differently from the pretty printer,
                     // makes sure it prints at the end of the log the spammy exception
                     warn_it!(
                         error,
                         restate.invocation.id = %invocation_id,
                         restate.invocation.target = %ism.invocation_target,
-                        restate.error.details = %error_details,
+                        restate.invocation.error.stacktrace = %error_stacktrace,
                         "Invocation error, retrying in {}.",
                         humantime::format_duration(next_retry_timer_duration));
                 } else {

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1109,12 +1109,24 @@ where
                     "transient" => "true"
                 )
                 .increment(1);
-                warn_it!(
-                    error,
-                    restate.invocation.id = %invocation_id,
-                    restate.invocation.target = %ism.invocation_target,
-                    "Error when executing the invocation, retrying in {}.",
-                    humantime::format_duration(next_retry_timer_duration));
+                if let Some(error_details) = error.error_details() {
+                    // The error details is treated differently from the pretty printer,
+                    // makes sure it prints at the end of the log the spammy exception
+                    warn_it!(
+                        error,
+                        restate.invocation.id = %invocation_id,
+                        restate.invocation.target = %ism.invocation_target,
+                        restate.error.details = %error_details,
+                        "Invocation error, retrying in {}.",
+                        humantime::format_duration(next_retry_timer_duration));
+                } else {
+                    warn_it!(
+                        error,
+                        restate.invocation.id = %invocation_id,
+                        restate.invocation.target = %ism.invocation_target,
+                        "Invocation error, retrying in {}.",
+                        humantime::format_duration(next_retry_timer_duration));
+                }
                 trace!("Invocation state: {:?}.", ism.invocation_state_debug());
                 let next_retry_at = SystemTime::now() + next_retry_timer_duration;
 

--- a/crates/service-protocol-v4/src/entry_codec.rs
+++ b/crates/service-protocol-v4/src/entry_codec.rs
@@ -1607,10 +1607,10 @@ fn parse_complete_awakeable_id(awakeable_id: String) -> Result<CompleteAwakeable
 
 impl From<proto::ErrorMessage> for InvocationError {
     fn from(value: proto::ErrorMessage) -> Self {
-        if value.description.is_empty() {
+        if value.stacktrace.is_empty() {
             InvocationError::new(value.code, value.message)
         } else {
-            InvocationError::new(value.code, value.message).with_description(value.description)
+            InvocationError::new(value.code, value.message).with_stacktrace(value.stacktrace)
         }
     }
 }

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -45,6 +45,10 @@ use crate::pretty::PrettyFields;
 pub use exporter::set_global_node_id;
 
 const SERVICE_INSTANCE_NAME: &str = "service.instance.name";
+const RESTATE_INVOCATION_ID: &str ="restate.invocation.id";
+const RESTATE_INVOCATION_TARGET: &str = "restate.invocation.target";
+const RESTATE_ERROR_CODE: &str = "restate.error.code";
+const RESTATE_INVOCATION_ERROR_STACKTRACE: &str = "restate.invocation.error.stacktrace";
 
 #[derive(Debug, thiserror::Error)]
 #[error("could not initialize tracing {trace_error}")]

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -45,7 +45,7 @@ use crate::pretty::PrettyFields;
 pub use exporter::set_global_node_id;
 
 const SERVICE_INSTANCE_NAME: &str = "service.instance.name";
-const RESTATE_INVOCATION_ID: &str ="restate.invocation.id";
+const RESTATE_INVOCATION_ID: &str = "restate.invocation.id";
 const RESTATE_INVOCATION_TARGET: &str = "restate.invocation.target";
 const RESTATE_ERROR_CODE: &str = "restate.error.code";
 const RESTATE_INVOCATION_ERROR_STACKTRACE: &str = "restate.invocation.error.stacktrace";

--- a/crates/tracing-instrumentation/src/pretty.rs
+++ b/crates/tracing-instrumentation/src/pretty.rs
@@ -332,7 +332,9 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
             RESTATE_ERROR_CODE if self.skip_restate_code => {
                 // skip, this is printed by the restate specific event printer below
             }
-            RESTATE_INVOCATION_ERROR_STACKTRACE if self.skip_restate_invocation_error_stacktrace => {
+            RESTATE_INVOCATION_ERROR_STACKTRACE
+                if self.skip_restate_invocation_error_stacktrace =>
+            {
                 // skip, this is printed by the restate specific event printer below
             }
             RESTATE_INVOCATION_ID => {

--- a/crates/tracing-instrumentation/src/pretty.rs
+++ b/crates/tracing-instrumentation/src/pretty.rs
@@ -243,7 +243,7 @@ impl<'writer, T> FormatFields<'writer> for Pretty<T> {
 pub struct PrettyVisitor<'a> {
     writer: WriterWrapper<'a>,
     skip_restate_code: bool,
-    skip_restate_error_details: bool,
+    skip_restate_invocation_error_stacktrace: bool,
 }
 
 #[derive(Debug, Default)]
@@ -270,7 +270,7 @@ impl<'a> PrettyVisitor<'a> {
         Self {
             writer: WriterWrapper::new(writer, style),
             skip_restate_code,
-            skip_restate_error_details,
+            skip_restate_invocation_error_stacktrace: skip_restate_error_details,
         }
     }
 }
@@ -329,18 +329,18 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
                     FIELD_NEW_LINE_INDENT,
                 )
             }
-            "restate.error.code" if self.skip_restate_code => {
+            RESTATE_ERROR_CODE if self.skip_restate_code => {
                 // skip, this is printed by the restate specific event printer below
             }
-            "restate.error.details" if self.skip_restate_error_details => {
+            RESTATE_INVOCATION_ERROR_STACKTRACE if self.skip_restate_invocation_error_stacktrace => {
                 // skip, this is printed by the restate specific event printer below
             }
-            "restate.invocation.id" => {
+            RESTATE_INVOCATION_ID => {
                 let bold = self.writer.bold();
                 let italic = self.writer.italic();
                 self.writer.write_padded(
                     &format_args!(
-                        "{}restate.invocation.id{}: {}{value:?}{}",
+                        "{}{RESTATE_INVOCATION_ID}{}: {}{value:?}{}",
                         bold.prefix(),
                         bold.infix(self.writer.style()),
                         italic.prefix(),
@@ -350,12 +350,12 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
                     FIELD_NEW_LINE_INDENT,
                 )
             }
-            "restate.invocation.target" => {
+            RESTATE_INVOCATION_TARGET => {
                 let bold = self.writer.bold();
                 let italic = self.writer.italic();
                 self.writer.write_padded(
                     &format_args!(
-                        "{}restate.invocation.target{}: {}{value:?}{}",
+                        "{}{RESTATE_INVOCATION_TARGET}{}: {}{value:?}{}",
                         bold.prefix(),
                         bold.infix(self.writer.style()),
                         italic.prefix(),
@@ -418,9 +418,9 @@ impl<'a> RestateErrorCodeAndDetailsWriter<'a> {
 
 impl<'a> field::Visit for RestateErrorCodeAndDetailsWriter<'a> {
     fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
-        if field.name() == "restate.error.code" {
+        if field.name() == RESTATE_ERROR_CODE {
             self.0.write_padded(
-                &format_args!("restate.error.code: {value:?}"),
+                &format_args!("{RESTATE_ERROR_CODE}: {value:?}"),
                 FIELD_INDENT,
                 FIELD_NEW_LINE_INDENT,
             );
@@ -431,9 +431,9 @@ impl<'a> field::Visit for RestateErrorCodeAndDetailsWriter<'a> {
                 italic_bold.prefix(),
                 italic_bold.infix(self.0.style())
             ), FIELD_INDENT, FIELD_NEW_LINE_INDENT);
-        } else if field.name() == "restate.error.details" {
+        } else if field.name() == RESTATE_INVOCATION_ERROR_STACKTRACE {
             self.0.write_padded(
-                &format_args!("restate.error.details: {value:?}"),
+                &format_args!("{RESTATE_INVOCATION_ERROR_STACKTRACE}:\n{value:?}"),
                 FIELD_INDENT,
                 FIELD_NEW_LINE_INDENT,
             );

--- a/crates/tracing-instrumentation/src/pretty.rs
+++ b/crates/tracing-instrumentation/src/pretty.rs
@@ -141,14 +141,15 @@ where
             target_style.infix(style)
         )?;
 
-        let mut v = PrettyVisitor::new(writer.by_ref(), style);
+        let mut v = PrettyVisitor::new(writer.by_ref(), style, true, true);
         event.record(&mut v);
         v.finish()?;
 
         // Pretty print the restate error code description, if present
-        let mut restate_error_code_visitor = RestateErrorCodeWriter::new(writer.by_ref(), style);
-        event.record(&mut restate_error_code_visitor);
-        restate_error_code_visitor.finish()?;
+        let mut restate_error_code_and_details_visitor =
+            RestateErrorCodeAndDetailsWriter::new(writer.by_ref(), style);
+        event.record(&mut restate_error_code_and_details_visitor);
+        restate_error_code_and_details_visitor.finish()?;
         writer.write_char('\n')?;
 
         let dimmed = if writer.has_ansi_escapes() {
@@ -217,7 +218,7 @@ where
 
 impl<'writer, T> FormatFields<'writer> for Pretty<T> {
     fn format_fields<R: RecordFields>(&self, writer: Writer<'writer>, fields: R) -> fmt::Result {
-        let mut v = PrettyVisitor::new(writer, Style::default());
+        let mut v = PrettyVisitor::new(writer, Style::default(), false, false);
         fields.record(&mut v);
         v.finish()
     }
@@ -228,7 +229,7 @@ impl<'writer, T> FormatFields<'writer> for Pretty<T> {
         fields: &span::Record<'_>,
     ) -> fmt::Result {
         let writer = current.as_writer();
-        let mut v = PrettyVisitor::new(writer, Style::default());
+        let mut v = PrettyVisitor::new(writer, Style::default(), false, false);
         fields.record(&mut v);
         v.finish()
     }
@@ -239,7 +240,11 @@ impl<'writer, T> FormatFields<'writer> for Pretty<T> {
 /// [visitor]: field::Visit
 /// [`MakeVisitor`]: crate::field::MakeVisitor
 #[derive(Debug)]
-pub struct PrettyVisitor<'a>(WriterWrapper<'a>);
+pub struct PrettyVisitor<'a> {
+    writer: WriterWrapper<'a>,
+    skip_restate_code: bool,
+    skip_restate_error_details: bool,
+}
 
 #[derive(Debug, Default)]
 pub struct PrettyFields;
@@ -249,21 +254,30 @@ impl<'a> MakeVisitor<Writer<'a>> for PrettyFields {
 
     #[inline]
     fn make_visitor(&self, target: Writer<'a>) -> Self::Visitor {
-        PrettyVisitor::new(target, Style::default())
+        PrettyVisitor::new(target, Style::default(), false, false)
     }
 }
 
 // === impl PrettyVisitor ===
 
 impl<'a> PrettyVisitor<'a> {
-    pub fn new(writer: Writer<'a>, style: Style) -> Self {
-        Self(WriterWrapper::new(writer, style))
+    pub fn new(
+        writer: Writer<'a>,
+        style: Style,
+        skip_restate_code: bool,
+        skip_restate_error_details: bool,
+    ) -> Self {
+        Self {
+            writer: WriterWrapper::new(writer, style),
+            skip_restate_code,
+            skip_restate_error_details,
+        }
     }
 }
 
 impl<'a> field::Visit for PrettyVisitor<'a> {
     fn record_str(&mut self, field: &Field, value: &str) {
-        if self.0.result.is_err() {
+        if self.writer.result.is_err() {
             return;
         }
 
@@ -286,69 +300,77 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if self.0.result.is_err() {
+        if self.writer.result.is_err() {
             return;
         }
         match field.name() {
             "message" => {
-                let bold = self.0.bold();
-                self.0.write_padded(
-                    &format_args!("{}{:?}{}", bold.prefix(), value, bold.infix(self.0.style())),
+                let bold = self.writer.bold();
+                self.writer.write_padded(
+                    &format_args!(
+                        "{}{:?}{}",
+                        bold.prefix(),
+                        value,
+                        bold.infix(self.writer.style())
+                    ),
                     MESSAGE_INDENT,
                     MESSAGE_NEW_LINE_INDENT,
                 )
             }
             "error" => {
-                let bold = self.0.bold();
-                self.0.write_padded(
+                let bold = self.writer.bold();
+                self.writer.write_padded(
                     &format_args!(
                         "{}error{}: {value:?}",
                         bold.prefix(),
-                        bold.infix(self.0.style)
+                        bold.infix(self.writer.style)
                     ),
                     FIELD_INDENT,
                     FIELD_NEW_LINE_INDENT,
                 )
             }
-            "restate.error.code" => {
-                // skip, this is printed by the restate.error.code printer below
+            "restate.error.code" if self.skip_restate_code => {
+                // skip, this is printed by the restate specific event printer below
+            }
+            "restate.error.details" if self.skip_restate_error_details => {
+                // skip, this is printed by the restate specific event printer below
             }
             "restate.invocation.id" => {
-                let bold = self.0.bold();
-                let italic = self.0.italic();
-                self.0.write_padded(
+                let bold = self.writer.bold();
+                let italic = self.writer.italic();
+                self.writer.write_padded(
                     &format_args!(
                         "{}restate.invocation.id{}: {}{value:?}{}",
                         bold.prefix(),
-                        bold.infix(self.0.style()),
+                        bold.infix(self.writer.style()),
                         italic.prefix(),
-                        italic.infix(self.0.style())
+                        italic.infix(self.writer.style())
                     ),
                     FIELD_INDENT,
                     FIELD_NEW_LINE_INDENT,
                 )
             }
             "restate.invocation.target" => {
-                let bold = self.0.bold();
-                let italic = self.0.italic();
-                self.0.write_padded(
+                let bold = self.writer.bold();
+                let italic = self.writer.italic();
+                self.writer.write_padded(
                     &format_args!(
                         "{}restate.invocation.target{}: {}{value:?}{}",
                         bold.prefix(),
-                        bold.infix(self.0.style()),
+                        bold.infix(self.writer.style()),
                         italic.prefix(),
-                        italic.infix(self.0.style())
+                        italic.infix(self.writer.style())
                     ),
                     FIELD_INDENT,
                     FIELD_NEW_LINE_INDENT,
                 )
             }
-            name if name.starts_with("r#") => self.0.write_padded(
+            name if name.starts_with("r#") => self.writer.write_padded(
                 &format_args!("{}: {:?}", &name[2..], value),
                 FIELD_INDENT,
                 FIELD_NEW_LINE_INDENT,
             ),
-            name => self.0.write_padded(
+            name => self.writer.write_padded(
                 &format_args!("{name}: {value:?}"),
                 FIELD_INDENT,
                 FIELD_NEW_LINE_INDENT,
@@ -359,13 +381,13 @@ impl<'a> field::Visit for PrettyVisitor<'a> {
 
 impl<'a> VisitOutput<fmt::Result> for PrettyVisitor<'a> {
     fn finish(self) -> fmt::Result {
-        self.0.end()
+        self.writer.end()
     }
 }
 
 impl<'a> VisitFmt for PrettyVisitor<'a> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
-        &mut self.0.writer
+        &mut self.writer.writer
     }
 }
 
@@ -386,15 +408,15 @@ impl<'a> Display for ErrorSourceList<'a> {
 // --- Visitor to record as alternate the restate.error.code field
 
 #[derive(Debug)]
-struct RestateErrorCodeWriter<'a>(WriterWrapper<'a>);
+struct RestateErrorCodeAndDetailsWriter<'a>(WriterWrapper<'a>);
 
-impl<'a> RestateErrorCodeWriter<'a> {
+impl<'a> RestateErrorCodeAndDetailsWriter<'a> {
     pub fn new(writer: Writer<'a>, style: Style) -> Self {
         Self(WriterWrapper::new(writer, style))
     }
 }
 
-impl<'a> field::Visit for RestateErrorCodeWriter<'a> {
+impl<'a> field::Visit for RestateErrorCodeAndDetailsWriter<'a> {
     fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
         if field.name() == "restate.error.code" {
             self.0.write_padded(
@@ -409,11 +431,17 @@ impl<'a> field::Visit for RestateErrorCodeWriter<'a> {
                 italic_bold.prefix(),
                 italic_bold.infix(self.0.style())
             ), FIELD_INDENT, FIELD_NEW_LINE_INDENT);
+        } else if field.name() == "restate.error.details" {
+            self.0.write_padded(
+                &format_args!("restate.error.details: {value:?}"),
+                FIELD_INDENT,
+                FIELD_NEW_LINE_INDENT,
+            );
         }
     }
 }
 
-impl<'a> VisitOutput<fmt::Result> for RestateErrorCodeWriter<'a> {
+impl<'a> VisitOutput<fmt::Result> for RestateErrorCodeAndDetailsWriter<'a> {
     fn finish(self) -> fmt::Result {
         self.0.end()
     }

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -179,7 +179,7 @@ pub struct InvocationError {
     code: InvocationErrorCode,
     message: Cow<'static, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<Cow<'static, str>>,
+    stacktrace: Option<Cow<'static, str>>,
 }
 
 pub const UNKNOWN_INVOCATION_ERROR: InvocationError =
@@ -194,8 +194,8 @@ impl Default for InvocationError {
 impl fmt::Display for InvocationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}] {}", self.code(), self.message())?;
-        if self.description.is_some() {
-            write!(f, "\n{}", self.description().unwrap())?;
+        if self.stacktrace.is_some() {
+            write!(f, "\n{}", self.stacktrace().unwrap())?;
         }
         Ok(())
     }
@@ -208,7 +208,7 @@ impl InvocationError {
         Self {
             code,
             message: Cow::Borrowed(message),
-            description: None,
+            stacktrace: None,
         }
     }
 
@@ -216,7 +216,7 @@ impl InvocationError {
         Self {
             code: code.into(),
             message: Cow::Owned(message.to_string()),
-            description: None,
+            stacktrace: None,
         }
     }
 
@@ -224,7 +224,7 @@ impl InvocationError {
         Self {
             code: codes::INTERNAL,
             message: Cow::Owned(message.to_string()),
-            description: None,
+            stacktrace: None,
         }
     }
 
@@ -232,7 +232,7 @@ impl InvocationError {
         Self {
             code: codes::NOT_FOUND,
             message: Cow::Owned(format!("Service '{service}' not found. Check whether the deployment containing the service is registered.")),
-            description: None,
+            stacktrace: None,
         }
     }
 
@@ -243,7 +243,7 @@ impl InvocationError {
         Self {
             code: codes::NOT_FOUND,
             message: Cow::Owned(format!("Service handler '{service}/{handler}' not found. Check whether you've registered the correct version of your service.")),
-            description: None,
+            stacktrace: None,
         }
     }
 
@@ -257,13 +257,8 @@ impl InvocationError {
         self
     }
 
-    pub fn with_static_description(mut self, description: &'static str) -> InvocationError {
-        self.description = Some(Cow::Borrowed(description));
-        self
-    }
-
-    pub fn with_description(mut self, description: impl fmt::Display) -> InvocationError {
-        self.description = Some(Cow::Owned(description.to_string()));
+    pub fn with_stacktrace(mut self, stacktrace: impl fmt::Display) -> InvocationError {
+        self.stacktrace = Some(Cow::Owned(stacktrace.to_string()));
         self
     }
 
@@ -275,8 +270,8 @@ impl InvocationError {
         &self.message
     }
 
-    pub fn description(&self) -> Option<&str> {
-        self.description.as_deref()
+    pub fn stacktrace(&self) -> Option<&str> {
+        self.stacktrace.as_deref()
     }
 }
 

--- a/crates/types/src/service_protocol.rs
+++ b/crates/types/src/service_protocol.rs
@@ -55,7 +55,7 @@ impl From<ErrorMessage> for InvocationError {
         if value.description.is_empty() {
             InvocationError::new(value.code, value.message)
         } else {
-            InvocationError::new(value.code, value.message).with_description(value.description)
+            InvocationError::new(value.code, value.message).with_stacktrace(value.description)
         }
     }
 }

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -95,8 +95,8 @@ message ErrorMessage {
   uint32 code = 1;
   // Contains a concise error message, e.g. Throwable#getMessage() in Java.
   string message = 2;
-  // Contains a verbose error description, e.g. the exception stacktrace.
-  string description = 3;
+  // The exception stacktrace, if available.
+  string stacktrace = 3;
 
   // Command that caused the failure. This may be outside the current stored journal size.
   // If no specific entry caused the failure, the current replayed/processed entry can be used.


### PR DESCRIPTION
This makes the logs leaner.

![image](https://github.com/user-attachments/assets/05413cbb-3516-4c99-a5b5-46bf63760024)
