### PR TITLE
Unify the `range input` for some ids

### DIFF
--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -21,16 +21,16 @@ use restate_types::nodes_config::NodesConfiguration;
 use restate_types::replicated_loglet::{LogNodeSetExt, ReplicatedLogletParams};
 use restate_types::Versioned;
 
-use super::LogIdRange;
 use crate::commands::log;
 use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "describe_logs")]
 pub struct DescribeLogIdOpts {
     /// The log id or range to describe, e.g. "0", "1-4"; all logs are shown by default
-    #[arg(value_parser = value_parser!(LogIdRange))]
-    log_id: Vec<LogIdRange>,
+    #[arg()]
+    log_id: Vec<RangeParam>,
 
     /// The first segment id to display
     #[arg(long)]
@@ -73,7 +73,7 @@ async fn describe_logs(
     let log_ids = if opts.log_id.is_empty() {
         logs.iter()
             .sorted_by(|a, b| Ord::cmp(a.0, b.0))
-            .map(|(id, _)| LogIdRange::from(id))
+            .map(|(id, _)| RangeParam::from(*id))
             .collect::<Vec<_>>()
     } else {
         opts.log_id.clone()

--- a/tools/restatectl/src/commands/log/find_tail.rs
+++ b/tools/restatectl/src/commands/log/find_tail.rs
@@ -21,15 +21,15 @@ use restate_cli_util::ui::console::StyledTable;
 use restate_types::nodes_config::Role;
 use tonic::IntoRequest;
 
-use super::LogIdRange;
 use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "find_tail")]
 pub struct FindTailOpts {
-    /// The log id(s) to find its tail.
+    /// The log id or range to find its tail, e.g. "0", "1-4".
     #[arg(required = true)]
-    log_id: Vec<LogIdRange>,
+    log_id: Vec<RangeParam>,
 }
 
 async fn find_tail(connection: &ConnectionInfo, opts: &FindTailOpts) -> anyhow::Result<()> {

--- a/tools/restatectl/src/commands/snapshot/create_snapshot.rs
+++ b/tools/restatectl/src/commands/snapshot/create_snapshot.rs
@@ -10,30 +10,80 @@
 
 use anyhow::Context;
 use cling::prelude::*;
-use tonic::codec::CompressionEncoding;
+use tracing::error;
 
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_admin::cluster_controller::protobuf::CreatePartitionSnapshotRequest;
 use restate_cli_util::c_println;
+use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
+use restate_core::protobuf::node_ctl_svc::GetMetadataRequest;
+use restate_types::identifiers::PartitionId;
 use restate_types::nodes_config::Role;
+use restate_types::partition_table::PartitionTable;
+use restate_types::protobuf::common::MetadataKind;
+use restate_types::storage::StorageCodec;
+use tonic::codec::CompressionEncoding;
 
 use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(visible_alias = "create")]
 #[cling(run = "create_snapshot")]
 pub struct CreateSnapshotOpts {
-    /// The partition to snapshot
-    #[arg(short, long)]
-    partition_id: u16,
+    /// The partition id or range to snapshot, e.g. "0", "1-4".
+    /// All partitions if not provided
+    #[arg()]
+    partition_id: Vec<RangeParam>,
 }
 
 async fn create_snapshot(
     connection: &ConnectionInfo,
     opts: &CreateSnapshotOpts,
 ) -> anyhow::Result<()> {
+    let ids: Vec<_> = if opts.partition_id.is_empty() {
+        let mut response = connection
+            .try_each(None, |channel| async move {
+                let mut client = NodeCtlSvcClient::new(channel.clone())
+                    .accept_compressed(CompressionEncoding::Gzip)
+                    .send_compressed(CompressionEncoding::Gzip);
+                client
+                    .get_metadata(GetMetadataRequest {
+                        kind: MetadataKind::PartitionTable.into(),
+                        sync: false,
+                    })
+                    .await
+            })
+            .await?
+            .into_inner();
+
+        let partition_table: PartitionTable = StorageCodec::decode(&mut response.encoded)?;
+
+        partition_table.partition_ids().cloned().collect()
+    } else {
+        opts.partition_id
+            .iter()
+            .flatten()
+            .map(|id| PartitionId::new_unchecked(id as u16))
+            .collect()
+    };
+
+    for partition_id in ids {
+        // make sure partition_id fits in a u16
+        if let Err(err) = inner_create_snapshot(connection, partition_id).await {
+            error!("Failed to create snapshot for partition {partition_id}: {err}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn inner_create_snapshot(
+    connection: &ConnectionInfo,
+    partition_id: PartitionId,
+) -> anyhow::Result<()> {
     let request = CreatePartitionSnapshotRequest {
-        partition_id: opts.partition_id as u32,
+        partition_id: partition_id.into(),
     };
 
     let response = connection
@@ -48,7 +98,10 @@ async fn create_snapshot(
         .context("Failed to request snapshot")?
         .into_inner();
 
-    c_println!("Snapshot created: {}", response.snapshot_id);
+    c_println!(
+        "Snapshot created for partition {partition_id}: {}",
+        response.snapshot_id
+    );
 
     Ok(())
 }

--- a/tools/restatectl/src/util.rs
+++ b/tools/restatectl/src/util.rs
@@ -8,8 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    num::ParseIntError,
+    ops::RangeInclusive,
+    str::FromStr,
+};
 
+use cling::{prelude::Parser, Collect};
 use tonic::transport::Channel;
 
 use restate_cli_util::CliContext;
@@ -68,4 +74,80 @@ pub fn write_leaf<W: fmt::Write>(
     let depth = depth + 1;
     let chr = if last { '└' } else { '├' };
     writeln!(w, "{chr:>depth$} {title}: {value}")
+}
+
+#[derive(Parser, Collect, Clone, Debug)]
+pub struct RangeParam {
+    from: u32,
+    to: u32,
+}
+
+impl RangeParam {
+    fn new(from: u32, to: u32) -> Result<Self, RangeParamError> {
+        if from > to {
+            Err(RangeParamError::InvalidRange(from, to))
+        } else {
+            Ok(RangeParam { from, to })
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = u32> {
+        self.from..=self.to
+    }
+}
+
+impl<T> From<T> for RangeParam
+where
+    T: Into<u32>,
+{
+    fn from(value: T) -> Self {
+        let id = value.into();
+        Self::new(id, id).expect("equal values")
+    }
+}
+
+impl IntoIterator for RangeParam {
+    type IntoIter = RangeInclusive<u32>;
+    type Item = u32;
+    fn into_iter(self) -> Self::IntoIter {
+        self.from..=self.to
+    }
+}
+
+impl IntoIterator for &RangeParam {
+    type IntoIter = RangeInclusive<u32>;
+    type Item = u32;
+    fn into_iter(self) -> Self::IntoIter {
+        self.from..=self.to
+    }
+}
+
+impl FromStr for RangeParam {
+    type Err = RangeParamError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split("-").collect();
+        match parts.len() {
+            1 => {
+                let n = parts[0].parse()?;
+                Ok(RangeParam::new(n, n)?)
+            }
+            2 => {
+                let from = parts[0].parse()?;
+                let to = parts[1].parse()?;
+                Ok(RangeParam::new(from, to)?)
+            }
+            _ => Err(RangeParamError::InvalidSyntax(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum RangeParamError {
+    #[error("Invalid id range: {0}..{1} start must be <= end range")]
+    InvalidRange(u32, u32),
+    #[error("Invalid range syntax '{0}'")]
+    InvalidSyntax(String),
+    #[error(transparent)]
+    ParseError(#[from] ParseIntError),
 }


### PR DESCRIPTION
Unify the `range input` for some ids

Summary:
- Support parsing an "range" input.
- Handle id range in some common operations
  - `logs describe`
  - `logs find-tail`
  - `logs reconfigure`
  - `snapshots create-snapshot`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2723).
* #2714
* __->__ #2723