### PR TITLE
Harden `restatectl reconfigure` and avoid sending full LogletParams

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -99,7 +99,17 @@ message ChainExtension {
   optional uint32 segment_index = 2;
   // check `ProviderKind` for possible values.
   string provider = 4;
+
+  // [deprecated] We return an error if this
+  // field is set.
   string params = 5;
+
+  // replication_property is required if provider=="replicated"
+  optional restate.cluster.ReplicationProperty replication = 6;
+  // optional if provider=="replicated", otherwise ignored
+  optional restate.common.NodeId sequencer = 7;
+  // optional if provider="replicated", otherwise ignored
+  repeated restate.common.NodeId nodeset = 8;
 }
 
 message SealAndExtendChainRequest {


### PR DESCRIPTION
Harden `restatectl reconfigure` and avoid sending full LogletParams

Summary:
- Arguments provided to this command (in case of replicated provider) act as "hints" to
the node to consider during replication. It still possible that the node decides to
use more nodes or different than the provided nodeset
- `sequencer` can also be a PlainNodeId
- Most arguments are optional in case previous loglet is a replicated loglet, Otherwise the user needs
  to provide most arguments
