### PR TITLE
Add pass-through parameters for S3 client configuration

### DIFF
--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -342,7 +342,7 @@ impl StorageOptions {
         super::data_dir("pp-snapshots")
     }
 
-    pub fn persist_lsn_interval(&self) -> Option<std::time::Duration> {
+    pub fn persist_lsn_interval(&self) -> Option<Duration> {
         if self.persist_lsn_interval.is_zero() {
             None
         } else {
@@ -410,6 +410,31 @@ pub struct SnapshotsOptions {
     ///
     /// Default: `None` - automatic snapshots are disabled by default
     pub snapshot_interval_num_records: Option<NonZeroU64>,
+
+    /// The AWS configuration profile to use for S3 object store destinations.
+    pub aws_profile: Option<String>,
+
+    /// AWS region to use with S3 object store destinations.
+    pub aws_region: Option<String>,
+
+    /// AWS access key. We strongly recommend against using long-lived credentials; set up a
+    /// configuration profile with a role-based session credentials provider instead.
+    pub aws_access_key_id: Option<String>,
+
+    /// AWS secret key. We strongly recommend against using long-lived credentials; set up a
+    /// configuration profile with a role-based session credentials provider instead.
+    pub aws_secret_access_key: Option<String>,
+
+    /// AWS session token. We strongly recommend against using long-lived credentials; set up a
+    /// configuration profile with a role-based session credentials provider instead.
+    pub aws_session_token: Option<String>,
+
+    /// AWS endpoint URL for S3 object store destinations. Some S3-compatible stores may require
+    /// you to use this.
+    pub aws_endpoint_url: Option<String>,
+
+    /// Allow plain HTTP to be used with the object store endpoint.
+    pub aws_allow_http: Option<bool>,
 }
 
 fn is_default_snapshots_options(opts: &SnapshotsOptions) -> bool {

--- a/crates/worker/src/partition/snapshots/repository.rs
+++ b/crates/worker/src/partition/snapshots/repository.rs
@@ -620,10 +620,7 @@ async fn create_object_store_client(
             }
 
             None => {
-                let default_region = DefaultRegionChain::builder()
-                    .build()
-                    .region()
-                    .await;
+                let default_region = DefaultRegionChain::builder().build().region().await;
 
                 let region = options
                     .aws_region

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -11,7 +11,7 @@
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use tracing::{debug, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use restate_core::worker_api::SnapshotError;
 use restate_partition_store::snapshots::{
@@ -42,9 +42,10 @@ impl SnapshotPartitionTask {
 
         result
             .inspect(|metadata| {
-                debug!(
+                info!(
                     archived_lsn = %metadata.min_applied_lsn,
-                    "Partition snapshot created"
+                    snapshot_id = %metadata.snapshot_id,
+                    "Created partition snapshot"
                 );
             })
             .inspect_err(|err| {


### PR DESCRIPTION
This change enables a separate profile - or granular explicit configuration - to be used with the snapshot repository. This is helpful when using a non-AWS S3-compatible object store and in particular, helps avoid interfering with the AWS configuration needed by the Lambda invoker.

```toml
[worker.snapshots]
aws_profile = "profile"

# or, explicitly control each setting
aws_allow_http = true
aws_region = "..."
aws_access_key_id = "..."
aws_secret_access_key = "..."
```

The logic here will be to either use whatever creds are available, in the conventional order of precedence (env vars, config profile, EC2 metadata service, ...).