### PR TITLE
Forbid using node id zero and add auto migration path

### DIFF
--- a/crates/core/src/metadata_store/providers/objstore/mod.rs
+++ b/crates/core/src/metadata_store/providers/objstore/mod.rs
@@ -42,7 +42,7 @@ pub async fn create_object_store_based_meta_store(
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let server = glue::Server::new(store_builder, rx);
     TaskCenter::spawn(
-        TaskKind::MetadataStore,
+        TaskKind::MetadataServer,
         "metadata-store-client",
         server.run(),
     )

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -233,10 +233,9 @@ impl<T: TransportConnect> ConnectionManager<T> {
         ))?;
 
         // we don't allow node-id 0 in this version.
-        // todo (remove after we finish precursory work of auto-migrating existing users)
-        // if peer_node_id.id == 0 {
-        //     return Err(ProtocolError::HandshakeFailed("Peer cannot have node Id of 0").into());
-        // }
+        if peer_node_id.id == 0 {
+            return Err(ProtocolError::HandshakeFailed("Peer cannot have node Id of 0").into());
+        }
 
         if peer_node_id.generation == 0 {
             return Err(

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -109,7 +109,7 @@ pub enum TaskKind {
     ConnectionReactor,
     Shuffle,
     Cleaner,
-    MetadataStore,
+    MetadataServer,
     Background,
     // -- Bifrost Tasks
     /// A background task that the system needs for its operation. The task requires a system

--- a/crates/metadata-server/src/local/tests.rs
+++ b/crates/metadata-server/src/local/tests.rs
@@ -205,7 +205,7 @@ async fn durable_storage() -> anyhow::Result<()> {
     }
 
     // restart the metadata store
-    TaskCenter::cancel_tasks(Some(TaskKind::MetadataStore), None).await;
+    TaskCenter::cancel_tasks(Some(TaskKind::MetadataServer), None).await;
     // reset RocksDbManager to allow restarting the metadata store
     RocksDbManager::get().reset().await?;
 
@@ -298,7 +298,7 @@ async fn start_metadata_server(
     })?;
 
     TaskCenter::spawn(
-        TaskKind::MetadataStore,
+        TaskKind::MetadataServer,
         "local-metadata-store",
         async move {
             server.run().await;

--- a/crates/metadata-server/src/local/tests.rs
+++ b/crates/metadata-server/src/local/tests.rs
@@ -300,10 +300,7 @@ async fn start_metadata_server(
     TaskCenter::spawn(
         TaskKind::MetadataServer,
         "local-metadata-store",
-        async move {
-            server.run().await;
-            Ok(())
-        },
+        server.run(),
     )?;
 
     assert2::let_assert!(

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -124,7 +124,7 @@ pub struct Node {
     partition_routing_refresher: PartitionRoutingRefresher,
     metadata_store_client: MetadataStoreClient,
     bifrost: BifrostService,
-    metadata_store_role: Option<BoxedMetadataServer>,
+    metadata_server_role: Option<BoxedMetadataServer>,
     base_role: BaseRole,
     admin_role: Option<AdminRole<GrpcConnector>>,
     worker_role: Option<WorkerRole>,
@@ -324,7 +324,7 @@ impl Node {
             metadata_manager,
             partition_routing_refresher,
             bifrost: bifrost_svc,
-            metadata_store_role,
+            metadata_server_role: metadata_store_role,
             metadata_store_client,
             base_role,
             admin_role,
@@ -367,11 +367,11 @@ impl Node {
         let node_rpc_status = TaskCenter::with_current(|tc| tc.health().node_rpc_status());
         node_rpc_status.wait_for_value(NodeRpcStatus::Ready).await;
 
-        if let Some(metadata_store) = self.metadata_store_role {
+        if let Some(metadata_server) = self.metadata_server_role {
             TaskCenter::spawn(
-                TaskKind::MetadataStore,
-                "metadata-store",
-                metadata_store.run(),
+                TaskKind::MetadataServer,
+                "metadata-server",
+                metadata_server.run(),
             )?;
         }
 

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -92,8 +92,8 @@ impl FromStr for GenerationalNodeId {
 }
 
 impl GenerationalNodeId {
-    // Start with 1 as id to leave 0 as a special value in the future
-    pub const INITIAL_NODE_ID: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+    pub const INITIAL_NODE_ID: GenerationalNodeId =
+        PlainNodeId::MIN_PLAIN_NODE_ID.with_generation(1);
 
     pub fn decode<B: Buf>(mut data: B) -> Self {
         // generational node id is stored as two u32s next to each other, each in big-endian.
@@ -281,6 +281,9 @@ impl From<GenerationalNodeId> for PlainNodeId {
 }
 
 impl PlainNodeId {
+    // Start with 1 as plain node id to leave 0 as a special value in the future
+    pub const MIN_PLAIN_NODE_ID: PlainNodeId = PlainNodeId::new(1);
+
     pub const fn new(id: u32) -> PlainNodeId {
         PlainNodeId(id)
     }
@@ -289,7 +292,7 @@ impl PlainNodeId {
         self.0 != 0
     }
 
-    pub fn with_generation(self, generation: u32) -> GenerationalNodeId {
+    pub const fn with_generation(self, generation: u32) -> GenerationalNodeId {
         GenerationalNodeId(self, generation)
     }
 

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -156,6 +156,21 @@ impl NodesConfiguration {
         self.version = version;
     }
 
+    /// Removes the node with the given `id` by inserting a tombstone for it.
+    ///
+    /// # Important
+    /// You should only remove nodes from the nodes configuration once they are fully drained. This
+    /// means they shouldn't be part of any node set, be a member of the latest metadata cluster
+    /// configuration, or run any partition processors. It is your responsibility to ensure this
+    /// condition before removing a node!
+    pub fn remove_node_unchecked(&mut self, id: impl Into<NodeId>) {
+        let node_id = id.into();
+        // only keep tombstones for known nodes
+        self.nodes
+            .entry(node_id.id())
+            .and_modify(|value| *value = MaybeNode::Tombstone);
+    }
+
     /// Insert or replace a node with a config.
     pub fn upsert_node(&mut self, node: NodeConfig) {
         debug_assert!(!node.name.is_empty());

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -55,8 +55,8 @@ pub async fn start_metadata_server(
     })?;
 
     TaskCenter::spawn(
-        TaskKind::MetadataStore,
-        "local-metadata-store",
+        TaskKind::MetadataServer,
+        "local-metadata-server",
         async move {
             service.run().await?;
             Ok(())


### PR DESCRIPTION
[Forbid forcing node id 0](https://github.com/restatedev/restate/commit/b834250dc2260a0e9ee96a9bd560096b0fbe030e) 

With this commit we no longer allow users to set the node id to 0 since it is a reserved value
now. In case the user forces this node id, we will fail with an explanatory error message.

[Auto migrate PlainNodeId 0 to the forced node id or the next available PlainNodeId](https://github.com/restatedev/restate/commit/b8ed192fd54dfc5aa36c13d0386c07e674c2aabb) 

This commit adds a migration path for the LocalMetadataServer which updates a 0 PlainNodeId to a
non-zero value in the NodesConfiguration. If the node that runs the local metadata server had the
node id 0, then the migration path will respect a potentially forced node id if it is set and not
yet taken. Otherwise, the migration path will pick the next available PlainNodeId.

This fixes https://github.com/restatedev/restate/issues/2550.