### PR TITLE
[Bifrost] RecordCache record swap efficiency

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -128,10 +128,7 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
         payloads,
     };
 
-    let body = serialize_message(
-        append_message,
-        restate_types::net::ProtocolVersion::Flexbuffers,
-    )?;
+    let body = serialize_message(append_message, restate_types::net::ProtocolVersion::V1)?;
 
     let message = Message {
         header: Some(restate_types::protobuf::node::Header {
@@ -149,12 +146,12 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
 }
 
 fn deserialize_append_message(serialized_message: Bytes) -> anyhow::Result<Append> {
-    let protocol_version = restate_types::net::ProtocolVersion::Flexbuffers;
+    let protocol_version = restate_types::net::ProtocolVersion::V1;
     let msg = Message::decode(serialized_message)?;
     let body = msg.body.unwrap();
     // we ignore non-deserializable messages (serde errors, or control signals in drain)
-    let mut msg_body = body.try_as_binary_body(restate_types::net::ProtocolVersion::Flexbuffers)?;
-    Ok(Append::decode(&mut msg_body.payload, protocol_version)?)
+    let msg_body = body.try_as_binary_body(restate_types::net::ProtocolVersion::V1)?;
+    Ok(Append::decode(msg_body.payload, protocol_version)?)
 }
 
 fn replicated_loglet_append_serde(c: &mut Criterion) {

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -315,7 +315,6 @@ pub mod test_util {
     use async_trait::async_trait;
     use futures::stream::BoxStream;
     use futures::StreamExt;
-    use restate_types::net::CodecError;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::error::TrySendError;
     use tokio_stream::wrappers::ReceiverStream;
@@ -325,6 +324,7 @@ pub mod test_util {
     use restate_types::net::codec::MessageBodyExt;
     use restate_types::net::codec::Targeted;
     use restate_types::net::codec::{serialize_message, WireEncode};
+    use restate_types::net::CodecError;
     use restate_types::net::ProtocolVersion;
     use restate_types::nodes_config::NodesConfiguration;
     use restate_types::protobuf::node::message;
@@ -335,7 +335,6 @@ pub mod test_util {
     use restate_types::protobuf::node::Hello;
     use restate_types::protobuf::node::Message;
     use restate_types::protobuf::node::Welcome;
-    use restate_types::NodeId;
     use restate_types::{GenerationalNodeId, Version};
 
     use crate::cancellation_watcher;
@@ -414,10 +413,8 @@ pub mod test_util {
                 _ => anyhow::bail!("unexpected message, we expect Welcome instead"),
             };
 
-            let peer: NodeId = welcome.my_node_id.expect("peer node id must be set").into();
-            let peer = peer
-                .as_generational()
-                .expect("peer must be generational node id");
+            let peer: GenerationalNodeId =
+                welcome.my_node_id.expect("peer node id must be set").into();
 
             Ok(Self {
                 my_node_id: from_node_id,

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -497,8 +497,8 @@ mod test {
     }
 
     impl WireDecode for TestResponse {
-        fn decode<B: bytes::Buf>(
-            _: &mut B,
+        fn decode(
+            _: impl bytes::Buf,
             _: restate_types::net::ProtocolVersion,
         ) -> Result<Self, CodecError>
         where

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -208,7 +208,7 @@ impl LogStoreWriter {
         for payload in store_message.payloads.iter() {
             let key_bytes =
                 DataRecordKey::new(store_message.header.loglet_id, offset).encode_and_split(buffer);
-            record_cache.add(store_message.header.loglet_id, offset, payload.clone());
+            record_cache.add(store_message.header.loglet_id, offset, payload);
             let value_bytes = DataRecordEncoder::from(payload).encode_to_disk_format(buffer);
             write_batch.put_cf(data_cf, key_bytes, value_bytes);
             // advance the offset for the next record

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -13,12 +13,17 @@ package restate.common;
 
 enum ProtocolVersion {
   ProtocolVersion_UNKNOWN = 0;
-  FLEXBUFFERS = 1;
+  V1 = 1;
 }
 
 message NodeId {
   uint32 id = 1;
   optional uint32 generation = 2;
+}
+
+message GenerationalNodeId {
+  uint32 id = 1;
+  uint32 generation = 2;
 }
 
 // Partition Processor leadership epoch number

--- a/crates/types/protobuf/restate/log_server_common.proto
+++ b/crates/types/protobuf/restate/log_server_common.proto
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2024 - 2025 Restate Software, Inc., Restate GmbH.
 // All rights reserved.
 //

--- a/crates/types/protobuf/restate/node.proto
+++ b/crates/types/protobuf/restate/node.proto
@@ -42,14 +42,15 @@ message Hello {
   restate.common.ProtocolVersion min_protocol_version = 1;
   restate.common.ProtocolVersion max_protocol_version = 2;
   // generational node id of sender (who am I)
-  restate.common.NodeId my_node_id = 3;
+  // this is optional for future-proofing with anonymous clients using this protocol
+  optional restate.common.GenerationalNodeId my_node_id = 3;
   string cluster_name = 4;
 }
 
 message Welcome {
   restate.common.ProtocolVersion protocol_version = 2;
   // generational node id of sender
-  restate.common.NodeId my_node_id = 3;
+  restate.common.GenerationalNodeId my_node_id = 3;
 }
 
 // Bidirectional Communication

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -32,8 +32,8 @@ use self::codec::{Targeted, WireEncode};
 pub use crate::protobuf::common::ProtocolVersion;
 pub use crate::protobuf::common::TargetName;
 
-pub static MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::Flexbuffers;
-pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::Flexbuffers;
+pub static MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1;
+pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1;
 
 #[derive(
     Debug,
@@ -179,8 +179,8 @@ macro_rules! define_message {
         }
 
         impl $crate::net::codec::WireDecode for $message {
-            fn decode<B: bytes::Buf>(
-                buf: &mut B,
+            fn decode(
+                buf: impl bytes::Buf,
                 protocol_version: $crate::net::ProtocolVersion,
             ) -> Result<Self, $crate::net::CodecError>
             where

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -55,6 +55,12 @@ pub enum NodeId {
 #[debug("{}:{}", _0, _1)]
 pub struct GenerationalNodeId(PlainNodeId, u32);
 
+impl From<crate::protobuf::common::GenerationalNodeId> for GenerationalNodeId {
+    fn from(value: crate::protobuf::common::GenerationalNodeId) -> Self {
+        Self(PlainNodeId(value.id), value.generation)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("invalid plain node id: {0}")]
 pub struct MalformedPlainNodeId(String);

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -23,6 +23,21 @@ pub mod common {
         }
     }
 
+    impl From<crate::GenerationalNodeId> for GenerationalNodeId {
+        fn from(value: crate::GenerationalNodeId) -> Self {
+            Self {
+                id: value.id(),
+                generation: value.generation(),
+            }
+        }
+    }
+
+    impl std::fmt::Display for GenerationalNodeId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Display::fmt(&crate::GenerationalNodeId::from(*self), f)
+        }
+    }
+
     impl std::fmt::Display for NodeId {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             if let Some(generation) = self.generation {

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -190,6 +190,13 @@ pub enum PolyBytes {
     Typed(Arc<dyn StorageEncode>),
 }
 
+impl PolyBytes {
+    /// Returns true if we are holding raw encoded bytes
+    pub fn is_encoded(&self) -> bool {
+        matches!(self, PolyBytes::Bytes(_))
+    }
+}
+
 impl StorageEncode for PolyBytes {
     fn encode(&self, buf: &mut BytesMut) -> Result<(), StorageEncodeError> {
         match self {


### PR DESCRIPTION

We were swapping records in the record cache with serialized ones, that hurts the use-case where the sequencer and the reader are co-located. The reason this was happening was because after the sequencer adds the "Typed" variant of the entry into cache, the co-located log-server would overwrite it.

This lets us gain 10-20% more throughput (YMMV).

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2694).
* #2697
* __->__ #2694
* #2691