### PR TITLE
Make sure to set our effective_mode to follower when seeing AnnounceL…

### DIFF
--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -485,6 +485,10 @@ where
 
                             if is_leader {
                                 self.status.effective_mode = RunMode::Leader;
+                            } else {
+                                // make sure that we set our effective_mode to follower also when
+                                // not being explicitly asked by the PPM
+                                self.status.effective_mode = RunMode::Follower;
                             }
 
                             transaction = partition_store.transaction();


### PR DESCRIPTION
…eadership message

This commit makes sure that we set our effective_mode to follower if we see an AnnounceLeadership message with the leadership of a different node. Before, this happened only when being asked by the PPM. This was an oversight, since it can also happen that we aren't asked by the CC to step down explicitly.