### PR TITLE
Add the ability to remove nodes from the cluster

### DIFF
--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -27,6 +27,9 @@ service NodeCtlSvc {
 
   // Returns the cluster health from the point of view of this node.
   rpc ClusterHealth(google.protobuf.Empty) returns (ClusterHealthResponse);
+
+  // Remove a node from the cluster.
+  rpc RemoveNode(RemoveNodeRequest) returns (google.protobuf.Empty);
 }
 
 message ProvisionClusterRequest {
@@ -91,4 +94,9 @@ message ClusterHealthResponse {
 
 message EmbeddedMetadataClusterHealth {
   repeated restate.common.NodeId members = 1;
+}
+
+message RemoveNodeRequest {
+  uint32 nodes_config_version = 1;
+  uint32 node_id = 2;
 }

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -266,7 +266,7 @@ impl<'a> NodeInit<'a> {
                                 warn!(
                                     "Node location has changed from '{current_location}' to '{new_location}'. \
                                     This change can be dangerous if the cluster is configured with geo-aware replication, but we'll still apply it. \
-                                    You can reverted back on the next server restart.",
+                                    You can revert it in the configuration and it will be updated on the next server restart.",
                                 );
                                 node_config.location = common_opts.location().clone();
                             }

--- a/tools/restatectl/src/commands/node/mod.rs
+++ b/tools/restatectl/src/commands/node/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 pub mod list_nodes;
+pub mod remove_node;
 
 use cling::prelude::*;
 
@@ -16,4 +17,6 @@ use cling::prelude::*;
 pub enum Nodes {
     /// Print a summary of active nodes in cluster
     List(list_nodes::ListNodesOpts),
+    /// Remove a node entry from the cluster
+    Remove(remove_node::RemoveNodeOpts),
 }

--- a/tools/restatectl/src/commands/node/remove_node.rs
+++ b/tools/restatectl/src/commands/node/remove_node.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use chrono::TimeDelta;
+use cling::prelude::*;
+use tonic::codec::CompressionEncoding;
+
+use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
+use restate_admin::cluster_controller::protobuf::ClusterStateRequest;
+use restate_cli_util::ui::console::confirm_or_exit;
+use restate_cli_util::ui::{duration_to_human_rough, Tense};
+use restate_cli_util::{c_error, c_println};
+use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
+use restate_core::protobuf::node_ctl_svc::RemoveNodeRequest;
+use restate_types::nodes_config::Role;
+use restate_types::protobuf::cluster::node_state::State;
+use restate_types::protobuf::cluster::DeadNode;
+use restate_types::PlainNodeId;
+
+use crate::connection::ConnectionInfo;
+use crate::util::grpc_channel;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "remove_node")]
+pub struct RemoveNodeOpts {
+    /// The node id to remove from the cluster. Remove permanently decommissioned nodes from the
+    /// cluster so that they are no longer reported as dead.
+    #[arg(long)]
+    pub(crate) node: PlainNodeId,
+}
+
+pub async fn remove_node(connection: &ConnectionInfo, opts: &RemoveNodeOpts) -> anyhow::Result<()> {
+    let cluster_state = connection
+        .try_each(Some(Role::Admin), |channel| async {
+            let mut client = ClusterCtrlSvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+
+            client
+                .get_cluster_state(ClusterStateRequest::default())
+                .await
+        })
+        .await?
+        .into_inner()
+        .cluster_state
+        .ok_or_else(|| anyhow::anyhow!("no cluster state returned"))?;
+
+    let nodes_configuration = connection.get_nodes_configuration().await?;
+
+    let nodes = nodes_configuration.iter().collect::<BTreeMap<_, _>>();
+    let Some(node) = nodes.get(&opts.node) else {
+        c_error!("Node {} not found in cluster", opts.node);
+        return Ok(());
+    };
+
+    let last_seen = match cluster_state
+        .nodes
+        .get(&opts.node.into())
+        .and_then(|n| n.state.as_ref())
+    {
+        Some(State::Dead(DeadNode { last_seen_alive })) => last_seen_alive,
+        None => {
+            c_error!(
+                "The was found in the cluster nodes list but not reported in the cluster status. \
+                Please try again.",
+            );
+            anyhow::bail!("Refusing to operate on node {}", opts.node)
+        }
+        Some(_) => {
+            c_error!(
+                "Node {} ({}) is not reported as dead and cannot be removed. Use this tool to permanently \
+                remove decommissioned nodes from cluster configuration.",
+                opts.node,
+                node.name,
+            );
+            anyhow::bail!("Node {} is not dead and cannot be removed", opts.node)
+        }
+    };
+
+    confirm_or_exit(&format!(
+        "Are you sure you want to remove node {} ({}) from the cluster?{}",
+        opts.node,
+        node.name,
+        last_seen
+            .and_then(|ts| TimeDelta::new(
+                ts.seconds,
+                u32::try_from(ts.nanos).expect("i32 fits into u32")
+            ))
+            .map(|delta| format!(
+                " The node was last seen by the cluster {}.",
+                duration_to_human_rough(delta, Tense::Past),
+            ))
+            .unwrap_or_else(|| "".to_string())
+    ))?;
+
+    let address = connection.addresses.first().expect("address");
+    let channel = grpc_channel(address.clone());
+
+    let mut node_ctl_svc_client = NodeCtlSvcClient::new(channel)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(CompressionEncoding::Gzip);
+
+    node_ctl_svc_client
+        .remove_node(RemoveNodeRequest {
+            node_id: opts.node.into(),
+            nodes_config_version: cluster_state
+                .nodes_config_version
+                .expect("nodes_config_version")
+                .value,
+        })
+        .await
+        .map_err(|e| {
+            // we ignore individual errors in table rendering so this is the only place to log them
+            c_println!("failed to remove node {}: {:?}", opts.node, e);
+            anyhow::anyhow!(e)
+        })?
+        .into_inner();
+    Ok(())
+}


### PR DESCRIPTION
The Node Control Service now exposes a remove_node operation, which is made available via the restatectl tool. This allows permanently decommissioned nodes to be removed from service so that they are not reported as dead.