### PR TITLE
[Bifrost] auto-drain the sequencer on exhausting offset limit

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -180,15 +180,18 @@ impl LogStore for RocksDbLogStore {
             local_tail = trim_point.next();
         }
 
-        // todo(asoli): Persist last_known_global_tail for more efficient tail repairs
-        // perhaps we can set the known_tail to the trim_point.next() here but let's do that only
-        // when the need rises.
+        // We can only trim records that are known to be globally committed, let's use that trim
+        // point to initialize our known_global_tail
+        let known_global_tail = trim_point.next();
+
+        // todo(asoli): Persist last_known_global_tail for more efficient tail repairs if the
+        // loglet is not trimmed.
         Ok(LogletState::new(
             sequencer,
             local_tail,
             is_sealed,
             trim_point,
-            LogletOffset::OLDEST,
+            known_global_tail,
         ))
     }
 


### PR DESCRIPTION

The soft-limit is i32::MAX (2B records) to give sufficient slop for race scenarios with reasonable coverage. The loglet's will drain itself once it reaches this soft limit and Bifrost appender will use this a signal for the auto-recovery mechanism to seal and extend the chain.
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2690).
* #2691
* __->__ #2690
* #2689