### PR TITLE
[restatectl] rename --addresses to --address or -s

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,7 +38,7 @@ base64 = { workspace = true }
 bs58 = { version = "0.5.0" }
 chrono = { workspace = true }
 chrono-humanize = { workspace = true }
-clap = { workspace = true, features = ["derive", "env", "wrap_help", "color"] }
+clap = { workspace = true, features = ["derive", "env", "wrap_help", "color", "std", "suggestions", "usage"] }
 clap-verbosity-flag = { workspace = true }
 cling = { workspace = true }
 comfy-table = { workspace = true }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -18,6 +18,11 @@ use restate_cli_util::{CliContext, CommonOpts};
 use crate::cli_env::{CliEnv, EnvironmentSource};
 use crate::commands::*;
 
+/// Restate Command Line Interface
+///
+/// A command-line tool to inspect restate services status, invocations, deployment, and much more.
+///
+/// https://docs.restate.dev
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]
 #[cling(run = "init")]

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -38,7 +38,7 @@ bytes = { workspace = true }
 bytesize = { workspace = true }
 bytestring = { workspace = true }
 chrono = { workspace = true }
-clap = { workspace = true, features = ["derive", "env", "wrap_help", "color"] }
+clap = { workspace = true, features = ["derive", "env", "wrap_help", "color", "std", "suggestions", "usage"] }
 clap-stdin = "0.5.1"
 cling = { workspace = true }
 crossterm = { version = "0.27.0" }

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -24,45 +24,53 @@ use crate::commands::replicated_loglet::ReplicatedLoglet;
 use crate::commands::snapshot::Snapshot;
 use crate::connection::ConnectionInfo;
 
+/// Restate Cluster Administration Tool
+///
+/// A command-line tool for managing Restate clusters. Designed to be be used by administrators,
+/// restatectl can be used to inspect cluster health and perform low-level maintenance operations
+/// on live nodes. It requires access to restate's node-to-node communication addresses (default on
+/// port 5122)
+///
+/// https://docs.restate.dev
 #[derive(Run, Parser, Clone)]
 #[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]
 #[cling(run = "init")]
 pub struct CliApp {
     #[clap(flatten)]
-    pub common_opts: CommonOpts,
-    #[clap(flatten)]
     pub connection: ConnectionInfo,
+    #[clap(flatten)]
+    pub common_opts: CommonOpts,
     #[clap(subcommand)]
     pub cmd: Command,
 }
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Command {
-    /// Cluster operations
-    #[clap(subcommand)]
-    Cluster(Cluster),
+    /// Provision a new cluster
+    Provision(ProvisionOpts),
     /// Print cluster status overview (shortcut to `cluster status`)
     Status(ClusterStatusOpts),
-    /// Log operations
-    #[clap(subcommand)]
-    Logs(Logs),
     /// Cluster node status
     #[clap(subcommand)]
     Nodes(Nodes),
     /// Manage partition table
     #[clap(subcommand)]
     Partitions(Partitions),
-    /// Metadata store operations
+    /// Log operations
     #[clap(subcommand)]
-    Metadata(Metadata),
+    Logs(Logs),
     /// Partition processor snapshots
     #[clap(subcommand)]
     Snapshots(Snapshot),
-    /// Commands that operate on replicated loglets
+    /// Cluster operations
+    #[clap(subcommand)]
+    Cluster(Cluster),
+    /// Metadata store operations
+    #[clap(subcommand)]
+    Metadata(Metadata),
+    /// [low-level] Commands that operate on replicated loglets
     #[clap(subcommand)]
     ReplicatedLoglet(ReplicatedLoglet),
-    /// Provision a new cluster
-    Provision(ProvisionOpts),
 }
 
 fn init(common_opts: &CommonOpts) {

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -55,15 +55,15 @@ async fn provision_cluster(
     connection: &ConnectionInfo,
     provision_opts: &ProvisionOpts,
 ) -> anyhow::Result<()> {
-    let address = match connection.addresses.len().cmp(&1) {
+    let address = match connection.address.len().cmp(&1) {
         Ordering::Greater => {
-            let address = &connection.addresses[0];
+            let address = &connection.address[0];
             c_println!(
                 "Cluster provisioning must be performed on a single node. Using {address} for provisioning.",
             );
             address
         }
-        Ordering::Equal => &connection.addresses[0],
+        Ordering::Equal => &connection.address[0],
         Ordering::Less => {
             anyhow::bail!("At least one address must be specified to provision");
         }


### PR DESCRIPTION

- Advertised address now uses `http` by default if scheme is now supplied, so addresses like `localhost:5122` will now be accepted
- Added description to Restatectl and restate cli for `--help`
- Orders commands and options in help (more important commands and options first)
- feature unification for clap
