### PR TITLE
Minor restatectl improvements

### DIFF
--- a/tools/restatectl/src/commands/cluster/config.rs
+++ b/tools/restatectl/src/commands/cluster/config.rs
@@ -11,13 +11,15 @@
 mod get;
 mod set;
 
-use std::fmt::{self, Display, Write};
+use std::fmt::Write;
 
 use cling::prelude::*;
 
 use restate_types::{
     logs::metadata::ProviderConfiguration, protobuf::cluster::ClusterConfiguration,
 };
+
+use crate::util::{write_default_provider, write_leaf};
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Config {
@@ -32,7 +34,7 @@ pub fn cluster_config_string(config: &ClusterConfiguration) -> anyhow::Result<St
     writeln!(w, "⚙️ Cluster Configuration")?;
     write_leaf(
         &mut w,
-        1,
+        0,
         false,
         "Number of partitions",
         config.num_partitions,
@@ -43,63 +45,15 @@ pub fn cluster_config_string(config: &ClusterConfiguration) -> anyhow::Result<St
         .map(|p| p.replication_property.as_str())
         .unwrap_or("*");
 
-    write_leaf(&mut w, 1, false, "Partition replication", strategy)?;
+    write_leaf(&mut w, 0, false, "Partition replication", strategy)?;
 
     let provider: ProviderConfiguration = config
         .bifrost_provider
         .clone()
         .unwrap_or_default()
         .try_into()?;
-    write_default_provider(&mut w, 1, &provider)?;
+
+    write_default_provider(&mut w, 0, &provider)?;
 
     Ok(w)
-}
-
-fn write_default_provider<W: fmt::Write>(
-    w: &mut W,
-    depth: usize,
-    provider: &ProviderConfiguration,
-) -> Result<(), fmt::Error> {
-    let title = "Bifrost Provider";
-    match provider {
-        #[cfg(any(test, feature = "memory-loglet"))]
-        ProviderConfiguration::InMemory => {
-            write_leaf(w, depth, true, title, "in-memory")?;
-        }
-        ProviderConfiguration::Local => {
-            write_leaf(w, depth, true, title, "local")?;
-        }
-        #[cfg(feature = "replicated-loglet")]
-        ProviderConfiguration::Replicated(config) => {
-            write_leaf(w, depth, true, title, "replicated")?;
-            let depth = depth + 1;
-            write_leaf(
-                w,
-                depth,
-                true,
-                "Replication property",
-                config.replication_property.to_string(),
-            )?;
-            write_leaf(
-                w,
-                depth,
-                true,
-                "Nodeset size",
-                config.target_nodeset_size.to_string(),
-            )?;
-        }
-    }
-    Ok(())
-}
-
-fn write_leaf<W: fmt::Write>(
-    w: &mut W,
-    depth: usize,
-    last: bool,
-    title: impl Display,
-    value: impl Display,
-) -> Result<(), fmt::Error> {
-    let depth = depth + 1;
-    let chr = if last { '└' } else { '├' };
-    writeln!(w, "{chr:>depth$} {title}: {value}")
 }

--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -15,12 +15,14 @@ use cling::prelude::*;
 use restate_cli_util::_comfy_table::{Cell, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::output::Console;
 use restate_types::logs::metadata::Chain;
 use restate_types::logs::LogId;
 use restate_types::Versioned;
 
 use crate::commands::log::{deserialize_replicated_log_params, render_loglet_params};
 use crate::connection::ConnectionInfo;
+use crate::util::write_default_provider;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(visible_alias = "ls")]
@@ -32,12 +34,13 @@ pub async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> any
 
     let mut logs_table = Table::new_styled();
 
-    c_println!("Log Configuration ({})", logs.version());
+    c_println!("Log chain {}", logs.version());
 
-    c_println!(
-        "Default Provider Config: {:?}",
-        logs.configuration().default_provider
-    );
+    write_default_provider(
+        &mut Console::stdout(),
+        0,
+        &logs.configuration().default_provider,
+    )?;
 
     // sort by log-id for display
     let logs: BTreeMap<LogId, &Chain> = logs.iter().map(|(id, chain)| (*id, chain)).collect();

--- a/tools/restatectl/src/util.rs
+++ b/tools/restatectl/src/util.rs
@@ -8,13 +8,64 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::{self, Display};
+
 use tonic::transport::Channel;
 
 use restate_cli_util::CliContext;
 use restate_core::network::net_util::create_tonic_channel;
-use restate_types::net::AdvertisedAddress;
+use restate_types::{logs::metadata::ProviderConfiguration, net::AdvertisedAddress};
 
 pub fn grpc_channel(address: AdvertisedAddress) -> Channel {
     let ctx = CliContext::get();
     create_tonic_channel(address, &ctx.network)
+}
+
+pub fn write_default_provider<W: fmt::Write>(
+    w: &mut W,
+    depth: usize,
+    provider: &ProviderConfiguration,
+) -> Result<(), fmt::Error> {
+    let title = "Logs Provider";
+    match provider {
+        #[cfg(any(test, feature = "memory-loglet"))]
+        ProviderConfiguration::InMemory => {
+            write_leaf(w, depth, true, title, "in-memory")?;
+        }
+        ProviderConfiguration::Local => {
+            write_leaf(w, depth, true, title, "local")?;
+        }
+        #[cfg(feature = "replicated-loglet")]
+        ProviderConfiguration::Replicated(config) => {
+            write_leaf(w, depth, true, title, "replicated")?;
+            let depth = depth + 1;
+            write_leaf(
+                w,
+                depth,
+                false,
+                "Log replication",
+                config.replication_property.to_string(),
+            )?;
+            write_leaf(
+                w,
+                depth,
+                true,
+                "Nodeset size",
+                config.target_nodeset_size.to_string(),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub fn write_leaf<W: fmt::Write>(
+    w: &mut W,
+    depth: usize,
+    last: bool,
+    title: impl Display,
+    value: impl Display,
+) -> Result<(), fmt::Error> {
+    let depth = depth + 1;
+    let chr = if last { '└' } else { '├' };
+    writeln!(w, "{chr:>depth$} {title}: {value}")
 }


### PR DESCRIPTION
Minor restatectl improvements

This fixes the `logs list` view and shows the configuration in a proper way
```
Log Configuration (v3)
└ Logs Provider: replicated
  ├ Log replication: {node: 2}
  └ Nodeset size: 0
 L-ID  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     2         Replicated  0_1        {node: 2}    N1:2       [N1, N2, N3]
 1     1         Replicated  1_1        {node: 2}    N3:1       [N1, N2, N3]
 2     2         Replicated  2_1        {node: 2}    N1:2       [N1, N2, N3]
 3     1         Replicated  3_1        {node: 2}    N3:1       [N1, N2, N3]
```
instead of
```
Log Configuration (v3)
Default Provider Config: Replicated(ReplicatedLogletConfig { replication_property: {node: 2}, target_nodeset_size: NodeSetSize(0) })
 L-ID  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     2         Replicated  0_1        {node: 2}    N1:2       [N1, N2, N3]
 1     1         Replicated  1_1        {node: 2}    N3:1       [N1, N2, N3]
 2     2         Replicated  2_1        {node: 2}    N1:2       [N1, N2, N3]
 3     1         Replicated  3_1        {node: 2}    N3:1       [N1, N2, N3]
```
