### PR TITLE
[Core] Enable concurrent connections between nodes

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -778,6 +778,7 @@ mod tests {
     use super::Service;
 
     use std::collections::BTreeSet;
+    use std::num::NonZero;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -796,7 +797,7 @@ mod tests {
     use restate_core::test_env::NoOpMessageHandler;
     use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
     use restate_types::cluster::cluster_state::{NodeState, PartitionProcessorStatus};
-    use restate_types::config::{AdminOptions, BifrostOptions, Configuration};
+    use restate_types::config::{AdminOptions, BifrostOptions, Configuration, NetworkingOptions};
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::PartitionId;
     use restate_types::live::Live;
@@ -898,7 +899,13 @@ mod tests {
         let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
         admin_options.log_trim_interval = Some(interval_duration.into());
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
         let config = Configuration {
+            networking,
             admin: admin_options,
             ..Default::default()
         };
@@ -966,10 +973,17 @@ mod tests {
     async fn auto_trim_log() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
         let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
         admin_options.log_trim_interval = Some(interval_duration.into());
         let config = Configuration {
+            networking,
             admin: admin_options,
             ..Default::default()
         };
@@ -1042,7 +1056,14 @@ mod tests {
         admin_options.log_trim_interval = Some(interval_duration.into());
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
+
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
         let config = Configuration {
+            networking,
             admin: admin_options,
             bifrost: bifrost_options,
             ..Default::default()
@@ -1096,7 +1117,16 @@ mod tests {
         const LOG_ID: LogId = LogId::new(0);
         let interval_duration = Duration::from_secs(10);
 
-        let mut config: Configuration = Default::default();
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
+        let mut config: Configuration = Configuration {
+            networking,
+            ..Default::default()
+        };
         config.admin.log_trim_interval = Some(interval_duration.into());
         config.bifrost.default_provider = ProviderKind::InMemory;
         config.worker.snapshots.destination = Some("a-repository-somewhere".to_string());
@@ -1253,7 +1283,14 @@ mod tests {
         admin_options.log_trim_interval = Some(interval_duration.into());
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
         let config = Configuration {
+            networking,
             admin: admin_options,
             bifrost: bifrost_options,
             ..Default::default()

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -99,11 +99,20 @@ impl ConnectionManagerInner {
     fn get_random_connection(
         &self,
         peer_node_id: &GenerationalNodeId,
+        target_concurrency: usize,
     ) -> Option<Arc<OwnedConnection>> {
         use rand::prelude::IndexedRandom;
         self.connection_by_gen_id
             .get(peer_node_id)
-            .and_then(|connections| connections.choose(&mut rand::rng())?.upgrade())
+            .and_then(|connections| {
+                // Suggest we create new connection if the number
+                // of connections is below the target
+                if connections.len() >= target_concurrency {
+                    connections.choose(&mut rand::rng())?.upgrade()
+                } else {
+                    None
+                }
+            })
     }
 }
 
@@ -141,13 +150,14 @@ impl<T> Clone for ConnectionManager<T> {
 /// used for testing. Accepts connections but can't establish new connections
 impl ConnectionManager<super::FailingConnector> {
     pub fn new_incoming_only(metadata: Metadata) -> Self {
+        use restate_types::config::Configuration;
         let inner = Arc::new(Mutex::new(ConnectionManagerInner::default()));
 
         Self {
             metadata,
             inner,
             transport_connector: Arc::new(super::FailingConnector::default()),
-            networking_options: NetworkingOptions::default(),
+            networking_options: Configuration::pinned().networking.clone(),
         }
     }
 }
@@ -294,10 +304,18 @@ impl<T: TransportConnect> ConnectionManager<T> {
         &self,
         node_id: GenerationalNodeId,
     ) -> Result<Arc<OwnedConnection>, NetworkError> {
+        // fail fast if we are connecting to our previous self
+        if self.metadata.my_node_id().is_same_but_different(&node_id) {
+            return Err(NetworkError::NodeIsGone(node_id));
+        }
+
         // find a connection by node_id
         let maybe_connection: Option<Arc<OwnedConnection>> = {
             let guard = self.inner.lock();
-            guard.get_random_connection(&node_id)
+            guard.get_random_connection(
+                &node_id,
+                self.networking_options.num_concurrent_connections(),
+            )
             // lock is dropped.
         };
 
@@ -669,8 +687,12 @@ where
                     global::get_text_map_propagator(|propagator| propagator.extract(span_ctx))
                 });
 
-                if let Err(e) = router
-                    .call(
+                // unconstrained: We want to avoid yielding if the message router has capacity,
+                // this is to improve tail latency of message processing. We still give tokio
+                // a yielding point when reading the next message but it would be excessive to
+                // introduce more than one yielding point in this reactor loop.
+                if let Err(e) = tokio::task::unconstrained(
+                    router.call(
                         Incoming::from_parts(
                             msg,
                             connection.downgrade(),
@@ -680,8 +702,9 @@ where
                         )
                         .with_parent_context(parent_context),
                         connection.protocol_version,
-                    )
-                    .await
+                    ),
+                )
+                .await
                 {
                     warn!("Error processing message: {:?}", e);
                 }

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -80,8 +80,9 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
+    #[strum(props(runtime = "default"))]
     SocketHandler,
-    #[strum(props(OnError = "log"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     H2Stream,
     /// A task that handles a single RPC request. The task is executed on the default runtime to
     /// decouple it from the lifetime of the originating runtime. Use this task kind if you want to
@@ -104,7 +105,7 @@ pub enum TaskKind {
     /// Low-priority tasks responsible for partition snapshot-related I/O.
     #[strum(props(OnCancel = "abort", OnError = "log"))]
     PartitionSnapshotProducer,
-    #[strum(props(OnError = "log"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     ConnectionReactor,
     Shuffle,
     Cleaner,

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -63,6 +63,20 @@ pub struct NetworkingOptions {
     /// The number of messages that can be queued on the outbound stream of a single
     /// connection.
     pub outbound_queue_length: NonZeroUsize,
+
+    /// # Number of connections to each peer
+    ///
+    /// This is used as a guiding value for how many connections every node can
+    /// maintain with each peer. With more connections, concurrency of network message
+    /// processing increases, but it also increases the memory and CPU overhead.
+    pub num_concurrent_connections: NonZeroUsize,
+}
+
+impl NetworkingOptions {
+    #[inline(always)]
+    pub fn num_concurrent_connections(&self) -> usize {
+        self.num_concurrent_connections.get()
+    }
 }
 
 impl Default for NetworkingOptions {
@@ -80,6 +94,7 @@ impl Default for NetworkingOptions {
             http2_keep_alive_interval: Duration::from_secs(5).into(),
             http2_keep_alive_timeout: Duration::from_secs(5).into(),
             http2_adaptive_window: true,
+            num_concurrent_connections: NonZeroUsize::new(13).unwrap(),
         }
     }
 }

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -106,6 +106,12 @@ impl GenerationalNodeId {
         self.encode(buf);
         buf.split()
     }
+
+    /// Same plain node-id but not the same generation
+    #[inline(always)]
+    pub fn is_same_but_different(&self, other: &GenerationalNodeId) -> bool {
+        self.0 == other.0 && self.1 != other.1
+    }
 }
 
 impl From<GenerationalNodeId> for u64 {


### PR DESCRIPTION

This enables nodes to maintain concurrent connections across different actual TCP connections to increase message processing concurrency. This is controlled by a new configuration option in `[networking]` section.

This also tags a few operations with `tokio::task::unconstrained` to reduce unnecessary coop-driven yields that happen at some hot-paths.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2664).
* #2672
* #2670
* #2669
* #2665
* __->__ #2664
* #2654