### PR TITLE
Rename log-trim-interval to log-trim-check-interval

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -900,7 +900,7 @@ mod tests {
 
         let interval_duration = Duration::from_secs(10);
         let admin_options = AdminOptionsBuilder::default()
-            .log_trim_interval(interval_duration.into())
+            .log_trim_check_interval(interval_duration.into())
             .build()
             .unwrap();
         let networking = NetworkingOptions {
@@ -985,7 +985,7 @@ mod tests {
 
         let interval_duration = Duration::from_secs(10);
         let admin_options = AdminOptionsBuilder::default()
-            .log_trim_interval(interval_duration.into())
+            .log_trim_check_interval(interval_duration.into())
             .build()
             .unwrap();
         let interval_duration = Duration::from_secs(10);
@@ -1060,7 +1060,7 @@ mod tests {
 
         let interval_duration = Duration::from_secs(10);
         let admin_options = AdminOptionsBuilder::default()
-            .log_trim_interval(interval_duration.into())
+            .log_trim_check_interval(interval_duration.into())
             .build()
             .unwrap();
         let mut bifrost_options = BifrostOptions::default();
@@ -1133,7 +1133,7 @@ mod tests {
 
         let interval_duration = Duration::from_secs(10);
         let admin_options = AdminOptionsBuilder::default()
-            .log_trim_interval(interval_duration.into())
+            .log_trim_check_interval(interval_duration.into())
             .build()
             .unwrap();
         let mut config: Configuration = Configuration {
@@ -1216,7 +1216,7 @@ mod tests {
 
         let interval_duration = Duration::from_secs(10);
         let admin_options = AdminOptionsBuilder::default()
-            .log_trim_interval(interval_duration.into())
+            .log_trim_check_interval(interval_duration.into())
             .build()
             .unwrap();
 
@@ -1296,7 +1296,7 @@ mod tests {
 
         let interval_duration = Duration::from_secs(10);
         let admin_options = AdminOptionsBuilder::default()
-            .log_trim_interval(interval_duration.into())
+            .log_trim_check_interval(interval_duration.into())
             .build()
             .unwrap();
 

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -354,7 +354,7 @@ fn create_log_trim_check_interval(options: &AdminOptions) -> Option<Interval> {
         .log_trim_threshold
         .inspect(|_| info!("The log trim threshold setting is deprecated and will be ignored"));
 
-    options.log_trim_interval().map(|interval| {
+    options.log_trim_check_interval().map(|interval| {
         // delay the initial trim check, and introduces small amount of jitter (+/-10%) to avoid synchronization
         // among partition leaders in case of coordinated cluster restarts
         let effective_interval = with_jitter(interval, 0.1);


### PR DESCRIPTION
Testing:

```
❯ RESTATE_ADMIN__LOG_TRIM_INTERVAL=7m restate-server --dump-config | grep trim.\*check
Using the deprecated config option 'log-trim-interval' instead of 'admin.log-trim-check-interval'. Please update the config to use 'admin.log-trim-check-interval' instead.
log-trim-check-interval = "7m"

❯ cat test.toml
[admin]
log-trim-interval = "3m"

❯ restate-server --config-file test.toml --dump-config | grep log-trim
Using the deprecated config option 'log-trim-interval' instead of 'admin.log-trim-check-interval'. Please update the config to use 'admin.log-trim-check-interval' instead.
log-trim-check-interval = "3m"
```

