### PR TITLE
Avoid (some) feature unification in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
         with:
           cache-on-failure: "true"
 
+      - name: Install cargo-hakari
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hakari
+
+      - name: Disable hakari
+        run: cargo hakari disable
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       pushToDockerHub: true
       parca: true
+      buildIndividually: true
 
   docker-cli:
     name: Push CLI Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,32 +4,37 @@ on:
   workflow_call:
     inputs:
       uploadImageAsTarball:
-        description: 'uploads the Docker image additionally as a tarball'
+        description: "uploads the Docker image additionally as a tarball"
         required: false
         default: false
         type: boolean
       platforms:
-        description: 'platforms for docker build step'
+        description: "platforms for docker build step"
         required: false
-        default: ''
+        default: ""
         type: string
       debug:
-        description: 'include debug symbols in built image'
+        description: "include debug symbols in built image"
         required: false
         default: false
         type: boolean
       parca:
-        description: 'split out debug symbols and upload to polar signals'
+        description: "split out debug symbols and upload to polar signals"
+        required: false
+        default: false
+        type: boolean
+      buildIndividually:
+        description: "build separate binaries individually to avoid feature unification"
         required: false
         default: false
         type: boolean
       features:
-        description: 'features to enable in the build'
+        description: "features to enable in the build"
         required: false
-        default: ''
+        default: ""
         type: string
       pushToDockerHub:
-        description: 'push image to DockerHub'
+        description: "push image to DockerHub"
         required: false
         default: false
         type: boolean
@@ -37,34 +42,39 @@ on:
   workflow_dispatch:
     inputs:
       uploadImageAsTarball:
-        description: 'uploads the Docker image additionally as a tarball'
+        description: "uploads the Docker image additionally as a tarball"
         required: false
         default: false
         type: boolean
       platforms:
-        description: 'platforms for docker build step'
+        description: "platforms for docker build step"
         required: false
-        default: ''
+        default: ""
         type: string
       debug:
-        description: 'include debug symbols in built image'
+        description: "include debug symbols in built image"
         required: false
         default: false
         type: boolean
       parca:
-        description: 'upload debug symbols to polar signals'
+        description: "upload debug symbols to polar signals"
+        required: false
+        default: false
+        type: boolean
+      buildIndividually:
+        description: "build separate binaries individually to avoid feature unification"
         required: false
         default: false
         type: boolean
       pushToDockerHub:
-        description: 'push image to DockerHub'
+        description: "push image to DockerHub"
         required: false
         default: false
         type: boolean
 
 env:
   REPOSITORY_OWNER: ${{ github.repository_owner }}
-  GHCR_REGISTRY: 'ghcr.io'
+  GHCR_REGISTRY: "ghcr.io"
   GHCR_REGISTRY_USERNAME: ${{ github.actor }}
   GHCR_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -76,6 +86,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install cargo-hakari
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hakari
+
+      - name: Disable hakari
+        run: cargo hakari disable
 
       # this is needed to be able to load and push a multiplatform image in one step
       - name: Set up Docker containerd snapshotter
@@ -97,7 +115,7 @@ jobs:
           # https://docs.warpbuild.com/cache/docker-layer-caching#step-1-set-up-docker-buildx-action
           driver-opts: |
             network=host
-      
+
       - name: Cache sccache
         id: cache
         uses: WarpBuilds/cache@v1
@@ -113,7 +131,7 @@ jobs:
               "sccache-cache": "/var/cache/sccache"
             }
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
-          
+
       - name: Log into GitHub container registry
         uses: docker/login-action@v3
         with:
@@ -137,7 +155,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: | 
+          images: |
             ${{ env.GHCR_REGISTRY }}/${{ env.REPOSITORY_OWNER }}/${{ env.IMAGE_NAME }}
             ${{ inputs.pushToDockerHub && format('docker.io/{0}/{1}', env.REPOSITORY_OWNER, env.IMAGE_NAME) || '' }}
 
@@ -166,13 +184,14 @@ jobs:
           network: host
           build-args: |
             CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug || inputs.parca }}
+            BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
             UPLOAD_DEBUGINFO=${{ inputs.parca }}
             RESTATE_FEATURES=${{ inputs.features || '' }}
           secrets: |
             parca=${{ secrets.PARCA_TOKEN }}
           cache-from: type=gha,url=http://127.0.0.1:49160/
           cache-to: type=gha,url=http://127.0.0.1:49160/,mode=max
-    
+
       - name: Upload docker image tar as artifact
         if: ${{ inputs.uploadImageAsTarball }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,12 @@ jobs:
         if: "${{ runner.os == 'macOS' }}"
         env:
           "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+      - name: "Install cargo-hakari"
+        uses: "taiki-e/install-action@v2"
+        with:
+          "tool": "cargo-hakari"
+      - name: "Disable hakari"
+        run: "cargo hakari disable"
       - name: "Allowlist git directory"
         if: "${{ runner.os == 'Linux' }}"
         run: "git config --global --add safe.directory /__w/restate/restate"

--- a/.github/workflows/steps/release-build-setup.yml
+++ b/.github/workflows/steps/release-build-setup.yml
@@ -8,6 +8,14 @@
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+- name: Install cargo-hakari
+  uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-hakari
+
+- name: Disable hakari
+  run: cargo hakari disable
+
 - name: Allowlist git directory
   if: ${{ runner.os == 'Linux' }} # only required inside the dev-tools container
   run: git config --global --add safe.directory /__w/restate/restate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,14 +35,28 @@ ENV SCCACHE_DIR=/var/cache/sccache
 # Overrides the behaviour of the release profile re including debug symbols, which in our repo is not to include them.
 # Should be set to 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html
 ARG CARGO_PROFILE_RELEASE_DEBUG=false
+# Avoids feature unification by building the three binaries individually
+ARG BUILD_INDIVIDUALLY=false
 ARG RESTATE_FEATURES=''
-RUN just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release --bins
+RUN if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-server && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restatectl; \
+    else \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli -p restate-server -p restatectl; \
+    fi
 COPY . .
 # Mount the sccache directory as a cache to leverage sccache during build
 # Caching layer if nothing has changed
 # Use sccache during the main build
 RUN --mount=type=cache,target=/var/cache/sccache \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release --bins && \
+    if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-server && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restatectl; \
+    else \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli -p restate-server -p restatectl; \
+    fi && \
     just notice-file && \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server && \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \


### PR DESCRIPTION
Currently we have hakari unification for some targets, and we also are unifying in restate-local-cluster-runner unnecessarily in docker builds.

Also, we can ensure that in release docker builds, we actually build the 3 binaries individually, instead of feature unifying them