### PR TITLE
[restatectl] Improve performance and information display with unprovisioned clusters or under partial node connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7627,6 +7627,7 @@ dependencies = [
  "crossterm 0.27.0",
  "ctrlc",
  "diff",
+ "futures",
  "futures-util",
  "itertools 0.14.0",
  "json-patch",

--- a/crates/cli-util/src/opts.rs
+++ b/crates/cli-util/src/opts.rs
@@ -16,7 +16,7 @@ use cling::Collect;
 
 use restate_core::network::net_util::CommonClientConnectionOptions;
 
-const DEFAULT_CONNECT_TIMEOUT: u64 = 5_000;
+const DEFAULT_CONNECT_TIMEOUT: u64 = 3_000;
 const DEFAULT_REQUEST_TIMEOUT: u64 = 13_000;
 
 #[derive(ValueEnum, Clone, Copy, Default, PartialEq, Eq)]

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -44,6 +44,7 @@ cling = { workspace = true }
 crossterm = { version = "0.27.0" }
 ctrlc = { version = "3.4" }
 diff = "0.1.13"
+futures = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 json-patch = "2.0.0"

--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -34,7 +34,7 @@ pub async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> any
 
     let mut logs_table = Table::new_styled();
 
-    c_println!("Log chain {}", logs.version());
+    c_println!("Logs {}", logs.version());
 
     write_default_provider(
         &mut Console::stdout(),
@@ -45,29 +45,33 @@ pub async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> any
     // sort by log-id for display
     let logs: BTreeMap<LogId, &Chain> = logs.iter().map(|(id, chain)| (*id, chain)).collect();
 
-    for (log_id, chain) in logs {
-        let params = deserialize_replicated_log_params(&chain.tail());
-        logs_table.add_row(vec![
-            Cell::new(log_id),
-            Cell::new(format!("{}", &chain.tail().base_lsn)),
-            Cell::new(format!("{:?}", chain.tail().config.kind)),
-            render_loglet_params(&params, |p| Cell::new(p.loglet_id)),
-            render_loglet_params(&params, |p| Cell::new(format!("{:#}", p.replication))),
-            render_loglet_params(&params, |p| Cell::new(format!("{:#}", p.sequencer))),
-            render_loglet_params(&params, |p| Cell::new(format!("{:#}", p.nodeset))),
-        ]);
-    }
+    if logs.is_empty() {
+        c_println!("No logs found. Has the cluster been provisioned yet?");
+    } else {
+        for (log_id, chain) in logs {
+            let params = deserialize_replicated_log_params(&chain.tail());
+            logs_table.add_row(vec![
+                Cell::new(log_id),
+                Cell::new(format!("{}", &chain.tail().base_lsn)),
+                Cell::new(format!("{:?}", chain.tail().config.kind)),
+                render_loglet_params(&params, |p| Cell::new(p.loglet_id)),
+                render_loglet_params(&params, |p| Cell::new(format!("{:#}", p.replication))),
+                render_loglet_params(&params, |p| Cell::new(format!("{:#}", p.sequencer))),
+                render_loglet_params(&params, |p| Cell::new(format!("{:#}", p.nodeset))),
+            ]);
+        }
 
-    logs_table.set_styled_header(vec![
-        "L-ID",
-        "FROM-LSN",
-        "KIND",
-        "LOGLET-ID",
-        "REPLICATION",
-        "SEQUENCER",
-        "NODESET",
-    ]);
-    c_println!("{}", logs_table);
+        logs_table.set_styled_header(vec![
+            "L-ID",
+            "FROM-LSN",
+            "KIND",
+            "LOGLET-ID",
+            "REPLICATION",
+            "SEQUENCER",
+            "NODESET",
+        ]);
+        c_println!("{}", logs_table);
+    }
 
     Ok(())
 }

--- a/tools/restatectl/src/commands/log/reconfigure.rs
+++ b/tools/restatectl/src/commands/log/reconfigure.rs
@@ -157,7 +157,7 @@ async fn inner_reconfigure(
     c_println!(" ├ Tail LSN: {}", sealed_segment.tail_offset);
     c_println!(" ├ Provider: {}", sealed_segment.provider);
     let Ok(provider) = ProviderKind::from_str(&sealed_segment.provider, true) else {
-        c_eprintln!("Unkown provider type '{}'", sealed_segment.provider);
+        c_eprintln!("Unknown provider type '{}'", sealed_segment.provider);
         return Ok(());
     };
 
@@ -200,7 +200,7 @@ fn replicated_loglet_params(
         ReplicatedLogletParams {
             loglet_id,
             nodeset: if opts.nodeset.is_empty() {
-                anyhow::bail!("Missing nodeset. Nodeset is required if last segment is not of replicated type");
+                bail!("Missing nodeset. Nodeset is required if last segment is not of replicated type");
             } else {
                 NodeSet::from_iter(opts.nodeset.iter().cloned())
             },

--- a/tools/restatectl/src/commands/metadata_server/status.rs
+++ b/tools/restatectl/src/commands/metadata_server/status.rs
@@ -70,7 +70,10 @@ pub async fn list_metadata_servers(connection: &ConnectionInfo) -> anyhow::Resul
                     (node_id, metadata_store_status)
                 }
             });
-    let results = join_all(futures).await;
+    let results = join_all(futures)
+        .await
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
 
     for (node_id, metadata_store_status) in results {
         let status = match metadata_store_status {

--- a/tools/restatectl/src/commands/metadata_server/status.rs
+++ b/tools/restatectl/src/commands/metadata_server/status.rs
@@ -119,6 +119,7 @@ pub async fn list_metadata_servers(connection: &ConnectionInfo) -> anyhow::Resul
         ]);
     }
 
+    c_println!("Metadata service");
     c_println!("{}", metadata_nodes_table);
 
     if !unreachable_nodes.is_empty() {


### PR DESCRIPTION
This PR aims to improve the overall responsiveness of `restatectl` with clusters that are still busy provisioning or otherwise only partially connected to the host running the tool.

- iterating over the nodes for nodes config or metadata remembers unresponsive nodes
- Metadata status polls the known metadata role servers concurrently, respecting unreachable nodes flagged by prior connections
- overall CLI connect timeout is reduced to 3s (from 5s)
- we now print a heading for the Metadata section of `restatectl status` to visually separate it from the others
- general sprinkling of debug logging

Further work:

- update `get_latest_metadata` to gather `IdentResponse`s concurrently and cache them (so they can be reused between get nodes and logs)
- be smarter with contacting nodes based on the returned status

---

## Testing

Single alive node of a three-node cluster (not yet provisioned):

```
❯ rc st -s node1.cluster.orb.local:5122
Node Configuration (v3)
 NODE  GEN  NAME   ADDRESS                               ROLES                                         
 N1    2    node1  http://node1.cluster.orb.local:5122/  admin | log-server | metadata-server | worker 

Logs v1
└ Logs Provider: replicated
 ├ Log replication: {node: 2}
 └ Nodeset size: 0
No logs found. Has the cluster been provisioned yet?

Alive partition processors (nodes config v3, partition table v1)
 P-ID  NODE  MODE  STATUS  LEADER  EPOCH  SEQUENCER  APPLIED-LSN  PERSISTED-LSN  SKIPPED-RECORDS  ARCHIVED-LSN  LAST-UPDATE 

Metadata service nodes
 NODE  STATUS  VERSION  LEADER  MEMBERS  APPLIED  COMMITTED  TERM  LOG-LENGTH  SNAP-INDEX  SNAP-SIZE 
 N1    Member  v1       N1      [N1]     2        2          2     1           1           472 B    
```

Single dead node:

```
❯ time rc st -s node2.cluster.orb.local:5122
Error: Encountered multiple errors:
 - http://node2.cluster.orb.local:5122/ -> status: Unavailable, message: "tcp connect error: deadline has elapsed", details: [], metadata: MetadataMap { headers: {} }

restatectl st -s node2.cluster.orb.local:5122  0.03s user 0.01s system 0% cpu 5.348 total
```


Provisioned cluster with two alive and one dead nodes:

```
❯ time rc st -s node1.cluster.orb.local:5122
Node Configuration (v9)
 NODE  GEN  NAME   ADDRESS                               ROLES                                         
 N1    2    node1  http://node1.cluster.orb.local:5122/  admin | log-server | metadata-server | worker 
 N2    1    node2  http://node2.cluster.orb.local:5122/  admin | log-server | metadata-server | worker 
 N3    1    node3  http://node3.cluster.orb.local:5122/  admin | log-server | metadata-server | worker 

Logs v3
└ Logs Provider: replicated
 ├ Log replication: {node: 2}
 └ Nodeset size: 0
 L-ID  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  NODESET      
 0     2         Replicated  0_1        {node: 2}    N2:1       [N1, N2, N3] 
 1     2         Replicated  1_1        {node: 2}    N2:1       [N1, N2, N3] 
 2     2         Replicated  2_1        {node: 2}    N1:2       [N1, N2, N3] 
 3     2         Replicated  3_1        {node: 2}    N1:2       [N1, N2, N3] 
...

Alive partition processors (nodes config v9, partition table v4)
 P-ID  NODE  MODE      STATUS  LEADER  EPOCH  SEQUENCER  APPLIED-LSN  PERSISTED-LSN  SKIPPED-RECORDS  ARCHIVED-LSN  LAST-UPDATE             
 0     N1:2  Follower  Active  N2:1    e1                1            -              0                -             582 ms ago              
 0     N2:1  Leader    Active  N2:1    e1                1            -              0                -             802 ms ago              
 1     N1:2  Follower  Active  N2:1    e1                1            -              0                -             1 second and 92 ms ago  
 1     N2:1  Leader    Active  N2:1    e1                1            -              0                -             802 ms ago              
 2     N1:2  Leader    Active  N1:2    e1                1            -              0                -             517 ms ago              
 2     N2:1  Follower  Active  N1:2    e1                1            -              0                -             608 ms ago              
 3     N1:2  Leader    Active  N1:2    e1                1            -              0                -             971 ms ago              
 3     N2:1  Follower  Active  N1:2    e1                1            -              0                -             923 ms ago              
...

☠️ Dead nodes
 NODE  LAST-SEEN                           
 N3    1 minute, 33 seconds and 503 ms ago 

Metadata service nodes
 NODE  STATUS  VERSION  LEADER  MEMBERS     APPLIED  COMMITTED  TERM  LOG-LENGTH  SNAP-INDEX  SNAP-SIZE 
 N2    Member  v3       N1      [N1,N2,N3]  41       41         2     4           37          8.8 kiB   
 N1    Member  v3       N1      [N1,N2,N3]  41       41         2     4           37          8.8 kiB   

🔌 Unreachable nodes
 NODE  REASON                                                                                              
 N3    status: Unknown, message: "Node is unreachable", details: [], metadata: MetadataMap { headers: {} } 
restatectl st -s node1.cluster.orb.local:5122  0.06s user 0.02s system 1% cpu 5.405 total

~/restate/restate feat/restatectl-node-connections* 5s ❯ 
```

