### PR TITLE
Add config option to configure the ingress_endpoint in the admin configuration. This will be used by the Web UI.

### DIFF
--- a/crates/admin-rest-model/src/version.rs
+++ b/crates/admin-rest-model/src/version.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use http::Uri;
 use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
 
@@ -63,6 +64,12 @@ pub struct VersionInformation {
     ///
     /// Maximum supported admin API version by the admin server
     pub max_admin_api_version: u16,
+    /// # Ingress endpoint
+    ///
+    /// Ingress endpoint that the Web UI should use to interact with.
+    #[serde(with = "serde_with::As::<Option<serde_with::DisplayFromStr>>")]
+    #[cfg_attr(feature = "schema", schemars(with = "String", url))]
+    pub ingress_endpoint: Option<Uri>,
 }
 
 #[cfg(test)]

--- a/crates/admin/src/rest_api/version.rs
+++ b/crates/admin/src/rest_api/version.rs
@@ -11,6 +11,7 @@
 use axum::Json;
 use okapi_operation::*;
 use restate_admin_rest_model::version::{AdminApiVersion, VersionInformation};
+use restate_types::config::Configuration;
 
 /// Min/max supported admin api versions by the server
 pub const MIN_ADMIN_API_VERSION: AdminApiVersion = AdminApiVersion::V1;
@@ -28,5 +29,9 @@ pub async fn version() -> Json<VersionInformation> {
         version: env!("CARGO_PKG_VERSION").to_owned(),
         min_admin_api_version: MIN_ADMIN_API_VERSION.as_repr(),
         max_admin_api_version: MAX_ADMIN_API_VERSION.as_repr(),
+        ingress_endpoint: Configuration::pinned()
+            .admin
+            .advertised_ingress_endpoint
+            .clone(),
     })
 }

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -11,6 +11,7 @@
 use crate::partition_table::PartitionReplication;
 
 use super::QueryEngineOptions;
+use http::Uri;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::net::SocketAddr;
@@ -75,6 +76,13 @@ pub struct AdminOptions {
 
     #[cfg(any(test, feature = "test-util"))]
     pub disable_cluster_controller: bool,
+
+    /// # Ingress endpoint
+    ///
+    /// Ingress endpoint that the Web UI should use to interact with.
+    #[serde(with = "serde_with::As::<Option<serde_with::DisplayFromStr>>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String", url))]
+    pub advertised_ingress_endpoint: Option<Uri>,
 }
 
 impl AdminOptions {
@@ -114,6 +122,7 @@ impl Default for AdminOptions {
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
             log_tail_update_interval: Duration::from_secs(5 * 60).into(),
+            advertised_ingress_endpoint: Some("http://localhost:8080/".parse().unwrap()),
         }
     }
 }


### PR DESCRIPTION
To configure via env var: `RESTATE_ADMIN__ADVERTISED_INGRESS_ENDPOINT="http://localhost:8081/"`