### PR TITLE
[LogServer] Support for data-loss transition

### DIFF
--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -183,11 +183,11 @@ impl RaftMetadataServer {
             .map_err(|err| BuildError::InitStorage(err.to_string()))?
         {
             if storage_marker.id() != Configuration::pinned().common.node_name() {
-                return Err(BuildError::InitStorage(format!("StorageMarker does not match our own node name. Found node name '{}' while our node name is '{}'", storage_marker.id(), Configuration::pinned().common.node_name())));
+                return Err(BuildError::InitStorage(format!("metadata-server storage marker was found but it was created by another node. Found node name '{}' while this node name is '{}'", storage_marker.id(), Configuration::pinned().common.node_name())));
             } else {
                 debug!(
-                    "Found matching StorageMarker in raft-storage, written at '{}'",
-                    storage_marker.created_at()
+                    "Found matching metadata-server storage marker in raft-storage, written at '{}'",
+                    storage_marker.created_at().to_rfc2822()
                 );
             }
         }
@@ -816,7 +816,7 @@ impl Member {
         }
 
         if self.is_member_plain_node_id(joining_member_id.node_id) {
-            let warning = format!("Node '{}' has registered before with a different storage id. This indicates that this node has lost it's disk. Rejecting the join attempt.", joining_member_id);
+            let warning = format!("Node '{}' has registered before with a different storage id. This indicates that this node has lost its disk. Rejecting the join attempt.", joining_member_id);
             warn!(warning);
             let _ = response_tx.send(Err(JoinClusterError::Internal(warning)));
             return;


### PR DESCRIPTION

- Log-server auto-transitions into `data-loss` if it detected that its marker is lost
- log-server rejects to start if the not has lost its marker and not in provisioning state

Note that this still doesn't mark the node as data-loss if corruption was detected in rocksdb. Current behaviour is that the log-server will fail to start but the node remains in read-write.

If the node detected marker loss, this is what it prints on the log
```
on rs:worker-8
2025-02-14T09:40:24.606443Z WARN restate_log_server::service
  Detected data loss for log-server of my node N1. The log-server marker is missing, storage-state was read-write, will transition into `data-loss`
on rs:worker-11
  in restate_log_server::service::provision_node
2025-02-14T09:40:24.609743Z ERROR restate_core::task_center
  Shutting down: task 4 failed with: Node cannot start a log-server on N1, it has detected that it has lost its data. storage-state is `data-loss`
    kind: SystemBoot
    name: "init"
on rs:worker-5
2025-02-14T09:40:24.609794Z WARN restate_core::task_center
  ** Shutdown requested
    reason: task init failed and requested a shutdown
```

And on restart:
```
2025-02-14T09:42:54.172461Z ERROR restate_core::task_center
  Shutting down: task 4 failed with: A previous generation of my node N1 has marked this log-server's storage-state as `data-loss`.If this is a new node, please choose a different node-name to provision it as a new node
    kind: SystemBoot
    name: "init"
```

The node will start if log-server role was removed, albeit the cluster will spew many networking warnings due to log-server messages not being registered. Handling this scenario is a separate issue.
