### PR TITLE
Use PlainNodeId in networking layer of replicated metadata server

### DIFF
--- a/crates/metadata-server/src/raft/mod.rs
+++ b/crates/metadata-server/src/raft/mod.rs
@@ -18,13 +18,14 @@ use anyhow::Context;
 use bytes::{Buf, BufMut};
 use network::NetworkMessage;
 use protobuf::Message as ProtobufMessage;
+use restate_types::PlainNodeId;
 pub use server::RaftMetadataServer;
 
 type StorageMarker = restate_types::storage::StorageMarker<String>;
 
 impl NetworkMessage for raft::prelude::Message {
-    fn to(&self) -> u64 {
-        self.to
+    fn to(&self) -> PlainNodeId {
+        to_plain_node_id(self.to)
     }
 
     fn serialize<B: BufMut>(&self, buffer: &mut B) {
@@ -47,4 +48,12 @@ enum RaftServerState {
     },
     #[default]
     Standby,
+}
+
+fn to_plain_node_id(id: u64) -> PlainNodeId {
+    PlainNodeId::from(u32::try_from(id).expect("node id is derived from PlainNodeId"))
+}
+
+fn to_raft_id(plain_node_id: PlainNodeId) -> u64 {
+    u64::from(u32::from(plain_node_id))
 }

--- a/crates/metadata-server/src/raft/network/handler.rs
+++ b/crates/metadata-server/src/raft/network/handler.rs
@@ -11,7 +11,7 @@
 use crate::raft::network::connection_manager::ConnectionError;
 use crate::raft::network::grpc_svc::metadata_server_network_svc_server::MetadataServerNetworkSvc;
 use crate::raft::network::grpc_svc::JoinClusterRequest;
-use crate::raft::network::{grpc_svc, ConnectionManager, NetworkMessage};
+use crate::raft::network::{grpc_svc, ConnectionManager, NetworkMessage, PEER_METADATA_KEY};
 use crate::{JoinClusterError, JoinClusterHandle, MemberId};
 use arc_swap::access::Access;
 use arc_swap::ArcSwapOption;
@@ -20,8 +20,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tonic::codegen::BoxStream;
 use tonic::{Request, Response, Status, Streaming};
-
-pub const PEER_METADATA_KEY: &str = "x-restate-metadata-server-peer";
 
 #[derive(Debug)]
 pub struct MetadataServerNetworkHandler<M> {
@@ -61,7 +59,7 @@ where
                         "'{}' is missing",
                         PEER_METADATA_KEY
                     )))?;
-            let peer = u64::from_str(
+            let peer = PlainNodeId::from_str(
                 peer_metadata
                     .to_str()
                     .map_err(|err| Status::invalid_argument(err.to_string()))?,

--- a/crates/metadata-server/src/raft/network/mod.rs
+++ b/crates/metadata-server/src/raft/network/mod.rs
@@ -18,3 +18,5 @@ pub use grpc_svc::metadata_server_network_svc_server::MetadataServerNetworkSvcSe
 pub use grpc_svc::FILE_DESCRIPTOR_SET;
 pub use handler::MetadataServerNetworkHandler;
 pub use networking::{NetworkMessage, Networking};
+
+const PEER_METADATA_KEY: &str = "x-restate-metadata-server-peer";

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -29,7 +29,7 @@ pub struct GetNodeState {}
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeStateResponse {
-    /// State of paritions processor per parition. Is set to None if this node is not a `Worker` node
+    /// Partition processor status per partition. Is set to None if this node is not a `Worker` node
     #[serde_as(as = "Option<serde_with::Seq<(_, _)>>")]
     pub partition_processor_state: Option<BTreeMap<PartitionId, PartitionProcessorStatus>>,
 }


### PR DESCRIPTION
This should improve the log output to use the PlainNodeId formatting.