### PR TITLE
Make LocalMetadataServer not reachable from outside of the process 

### DIFF
--- a/crates/core/src/network/server_builder.rs
+++ b/crates/core/src/network/server_builder.rs
@@ -34,6 +34,10 @@ pub struct NetworkServerBuilder {
 }
 
 impl NetworkServerBuilder {
+    pub fn is_empty(&self) -> bool {
+        self.grpc_routes.is_none() && self.axum_router.is_none()
+    }
+
     pub fn register_grpc_service<S>(
         &mut self,
         svc: S,

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -229,7 +229,7 @@ impl Node {
 
         // update nodes with the addresses of the other nodes
         for node in &mut nodes {
-            *node.metadata_store_client_mut() = MetadataClientKind::Native {
+            *node.metadata_store_client_mut() = MetadataClientKind::Replicated {
                 addresses: node_addresses.clone(),
             }
         }
@@ -249,7 +249,7 @@ impl Node {
         let base_dir = base_dir.into();
 
         // ensure file paths are relative to the base dir
-        if let MetadataClientKind::Native { addresses } =
+        if let MetadataClientKind::Replicated { addresses } =
             &mut self.base_config.common.metadata_client.kind
         {
             for advertised_address in addresses {

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -15,9 +15,8 @@ pub mod local;
 mod metric_definitions;
 pub mod raft;
 
-use crate::grpc::client::GrpcMetadataServerClient;
 use crate::local::LocalMetadataServer;
-use crate::raft::RaftMetadataServer;
+use crate::raft::{create_replicated_metadata_client, RaftMetadataServer};
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
@@ -35,11 +34,11 @@ pub use restate_core::metadata_store::{
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataWriter, ShutdownError};
 use restate_types::config::{
-    Configuration, MetadataClientOptions, MetadataServerKind, MetadataServerOptions, RocksDbOptions,
+    Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind,
 };
-use restate_types::errors::GenericError;
+use restate_types::errors::{GenericError, MaybeRetryableError};
 use restate_types::health::HealthStatus;
-use restate_types::live::BoxedLiveLoad;
+use restate_types::live::Live;
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
@@ -49,6 +48,7 @@ use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use restate_types::{config, GenerationalNodeId, PlainNodeId, Version};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, watch};
 use tonic::Status;
 use tracing::debug;
@@ -81,6 +81,19 @@ pub enum RequestError {
     Encode(#[from] StorageEncodeError),
     #[error("decode error: {0}")]
     Decode(#[from] StorageDecodeError),
+}
+
+impl MaybeRetryableError for RequestError {
+    fn retryable(&self) -> bool {
+        match self {
+            RequestError::Internal(_) => false,
+            RequestError::Unavailable(_, _) => true,
+            RequestError::FailedPrecondition(_) => false,
+            RequestError::InvalidArgument(_) => false,
+            RequestError::Encode(_) => false,
+            RequestError::Decode(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -188,28 +201,56 @@ pub struct ProvisionRequest {
     result_tx: oneshot::Sender<Result<bool, ProvisionError>>,
 }
 
-pub async fn create_metadata_server(
-    metadata_server_options: &MetadataServerOptions,
-    rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+pub async fn create_metadata_server_and_client(
+    config: Live<Configuration>,
     health_status: HealthStatus<MetadataServerStatus>,
     server_builder: &mut NetworkServerBuilder,
-) -> anyhow::Result<BoxedMetadataServer> {
+) -> anyhow::Result<(BoxedMetadataServer, MetadataStoreClient)> {
     metric_definitions::describe_metrics();
-    match metadata_server_options.kind() {
-        MetadataServerKind::Local => LocalMetadataServer::create(
-            metadata_server_options,
-            rocksdb_options,
-            health_status,
-            server_builder,
-        )
-        .await
-        .map_err(anyhow::Error::from)
-        .map(|server| server.boxed()),
+    let rocksdb_options = config
+        .clone()
+        .map(|config| &config.metadata_server.rocksdb)
+        .boxed();
+    let config = config.pinned();
+    match config.metadata_server.kind() {
+        MetadataServerKind::Local => {
+            LocalMetadataServer::create(&config.metadata_server, rocksdb_options, health_status)
+                .await
+                .map_err(anyhow::Error::from)
+                .map(|server| {
+                    let client = server.client();
+                    (server.boxed(), client)
+                })
+        }
         MetadataServerKind::Raft { .. } => {
             RaftMetadataServer::create(rocksdb_options, health_status, server_builder)
                 .await
                 .map_err(anyhow::Error::from)
-                .map(|server| server.boxed())
+                .and_then(|server| {
+                    let metadata_client_options = config.common.metadata_client.clone();
+                    let backoff_policy = metadata_client_options.backoff_policy.clone();
+
+                    let MetadataClientKind::Native { addresses } =
+                        config.common.metadata_client.kind.clone()
+                    else {
+                        anyhow::bail!(
+                            "Detected a possible misconfiguration of the cluster. The \
+                        cluster runs a replicated metadata server but not the native metadata \
+                        client. If you don't want to run a metadata server, then remove the \
+                        metadata-server role. If you want to run the replicated metadata server, \
+                        then configure metadata-client.type = \"replicated\""
+                        );
+                    };
+
+                    Ok((
+                        server.boxed(),
+                        create_replicated_metadata_client(
+                            addresses,
+                            Some(backoff_policy),
+                            Arc::new(metadata_client_options),
+                        ),
+                    ))
+                })
         }
     }
 }
@@ -593,20 +634,20 @@ impl Default for MetadataServerConfiguration {
     }
 }
 
-/// Creates a [`MetadataStoreClient`] for configured metadata store.
+/// Creates a [`MetadataStoreClient`] for the configured metadata store.
 pub async fn create_client(
-    metadata_store_client_options: MetadataClientOptions,
+    metadata_client_options: MetadataClientOptions,
 ) -> anyhow::Result<MetadataStoreClient> {
-    let backoff_policy = Some(metadata_store_client_options.backoff_policy.clone());
+    let backoff_policy = Some(metadata_client_options.backoff_policy.clone());
 
-    let client = match metadata_store_client_options.kind.clone() {
-        config::MetadataClientKind::Native { addresses } => {
-            let inner_client =
-                GrpcMetadataServerClient::new(addresses, metadata_store_client_options);
-            MetadataStoreClient::new(inner_client, backoff_policy)
-        }
+    let client = match metadata_client_options.kind.clone() {
+        config::MetadataClientKind::Native { addresses } => create_replicated_metadata_client(
+            addresses,
+            backoff_policy,
+            Arc::new(metadata_client_options),
+        ),
         config::MetadataClientKind::Etcd { addresses } => {
-            let store = EtcdMetadataStore::new(addresses, &metadata_store_client_options).await?;
+            let store = EtcdMetadataStore::new(addresses, &metadata_client_options).await?;
             MetadataStoreClient::new(store, backoff_policy)
         }
         conf @ config::MetadataClientKind::ObjectStore { .. } => {

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -230,12 +230,12 @@ pub async fn create_metadata_server_and_client(
                     let metadata_client_options = config.common.metadata_client.clone();
                     let backoff_policy = metadata_client_options.backoff_policy.clone();
 
-                    let MetadataClientKind::Native { addresses } =
+                    let MetadataClientKind::Replicated { addresses } =
                         config.common.metadata_client.kind.clone()
                     else {
                         anyhow::bail!(
                             "Detected a possible misconfiguration of the cluster. The \
-                        cluster runs a replicated metadata server but not the native metadata \
+                        cluster runs a replicated metadata server but not the replicated metadata \
                         client. If you don't want to run a metadata server, then remove the \
                         metadata-server role. If you want to run the replicated metadata server, \
                         then configure metadata-client.type = \"replicated\""
@@ -641,7 +641,7 @@ pub async fn create_client(
     let backoff_policy = Some(metadata_client_options.backoff_policy.clone());
 
     let client = match metadata_client_options.kind.clone() {
-        config::MetadataClientKind::Native { addresses } => create_replicated_metadata_client(
+        config::MetadataClientKind::Replicated { addresses } => create_replicated_metadata_client(
             addresses,
             backoff_policy,
             Arc::new(metadata_client_options),

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -12,9 +12,9 @@ use crate::grpc::handler::MetadataServerHandler;
 use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
 use crate::local::storage::RocksDbStorage;
 use crate::{grpc, MetadataServer, MetadataStoreRequest, RequestError, RequestReceiver};
-use restate_core::cancellation_watcher;
 use restate_core::metadata_store::{serialize_value, Precondition};
 use restate_core::network::NetworkServerBuilder;
+use restate_core::{cancellation_watcher, MetadataWriter};
 use restate_rocksdb::RocksError;
 use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
@@ -133,7 +133,7 @@ impl LocalMetadataServer {
 
 #[async_trait::async_trait]
 impl MetadataServer for LocalMetadataServer {
-    async fn run(self) -> anyhow::Result<()> {
+    async fn run(self, _metadata_writer: Option<MetadataWriter>) -> anyhow::Result<()> {
         self.run().await.map_err(Into::into)
     }
 }

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -8,13 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::grpc::handler::MetadataServerHandler;
-use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
 use crate::local::storage::RocksDbStorage;
-use crate::{grpc, MetadataServer, MetadataStoreRequest, RequestError, RequestReceiver};
-use restate_core::metadata_store::{serialize_value, Precondition};
-use restate_core::network::NetworkServerBuilder;
-use restate_core::{cancellation_watcher, MetadataWriter};
+use crate::{MetadataServer, MetadataStoreRequest, RequestError, RequestReceiver, RequestSender};
+use bytestring::ByteString;
+use restate_core::metadata_store::{
+    serialize_value, MetadataStoreClient, Precondition, ProvisionedMetadataStore, ReadError,
+    VersionedValue, WriteError,
+};
+use restate_core::{cancellation_watcher, MetadataWriter, ShutdownError};
 use restate_rocksdb::RocksError;
 use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
@@ -23,9 +24,8 @@ use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration};
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::storage::{StorageCodec, StorageDecodeError, StorageEncodeError};
-use restate_types::PlainNodeId;
-use tokio::sync::mpsc;
-use tonic::codec::CompressionEncoding;
+use restate_types::{PlainNodeId, Version};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, trace};
 
 /// Single node metadata store which stores the key value pairs in RocksDB.
@@ -34,6 +34,7 @@ use tracing::{debug, info, trace};
 /// store in a single thread.
 pub struct LocalMetadataServer {
     storage: RocksDbStorage,
+    request_tx: RequestSender,
     request_rx: RequestReceiver,
     health_status: HealthStatus<MetadataServerStatus>,
 }
@@ -43,25 +44,31 @@ impl LocalMetadataServer {
         options: &MetadataServerOptions,
         updateable_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
         health_status: HealthStatus<MetadataServerStatus>,
-        server_builder: &mut NetworkServerBuilder,
     ) -> Result<Self, RocksError> {
         health_status.update(MetadataServerStatus::StartingUp);
         let (request_tx, request_rx) = mpsc::channel(options.request_queue_length());
 
         let storage = RocksDbStorage::create(options, updateable_rocksdb_options).await?;
 
-        server_builder.register_grpc_service(
-            MetadataServerSvcServer::new(MetadataServerHandler::new(request_tx, None, None))
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip),
-            grpc::FILE_DESCRIPTOR_SET,
-        );
-
         Ok(Self {
             storage,
             health_status,
+            request_tx,
             request_rx,
         })
+    }
+
+    pub fn client(&self) -> MetadataStoreClient {
+        MetadataStoreClient::new(
+            LocalMetadataStoreClient::new(self.request_tx.clone()),
+            Some(
+                Configuration::pinned()
+                    .common
+                    .metadata_client
+                    .backoff_policy
+                    .clone(),
+            ),
+        )
     }
 
     pub async fn run(mut self) -> anyhow::Result<()> {
@@ -240,4 +247,103 @@ pub async fn migrate_nodes_configuration(
     }
 
     Ok(())
+}
+
+struct LocalMetadataStoreClient {
+    request_tx: RequestSender,
+}
+
+impl LocalMetadataStoreClient {
+    fn new(request_tx: RequestSender) -> Self {
+        Self { request_tx }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProvisionedMetadataStore for LocalMetadataStoreClient {
+    async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let get_request = MetadataStoreRequest::Get { key, result_tx };
+        self.request_tx
+            .send(get_request)
+            .await
+            .map_err(|_| ReadError::terminal(ShutdownError))?;
+
+        result_rx
+            .await
+            .map_err(|_| ReadError::terminal(ShutdownError))?
+            .map_err(ReadError::other)
+    }
+
+    async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let get_version_request = MetadataStoreRequest::GetVersion { key, result_tx };
+        self.request_tx
+            .send(get_version_request)
+            .await
+            .map_err(|_| ReadError::terminal(ShutdownError))?;
+
+        result_rx
+            .await
+            .map_err(|_| ReadError::terminal(ShutdownError))?
+            .map_err(ReadError::other)
+    }
+
+    async fn put(
+        &self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let put_request = MetadataStoreRequest::Put {
+            key,
+            value,
+            precondition,
+            result_tx,
+        };
+        self.request_tx
+            .send(put_request)
+            .await
+            .map_err(|_| WriteError::terminal(ShutdownError))?;
+
+        result_rx
+            .await
+            .map_err(|_| WriteError::terminal(ShutdownError))?
+            .map_err(WriteError::from)
+    }
+
+    async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let delete_request = MetadataStoreRequest::Delete {
+            key,
+            precondition,
+            result_tx,
+        };
+        self.request_tx
+            .send(delete_request)
+            .await
+            .map_err(|_| WriteError::terminal(ShutdownError))?;
+
+        result_rx
+            .await
+            .map_err(|_| WriteError::terminal(ShutdownError))?
+            .map_err(WriteError::from)
+    }
+}
+
+impl From<RequestError> for WriteError {
+    fn from(value: RequestError) -> Self {
+        match value {
+            err @ (RequestError::Internal(_)
+            | RequestError::Unavailable(_, _)
+            | RequestError::InvalidArgument(_)) => WriteError::other(err),
+            RequestError::FailedPrecondition(err) => {
+                WriteError::FailedPrecondition(err.to_string())
+            }
+            err @ (RequestError::Encode(_) | RequestError::Decode(_)) => {
+                WriteError::Codec(err.into())
+            }
+        }
+    }
 }

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -117,7 +117,6 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
 
     let metadata_server = RaftMetadataServer::create(
         Constant::new(RocksDbOptions::default()).boxed(),
-        None,
         health.metadata_server_status(),
         &mut server_builder,
     )
@@ -131,7 +130,7 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
     TaskCenter::spawn_child(
         TaskKind::MetadataServer,
         "replicated-metadata-server",
-        metadata_server.run().map_err(Into::into),
+        metadata_server.run(None).map_err(Into::into),
     )?;
 
     let metadata_client_options = MetadataClientOptions {

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -134,7 +134,7 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
     )?;
 
     let metadata_client_options = MetadataClientOptions {
-        kind: MetadataClientKind::Native {
+        kind: MetadataClientKind::Replicated {
             addresses: vec![advertised_address],
         },
         ..Default::default()

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -149,30 +149,25 @@ impl Node {
         let is_provisioned =
             cluster_marker::validate_and_update_cluster_marker(config.common.cluster_name())?;
 
-        let metadata_store_role = if config.has_role(Role::MetadataServer) {
-            Some(
-                restate_metadata_server::create_metadata_server(
-                    &config.metadata_server,
-                    updateable_config
-                        .clone()
-                        .map(|config| &config.metadata_server.rocksdb)
-                        .boxed(),
-                    TaskCenter::with_current(|tc| tc.health().metadata_server_status()),
-                    &mut server_builder,
-                )
-                .await?,
+        let (metadata_store_role, metadata_store_client) = if config.has_role(Role::MetadataServer)
+        {
+            restate_metadata_server::create_metadata_server_and_client(
+                updateable_config.clone(),
+                TaskCenter::with_current(|tc| tc.health().metadata_server_status()),
+                &mut server_builder,
             )
+            .await
+            .map(|(server, client)| (Some(server), client))?
         } else {
-            None
+            let metadata_store_client =
+                restate_metadata_server::create_client(config.common.metadata_client.clone())
+                    .await
+                    .map_err(BuildError::MetadataStoreClient)?;
+            (None, metadata_store_client)
         };
 
-        let metadata_store_client =
-            restate_metadata_server::create_client(config.common.metadata_client.clone())
-                .await
-                .map_err(BuildError::MetadataStoreClient)?;
         let metadata_manager =
             MetadataManager::new(metadata_builder, metadata_store_client.clone());
-
         let mut router_builder = MessageRouterBuilder::default();
         let networking = Networking::new(metadata.clone(), config.networking.clone());
         metadata_manager.register_in_message_router(&mut router_builder);

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -539,7 +539,7 @@ pub struct MetadataClientOptions {
 impl Default for MetadataClientOptions {
     fn default() -> Self {
         Self {
-            kind: MetadataClientKind::Native {
+            kind: MetadataClientKind::Replicated {
                 addresses: vec![DEFAULT_ADVERTISED_ADDRESS
                     .parse()
                     .expect("valid metadata store address")],
@@ -594,8 +594,8 @@ pub enum ObjectStoreCredentials {
     )
 )]
 pub enum MetadataClientKind {
-    /// Store metadata on the native metadata store that runs on nodes with the metadata-server role.
-    Native {
+    /// Store metadata on the replicated metadata store that runs on nodes with the metadata-server role.
+    Replicated {
         #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
         addresses: Vec<AdvertisedAddress>,
     },
@@ -626,7 +626,7 @@ pub enum MetadataClientKind {
 // the `address` configuration param.
 enum MetadataClientKindShadow {
     #[serde(alias = "embedded")]
-    Native {
+    Replicated {
         address: Option<AdvertisedAddress>,
         #[serde(default)]
         addresses: Vec<AdvertisedAddress>,
@@ -652,11 +652,11 @@ impl TryFrom<MetadataClientKindShadow> for MetadataClientKind {
                 bucket,
             },
             MetadataClientKindShadow::Etcd { addresses } => Self::Etcd { addresses },
-            MetadataClientKindShadow::Native { address, addresses } => {
+            MetadataClientKindShadow::Replicated { address, addresses } => {
                 let default_address: AdvertisedAddress =
                     DEFAULT_ADVERTISED_ADDRESS.parse().unwrap();
 
-                Self::Native {
+                Self::Replicated {
                     addresses: match address {
                         Some(address)
                             if addresses.is_empty() || addresses == vec![default_address] =>

--- a/server/tests/raft_metadata_cluster.rs
+++ b/server/tests/raft_metadata_cluster.rs
@@ -55,7 +55,7 @@ async fn raft_metadata_cluster_smoke_test() -> googletest::Result<()> {
         .collect();
 
     let metadata_store_client_options = MetadataClientOptions {
-        kind: MetadataClientKind::Native { addresses },
+        kind: MetadataClientKind::Replicated { addresses },
         ..MetadataClientOptions::default()
     };
     let client = create_client(metadata_store_client_options)
@@ -151,7 +151,7 @@ async fn raft_metadata_cluster_chaos_test() -> googletest::Result<()> {
         .collect();
 
     let metadata_store_client_options = MetadataClientOptions {
-        kind: MetadataClientKind::Native { addresses },
+        kind: MetadataClientKind::Replicated { addresses },
         ..MetadataClientOptions::default()
     };
     let client = create_client(metadata_store_client_options)

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -147,7 +147,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         BinarySource::CargoTest,
         enum_set!(Role::Worker),
     );
-    *worker_3.metadata_store_client_mut() = MetadataClientKind::Native {
+    *worker_3.metadata_store_client_mut() = MetadataClientKind::Replicated {
         addresses: vec![cluster.nodes[0].node_address().clone()],
     };
 
@@ -172,7 +172,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         BinarySource::CargoTest,
         enum_set!(Role::Worker),
     );
-    *worker_3.metadata_store_client_mut() = MetadataClientKind::Native {
+    *worker_3.metadata_store_client_mut() = MetadataClientKind::Replicated {
         addresses: vec![cluster.nodes[0].node_address().clone()],
     };
 

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -21,7 +21,6 @@ use restate_core::network::MessageRouterBuilder;
 use restate_core::{MetadataBuilder, MetadataManager, TaskCenter, TaskKind};
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
-use restate_types::live::Live;
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
 use restate_wal_protocol::Envelope;
 
@@ -74,14 +73,7 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
         let metadata = metadata_builder.to_metadata();
         TaskCenter::try_set_global_metadata(metadata.clone());
 
-        let metadata_store_client = metadata_store::start_metadata_server(
-            config.common.metadata_client.clone(),
-            &config.metadata_server,
-            Live::from_value(config.metadata_server.clone())
-                .map(|c| &c.rocksdb)
-                .boxed(),
-        )
-        .await?;
+        let metadata_store_client = metadata_store::start_metadata_server(config.clone()).await?;
         debug!("Metadata store client created");
 
         let metadata_manager =

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -15,7 +15,6 @@ use tracing::debug;
 
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
-use restate_types::live::Live;
 
 use crate::commands::metadata::{
     create_metadata_store_client, GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts,
@@ -65,14 +64,7 @@ async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericM
         let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
         debug!("RocksDB Initialized");
 
-        let metadata_store_client = metadata_store::start_metadata_server(
-            config.common.metadata_client.clone(),
-            &config.metadata_server,
-            Live::from_value(config.metadata_server.clone())
-                .map(|c| &c.rocksdb)
-                .boxed(),
-        )
-        .await?;
+        let metadata_store_client = metadata_store::start_metadata_server(config.clone()).await?;
         debug!("Metadata store client created");
 
         let value: Option<GenericMetadataValue> = metadata_store_client

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -116,7 +116,7 @@ pub async fn create_metadata_store_client(
                 .iter_role(Role::MetadataServer)
                 .map(|(_, node)| node.address.clone())
                 .collect();
-            restate_types::config::MetadataClientKind::Native { addresses }
+            restate_types::config::MetadataClientKind::Replicated { addresses }
         }
         RemoteServiceType::Etcd => restate_types::config::MetadataClientKind::Etcd {
             addresses: opts.etcd.clone(),

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -18,7 +18,6 @@ use tracing::debug;
 use restate_core::metadata_store::{MetadataStoreClient, Precondition};
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::Configuration;
-use restate_types::live::Live;
 use restate_types::Version;
 
 use crate::commands::metadata::{
@@ -89,14 +88,7 @@ async fn patch_value_direct(
         let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
         debug!("RocksDB Initialized");
 
-        let metadata_store_client = start_metadata_server(
-            config.common.metadata_client.clone(),
-            &config.metadata_server,
-            Live::from_value(config.metadata_server.clone())
-                .map(|c| &c.rocksdb)
-                .boxed(),
-        )
-        .await?;
+        let metadata_store_client = start_metadata_server(config.clone()).await?;
         debug!("Metadata store client created");
 
         let result = patch_value_inner(opts, &patch, &metadata_store_client).await;

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -15,43 +15,45 @@ use restate_core::network::NetworkServerBuilder;
 use restate_core::{TaskCenter, TaskKind};
 use restate_metadata_server::MetadataServer;
 use restate_types::config;
-use restate_types::config::{MetadataClientOptions, MetadataServerOptions, RocksDbOptions};
+use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
-use restate_types::live::BoxedLiveLoad;
+use restate_types::live::Live;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 use restate_types::protobuf::common::NodeRpcStatus;
 
 pub async fn start_metadata_server(
-    mut metadata_store_client_options: MetadataClientOptions,
-    opts: &MetadataServerOptions,
-    updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+    mut config: Configuration,
 ) -> anyhow::Result<MetadataStoreClient> {
     let mut server_builder = NetworkServerBuilder::default();
 
-    let service = restate_metadata_server::create_metadata_server(
-        opts,
-        updateables_rocksdb_options,
+    // right now we only support running a local metadata store
+    let uds = tempfile::tempdir()?.into_path().join("metadata-rpc-server");
+    let bind_address = BindAddress::Uds(uds.clone());
+    config.common.metadata_client.kind = config::MetadataClientKind::Native {
+        addresses: vec![AdvertisedAddress::Uds(uds)],
+    };
+
+    let (service, client) = restate_metadata_server::create_metadata_server_and_client(
+        Live::from_value(config),
         HealthStatus::default(),
         &mut server_builder,
     )
     .await?;
 
-    // right now we only support running a local metadata store
-    let uds = tempfile::tempdir()?.into_path().join("metadata-rpc-server");
-    let bind_address = BindAddress::Uds(uds.clone());
-    metadata_store_client_options.kind = config::MetadataClientKind::Native {
-        addresses: vec![AdvertisedAddress::Uds(uds)],
+    let rpc_server_health = if !server_builder.is_empty() {
+        let rpc_server_health_status = HealthStatus::default();
+        TaskCenter::spawn(TaskKind::RpcServer, "metadata-rpc-server", {
+            let rpc_server_health_status = rpc_server_health_status.clone();
+            async move {
+                server_builder
+                    .run(rpc_server_health_status, &bind_address)
+                    .await
+            }
+        })?;
+        Some(rpc_server_health_status)
+    } else {
+        None
     };
-
-    let rpc_server_health_status = HealthStatus::default();
-    TaskCenter::spawn(TaskKind::RpcServer, "metadata-rpc-server", {
-        let rpc_server_health_status = rpc_server_health_status.clone();
-        async move {
-            server_builder
-                .run(rpc_server_health_status, &bind_address)
-                .await
-        }
-    })?;
 
     TaskCenter::spawn(
         TaskKind::MetadataServer,
@@ -61,14 +63,11 @@ pub async fn start_metadata_server(
             Ok(())
         },
     )?;
-    info!("Waiting for local metadata store to startup");
-    rpc_server_health_status
-        .wait_for_value(NodeRpcStatus::Ready)
-        .await;
 
-    let client = restate_metadata_server::create_client(metadata_store_client_options)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))?;
+    if let Some(rpc_server_health) = rpc_server_health {
+        info!("Waiting for local metadata store to startup");
+        rpc_server_health.wait_for_value(NodeRpcStatus::Ready).await;
+    }
 
     Ok(client)
 }

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -29,7 +29,7 @@ pub async fn start_metadata_server(
     // right now we only support running a local metadata store
     let uds = tempfile::tempdir()?.into_path().join("metadata-rpc-server");
     let bind_address = BindAddress::Uds(uds.clone());
-    config.common.metadata_client.kind = config::MetadataClientKind::Native {
+    config.common.metadata_client.kind = config::MetadataClientKind::Replicated {
         addresses: vec![AdvertisedAddress::Uds(uds)],
     };
 

--- a/tools/restatectl/src/environment/metadata_store.rs
+++ b/tools/restatectl/src/environment/metadata_store.rs
@@ -32,7 +32,6 @@ pub async fn start_metadata_server(
         opts,
         updateables_rocksdb_options,
         HealthStatus::default(),
-        None,
         &mut server_builder,
     )
     .await?;
@@ -58,7 +57,7 @@ pub async fn start_metadata_server(
         TaskKind::MetadataServer,
         "local-metadata-server",
         async move {
-            service.run().await?;
+            service.run(None).await?;
             Ok(())
         },
     )?;


### PR DESCRIPTION
This is probably for after the release of 1.2.0.

This commit removes the grpc interface from the LocalMetadataServer so
that it is no longer reachable from outside of the process. This is a
precaution to prevent users from using the LocalMetadataServer across
multiple processes.

This fixes https://github.com/restatedev/restate/issues/2717.