### PR TITLE
Hide empty sections

### DIFF
--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -183,7 +183,7 @@ impl Node {
             base_config.metadata_server.kind(),
             MetadataServerKind::Raft(_)
         ) {
-            info!("Setting the metadata server to embedded");
+            info!("Setting the metadata server to replicated");
             base_config
                 .metadata_server
                 .set_kind(MetadataServerKind::Raft(RaftOptions::default()));

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -739,6 +739,8 @@ pub struct TracingOptions {
     ///
     /// Specify additional headers you want the system to send to the tracing endpoint (e.g.
     /// authentication headers).
+    #[serde(skip_serializing_if = "SerdeableHeaderHashMap::is_empty")]
+    #[serde(default)]
     pub tracing_headers: SerdeableHeaderHashMap,
 }
 

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -68,6 +68,8 @@ pub struct WorkerOptions {
     ///
     /// Snapshots provide a mechanism for safely trimming the log and efficient bootstrapping of new
     /// worker nodes.
+    #[serde(skip_serializing_if = "is_default_snapshots_options")]
+    #[serde(default)]
     pub snapshots: SnapshotsOptions,
 }
 
@@ -366,7 +368,7 @@ impl Default for StorageOptions {
 ///
 /// Partition store snapshotting settings.
 #[serde_as]
-#[derive(Default, Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(rename = "SnapshotsOptions", default))]
 #[serde(rename_all = "kebab-case")]
@@ -400,6 +402,10 @@ pub struct SnapshotsOptions {
     ///
     /// Default: `None` - automatic snapshots are disabled by default
     pub snapshot_interval_num_records: Option<NonZeroU64>,
+}
+
+fn is_default_snapshots_options(opts: &SnapshotsOptions) -> bool {
+    opts == &SnapshotsOptions::default()
 }
 
 impl SnapshotsOptions {


### PR DESCRIPTION
Hide empty sections

Summary:
Avoid dumping empty sections in config files.

I think they look weird in config
```toml
[tracing-headers]

[worker.snaphosts]
```
