### PR TITLE
Use scarf urls for downloading binaries

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,4 +1,5 @@
 # Lifted from what dist would generate as the homebrew publish step, except rewriting the download urls to use scarf.
+# We also need to deliberately skip any publish steps here if this is a pre-release, as Homebrew doesn't support prereleases.'
 
 name: Publish homebrew formulae
 
@@ -15,6 +16,8 @@ env:
 
 jobs:
   publish-homebrew-formula:
+    # homebrew only really has a single 'latest' version, so we must skip prereleases
+    if: ${{ !fromJson(inputs.plan).announcement_is_prerelease }}
     runs-on: "ubuntu-20.04"
     env:
       GITHUB_USER: "Restate bot"

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,58 @@
+# Lifted from what dist would generate as the homebrew publish step, except rewriting the download urls to use scarf.
+
+name: Publish homebrew formulae
+
+on:
+  workflow_call:
+    inputs:
+      # comes from cargo-dist workflow call
+      plan:
+        required: true
+        type: string
+
+env:
+  PLAN: ${{ inputs.plan }}
+
+jobs:
+  publish-homebrew-formula:
+    runs-on: "ubuntu-20.04"
+    env:
+      GITHUB_USER: "Restate bot"
+      GITHUB_EMAIL: "code+bot@restate.dev"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: "restatedev/homebrew-tap"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+
+            # Set the Scarf download URLs
+            sed -i -E 's%https://github.com/restatedev/restate/releases/download/([^/]+)/([^"]+)%https://restate.gateway.scarf.sh/\1/\2%g' "Formula/${filename}"
+
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,3 +1,6 @@
+# We do this manually instead of using dist's native npm functionality because this way, the binary is actually hosted on npm, instead
+# of being downloaded as a postinstall step. Also so that we can set --tag next on prerelease.
+
 name: Publish npm binary packages
 
 on:
@@ -59,6 +62,7 @@ jobs:
         shell: bash
         run: |
           bin="$(echo "$PLAN" | jq -r '.artifacts["${{ matrix.app_name }}-${{ matrix.build.target }}.tar.xz"].assets[] | select(.kind == "executable").name')"
+          tag="${{ fromJson(inputs.plan).announcement_is_prerelease && 'next' || 'latest' }}"
 
           cd npm
           node_os="${{ matrix.build.node_os }}"
@@ -86,7 +90,7 @@ jobs:
           cp "${dir}/README.md" "${node_pkg}"
           # publish the package
           pushd "${node_pkg}"
-          npm publish --access public
+          npm publish --access public --tag "${tag}"
           popd
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -114,6 +118,7 @@ jobs:
         run: |
           node_version=$(echo "$PLAN" | jq -r '.releases[] | select(.app_name == "${{ matrix.app_name }}").app_version')"
           bin="$(echo "$PLAN" | jq -r '.artifacts["${{ matrix.package.artifact }}-${{ matrix.build.target }}.tar.xz"].assets[] | select(.kind == "executable").name')"
+          tag="${{ fromJson(inputs.plan).announcement_is_prerelease && 'next' || 'latest' }}"
 
           cd npm
           if npm view "@restatedev/${bin}@${node_version}"
@@ -132,7 +137,7 @@ jobs:
           curl https://raw.githubusercontent.com/restatedev/restate/main/README.md -o README.md
           npm install
           npm run build
-          npm publish --access public
+          npm publish --access public --tag "${tag}"
           popd
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,11 +190,28 @@ jobs:
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
 
+  custom-ci:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' }}
+    uses: ./.github/workflows/ci.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    permissions:
+      "actions": "read"
+      "checks": "write"
+      "contents": "read"
+      "issues": "read"
+      "packages": "read"
+      "pull-requests": "write"
+
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
       - build-local-artifacts
+      - custom-ci
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -240,6 +257,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
+      - custom-ci
     uses: ./.github/workflows/notarize.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
@@ -249,10 +267,11 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
+      - custom-ci
       - build-global-artifacts
       - custom-notarize
     # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-notarize.result == 'skipped' || needs.custom-notarize.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-notarize.result == 'skipped' || needs.custom-notarize.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.custom-ci.result == 'skipped' || needs.custom-ci.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-20.04"
@@ -311,29 +330,10 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  custom-ci:
-    needs:
-      - plan
-      - build-local-artifacts
-      - build-global-artifacts
-      - custom-notarize
-    uses: ./.github/workflows/ci.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
-    permissions:
-      "actions": "read"
-      "checks": "write"
-      "contents": "read"
-      "issues": "read"
-      "packages": "read"
-      "pull-requests": "write"
-
   custom-homebrew:
     needs:
       - plan
       - host
-      - custom-ci
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     uses: ./.github/workflows/homebrew.yml
     with:
@@ -348,7 +348,6 @@ jobs:
     needs:
       - plan
       - host
-      - custom-ci
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     uses: ./.github/workflows/docker-release.yml
     with:
@@ -363,7 +362,6 @@ jobs:
     needs:
       - plan
       - host
-      - custom-ci
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     uses: ./.github/workflows/npm.yml
     with:
@@ -381,7 +379,6 @@ jobs:
       - custom-homebrew
       - custom-docker-release
       - custom-npm
-      - custom-ci
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,51 +329,20 @@ jobs:
       "packages": "read"
       "pull-requests": "write"
 
-  publish-homebrew-formula:
+  custom-homebrew:
     needs:
       - plan
       - host
       - custom-ci
-    runs-on: "ubuntu-20.04"
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PLAN: ${{ needs.plan.outputs.val }}
-      GITHUB_USER: "axo bot"
-      GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: "restatedev/homebrew-tap"
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      # So we have access to the formula
-      - name: Fetch homebrew formulae
-        uses: actions/download-artifact@v4
-        with:
-          pattern: artifacts-*
-          path: Formula/
-          merge-multiple: true
-      # This is extra complex because you can make your Formula name not match your app name
-      # so we need to find releases with a *.rb file, and publish with that filename.
-      - name: Commit formula files
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_EMAIL}"
-
-          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
-            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
-            name=$(echo "$filename" | sed "s/\.rb$//")
-            version=$(echo "$release" | jq .app_version --raw-output)
-
-            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-            brew update
-            # We avoid reformatting user-provided data such as the app description and homepage.
-            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
-
-            git add "Formula/${filename}"
-            git commit -m "${name} ${version}"
-          done
-          git push
+    uses: ./.github/workflows/homebrew.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
+    permissions:
+      "id-token": "write"
+      "packages": "write"
 
   custom-docker-release:
     needs:
@@ -409,14 +378,14 @@ jobs:
     needs:
       - plan
       - host
-      - publish-homebrew-formula
+      - custom-homebrew
       - custom-docker-release
       - custom-npm
       - custom-ci
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.custom-docker-release.result == 'skipped' || needs.custom-docker-release.result == 'success') && (needs.custom-npm.result == 'skipped' || needs.custom-npm.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-homebrew.result == 'skipped' || needs.custom-homebrew.result == 'success') && (needs.custom-docker-release.result == 'skipped' || needs.custom-docker-release.result == 'success') && (needs.custom-npm.result == 'skipped' || needs.custom-npm.result == 'success') }}
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,3 +399,14 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+
+  custom-scarf-release-notes:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/scarf-release-notes.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    permissions:
+      "contents": "write"

--- a/.github/workflows/scarf-release-notes.yml
+++ b/.github/workflows/scarf-release-notes.yml
@@ -1,0 +1,32 @@
+name: Rewrite release description to use scarf URLs
+
+on:
+  workflow_call:
+    inputs:
+      # comes from cargo-dist workflow call
+      plan:
+        required: true
+        type: string
+
+env:
+  PLAN: ${{ inputs.plan }}
+
+jobs:
+  scarf:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Amend GitHub Release
+        run: |
+          # Download the release notes
+          gh release view --json body -q '.body' > "$RUNNER_TEMP/notes.txt"
+
+          # Set the Scarf download URLs
+          sed -i -E 's%https://github.com/restatedev/restate/releases/download/([^/]+)/(.+\.tar\.xz)%https://restate.gateway.scarf.sh/\1/\2%g' "$RUNNER_TEMP/notes.txt"
+
+          # Update the release notes
+          gh release edit "${{ github.ref_name }}" --notes-file "$RUNNER_TEMP/notes.txt"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 [package.metadata.dist]
 dist = true
 formula = "restate"
+npm-package = "restate"
 
 [features]
 default = ["cloud", "no-trace-logging"]

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -273,7 +273,7 @@ pub struct CommonOptions {
     /// # Disable telemetry
     ///
     /// Restate uses Scarf to collect anonymous usage data to help us understand how the software is being used.
-    /// You can set this flag to true to disable this collection. It can also be set with the environment variable DO_NOT_TRACK=true.
+    /// You can set this flag to true to disable this collection. It can also be set with the environment variable DO_NOT_TRACK=1.
     pub disable_telemetry: bool,
 }
 

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -95,6 +95,8 @@ impl ConfigLoader {
             )
             .merge(
                 Env::raw()
+                    // will accept true, yes, 1, on as true
+                    // and false, no, 0, off as false
                     .only(&["DO_NOT_TRACK"])
                     .map(|_| "disable-telemetry".into()),
             );

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,7 +27,7 @@ local-artifacts-jobs = ["./ci"]
 global-artifacts-jobs = ["./notarize"]
 publish-jobs = ["./homebrew", "./docker-release", "./npm"]
 # helm goes here because it shouldn't exist before docker-release happens
-post-announce-jobs = ["./helm"]
+post-announce-jobs = ["./helm", "./scarf-release-notes"]
 
 [dist.github-custom-job-permissions.ci]
 packages = "read"
@@ -40,6 +40,9 @@ actions = "read"
 [dist.github-custom-job-permissions.npm]
 packages = "read"
 contents = "read"
+
+[dist.github-custom-job-permissions.scarf-release-notes]
+contents = "write"
 
 [dist.dependencies.homebrew]
 protobuf = "*"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,9 +21,12 @@ include = ["NOTICE"]
 precise-builds = true
 cache-builds = false
 
-host-jobs = ["./ci"]
+# ci goes here because we want it to start early, and we don't want to create a release unless it succeeds
+local-artifacts-jobs = ["./ci"]
+# create release goes here because it needs to have happened before the host steps, which expect a draft release to already exist
 global-artifacts-jobs = ["./notarize"]
 publish-jobs = ["./homebrew", "./docker-release", "./npm"]
+# helm goes here because it shouldn't exist before docker-release happens
 post-announce-jobs = ["./helm"]
 
 [dist.github-custom-job-permissions.ci]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -20,6 +20,8 @@ github-build-setup = "steps/release-build-setup.yml"
 include = ["NOTICE"]
 precise-builds = true
 cache-builds = false
+# npm and docker can handle pre-releases, we will skip homebrew manually
+publish-preleases = true
 
 # ci goes here because we want it to start early, and we don't want to create a release unless it succeeds
 local-artifacts-jobs = ["./ci"]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,9 +9,11 @@ cargo-dist-version = "0.28.0"
 ci = "github"
 github-attestations = true
 # The installers to generate for each app
-installers = ["homebrew"]
+installers = ["homebrew", "npm"]
 # A GitHub repo to push Homebrew formulas to
 tap = "restatedev/homebrew-tap"
+# The npm scope that our npm packages are under
+npm-scope = "@restatedev"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
 macos-sign = true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -23,7 +23,7 @@ cache-builds = false
 
 host-jobs = ["./ci"]
 global-artifacts-jobs = ["./notarize"]
-publish-jobs = ["./docker-release", "homebrew", "./npm"]
+publish-jobs = ["./homebrew", "./docker-release", "./npm"]
 post-announce-jobs = ["./helm"]
 
 [dist.github-custom-job-permissions.ci]

--- a/npm/restate-server/package.json
+++ b/npm/restate-server/package.json
@@ -21,6 +21,9 @@
     "build": "tsc",
     "dev": "npm run build && node lib/index.js"
   },
+  "dependencies": {
+    "@scarf/scarf": "^1.4.0"
+  },
   "devDependencies": {
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/npm/restate/package.json
+++ b/npm/restate/package.json
@@ -21,6 +21,9 @@
     "build": "tsc",
     "dev": "npm run build && node lib/index.js"
   },
+  "dependencies": {
+    "@scarf/scarf": "^1.4.0"
+  },
   "devDependencies": {
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/npm/restatectl/package.json
+++ b/npm/restatectl/package.json
@@ -21,6 +21,9 @@
     "build": "tsc",
     "dev": "npm run build && node lib/index.js"
   },
+  "dependencies": {
+    "@scarf/scarf": "^1.4.0"
+  },
   "devDependencies": {
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.0",


### PR DESCRIPTION
1. Use scarf urls in homebrew
2. Use scarf urls in release notes install instructions
3. Include scarf dependency in binary NPM packages
4. Publish npm (under 'next' tag) and docker ('latest' will not be set) when pre-releasing, but not homebrew (as this basically doesn't have versions)
5. Tell dist to create an npm installer, just so it mentions it in the release notes.