### PR TITLE
[restatectl] Improve status display during cluster provisioning

### DIFF
--- a/tools/restatectl/src/commands/log/list_logs.rs
+++ b/tools/restatectl/src/commands/log/list_logs.rs
@@ -10,6 +10,7 @@
 
 use std::collections::BTreeMap;
 
+use anyhow::bail;
 use cling::prelude::*;
 
 use restate_cli_util::_comfy_table::{Cell, Table};
@@ -46,7 +47,12 @@ pub async fn list_logs(connection: &ConnectionInfo, _opts: &ListLogsOpts) -> any
     let logs: BTreeMap<LogId, &Chain> = logs.iter().map(|(id, chain)| (*id, chain)).collect();
 
     if logs.is_empty() {
-        c_println!("No logs found. Has the cluster been provisioned yet?");
+        c_println!("No logs found. Has the cluster been provisioned yet? You can do so with `restatectl provision`.");
+
+        // short-circuits `restatectl status` to avoid trying to list partitions
+        bail!(
+            "The cluster appears to not be provisioned. You can do so with `restatectl provision`"
+        );
     } else {
         for (log_id, chain) in logs {
             let params = deserialize_replicated_log_params(&chain.tail());

--- a/tools/restatectl/src/commands/node/list_nodes.rs
+++ b/tools/restatectl/src/commands/node/list_nodes.rs
@@ -16,6 +16,7 @@ use cling::prelude::*;
 use itertools::Itertools;
 use tokio::task::JoinSet;
 use tonic::codec::CompressionEncoding;
+use tracing::warn;
 
 use restate_cli_util::_comfy_table::{Cell, Table};
 use restate_cli_util::c_println;
@@ -23,10 +24,12 @@ use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::ui::{duration_to_human_rough, Tense};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::IdentResponse;
+use restate_types::health::MetadataServerStatus;
+use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::PlainNodeId;
 
-use crate::connection::ConnectionInfo;
+use crate::connection::{ConnectionInfo, ConnectionInfoError};
 use crate::util::grpc_channel;
 
 // Default timeout for the [optional] GetIdent call made to all nodes
@@ -43,12 +46,35 @@ pub struct ListNodesOpts {
 }
 
 pub async fn list_nodes(connection: &ConnectionInfo, opts: &ListNodesOpts) -> anyhow::Result<()> {
-    let nodes_configuration = connection.get_nodes_configuration().await?;
+    match connection.get_nodes_configuration().await {
+        Ok(nodes_configuration) => list_nodes_configuration(&nodes_configuration, opts).await,
+        Err(ConnectionInfoError::MissingMetadata(ident_responses))
+            if !ident_responses.is_empty() =>
+        {
+            warn!("Could not read nodes configuration from cluster, using GetIdent responses to render basic list");
+            list_nodes_lite(&ident_responses, opts);
 
+            // short-circuit if called as part of `restatectl status`
+            if ident_responses.iter().any(|(_, ident)| {
+                ident.metadata_server_status() == MetadataServerStatus::AwaitingProvisioning
+            }) {
+                Err(ConnectionInfoError::ClusterNotProvisioned.into())
+            } else {
+                Err(ConnectionInfoError::MissingMetadata(ident_responses).into())
+            }
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+async fn list_nodes_configuration(
+    nodes_configuration: &NodesConfiguration,
+    opts: &ListNodesOpts,
+) -> anyhow::Result<()> {
     let nodes = nodes_configuration.iter().collect::<BTreeMap<_, _>>();
 
     let nodes_extra_info = if opts.extra {
-        fetch_extra_info(&nodes_configuration).await?
+        fetch_extra_info(nodes_configuration).await?
     } else {
         HashMap::new()
     };
@@ -83,30 +109,9 @@ pub async fn list_nodes(connection: &ConnectionInfo, opts: &ListNodesOpts) -> an
         ];
 
         if opts.extra {
-            node_row.extend(render_extra_columns(
+            node_row.extend(render_optional_columns(
                 nodes_extra_info.get(&node_id),
-                |ident_response| {
-                    vec![
-                        duration_to_human_rough(
-                            TimeDelta::seconds(ident_response.age_s as i64),
-                            Tense::Present,
-                        ),
-                        // We reuse the prost-generated Debug formatting but cut out the "Unknown"s
-                        format!("{:?}", ident_response.status()).replace("Unknown", "-"),
-                        format!("{:?}", ident_response.admin_status()).replace("Unknown", "-"),
-                        format!("{:?}", ident_response.worker_status()).replace("Unknown", "-"),
-                        format!("{:?}", ident_response.log_server_status()).replace("Unknown", "-"),
-                        format!("{:?}", ident_response.metadata_server_status())
-                            .replace("Unknown", "-"),
-                        format!("v{}", ident_response.nodes_config_version),
-                        format!("v{}", ident_response.logs_version),
-                        format!("v{}", ident_response.schema_version),
-                        format!("v{}", ident_response.partition_table_version),
-                    ]
-                    .iter()
-                    .map(Cell::new)
-                    .collect()
-                },
+                render_ident_extras,
             ));
         }
         nodes_table.add_row(node_row);
@@ -116,13 +121,91 @@ pub async fn list_nodes(connection: &ConnectionInfo, opts: &ListNodesOpts) -> an
     Ok(())
 }
 
-fn render_extra_columns<F>(ident_response: Option<&IdentResponse>, f: F) -> Vec<Cell>
+pub fn list_nodes_lite(
+    ident_responses: &HashMap<AdvertisedAddress, IdentResponse>,
+    opts: &ListNodesOpts,
+) {
+    let mut nodes_table = Table::new_styled();
+    let mut header = vec!["NODE", "GEN", "NAME", "ADDRESS", "ROLES"];
+    if opts.extra {
+        header.extend(vec![
+            "UPTIME", "STATUS", "ADMIN", "WORKER", "LOG-SVR", "META", "NODES", "LOGS", "SCHEMA",
+            "PRTNS",
+        ]);
+    }
+    nodes_table.set_styled_header(header);
+
+    for (address, ident) in ident_responses
+        .iter()
+        .sorted_by_key(|&(addr, _)| addr.to_string())
+    {
+        let mut node_row = vec![
+            Cell::new(
+                ident
+                    .node_id
+                    .map(|id| format!("{}", id.id))
+                    .unwrap_or("n/a".to_owned()),
+            ),
+            Cell::new(
+                ident
+                    .node_id
+                    .and_then(|id| id.generation)
+                    .map(|gen| format!("{}", gen))
+                    .unwrap_or("".to_owned()),
+            ),
+            Cell::new("-"),
+            Cell::new(address.to_string()),
+            Cell::new(
+                ident
+                    .roles
+                    .iter()
+                    .map(|r| r.to_string())
+                    .sorted()
+                    .collect::<Vec<_>>()
+                    .join(" | "),
+            ),
+        ];
+        if opts.extra {
+            node_row.extend(render_ident_extras(ident));
+        }
+        nodes_table.add_row(node_row);
+    }
+
+    c_println!(
+        "The cluster metadata service was unavailable but the following nodes responded directly"
+    );
+    c_println!("{}", nodes_table);
+}
+
+fn render_optional_columns<F>(ident_response: Option<&IdentResponse>, f: F) -> Vec<Cell>
 where
     F: FnOnce(&IdentResponse) -> Vec<Cell>,
 {
     ident_response
         .map(f)
         .unwrap_or(vec![Cell::new("N/A"), Cell::new("Unknown")])
+}
+
+fn render_ident_extras(ident_response: &IdentResponse) -> Vec<Cell> {
+    vec![
+        duration_to_human_rough(
+            TimeDelta::seconds(ident_response.age_s as i64),
+            Tense::Present,
+        ),
+        // We reuse the prost-generated Debug formatting but cut out the "Unknown"s
+        format!("{:?}", ident_response.status()).replace("Unknown", "-"),
+        format!("{:?}", ident_response.admin_status()).replace("Unknown", "-"),
+        format!("{:?}", ident_response.worker_status()).replace("Unknown", "-"),
+        format!("{:?}", ident_response.log_server_status()).replace("Unknown", "-"),
+        format!("{:?}", ident_response.metadata_server_status()).replace("Unknown", "-"),
+        format!("v{}", ident_response.nodes_config_version),
+        format!("v{}", ident_response.logs_version),
+        format!("v{}", ident_response.schema_version),
+        format!("v{}", ident_response.partition_table_version),
+    ]
+    .iter()
+    .map(Cell::new)
+    .collect()
 }
 
 async fn fetch_extra_info(

--- a/tools/restatectl/src/commands/node/mod.rs
+++ b/tools/restatectl/src/commands/node/mod.rs
@@ -14,6 +14,6 @@ use cling::prelude::*;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum Nodes {
-    /// Print a summary of active nodes in cluster
+    /// Print a summary of the active nodes registered in a cluster
     List(list_nodes::ListNodesOpts),
 }

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -19,7 +19,7 @@ use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvc
 use restate_types::health::MetadataServerStatus;
 use tonic::codec::CompressionEncoding;
 use tonic::{Code, IntoRequest};
-use tracing::error;
+use tracing::{error, warn};
 
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_admin::cluster_controller::protobuf::ClusterStateRequest;
@@ -27,16 +27,16 @@ use restate_cli_util::_comfy_table::{Cell, Color, Row, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
 use restate_types::logs::metadata::Logs;
-use restate_types::nodes_config::{NodeConfig, Role};
+use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
 use restate_types::protobuf::cluster::node_state::State;
 use restate_types::protobuf::cluster::{AliveNode, RunMode};
 use restate_types::{GenerationalNodeId, NodeId};
 
 use crate::commands::log::list_logs::{list_logs, ListLogsOpts};
 use crate::commands::metadata_server::status::list_metadata_servers;
-use crate::commands::node::list_nodes::{list_nodes, ListNodesOpts};
+use crate::commands::node::list_nodes::{list_nodes, list_nodes_lite, ListNodesOpts};
 use crate::commands::partition::list::{list_partitions, ListPartitionsOpts};
-use crate::connection::ConnectionInfo;
+use crate::connection::{ConnectionInfo, ConnectionInfoError};
 use crate::util::grpc_channel;
 
 use super::log::deserialize_replicated_log_params;
@@ -55,12 +55,27 @@ async fn cluster_status(
     status_opts: &ClusterStatusOpts,
 ) -> anyhow::Result<()> {
     if !status_opts.extra {
-        compact_cluster_status(connection).await?;
+        return match connection.get_nodes_configuration().await {
+            Ok(nodes_config) => compact_cluster_status(nodes_config, connection).await,
+            Err(ConnectionInfoError::MissingMetadata(ident_responses)) => {
+                warn!("Could not read nodes configuration from cluster, using GetIdent responses to render basic list");
 
-        return Ok(());
+                list_nodes_lite(&ident_responses, &ListNodesOpts { extra: false });
+
+                // short-circuit if called as part of `restatectl status`
+                Err(ConnectionInfoError::ClusterNotProvisioned.into())
+            }
+            Err(err) => Err(err.into()),
+        };
     }
 
-    list_nodes(connection, &ListNodesOpts { extra: false }).await?;
+    list_nodes(
+        connection,
+        &ListNodesOpts {
+            extra: status_opts.extra,
+        },
+    )
+    .await?;
     c_println!();
 
     list_logs(connection, &ListLogsOpts {}).await?;
@@ -74,8 +89,10 @@ async fn cluster_status(
     Ok(())
 }
 
-async fn compact_cluster_status(connection: &ConnectionInfo) -> anyhow::Result<()> {
-    let nodes_config = connection.get_nodes_configuration().await?;
+async fn compact_cluster_status(
+    nodes_config: NodesConfiguration,
+    connection: &ConnectionInfo,
+) -> anyhow::Result<()> {
     let logs = connection.get_logs().await?;
 
     let cluster_state = connection

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -57,10 +57,10 @@ async fn cluster_status(
     if !status_opts.extra {
         return match connection.get_nodes_configuration().await {
             Ok(nodes_config) => compact_cluster_status(nodes_config, connection).await,
-            Err(ConnectionInfoError::MissingMetadata(ident_responses)) => {
+            Err(ConnectionInfoError::MetadataValueNotAvailable { contacted_nodes }) => {
                 warn!("Could not read nodes configuration from cluster, using GetIdent responses to render basic list");
 
-                list_nodes_lite(&ident_responses, &ListNodesOpts { extra: false });
+                list_nodes_lite(&contacted_nodes, &ListNodesOpts { extra: false });
 
                 // short-circuit if called as part of `restatectl status`
                 Err(ConnectionInfoError::ClusterNotProvisioned.into())

--- a/tools/restatectl/src/connection.rs
+++ b/tools/restatectl/src/connection.rs
@@ -13,7 +13,7 @@ use std::sync::RwLock;
 use std::{cmp::Ordering, fmt::Display, future::Future, sync::Arc};
 
 use cling::{prelude::Parser, Collect};
-use itertools::{Either, Itertools};
+use itertools::{Either, Itertools, Position};
 use rand::{rng, seq::SliceRandom};
 use tokio::sync::{Mutex, MutexGuard};
 use tonic::{codec::CompressionEncoding, transport::Channel, Code, Response, Status};
@@ -163,6 +163,7 @@ impl ConnectionInfo {
         }
 
         let mut latest_value: Option<T> = None;
+        let mut ident_responses = HashMap::new();
         let mut any_node_responded = false;
         let mut errors = NodesErrors::default();
         let mut open_connections = self.open_connections.lock().await;
@@ -190,10 +191,11 @@ impl ConnectionInfo {
                     continue;
                 }
             };
+            ident_responses.insert(address.clone(), response.clone());
 
             any_node_responded = true;
             if response.status != NodeStatus::Alive as i32 {
-                debug!("Node {address} responded but it is not reporting itself as alive, and will be skipped");
+                debug!("Node {address} responded to GetIdent but it is not reporting itself as alive, and will be skipped");
                 continue;
             }
 
@@ -245,7 +247,7 @@ impl ConnectionInfo {
         }
 
         *guard = latest_value.clone();
-        latest_value.ok_or(ConnectionInfoError::MissingMetadata)
+        latest_value.ok_or(ConnectionInfoError::MissingMetadata(ident_responses))
     }
 
     /// Attempts to contact each node in the cluster that matches the specified role
@@ -368,7 +370,12 @@ impl ConnectionInfo {
 #[derive(Debug, thiserror::Error)]
 pub enum ConnectionInfoError {
     #[error("Could not retrieve cluster metadata. Has the cluster been provisioned yet?")]
-    MissingMetadata,
+    MissingMetadata(HashMap<AdvertisedAddress, IdentResponse>),
+
+    #[error(
+        "The cluster appears to not be provisioned. You can do so with `restatectl provision`"
+    )]
+    ClusterNotProvisioned,
 
     #[error("Failed to decode metadata from node {0}: {1}")]
     DecoderError(AdvertisedAddress, StorageDecodeError),
@@ -418,9 +425,19 @@ impl NodesErrors {
 
 impl Display for NodesErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Encountered multiple errors:")?;
-        for (address, status) in &self.node_status {
-            writeln!(f, " - {address} -> {status}")?;
+        for (position, (address, status)) in self.node_status.iter().with_position() {
+            match position {
+                Position::Only => {
+                    writeln!(f, "{address}: {status}")?;
+                }
+                Position::First => {
+                    writeln!(f, "Encountered multiple errors:")?;
+                    writeln!(f, " - {address} -> {status}")?;
+                }
+                Position::Middle | Position::Last => {
+                    writeln!(f, " - {address} -> {status}")?;
+                }
+            }
         }
         Ok(())
     }

--- a/tools/restatectl/src/connection.rs
+++ b/tools/restatectl/src/connection.rs
@@ -247,7 +247,9 @@ impl ConnectionInfo {
         }
 
         *guard = latest_value.clone();
-        latest_value.ok_or(ConnectionInfoError::MissingMetadata(ident_responses))
+        latest_value.ok_or(ConnectionInfoError::MetadataValueNotAvailable {
+            contacted_nodes: ident_responses,
+        })
     }
 
     /// Attempts to contact each node in the cluster that matches the specified role
@@ -369,8 +371,12 @@ impl ConnectionInfo {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConnectionInfoError {
+    /// The requested metadata key could not be retrieved from any known metadata servers.
+    /// The servers which did respond are included in the error.
     #[error("Could not retrieve cluster metadata. Has the cluster been provisioned yet?")]
-    MissingMetadata(HashMap<AdvertisedAddress, IdentResponse>),
+    MetadataValueNotAvailable {
+        contacted_nodes: HashMap<AdvertisedAddress, IdentResponse>,
+    },
 
     #[error(
         "The cluster appears to not be provisioned. You can do so with `restatectl provision`"


### PR DESCRIPTION
This change improves the rendering of nodes during cluster provisioning.

Both the `status` and `nodes list` can now render a partial nodes list based on just the `GetIdentResponse`s received during the attempt to obtain metadata. If we detect that the metadata services are in provisioning status, this is a strong signal that the cluster as a whole may not be provisioned yet so we'll print a hint about `restatectl provision`.

```
❯ restatectl status -s node1.cluster.orb.local:5122,node2.cluster.orb.local:5122,node3.cluster.orb.local:5122
Error: Encountered multiple errors:
 - http://node1.cluster.orb.local:5122/ -> status: Unavailable, message: "tcp connect error: deadline has elapsed", details: [], metadata: MetadataMap { headers: {} }
 - http://node2.cluster.orb.local:5122/ -> status: Unavailable, message: "tcp connect error: deadline has elapsed", details: [], metadata: MetadataMap { headers: {} }
 - http://node3.cluster.orb.local:5122/ -> status: Unavailable, message: "tcp connect error: deadline has elapsed", details: [], metadata: MetadataMap { headers: {} }

❯ restatectl status -s node1.cluster.orb.local:5122,node2.cluster.orb.local:5122,node3.cluster.orb.local:5122
The cluster metadata service was unavailable but the following nodes responded directly
 NODE  GEN  NAME  ADDRESS                               ROLES
 n/a        -     http://node1.cluster.orb.local:5122/  admin | log-server | metadata-server | worker
 n/a        -     http://node2.cluster.orb.local:5122/  admin | log-server | metadata-server | worker
 n/a        -     http://node3.cluster.orb.local:5122/  admin | log-server | metadata-server | worker
Error: The cluster appears to not be provisioned. You can do so with `restatectl provision`

❯ restatectl status -s node1.cluster.orb.local:5122,node2.cluster.orb.local:5122,node3.cluster.orb.local:5122 --extra
The cluster metadata service was unavailable but the following nodes responded directly
 NODE  GEN  NAME  ADDRESS                               ROLES                                          UPTIME    STATUS      ADMIN       WORKER      LOG-SVR     META                  NODES  LOGS  SCHEMA  PRTNS
 n/a        -     http://node1.cluster.orb.local:5122/  admin | log-server | metadata-server | worker  a minute  StartingUp  StartingUp  StartingUp  StartingUp  AwaitingProvisioning  v0     v0    v0      v0
 n/a        -     http://node2.cluster.orb.local:5122/  admin | log-server | metadata-server | worker  a minute  StartingUp  StartingUp  StartingUp  StartingUp  AwaitingProvisioning  v0     v0    v0      v0
 n/a        -     http://node3.cluster.orb.local:5122/  admin | log-server | metadata-server | worker  a minute  StartingUp  StartingUp  StartingUp  StartingUp  AwaitingProvisioning  v0     v0    v0      v0
Error: The cluster appears to not be provisioned. You can do so with `restatectl provision`
```

cc: @tillrohrmann - feel free to take a look at the output aboe if not the diff itself

Closes #2453, #2609