### PR TITLE
Avoid per invocation info logging

### DIFF
--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -18,7 +18,7 @@ use metrics::{counter, histogram};
 use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use tracing::{info, trace, trace_span, Instrument};
+use tracing::{debug, trace, trace_span, Instrument};
 
 use super::path_parsing::{InvokeType, ServiceRequestType, TargetType};
 use super::tracing::prepare_tracing_span;
@@ -144,7 +144,7 @@ where
             let ingress_span_context =
                 prepare_tracing_span(&invocation_id, &invocation_target, &req);
 
-            info!("Processing ingress request");
+            debug!("Processing ingress request");
 
             let (parts, body) = req.into_parts();
 

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -47,7 +47,7 @@ use std::future::poll_fn;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 ///  Provides the value of the invocation id
 const INVOCATION_ID_HEADER_NAME: HeaderName = HeaderName::from_static("x-restate-invocation-id");
@@ -129,7 +129,7 @@ where
 
         let journal_size = journal_metadata.length;
 
-        info!(
+        debug!(
             restate.invocation.id = %self.invocation_task.invocation_id,
             deployment.address = %deployment.metadata.address_display(),
             deployment.service_protocol_version = %self.service_protocol_version.as_repr(),

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -59,7 +59,7 @@ use std::ops::Deref;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 ///  Provides the value of the invocation id
 const INVOCATION_ID_HEADER_NAME: HeaderName = HeaderName::from_static("x-restate-invocation-id");
@@ -141,7 +141,7 @@ where
 
         let journal_size = journal_metadata.length;
 
-        info!(
+        debug!(
             restate.invocation.id = %self.invocation_task.invocation_id,
             deployment.address = %deployment.metadata.address_display(),
             deployment.service_protocol_version = %self.service_protocol_version.as_repr(),


### PR DESCRIPTION
This commit tunes down the logging of the service_protocol_runner and the service_handler. Instead of logging invocations on the info level, we are now logging it on debug level.