### PR TITLE
Reconfigure respect `--sequencer` and `--nodeset` if provider is not supplied

### DIFF
--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -44,7 +44,7 @@ pub struct PatchValueOpts {
     pub patch: String,
 
     /// Expected version for conditional update
-    #[arg(short = 'e', long)]
+    #[arg(long)]
     pub version: Option<u32>,
 
     /// Preview the change without applying it

--- a/tools/restatectl/src/commands/metadata/put.rs
+++ b/tools/restatectl/src/commands/metadata/put.rs
@@ -34,7 +34,7 @@ pub struct PutValueOpts {
     doc: FileOrStdin,
 
     /// Expected version for conditional update
-    #[arg(short = 'e', long)]
+    #[arg(long)]
     version: Option<u32>,
 
     /// Preview the change without applying it


### PR DESCRIPTION
Reconfigure respect `--sequencer` and `--nodeset` if provider is not supplied

Summary:
Respect both the sequencer and nodeset flag if provider is not supplied
as long as the loglet is already using replicated provider.

Also make sure there is noway you can go back to local or in-memory provider
once you go replicated

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2721).
* #2714
* __->__ #2721
* #2719