### PR TITLE
Make provision a top-level command 

### DIFF
--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -19,6 +19,7 @@ use crate::commands::log::Logs;
 use crate::commands::metadata::Metadata;
 use crate::commands::node::Nodes;
 use crate::commands::partition::Partitions;
+use crate::commands::provision::ProvisionOpts;
 use crate::commands::replicated_loglet::ReplicatedLoglet;
 use crate::commands::snapshot::Snapshot;
 use crate::connection::ConnectionInfo;
@@ -60,6 +61,8 @@ pub enum Command {
     /// Commands that operate on replicated loglets
     #[clap(subcommand)]
     ReplicatedLoglet(ReplicatedLoglet),
+    /// Provision a new cluster
+    Provision(ProvisionOpts),
 }
 
 fn init(common_opts: &CommonOpts) {

--- a/tools/restatectl/src/commands/cluster/config/set.rs
+++ b/tools/restatectl/src/commands/cluster/config/set.rs
@@ -36,8 +36,8 @@ pub struct ConfigSetOpts {
     partition_replication: Option<ReplicationProperty>,
 
     /// Bifrost provider kind.
-    #[clap(long, alias("log-provider"))]
-    bifrost_provider: Option<ProviderKind>,
+    #[clap(long)]
+    log_provider: Option<ProviderKind>,
 
     /// Replication property of bifrost logs if using replicated as log provider
     #[clap(long)]
@@ -72,7 +72,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
     //  replication to everywhere. Everywhere should probably be an explicit value.
     current.partition_replication = set_opts.partition_replication.clone().map(Into::into);
 
-    set_opts.bifrost_provider.inspect(|provider| {
+    set_opts.log_provider.inspect(|provider| {
         match provider {
             ProviderKind::InMemory | ProviderKind::Local => {
                 c_warn!("You are about to reconfigure your cluster with a Bifrost provider that only supports a single node cluster.");
@@ -87,7 +87,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
         anyhow::bail!("The cluster has no Bifrost provider configured. This indicates a problem with the cluster.");
     };
 
-    if let Some(provider) = set_opts.bifrost_provider {
+    if let Some(provider) = set_opts.log_provider {
         bifrost_provider.provider = provider.to_string();
     }
 

--- a/tools/restatectl/src/commands/cluster/mod.rs
+++ b/tools/restatectl/src/commands/cluster/mod.rs
@@ -8,15 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod config;
+pub(crate) mod config;
 pub(crate) mod overview;
-mod provision;
 
 use cling::prelude::*;
 use config::Config;
 
 use crate::commands::cluster::overview::ClusterStatusOpts;
-use crate::commands::cluster::provision::ProvisionOpts;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Cluster {
@@ -25,6 +23,4 @@ pub enum Cluster {
     /// Manage cluster configuration
     #[clap(subcommand)]
     Config(Config),
-    /// Provision a new cluster
-    Provision(ProvisionOpts),
 }

--- a/tools/restatectl/src/commands/cluster/provision.rs
+++ b/tools/restatectl/src/commands/cluster/provision.rs
@@ -38,8 +38,8 @@ pub struct ProvisionOpts {
     partition_replication: Option<ReplicationProperty>,
 
     /// Default log provider kind
-    #[clap(long, alias = "log-provider")]
-    bifrost_provider: Option<ProviderKind>,
+    #[clap(long)]
+    log_provider: Option<ProviderKind>,
 
     /// Replication property of bifrost logs if using replicated as log provider
     #[clap(long)]
@@ -80,7 +80,7 @@ async fn cluster_provision(
         num_partitions: provision_opts.num_partitions.map(|n| u32::from(n.get())),
         partition_replication: provision_opts.partition_replication.clone().map(Into::into),
         log_provider: provision_opts
-            .bifrost_provider
+            .log_provider
             .map(|provider| provider.to_string()),
         log_replication: provision_opts.log_replication.clone().map(Into::into),
         target_nodeset_size: provision_opts.log_default_nodeset_size.map(Into::into),

--- a/tools/restatectl/src/commands/mod.rs
+++ b/tools/restatectl/src/commands/mod.rs
@@ -15,5 +15,6 @@ pub mod log;
 pub mod metadata;
 pub mod node;
 pub mod partition;
+pub mod provision;
 pub mod replicated_loglet;
 pub mod snapshot;

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -25,7 +25,7 @@ use tonic::codec::CompressionEncoding;
 use tonic::Code;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
-#[cling(run = "cluster_provision")]
+#[cling(run = "provision_cluster")]
 pub struct ProvisionOpts {
     /// Number of partitions
     #[clap(long)]
@@ -51,7 +51,7 @@ pub struct ProvisionOpts {
     log_default_nodeset_size: Option<u16>,
 }
 
-async fn cluster_provision(
+async fn provision_cluster(
     connection: &ConnectionInfo,
     provision_opts: &ProvisionOpts,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
Instead of calling restatectl cluster provision one now can call
restatectl provision to provision a Restate cluster.