### PR TITLE
Fixes restatectl setting target nodeset size

### DIFF
--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -248,9 +248,18 @@ pub struct ReplicatedLogletConfig {
 
 /// New type that enforces that the nodeset size is never larger than 128.
 #[derive(
-    Debug, Clone, Copy, derive_more::Into, serde::Serialize, serde::Deserialize, Eq, PartialEq,
+    Debug,
+    Clone,
+    Copy,
+    derive_more::Into,
+    serde::Serialize,
+    serde::Deserialize,
+    Eq,
+    PartialEq,
+    derive_more::Display,
 )]
 #[serde(try_from = "u16", into = "u16")]
+#[display("{_0}")]
 pub struct NodeSetSize(u16);
 
 impl NodeSetSize {

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -80,6 +80,13 @@ fn write_default_provider<W: fmt::Write>(
                 "Replication property",
                 config.replication_property.to_string(),
             )?;
+            write_leaf(
+                w,
+                depth,
+                true,
+                "Nodeset size",
+                config.target_nodeset_size.to_string(),
+            )?;
         }
     }
     Ok(())


### PR DESCRIPTION

Previously, setting target nodeset size with restatectl would tell you that "No change"
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2645).
* #2654
* #2651
* #2650
* #2649
* #2638
* #2646
* __->__ #2645