### PR TITLE
Add automatic migration path from local to replicated metadata server 

### DIFF
--- a/crates/core/src/metadata_store/providers/objstore/mod.rs
+++ b/crates/core/src/metadata_store/providers/objstore/mod.rs
@@ -14,7 +14,6 @@ use crate::metadata_store::providers::objstore::version_repository::VersionRepos
 use crate::metadata_store::MetadataStore;
 use crate::{TaskCenter, TaskKind};
 use restate_types::config::MetadataClientKind;
-use restate_types::errors::GenericError;
 
 mod glue;
 mod object_store_version_repository;
@@ -23,7 +22,7 @@ mod version_repository;
 
 pub async fn create_object_store_based_meta_store(
     configuration: MetadataClientKind,
-) -> Result<impl MetadataStore, GenericError> {
+) -> anyhow::Result<impl MetadataStore> {
     // obtain an instance of a version repository from the configuration.
     // we use an object_store backed version repository.
     let version_repository = Box::new(ObjectStoreVersionRepository::from_configuration(

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -715,7 +715,7 @@ impl StartedNode {
     /// Obtain a metadata client based on this nodes client config.
     pub async fn metadata_client(
         &self,
-    ) -> Result<restate_metadata_server::MetadataStoreClient, GenericError> {
+    ) -> anyhow::Result<restate_metadata_server::MetadataStoreClient> {
         restate_metadata_server::create_client(self.config().common.metadata_client.clone()).await
     }
 

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -343,13 +343,6 @@ struct WriteRequest {
 }
 
 impl WriteRequest {
-    pub fn new(kind: RequestKind) -> Self {
-        WriteRequest {
-            request_id: Ulid::new(),
-            kind,
-        }
-    }
-
     fn encode_to_vec(self) -> Result<Vec<u8>, StorageEncodeError> {
         let request = grpc::WriteRequest::from(self);
         Ok(request.encode_to_vec())

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -594,7 +594,7 @@ impl Default for MetadataServerConfiguration {
 /// Creates a [`MetadataStoreClient`] for configured metadata store.
 pub async fn create_client(
     metadata_store_client_options: MetadataClientOptions,
-) -> Result<MetadataStoreClient, GenericError> {
+) -> anyhow::Result<MetadataStoreClient> {
     let backoff_policy = Some(metadata_store_client_options.backoff_policy.clone());
 
     let client = match metadata_store_client_options.kind.clone() {

--- a/crates/metadata-server/src/local/mod.rs
+++ b/crates/metadata-server/src/local/mod.rs
@@ -10,11 +10,19 @@
 
 mod server;
 
+use crate::local::storage::RocksDbStorage;
+use std::path::PathBuf;
 pub use {server::migrate_nodes_configuration, server::LocalMetadataServer};
 
 pub mod storage;
 #[cfg(test)]
 mod tests;
 
+const DATA_DIR: &str = "local-metadata-store";
 const DB_NAME: &str = "local-metadata-store";
 const KV_PAIRS: &str = "kv_pairs";
+
+/// Data directory of the local metadata server
+pub fn data_dir() -> PathBuf {
+    RocksDbStorage::data_dir()
+}

--- a/crates/metadata-server/src/local/mod.rs
+++ b/crates/metadata-server/src/local/mod.rs
@@ -10,7 +10,11 @@
 
 mod server;
 
-pub use server::LocalMetadataServer;
+pub use {server::migrate_nodes_configuration, server::LocalMetadataServer};
 
+pub mod storage;
 #[cfg(test)]
 mod tests;
+
+const DB_NAME: &str = "local-metadata-store";
+const KV_PAIRS: &str = "kv_pairs";

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -10,48 +10,31 @@
 
 use crate::grpc::handler::MetadataServerHandler;
 use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
-use crate::{
-    grpc, MetadataServer, MetadataStoreRequest, PreconditionViolation, RequestError,
-    RequestReceiver,
-};
-use bytes::BytesMut;
-use bytestring::ByteString;
+use crate::local::storage::RocksDbStorage;
+use crate::{grpc, MetadataServer, MetadataStoreRequest, RequestError, RequestReceiver};
 use restate_core::cancellation_watcher;
-use restate_core::metadata_store::{serialize_value, Precondition, VersionedValue};
+use restate_core::metadata_store::{serialize_value, Precondition};
 use restate_core::network::NetworkServerBuilder;
-use restate_rocksdb::{
-    CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
-    RocksError,
-};
+use restate_rocksdb::RocksError;
 use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration};
 use restate_types::protobuf::common::MetadataServerStatus;
-use restate_types::storage::{
-    StorageCodec, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError,
-};
-use restate_types::{PlainNodeId, Version};
-use rocksdb::{BoundColumnFamily, DBCompressionType, WriteBatch, WriteOptions, DB};
-use std::sync::Arc;
+use restate_types::storage::{StorageCodec, StorageDecodeError, StorageEncodeError};
+use restate_types::PlainNodeId;
 use tokio::sync::mpsc;
 use tonic::codec::CompressionEncoding;
 use tracing::{debug, info, trace};
-
-const DB_NAME: &str = "local-metadata-store";
-const KV_PAIRS: &str = "kv_pairs";
 
 /// Single node metadata store which stores the key value pairs in RocksDB.
 ///
 /// In order to avoid issues arising from concurrency, we run the metadata
 /// store in a single thread.
 pub struct LocalMetadataServer {
-    db: Arc<DB>,
-    rocksdb: Arc<RocksDb>,
-    rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+    storage: RocksDbStorage,
     request_rx: RequestReceiver,
-    buffer: BytesMut,
     health_status: HealthStatus<MetadataServerStatus>,
 }
 
@@ -65,24 +48,7 @@ impl LocalMetadataServer {
         health_status.update(MetadataServerStatus::StartingUp);
         let (request_tx, request_rx) = mpsc::channel(options.request_queue_length());
 
-        let db_name = DbName::new(DB_NAME);
-        let db_manager = RocksDbManager::get();
-        let cfs = vec![CfName::new(KV_PAIRS)];
-        let db_spec = DbSpecBuilder::new(db_name.clone(), options.data_dir(), db_options(options))
-            .add_cf_pattern(
-                CfPrefixPattern::ANY,
-                cf_options(options.rocksdb_memory_budget()),
-            )
-            .ensure_column_families(cfs)
-            .build()
-            .expect("valid spec");
-
-        let db = db_manager
-            .open_db(updateable_rocksdb_options.clone(), db_spec)
-            .await?;
-        let rocksdb = db_manager
-            .get_db(db_name)
-            .expect("metadata store db is open");
+        let storage = RocksDbStorage::create(options, updateable_rocksdb_options).await?;
 
         server_builder.register_grpc_service(
             MetadataServerSvcServer::new(MetadataServerHandler::new(request_tx, None, None))
@@ -92,34 +58,17 @@ impl LocalMetadataServer {
         );
 
         Ok(Self {
-            db,
-            rocksdb,
-            rocksdb_options: updateable_rocksdb_options,
-            buffer: BytesMut::default(),
+            storage,
             health_status,
             request_rx,
         })
-    }
-
-    fn write_options(&mut self) -> WriteOptions {
-        let opts = self.rocksdb_options.live_load();
-        let mut write_opts = WriteOptions::default();
-
-        write_opts.disable_wal(opts.rocksdb_disable_wal());
-
-        if !opts.rocksdb_disable_wal() {
-            // always sync if we have wal enabled
-            write_opts.set_sync(true);
-        }
-
-        write_opts
     }
 
     pub async fn run(mut self) -> anyhow::Result<()> {
         debug!("Running LocalMetadataStore");
         self.health_status.update(MetadataServerStatus::Member);
 
-        self.migrate_nodes_configuration().await?;
+        migrate_nodes_configuration(&mut self.storage).await?;
 
         loop {
             tokio::select! {
@@ -139,114 +88,17 @@ impl LocalMetadataServer {
         Ok(())
     }
 
-    async fn migrate_nodes_configuration(&mut self) -> Result<(), MigrationError> {
-        let value = self.get(&NODES_CONFIG_KEY)?;
-
-        if value.is_none() {
-            // nothing to migrate
-            return Ok(());
-        };
-
-        let value = value.unwrap();
-        let mut bytes = value.value.as_ref();
-
-        let mut nodes_configuration = StorageCodec::decode::<NodesConfiguration, _>(&mut bytes)?;
-
-        let mut modified = false;
-
-        if let Some(node_config) =
-            nodes_configuration.find_node_by_name(Configuration::pinned().common.node_name())
-        {
-            // Only needed if we resume from a Restate version that has not properly set the
-            // MetadataServerState to Member in the NodesConfiguration.
-            if !matches!(
-                node_config.metadata_server_config.metadata_server_state,
-                MetadataServerState::Member
-            ) {
-                info!(
-                    "Setting MetadataServerState to Member in NodesConfiguration for node {}",
-                    node_config.name
-                );
-                let mut new_node_config = node_config.clone();
-                new_node_config.metadata_server_config.metadata_server_state =
-                    MetadataServerState::Member;
-
-                nodes_configuration.upsert_node(new_node_config);
-                modified = true;
-            }
-        }
-
-        // If we have a node-id 0 in our NodesConfiguration, then we need to migrate it to another
-        // value since node-id 0 is a reserved value now.
-        let zero = PlainNodeId::new(0);
-        if let Ok(node_config) = nodes_configuration.find_node_by_id(zero) {
-            if nodes_configuration.len() > 1 {
-                return Err(MigrationError::MultiNodeCluster);
-            }
-
-            assert_eq!(node_config.name, Configuration::pinned().node_name(), "The only known node of this cluster is {} but my node name is {}. This indicates that my node name was changed after an initial provisioning of the node", node_config.name, Configuration::pinned().node_name());
-
-            let plain_node_id_to_migrate_to =
-                if let Some(force_node_id) = Configuration::pinned().common.force_node_id {
-                    assert_ne!(
-                        force_node_id, zero,
-                        "It should no longer be allowed to force the node id to 0"
-                    );
-                    force_node_id
-                } else {
-                    PlainNodeId::MIN_PLAIN_NODE_ID
-                };
-
-            let mut new_node_config = node_config.clone();
-            new_node_config.current_generation = plain_node_id_to_migrate_to
-                .with_generation(node_config.current_generation.generation());
-            info!(
-                "Migrating node id of node '{}' from '{}' to '{}'",
-                node_config.name,
-                node_config.current_generation,
-                new_node_config.current_generation
-            );
-
-            nodes_configuration.remove_node_unchecked(node_config.current_generation);
-            nodes_configuration.upsert_node(new_node_config);
-            modified = true;
-        }
-
-        if modified {
-            nodes_configuration.increment_version();
-
-            let new_nodes_configuration = serialize_value(&nodes_configuration)?;
-
-            self.put(
-                &NODES_CONFIG_KEY,
-                &new_nodes_configuration,
-                Precondition::MatchesVersion(value.version),
-            )
-            .await?;
-
-            info!("Successfully completed NodesConfiguration migration");
-        }
-
-        Ok(())
-    }
-
-    fn kv_cf_handle(&self) -> Arc<BoundColumnFamily> {
-        self.db
-            .cf_handle(KV_PAIRS)
-            .expect("KV_PAIRS column family exists")
-    }
-
     async fn handle_request(&mut self, request: MetadataStoreRequest) {
         trace!("Handle request '{:?}'", request);
 
         match request {
             MetadataStoreRequest::Get { key, result_tx } => {
-                let result = self.get(&key);
+                let result = self.storage.get(&key);
                 Self::log_error(&result, "Get");
                 let _ = result_tx.send(result);
             }
             MetadataStoreRequest::GetVersion { key, result_tx } => {
-                let result = self.get_version(&key);
+                let result = self.storage.get_version(&key);
                 Self::log_error(&result, "GetVersion");
                 let _ = result_tx.send(result);
             }
@@ -256,7 +108,7 @@ impl LocalMetadataServer {
                 precondition,
                 result_tx,
             } => {
-                let result = self.put(&key, &value, precondition).await;
+                let result = self.storage.put(&key, &value, precondition).await;
                 Self::log_error(&result, "Put");
                 let _ = result_tx.send(result);
             }
@@ -265,141 +117,11 @@ impl LocalMetadataServer {
                 precondition,
                 result_tx,
             } => {
-                let result = self.delete(&key, precondition);
+                let result = self.storage.delete(&key, precondition);
                 Self::log_error(&result, "Delete");
                 let _ = result_tx.send(result);
             }
         };
-    }
-
-    fn get(&self, key: &ByteString) -> Result<Option<VersionedValue>, RequestError> {
-        let cf_handle = self.kv_cf_handle();
-        let slice = self
-            .db
-            .get_pinned_cf(&cf_handle, key)
-            .map_err(|err| RequestError::Internal(err.into()))?;
-
-        if let Some(bytes) = slice {
-            Ok(Some(Self::decode(bytes)?))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_version(&self, key: &ByteString) -> Result<Option<Version>, RequestError> {
-        let cf_handle = self.kv_cf_handle();
-        let slice = self
-            .db
-            .get_pinned_cf(&cf_handle, key)
-            .map_err(|err| RequestError::Internal(err.into()))?;
-
-        if let Some(bytes) = slice {
-            // todo only deserialize the version part
-            let versioned_value = Self::decode::<VersionedValue>(bytes)?;
-            Ok(Some(versioned_value.version))
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn put(
-        &mut self,
-        key: &ByteString,
-        value: &VersionedValue,
-        precondition: Precondition,
-    ) -> Result<(), RequestError> {
-        match precondition {
-            Precondition::None => Ok(self.write_versioned_kv_pair(key, value).await?),
-            Precondition::DoesNotExist => {
-                let current_version = self.get_version(key)?;
-                if current_version.is_none() {
-                    Ok(self.write_versioned_kv_pair(key, value).await?)
-                } else {
-                    Err(PreconditionViolation::kv_pair_exists())?
-                }
-            }
-            Precondition::MatchesVersion(version) => {
-                let current_version = self.get_version(key)?;
-                if current_version == Some(version) {
-                    Ok(self.write_versioned_kv_pair(key, value).await?)
-                } else {
-                    Err(PreconditionViolation::version_mismatch(
-                        version,
-                        current_version,
-                    ))?
-                }
-            }
-        }
-    }
-
-    async fn write_versioned_kv_pair(
-        &mut self,
-        key: &ByteString,
-        value: &VersionedValue,
-    ) -> Result<(), RequestError> {
-        self.buffer.clear();
-        Self::encode(value, &mut self.buffer)?;
-
-        let write_options = self.write_options();
-        let cf_handle = self.kv_cf_handle();
-        let mut wb = WriteBatch::default();
-        wb.put_cf(&cf_handle, key, self.buffer.as_ref());
-        self.rocksdb
-            .write_batch(
-                "local-metadata-write-batch",
-                Priority::High,
-                IoMode::default(),
-                write_options,
-                wb,
-            )
-            .await
-            .map_err(|err| RequestError::Internal(err.into()))
-    }
-
-    fn delete(&mut self, key: &ByteString, precondition: Precondition) -> Result<(), RequestError> {
-        match precondition {
-            Precondition::None => self.delete_kv_pair(key),
-            // this condition does not really make sense for the delete operation
-            Precondition::DoesNotExist => {
-                let current_version = self.get_version(key)?;
-
-                if current_version.is_none() {
-                    // nothing to do
-                    Ok(())
-                } else {
-                    Err(PreconditionViolation::kv_pair_exists())?
-                }
-            }
-            Precondition::MatchesVersion(version) => {
-                let current_version = self.get_version(key)?;
-
-                if current_version == Some(version) {
-                    self.delete_kv_pair(key)
-                } else {
-                    Err(PreconditionViolation::version_mismatch(
-                        version,
-                        current_version,
-                    ))?
-                }
-            }
-        }
-    }
-
-    fn delete_kv_pair(&mut self, key: &ByteString) -> Result<(), RequestError> {
-        let write_options = self.write_options();
-        self.db
-            .delete_cf_opt(&self.kv_cf_handle(), key, &write_options)
-            .map_err(|err| RequestError::Internal(err.into()))
-    }
-
-    fn encode<T: StorageEncode>(value: &T, buf: &mut BytesMut) -> Result<(), RequestError> {
-        StorageCodec::encode(value, buf)?;
-        Ok(())
-    }
-
-    fn decode<T: StorageDecode>(buf: impl AsRef<[u8]>) -> Result<T, RequestError> {
-        let value = StorageCodec::decode(&mut buf.as_ref())?;
-        Ok(value)
     }
 
     fn log_error<T>(result: &Result<T, RequestError>, request: &str) {
@@ -428,42 +150,94 @@ pub enum MigrationError {
     MultiNodeCluster,
 }
 
-pub fn db_options(_options: &MetadataServerOptions) -> rocksdb::Options {
-    rocksdb::Options::default()
-}
+pub async fn migrate_nodes_configuration(
+    storage: &mut RocksDbStorage,
+) -> Result<(), MigrationError> {
+    let value = storage.get(&NODES_CONFIG_KEY)?;
 
-pub fn cf_options(
-    memory_budget: usize,
-) -> impl Fn(rocksdb::Options) -> rocksdb::Options + Send + Sync + 'static {
-    move |mut opts| {
-        set_memory_related_opts(&mut opts, memory_budget);
-        opts.set_compaction_style(rocksdb::DBCompactionStyle::Level);
-        opts.set_num_levels(3);
+    if value.is_none() {
+        // nothing to migrate
+        return Ok(());
+    };
 
-        opts.set_compression_per_level(&[
-            DBCompressionType::None,
-            DBCompressionType::None,
-            DBCompressionType::Zstd,
-        ]);
+    let value = value.unwrap();
+    let mut bytes = value.value.as_ref();
 
-        //
-        opts
+    let mut nodes_configuration = StorageCodec::decode::<NodesConfiguration, _>(&mut bytes)?;
+
+    let mut modified = false;
+
+    if let Some(node_config) =
+        nodes_configuration.find_node_by_name(Configuration::pinned().common.node_name())
+    {
+        // Only needed if we resume from a Restate version that has not properly set the
+        // MetadataServerState to Member in the NodesConfiguration.
+        if !matches!(
+            node_config.metadata_server_config.metadata_server_state,
+            MetadataServerState::Member
+        ) {
+            info!(
+                "Setting MetadataServerState to Member in NodesConfiguration for node {}",
+                node_config.name
+            );
+            let mut new_node_config = node_config.clone();
+            new_node_config.metadata_server_config.metadata_server_state =
+                MetadataServerState::Member;
+
+            nodes_configuration.upsert_node(new_node_config);
+            modified = true;
+        }
     }
-}
 
-pub fn set_memory_related_opts(opts: &mut rocksdb::Options, memtables_budget: usize) {
-    // We set the budget to allow 1 mutable + 3 immutable.
-    opts.set_write_buffer_size(memtables_budget / 4);
+    // If we have a node-id 0 in our NodesConfiguration, then we need to migrate it to another
+    // value since node-id 0 is a reserved value now.
+    let zero = PlainNodeId::new(0);
+    if let Ok(node_config) = nodes_configuration.find_node_by_id(zero) {
+        if nodes_configuration.len() > 1 {
+            return Err(MigrationError::MultiNodeCluster);
+        }
 
-    // merge 2 memtables when flushing to L0
-    opts.set_min_write_buffer_number_to_merge(2);
-    opts.set_max_write_buffer_number(4);
-    // start flushing L0->L1 as soon as possible. each file on level0 is
-    // (memtable_memory_budget / 2). This will flush level 0 when it's bigger than
-    // memtable_memory_budget.
-    opts.set_level_zero_file_num_compaction_trigger(2);
-    // doesn't really matter much, but we don't want to create too many files
-    opts.set_target_file_size_base(memtables_budget as u64 / 8);
-    // make Level1 size equal to Level0 size, so that L0->L1 compactions are fast
-    opts.set_max_bytes_for_level_base(memtables_budget as u64);
+        assert_eq!(node_config.name, Configuration::pinned().node_name(), "The only known node of this cluster is {} but my node name is {}. This indicates that my node name was changed after an initial provisioning of the node", node_config.name, Configuration::pinned().node_name());
+
+        let plain_node_id_to_migrate_to =
+            if let Some(force_node_id) = Configuration::pinned().common.force_node_id {
+                assert_ne!(
+                    force_node_id, zero,
+                    "It should no longer be allowed to force the node id to 0"
+                );
+                force_node_id
+            } else {
+                PlainNodeId::MIN_PLAIN_NODE_ID
+            };
+
+        let mut new_node_config = node_config.clone();
+        new_node_config.current_generation = plain_node_id_to_migrate_to
+            .with_generation(node_config.current_generation.generation());
+        info!(
+            "Migrating node id of node '{}' from '{}' to '{}'",
+            node_config.name, node_config.current_generation, new_node_config.current_generation
+        );
+
+        nodes_configuration.remove_node_unchecked(node_config.current_generation);
+        nodes_configuration.upsert_node(new_node_config);
+        modified = true;
+    }
+
+    if modified {
+        nodes_configuration.increment_version();
+
+        let new_nodes_configuration = serialize_value(&nodes_configuration)?;
+
+        storage
+            .put(
+                &NODES_CONFIG_KEY,
+                &new_nodes_configuration,
+                Precondition::MatchesVersion(value.version),
+            )
+            .await?;
+
+        info!("Successfully completed NodesConfiguration migration");
+    }
+
+    Ok(())
 }

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -207,7 +207,7 @@ pub async fn migrate_nodes_configuration(
                 );
                 force_node_id
             } else {
-                PlainNodeId::MIN_PLAIN_NODE_ID
+                PlainNodeId::MIN
             };
 
         let mut new_node_config = node_config.clone();

--- a/crates/metadata-server/src/local/storage.rs
+++ b/crates/metadata-server/src/local/storage.rs
@@ -66,7 +66,7 @@ impl RocksDbStorage {
         })
     }
 
-    pub(super) fn data_dir() -> PathBuf {
+    pub fn data_dir() -> PathBuf {
         data_dir(DATA_DIR)
     }
 

--- a/crates/metadata-server/src/local/storage.rs
+++ b/crates/metadata-server/src/local/storage.rs
@@ -1,0 +1,285 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::local::{DB_NAME, KV_PAIRS};
+use crate::{PreconditionViolation, RequestError};
+use bytes::BytesMut;
+use bytestring::ByteString;
+use itertools::Itertools;
+use restate_core::metadata_store::{Precondition, VersionedValue};
+use restate_rocksdb::{
+    CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
+    RocksError,
+};
+use restate_types::config::{MetadataServerOptions, RocksDbOptions};
+use restate_types::live::BoxedLiveLoad;
+use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
+use restate_types::Version;
+use rocksdb::{
+    BoundColumnFamily, DBCompressionType, Error, IteratorMode, ReadOptions, WriteBatch,
+    WriteOptions,
+};
+use std::sync::Arc;
+
+pub struct RocksDbStorage {
+    rocksdb: Arc<RocksDb>,
+    rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+    buffer: BytesMut,
+}
+
+impl RocksDbStorage {
+    pub async fn create(
+        options: &MetadataServerOptions,
+        rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+    ) -> Result<Self, RocksError> {
+        let db_name = DbName::new(DB_NAME);
+        let db_manager = RocksDbManager::get();
+        let cfs = vec![CfName::new(KV_PAIRS)];
+        let db_spec = DbSpecBuilder::new(db_name.clone(), options.data_dir(), db_options(options))
+            .add_cf_pattern(
+                CfPrefixPattern::ANY,
+                cf_options(options.rocksdb_memory_budget()),
+            )
+            .ensure_column_families(cfs)
+            .add_to_flush_on_shutdown(CfPrefixPattern::ANY)
+            .build()
+            .expect("valid spec");
+
+        let _db = db_manager.open_db(rocksdb_options.clone(), db_spec).await?;
+        let rocksdb = db_manager
+            .get_db(db_name)
+            .expect("metadata store db is open");
+
+        Ok(Self {
+            rocksdb,
+            rocksdb_options,
+            buffer: BytesMut::default(),
+        })
+    }
+
+    fn write_options(&mut self) -> WriteOptions {
+        let opts = self.rocksdb_options.live_load();
+        let mut write_opts = WriteOptions::default();
+
+        write_opts.disable_wal(opts.rocksdb_disable_wal());
+
+        if !opts.rocksdb_disable_wal() {
+            // always sync if we have wal enabled
+            write_opts.set_sync(true);
+        }
+
+        write_opts
+    }
+
+    fn kv_cf_handle(&self) -> Arc<BoundColumnFamily> {
+        self.rocksdb
+            .inner()
+            .as_raw_db()
+            .cf_handle(KV_PAIRS)
+            .expect("KV_PAIRS column family exists")
+    }
+
+    pub fn get(&self, key: &ByteString) -> Result<Option<VersionedValue>, RequestError> {
+        let cf_handle = self.kv_cf_handle();
+        let slice = self
+            .rocksdb
+            .inner()
+            .as_raw_db()
+            .get_pinned_cf(&cf_handle, key)
+            .map_err(|err| RequestError::Internal(err.into()))?;
+
+        if let Some(bytes) = slice {
+            Ok(Some(Self::decode(bytes)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_version(&self, key: &ByteString) -> Result<Option<Version>, RequestError> {
+        let cf_handle = self.kv_cf_handle();
+        let slice = self
+            .rocksdb
+            .inner()
+            .as_raw_db()
+            .get_pinned_cf(&cf_handle, key)
+            .map_err(|err| RequestError::Internal(err.into()))?;
+
+        if let Some(bytes) = slice {
+            // todo only deserialize the version part
+            let versioned_value = Self::decode::<VersionedValue>(bytes)?;
+            Ok(Some(versioned_value.version))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn put(
+        &mut self,
+        key: &ByteString,
+        value: &VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), RequestError> {
+        match precondition {
+            Precondition::None => Ok(self.write_versioned_kv_pair(key, value).await?),
+            Precondition::DoesNotExist => {
+                let current_version = self.get_version(key)?;
+                if current_version.is_none() {
+                    Ok(self.write_versioned_kv_pair(key, value).await?)
+                } else {
+                    Err(PreconditionViolation::kv_pair_exists())?
+                }
+            }
+            Precondition::MatchesVersion(version) => {
+                let current_version = self.get_version(key)?;
+                if current_version == Some(version) {
+                    Ok(self.write_versioned_kv_pair(key, value).await?)
+                } else {
+                    Err(PreconditionViolation::version_mismatch(
+                        version,
+                        current_version,
+                    ))?
+                }
+            }
+        }
+    }
+
+    async fn write_versioned_kv_pair(
+        &mut self,
+        key: &ByteString,
+        value: &VersionedValue,
+    ) -> Result<(), RequestError> {
+        self.buffer.clear();
+        Self::encode(value, &mut self.buffer)?;
+
+        let write_options = self.write_options();
+        let cf_handle = self.kv_cf_handle();
+        let mut wb = WriteBatch::default();
+        wb.put_cf(&cf_handle, key, self.buffer.as_ref());
+        self.rocksdb
+            .write_batch(
+                "local-metadata-write-batch",
+                Priority::High,
+                IoMode::default(),
+                write_options,
+                wb,
+            )
+            .await
+            .map_err(|err| RequestError::Internal(err.into()))
+    }
+
+    pub fn delete(
+        &mut self,
+        key: &ByteString,
+        precondition: Precondition,
+    ) -> Result<(), RequestError> {
+        match precondition {
+            Precondition::None => self.delete_kv_pair(key),
+            // this condition does not really make sense for the delete operation
+            Precondition::DoesNotExist => {
+                let current_version = self.get_version(key)?;
+
+                if current_version.is_none() {
+                    // nothing to do
+                    Ok(())
+                } else {
+                    Err(PreconditionViolation::kv_pair_exists())?
+                }
+            }
+            Precondition::MatchesVersion(version) => {
+                let current_version = self.get_version(key)?;
+
+                if current_version == Some(version) {
+                    self.delete_kv_pair(key)
+                } else {
+                    Err(PreconditionViolation::version_mismatch(
+                        version,
+                        current_version,
+                    ))?
+                }
+            }
+        }
+    }
+
+    fn delete_kv_pair(&mut self, key: &ByteString) -> Result<(), RequestError> {
+        let write_options = self.write_options();
+        self.rocksdb
+            .inner()
+            .as_raw_db()
+            .delete_cf_opt(&self.kv_cf_handle(), key, &write_options)
+            .map_err(|err| RequestError::Internal(err.into()))
+    }
+
+    fn encode<T: StorageEncode>(value: &T, buf: &mut BytesMut) -> Result<(), RequestError> {
+        StorageCodec::encode(value, buf)?;
+        Ok(())
+    }
+
+    fn decode<T: StorageDecode>(buf: impl AsRef<[u8]>) -> Result<T, RequestError> {
+        let value = StorageCodec::decode(&mut buf.as_ref())?;
+        Ok(value)
+    }
+
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = Result<(ByteString, VersionedValue), Error>> + use<'_> {
+        let cf_handle = self.kv_cf_handle();
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_async_io(true);
+        self.rocksdb
+            .inner()
+            .as_raw_db()
+            .full_iterator_cf(&cf_handle, IteratorMode::Start)
+            .map_ok(|(key, value)| {
+                let key = ByteString::try_from(key.as_ref()).expect("valid byte string as key");
+                let value = RocksDbStorage::decode(value.as_ref()).expect("valid versioned value");
+                (key, value)
+            })
+    }
+}
+
+pub fn db_options(_options: &MetadataServerOptions) -> rocksdb::Options {
+    rocksdb::Options::default()
+}
+
+pub fn cf_options(
+    memory_budget: usize,
+) -> impl Fn(rocksdb::Options) -> rocksdb::Options + Send + Sync + 'static {
+    move |mut opts| {
+        set_memory_related_opts(&mut opts, memory_budget);
+        opts.set_compaction_style(rocksdb::DBCompactionStyle::Level);
+        opts.set_num_levels(3);
+
+        opts.set_compression_per_level(&[
+            DBCompressionType::None,
+            DBCompressionType::None,
+            DBCompressionType::Zstd,
+        ]);
+
+        //
+        opts
+    }
+}
+
+pub fn set_memory_related_opts(opts: &mut rocksdb::Options, memtables_budget: usize) {
+    // We set the budget to allow 1 mutable + 3 immutable.
+    opts.set_write_buffer_size(memtables_budget / 4);
+
+    // merge 2 memtables when flushing to L0
+    opts.set_min_write_buffer_number_to_merge(2);
+    opts.set_max_write_buffer_number(4);
+    // start flushing L0->L1 as soon as possible. each file on level0 is
+    // (memtable_memory_budget / 2). This will flush level 0 when it's bigger than
+    // memtable_memory_budget.
+    opts.set_level_zero_file_num_compaction_trigger(2);
+    // doesn't really matter much, but we don't want to create too many files
+    opts.set_target_file_size_base(memtables_budget as u64 / 8);
+    // make Level1 size equal to Level0 size, so that L0->L1 compactions are fast
+    opts.set_max_bytes_for_level_base(memtables_budget as u64);
+}

--- a/crates/metadata-server/src/local/tests.rs
+++ b/crates/metadata-server/src/local/tests.rs
@@ -27,7 +27,7 @@ use restate_types::protobuf::common::NodeRpcStatus;
 use restate_types::{Version, Versioned};
 
 use crate::grpc::client::GrpcMetadataServerClient;
-use crate::local::LocalMetadataServer;
+use crate::local::{data_dir, LocalMetadataServer};
 use crate::tests::Value;
 use crate::{MetadataStoreClient, Precondition, WriteError};
 
@@ -184,7 +184,7 @@ async fn durable_storage() -> anyhow::Result<()> {
     let tmp = std::env::temp_dir();
     let opts = MetadataServerOptions::default();
     assert!(base_path.starts_with(tmp));
-    assert_eq!(base_path.join("local-metadata-store"), opts.data_dir());
+    assert_eq!(base_path.join("local-metadata-store"), data_dir());
 
     let (client, _env) = create_test_environment(&opts).await?;
 

--- a/crates/metadata-server/src/raft/mod.rs
+++ b/crates/metadata-server/src/raft/mod.rs
@@ -12,6 +12,8 @@ mod kv_memory_storage;
 mod network;
 mod server;
 mod storage;
+#[cfg(test)]
+mod tests;
 
 use crate::MemberId;
 use anyhow::Context;

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -429,8 +429,20 @@ impl RaftMetadataServer {
     async fn load_initial_state_from_local_metadata_server(
         &mut self,
     ) -> anyhow::Result<KvMemoryStorage> {
+        let local_metadata_server_options = MetadataServerOptions::default();
+
+        // check whether local metadata server data exists to avoid wrong intentions and possible
+        // misconfigurations
+        if !local::storage::RocksDbStorage::data_dir_exists() {
+            anyhow::bail!(
+                "Trying to migrate from local metadata server but couldn't find any data. \
+            Please make sure that this node has been run with the local metadata server before or \
+            unset the metadata-server.migrate-from-local-metadata-server option."
+            );
+        }
+
         let mut local_storage = local::storage::RocksDbStorage::create(
-            &MetadataServerOptions::default(),
+            &local_metadata_server_options,
             Constant::new(RocksDbOptions::default()).boxed(),
         )
         .await?;

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -309,15 +309,15 @@ impl RaftMetadataServer {
                 "Replicated metadata server must have been configured"
             );
 
-            if raft_options.migrate_from_local_metadata_server {
-                info!("Trying to migrate from local metadata to replicated metadata server");
+            if raft_options.migrate_local_metadata {
+                info!("Trying to migrate from local to replicated metadata");
 
                 let my_member_id = self
                     .initialize_storage_from_local_metadata_server()
                     .await
                     .map_err(|err| Error::ProvisionFromLocal(err.into()))?;
 
-                info!(member_id = %my_member_id, "Successfully migrated all data from local metadata to replicated metadata server");
+                info!(member_id = %my_member_id, "Successfully migrated all local to replicated metadata");
                 let member = self.become_member(my_member_id)?;
                 Provisioned::Member(member)
             } else {
@@ -437,7 +437,7 @@ impl RaftMetadataServer {
             anyhow::bail!(
                 "Trying to migrate from local metadata server but couldn't find any data. \
             Please make sure that this node has been run with the local metadata server before or \
-            unset the metadata-server.migrate-from-local-metadata-server option."
+            unset the metadata-server.migrate-local-metadata option."
             );
         }
 

--- a/crates/metadata-server/src/raft/storage/rocksdb.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb.rs
@@ -646,19 +646,6 @@ impl<'a> Transaction<'a> {
         Ok(())
     }
 
-    pub fn store_nodes_configuration(
-        &mut self,
-        raft_configuration: &NodesConfiguration,
-    ) -> Result<(), Error> {
-        self.put_bytes_metadata_cf(
-            NODES_CONFIGURATION_KEY,
-            &RocksDbStorage::serialize_value(raft_configuration)
-                .map_err(|err| Error::Encode(err.into()))?,
-        );
-
-        Ok(())
-    }
-
     pub fn store_snapshot(&mut self, snapshot: &Snapshot) -> Result<(), Error> {
         self.put_value_ref_metadata_cf(SNAPSHOT_KEY, snapshot)
     }

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -39,11 +39,7 @@ use std::collections::HashMap;
 #[test_log::test(restate_core::test)]
 async fn migration_local_to_replicated() -> googletest::Result<()> {
     let mut configuration = Configuration::default();
-    let raft_options = RaftOptions {
-        // enable migration from local metadata
-        migrate_local_metadata: true,
-        ..Default::default()
-    };
+    let raft_options = RaftOptions::default();
 
     configuration
         .metadata_server

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::create_client;
+use crate::raft::RaftMetadataServer;
+use crate::tests::Value;
+use bytestring::ByteString;
+use futures::TryFutureExt;
+use googletest::IntoTestResult;
+use rand::distr::{Alphanumeric, SampleString};
+use rand::RngCore;
+use restate_core::metadata_store::{serialize_value, Precondition};
+use restate_core::network::NetworkServerBuilder;
+use restate_core::{cancellation_token, MetadataBuilder, TaskCenter, TaskKind};
+use restate_rocksdb::RocksDbManager;
+use restate_types::config::{
+    set_current_config, CommonOptions, Configuration, MetadataClientKind, MetadataClientOptions,
+    MetadataServerKind, MetadataServerOptions, RaftOptions, RocksDbOptions,
+};
+use restate_types::health::Health;
+use restate_types::live::Constant;
+use restate_types::locality::NodeLocation;
+use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
+use restate_types::net::{AdvertisedAddress, BindAddress};
+use restate_types::nodes_config::{
+    LogServerConfig, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
+    Role,
+};
+use restate_types::{PlainNodeId, Version};
+use std::collections::HashMap;
+
+#[test_log::test(restate_core::test)]
+async fn migration_local_to_replicated() -> googletest::Result<()> {
+    let mut configuration = Configuration::default();
+    let raft_options = RaftOptions {
+        // enable migration from local metadata
+        migrate_local_metadata: true,
+        ..Default::default()
+    };
+
+    configuration
+        .metadata_server
+        .set_kind(MetadataServerKind::Raft(raft_options));
+    set_current_config(configuration);
+
+    let uds = tempfile::tempdir()?.into_path().join("server.sock");
+    let bind_address = BindAddress::Uds(uds.clone());
+    let advertised_address = AdvertisedAddress::Uds(uds);
+
+    RocksDbManager::init(Constant::new(CommonOptions::default()));
+
+    // initialize the local storage with some data that we can migrate
+    let mut local_storage = crate::local::storage::RocksDbStorage::create(
+        &MetadataServerOptions::default(),
+        Constant::new(RocksDbOptions::default()).boxed(),
+    )
+    .await?;
+
+    let my_generation = 1;
+    let zero_plain_node_id = PlainNodeId::from(0);
+    let mut nodes_configuration =
+        NodesConfiguration::new(Version::MIN, "migration-local-to-replicated".to_owned());
+    let my_node_config = NodeConfig::new(
+        Configuration::pinned().common.node_name().to_owned(),
+        // configure a zero node id to test the migration path for zero node ids
+        PlainNodeId::from(0).with_generation(my_generation),
+        NodeLocation::default(),
+        advertised_address.clone(),
+        Role::MetadataServer.into(),
+        LogServerConfig::default(),
+        MetadataServerConfig::default(),
+    );
+    nodes_configuration.upsert_node(my_node_config);
+
+    let serialized_nodes_configuration = serialize_value(&nodes_configuration)?;
+    local_storage
+        .put(
+            &NODES_CONFIG_KEY,
+            &serialized_nodes_configuration,
+            Precondition::DoesNotExist,
+        )
+        .await?;
+
+    let mut rng = rand::rng();
+    let number_kv_entries = 100;
+    let mut expected_kv_entries: HashMap<_, _> = HashMap::default();
+
+    for _ in 0..number_kv_entries {
+        let random_key = Alphanumeric.sample_string(&mut rng, 10);
+        let key = ByteString::from(random_key);
+        let value = Value {
+            value: rng.next_u32(),
+            version: Version::from(rng.next_u32().saturating_add(1)),
+        };
+        let versioned_value = serialize_value(&value)?;
+
+        local_storage
+            .put(&key, &versioned_value, Precondition::None)
+            .await?;
+        expected_kv_entries.insert(key, value);
+    }
+
+    drop(local_storage);
+    RocksDbManager::get().reset().await.into_test_result()?;
+
+    let metadata_builder = MetadataBuilder::default();
+    assert!(TaskCenter::try_set_global_metadata(
+        metadata_builder.to_metadata()
+    ));
+
+    // start the replicated metadata store and let it migrate from local metadata
+    let mut server_builder = NetworkServerBuilder::default();
+    let health = Health::default();
+
+    let metadata_server = RaftMetadataServer::create(
+        Constant::new(RocksDbOptions::default()).boxed(),
+        None,
+        health.metadata_server_status(),
+        &mut server_builder,
+    )
+    .await?;
+
+    TaskCenter::spawn_child(TaskKind::RpcServer, "node-rpc-server", async move {
+        server_builder
+            .run(health.node_rpc_status(), &bind_address)
+            .await
+    })?;
+    TaskCenter::spawn_child(
+        TaskKind::MetadataServer,
+        "replicated-metadata-server",
+        metadata_server.run().map_err(Into::into),
+    )?;
+
+    let metadata_client_options = MetadataClientOptions {
+        kind: MetadataClientKind::Native {
+            addresses: vec![advertised_address],
+        },
+        ..Default::default()
+    };
+    let metadata_client = create_client(metadata_client_options)
+        .await
+        .into_test_result()?;
+
+    for (key, expected_value) in expected_kv_entries {
+        let actual_value = metadata_client.get::<Value>(key).await?;
+        assert_eq!(actual_value, Some(expected_value))
+    }
+
+    let actual_nodes_configuration = metadata_client
+        .get::<NodesConfiguration>(NODES_CONFIG_KEY.clone())
+        .await?
+        .expect("NodesConfiguration was present in local metadata");
+
+    assert_eq!(actual_nodes_configuration.len(), 1);
+
+    let my_actual_node_config = actual_nodes_configuration
+        .find_node_by_name(Configuration::pinned().common.node_name())
+        .expect("my node config should be present");
+    // validate that the zero node id was migrated to a non-zero value
+    assert_ne!(
+        my_actual_node_config.current_generation.as_plain(),
+        zero_plain_node_id,
+    );
+    assert_eq!(
+        my_actual_node_config.current_generation.generation(),
+        my_generation
+    );
+    assert_eq!(
+        my_actual_node_config
+            .metadata_server_config
+            .metadata_server_state,
+        MetadataServerState::Member
+    );
+
+    // shut down all child tasks
+    let cancellation_token = cancellation_token();
+    cancellation_token.cancel();
+
+    RocksDbManager::get().shutdown().await;
+    Ok(())
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -40,7 +40,6 @@ use restate_metadata_server::{
     BoxedMetadataServer, MetadataServer, MetadataStoreClient, ReadModifyWriteError,
 };
 use restate_types::config::{CommonOptions, Configuration};
-use restate_types::errors::GenericError;
 use restate_types::live::Live;
 use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfiguration};
 #[cfg(feature = "replicated-loglet")]
@@ -110,7 +109,7 @@ pub enum BuildError {
 
     #[error("failed to initialize metadata store client: {0}")]
     #[code(unknown)]
-    MetadataStoreClient(GenericError),
+    MetadataStoreClient(anyhow::Error),
 
     #[error("building metadata store failed: {0}")]
     #[code(unknown)]

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -168,11 +168,6 @@ pub struct RaftOptions {
     #[serde_as(as = "serde_with::DisplayFromStr")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub status_update_interval: humantime::Duration,
-    /// # Migrate local to replicated metadata
-    ///
-    /// If true, then this node will try to provision itself from data of the local metadata server.
-    /// This can only work if the node has been run before with the local metadata server.
-    pub migrate_local_metadata: bool,
 }
 
 impl Default for RaftOptions {
@@ -182,7 +177,6 @@ impl Default for RaftOptions {
             raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
             raft_tick_interval: Duration::from_millis(100).into(),
             status_update_interval: Duration::from_secs(5).into(),
-            migrate_local_metadata: false,
         }
     }
 }

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -168,11 +168,11 @@ pub struct RaftOptions {
     #[serde_as(as = "serde_with::DisplayFromStr")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub status_update_interval: humantime::Duration,
-    /// # Migrate from local metadata server
+    /// # Migrate local to replicated metadata
     ///
     /// If true, then this node will try to provision itself from data of the local metadata server.
     /// This can only work if the node has been run before with the local metadata server.
-    pub migrate_from_local_metadata_server: bool,
+    pub migrate_local_metadata: bool,
 }
 
 impl Default for RaftOptions {
@@ -182,7 +182,7 @@ impl Default for RaftOptions {
             raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
             raft_tick_interval: Duration::from_millis(100).into(),
             status_update_interval: Duration::from_secs(5).into(),
-            migrate_from_local_metadata_server: false,
+            migrate_local_metadata: false,
         }
     }
 }

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -173,6 +173,11 @@ pub struct RaftOptions {
     #[serde_as(as = "serde_with::DisplayFromStr")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub status_update_interval: humantime::Duration,
+    /// # Migrate from local metadata server
+    ///
+    /// If true, then this node will try to provision itself from data of the local metadata server.
+    /// This can only work if the node has been run before with the local metadata server.
+    pub migrate_from_local_metadata_server: bool,
 }
 
 impl Default for RaftOptions {
@@ -182,6 +187,7 @@ impl Default for RaftOptions {
             raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
             raft_tick_interval: Duration::from_millis(100).into(),
             status_update_interval: Duration::from_secs(5).into(),
+            migrate_from_local_metadata_server: false,
         }
     }
 }

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -11,13 +11,12 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use restate_serde_util::NonZeroByteCount;
 use tracing::warn;
 
-use super::{data_dir, CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
+use super::{CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
 
 /// # Metadata store options
 #[serde_as]
@@ -112,10 +111,6 @@ impl MetadataServerOptions {
                 NonZeroUsize::new(1024 * 1024).unwrap()
             })
             .get()
-    }
-
-    pub fn data_dir(&self) -> PathBuf {
-        data_dir("local-metadata-store")
     }
 
     pub fn request_queue_length(&self) -> usize {

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -92,8 +92,7 @@ impl FromStr for GenerationalNodeId {
 }
 
 impl GenerationalNodeId {
-    pub const INITIAL_NODE_ID: GenerationalNodeId =
-        PlainNodeId::MIN_PLAIN_NODE_ID.with_generation(1);
+    pub const INITIAL_NODE_ID: GenerationalNodeId = PlainNodeId::MIN.with_generation(1);
 
     pub fn decode<B: Buf>(mut data: B) -> Self {
         // generational node id is stored as two u32s next to each other, each in big-endian.
@@ -282,7 +281,7 @@ impl From<GenerationalNodeId> for PlainNodeId {
 
 impl PlainNodeId {
     // Start with 1 as plain node id to leave 0 as a special value in the future
-    pub const MIN_PLAIN_NODE_ID: PlainNodeId = PlainNodeId::new(1);
+    pub const MIN: PlainNodeId = PlainNodeId::new(1);
 
     pub const fn new(id: u32) -> PlainNodeId {
         PlainNodeId(id)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,6 +40,7 @@ restate-bifrost = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-fs-util = { workspace = true }
+restate-metadata-server = { workspace = true }
 restate-node = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-service-client = { workspace = true }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -105,9 +105,10 @@ impl WipeMode {
             Some(WipeMode::LocalLoglet) => {
                 restate_fs_util::remove_dir_all_if_exists(config.bifrost.local.data_dir()).await?
             }
-            Some(WipeMode::MetadataServer) => {
-                restate_fs_util::remove_dir_all_if_exists(config.metadata_server.data_dir()).await?
-            }
+            Some(WipeMode::MetadataServer) => restate_fs_util::remove_dir_all_if_exists(
+                restate_metadata_server::local::data_dir(),
+            )
+            .await?,
             Some(WipeMode::All) => restate_fs_util::remove_dir_all_if_exists(node_dir()).await?,
             _ => {}
         }


### PR DESCRIPTION
This commit adds an automatic migration path from a local to a replicated metadata
server. To make use of it, users need to set

metadata-server.type = replicated
metadata-server.migrate_from_local_metadata_server = true

If the replicated metadata server hasn't provisioned before, then it will read the
key-value pairs from the local metadata store and initialize its own storage with it.
It will also run the migration logic for older NodesConfiguration versions (those
that might still have a node id of 0 configured).