### PR TITLE
[1/n] Remove one memory copy from network serialization

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -132,7 +132,7 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
 
     let message = Message {
         header: Some(restate_types::protobuf::node::Header {
-            my_nodes_config_version: Some(restate_types::protobuf::common::Version { value: 5 }),
+            my_nodes_config_version: Some(5),
             my_logs_version: None,
             my_schema_version: None,
             my_partition_table_version: None,

--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -26,8 +26,9 @@ use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionProcessorRp
 use restate_types::invocation::{
     InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext,
 };
-use restate_types::logs::{LogId, LogletId, Record};
-use restate_types::net::codec::{serialize_message, MessageBodyExt, WireDecode};
+use restate_types::logs::{LogId, LogletId, LogletOffset, Record, SequenceNumber};
+use restate_types::net::codec::{MessageBodyExt, WireDecode, WireEncode};
+use restate_types::net::log_server::{LogServerRequestHeader, Store, StoreFlags};
 use restate_types::net::replicated_loglet::{Append, CommonRequestHeader};
 use restate_types::protobuf::node::Message;
 use restate_types::time::MillisSinceEpoch;
@@ -65,7 +66,7 @@ pub fn generate_envelope() -> Arc<Envelope> {
 
     let request_id = PartitionProcessorRpcRequestId::new();
     let inv_source = restate_types::invocation::Source::Ingress(request_id);
-    let handler: ByteString = format!("aFunction_{}", rand_string(1)).into();
+    let handler: ByteString = format!("aFunction_{}", rand_string(10)).into();
 
     let header = restate_wal_protocol::Header {
         source: restate_wal_protocol::Source::Processor {
@@ -118,6 +119,37 @@ pub fn generate_envelope() -> Arc<Envelope> {
     Envelope::new(header, command).into()
 }
 
+fn serialize_store_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> {
+    let store_message = Store {
+        header: LogServerRequestHeader {
+            loglet_id: LogletId::new(12u16.into(), 4.into()),
+            known_global_tail: LogletOffset::new(55),
+        },
+        payloads,
+        timeout_at: Some(MillisSinceEpoch::now()),
+        flags: StoreFlags::empty(),
+        first_offset: LogletOffset::new(56),
+        sequencer: GenerationalNodeId::new(1, 1),
+        known_archived: LogletOffset::INVALID,
+    };
+
+    let body = store_message.encode(restate_types::net::ProtocolVersion::V1)?;
+
+    let message = Message {
+        header: Some(restate_types::protobuf::node::Header {
+            my_nodes_config_version: Some(5),
+            my_logs_version: None,
+            my_schema_version: None,
+            my_partition_table_version: None,
+            msg_id: random(),
+            in_response_to: None,
+            span_context: None,
+        }),
+        body: Some(body),
+    };
+    Ok(message)
+}
+
 fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> {
     let append_message = Append {
         header: CommonRequestHeader {
@@ -128,7 +160,7 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
         payloads,
     };
 
-    let body = serialize_message(append_message, restate_types::net::ProtocolVersion::V1)?;
+    let body = append_message.encode(restate_types::net::ProtocolVersion::V1)?;
 
     let message = Message {
         header: Some(restate_types::protobuf::node::Header {
@@ -169,18 +201,25 @@ fn replicated_loglet_append_serde(c: &mut Criterion) {
     let serialized = buf.freeze();
 
     group
-        .sample_size(40)
-        .measurement_time(Duration::from_secs(20))
-        .bench_function("serialize", |bencher| {
+        .sample_size(50)
+        .measurement_time(Duration::from_secs(5))
+        .bench_function("serialize-append", |bencher| {
             bencher.iter(|| {
                 let mut buf = BytesMut::new();
                 let message = black_box(serialize_append_message(payloads.clone()).unwrap());
                 black_box(message.encode(&mut buf)).unwrap();
             });
         })
-        .bench_function("deserialize", |bencher| {
+        .bench_function("deserialize-append", |bencher| {
             bencher.iter(|| {
                 black_box(deserialize_append_message(serialized.clone())).unwrap();
+            });
+        })
+        .bench_function("serialize-store", |bencher| {
+            bencher.iter(|| {
+                let mut buf = BytesMut::new();
+                let message = black_box(serialize_store_message(payloads.clone()).unwrap());
+                black_box(message.encode(&mut buf)).unwrap();
             });
         });
     group.finish();
@@ -189,6 +228,6 @@ fn replicated_loglet_append_serde(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(997, Output::Flamegraph(Some(flamegraph_options()))));
-    targets = replicated_loglet_append_serde
+    targets = replicated_loglet_append_serde,
 );
 criterion_main!(benches);

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -19,7 +19,7 @@ use tokio::time::Instant;
 use tracing::{debug, trace};
 
 use restate_types::net::codec::Targeted;
-use restate_types::net::codec::{serialize_message, WireEncode};
+use restate_types::net::codec::WireEncode;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::net::ProtocolVersion;
 use restate_types::protobuf::node::message;
@@ -70,7 +70,9 @@ where
             message.msg_id(),
             message.in_response_to(),
         );
-        let body = serialize_message(message.into_body(), self.protocol_version)
+        let body = message
+            .into_body()
+            .encode(self.protocol_version)
             .expect("message encoding infallible");
         self.send_raw(Message::new(header, body));
     }
@@ -323,7 +325,7 @@ pub mod test_util {
 
     use restate_types::net::codec::MessageBodyExt;
     use restate_types::net::codec::Targeted;
-    use restate_types::net::codec::{serialize_message, WireEncode};
+    use restate_types::net::codec::WireEncode;
     use restate_types::net::CodecError;
     use restate_types::net::ProtocolVersion;
     use restate_types::nodes_config::NodesConfiguration;
@@ -431,7 +433,9 @@ pub mod test_util {
         where
             M: WireEncode + Targeted,
         {
-            let body = serialize_message(message, self.protocol_version).expect("serde unfallible");
+            let body = message
+                .encode(self.protocol_version)
+                .expect("serde infallible");
             let message = Message::new(header, body);
 
             self.sender.send(message).await?;

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -451,9 +451,10 @@ mod test {
     use crate::network::{PeerMetadataVersion, WeakConnection};
 
     use super::*;
+    use bytes::Bytes;
     use futures::future::join_all;
-    use restate_types::net::codec::encode_default;
     use restate_types::net::{CodecError, TargetName};
+    use restate_types::protobuf::node::message;
     use restate_types::GenerationalNodeId;
     use serde::{Deserialize, Serialize};
     use tokio::sync::Barrier;
@@ -487,12 +488,15 @@ mod test {
     }
 
     impl WireEncode for TestResponse {
-        fn encode<B: bytes::BufMut>(
+        fn encode(
             self,
-            buf: &mut B,
-            protocol_version: restate_types::net::ProtocolVersion,
-        ) -> Result<(), CodecError> {
-            encode_default(self, buf, protocol_version)
+            _protocol_version: restate_types::net::ProtocolVersion,
+        ) -> Result<message::Body, CodecError> {
+            let target = Self::TARGET;
+            Ok(message::Body::Encoded(message::BinaryMessage {
+                target: target.into(),
+                payload: Bytes::from(self.text),
+            }))
         }
     }
 

--- a/crates/types/protobuf/restate/node.proto
+++ b/crates/types/protobuf/restate/node.proto
@@ -18,19 +18,20 @@ package restate.node;
 // -------------------------------------
 //
 message Header {
-  restate.common.Version my_nodes_config_version = 1;
-  optional restate.common.Version my_logs_version = 2;
-  optional restate.common.Version my_schema_version = 3;
-  optional restate.common.Version my_partition_table_version = 4;
   /// A unique monotonically increasing identifier of this message/request per
   /// producer. The uniqueness domain is the generational node id. This is
   /// always set for all messages (whether it's a request or a response)
-  uint64 msg_id = 5;
+  uint64 msg_id = 1;
   /// The msg_id at which we are responding to. Unset if this not to be
   /// considered a response. Note: If this is set, it's the responsibility of
   /// the message producer to ensure that the response is sent to the original
   /// producer (generational node id).
-  optional uint64 in_response_to = 6;
+  // Using raw value to be as compact as possible.
+  optional uint64 in_response_to = 2;
+  optional uint32 my_nodes_config_version = 3;
+  optional uint32 my_logs_version = 4;
+  optional uint32 my_schema_version = 5;
+  optional uint32 my_partition_table_version = 6;
   optional SpanContext span_context = 7;
 }
 
@@ -41,10 +42,10 @@ message SpanContext { map<string, string> fields = 1; }
 message Hello {
   restate.common.ProtocolVersion min_protocol_version = 1;
   restate.common.ProtocolVersion max_protocol_version = 2;
+  string cluster_name = 3;
   // generational node id of sender (who am I)
   // this is optional for future-proofing with anonymous clients using this protocol
-  optional restate.common.GenerationalNodeId my_node_id = 3;
-  string cluster_name = 4;
+  optional restate.common.GenerationalNodeId my_node_id = 4;
 }
 
 message Welcome {
@@ -80,6 +81,7 @@ message Message {
     Hello hello = 3;
     // Sent as first response
     Welcome welcome = 4;
-    BinaryMessage encoded = 5;
+    // keep this as last, always
+    BinaryMessage encoded = 1000;
   }
 }

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -177,13 +177,15 @@ macro_rules! define_message {
         }
 
         impl $crate::net::codec::WireEncode for $message {
-            fn encode<B: bytes::BufMut>(
+            fn encode(
                 self,
-                buf: &mut B,
                 protocol_version: $crate::net::ProtocolVersion,
-            ) -> Result<(), $crate::net::CodecError> {
-                // serialize message into buf
-                $crate::net::codec::encode_default(self, buf, protocol_version)
+            ) -> Result<$crate::protobuf::node::message::Body, $crate::net::CodecError> {
+                let payload = $crate::net::codec::encode_default(self, protocol_version)?;
+                let target = <$message as $crate::net::Targeted>::TARGET.into();
+                Ok($crate::protobuf::node::message::Body::Encoded(
+                    crate::protobuf::node::message::BinaryMessage { target, payload },
+                ))
             }
         }
 


### PR DESCRIPTION

- Network messages now perform one less memory copy during serialization
- One step closer to allowing some messages to be native proto types

More follow ups are incoming.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2706).
* __->__ #2706
* #2704