### PR TITLE
Fix Raft metadata join logic 

### DIFF
--- a/crates/metadata-server/src/raft/store.rs
+++ b/crates/metadata-server/src/raft/store.rs
@@ -1411,9 +1411,11 @@ impl Standby {
                             Span::current().record("member_id", MemberId::new(my_node_id.unwrap(), self.storage_id).to_string());
                         }
 
-                        if matches!(node_config.metadata_server_config.metadata_server_state, MetadataServerState::Member) && join_cluster.is_terminated() {
-                            debug!("Node is part of the metadata store cluster. Trying to join the raft cluster.");
-                            join_cluster.set(Some(Self::join_cluster(None, None, my_node_id.unwrap(), storage_id).fuse()).into());
+                        if matches!(node_config.metadata_server_config.metadata_server_state, MetadataServerState::Member) {
+                            if join_cluster.is_terminated() {
+                                debug!("Node is part of the metadata store cluster. Trying to join the raft cluster.");
+                                join_cluster.set(Some(Self::join_cluster(None, None, my_node_id.unwrap(), storage_id).fuse()).into());
+                            }
                         } else {
                             debug!("Node is not part of the metadata store cluster. Waiting to become a candidate.");
                             join_cluster.set(None.into());


### PR DESCRIPTION
Before, we stopped joining the cluster if were a member and had an ongoing join
operation in flight. This was clearly wrong. This is no changed to only stop
joining if one is no longer a member.