### PR TITLE
Allow to change the default provider to replicated

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -520,7 +520,7 @@ impl LogletConfiguration {
                         loglet_id = %params.loglet_id,
                         current_replication = %params.replication,
                         new_replication = %config.replication_property,
-                        "Replicated loglet default replication has can changed, will attempt reconfiguration"
+                        "Replicated loglet default replication has changed, will attempt reconfiguration"
                     );
                     return true;
                 }
@@ -546,8 +546,17 @@ impl LogletConfiguration {
 
                 false
             }
+            (x, y @ ProviderConfiguration::Replicated(_)) => {
+                debug!(
+                    %log_id,
+                    "Changing bifrost provider from {} to {}, will attempt reconfiguration",
+                    x.as_provider(), y.kind(),
+                );
+                true
+            }
             (x, y) => {
                 debug!(
+                    %log_id,
                     "Changing bifrost provider from {} to {} is not supported at the moment. Ignoring reconfiguration request",
                     x.as_provider(), y.kind(),
                 );


### PR DESCRIPTION
This commit allows users to change the default log provider to replicated even if the
cluster has been fully provisioned. This allows users to migrate from a single node
deployment with a local loglet to a replicated loglet and then a multi node deployment.
Additionally, this commit enables the LogsController to react to default provider changes.
If the new default provider is the replicated loglet, then the logs controller will reconfigure
all logs.