### PR TITLE
Rename serialized MetadataServerKind::Raft variant to replicated and MetadataStoreClientOptions into MetadataClientOptions

### DIFF
--- a/crates/core/src/metadata_store/providers/etcd.rs
+++ b/crates/core/src/metadata_store/providers/etcd.rs
@@ -16,7 +16,7 @@ use etcd_client::{
     TxnOp,
 };
 
-use restate_types::config::MetadataStoreClientOptions;
+use restate_types::config::MetadataClientOptions;
 use restate_types::errors::GenericError;
 
 use crate::metadata_store::{
@@ -73,7 +73,7 @@ pub struct EtcdMetadataStore {
 impl EtcdMetadataStore {
     pub async fn new<S: AsRef<[A]>, A: AsRef<str>>(
         addresses: S,
-        metadata_options: &MetadataStoreClientOptions,
+        metadata_options: &MetadataClientOptions,
     ) -> anyhow::Result<Self> {
         let opts = ConnectOptions::new()
             .with_connect_timeout(metadata_options.connect_timeout())
@@ -323,7 +323,7 @@ impl ProvisionedMetadataStore for EtcdMetadataStore {
 mod test {
     use bytes::Bytes;
     use bytestring::ByteString;
-    use restate_types::{config::MetadataStoreClientOptions, Version};
+    use restate_types::{config::MetadataClientOptions, Version};
 
     use super::EtcdMetadataStore;
     use crate::metadata_store::{MetadataStore, Precondition, VersionedValue, WriteError};
@@ -337,7 +337,7 @@ mod test {
     #[ignore]
     #[tokio::test]
     async fn test_put_does_not_exist() {
-        let opts = MetadataStoreClientOptions::default();
+        let opts = MetadataClientOptions::default();
         let client = EtcdMetadataStore::new(&TEST_ADDRESS, &opts).await.unwrap();
 
         let key: ByteString = "put_does_not_exist".into();
@@ -364,7 +364,7 @@ mod test {
     #[ignore]
     #[tokio::test]
     async fn test_put_with_version() {
-        let opts = MetadataStoreClientOptions::default();
+        let opts = MetadataClientOptions::default();
         let client = EtcdMetadataStore::new(&TEST_ADDRESS, &opts).await.unwrap();
 
         let key: ByteString = "put_with_version".into();
@@ -422,7 +422,7 @@ mod test {
     #[ignore]
     #[tokio::test]
     async fn test_put_force() {
-        let opts = MetadataStoreClientOptions::default();
+        let opts = MetadataClientOptions::default();
         let client = EtcdMetadataStore::new(&TEST_ADDRESS, &opts).await.unwrap();
 
         let key: ByteString = "put_force".into();
@@ -466,7 +466,7 @@ mod test {
     #[ignore]
     #[tokio::test]
     async fn test_delete() {
-        let opts = MetadataStoreClientOptions::default();
+        let opts = MetadataClientOptions::default();
         let client = EtcdMetadataStore::new(&TEST_ADDRESS, &opts).await.unwrap();
 
         let key: ByteString = "put_delete_me".into();

--- a/crates/core/src/metadata_store/providers/objstore/mod.rs
+++ b/crates/core/src/metadata_store/providers/objstore/mod.rs
@@ -13,7 +13,7 @@ use crate::metadata_store::providers::objstore::optimistic_store::OptimisticLock
 use crate::metadata_store::providers::objstore::version_repository::VersionRepository;
 use crate::metadata_store::MetadataStore;
 use crate::{TaskCenter, TaskKind};
-use restate_types::config::MetadataStoreClient;
+use restate_types::config::MetadataClientKind;
 use restate_types::errors::GenericError;
 
 mod glue;
@@ -22,7 +22,7 @@ mod optimistic_store;
 mod version_repository;
 
 pub async fn create_object_store_based_meta_store(
-    configuration: MetadataStoreClient,
+    configuration: MetadataClientKind,
 ) -> Result<impl MetadataStore, GenericError> {
     // obtain an instance of a version repository from the configuration.
     // we use an object_store backed version repository.

--- a/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
+++ b/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
@@ -18,7 +18,7 @@ use object_store::{Error, ObjectStore, PutMode, PutOptions, PutPayload, UpdateVe
 use crate::metadata_store::providers::objstore::version_repository::{
     Tag, TaggedValue, VersionRepository, VersionRepositoryError,
 };
-use restate_types::config::{MetadataStoreClient, ObjectStoreCredentials};
+use restate_types::config::{MetadataClientKind, ObjectStoreCredentials};
 
 #[derive(Debug)]
 pub(crate) struct ObjectStoreVersionRepository {
@@ -26,8 +26,8 @@ pub(crate) struct ObjectStoreVersionRepository {
 }
 
 impl ObjectStoreVersionRepository {
-    pub(crate) fn from_configuration(configuration: MetadataStoreClient) -> anyhow::Result<Self> {
-        let MetadataStoreClient::ObjectStore {
+    pub(crate) fn from_configuration(configuration: MetadataClientKind) -> anyhow::Result<Self> {
+        let MetadataClientKind::ObjectStore {
             credentials,
             bucket,
             ..

--- a/crates/core/src/metadata_store/providers/objstore/optimistic_store.rs
+++ b/crates/core/src/metadata_store/providers/objstore/optimistic_store.rs
@@ -17,17 +17,17 @@ use crate::metadata_store::providers::objstore::version_repository::{
     TaggedValue, VersionRepository, VersionRepositoryError,
 };
 use crate::metadata_store::{Precondition, ReadError, VersionedValue, WriteError};
-use restate_types::config::MetadataStoreClient;
+use restate_types::config::MetadataClientKind;
 use restate_types::Version;
 
 pub(crate) struct OptimisticLockingMetadataStoreBuilder {
     pub(crate) version_repository: Box<dyn VersionRepository>,
-    pub(crate) configuration: MetadataStoreClient,
+    pub(crate) configuration: MetadataClientKind,
 }
 
 impl OptimisticLockingMetadataStoreBuilder {
     pub(crate) async fn build(self) -> anyhow::Result<OptimisticLockingMetadataStore> {
-        let MetadataStoreClient::ObjectStore { .. } = self.configuration else {
+        let MetadataClientKind::ObjectStore { .. } = self.configuration else {
             anyhow::bail!("unexpected configuration value");
         };
         Ok(OptimisticLockingMetadataStore::new(self.version_repository))

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -24,7 +24,7 @@ use tokio_util::net::Listener;
 use tonic::transport::{Channel, Endpoint};
 use tracing::{debug, error_span, info, instrument, trace, Instrument, Span};
 
-use restate_types::config::{Configuration, MetadataStoreClientOptions, NetworkingOptions};
+use restate_types::config::{Configuration, MetadataClientOptions, NetworkingOptions};
 use restate_types::errors::GenericError;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 
@@ -292,9 +292,9 @@ impl CommonClientConnectionOptions for NetworkingOptions {
     }
 }
 
-impl CommonClientConnectionOptions for MetadataStoreClientOptions {
+impl CommonClientConnectionOptions for MetadataClientOptions {
     fn connect_timeout(&self) -> Duration {
-        self.metadata_store_connect_timeout.into()
+        self.connect_timeout.into()
     }
 
     fn request_timeout(&self) -> Option<Duration> {
@@ -302,11 +302,11 @@ impl CommonClientConnectionOptions for MetadataStoreClientOptions {
     }
 
     fn keep_alive_interval(&self) -> Duration {
-        self.metadata_store_keep_alive_interval.into()
+        self.keep_alive_interval.into()
     }
 
     fn keep_alive_timeout(&self) -> Duration {
-        self.metadata_store_keep_alive_timeout.into()
+        self.keep_alive_timeout.into()
     }
 
     fn http2_adaptive_window(&self) -> bool {

--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -22,7 +22,7 @@ use restate_core::metadata_store::{
 };
 use restate_core::network::net_util::create_tonic_channel;
 use restate_core::{cancellation_watcher, Metadata, TaskCenter, TaskKind};
-use restate_types::config::{Configuration, MetadataStoreClientOptions};
+use restate_types::config::{Configuration, MetadataClientOptions};
 use restate_types::net::metadata::MetadataKind;
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration, Role};
@@ -70,7 +70,7 @@ pub struct GrpcMetadataServerClient {
 impl GrpcMetadataServerClient {
     pub fn new(
         metadata_store_addresses: Vec<AdvertisedAddress>,
-        client_options: MetadataStoreClientOptions,
+        client_options: MetadataClientOptions,
     ) -> Self {
         let channel_manager = ChannelManager::new(metadata_store_addresses, client_options);
         let svc_client = Arc::new(Mutex::new(
@@ -362,13 +362,13 @@ impl StatusError {
 #[derive(Clone, Debug)]
 struct ChannelManager {
     channels: Arc<Mutex<Channels>>,
-    client_options: MetadataStoreClientOptions,
+    client_options: MetadataClientOptions,
 }
 
 impl ChannelManager {
     fn new(
         initial_addresses: Vec<AdvertisedAddress>,
-        client_options: MetadataStoreClientOptions,
+        client_options: MetadataClientOptions,
     ) -> Self {
         let initial_channels: Vec<_> = initial_addresses
             .into_iter()

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -35,22 +35,23 @@ use crate::metric_definitions::{
     STATUS_COMPLETED, STATUS_FAILED,
 };
 use crate::{
-    prepare_initial_nodes_configuration, MetadataStoreRequest, MetadataStoreSummary,
+    prepare_initial_nodes_configuration, MetadataServerSummary, MetadataStoreRequest,
     ProvisionError, ProvisionRequest, ProvisionSender, RequestError, RequestSender, StatusWatch,
 };
-/// Grpc svc handler for the metadata store.
+
+/// Grpc svc handler for the metadata server.
 #[derive(Debug)]
-pub struct MetadataStoreHandler {
+pub struct MetadataServerHandler {
     request_tx: RequestSender,
     provision_tx: Option<ProvisionSender>,
     status_watch: Option<StatusWatch>,
 }
 
-impl MetadataStoreHandler {
+impl MetadataServerHandler {
     pub fn new(
         request_tx: RequestSender,
         provision_tx: Option<ProvisionSender>,
-        status_watch: Option<watch::Receiver<MetadataStoreSummary>>,
+        status_watch: Option<watch::Receiver<MetadataServerSummary>>,
     ) -> Self {
         Self {
             request_tx,
@@ -61,7 +62,7 @@ impl MetadataStoreHandler {
 }
 
 #[async_trait]
-impl MetadataServerSvc for MetadataStoreHandler {
+impl MetadataServerSvc for MetadataServerHandler {
     async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
         let start_time = Instant::now();
 

--- a/crates/metadata-server/src/grpc/mod.rs
+++ b/crates/metadata-server/src/grpc/mod.rs
@@ -18,7 +18,7 @@ pub mod pb_conversions {
     use crate::grpc::{
         GetResponse, GetVersionResponse, PreconditionKind, Ulid, WriteRequest, WriteRequestKind,
     };
-    use crate::{grpc, MetadataStoreSummary};
+    use crate::{grpc, MetadataServerSummary};
     use restate_core::metadata_store::{Precondition, VersionedValue};
     use restate_types::Version;
 
@@ -131,10 +131,10 @@ pub mod pb_conversions {
         }
     }
 
-    impl From<MetadataStoreSummary> for grpc::StatusResponse {
-        fn from(value: MetadataStoreSummary) -> Self {
+    impl From<MetadataServerSummary> for grpc::StatusResponse {
+        fn from(value: MetadataServerSummary) -> Self {
             match value {
-                MetadataStoreSummary::Starting => grpc::StatusResponse {
+                MetadataServerSummary::Starting => grpc::StatusResponse {
                     status: restate_types::protobuf::common::MetadataServerStatus::StartingUp
                         .into(),
                     configuration: None,
@@ -142,7 +142,7 @@ pub mod pb_conversions {
                     raft: None,
                     snapshot: None,
                 },
-                MetadataStoreSummary::Provisioning => grpc::StatusResponse {
+                MetadataServerSummary::Provisioning => grpc::StatusResponse {
                     status:
                         restate_types::protobuf::common::MetadataServerStatus::AwaitingProvisioning
                             .into(),
@@ -151,14 +151,14 @@ pub mod pb_conversions {
                     raft: None,
                     snapshot: None,
                 },
-                MetadataStoreSummary::Standby => grpc::StatusResponse {
+                MetadataServerSummary::Standby => grpc::StatusResponse {
                     status: restate_types::protobuf::common::MetadataServerStatus::Standby.into(),
                     configuration: None,
                     leader: None,
                     raft: None,
                     snapshot: None,
                 },
-                MetadataStoreSummary::Member {
+                MetadataServerSummary::Member {
                     configuration,
                     leader,
                     raft,

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -15,8 +15,8 @@ pub mod raft;
 mod util;
 
 use crate::grpc::client::GrpcMetadataServerClient;
-use crate::grpc::handler::MetadataStoreHandler;
-use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
+use crate::local::LocalMetadataServer;
+use crate::raft::RaftMetadataServer;
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
@@ -48,14 +48,12 @@ use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use restate_types::{config, GenerationalNodeId, PlainNodeId, Version};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
-use std::future::Future;
 use tokio::sync::{mpsc, oneshot, watch};
-use tonic::codec::CompressionEncoding;
 use tonic::Status;
 use tracing::debug;
 use ulid::Ulid;
 
-pub type BoxedMetadataStoreService = Box<dyn MetadataServer>;
+pub type BoxedMetadataServer = Box<dyn MetadataServer>;
 
 pub type RequestSender = mpsc::Sender<MetadataStoreRequest>;
 pub type RequestReceiver = mpsc::Receiver<MetadataStoreRequest>;
@@ -139,7 +137,7 @@ impl<T: MetadataServer> MetadataServerBoxed for T {
 pub trait MetadataServer: MetadataServerBoxed + Send {
     async fn run(self) -> anyhow::Result<()>;
 
-    fn boxed(self) -> BoxedMetadataStoreService
+    fn boxed(self) -> BoxedMetadataServer
     where
         Self: Sized + 'static,
     {
@@ -183,69 +181,16 @@ pub struct ProvisionRequest {
     result_tx: oneshot::Sender<Result<bool, ProvisionError>>,
 }
 
-trait MetadataServerBackend {
-    /// Create a request sender for this backend.
-    fn request_sender(&self) -> RequestSender;
-
-    /// Create a provision sender for this backend.
-    fn provision_sender(&self) -> Option<ProvisionSender>;
-
-    /// Create a status watch for this backend.
-    fn status_watch(&self) -> Option<StatusWatch>;
-
-    /// Run the metadata store backend
-    fn run(self) -> impl Future<Output = anyhow::Result<()>> + Send + 'static;
-}
-
-struct MetadataServerRunner<S> {
-    store: S,
-}
-
-impl<S> MetadataServerRunner<S>
-where
-    S: MetadataServerBackend,
-{
-    pub fn new(store: S, server_builder: &mut NetworkServerBuilder) -> Self {
-        server_builder.register_grpc_service(
-            MetadataServerSvcServer::new(MetadataStoreHandler::new(
-                store.request_sender(),
-                store.provision_sender(),
-                store.status_watch(),
-            ))
-            .accept_compressed(CompressionEncoding::Gzip)
-            .send_compressed(CompressionEncoding::Gzip),
-            grpc::FILE_DESCRIPTOR_SET,
-        );
-
-        Self { store }
-    }
-}
-
-#[async_trait::async_trait]
-impl<S> MetadataServer for MetadataServerRunner<S>
-where
-    S: MetadataServerBackend + Send,
-{
-    async fn run(self) -> anyhow::Result<()> {
-        let MetadataServerRunner { store } = self;
-
-        store.run().await?;
-
-        Ok(())
-    }
-}
-
 pub async fn create_metadata_server(
     metadata_server_options: &MetadataServerOptions,
     rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
     health_status: HealthStatus<MetadataServerStatus>,
     metadata_writer: Option<MetadataWriter>,
     server_builder: &mut NetworkServerBuilder,
-) -> anyhow::Result<BoxedMetadataStoreService> {
+) -> anyhow::Result<BoxedMetadataServer> {
     metric_definitions::describe_metrics();
-
     match metadata_server_options.kind {
-        MetadataServerKind::Local => local::create_server(
+        MetadataServerKind::Local => LocalMetadataServer::create(
             metadata_server_options,
             rocksdb_options,
             health_status,
@@ -253,16 +198,16 @@ pub async fn create_metadata_server(
         )
         .await
         .map_err(anyhow::Error::from)
-        .map(|store| store.boxed()),
-        MetadataServerKind::Raft { .. } => raft::create_server(
+        .map(|server| server.boxed()),
+        MetadataServerKind::Raft { .. } => RaftMetadataServer::create(
             rocksdb_options,
-            health_status,
             metadata_writer,
+            health_status,
             server_builder,
         )
         .await
         .map_err(anyhow::Error::from)
-        .map(|store| store.boxed()),
+        .map(|server| server.boxed()),
     }
 }
 impl MetadataStoreRequest {

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -60,8 +60,8 @@ pub type RequestReceiver = mpsc::Receiver<MetadataStoreRequest>;
 pub type ProvisionSender = mpsc::Sender<ProvisionRequest>;
 pub type ProvisionReceiver = mpsc::Receiver<ProvisionRequest>;
 
-type StatusWatch = watch::Receiver<MetadataStoreSummary>;
-type StatusSender = watch::Sender<MetadataStoreSummary>;
+type StatusWatch = watch::Receiver<MetadataServerSummary>;
+type StatusSender = watch::Sender<MetadataServerSummary>;
 
 pub const KNOWN_LEADER_KEY: &str = "x-restate-known-leader";
 
@@ -553,9 +553,9 @@ impl Display for MemberId {
     }
 }
 
-/// Status summary of the metadata store.
+/// Status summary of the metadata server.
 #[derive(Clone, Debug, Default)]
-enum MetadataStoreSummary {
+enum MetadataServerSummary {
     #[default]
     Starting,
     Provisioning,

--- a/crates/metadata-server/src/local/mod.rs
+++ b/crates/metadata-server/src/local/mod.rs
@@ -8,29 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_core::network::NetworkServerBuilder;
-use restate_rocksdb::RocksError;
-use restate_types::config::{MetadataServerOptions, RocksDbOptions};
-use restate_types::health::HealthStatus;
-use restate_types::live::BoxedLiveLoad;
-use restate_types::protobuf::common::MetadataServerStatus;
+mod server;
 
-mod store;
-
-use crate::MetadataServerRunner;
-pub use store::LocalMetadataServer;
-
-pub(crate) async fn create_server(
-    metadata_server_options: &MetadataServerOptions,
-    rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
-    health_status: HealthStatus<MetadataServerStatus>,
-    server_builder: &mut NetworkServerBuilder,
-) -> Result<MetadataServerRunner<LocalMetadataServer>, RocksError> {
-    let store =
-        LocalMetadataServer::create(metadata_server_options, rocksdb_options, health_status)
-            .await?;
-    Ok(MetadataServerRunner::new(store, server_builder))
-}
+pub use server::LocalMetadataServer;
 
 #[cfg(test)]
 mod tests;

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::grpc::handler::MetadataStoreHandler;
+use crate::grpc::handler::MetadataServerHandler;
 use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
 use crate::{
     grpc, util, MetadataServer, MetadataStoreRequest, PreconditionViolation, RequestError,
@@ -87,7 +87,7 @@ impl LocalMetadataServer {
             .expect("metadata store db is open");
 
         server_builder.register_grpc_service(
-            MetadataServerSvcServer::new(MetadataStoreHandler::new(request_tx, None, None))
+            MetadataServerSvcServer::new(MetadataServerHandler::new(request_tx, None, None))
                 .accept_compressed(CompressionEncoding::Gzip)
                 .send_compressed(CompressionEncoding::Gzip),
             grpc::FILE_DESCRIPTOR_SET,

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -8,15 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::grpc::handler::MetadataStoreHandler;
+use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
 use crate::{
-    util, MetadataServerBackend, MetadataStoreRequest, PreconditionViolation, ProvisionSender,
-    RequestError, RequestReceiver, RequestSender, StatusWatch,
+    grpc, util, MetadataServer, MetadataStoreRequest, PreconditionViolation, RequestError,
+    RequestReceiver,
 };
 use bytes::BytesMut;
 use bytestring::ByteString;
-use futures::FutureExt;
 use restate_core::cancellation_watcher;
 use restate_core::metadata_store::{serialize_value, Precondition, VersionedValue};
+use restate_core::network::NetworkServerBuilder;
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
@@ -30,9 +32,9 @@ use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
 use restate_types::Version;
 use rocksdb::{BoundColumnFamily, WriteBatch, WriteOptions, DB};
-use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use tonic::codec::CompressionEncoding;
 use tracing::{debug, info, trace};
 
 const DB_NAME: &str = "local-metadata-store";
@@ -49,9 +51,6 @@ pub struct LocalMetadataServer {
     request_rx: RequestReceiver,
     buffer: BytesMut,
     health_status: HealthStatus<MetadataServerStatus>,
-
-    // for creating other senders
-    request_tx: RequestSender,
 }
 
 impl LocalMetadataServer {
@@ -59,6 +58,7 @@ impl LocalMetadataServer {
         options: &MetadataServerOptions,
         updateable_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
         health_status: HealthStatus<MetadataServerStatus>,
+        server_builder: &mut NetworkServerBuilder,
     ) -> Result<Self, RocksError> {
         health_status.update(MetadataServerStatus::StartingUp);
         let (request_tx, request_rx) = mpsc::channel(options.request_queue_length());
@@ -86,6 +86,13 @@ impl LocalMetadataServer {
             .get_db(db_name)
             .expect("metadata store db is open");
 
+        server_builder.register_grpc_service(
+            MetadataServerSvcServer::new(MetadataStoreHandler::new(request_tx, None, None))
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip),
+            grpc::FILE_DESCRIPTOR_SET,
+        );
+
         Ok(Self {
             db,
             rocksdb,
@@ -93,7 +100,6 @@ impl LocalMetadataServer {
             buffer: BytesMut::default(),
             health_status,
             request_rx,
-            request_tx,
         })
     }
 
@@ -111,10 +117,6 @@ impl LocalMetadataServer {
         write_opts
     }
 
-    pub fn request_sender(&self) -> RequestSender {
-        self.request_tx.clone()
-    }
-
     pub async fn run(mut self) {
         debug!("Running LocalMetadataStore");
         self.health_status.update(MetadataServerStatus::Member);
@@ -127,8 +129,7 @@ impl LocalMetadataServer {
 
         loop {
             tokio::select! {
-                request = self.request_rx.recv() => {
-                    let request = request.expect("receiver should not be closed since we own one clone.");
+                Some(request) = self.request_rx.recv() => {
                     self.handle_request(request).await;
                 },
                 _ = cancellation_watcher() => {
@@ -367,20 +368,10 @@ impl LocalMetadataServer {
     }
 }
 
-impl MetadataServerBackend for LocalMetadataServer {
-    fn request_sender(&self) -> RequestSender {
-        self.request_sender()
-    }
-
-    fn provision_sender(&self) -> Option<ProvisionSender> {
-        None
-    }
-
-    fn status_watch(&self) -> Option<StatusWatch> {
-        None
-    }
-
-    fn run(self) -> impl Future<Output = anyhow::Result<()>> + Send + 'static {
-        self.run().map(Ok)
+#[async_trait::async_trait]
+impl MetadataServer for LocalMetadataServer {
+    async fn run(self) -> anyhow::Result<()> {
+        self.run().await;
+        Ok(())
     }
 }

--- a/crates/metadata-server/src/local/tests.rs
+++ b/crates/metadata-server/src/local/tests.rs
@@ -17,8 +17,8 @@ use restate_core::network::{FailingConnector, NetworkServerBuilder};
 use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::{
-    self, reset_base_temp_dir_and_retain, Configuration, MetadataServerOptions,
-    MetadataStoreClientOptions, RocksDbOptions,
+    self, reset_base_temp_dir_and_retain, Configuration, MetadataClientOptions,
+    MetadataServerOptions, RocksDbOptions,
 };
 use restate_types::health::HealthStatus;
 use restate_types::live::{BoxedLiveLoad, Live};
@@ -209,7 +209,7 @@ async fn durable_storage() -> anyhow::Result<()> {
     // reset RocksDbManager to allow restarting the metadata store
     RocksDbManager::get().reset().await?;
 
-    let metadata_store_client_opts = MetadataStoreClientOptions::default();
+    let metadata_store_client_opts = MetadataClientOptions::default();
     let metadata_store_opts = opts.clone();
     let metadata_store_opts = Live::from_value(metadata_store_opts);
     let client = start_metadata_server(
@@ -258,7 +258,7 @@ async fn create_test_environment(
     RocksDbManager::init(config.clone().map(|c| &c.common));
 
     let client = start_metadata_server(
-        config.pinned().common.metadata_store_client.clone(),
+        config.pinned().common.metadata_client.clone(),
         &config.pinned().metadata_server,
         config.clone().map(|c| &c.metadata_server.rocksdb).boxed(),
     )
@@ -268,7 +268,7 @@ async fn create_test_environment(
 }
 
 async fn start_metadata_server(
-    mut metadata_store_client_options: MetadataStoreClientOptions,
+    mut metadata_store_client_options: MetadataClientOptions,
     opts: &MetadataServerOptions,
     updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
 ) -> anyhow::Result<MetadataStoreClient> {
@@ -283,7 +283,7 @@ async fn start_metadata_server(
 
     let uds = tempfile::tempdir()?.into_path().join("metadata-rpc-server");
     let bind_address = BindAddress::Uds(uds.clone());
-    metadata_store_client_options.metadata_store_client = config::MetadataStoreClient::Embedded {
+    metadata_store_client_options.kind = config::MetadataClientKind::Native {
         addresses: vec![AdvertisedAddress::Uds(uds)],
     };
 
@@ -307,8 +307,8 @@ async fn start_metadata_server(
     )?;
 
     assert2::let_assert!(
-        config::MetadataStoreClient::Embedded { addresses } =
-            metadata_store_client_options.metadata_store_client.clone()
+        config::MetadataClientKind::Native { addresses } =
+            metadata_store_client_options.kind.clone()
     );
 
     rpc_server_health_status
@@ -319,7 +319,7 @@ async fn start_metadata_server(
         GrpcMetadataServerClient::new(addresses, metadata_store_client_options.clone());
     let client = MetadataStoreClient::new(
         grpc_client,
-        Some(metadata_store_client_options.metadata_store_client_backoff_policy),
+        Some(metadata_store_client_options.backoff_policy),
     );
 
     Ok(client)

--- a/crates/metadata-server/src/raft/network/handler.rs
+++ b/crates/metadata-server/src/raft/network/handler.rs
@@ -23,12 +23,12 @@ use tonic::{Request, Response, Status, Streaming};
 pub const PEER_METADATA_KEY: &str = "x-restate-metadata-server-peer";
 
 #[derive(Debug)]
-pub struct MetadataStoreNetworkHandler<M> {
+pub struct MetadataServerNetworkHandler<M> {
     connection_manager: Arc<ArcSwapOption<ConnectionManager<M>>>,
     join_cluster_handle: Option<JoinClusterHandle>,
 }
 
-impl<M> MetadataStoreNetworkHandler<M> {
+impl<M> MetadataServerNetworkHandler<M> {
     pub fn new(
         connection_manager: Arc<ArcSwapOption<ConnectionManager<M>>>,
         join_cluster_handle: Option<JoinClusterHandle>,
@@ -41,7 +41,7 @@ impl<M> MetadataStoreNetworkHandler<M> {
 }
 
 #[async_trait::async_trait]
-impl<M> MetadataServerNetworkSvc for MetadataStoreNetworkHandler<M>
+impl<M> MetadataServerNetworkSvc for MetadataServerNetworkHandler<M>
 where
     M: NetworkMessage + Send + 'static,
 {

--- a/crates/metadata-server/src/raft/network/mod.rs
+++ b/crates/metadata-server/src/raft/network/mod.rs
@@ -16,5 +16,5 @@ mod networking;
 pub use connection_manager::ConnectionManager;
 pub use grpc_svc::metadata_server_network_svc_server::MetadataServerNetworkSvcServer;
 pub use grpc_svc::FILE_DESCRIPTOR_SET;
-pub use handler::MetadataStoreNetworkHandler;
+pub use handler::MetadataServerNetworkHandler;
 pub use networking::{NetworkMessage, Networking};

--- a/crates/metadata-server/src/raft/store.rs
+++ b/crates/metadata-server/src/raft/store.rs
@@ -553,7 +553,7 @@ impl Member {
 
         let_assert!(
             MetadataServerKind::Raft(raft_options) = &Configuration::pinned().metadata_server.kind,
-            "Expecting that the embedded/raft metadata server has been configured"
+            "Expecting that the replicated/raft metadata server has been configured"
         );
 
         let mut config = Config {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -37,7 +37,7 @@ use restate_core::{Metadata, TaskKind};
 #[cfg(feature = "replicated-loglet")]
 use restate_log_server::LogServerService;
 use restate_metadata_server::{
-    BoxedMetadataStoreService, MetadataServer, MetadataStoreClient, ReadModifyWriteError,
+    BoxedMetadataServer, MetadataServer, MetadataStoreClient, ReadModifyWriteError,
 };
 use restate_types::config::{CommonOptions, Configuration};
 use restate_types::errors::GenericError;
@@ -120,7 +120,7 @@ pub struct Node {
     partition_routing_refresher: PartitionRoutingRefresher,
     metadata_store_client: MetadataStoreClient,
     bifrost: BifrostService,
-    metadata_store_role: Option<BoxedMetadataStoreService>,
+    metadata_store_role: Option<BoxedMetadataServer>,
     base_role: BaseRole,
     admin_role: Option<AdminRole<GrpcConnector>>,
     worker_role: Option<WorkerRole>,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -145,7 +145,7 @@ impl Node {
         cluster_marker::validate_and_update_cluster_marker(config.common.cluster_name())?;
 
         let metadata_store_client =
-            restate_metadata_server::create_client(config.common.metadata_store_client.clone())
+            restate_metadata_server::create_client(config.common.metadata_client.clone())
                 .await
                 .map_err(BuildError::MetadataStoreClient)?;
         let metadata_manager =

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -72,7 +72,8 @@ pub struct MetadataServerOptions {
 pub enum MetadataServerKind {
     #[default]
     Local,
-    #[serde(alias = "embedded")]
+    // make the Raft based metadata server primarily known as the replicated metadata server
+    #[serde(rename = "replicated")]
     Raft(RaftOptions),
 }
 

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -64,11 +64,7 @@ async fn replicated_loglet_client(
         .set_cluster_name(cluster.cluster_name().to_owned());
     config.common.advertised_address = AdvertisedAddress::Uds(node_socket.clone());
     config.common.bind_address = Some(BindAddress::Uds(node_socket.clone()));
-    config.common.metadata_store_client = cluster.nodes[0]
-        .config()
-        .common
-        .metadata_store_client
-        .clone();
+    config.common.metadata_client = cluster.nodes[0].config().common.metadata_client.clone();
 
     restate_types::config::set_current_config(config.clone());
 

--- a/server/tests/raft_metadata_cluster.rs
+++ b/server/tests/raft_metadata_cluster.rs
@@ -20,7 +20,7 @@ use restate_local_cluster_runner::node::{BinarySource, HealthCheck, Node};
 use restate_metadata_server::create_client;
 use restate_metadata_server::tests::Value;
 use restate_types::config::{
-    Configuration, MetadataServerKind, MetadataStoreClient, MetadataStoreClientOptions, RaftOptions,
+    Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind, RaftOptions,
 };
 use restate_types::Versioned;
 use std::num::NonZeroUsize;
@@ -54,9 +54,9 @@ async fn raft_metadata_cluster_smoke_test() -> googletest::Result<()> {
         .map(|node| node.node_address().clone())
         .collect();
 
-    let metadata_store_client_options = MetadataStoreClientOptions {
-        metadata_store_client: MetadataStoreClient::Embedded { addresses },
-        ..MetadataStoreClientOptions::default()
+    let metadata_store_client_options = MetadataClientOptions {
+        kind: MetadataClientKind::Native { addresses },
+        ..MetadataClientOptions::default()
     };
     let client = create_client(metadata_store_client_options)
         .await
@@ -148,9 +148,9 @@ async fn raft_metadata_cluster_chaos_test() -> googletest::Result<()> {
         .map(|node| node.node_address().clone())
         .collect();
 
-    let metadata_store_client_options = MetadataStoreClientOptions {
-        metadata_store_client: MetadataStoreClient::Embedded { addresses },
-        ..MetadataStoreClientOptions::default()
+    let metadata_store_client_options = MetadataClientOptions {
+        kind: MetadataClientKind::Native { addresses },
+        ..MetadataClientOptions::default()
     };
     let client = create_client(metadata_store_client_options)
         .await

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -29,7 +29,7 @@ use restate_local_cluster_runner::{
     cluster::Cluster,
     node::{BinarySource, Node},
 };
-use restate_types::config::{LogFormat, MetadataStoreClient};
+use restate_types::config::{LogFormat, MetadataClientKind};
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::metadata::ProviderKind::Replicated;
 use restate_types::logs::{LogId, Lsn};
@@ -147,7 +147,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         BinarySource::CargoTest,
         enum_set!(Role::HttpIngress | Role::Worker),
     );
-    *worker_3.metadata_store_client_mut() = MetadataStoreClient::Embedded {
+    *worker_3.metadata_store_client_mut() = MetadataClientKind::Native {
         addresses: vec![cluster.nodes[0].node_address().clone()],
     };
 
@@ -172,7 +172,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         BinarySource::CargoTest,
         enum_set!(Role::HttpIngress | Role::Worker),
     );
-    *worker_3.metadata_store_client_mut() = MetadataStoreClient::Embedded {
+    *worker_3.metadata_store_client_mut() = MetadataClientKind::Native {
         addresses: vec![cluster.nodes[0].node_address().clone()],
     };
 

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -75,7 +75,7 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
         TaskCenter::try_set_global_metadata(metadata.clone());
 
         let metadata_store_client = metadata_store::start_metadata_server(
-            config.common.metadata_store_client.clone(),
+            config.common.metadata_client.clone(),
             &config.metadata_server,
             Live::from_value(config.metadata_server.clone())
                 .map(|c| &c.rocksdb)

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -66,7 +66,7 @@ async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericM
         debug!("RocksDB Initialized");
 
         let metadata_store_client = metadata_store::start_metadata_server(
-            config.common.metadata_store_client.clone(),
+            config.common.metadata_client.clone(),
             &config.metadata_server,
             Live::from_value(config.metadata_server.clone())
                 .map(|c| &c.rocksdb)

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -20,7 +20,7 @@ use restate_types::nodes_config::Role;
 
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_metadata_server::create_client;
-use restate_types::config::MetadataStoreClientOptions;
+use restate_types::config::MetadataClientOptions;
 use restate_types::{flexbuffers_storage_encode_decode, Version, Versioned};
 
 use crate::connection::ConnectionInfo;
@@ -119,16 +119,16 @@ pub async fn create_metadata_store_client(
                 .iter_role(Role::MetadataServer)
                 .map(|(_, node)| node.address.clone())
                 .collect();
-            restate_types::config::MetadataStoreClient::Embedded { addresses }
+            restate_types::config::MetadataClientKind::Native { addresses }
         }
-        RemoteServiceType::Etcd => restate_types::config::MetadataStoreClient::Etcd {
+        RemoteServiceType::Etcd => restate_types::config::MetadataClientKind::Etcd {
             addresses: opts.etcd.clone(),
         },
     };
 
-    let metadata_store_client_options = MetadataStoreClientOptions {
-        metadata_store_client: client,
-        ..MetadataStoreClientOptions::default()
+    let metadata_store_client_options = MetadataClientOptions {
+        kind: client,
+        ..MetadataClientOptions::default()
     };
 
     create_client(metadata_store_client_options)

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -90,7 +90,7 @@ async fn patch_value_direct(
         debug!("RocksDB Initialized");
 
         let metadata_store_client = start_metadata_server(
-            config.common.metadata_store_client.clone(),
+            config.common.metadata_client.clone(),
             &config.metadata_server,
             Live::from_value(config.metadata_server.clone())
                 .map(|c| &c.rocksdb)

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -15,14 +15,14 @@ use restate_core::network::NetworkServerBuilder;
 use restate_core::{TaskCenter, TaskKind};
 use restate_metadata_server::MetadataServer;
 use restate_types::config;
-use restate_types::config::{MetadataServerOptions, MetadataStoreClientOptions, RocksDbOptions};
+use restate_types::config::{MetadataClientOptions, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 use restate_types::protobuf::common::NodeRpcStatus;
 
 pub async fn start_metadata_server(
-    mut metadata_store_client_options: MetadataStoreClientOptions,
+    mut metadata_store_client_options: MetadataClientOptions,
     opts: &MetadataServerOptions,
     updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
 ) -> anyhow::Result<MetadataStoreClient> {
@@ -40,7 +40,7 @@ pub async fn start_metadata_server(
     // right now we only support running a local metadata store
     let uds = tempfile::tempdir()?.into_path().join("metadata-rpc-server");
     let bind_address = BindAddress::Uds(uds.clone());
-    metadata_store_client_options.metadata_store_client = config::MetadataStoreClient::Embedded {
+    metadata_store_client_options.kind = config::MetadataClientKind::Native {
         addresses: vec![AdvertisedAddress::Uds(uds)],
     };
 


### PR DESCRIPTION
[Rename serialized MetadataServerKind::Raft variant to replicated](https://github.com/restatedev/restate/commit/e77d90c1fcf2ae92f81d299172547d3e4c7e465c) 

With this commit, the default way to configure the Raft based metadata server
is to configure metadata-server.type = "replicated".

[Rename MetadataStoreClientOptions into MetadataClientOptions](https://github.com/restatedev/restate/commit/7492101c1639fbed4d2a82cc3b5be06f6c3076a9) 

This commit also moves some of the metadata client specific options back
under the [metadata-client] key. It tries to achieve backwards compatibility
with the previous configuration names. The metadata client used with the local
and the replicated metadata server is now called "native" ("embedded" still works
as an alias).