### PR TITLE
Document the http-ingress role as experimental

### DIFF
--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -39,10 +39,11 @@ pub struct IngressOptions {
 
     /// # Experimental feature to run the ingress independent of the worker role
     ///
-    /// This feature is experimental and should be used with caution. It allows to run the ingress
-    /// role independent of the worker role. It requires that you configure the [`Role::Ingress`]
-    /// role for nodes explicitly. If you enable this feature, then you might not be able to roll
-    /// back to a previous version.
+    /// This feature is experimental and should be used with caution. It enables the HTTP ingress
+    /// to run role independently of the worker role. If you activate this feature, you will need
+    /// to specify the [`Role::HttpIngress`] role for nodes explicitly, and nodes that run
+    /// only [`Role::Worker`] will not accept HTTP ingress requests. If you enable this feature,
+    /// then you might not be able to roll back to a previous version.
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub experimental_feature_enable_separate_ingress_role: bool,
 

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -51,6 +51,8 @@ pub enum Role {
     MetadataServer,
     /// [PREVIEW FEATURE] Serves a log-server for replicated loglets
     LogServer,
+    /// [EXPERIMENTAL FEATURE] Serves HTTP ingress requests (requires
+    /// `experimental-feature-enable-separate-ingress-role` to be enabled)
     HttpIngress,
 }
 

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -145,7 +145,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         "node-3",
         no_snapshot_repository_config,
         BinarySource::CargoTest,
-        enum_set!(Role::HttpIngress | Role::Worker),
+        enum_set!(Role::Worker),
     );
     *worker_3.metadata_store_client_mut() = MetadataClientKind::Native {
         addresses: vec![cluster.nodes[0].node_address().clone()],
@@ -170,7 +170,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         "node-3",
         base_config.clone(),
         BinarySource::CargoTest,
-        enum_set!(Role::HttpIngress | Role::Worker),
+        enum_set!(Role::Worker),
     );
     *worker_3.metadata_store_client_mut() = MetadataClientKind::Native {
         addresses: vec![cluster.nodes[0].node_address().clone()],


### PR DESCRIPTION
This change also makes it impossible to use the role without the experimental flag that enables it.

After the change:

```
% restate-server --help

...
      --roles [<ROLES>...]
          Defines the roles which this Restate node should run, by default the node starts with all roles.

          Roles can be comma-separated list without spaces (`--roles=worker,admin,log-server`), or a repeated option like `--roles=worker --roles=admin`.

          Possible values:
          - worker:          A worker runs partition processor (journal, state, and drives invocations)
          - admin:           Admin runs cluster controller and user-facing admin APIs
          - metadata-server: Serves the metadata store
          - log-server:      [PREVIEW FEATURE] Serves a log-server for replicated loglets
          - http-ingress:    [EXPERIMENTAL FEATURE] Serves HTTP ingress requests (requires `experimental-feature-enable-separate-ingress-role` to be enabled)

...

% restate-server --roles http-ingress

     →↓→↓
    →↓→↓→↓→→→               →→→→
    ↓→↓→↓→↓↓→↓→→           →↓↓→↓→↓→
    →↓→↓→↓→↓→↓↓→↓→↓       →↓→↓→↓→↓→↓→
    →↓→↓→↓→↓→↓→↓→↓→↓→→      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→ →↓→↓→↓→↓→↓→↓→      →↓→↓→↓→↓↓→↓→↗
    →↓→↓→↓→    →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓↓→↓→
    →↓→↓→↓→       →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓→↓→→
    →↓→↓→↓→          →↓→↓→↓→↓→↓→↓→     →→↓→↓→↓→↓↓→↓→
    →↓→↓→↓→             →↓→↓→↓→↓→↓→       →→↓→↓→↓→↓→↓
    →↓→↓→↓→             →↓→↓→↓→↓→↓→      →→↓→↓→↓→↓→↓→
    →↓→↓→↓→          →↓→↓→↓→↓→↓→↓      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→       →→↓→↓→↓→↓→↓→→     →↓→↓→↓→↓→↓→→
    →↓→↓→↓→      →↓→↓→↓→↓→↓→     →↓→↓→↓→↓→↓→↓
    →↓→↓→↓→     →↓→↓→↓→↓→     →↓→↓→↓→↓→↓→↓→
    →↓→↓→↓→      ↓→↓→→      →↓→↓→↓→↓→↓→→
    →↓→↓→↓→               →↓→↓→↓→↓→↓→
    →↓→↓→↓→                →↓→↓→↓→
    ↓→↓→↓→↓
     →↓→→

           Restate 1.2.0-dev
          https://restate.dev/

2025-02-10T10:03:54.701543Z INFO restate_server
  Starting Restate Server 1.2.0-dev (debug) (6ffa0b215 aarch64-apple-darwin 2025-02-10)
    node_name: "Pavels-MacBook-Pro-2.local"
    config_source: [default]
    base_dir: /Users/pavel/restate/restate/restate-data/Pavels-MacBook-Pro-2.local/
on main
2025-02-10T10:03:54.755135Z ERROR restate_server
  Restate application failed
    error: Invalid configuration: The http-ingress role is used but experimental-feature-enable-separate-ingress-role is not set.
    restate.error.code: None
    Visit https://docs.restate.dev/references/errors#None for more info about this error.
on main 
```