### PR TITLE
CreateSnapshot RPC returns min applied LSN

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -87,7 +87,10 @@ message TrimLogRequest {
 
 message CreatePartitionSnapshotRequest { uint32 partition_id = 1; }
 
-message CreatePartitionSnapshotResponse { string snapshot_id = 1; }
+message CreatePartitionSnapshotResponse {
+  string snapshot_id = 1;
+  uint64 min_applied_lsn = 2;
+}
 
 message ChainExtension {
   // segment_index will be automatically selected (to the index of last segment)

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -18,6 +18,7 @@ use restate_types::identifiers::PartitionId;
 use restate_types::logs::metadata::{Logs, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, NODES_CONFIG_KEY};
+use restate_types::net::partition_processor_manager::Snapshot;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::protobuf::cluster::ClusterConfiguration;
 use restate_types::storage::{StorageCodec, StorageEncode};
@@ -179,8 +180,12 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 info!("Failed creating partition snapshot: {err}");
                 Err(Status::internal(err.to_string()))
             }
-            Ok(snapshot_id) => Ok(Response::new(CreatePartitionSnapshotResponse {
+            Ok(Snapshot {
+                snapshot_id,
+                min_applied_lsn,
+            }) => Ok(Response::new(CreatePartitionSnapshotResponse {
                 snapshot_id: snapshot_id.to_string(),
+                min_applied_lsn: min_applied_lsn.as_u64(),
             })),
         }
     }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -45,11 +45,11 @@ use restate_core::{
 use restate_types::cluster::cluster_state::ClusterState;
 use restate_types::config::{AdminOptions, Configuration};
 use restate_types::health::HealthStatus;
-use restate_types::identifiers::{PartitionId, SnapshotId};
+use restate_types::identifiers::PartitionId;
 use restate_types::live::Live;
 use restate_types::logs::{LogId, LogletId, Lsn};
 use restate_types::net::metadata::MetadataKind;
-use restate_types::net::partition_processor_manager::CreateSnapshotRequest;
+use restate_types::net::partition_processor_manager::{CreateSnapshotRequest, Snapshot};
 use restate_types::protobuf::common::AdminStatus;
 use restate_types::{GenerationalNodeId, Version};
 
@@ -169,7 +169,7 @@ enum ClusterControllerCommand {
     },
     CreateSnapshot {
         partition_id: PartitionId,
-        response_tx: oneshot::Sender<anyhow::Result<SnapshotId>>,
+        response_tx: oneshot::Sender<anyhow::Result<Snapshot>>,
     },
     UpdateClusterConfiguration {
         partition_replication: PartitionReplication,
@@ -221,7 +221,7 @@ impl ClusterControllerHandle {
     pub async fn create_partition_snapshot(
         &self,
         partition_id: PartitionId,
-    ) -> Result<Result<SnapshotId, anyhow::Error>, ShutdownError> {
+    ) -> Result<Result<Snapshot, anyhow::Error>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let _ = self
@@ -369,7 +369,7 @@ impl<T: TransportConnect> Service<T> {
     async fn create_partition_snapshot(
         &self,
         partition_id: PartitionId,
-        response_tx: oneshot::Sender<anyhow::Result<SnapshotId>>,
+        response_tx: oneshot::Sender<anyhow::Result<Snapshot>>,
     ) {
         let cluster_state = self.cluster_state_refresher.get_cluster_state();
 
@@ -649,7 +649,7 @@ where
         &mut self,
         node_id: GenerationalNodeId,
         partition_id: PartitionId,
-    ) -> anyhow::Result<SnapshotId> {
+    ) -> anyhow::Result<Snapshot> {
         // todo(pavel): make snapshot RPC timeout configurable, especially if this includes remote upload in the future
         let response = tokio::time::timeout(
             Duration::from_secs(90),

--- a/crates/core/src/worker_api/partition_processor_manager.rs
+++ b/crates/core/src/worker_api/partition_processor_manager.rs
@@ -13,6 +13,7 @@ use std::io;
 
 use tokio::sync::{mpsc, oneshot};
 
+use restate_types::logs::Lsn;
 use restate_types::{
     cluster::cluster_state::PartitionProcessorStatus,
     identifiers::{PartitionId, SnapshotId},
@@ -68,6 +69,7 @@ pub type SnapshotResult = Result<SnapshotCreated, SnapshotError>;
 #[display("{}", snapshot_id)]
 pub struct SnapshotCreated {
     pub snapshot_id: SnapshotId,
+    pub min_applied_lsn: Lsn,
     pub partition_id: PartitionId,
 }
 

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cluster::cluster_state::RunMode;
 use crate::identifiers::{PartitionId, SnapshotId};
+use crate::logs::Lsn;
 use crate::net::define_rpc;
 use crate::net::{define_message, TargetName};
 use crate::Version;
@@ -74,7 +75,13 @@ pub struct CreateSnapshotRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateSnapshotResponse {
-    pub result: Result<SnapshotId, SnapshotError>,
+    pub result: Result<Snapshot, SnapshotError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub snapshot_id: SnapshotId,
+    pub min_applied_lsn: Lsn,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -761,6 +761,7 @@ impl PartitionProcessorManager {
                     metadata.partition_id,
                     Ok(SnapshotCreated {
                         snapshot_id: metadata.snapshot_id,
+                        min_applied_lsn: metadata.min_applied_lsn,
                         partition_id: metadata.partition_id,
                     }),
                 )

--- a/crates/worker/src/partition_processor_manager/message_handler.rs
+++ b/crates/worker/src/partition_processor_manager/message_handler.rs
@@ -12,7 +12,7 @@ use restate_core::network::{Incoming, MessageHandler};
 use restate_core::worker_api::ProcessorsManagerHandle;
 use restate_core::{TaskCenter, TaskKind};
 use restate_types::net::partition_processor_manager::{
-    CreateSnapshotRequest, CreateSnapshotResponse, SnapshotError,
+    CreateSnapshotRequest, CreateSnapshotResponse, Snapshot, SnapshotError,
 };
 use tracing::warn;
 
@@ -46,7 +46,10 @@ impl MessageHandler for PartitionProcessorManagerMessageHandler {
 
                 match create_snapshot_result.as_ref() {
                     Ok(snapshot) => msg.to_rpc_response(CreateSnapshotResponse {
-                        result: Ok(snapshot.snapshot_id),
+                        result: Ok(Snapshot {
+                            snapshot_id: snapshot.snapshot_id,
+                            min_applied_lsn: snapshot.min_applied_lsn,
+                        }),
                     }),
                     Err(err) => msg.to_rpc_response(CreateSnapshotResponse {
                         result: Err(SnapshotError::SnapshotCreationFailed(err.to_string())),

--- a/tools/restatectl/src/commands/snapshot/create_snapshot.rs
+++ b/tools/restatectl/src/commands/snapshot/create_snapshot.rs
@@ -99,8 +99,9 @@ async fn inner_create_snapshot(
         .into_inner();
 
     c_println!(
-        "Snapshot created for partition {partition_id}: {}",
-        response.snapshot_id
+        "Snapshot created for partition {partition_id}: {} (LSN >= {})",
+        response.snapshot_id,
+        response.min_applied_lsn,
     );
 
     Ok(())


### PR DESCRIPTION
This enables the restatectl tool to print the minimum included LSN when ad-hoc snapshots are created.

This also enables the trim gap test to trim right up to the snapshotted LSN.