### PR TITLE
Fixes for trim interval and persisted lsn watcher

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -797,7 +797,9 @@ mod tests {
     use restate_core::test_env::NoOpMessageHandler;
     use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
     use restate_types::cluster::cluster_state::{NodeState, PartitionProcessorStatus};
-    use restate_types::config::{AdminOptions, BifrostOptions, Configuration, NetworkingOptions};
+    use restate_types::config::{
+        AdminOptionsBuilder, BifrostOptions, Configuration, NetworkingOptions,
+    };
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::PartitionId;
     use restate_types::live::Live;
@@ -896,9 +898,11 @@ mod tests {
     async fn auto_log_trim() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
-        let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
-        admin_options.log_trim_interval = Some(interval_duration.into());
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_interval(interval_duration.into())
+            .build()
+            .unwrap();
         let networking = NetworkingOptions {
             // we are using failing transport so we only want to use the mock connection we created.
             num_concurrent_connections: NonZero::new(1).unwrap(),
@@ -979,9 +983,12 @@ mod tests {
             ..Default::default()
         };
 
-        let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
-        admin_options.log_trim_interval = Some(interval_duration.into());
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_interval(interval_duration.into())
+            .build()
+            .unwrap();
+        let interval_duration = Duration::from_secs(10);
         let config = Configuration {
             networking,
             admin: admin_options,
@@ -1051,9 +1058,11 @@ mod tests {
     async fn do_not_trim_unless_all_nodes_report_persisted_lsn() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
-        let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
-        admin_options.log_trim_interval = Some(interval_duration.into());
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_interval(interval_duration.into())
+            .build()
+            .unwrap();
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
 
@@ -1115,7 +1124,6 @@ mod tests {
     async fn do_not_trim_by_persisted_lsn_if_snapshot_repository_configured() -> anyhow::Result<()>
     {
         const LOG_ID: LogId = LogId::new(0);
-        let interval_duration = Duration::from_secs(10);
 
         let networking = NetworkingOptions {
             // we are using failing transport so we only want to use the mock connection we created.
@@ -1123,11 +1131,16 @@ mod tests {
             ..Default::default()
         };
 
+        let interval_duration = Duration::from_secs(10);
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_interval(interval_duration.into())
+            .build()
+            .unwrap();
         let mut config: Configuration = Configuration {
             networking,
+            admin: admin_options,
             ..Default::default()
         };
-        config.admin.log_trim_interval = Some(interval_duration.into());
         config.bifrost.default_provider = ProviderKind::InMemory;
         config.worker.snapshots.destination = Some("a-repository-somewhere".to_string());
 
@@ -1201,9 +1214,12 @@ mod tests {
     async fn auto_trim_by_archived_lsn_when_dead_nodes_present() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
-        let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
-        admin_options.log_trim_interval = Some(interval_duration.into());
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_interval(interval_duration.into())
+            .build()
+            .unwrap();
+
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
         let config = Configuration {
@@ -1278,9 +1294,12 @@ mod tests {
     async fn do_not_trim_by_archived_lsn_if_slow_nodes_present() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
-        let mut admin_options = AdminOptions::default();
         let interval_duration = Duration::from_secs(10);
-        admin_options.log_trim_interval = Some(interval_duration.into());
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_interval(interval_duration.into())
+            .build()
+            .unwrap();
+
         let mut bifrost_options = BifrostOptions::default();
         bifrost_options.default_provider = ProviderKind::InMemory;
         let networking = NetworkingOptions {

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -110,12 +110,12 @@ impl Appender {
             };
             match loglet.append_batch(batch.clone()).await {
                 Ok(lsn) => return Ok(lsn),
-                Err(AppendError::Sealed) => {
+                Err(err @ AppendError::Sealed | err @ AppendError::ReconfigurationNeeded(_)) => {
                     debug!(
                         log_id = %self.log_id,
                         attempt = attempt,
                         segment_index = %loglet.segment_index(),
-                        "Batch append failed but will be retried (loglet has been sealed). Waiting for reconfiguration to complete"
+                        "Batch append failed but will be retried ({err}). Waiting for reconfiguration to complete"
                     );
                     let new_loglet = Self::on_sealed_loglet(
                         self.log_id,

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -16,19 +16,19 @@ pub mod util;
 
 // exports
 pub use error::*;
-use futures::stream::BoxStream;
 pub use provider::{LogletProvider, LogletProviderFactory};
-use restate_types::logs::metadata::ProviderKind;
-use tokio::sync::oneshot;
 
+use std::borrow::Cow;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{ready, Poll};
 
 use async_trait::async_trait;
+use futures::stream::BoxStream;
 use futures::{FutureExt, Stream};
+use tokio::sync::oneshot;
 
-use restate_core::ShutdownError;
+use restate_types::logs::metadata::ProviderKind;
 use restate_types::logs::{KeyFilter, LogletId, LogletOffset, Record, TailState};
 
 use crate::LogEntry;
@@ -190,6 +190,12 @@ impl LogletCommit {
         Self { rx }
     }
 
+    pub fn reconfiguration_needed(reason: impl Into<Cow<'static, str>>) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(AppendError::ReconfigurationNeeded(reason.into())));
+        Self { rx }
+    }
+
     pub fn resolved(offset: LogletOffset) -> Self {
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(Ok(offset));
@@ -211,7 +217,9 @@ impl std::future::Future for LogletCommit {
     ) -> Poll<Self::Output> {
         match ready!(self.rx.poll_unpin(cx)) {
             Ok(res) => Poll::Ready(res),
-            Err(_) => Poll::Ready(Err(AppendError::Shutdown(ShutdownError))),
+            Err(_) => Poll::Ready(Err(AppendError::ReconfigurationNeeded(
+                "loglet gave up on this batch".into(),
+            ))),
         }
     }
 }

--- a/crates/bifrost/src/loglet/error.rs
+++ b/crates/bifrost/src/loglet/error.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -16,8 +17,10 @@ use restate_types::errors::{IntoMaybeRetryable, MaybeRetryableError};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum AppendError {
-    #[error("Loglet is sealed")]
+    #[error("Loglet has been sealed")]
     Sealed,
+    #[error("Loglet needs reconfiguration; {0}")]
+    ReconfigurationNeeded(Cow<'static, str>),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
     #[error(transparent)]

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -510,6 +510,10 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
                             println!("append failed({i}) => SEALED");
                             break;
                         }
+                        Err(AppendError::ReconfigurationNeeded(reason)) => {
+                            println!("append failed({i}) => ReconfigurationNeeded({reason})");
+                            break;
+                        }
                         Err(AppendError::Shutdown(_)) => {
                             break;
                         }

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -370,8 +370,6 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
     /// trim_point is inclusive (will be trimmed)
     async fn trim(&self, trim_point: LogletOffset) -> Result<(), OperationError> {
         trace!("trim() called");
-        let trim_point = trim_point.min(self.known_global_tail.latest_offset().prev_unchecked());
-
         TrimTask::new(
             &self.my_params,
             self.logservers_rpc.clone(),

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -219,7 +219,7 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
                             }
                             CheckSealOutcome::FullySealed => {
                                 // already fully sealed, just make sure the sequencer is drained.
-                                handle.drain().await?;
+                                handle.drain().await;
                                 // note that we can only do that if we are the sequencer because
                                 // our known_global_tail is authoritative. We have no doubt about
                                 // whether the tail needs to be repaired or not.
@@ -420,7 +420,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
         .await?;
         // If we are the sequencer, we need to wait until the sequencer is drained.
         if let SequencerAccess::Local { handle } = &self.sequencer {
-            handle.drain().await?;
+            handle.drain().await;
             self.known_global_tail.notify_seal();
         };
         // Primarily useful for remote sequencer to enforce seal check on the next find_tail() call

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -395,6 +395,14 @@ impl WaitForCommitTask {
                 },
                 last_offset: LogletOffset::INVALID,
             },
+            Err(AppendError::ReconfigurationNeeded(_)) => Appended {
+                header: CommonResponseHeader {
+                    known_global_tail: Some(self.global_tail.latest_offset()),
+                    sealed: Some(self.global_tail.is_sealed()), // this must be true
+                    status: SequencerStatus::Gone,
+                },
+                last_offset: LogletOffset::INVALID,
+            },
             Err(AppendError::Shutdown(_)) => Appended {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -545,7 +545,7 @@ impl ReadStreamTask {
                     loglet_id = %self.my_params.loglet_id,
                     from_offset = %self.read_pointer,
                     %to_offset,
-                    ?e,
+                    %e,
                     "Could not request record batch from node {}", server
                 );
                 Ok(ServerReadResult::Skip)

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer.rs
@@ -189,7 +189,7 @@ impl<T: TransportConnect> Sequencer<T> {
     /// observed global_tail with is_sealed=true)
     ///
     /// This method is cancellation safe.
-    pub async fn drain(&self) -> Result<(), ShutdownError> {
+    pub async fn drain(&self) {
         // stop issuing new permits
         self.record_permits.close();
         // required to allow in_flight.wait() to finish.
@@ -199,7 +199,7 @@ impl<T: TransportConnect> Sequencer<T> {
         // we are assuming here that seal has been already executed on majority of nodes. This is
         // important since in_flight.close() doesn't prevent new tasks from being spawned.
         if self.sequencer_shared_state.known_global_tail.is_sealed() {
-            return Ok(());
+            return;
         }
 
         // wait for in-flight tasks to complete before returning
@@ -214,8 +214,6 @@ impl<T: TransportConnect> Sequencer<T> {
             loglet_id = %self.sequencer_shared_state.my_params.loglet_id,
             "Sequencer drained",
         );
-
-        Ok(())
     }
 
     fn ensure_enough_permits(&self, required: usize) {

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -17,8 +17,10 @@ use tracing::{debug, instrument, trace, warn};
 
 use restate_core::{
     network::{rpc_router::RpcRouter, Incoming, NetworkError, Networking, TransportConnect},
-    ShutdownError, TaskCenterFutureExt,
+    TaskCenterFutureExt,
 };
+use restate_types::replicated_loglet::Spread;
+use restate_types::retries::with_jitter;
 use restate_types::{
     config::Configuration,
     live::Live,
@@ -31,6 +33,7 @@ use restate_types::{
 
 use super::{RecordsExt, SequencerSharedState};
 use crate::providers::replicated_loglet::metric_definitions::BIFROST_SEQ_APPEND_DURATION;
+use crate::providers::replicated_loglet::replication::spread_selector::SpreadSelectorError;
 use crate::{
     loglet::{AppendError, LogletCommitResolver},
     providers::replicated_loglet::{
@@ -46,10 +49,7 @@ const DEFAULT_BACKOFF_TIME: Duration = Duration::from_millis(1000);
 const TONE_ESCALATION_THRESHOLD: usize = 5;
 
 enum State {
-    Wave {
-        // nodes that should be avoided by the spread selector
-        graylist: NodeSet,
-    },
+    Wave,
     Backoff,
     Done,
     Sealed,
@@ -72,6 +72,8 @@ pub(crate) struct SequencerAppender<T> {
     permit: Option<OwnedSemaphorePermit>,
     commit_resolver: Option<LogletCommitResolver>,
     configuration: Live<Configuration>,
+    // nodes that should be avoided by the spread selector
+    graylist: NodeSet,
 }
 
 impl<T: TransportConnect> SequencerAppender<T> {
@@ -109,6 +111,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
             permit: Some(permit),
             commit_resolver: Some(commit_resolver),
             configuration: Configuration::updateable(),
+            graylist: NodeSet::default(),
         }
     }
 
@@ -126,9 +129,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
     pub async fn run(mut self, cancellation_token: CancellationToken) {
         let start = Instant::now();
         // initial wave has 0 replicated and 0 gray listed node
-        let mut state = State::Wave {
-            graylist: NodeSet::default(),
-        };
+        let mut state = State::Wave;
 
         let retry_policy = self
             .configuration
@@ -145,7 +146,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
             state = match state {
                 // termination conditions
                 State::Done | State::Cancelled | State::Sealed => break state,
-                State::Wave { graylist } => {
+                State::Wave => {
                     self.current_wave += 1;
                     // # Why is this cancellation safe?
                     // Because we don't await any futures inside the join_next() loop, so we are
@@ -158,7 +159,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                     // their perspective it has failed, and because the global tail was not moved, all
                     // appends after this one cannot move the global tail as well.
                     let Some(next_state) = cancellation_token
-                        .run_until_cancelled(self.send_wave(graylist))
+                        .run_until_cancelled(self.send_wave())
                         .await
                     else {
                         break State::Cancelled;
@@ -168,7 +169,9 @@ impl<T: TransportConnect> SequencerAppender<T> {
                 State::Backoff => {
                     // since backoff can be None, or run out of iterations,
                     // but appender should never give up we fall back to fixed backoff
-                    let delay = retry.next().unwrap_or(DEFAULT_BACKOFF_TIME);
+                    let delay = retry
+                        .next()
+                        .unwrap_or(with_jitter(DEFAULT_BACKOFF_TIME, 0.5));
                     if self.current_wave >= TONE_ESCALATION_THRESHOLD {
                         warn!(
                             wave = %self.current_wave,
@@ -189,9 +192,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                         break State::Cancelled;
                     };
 
-                    State::Wave {
-                        graylist: NodeSet::default(),
-                    }
+                    State::Wave
                 }
             }
         };
@@ -216,7 +217,9 @@ impl<T: TransportConnect> SequencerAppender<T> {
             State::Cancelled => {
                 trace!("Append cancelled");
                 if let Some(commit_resolver) = self.commit_resolver.take() {
-                    commit_resolver.error(AppendError::Shutdown(ShutdownError));
+                    commit_resolver.error(AppendError::ReconfigurationNeeded(
+                        "sequencer is draining".into(),
+                    ));
                 }
             }
             State::Sealed => {
@@ -231,26 +234,55 @@ impl<T: TransportConnect> SequencerAppender<T> {
         }
     }
 
-    #[instrument(skip_all, fields(wave = %self.current_wave))]
-    async fn send_wave(&mut self, mut graylist: NodeSet) -> State {
-        // select the spread
-        let spread = match self.sequencer_shared_state.selector.select(
-            &mut rand::rng(),
-            &self.networking.metadata().nodes_config_ref(),
-            &graylist,
-        ) {
-            Ok(spread) => spread,
-            Err(_) => {
-                graylist.clear();
+    fn reset_graylist(&mut self) {
+        self.graylist.clear();
+        // add back the sealed nodes to the gray list, those will never be writeable again.
+        self.graylist.extend(
+            self.checker
+                .filter(|attr| attr.sealed)
+                .map(|(node_id, _)| *node_id),
+        );
+    }
+
+    fn generate_spread(&mut self) -> Result<Spread, SpreadSelectorError> {
+        let rng = &mut rand::rng();
+        let nodes_config = &self.networking.metadata().nodes_config_ref();
+        match self
+            .sequencer_shared_state
+            .selector
+            .select(rng, nodes_config, &self.graylist)
+        {
+            Ok(spread) => Ok(spread),
+            Err(err) => {
                 trace!(
-                    %graylist,
+                    nodeset_status = %self.nodeset_status,
+                    graylist = %self.graylist,
+                    %err,
                     "Cannot select a spread, perhaps too many nodes are graylisted, will clear the list and try again"
+                );
+                self.reset_graylist();
+                self.sequencer_shared_state
+                    .selector
+                    .select(rng, nodes_config, &self.graylist)
+            }
+        }
+    }
+
+    #[instrument(skip_all, fields(wave = %self.current_wave))]
+    async fn send_wave(&mut self) -> State {
+        // select the spread
+        let spread = match self.generate_spread() {
+            Ok(spread) => spread,
+            Err(err) => {
+                trace!(
+                    nodeset_status = %self.nodeset_status,
+                    "Cannot select a spread: {err}"
                 );
                 return State::Backoff;
             }
         };
 
-        trace!(%graylist, %spread, "Sending append wave");
+        trace!(graylist = %self.graylist, %spread, wave = %self.current_wave, nodeset_status = %self.nodeset_status, "Sending append wave");
         let last_offset = self.records.last_offset(self.first_offset).unwrap();
 
         // todo: should be exponential backoff
@@ -273,18 +305,22 @@ impl<T: TransportConnect> SequencerAppender<T> {
                     continue;
                 }
             }
-            store_tasks.spawn({
-                let store_task = LogServerStoreTask {
-                    node_id,
-                    sequencer_shared_state: self.sequencer_shared_state.clone(),
-                    networking: self.networking.clone(),
-                    first_offset: self.first_offset,
-                    records: self.records.clone(),
-                    rpc_router: self.store_router.clone(),
-                    store_timeout,
-                };
-                async move { (node_id, store_task.run().await) }.in_current_tc()
-            });
+            store_tasks
+                .build_task()
+                .name(&format!("store-to-{}", node_id))
+                .spawn({
+                    let store_task = LogServerStoreTask {
+                        node_id,
+                        sequencer_shared_state: self.sequencer_shared_state.clone(),
+                        networking: self.networking.clone(),
+                        first_offset: self.first_offset,
+                        records: self.records.clone(),
+                        rpc_router: self.store_router.clone(),
+                        store_timeout,
+                    };
+                    async move { (node_id, store_task.run().await) }.in_current_tc()
+                })
+                .unwrap();
         }
 
         // NOTE: It's very important to keep this loop cancellation safe. If the appender future
@@ -313,7 +349,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                         trace!(peer = %node_id, "Timeout waiting for node {} to commit a batch", node_id);
                     }
                     self.nodeset_status.merge(node_id, PerNodeStatus::timeout());
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                     continue;
                 }
                 StoreTaskStatus::Error(err) => {
@@ -324,7 +360,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
                         trace!(peer = %node_id, %err, "Failed to send batch to node");
                     }
                     self.nodeset_status.merge(node_id, PerNodeStatus::failed());
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                     continue;
                 }
                 StoreTaskStatus::Sealed => {
@@ -353,20 +389,20 @@ impl<T: TransportConnect> SequencerAppender<T> {
                 Status::Sealed | Status::Sealing => {
                     self.checker
                         .set_attribute(node_id, NodeAttributes::sealed());
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
                 Status::Dropped => {
                     // Overloaded, or request expired
                     debug!(peer = %node_id, status=?stored.status, "Store failed on peer. Peer is load shedding");
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
                 Status::Disabled => {
                     debug!(peer = %node_id, status=?stored.status, "Store failed on peer. Peer's log-store is disabled");
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
                 Status::SequencerMismatch | Status::Malformed | Status::OutOfBounds => {
                     warn!(peer = %node_id, status=?stored.status, "Store failed on peer due to unexpected error, please check logs of the peer to investigate");
-                    graylist.insert(node_id);
+                    self.graylist.insert(node_id);
                 }
             }
 
@@ -387,10 +423,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
         if self.checker.check_fmajority(|attr| attr.sealed).passed() {
             State::Sealed
         } else {
-            // We couldn't achieve write quorum with this wave. We will try again, as fast as
-            // possible until the graylist eats up enough nodes such that we won't be able to
-            // generate node nodesets. Only then we backoff.
-            State::Wave { graylist }
+            State::Backoff
         }
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/repair_tail.rs
@@ -319,9 +319,8 @@ impl<T: TransportConnect> RepairTail<T> {
             info!(
                 loglet_id = %self.my_params.loglet_id,
                 known_global_tail = %self.known_global_tail.latest_offset(),
-                target_tail = %self.digests.target_tail(),
                 elapsed = ?start.elapsed(),
-                "Repair task completed, {} records have been repaired",
+                "Repair task completed, {} record(s) have been repaired",
                 self.digests.num_fixups(),
             );
             return RepairTailResult::Completed;

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
@@ -176,7 +176,7 @@ impl<'a> TrimTask<'a> {
         // Not enough nodes have successful responses
         warn!(
             loglet_id = %self.my_params.loglet_id,
-             trim_point = %trim_point,
+            trim_point = %trim_point,
             known_global_tail = %self.known_global_tail,
             effective_nodeset = %effective_nodeset,
             "Could not trim the loglet, since we could not confirm the new trim point with write-quorum nodes. Nodes that have confirmed are {}",

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -638,8 +638,8 @@ where
         if let message::Body::ConnectionControl(ctrl_msg) = &body {
             // do something
             info!(
-                "Terminating connection based on signal from peer: {:?} {}",
-                ctrl_msg.signal(),
+                "Terminating connection based on signal from {}: {}",
+                connection.peer(),
                 ctrl_msg.message
             );
             if ctrl_msg.signal() == message::Signal::Shutdown {

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -385,22 +385,11 @@ impl<S: LogStore> LogletWorker<S> {
         }
 
         if body.flags.contains(StoreFlags::IgnoreSeal) {
-            // We must be sealed (sanity check)
-            // Accept repair store only on sealed loglet.
-            if !self.loglet_state.is_sealed() {
-                warn!(
-                    loglet_id = %self.loglet_id,
-                    %peer,
-                    first_offset = %body.first_offset,
-                    "Ignoring repair store on unsealed loglet, repair should only happen on sealed loglets"
-                );
-                return (Status::Malformed, None);
-            }
             trace!(
                 loglet_id = %self.loglet_id,
                 %peer,
                 first_offset = %body.first_offset,
-                "Admitting a repair store for sealed loglet to restore replication"
+                "Admitting a repair store loglet to restore replication"
             );
         }
 

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -49,10 +49,10 @@ pub struct AdminOptions {
     /// # Log trim interval
     ///
     /// Controls the interval at which cluster controller tries to trim the logs. Log trimming
-    /// can be disabled by setting it to "".
-    #[serde(with = "serde_with::As::<Option<serde_with::DisplayFromStr>>")]
-    #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
-    pub log_trim_interval: Option<humantime::Duration>,
+    /// can be disabled by setting it to "0s".
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    log_trim_interval: humantime::Duration,
 
     /// # Log trim threshold (deprecated)
     ///
@@ -111,6 +111,14 @@ impl AdminOptions {
         #[cfg(any(test, feature = "test-util"))]
         return !self.disable_cluster_controller;
     }
+
+    pub fn log_trim_interval(&self) -> Option<std::time::Duration> {
+        if self.log_trim_interval.is_zero() {
+            None
+        } else {
+            Some(*self.log_trim_interval)
+        }
+    }
 }
 
 impl Default for AdminOptions {
@@ -122,7 +130,7 @@ impl Default for AdminOptions {
             query_engine: Default::default(),
             heartbeat_interval: Duration::from_millis(1500).into(),
             // try to trim the log every hour
-            log_trim_interval: Some(Duration::from_secs(60 * 60).into()),
+            log_trim_interval: Duration::from_secs(60 * 60).into(),
             log_trim_threshold: None,
             default_partition_replication: PartitionReplication::default(),
             #[cfg(any(test, feature = "test-util"))]

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -275,10 +275,10 @@ pub struct StorageOptions {
     /// # Persist lsn interval
     ///
     /// Controls the interval at which worker tries to persist the last applied lsn. Lsn persisting
-    /// can be disabled by setting it to "".
-    #[serde(with = "serde_with::As::<Option<serde_with::DisplayFromStr>>")]
-    #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
-    pub persist_lsn_interval: Option<humantime::Duration>,
+    /// can be disabled by setting it to "0s".
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    persist_lsn_interval: humantime::Duration,
 
     /// # Persist lsn threshold
     ///
@@ -341,6 +341,14 @@ impl StorageOptions {
     pub fn snapshots_staging_dir(&self) -> PathBuf {
         super::data_dir("pp-snapshots")
     }
+
+    pub fn persist_lsn_interval(&self) -> Option<std::time::Duration> {
+        if self.persist_lsn_interval.is_zero() {
+            None
+        } else {
+            Some(*self.persist_lsn_interval)
+        }
+    }
 }
 
 impl Default for StorageOptions {
@@ -357,7 +365,7 @@ impl Default for StorageOptions {
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.49,
             // persist the lsn every hour
-            persist_lsn_interval: Some(Duration::from_secs(60 * 60).into()),
+            persist_lsn_interval: Duration::from_secs(60 * 60).into(),
             persist_lsn_threshold: 1000,
             always_commit_in_background: false,
         }

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -44,6 +44,8 @@ pub enum SequencerStatus {
     /// Sealed is returned when the sequencer cannot accept more
     /// [`Append`] requests because it's sealed
     Sealed,
+    /// Local sequencer is not available anymore, reconfiguration is needed
+    Gone,
     /// LogletID does not match Segment
     LogletIdMismatch,
     /// Invalid LogId

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -128,8 +128,8 @@ where
         loglet_id: LogletId::new(LogId::from(1u32), SegmentIndex::OLDEST),
         sequencer,
         replication,
-        // node 1 is the metadata, 2..=count+1 are logservers
-        nodeset: (2..=log_server_count + 1).collect(),
+        // all nodes are log-servers
+        nodeset: (1..=log_server_count).collect(),
     };
     let loglet_params = loglet_params.serialize()?;
 

--- a/tools/restatectl/src/commands/replicated_loglet/digest.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/digest.rs
@@ -8,26 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::Context;
+use std::collections::HashMap;
+
 use cling::prelude::*;
-use itertools::Itertools;
 use tonic::codec::CompressionEncoding;
 use tracing::{info, warn};
 
 use restate_bifrost::loglet::util::TailOffsetWatch;
 use restate_bifrost::providers::replicated_loglet::replication::NodeSetChecker;
 use restate_cli_util::_comfy_table::{Cell, Color, Table};
+use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::{c_eprintln, c_println};
 use restate_log_server::protobuf::log_server_svc_client::LogServerSvcClient;
-use restate_log_server::protobuf::GetDigestRequest;
+use restate_log_server::protobuf::{GetDigestRequest, GetLogletInfoRequest};
 use restate_types::logs::{LogletId, LogletOffset, SequenceNumber, TailState};
 use restate_types::net::log_server::RecordStatus;
 use restate_types::nodes_config::Role;
 use restate_types::replicated_loglet::LogNodeSetExt;
-use restate_types::Versioned;
+use restate_types::PlainNodeId;
 
 use crate::commands::replicated_loglet::digest_util::DigestsHelper;
+use crate::commands::replicated_loglet::info::gen_loglet_info_table;
 use crate::connection::ConnectionInfo;
 use crate::util::grpc_channel;
 
@@ -37,77 +38,116 @@ pub struct DigestOpts {
     /// The replicated loglet id
     loglet_id: LogletId,
 
-    /// From offset. Requests from oldest if unset.
-    #[arg(long, default_value = "1")]
-    from: u32,
-    /// to offset
+    /// From offset (inclusive)
     #[arg(long)]
-    to: u32,
+    from: Option<u32>,
+    /// to offset (inclusive)
+    #[arg(long)]
+    to: Option<u32>,
+    /// Only print under-replicated offsets
+    #[arg(long, short)]
+    under_replicated_only: bool,
 }
 
 async fn get_digest(connection: &ConnectionInfo, opts: &DigestOpts) -> anyhow::Result<()> {
     let logs = connection.get_logs().await?;
 
-    c_println!("Log Configuration ({})", logs.version());
     let Some(loglet_ref) = logs.get_replicated_loglet(&opts.loglet_id) else {
         return Err(anyhow::anyhow!("loglet {} not found", opts.loglet_id));
     };
-
     let nodes_config = connection.get_nodes_configuration().await?;
-    c_println!("Nodes Configuration ({})", nodes_config.version());
-    c_println!();
 
-    let nodeset = loglet_ref.params.nodeset.to_effective(&nodes_config);
-    c_println!("Loglet Id: {}", opts.loglet_id);
-    c_println!("Nodeset: {nodeset}");
-    c_println!("Replication: {}", loglet_ref.params.replication);
+    let mut nodeset = loglet_ref.params.nodeset.to_effective(&nodes_config);
+    nodeset.sort();
     let known_global_tail = TailOffsetWatch::new(TailState::new(false, LogletOffset::INVALID));
-    let mut digests = DigestsHelper::new(&loglet_ref.params, opts.from.into(), opts.to.into());
-    for node_id in nodeset.iter() {
-        let node = nodes_config.find_node_by_id(*node_id).with_context(|| {
-            format!("Node {node_id} doesn't seem to exist in nodes configuration")
-        })?;
-        info!(
-            "Requesting digest from node {} at {}",
-            node_id, node.address
-        );
-        if !node.has_role(Role::LogServer) {
-            warn!(
-                "Node {} is not running the log-server role, will not connect to it",
-                node_id
+    let nodeset_channels: HashMap<PlainNodeId, _> = nodeset
+        .iter()
+        .copied()
+        .filter_map(|node_id| {
+            let node = nodes_config.find_node_by_id(node_id).unwrap_or_else(|_| {
+                panic!("Node {node_id} doesn't seem to exist in nodes configuration");
+            });
+            info!(
+                "Requesting digest from node {} at {}",
+                node_id, node.address
             );
-            continue;
-        }
+            if !node.has_role(Role::LogServer) {
+                warn!(
+                    "Node {} is not running the log-server role, will not connect to it",
+                    node_id
+                );
+                return None;
+            }
+            Some((node_id, grpc_channel(node.address.clone())))
+        })
+        .collect();
 
-        let channel = grpc_channel(node.address.clone());
+    // get loglet info
+    let mut loglet_infos: HashMap<PlainNodeId, _> = HashMap::default();
+    for (node_id, channel) in nodeset_channels.iter() {
+        let mut client = LogServerSvcClient::new(channel.clone());
+        let Ok(Some(loglet_info)) = client
+            .get_loglet_info(GetLogletInfoRequest {
+                loglet_id: opts.loglet_id.into(),
+            })
+            .await
+            .map(|resp| resp.into_inner().info)
+        else {
+            continue;
+        };
+        loglet_infos.insert(*node_id, loglet_info);
+    }
+    // we want to request data that's within trim points -> max-tail to avoid blowing up Digest's
+    // internal btree
+    let min_trim_point = loglet_infos
+        .values()
+        .map(|info| info.trim_point)
+        .min()
+        .unwrap_or(0);
+    // clamp from_offset at next point after the smallest trim point
+    let from_offset = (min_trim_point + 1).max(opts.from.unwrap_or(1));
+    let Some(max_local_tail) = loglet_infos
+        .values()
+        .map(|info| info.header.unwrap().local_tail)
+        .max()
+    else {
+        return Err(anyhow::anyhow!(
+            "Couldn't determine local-tail of any node in the nodeset"
+        ));
+    };
+    // clamp to-offset to max-local-tail - 1;
+    let to_offset = max_local_tail
+        .saturating_sub(1)
+        .min(opts.to.unwrap_or(u32::MAX - 1));
+
+    // digests
+    let mut digests = DigestsHelper::new(
+        &loglet_ref.params,
+        from_offset.into(),
+        // target tail is one offset after the inclusive to_offset arg.
+        (to_offset + 1).into(),
+    );
+    for (node_id, channel) in nodeset_channels.iter() {
         let mut client =
-            LogServerSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
+            LogServerSvcClient::new(channel.clone()).accept_compressed(CompressionEncoding::Gzip);
 
         let req = GetDigestRequest {
             loglet_id: opts.loglet_id.into(),
-            from_offset: opts.from,
-            to_offset: opts.to,
+            from_offset,
+            to_offset,
         };
         let digest = match client.get_digest(req).await {
             Ok(response) => response.into_inner().digest.expect("always set by servers"),
             Err(err) => {
-                c_eprintln!("Couldn't get digest from {}: {}", node_id, err);
+                warn!("Couldn't get digest from {}: {}", node_id, err);
                 continue;
             }
         };
         digests.add_digest_message(*node_id, digest.into(), &known_global_tail);
     }
-    c_println!(
-        "Max Returned Global Tail: {}",
-        *known_global_tail.get().offset()
-    );
-    c_println!("Seal Observed?: {}", known_global_tail.get().is_sealed());
-    c_println!("Max Observed Trim Point: {}", digests.max_trim_point());
-    c_println!("Max Local Tail: {}", digests.max_local_tail());
-    c_println!();
 
     let mut records_table = Table::new_styled();
-    let node_ids = nodeset.iter().sorted().map(|n| {
+    let node_ids = nodeset.iter().map(|n| {
         match digests.is_sealed(n) {
             Some(true) => Cell::new(format!("{n}(S)")).fg(Color::Magenta),
             Some(false) => Cell::new(n.to_string()),
@@ -120,7 +160,9 @@ async fn get_digest(connection: &ConnectionInfo, opts: &DigestOpts) -> anyhow::R
     heading.extend(vec![Cell::new("ISSUES")]);
     records_table.set_header(heading);
 
+    let mut checker = NodeSetChecker::new(&nodeset, &nodes_config, &loglet_ref.params.replication);
     for (offset, responses) in digests.iter() {
+        checker.fill_with_default();
         if *offset >= digests.max_local_tail() {
             break;
         }
@@ -128,11 +170,9 @@ async fn get_digest(connection: &ConnectionInfo, opts: &DigestOpts) -> anyhow::R
             // divider to indicate that everything after global tail
             records_table.add_row(std::iter::repeat("────").take(nodeset.len() + 2));
         }
-        let mut checker =
-            NodeSetChecker::new(&nodeset, &nodes_config, &loglet_ref.params.replication);
         let mut status_row = Vec::with_capacity(nodeset.len() + 2);
         status_row.push(Cell::new(offset.to_string()));
-        for node in nodeset.iter().sorted() {
+        for node in nodeset.iter() {
             if let Some(status) = responses.get(node) {
                 status_row.push(Cell::new(status.to_string()));
                 if let RecordStatus::Exists = status {
@@ -149,9 +189,65 @@ async fn get_digest(connection: &ConnectionInfo, opts: &DigestOpts) -> anyhow::R
         if !checker.check_write_quorum(|t| *t) {
             // record is under-replicated
             status_row.push(Cell::new("U").fg(Color::Red));
+            records_table.add_row(status_row);
+        } else if !opts.under_replicated_only {
+            records_table.add_row(status_row);
         }
-        records_table.add_row(status_row);
     }
+    // empty separator
+    records_table.add_row(vec![""]);
+    records_table.add_row(std::iter::repeat("═════════").take(nodeset.len() + 1));
+    // append the node-level info at the end
+    {
+        let mut row = Vec::with_capacity(nodeset.len() + 2);
+        row.push(Cell::new("LOCAL TAIL"));
+        for node in nodeset.iter() {
+            if let Some(header) = digests.get_response_header(node) {
+                let color = if header.sealed {
+                    Color::Magenta
+                } else {
+                    Color::Reset
+                };
+                row.push(Cell::new(header.local_tail.to_string()).fg(color));
+            } else {
+                row.push(Cell::new("?").fg(Color::Red));
+            }
+        }
+        records_table.add_row(row);
+    }
+    {
+        let mut row = Vec::with_capacity(nodeset.len() + 2);
+        row.push(Cell::new("GLOBAL TAIL"));
+        for node in nodeset.iter() {
+            if let Some(header) = digests.get_response_header(node) {
+                row.push(Cell::new(header.known_global_tail.to_string()));
+            } else {
+                row.push(Cell::new("?").fg(Color::Red));
+            }
+        }
+        records_table.add_row(row);
+    }
+    {
+        let mut row = Vec::with_capacity(nodeset.len() + 2);
+        row.push(Cell::new("TRIM POINT"));
+        for node in nodeset.iter() {
+            if let Some(header) = loglet_infos.get(node) {
+                row.push(Cell::new(header.trim_point.to_string()));
+            } else {
+                row.push(Cell::new("?").fg(Color::Red));
+            }
+        }
+        records_table.add_row(row);
+    }
+
     c_println!("{}", records_table);
+    c_println!();
+
+    let mut info_table = gen_loglet_info_table(&logs, loglet_ref, &nodes_config);
+    info_table.add_kv_row(
+        "Observed Global Tail:",
+        known_global_tail.latest_offset().to_string(),
+    );
+    c_println!("{}", info_table);
     Ok(())
 }

--- a/tools/restatectl/src/commands/replicated_loglet/digest_util.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/digest_util.rs
@@ -95,12 +95,12 @@ impl DigestsHelper {
         self.known_nodes.contains_key(node_id)
     }
 
-    pub fn max_trim_point(&self) -> LogletOffset {
-        self.max_trim_point
-    }
-
     pub fn max_local_tail(&self) -> LogletOffset {
         self.max_local_tail
+    }
+
+    pub fn get_response_header(&self, node_id: &PlainNodeId) -> Option<LogServerResponseHeader> {
+        self.known_nodes.get(node_id).cloned()
     }
 
     pub fn iter(

--- a/tools/restatectl/src/commands/replicated_loglet/info.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/info.rs
@@ -8,13 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use cling::prelude::*;
+use std::collections::HashMap;
 
-use restate_cli_util::{c_indentln, c_println};
+use cling::prelude::*;
+use tracing::warn;
+
+use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::{Styled, StyledTable};
+use restate_cli_util::ui::stylesheet::Style;
+use restate_log_server::protobuf::log_server_svc_client::LogServerSvcClient;
+use restate_log_server::protobuf::GetLogletInfoRequest;
+use restate_types::logs::metadata::{LogletRef, Logs};
 use restate_types::logs::LogletId;
-use restate_types::Versioned;
+use restate_types::nodes_config::{NodesConfigError, NodesConfiguration, Role};
+use restate_types::replicated_loglet::ReplicatedLogletParams;
+use restate_types::PlainNodeId;
 
 use crate::connection::ConnectionInfo;
+use crate::util::grpc_channel;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "get_info")]
@@ -23,29 +35,138 @@ pub struct InfoOpts {
     loglet_id: LogletId,
 }
 
+pub(super) fn gen_loglet_info_table(
+    logs: &Logs,
+    loglet: &LogletRef<ReplicatedLogletParams>,
+    nodes_config: &NodesConfiguration,
+) -> Table {
+    let references = loglet.references.iter().map(|(log_id, segment)| {
+        let is_sealed_segment = logs
+            .chain(log_id)
+            .map(|chain| chain.tail_index() > *segment)
+            .unwrap_or(false);
+
+        let note = if is_sealed_segment {
+            Styled(Style::Success, "(SEGMENT IS SEALED)")
+        } else {
+            Styled(Style::Normal, "")
+        };
+        format!("LogId={} at Segment={} {}", log_id, segment, note)
+    });
+    let sequencer = loglet.params.sequencer;
+    let sequencer_note_style = Style::Warn;
+    let sequencer_note = match nodes_config.find_node_by_id(sequencer.as_plain()) {
+        Ok(config) if config.current_generation.is_newer_than(sequencer) => Styled(
+            sequencer_note_style,
+            format!(
+                "(gone; current generation is {})",
+                config.current_generation
+            ),
+        ),
+        Ok(config) if config.current_generation.is_same_but_different(&sequencer) => Styled(
+            sequencer_note_style,
+            format!(
+                "(newer than nodes config, config has {})",
+                config.current_generation
+            ),
+        ),
+        // node is the same generation as config
+        Ok(_) => Styled(Style::Normal, String::default()),
+        Err(err @ NodesConfigError::Deleted(_)) => {
+            Styled(sequencer_note_style, format!("(gone; {err})"))
+        }
+        Err(err) => Styled(sequencer_note_style, format!("({err})")),
+    };
+
+    let mut table = Table::new_styled();
+    table.add_kv_row(
+        "Loglet Id:",
+        format!(
+            "{} (raw={})",
+            loglet.params.loglet_id, *loglet.params.loglet_id
+        ),
+    );
+    table.add_kv_row("Used in:", itertools::join(references, "\n"));
+    table.add_kv_row(
+        "Sequencer:",
+        Cell::new(format!("{sequencer} {sequencer_note}")),
+    );
+    table.add_kv_row("Replication:", loglet.params.replication.clone());
+    table.add_kv_row("Nodeset:", format!("{:#}", loglet.params.nodeset));
+    table
+}
+
 async fn get_info(connection: &ConnectionInfo, opts: &InfoOpts) -> anyhow::Result<()> {
     let logs = connection.get_logs().await?;
-    c_println!("Log Configuration ({})", logs.version());
-
-    let Some(loglet_ref) = logs.get_replicated_loglet(&opts.loglet_id) else {
+    let Some(loglet) = logs.get_replicated_loglet(&opts.loglet_id) else {
         return Err(anyhow::anyhow!("loglet {} not found", opts.loglet_id));
     };
 
-    c_println!("Loglet Referenced in: ");
-    for (log_id, segment) in &loglet_ref.references {
-        c_indentln!(2, "- LogId={}, Segment={}", log_id, segment);
-    }
+    let nodes_config = connection.get_nodes_configuration().await?;
+    let mut nodeset = loglet.params.nodeset.clone();
+    // display nodes sorted
+    nodeset.sort();
+
+    c_println!("{}", gen_loglet_info_table(&logs, loglet, &nodes_config));
     c_println!();
-    c_println!("Loglet Parameters:");
-    c_indentln!(
-        2,
-        "Loglet Id: {} ({})",
-        loglet_ref.params.loglet_id,
-        *loglet_ref.params.loglet_id
-    );
-    c_indentln!(2, "Sequencer: {}", loglet_ref.params.sequencer);
-    c_indentln!(2, "Replication: {}", loglet_ref.params.replication);
-    c_indentln!(2, "Node Set: {}", loglet_ref.params.nodeset);
+
+    let mut loglet_infos: HashMap<PlainNodeId, _> = HashMap::default();
+    for node_id in nodeset.iter().copied() {
+        let node = nodes_config.find_node_by_id(node_id).unwrap_or_else(|_| {
+            panic!("Node {node_id} doesn't seem to exist in nodes configuration");
+        });
+        if !node.has_role(Role::LogServer) {
+            warn!(
+                "Node {} is not running the log-server role, will not connect to it",
+                node_id
+            );
+            continue;
+        }
+        let mut client = LogServerSvcClient::new(grpc_channel(node.address.clone()));
+        let Ok(Some(loglet_info)) = client
+            .get_loglet_info(GetLogletInfoRequest {
+                loglet_id: opts.loglet_id.into(),
+            })
+            .await
+            .map(|resp| resp.into_inner().info)
+        else {
+            continue;
+        };
+        loglet_infos.insert(node_id, loglet_info);
+    }
+
+    let mut info_table = Table::new_styled();
+    info_table.set_styled_header(vec![
+        "",
+        "LOCAL TAIL",
+        "GLOBAL TAIL",
+        "TRIM POINT",
+        "SEALED",
+    ]);
+
+    for node_id in nodeset.iter() {
+        let mut row = Vec::with_capacity(5);
+        row.push(Cell::new(node_id.to_string()).add_attribute(Attribute::Bold));
+        if let Some(info) = loglet_infos.get(node_id) {
+            let header = info.header.unwrap();
+            row.push(Cell::new(header.local_tail.to_string()));
+            row.push(Cell::new(header.known_global_tail.to_string()));
+            row.push(Cell::new(info.trim_point.to_string()));
+            row.push(if header.sealed {
+                Cell::new("YES").fg(Color::Magenta)
+            } else {
+                Cell::new("NO")
+            });
+        } else {
+            row.push(Cell::new("?").fg(Color::Red));
+            row.push(Cell::new("?").fg(Color::Red));
+            row.push(Cell::new("?").fg(Color::Red));
+            row.push(Cell::new("?").fg(Color::Red));
+        }
+        info_table.add_row(row);
+    }
+
+    c_println!("{}", info_table);
 
     Ok(())
 }


### PR DESCRIPTION

The main fixes:
- It was not actually possible to disable those two intervals, the configuration fails to parse the empty string that was suggested in docs. This is now replaced by `0s` or `0ms` (unfortunately only `0` will still fail, but can be fixed by custom serde_as which I don't have time for)
- Fixed how `OptionFuture` is being used, select! in a loop will run indefinitely if OptionFuture contains None because it's always poll::Ready with value None. This is a critical bug that we didn't hit because it wasn't possible to disable those intervals before
- Added jitter with `with_jitter()`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2683).
* #2690
* #2689
* __->__ #2683
* #2682
* #2681
* #2680
* #2677
* #2676
* #2673