### PR TITLE
Add optional `advertised_admin_endpoint`

### DIFF
--- a/crates/admin/src/rest_api/version.rs
+++ b/crates/admin/src/rest_api/version.rs
@@ -30,7 +30,7 @@ pub async fn version() -> Json<VersionInformation> {
         min_admin_api_version: MIN_ADMIN_API_VERSION.as_repr(),
         max_admin_api_version: MAX_ADMIN_API_VERSION.as_repr(),
         ingress_endpoint: Configuration::pinned()
-            .admin
+            .ingress
             .advertised_ingress_endpoint
             .clone(),
     })

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -21,6 +21,7 @@ use restate_core::MetadataWriter;
 use restate_service_protocol::discovery::ServiceDiscovery;
 use restate_types::net::BindAddress;
 use restate_types::schema::subscriptions::SubscriptionValidator;
+use tracing::info;
 
 use crate::schema_registry::SchemaRegistry;
 use crate::{rest_api, state};
@@ -126,6 +127,11 @@ where
             );
 
         let service = hyper_util::service::TowerToHyperService::new(router.into_service());
+
+        info!(
+            "Admin API starting on: {}",
+            opts.advertised_admin_endpoint.as_ref().expect("is set")
+        );
 
         net_util::run_hyper_server(
             &BindAddress::Socket(opts.bind_address),

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -65,6 +65,9 @@ impl ConfigLoader {
         let mut config: Configuration = figment.extract()?;
 
         config.common.set_derived_values();
+        config.admin.set_derived_values();
+        config.ingress.set_derived_values();
+
         Ok(config.apply_cascading_values())
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use clap::Parser;
 use codederror::CodedError;
 use restate_core::TaskCenter;
+use restate_types::nodes_config::Role;
 use tokio::io;
 use tracing::error;
 use tracing::{info, trace, warn};
@@ -167,6 +168,38 @@ fn main() {
             format!("Restate {}", build_info::RESTATE_SERVER_VERSION)
         );
         let _ = writeln!(&mut stdout, "{:^40}", "https://restate.dev/");
+        if config.has_role(Role::Admin) {
+            let _ = writeln!(
+                &mut stdout,
+                "{:^40}",
+                format!(
+                    "Admin: {}",
+                    config
+                        .admin
+                        .advertised_admin_endpoint
+                        .as_ref()
+                        .expect("is set")
+                )
+            );
+        }
+
+        // todo: this should be changed to HttpIngress
+        // once it's fully supported
+        if config.has_role(Role::Worker) {
+            let _ = writeln!(
+                &mut stdout,
+                "{:^40}",
+                format!(
+                    "HTTP Ingress: {}",
+                    config
+                        .ingress
+                        .advertised_ingress_endpoint
+                        .as_ref()
+                        .expect("is set")
+                )
+            );
+        }
+
         let _ = writeln!(&mut stdout);
     }
 


### PR DESCRIPTION
Add optional `advertised_admin_endpoint`

Summary:
Adding `advertised_admin_endpoint` mainly to show to the
user while the node is starting

By default uses the admin bind address

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2700).
* #2703
* __->__ #2700