### PR TITLE
[Bifrost] Fix for tail-repair on previously trimmed logs

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -180,15 +180,18 @@ impl LogStore for RocksDbLogStore {
             local_tail = trim_point.next();
         }
 
-        // todo(asoli): Persist last_known_global_tail for more efficient tail repairs
-        // perhaps we can set the known_tail to the trim_point.next() here but let's do that only
-        // when the need rises.
+        // We can only trim records that are known to be globally committed, let's use that trim
+        // point to initialize our known_global_tail
+        let known_global_tail = trim_point.next();
+
+        // todo(asoli): Persist last_known_global_tail for more efficient tail repairs if the
+        // loglet is not trimmed.
         Ok(LogletState::new(
             sequencer,
             local_tail,
             is_sealed,
             trim_point,
-            LogletOffset::OLDEST,
+            known_global_tail,
         ))
     }
 


### PR DESCRIPTION

The issue happens when attempting to trim a loglet that's been already trimmed (fully or partially). If the global offset is unknown, find_tail on those old loglets will run on the background (periodic tail checker) to try and figure if they are sealed or not, this triggers a tail repair since records in the range [1..max-local] are trimmed/under-replicated. That wouldn't have been the case if the global tail was known.

The error itself is benign but it prints a message like this:
```
2025-02-09T17:18:58.181838Z ERROR restate_bifrost::providers::replicated_loglet::tasks::repair_tail
  Couldn't repair the tail! We have records to repair **and** enough nodes to repair, but we couldn't find any node with copies for the oldest record within the repair range. We'll not be able to re-replicate the missing records until we can read back this record
    loglet_id: 4_11
    start_offset: 1
    target_tail: 4970
    nodeset: [N5, N4, N6]
    nodes_responded: [N4, N5, N6]
    replication: {node: 2}
    elapsed: 24.746708ms
```
This PR fixes this by letting log-servers initialize their global known offset from their trim-point (basically, a todo that needed to happen). The screenshots attached in comment show the impact (the global tail value for old trimmed sealed loglet is now correct). The original scenario that triggered these errors has also been testsed and it's confirmed that this fixes the bug.

```
// left empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2689).
* #2691
* #2690
* __->__ #2689