### PR TITLE
[Core] Network Telemetry improvements

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -778,6 +778,7 @@ mod tests {
     use super::Service;
 
     use std::collections::BTreeSet;
+    use std::num::NonZero;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -796,7 +797,7 @@ mod tests {
     use restate_core::test_env::NoOpMessageHandler;
     use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
     use restate_types::cluster::cluster_state::{NodeState, PartitionProcessorStatus};
-    use restate_types::config::{AdminOptions, BifrostOptions, Configuration};
+    use restate_types::config::{AdminOptions, BifrostOptions, Configuration, NetworkingOptions};
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::PartitionId;
     use restate_types::live::Live;
@@ -898,7 +899,13 @@ mod tests {
         let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
         admin_options.log_trim_interval = Some(interval_duration.into());
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
         let config = Configuration {
+            networking,
             admin: admin_options,
             ..Default::default()
         };
@@ -966,10 +973,17 @@ mod tests {
     async fn auto_trim_log() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
         let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
         admin_options.log_trim_interval = Some(interval_duration.into());
         let config = Configuration {
+            networking,
             admin: admin_options,
             ..Default::default()
         };
@@ -1042,7 +1056,14 @@ mod tests {
         admin_options.log_trim_interval = Some(interval_duration.into());
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
+
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
         let config = Configuration {
+            networking,
             admin: admin_options,
             bifrost: bifrost_options,
             ..Default::default()
@@ -1096,7 +1117,16 @@ mod tests {
         const LOG_ID: LogId = LogId::new(0);
         let interval_duration = Duration::from_secs(10);
 
-        let mut config: Configuration = Default::default();
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
+        let mut config: Configuration = Configuration {
+            networking,
+            ..Default::default()
+        };
         config.admin.log_trim_interval = Some(interval_duration.into());
         config.bifrost.default_provider = ProviderKind::InMemory;
         config.worker.snapshots.destination = Some("a-repository-somewhere".to_string());
@@ -1253,7 +1283,14 @@ mod tests {
         admin_options.log_trim_interval = Some(interval_duration.into());
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
         let config = Configuration {
+            networking,
             admin: admin_options,
             bifrost: bifrost_options,
             ..Default::default()

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -11,11 +11,11 @@
 use std::sync::Arc;
 use std::sync::Weak;
 use std::time::Duration;
-use std::time::Instant;
 
 use enum_map::{enum_map, EnumMap};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
+use tokio::time::Instant;
 use tracing::{debug, trace};
 
 use restate_types::net::codec::Targeted;
@@ -27,7 +27,6 @@ use restate_types::protobuf::node::Header;
 use restate_types::protobuf::node::Message;
 use restate_types::{GenerationalNodeId, Version};
 
-use super::metric_definitions::MESSAGE_SENT;
 use super::NetworkError;
 use super::Outgoing;
 use crate::Metadata;
@@ -84,7 +83,6 @@ impl<M> SendPermit<'_, M> {
     /// associated with the message.
     pub(crate) fn send_raw(self, raw_message: Message) {
         self.permit.send(raw_message);
-        MESSAGE_SENT.increment(1);
     }
 }
 
@@ -313,7 +311,6 @@ pub mod test_util {
     use super::*;
 
     use std::sync::Arc;
-    use std::time::Instant;
 
     use async_trait::async_trait;
     use futures::stream::BoxStream;

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -99,11 +99,20 @@ impl ConnectionManagerInner {
     fn get_random_connection(
         &self,
         peer_node_id: &GenerationalNodeId,
+        target_concurrency: usize,
     ) -> Option<Arc<OwnedConnection>> {
         use rand::prelude::IndexedRandom;
         self.connection_by_gen_id
             .get(peer_node_id)
-            .and_then(|connections| connections.choose(&mut rand::rng())?.upgrade())
+            .and_then(|connections| {
+                // Suggest we create new connection if the number
+                // of connections is below the target
+                if connections.len() >= target_concurrency {
+                    connections.choose(&mut rand::rng())?.upgrade()
+                } else {
+                    None
+                }
+            })
     }
 }
 
@@ -141,13 +150,14 @@ impl<T> Clone for ConnectionManager<T> {
 /// used for testing. Accepts connections but can't establish new connections
 impl ConnectionManager<super::FailingConnector> {
     pub fn new_incoming_only(metadata: Metadata) -> Self {
+        use restate_types::config::Configuration;
         let inner = Arc::new(Mutex::new(ConnectionManagerInner::default()));
 
         Self {
             metadata,
             inner,
             transport_connector: Arc::new(super::FailingConnector::default()),
-            networking_options: NetworkingOptions::default(),
+            networking_options: Configuration::pinned().networking.clone(),
         }
     }
 }
@@ -294,10 +304,18 @@ impl<T: TransportConnect> ConnectionManager<T> {
         &self,
         node_id: GenerationalNodeId,
     ) -> Result<Arc<OwnedConnection>, NetworkError> {
+        // fail fast if we are connecting to our previous self
+        if self.metadata.my_node_id().is_same_but_different(&node_id) {
+            return Err(NetworkError::NodeIsGone(node_id));
+        }
+
         // find a connection by node_id
         let maybe_connection: Option<Arc<OwnedConnection>> = {
             let guard = self.inner.lock();
-            guard.get_random_connection(&node_id)
+            guard.get_random_connection(
+                &node_id,
+                self.networking_options.num_concurrent_connections(),
+            )
             // lock is dropped.
         };
 
@@ -669,8 +687,12 @@ where
                     global::get_text_map_propagator(|propagator| propagator.extract(span_ctx))
                 });
 
-                if let Err(e) = router
-                    .call(
+                // unconstrained: We want to avoid yielding if the message router has capacity,
+                // this is to improve tail latency of message processing. We still give tokio
+                // a yielding point when reading the next message but it would be excessive to
+                // introduce more than one yielding point in this reactor loop.
+                if let Err(e) = tokio::task::unconstrained(
+                    router.call(
                         Incoming::from_parts(
                             msg,
                             connection.downgrade(),
@@ -680,8 +702,9 @@ where
                         )
                         .with_parent_context(parent_context),
                         connection.protocol_version,
-                    )
-                    .await
+                    ),
+                )
+                .await
                 {
                     warn!("Error processing message: {:?}", e);
                 }

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -9,14 +9,15 @@
 // by the Apache License, Version 2.0.
 
 use std::sync::{Arc, Weak};
-use std::time::Instant;
 
 use ahash::HashMap;
 use enum_map::EnumMap;
 use futures::{FutureExt, Stream, StreamExt};
+use metrics::{counter, histogram};
 use opentelemetry::global;
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
+use tokio::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info, instrument, trace, warn, Instrument, Span};
 
@@ -32,13 +33,15 @@ use super::connection::{OwnedConnection, WeakConnection};
 use super::error::{NetworkError, ProtocolError};
 use super::handshake::wait_for_welcome;
 use super::metric_definitions::{
-    self, CONNECTION_DROPPED, INCOMING_CONNECTION, MESSAGE_PROCESSING_DURATION, MESSAGE_RECEIVED,
-    ONGOING_DRAIN, OUTGOING_CONNECTION,
+    self, CONNECTION_DROPPED, INCOMING_CONNECTION, OUTGOING_CONNECTION,
 };
 use super::transport_connector::TransportConnect;
 use super::{Handler, MessageRouter};
 use crate::metadata::Urgency;
 use crate::network::handshake::{negotiate_protocol_version, wait_for_hello};
+use crate::network::metric_definitions::{
+    NETWORK_MESSAGE_PROCESSING_DURATION, NETWORK_MESSAGE_RECEIVED, NETWORK_MESSAGE_RECEIVED_BYTES,
+};
 use crate::network::{Incoming, PeerMetadataVersion};
 use crate::{Metadata, TaskCenter, TaskContext, TaskId, TaskKind};
 
@@ -425,7 +428,7 @@ impl<T: TransportConnect> ConnectionManager<T> {
 
     #[instrument(skip_all)]
     fn connect_loopback(&self) -> Result<Arc<OwnedConnection>, NetworkError> {
-        let (tx, rx) = mpsc::channel(self.networking_options.outbound_queue_length.into());
+        let (tx, rx) = mpsc::channel(self.networking_options.outbound_queue_length.get());
         let connection = OwnedConnection::new(
             self.metadata.my_node_id(),
             restate_types::net::CURRENT_PROTOCOL_VERSION,
@@ -525,8 +528,7 @@ impl<T: TransportConnect> ConnectionManager<T> {
         let connection_weak = Arc::downgrade(&connection);
         let span = tracing::error_span!(parent: None, "network-reactor",
             task_id = tracing::field::Empty,
-            peer_node_id = %peer_node_id,
-            protocol_version = ?connection.protocol_version() as i32,
+            peer = %peer_node_id,
         );
         let router = guard.router.clone();
 
@@ -544,7 +546,7 @@ impl<T: TransportConnect> ConnectionManager<T> {
         )?;
         if peer_node_id != self.metadata.my_node_id() {
             debug!(
-                peer_node_id = %peer_node_id,
+                peer = %peer_node_id,
                 task_id = %task_id,
                 "Incoming connection accepted from node {}", peer_node_id
             );
@@ -615,7 +617,6 @@ where
             }
         };
 
-        MESSAGE_RECEIVED.increment(1);
         let processing_started = Instant::now();
 
         // body are not allowed to be empty.
@@ -674,14 +675,10 @@ where
                 }
             });
 
+        let encoded_len = body.encoded_len();
         match body.try_as_binary_body(connection.protocol_version) {
             Ok(msg) => {
-                trace!(
-                    peer = %connection.peer,
-                    ?header,
-                    target = ?msg.target(),
-                    "Message received"
-                );
+                let target = msg.target();
 
                 let parent_context = header.span_context.as_ref().map(|span_ctx| {
                     global::get_text_map_propagator(|propagator| propagator.extract(span_ctx))
@@ -706,14 +703,25 @@ where
                 )
                 .await
                 {
-                    warn!("Error processing message: {:?}", e);
+                    warn!(
+                        target = target.as_str_name(),
+                        "Error processing message: {e}"
+                    );
                 }
-                MESSAGE_PROCESSING_DURATION.record(processing_started.elapsed());
+                histogram!(NETWORK_MESSAGE_PROCESSING_DURATION, "target" => target.as_str_name())
+                    .record(processing_started.elapsed());
+                counter!(NETWORK_MESSAGE_RECEIVED, "target" => target.as_str_name()).increment(1);
+                counter!(NETWORK_MESSAGE_RECEIVED_BYTES, "target" => target.as_str_name())
+                    .increment(encoded_len as u64);
+                trace!(
+                    target = target.as_str_name(),
+                    "Processed message in {:?}",
+                    processing_started.elapsed()
+                );
             }
             Err(status) => {
                 // terminate the stream
-                info!("Error processing message, reporting error to peer: {status}");
-                MESSAGE_PROCESSING_DURATION.record(processing_started.elapsed());
+                warn!("Error processing message, reporting error to peer: {status}",);
                 connection.send_control_frame(ConnectionControl::codec_error(status.to_string()));
                 break;
             }
@@ -721,7 +729,6 @@ where
     }
 
     // remove from active set
-    ONGOING_DRAIN.increment(1.0);
     on_connection_draining(&connection, &connection_manager, is_peer_shutting_down);
     let protocol_version = connection.protocol_version;
     let peer_node_id = connection.peer;
@@ -775,7 +782,6 @@ where
     // We should also terminate response stream. This happens automatically when
     // the sender is dropped
     on_connection_terminated(&connection_manager);
-    ONGOING_DRAIN.decrement(1.0);
     CONNECTION_DROPPED.increment(1);
     debug!(
         "Connection terminated, drained {} messages in {:?}, total connection age is {:?}",

--- a/crates/core/src/network/metric_definitions.rs
+++ b/crates/core/src/network/metric_definitions.rs
@@ -8,21 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use metrics::{
-    counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram, Counter,
-    Gauge, Histogram, Unit,
-};
+use metrics::{counter, describe_counter, describe_histogram, Counter, Unit};
 use std::sync::LazyLock;
 
-const NETWORK_CONNECTION_CREATED: &str = "restate.network.connection_created.total";
-const NETWORK_CONNECTION_DROPPED: &str = "restate.network.connection_dropped.total";
-const NETWORK_ONGOING_DRAINS: &str = "restate.network.ongoing_drains";
-const NETWORK_MESSAGE_SENT: &str = "restate.network.message_sent.total";
-const NETWORK_MESSAGE_RECEIVED: &str = "restate.network.message_received.total";
+pub(crate) const NETWORK_CONNECTION_CREATED: &str = "restate.network.connection_created.total";
+pub(crate) const NETWORK_CONNECTION_DROPPED: &str = "restate.network.connection_dropped.total";
+pub(crate) const NETWORK_MESSAGE_RECEIVED: &str = "restate.network.message_received.total";
+pub(crate) const NETWORK_MESSAGE_RECEIVED_BYTES: &str =
+    "restate.network.message_received_bytes.total";
 
-const NETWORK_CONNECTION_SEND_DURATION: &str = "restate.network.connection_send_duration.seconds";
-const NETWORK_MESSAGE_PROCESSING_DURATION: &str =
+pub(crate) const NETWORK_MESSAGE_PROCESSING_DURATION: &str =
     "restate.network.message_processing_duration.seconds";
+
+#[cfg(debug_assertions)]
+pub(crate) const NETWORK_MESSAGE_DECODE_DURATION: &str =
+    "restate.network.message_decode_duration.seconds";
 
 pub static INCOMING_CONNECTION: LazyLock<Counter> =
     LazyLock::new(|| counter!(NETWORK_CONNECTION_CREATED, "direction" => "incoming"));
@@ -32,17 +32,6 @@ pub static OUTGOING_CONNECTION: LazyLock<Counter> =
 
 pub static CONNECTION_DROPPED: LazyLock<Counter> =
     LazyLock::new(|| counter!(NETWORK_CONNECTION_DROPPED));
-pub static ONGOING_DRAIN: LazyLock<Gauge> = LazyLock::new(|| gauge!(NETWORK_ONGOING_DRAINS));
-
-pub static MESSAGE_SENT: LazyLock<Counter> = LazyLock::new(|| counter!(NETWORK_MESSAGE_SENT));
-pub static MESSAGE_RECEIVED: LazyLock<Counter> =
-    LazyLock::new(|| counter!(NETWORK_MESSAGE_RECEIVED));
-
-pub static CONNECTION_SEND_DURATION: LazyLock<Histogram> =
-    LazyLock::new(|| histogram!(NETWORK_CONNECTION_SEND_DURATION));
-
-pub static MESSAGE_PROCESSING_DURATION: LazyLock<Histogram> =
-    LazyLock::new(|| histogram!(NETWORK_MESSAGE_PROCESSING_DURATION));
 
 pub fn describe_metrics() {
     describe_counter!(
@@ -55,25 +44,18 @@ pub fn describe_metrics() {
         Unit::Count,
         "Number of connections dropped"
     );
-    describe_gauge!(
-        NETWORK_ONGOING_DRAINS,
-        Unit::Count,
-        "Number of connections currently being drained"
+    describe_counter!(
+        NETWORK_MESSAGE_RECEIVED_BYTES,
+        Unit::Bytes,
+        "Number of bytes received by message name"
     );
-
-    describe_counter!(NETWORK_MESSAGE_SENT, Unit::Count, "Number of messages sent");
 
     describe_counter!(
         NETWORK_MESSAGE_RECEIVED,
         Unit::Count,
-        "Number of messages received"
+        "Number of messages received by message type"
     );
 
-    describe_histogram!(
-        NETWORK_CONNECTION_SEND_DURATION,
-        Unit::Seconds,
-        "Latency of sending a message over a single connection stream"
-    );
     describe_histogram!(
         NETWORK_MESSAGE_PROCESSING_DURATION,
         Unit::Seconds,

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -75,11 +75,11 @@ pub mod test_util {
     use super::*;
 
     use std::sync::Arc;
-    use std::time::Instant;
 
     use futures::{Stream, StreamExt};
     use parking_lot::Mutex;
     use tokio::sync::mpsc;
+    use tokio::time::Instant;
     use tokio_stream::wrappers::ReceiverStream;
     use tracing::info;
 

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -80,8 +80,9 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
+    #[strum(props(runtime = "default"))]
     SocketHandler,
-    #[strum(props(OnError = "log"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     H2Stream,
     /// A task that handles a single RPC request. The task is executed on the default runtime to
     /// decouple it from the lifetime of the originating runtime. Use this task kind if you want to
@@ -104,7 +105,7 @@ pub enum TaskKind {
     /// Low-priority tasks responsible for partition snapshot-related I/O.
     #[strum(props(OnCancel = "abort", OnError = "log"))]
     PartitionSnapshotProducer,
-    #[strum(props(OnError = "log"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     ConnectionReactor,
     Shuffle,
     Cleaner,

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -63,6 +63,20 @@ pub struct NetworkingOptions {
     /// The number of messages that can be queued on the outbound stream of a single
     /// connection.
     pub outbound_queue_length: NonZeroUsize,
+
+    /// # Number of connections to each peer
+    ///
+    /// This is used as a guiding value for how many connections every node can
+    /// maintain with each peer. With more connections, concurrency of network message
+    /// processing increases, but it also increases the memory and CPU overhead.
+    pub num_concurrent_connections: NonZeroUsize,
+}
+
+impl NetworkingOptions {
+    #[inline(always)]
+    pub fn num_concurrent_connections(&self) -> usize {
+        self.num_concurrent_connections.get()
+    }
 }
 
 impl Default for NetworkingOptions {
@@ -80,6 +94,7 @@ impl Default for NetworkingOptions {
             http2_keep_alive_interval: Duration::from_secs(5).into(),
             http2_keep_alive_timeout: Duration::from_secs(5).into(),
             http2_adaptive_window: true,
+            num_concurrent_connections: NonZeroUsize::new(13).unwrap(),
         }
     }
 }

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -106,6 +106,12 @@ impl GenerationalNodeId {
         self.encode(buf);
         buf.split()
     }
+
+    /// Same plain node-id but not the same generation
+    #[inline(always)]
+    pub fn is_same_but_different(&self, other: &GenerationalNodeId) -> bool {
+        self.0 == other.0 && self.1 != other.1
+    }
 }
 
 impl From<GenerationalNodeId> for u64 {


### PR DESCRIPTION

Introducing histograms and per-message counters. Histograms for processing duration per message are only enabled in debug builds but this decision can change if we found the need to use them for release build

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2665).
* #2672
* #2670
* #2669
* __->__ #2665
* #2664
* #2654