### PR TITLE
Update rust-rocksdb to v0.36.0-restate.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7757,8 +7757,8 @@ dependencies = [
 
 [[package]]
 name = "rust-librocksdb-sys"
-version = "0.25.0+9.5.2"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=8f832b7e742e0d826fb9fed05a62e4bd747969bf#8f832b7e742e0d826fb9fed05a62e4bd747969bf"
+version = "0.32.0+9.10.0.restate-1"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=135ed6b16b10ad2f9257cef1d069841860144758#135ed6b16b10ad2f9257cef1d069841860144758"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -7773,8 +7773,8 @@ dependencies = [
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.29.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=8f832b7e742e0d826fb9fed05a62e4bd747969bf#8f832b7e742e0d826fb9fed05a62e4bd747969bf"
+version = "0.36.0-restate.1"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=135ed6b16b10ad2f9257cef1d069841860144758#135ed6b16b10ad2f9257cef1d069841860144758"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.29.0", package = "rust-rocksdb", features = ["multi-threaded-cf", "jemalloc"], git = "https://github.com/restatedev/rust-rocksdb", rev = "8f832b7e742e0d826fb9fed05a62e4bd747969bf" }
+rocksdb = { version = "0.36.0-restate.1", package = "rust-rocksdb", features = ["multi-threaded-cf", "jemalloc"], git = "https://github.com/restatedev/rust-rocksdb", rev = "135ed6b16b10ad2f9257cef1d069841860144758" }
 rstest = "0.24.0"
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }


### PR DESCRIPTION
This brings in updated rust-librocksdb-sys @ v0.32.0+9.10.0.restate-1, which includes updated rocksdb @ v9.10.0.restate-1 rebased on the upstream RocksDB v9.10.0 release.

See: https://github.com/restatedev/rust-rocksdb/tree/v0.36.0-restate.1