### PR TITLE
Use full repo name in scarf docker urls :(

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -38,8 +38,8 @@ jobs:
           ### Pull the Docker images
 
           \`\`\`sh
-          docker pull docker.restate.dev/restate:$app_version
-          docker pull docker.restate.dev/restate-cli:$app_version
+          docker pull docker.restate.dev/restatedev/restate:$app_version
+          docker pull docker.restate.dev/restatedev/restate-cli:$app_version
           \`\`\`
 
           ### Install prebuilt binaries via Homebrew

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npx @restatedev/restate-server
 
 Run via docker:
 ```bash
-docker run --rm -it --network=host docker.io/restatedev/restate:latest
+docker run --rm -it --network=host docker.restate.dev/restatedev/restate:latest
 ```
 
 ### Install the CLI
@@ -122,4 +122,3 @@ For SDK compatibility, refer to the supported version matrix in the respective R
 ### Building Restate locally
 
 In order to build Restate locally [follow the build instructions](https://github.com/restatedev/restate/blob/main/docs/dev/local-development.md#building-restate).
-


### PR DESCRIPTION
While it does work, I think the repo name redirecting is going to be a source of weird bugs :( 