### PR TITLE
Return explicit log id in CreatePartitionSnapshotResponse

### DIFF
--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -89,7 +89,8 @@ message CreatePartitionSnapshotRequest { uint32 partition_id = 1; }
 
 message CreatePartitionSnapshotResponse {
   string snapshot_id = 1;
-  uint64 min_applied_lsn = 2;
+  uint32 log_id = 2;
+  uint64 min_applied_lsn = 3;
 }
 
 message ChainExtension {

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -182,9 +182,11 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             }
             Ok(Snapshot {
                 snapshot_id,
+                log_id,
                 min_applied_lsn,
             }) => Ok(Response::new(CreatePartitionSnapshotResponse {
                 snapshot_id: snapshot_id.to_string(),
+                log_id: log_id.as_u32(),
                 min_applied_lsn: min_applied_lsn.as_u64(),
             })),
         }

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -186,7 +186,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 min_applied_lsn,
             }) => Ok(Response::new(CreatePartitionSnapshotResponse {
                 snapshot_id: snapshot_id.to_string(),
-                log_id: log_id.as_u32(),
+                log_id: log_id.into(),
                 min_applied_lsn: min_applied_lsn.as_u64(),
             })),
         }

--- a/crates/core/src/worker_api/partition_processor_manager.rs
+++ b/crates/core/src/worker_api/partition_processor_manager.rs
@@ -13,7 +13,7 @@ use std::io;
 
 use tokio::sync::{mpsc, oneshot};
 
-use restate_types::logs::Lsn;
+use restate_types::logs::{LogId, Lsn};
 use restate_types::{
     cluster::cluster_state::PartitionProcessorStatus,
     identifiers::{PartitionId, SnapshotId},
@@ -69,6 +69,7 @@ pub type SnapshotResult = Result<SnapshotCreated, SnapshotError>;
 #[display("{}", snapshot_id)]
 pub struct SnapshotCreated {
     pub snapshot_id: SnapshotId,
+    pub log_id: LogId,
     pub min_applied_lsn: Lsn,
     pub partition_id: PartitionId,
 }

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -42,6 +42,7 @@ use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
 use crate::snapshots::LocalPartitionSnapshot;
 use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
+use restate_types::logs::LogId;
 use restate_types::storage::StorageCodec;
 
 pub type DB = rocksdb::DB;
@@ -463,6 +464,7 @@ impl PartitionStore {
             base_dir: snapshot_dir,
             files: metadata.get_files(),
             db_comparator_name: metadata.get_db_comparator_name(),
+            log_id: LogId::from(self.partition_id),
             min_applied_lsn: applied_lsn,
             key_range: self.key_range.clone(),
         })

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -19,7 +19,7 @@ use restate_storage_api::Transaction;
 use restate_types::config::WorkerOptions;
 use restate_types::identifiers::{PartitionKey, SnapshotId};
 use restate_types::live::Live;
-use restate_types::logs::Lsn;
+use restate_types::logs::{LogId, Lsn};
 use restate_types::time::MillisSinceEpoch;
 
 pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_store: PartitionStore) {
@@ -41,6 +41,7 @@ pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_stor
         created_at: humantime::Timestamp::from(SystemTime::from(MillisSinceEpoch::new(0))),
         snapshot_id: SnapshotId::from_parts(0, 0),
         key_range: key_range.clone(),
+        log_id: Some(LogId::from(partition_id)),
         min_applied_lsn: snapshot.min_applied_lsn,
         db_comparator_name: snapshot.db_comparator_name.clone(),
         files: snapshot.files.clone(),
@@ -56,6 +57,7 @@ pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_stor
 
     let snapshot = LocalPartitionSnapshot {
         base_dir: snapshots_dir.path().into(),
+        log_id: LogId::from(partition_id),
         min_applied_lsn: snapshot_meta.min_applied_lsn,
         db_comparator_name: snapshot_meta.db_comparator_name.clone(),
         files: snapshot_meta.files.clone(),

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -55,6 +55,10 @@ impl LogId {
     pub const fn new(value: u32) -> Self {
         Self(value)
     }
+
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
 }
 
 impl From<PartitionId> for LogId {

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -55,10 +55,6 @@ impl LogId {
     pub const fn new(value: u32) -> Self {
         Self(value)
     }
-
-    pub fn as_u32(self) -> u32 {
-        self.0
-    }
 }
 
 impl From<PartitionId> for LogId {

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cluster::cluster_state::RunMode;
 use crate::identifiers::{PartitionId, SnapshotId};
-use crate::logs::Lsn;
+use crate::logs::{LogId, Lsn};
 use crate::net::define_rpc;
 use crate::net::{define_message, TargetName};
 use crate::Version;
@@ -81,6 +81,7 @@ pub struct CreateSnapshotResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Snapshot {
     pub snapshot_id: SnapshotId,
+    pub log_id: LogId,
     pub min_applied_lsn: Lsn,
 }
 

--- a/crates/worker/src/partition/snapshots/repository.rs
+++ b/crates/worker/src/partition/snapshots/repository.rs
@@ -486,6 +486,7 @@ impl SnapshotRepository {
         );
         Ok(Some(LocalPartitionSnapshot {
             base_dir: snapshot_dir.into_path(),
+            log_id: snapshot_metadata.get_log_id(),
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
@@ -844,7 +845,7 @@ mod tests {
     use restate_partition_store::snapshots::{PartitionSnapshotMetadata, SnapshotFormatVersion};
     use restate_types::config::SnapshotsOptions;
     use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId};
-    use restate_types::logs::{Lsn, SequenceNumber};
+    use restate_types::logs::{LogId, Lsn, SequenceNumber};
 
     #[tokio::test]
     async fn test_overwrite_unparsable_latest() -> anyhow::Result<()> {
@@ -1047,6 +1048,7 @@ mod tests {
             created_at: humantime::Timestamp::from(SystemTime::now()),
             snapshot_id: SnapshotId::new(),
             key_range: PartitionKey::MIN..=PartitionKey::MAX,
+            log_id: Some(LogId::from(PartitionId::MIN)),
             min_applied_lsn: Lsn::new(1),
             db_comparator_name: "leveldb.BytewiseComparator".to_string(),
             // this is totally bogus, but it doesn't matter since we won't be importing it into RocksDB

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -86,6 +86,7 @@ impl SnapshotPartitionTask {
             created_at: humantime::Timestamp::from(created_at),
             snapshot_id: self.snapshot_id,
             key_range: snapshot.key_range.clone(),
+            log_id: Some(snapshot.log_id),
             min_applied_lsn: snapshot.min_applied_lsn,
             db_comparator_name: snapshot.db_comparator_name.clone(),
             files: snapshot.files.clone(),

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -765,6 +765,7 @@ impl PartitionProcessorManager {
                     metadata.partition_id,
                     Ok(SnapshotCreated {
                         snapshot_id: metadata.snapshot_id,
+                        log_id: metadata.get_log_id(),
                         min_applied_lsn: metadata.min_applied_lsn,
                         partition_id: metadata.partition_id,
                     }),

--- a/crates/worker/src/partition_processor_manager/message_handler.rs
+++ b/crates/worker/src/partition_processor_manager/message_handler.rs
@@ -48,6 +48,7 @@ impl MessageHandler for PartitionProcessorManagerMessageHandler {
                     Ok(snapshot) => msg.to_rpc_response(CreateSnapshotResponse {
                         result: Ok(Snapshot {
                             snapshot_id: snapshot.snapshot_id,
+                            log_id: snapshot.log_id,
                             min_applied_lsn: snapshot.min_applied_lsn,
                         }),
                     }),

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -134,7 +134,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
         .await?
         .into_inner();
     info!(
-        "Snapshot created up to at least LSN {}",
+        "Snapshot created including changes up to LSN {}",
         snapshot_response.min_applied_lsn
     );
 

--- a/tools/restatectl/src/commands/snapshot/create_snapshot.rs
+++ b/tools/restatectl/src/commands/snapshot/create_snapshot.rs
@@ -99,8 +99,9 @@ async fn inner_create_snapshot(
         .into_inner();
 
     c_println!(
-        "Snapshot created for partition {partition_id}: {} (LSN >= {})",
+        "Snapshot created for partition {partition_id}: {} (log {} @ LSN >= {})",
         response.snapshot_id,
+        response.log_id,
         response.min_applied_lsn,
     );
 


### PR DESCRIPTION
Follow up to https://github.com/restatedev/restate/pull/2743 adding explicit log ids to the CreateSnapshot response path - and adding an option for storing these in the snapshot metadata we publish to object stores.

In the future, only `PartitionStore::create_snapshot` needs to change to provide an explicit log id (of which presumably `PartitionStore` will be aware), if that differs from the `partition_id` from which it us currently derived.