### PR TITLE
Fix treatment of not-found nodes and update provisioning semantics

### DIFF
--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -110,12 +110,12 @@ impl Appender {
             };
             match loglet.append_batch(batch.clone()).await {
                 Ok(lsn) => return Ok(lsn),
-                Err(AppendError::Sealed) => {
+                Err(err @ AppendError::Sealed | err @ AppendError::ReconfigurationNeeded(_)) => {
                     debug!(
                         log_id = %self.log_id,
                         attempt = attempt,
                         segment_index = %loglet.segment_index(),
-                        "Batch append failed but will be retried (loglet has been sealed). Waiting for reconfiguration to complete"
+                        "Batch append failed but will be retried ({err}). Waiting for reconfiguration to complete"
                     );
                     let new_loglet = Self::on_sealed_loglet(
                         self.log_id,

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -16,19 +16,19 @@ pub mod util;
 
 // exports
 pub use error::*;
-use futures::stream::BoxStream;
 pub use provider::{LogletProvider, LogletProviderFactory};
-use restate_types::logs::metadata::ProviderKind;
-use tokio::sync::oneshot;
 
+use std::borrow::Cow;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{ready, Poll};
 
 use async_trait::async_trait;
+use futures::stream::BoxStream;
 use futures::{FutureExt, Stream};
+use tokio::sync::oneshot;
 
-use restate_core::ShutdownError;
+use restate_types::logs::metadata::ProviderKind;
 use restate_types::logs::{KeyFilter, LogletId, LogletOffset, Record, TailState};
 
 use crate::LogEntry;
@@ -190,6 +190,12 @@ impl LogletCommit {
         Self { rx }
     }
 
+    pub fn reconfiguration_needed(reason: impl Into<Cow<'static, str>>) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(AppendError::ReconfigurationNeeded(reason.into())));
+        Self { rx }
+    }
+
     pub fn resolved(offset: LogletOffset) -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Ok(offset));
@@ -211,7 +217,9 @@ impl std::future::Future for LogletCommit {
     ) -> Poll<Self::Output> {
         match ready!(self.rx.poll_unpin(cx)) {
             Ok(res) => Poll::Ready(res),
-            Err(_) => Poll::Ready(Err(AppendError::Shutdown(ShutdownError))),
+            Err(_) => Poll::Ready(Err(AppendError::ReconfigurationNeeded(
+                "loglet gave up on this batch".into(),
+            ))),
         }
     }
 }

--- a/crates/bifrost/src/loglet/error.rs
+++ b/crates/bifrost/src/loglet/error.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -16,8 +17,10 @@ use restate_types::errors::{IntoMaybeRetryable, MaybeRetryableError};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum AppendError {
-    #[error("Loglet is sealed")]
+    #[error("Loglet has been sealed")]
     Sealed,
+    #[error("Loglet needs reconfiguration; {0}")]
+    ReconfigurationNeeded(Cow<'static, str>),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
     #[error(transparent)]

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -510,6 +510,10 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
                             println!("append failed({i}) => SEALED");
                             break;
                         }
+                        Err(AppendError::ReconfigurationNeeded(reason)) => {
+                            println!("append failed({i}) => ReconfigurationNeeded({reason})");
+                            break;
+                        }
                         Err(AppendError::Shutdown(_)) => {
                             break;
                         }

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -219,7 +219,7 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
                             }
                             CheckSealOutcome::FullySealed => {
                                 // already fully sealed, just make sure the sequencer is drained.
-                                handle.drain().await?;
+                                handle.drain().await;
                                 // note that we can only do that if we are the sequencer because
                                 // our known_global_tail is authoritative. We have no doubt about
                                 // whether the tail needs to be repaired or not.
@@ -420,7 +420,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         .await?;
         // If we are the sequencer, we need to wait until the sequencer is drained.
         if let SequencerAccess::Local { handle } = &self.sequencer {
-            handle.drain().await?;
+            handle.drain().await;
             self.known_global_tail.notify_seal();
         };
         // Primarily useful for remote sequencer to enforce seal check on the next find_tail() call

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -395,6 +395,14 @@ impl WaitForCommitTask {
                 },
                 last_offset: LogletOffset::INVALID,
             },
+            Err(AppendError::ReconfigurationNeeded(_)) => Appended {
+                header: CommonResponseHeader {
+                    known_global_tail: Some(self.global_tail.latest_offset()),
+                    sealed: Some(self.global_tail.is_sealed()), // this must be true
+                    status: SequencerStatus::Gone,
+                },
+                last_offset: LogletOffset::INVALID,
+            },
             Err(AppendError::Shutdown(_)) => Appended {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -545,7 +545,7 @@ impl ReadStreamTask {
                     loglet_id = %self.my_params.loglet_id,
                     from_offset = %self.read_pointer,
                     %to_offset,
-                    ?e,
+                    %e,
                     "Could not request record batch from node {}", server
                 );
                 Ok(ServerReadResult::Skip)

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer.rs
@@ -189,7 +189,7 @@ impl<T: TransportConnect> Sequencer<T> {
     /// observed global_tail with is_sealed=true)
     ///
     /// This method is cancellation safe.
-    pub async fn drain(&self) -> Result<(), ShutdownError> {
+    pub async fn drain(&self) {
         // stop issuing new permits
         self.record_permits.close();
         // required to allow in_flight.wait() to finish.
@@ -199,7 +199,7 @@ impl<T: TransportConnect> Sequencer<T> {
         // we are assuming here that seal has been already executed on majority of nodes. This is
         // important since in_flight.close() doesn't prevent new tasks from being spawned.
         if self.sequencer_shared_state.known_global_tail.is_sealed() {
-            return Ok(());
+            return;
         }
 
         // wait for in-flight tasks to complete before returning
@@ -214,8 +214,6 @@ impl<T: TransportConnect> Sequencer<T> {
             loglet_id = %self.sequencer_shared_state.my_params.loglet_id,
             "Sequencer drained",
         );
-
-        Ok(())
     }
 
     fn ensure_enough_permits(&self, required: usize) {

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -17,8 +17,10 @@ use tracing::{debug, instrument, trace, warn};
 
 use restate_core::{
     network::{rpc_router::RpcRouter, Incoming, NetworkError, Networking, TransportConnect},
-    ShutdownError, TaskCenterFutureExt,
+    TaskCenterFutureExt,
 };
+use restate_types::replicated_loglet::Spread;
+use restate_types::retries::with_jitter;
 use restate_types::{
     config::Configuration,
     live::Live,
@@ -31,6 +33,7 @@ use restate_types::{
 
 use super::{RecordsExt, SequencerSharedState};
 use crate::providers::replicated_loglet::metric_definitions::BIFROST_SEQ_APPEND_DURATION;
+use crate::providers::replicated_loglet::replication::spread_selector::SpreadSelectorError;
 use crate::{
     loglet::{AppendError, LogletCommitResolver},
     providers::replicated_loglet::{
@@ -46,10 +49,7 @@ const DEFAULT_BACKOFF_TIME: Duration = Duration::from_millis(1000);
 const TONE_ESCALATION_THRESHOLD: usize = 5;
 
 enum State {
-    Wave {
-        // nodes that should be avoided by the spread selector
-        graylist: NodeSet,
-    },
+    Wave,
     Backoff,
     Done,
     Sealed,
@@ -72,6 +72,8 @@ pub(crate) struct SequencerAppender<T> {
     permit: Option<OwnedSemaphorePermit>,
     commit_resolver: Option<LogletCommitResolver>,
     configuration: Live<Configuration>,
+    // nodes that should be avoided by the spread selector
+    graylist: NodeSet,
 }
 
 impl<T: TransportConnect> SequencerAppender<T> {
@@ -109,6 +111,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
             permit: Some(permit),
             commit_resolver: Some(commit_resolver),
             configuration: Configuration::updateable(),
+            graylist: NodeSet::default(),
         }
     }
 
@@ -126,9 +129,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
     pub async fn run(mut self, cancellation_token: CancellationToken) {
         let start = Instant::now();
         // initial wave has 0 replicated and 0 gray listed node
-        let mut state = State::Wave {
-            graylist: NodeSet::default(),
-        };
+        let mut state = State::Wave;
 
         let retry_policy = self
             .configuration
@@ -145,7 +146,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
             state = match state {
                 // termination conditions
                 State::Done | State::Cancelled | State::Sealed => break state,
-                State::Wave { graylist } => {
+                State::Wave => {
                     self.current_wave += 1;
                     // # Why is this cancellation safe?
                     // Because we don't await any futures inside the join_next() loop, so we are
@@ -158,7 +159,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                     // their perspective it has failed, and because the global tail was not moved, all
                     // appends after this one cannot move the global tail as well.
                     let Some(next_state) = cancellation_token
-                        .run_until_cancelled(self.send_wave(graylist))
+                        .run_until_cancelled(self.send_wave())
                         .await
                     else {
                         break State::Cancelled;
@@ -168,7 +169,9 @@ impl<T: TransportConnect> SequencerAppender<T> {
                 State::Backoff => {
                     // since backoff can be None, or run out of iterations,
                     // but appender should never give up we fall back to fixed backoff
-                    let delay = retry.next().unwrap_or(DEFAULT_BACKOFF_TIME);
+                    let delay = retry
+                        .next()
+                        .unwrap_or(with_jitter(DEFAULT_BACKOFF_TIME, 0.5));
                     if self.current_wave >= TONE_ESCALATION_THRESHOLD {
                         warn!(
                             wave = %self.current_wave,
@@ -189,9 +192,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                         break State::Cancelled;
                     };
 
-                    State::Wave {
-                        graylist: NodeSet::default(),
-                    }
+                    State::Wave
                 }
             }
         };
@@ -216,7 +217,9 @@ impl<T: TransportConnect> SequencerAppender<T> {
             State::Cancelled => {
                 trace!("Append cancelled");
                 if let Some(commit_resolver) = self.commit_resolver.take() {
-                    commit_resolver.error(AppendError::Shutdown(ShutdownError));
+                    commit_resolver.error(AppendError::ReconfigurationNeeded(
+                        "sequencer is draining".into(),
+                    ));
                 }
             }
             State::Sealed => {
@@ -231,26 +234,55 @@ impl<T: TransportConnect> SequencerAppender<T> {
         }
     }
 
-    #[instrument(skip_all, fields(wave = %self.current_wave))]
-    async fn send_wave(&mut self, mut graylist: NodeSet) -> State {
-        // select the spread
-        let spread = match self.sequencer_shared_state.selector.select(
-            &mut rand::rng(),
-            &self.networking.metadata().nodes_config_ref(),
-            &graylist,
-        ) {
-            Ok(spread) => spread,
-            Err(_) => {
-                graylist.clear();
+    fn reset_graylist(&mut self) {
+        self.graylist.clear();
+        // add back the sealed nodes to the gray list, those will never be writeable again.
+        self.graylist.extend(
+            self.checker
+                .filter(|attr| attr.sealed)
+                .map(|(node_id, _)| *node_id),
+        );
+    }
+
+    fn generate_spread(&mut self) -> Result<Spread, SpreadSelectorError> {
+        let rng = &mut rand::rng();
+        let nodes_config = &self.networking.metadata().nodes_config_ref();
+        match self
+            .sequencer_shared_state
+            .selector
+            .select(rng, nodes_config, &self.graylist)
+        {
+            Ok(spread) => Ok(spread),
+            Err(err) => {
                 trace!(
-                    %graylist,
+                    nodeset_status = %self.nodeset_status,
+                    graylist = %self.graylist,
+                    %err,
                     "Cannot select a spread, perhaps too many nodes are graylisted, will clear the list and try again"
+                );
+                self.reset_graylist();
+                self.sequencer_shared_state
+                    .selector
+                    .select(rng, nodes_config, &self.graylist)
+            }
+        }
+    }
+
+    #[instrument(skip_all, fields(wave = %self.current_wave))]
+    async fn send_wave(&mut self) -> State {
+        // select the spread
+        let spread = match self.generate_spread() {
+            Ok(spread) => spread,
+            Err(err) => {
+                trace!(
+                    nodeset_status = %self.nodeset_status,
+                    "Cannot select a spread: {err}"
                 );
                 return State::Backoff;
             }
         };
 
-        trace!(%graylist, %spread, "Sending append wave");
+        trace!(graylist = %self.graylist, %spread, wave = %self.current_wave, nodeset_status = %self.nodeset_status, "Sending append wave");
         let last_offset = self.records.last_offset(self.first_offset).unwrap();
 
         // todo: should be exponential backoff
@@ -273,18 +305,22 @@ impl<T: TransportConnect> SequencerAppender<T> {
                     continue;
                 }
             }
-            store_tasks.spawn({
-                let store_task = LogServerStoreTask {
-                    node_id,
-                    sequencer_shared_state: self.sequencer_shared_state.clone(),
-                    networking: self.networking.clone(),
-                    first_offset: self.first_offset,
-                    records: self.records.clone(),
-                    rpc_router: self.store_router.clone(),
-                    store_timeout,
-                };
-                async move { (node_id, store_task.run().await) }.in_current_tc()
-            });
+            store_tasks
+                .build_task()
+                .name(&format!("store-to-{}", node_id))
+                .spawn({
+                    let store_task = LogServerStoreTask {
+                        node_id,
+                        sequencer_shared_state: self.sequencer_shared_state.clone(),
+                        networking: self.networking.clone(),
+                        first_offset: self.first_offset,
+                        records: self.records.clone(),
+                        rpc_router: self.store_router.clone(),
+                        store_timeout,
+                    };
+                    async move { (node_id, store_task.run().await) }.in_current_tc()
+                })
+                .unwrap();
         }
 
         // NOTE: It's very important to keep this loop cancellation safe. If the appender future
@@ -313,7 +349,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                         trace!(peer = %node_id, "Timeout waiting for node {} to commit a batch", node_id);
                     }
                     self.nodeset_status.merge(node_id, PerNodeStatus::timeout());
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                     continue;
                 }
                 StoreTaskStatus::Error(err) => {
@@ -324,7 +360,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                         trace!(peer = %node_id, %err, "Failed to send batch to node");
                     }
                     self.nodeset_status.merge(node_id, PerNodeStatus::failed());
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                     continue;
                 }
                 StoreTaskStatus::Sealed => {
@@ -353,20 +389,20 @@ impl<T: TransportConnect> SequencerAppender<T> {
                 Status::Sealed | Status::Sealing => {
                     self.checker
                         .set_attribute(node_id, NodeAttributes::sealed());
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
                 Status::Dropped => {
                     // Overloaded, or request expired
                     debug!(peer = %node_id, status=?stored.status, "Store failed on peer. Peer is load shedding");
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
                 Status::Disabled => {
                     debug!(peer = %node_id, status=?stored.status, "Store failed on peer. Peer's log-store is disabled");
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
                 Status::SequencerMismatch | Status::Malformed | Status::OutOfBounds => {
                     warn!(peer = %node_id, status=?stored.status, "Store failed on peer due to unexpected error, please check logs of the peer to investigate");
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
             }
 
@@ -387,10 +423,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
         if self.checker.check_fmajority(|attr| attr.sealed).passed() {
             State::Sealed
         } else {
-            // We couldn't achieve write quorum with this wave. We will try again, as fast as
-            // possible until the graylist eats up enough nodes such that we won't be able to
-            // generate node nodesets. Only then we backoff.
-            State::Wave { graylist }
+            State::Backoff
         }
     }
 }

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -638,8 +638,8 @@ where
         if let message::Body::ConnectionControl(ctrl_msg) = &body {
             // do something
             info!(
-                "Terminating connection based on signal from peer: {:?} {}",
-                ctrl_msg.signal(),
+                "Terminating connection based on signal from {}: {}",
+                connection.peer(),
                 ctrl_msg.message
             );
             if ctrl_msg.signal() == message::Signal::Shutdown {

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -44,6 +44,8 @@ pub enum SequencerStatus {
     /// Sealed is returned when the sequencer cannot accept more
     /// [`Append`] requests because it's sealed
     Sealed,
+    /// Local sequencer is not available anymore, reconfiguration is needed
+    Gone,
     /// LogletID does not match Segment
     LogletIdMismatch,
     /// Invalid LogId

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -128,8 +128,8 @@ where
         loglet_id: LogletId::new(LogId::from(1u32), SegmentIndex::OLDEST),
         sequencer,
         replication,
-        // node 1 is the metadata, 2..=count+1 are logservers
-        nodeset: (2..=log_server_count + 1).collect(),
+        // all nodes are log-servers
+        nodeset: (1..=log_server_count).collect(),
     };
     let loglet_params = loglet_params.serialize()?;
 


### PR DESCRIPTION

This fixes mishandling of deleted and unknown nodes in the config in f-majority checks. Integration tests were misconfigured where the nodeset was [N2..N4] where N4 didn't actually exist in config. In this case we should not accept f-majority seal if only one node is sealed (replication=2)
Although this bug wouldn't impact us immediately, it's best to fix this condition and I took it as an opportunity to update the semantics of provisioning state to match the latest design direction. Documentation has also been updated to reflect the correct semantics.

Summary:
- Nodes observed in node-set but not in nodes-config is treated as "provisioning" rather than "disabled"
- Nodes that are "deleted" in config (tombstone exists) are treated as "disabled"
- Nodes in provisioning are fully authoritative, but are automatically excluded from new nodesets (already filtered by candidacy filter in nodeset selector)
- If provisioning nodes were added to the nodeset, they are treated as fully authoritative and are required to participate in f-majority.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2677).
* #2690
* #2689
* #2683
* #2682
* #2681
* #2680
* __->__ #2677
* #2676
* #2673