### PR TITLE
`DecoratedNodeSet` Utility to display decorated nodesets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6425,6 +6425,7 @@ dependencies = [
 name = "restate-bifrost"
 version = "1.2.0-dev"
 dependencies = [
+ "ahash 0.8.11",
  "anyhow",
  "async-trait",
  "bytes",

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -25,6 +25,7 @@ restate-rocksdb = { workspace = true }
 restate-test-util = { workspace = true, optional = true }
 restate-types = { workspace = true }
 
+ahash = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use tracing::{debug, info, instrument};
+use tracing::{debug, instrument, warn};
 
 use restate_core::metadata_store::retry_on_retryable_error;
 use restate_core::{Metadata, MetadataKind};
@@ -158,7 +158,7 @@ impl<'a> BifrostAdmin<'a> {
         self.inner.writeable_loglet(log_id).await
     }
 
-    #[instrument(level = "debug", skip(self), err)]
+    #[instrument(level = "debug", skip(self))]
     pub async fn seal(&self, log_id: LogId, segment_index: SegmentIndex) -> Result<SealedSegment> {
         self.inner.fail_if_shutting_down()?;
         // first find the tail segment for this log.
@@ -177,7 +177,7 @@ impl<'a> BifrostAdmin<'a> {
             match err {
                 crate::loglet::OperationError::Shutdown(err) => return Err(err.into()),
                 crate::loglet::OperationError::Other(err) => {
-                    info!(
+                    warn!(
                         log_id = %log_id,
                         segment = %segment_index,
                         %err,

--- a/crates/bifrost/src/providers/replicated_loglet/error.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/error.rs
@@ -18,7 +18,7 @@ use restate_types::replication::DecoratedNodeSet;
 
 use crate::loglet::OperationError;
 
-#[derive(Default, derive_more::Display, derive_more::Debug)]
+#[derive(Default, derive_more::Display, derive_more::Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum NodeSealStatus {
     #[display("E")]
     Error,

--- a/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use itertools::Itertools;
+use restate_types::replication::DecoratedNodeSet;
 use tracing::warn;
 
 use restate_types::locality::{LocationScope, NodeLocation};
@@ -731,6 +733,22 @@ impl<Attr: Eq + Hash> LocationScopeState<Attr> {
             node_to_fd: HashMap::default(),
             replication_fds: HashMap::default(),
         }
+    }
+}
+
+impl<'a, Attr> IntoIterator for &'a NodeSetChecker<Attr> {
+    type Item = (&'a PlainNodeId, &'a Attr);
+
+    type IntoIter = <&'a HashMap<PlainNodeId, Attr> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.node_to_attr.iter()
+    }
+}
+
+impl<Attr> From<NodeSetChecker<Attr>> for DecoratedNodeSet<Attr> {
+    fn from(val: NodeSetChecker<Attr>) -> DecoratedNodeSet<Attr> {
+        DecoratedNodeSet::from_iter(val.node_to_attr)
     }
 }
 

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -248,9 +248,18 @@ pub struct ReplicatedLogletConfig {
 
 /// New type that enforces that the nodeset size is never larger than 128.
 #[derive(
-    Debug, Clone, Copy, derive_more::Into, serde::Serialize, serde::Deserialize, Eq, PartialEq,
+    Debug,
+    Clone,
+    Copy,
+    derive_more::Into,
+    serde::Serialize,
+    serde::Deserialize,
+    Eq,
+    PartialEq,
+    derive_more::Display,
 )]
 #[serde(try_from = "u16", into = "u16")]
+#[display("{_0}")]
 pub struct NodeSetSize(u16);
 
 impl NodeSetSize {

--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -80,6 +80,13 @@ fn write_default_provider<W: fmt::Write>(
                 "Replication property",
                 config.replication_property.to_string(),
             )?;
+            write_leaf(
+                w,
+                depth,
+                true,
+                "Nodeset size",
+                config.target_nodeset_size.to_string(),
+            )?;
         }
     }
     Ok(())


### PR DESCRIPTION

The PR also uses it in CheckSeal. This utility `DecoratedNodeSet` can be used when you want to add a nugget of information next to every node. It prints the nodeset sorted as well.
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2646).
* #2654
* #2651
* #2650
* #2649
* #2638
* __->__ #2646
* #2645