### PR TITLE
Allow mark_the_node_as_writeable to tolerate retry attempts 

### DIFF
--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -248,7 +248,7 @@ impl<'a> BifrostAdmin<'a> {
                 })
         })
         .await
-        .map_err(|e| e.transpose())?;
+        .map_err(|e| e.into_inner().transpose())?;
 
         self.inner.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())
@@ -287,7 +287,7 @@ impl<'a> BifrostAdmin<'a> {
                 )
         })
         .await
-        .map_err(|e| e.transpose())?;
+        .map_err(|e| e.into_inner().transpose())?;
 
         self.inner.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())
@@ -310,7 +310,8 @@ impl<'a> BifrostAdmin<'a> {
                     Logs::from_configuration(&Configuration::pinned())
                 })
         })
-        .await?;
+        .await
+        .map_err(|err| err.into_inner())?;
 
         self.inner.metadata_writer.update(Arc::new(logs)).await?;
         Ok(())

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -383,7 +383,6 @@ mod tests {
             HealthStatus::default(),
             config.clone(),
             node_env.metadata.clone(),
-            node_env.metadata_store_client.clone(),
             record_cache.clone(),
             &mut node_env.router_builder,
             &mut server_builder,

--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -490,7 +490,7 @@ pub enum ReadModifyWriteError<E = String> {
 
 impl<E> MaybeRetryableError for ReadModifyWriteError<E>
 where
-    E: std::error::Error + Send + Sync + 'static,
+    E: std::fmt::Display + std::fmt::Debug + 'static,
 {
     fn retryable(&self) -> bool {
         match self {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -217,7 +217,6 @@ impl Node {
                     health.log_server_status(),
                     updateable_config.clone(),
                     metadata.clone(),
-                    metadata_store_client.clone(),
                     record_cache,
                     &mut router_builder,
                     &mut server_builder,

--- a/crates/node/src/roles/base.rs
+++ b/crates/node/src/roles/base.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::Context;
 use futures::StreamExt;
 
 use restate_core::{
@@ -37,7 +36,7 @@ impl BaseRole {
         }
     }
 
-    pub fn start(self) -> anyhow::Result<()> {
+    pub fn start(self) -> Result<(), ShutdownError> {
         TaskCenter::spawn_child(TaskKind::RoleRunner, "base-role-service", async {
             let cancelled = cancellation_watcher();
 
@@ -49,8 +48,7 @@ impl BaseRole {
                     Ok(())
                 }
             }
-        })
-        .context("Failed to start base service")?;
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
In the presence of network errores, mark_the_node_as_writeable must be able to
tolerate retry attempts. This commit changes the behvaiour of this method to
only fail on the first attempt if the StorageState is not Provisioning. Moreover,
it adds a basic retry policy for retryable errors.

This fixes https://github.com/restatedev/restate/issues/2563.