### PR TITLE
Remember to strip debuginfo from restatectl and restate bins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,9 @@ FROM builder AS upload-false
 
 FROM builder AS upload-true
 RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --only-keep-debug target/restate-server target/restate-server.debug
-RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy  --strip-debug target/restate-server
+RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate-server
+RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restatectl
+RUN $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate
 RUN --mount=type=secret,id=parca parca-debuginfo upload --store-address=grpc.polarsignals.com:443 --bearer-token-file=/run/secrets/parca target/restate-server.debug
 
 FROM upload-$UPLOAD_DEBUGINFO AS upload


### PR DESCRIPTION
That explains why the docker cache was so large on release builds now! restatectl binary with symbols is 600Meg...