### PR TITLE
Bump CDK dependency in load-test template

### DIFF
--- a/scripts/loadtest-environment/package.json
+++ b/scripts/loadtest-environment/package.json
@@ -6,13 +6,13 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "20.14.9",
-    "aws-cdk": "2.156.0",
-    "aws-cdk-lib": "2.156.0",
+    "@types/node": "^20.14.9",
+    "aws-cdk": "^2.177.0",
+    "aws-cdk-lib": "^2.177.0",
     "constructs": "^10.0.0",
     "prettier": "^3.3.3",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
-    "typescript": "~5.5.3"
+    "typescript": "^5.7.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/restatedev/restate/security/dependabot/16

This is a trivial dependency bump - we don't actually run this anywhere, it's just here as a reference.