### PR TITLE
Improve invoker observability

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
@@ -37,7 +37,7 @@ impl PeriodicTailChecker {
             "Started a background periodic tail checker for this loglet",
         );
         // Optimization. Don't run the check if the tail/seal has been updated recently.
-        // Unfortunately this requires a litte bit more setup in the TailOffsetWatch so we don't do
+        // Unfortunately this requires a little bit more setup in the TailOffsetWatch so we don't do
         // it.
         loop {
             let Some(loglet) = loglet.upgrade() else {

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -23,7 +23,8 @@ use invocation_state_machine::InvocationStateMachine;
 use invocation_task::InvocationTask;
 use invocation_task::{InvocationTaskOutput, InvocationTaskOutputInner};
 use itertools::Itertools;
-use metrics::counter;
+use metric_definitions::{INVOKER_PENDING_TASKS, INVOKER_TASKS_IN_FLIGHT};
+use metrics::{counter, gauge};
 use restate_core::cancellation_watcher;
 use restate_errors::warn_it;
 use restate_invoker_api::{
@@ -347,6 +348,9 @@ where
     where
         F: Future<Output = ()>,
     {
+        gauge!(INVOKER_PENDING_TASKS).set(segmented_input_queue.len() as f64);
+        gauge!(INVOKER_TASKS_IN_FLIGHT).set(self.invocation_tasks.len() as f64);
+
         tokio::select! {
             Some(cmd) = self.status_rx.recv() => {
                 let keys = cmd.payload();

--- a/crates/invoker-impl/src/metric_definitions.rs
+++ b/crates/invoker-impl/src/metric_definitions.rs
@@ -13,9 +13,11 @@
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
 pub const INVOKER_ENQUEUE: &str = "restate.invoker.enqueue.total";
+pub const INVOKER_PENDING_TASKS: &str = "restate.invoker.pending_tasks";
 pub const INVOKER_INVOCATION_TASK: &str = "restate.invoker.invocation_task.total";
 pub const INVOKER_AVAILABLE_SLOTS: &str = "restate.invoker.available_slots";
 pub const INVOKER_TASK_DURATION: &str = "restate.invoker.task_duration.seconds";
+pub const INVOKER_TASKS_IN_FLIGHT: &str = "restate.invoker.inflight_tasks_count";
 
 pub const TASK_OP_STARTED: &str = "started";
 pub const TASK_OP_SUSPENDED: &str = "suspended";
@@ -27,6 +29,12 @@ pub(crate) fn describe_metrics() {
         INVOKER_ENQUEUE,
         Unit::Count,
         "Number of invocations that were added to the queue"
+    );
+
+    describe_gauge!(
+        INVOKER_PENDING_TASKS,
+        Unit::Count,
+        "Number of pending invocation tasks queued"
     );
 
     describe_counter!(
@@ -45,5 +53,11 @@ pub(crate) fn describe_metrics() {
         INVOKER_TASK_DURATION,
         Unit::Seconds,
         "Time taken to complete an invoker task"
-    )
+    );
+
+    describe_gauge!(
+        INVOKER_TASKS_IN_FLIGHT,
+        Unit::Count,
+        "Number of inflight invoker tasks"
+    );
 }

--- a/crates/invoker-impl/src/quota.rs
+++ b/crates/invoker-impl/src/quota.rs
@@ -28,7 +28,10 @@ impl InvokerConcurrencyQuota {
 
     pub(super) fn is_slot_available(&self) -> bool {
         match self {
-            Self::Unlimited => true,
+            Self::Unlimited => {
+                gauge!(INVOKER_AVAILABLE_SLOTS).set(f64::INFINITY);
+                true
+            }
             Self::Limited { available_slots } => {
                 gauge!(INVOKER_AVAILABLE_SLOTS).set(*available_slots as f64);
                 *available_slots > 0

--- a/crates/queue/src/segmented_queue.rs
+++ b/crates/queue/src/segmented_queue.rs
@@ -172,6 +172,11 @@ impl<T: Serialize + DeserializeOwned + Send + 'static> SegmentQueue<T> {
         };
         len
     }
+
+    /// Number of records in queue
+    pub fn len(&self) -> usize {
+        self.segments.iter().fold(0, |len, seg| len + seg.len())
+    }
 }
 
 impl<T> SegmentQueue<T> {

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -12,6 +12,8 @@
 /// the metrics' sink.
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
+pub const PARTITION_LABEL: &str = "partition";
+
 pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command.seconds";
 pub const PARTITION_ACTUATOR_HANDLED: &str = "restate.partition.actuator_handled.total";
 pub const PARTITION_STORAGE_TX_CREATED: &str = "restate.partition.storage_tx_created.total";
@@ -23,18 +25,27 @@ pub const PARTITION_TIME_SINCE_LAST_STATUS_UPDATE: &str =
     "restate.partition.time_since_last_status_update";
 pub const PARTITION_TIME_SINCE_LAST_RECORD: &str = "restate.partition.time_since_last_record";
 pub const PARTITION_LAST_APPLIED_LOG_LSN: &str = "restate.partition.last_applied_lsn";
+pub const PARTITION_LAST_APPLIED_LSN_LAG: &str = "restate.partition.applied_lsn_lag";
 pub const PARTITION_LAST_PERSISTED_LOG_LSN: &str = "restate.partition.last_persisted_lsn";
 pub const PARTITION_IS_EFFECTIVE_LEADER: &str = "restate.partition.is_effective_leader";
 pub const PARTITION_IS_ACTIVE: &str = "restate.partition.is_active";
 
-pub const PP_APPLY_COMMAND_DURATION: &str = "restate.partition.apply_command_duration.seconds";
-pub const PP_APPLY_COMMAND_BATCH_SIZE: &str = "restate.partition.apply_command_batch_size";
+pub const PARTITION_APPLY_COMMAND_DURATION: &str =
+    "restate.partition.apply_command_duration.seconds";
+pub const PARTITION_APPLY_COMMAND_BATCH_SIZE: &str = "restate.partition.apply_command_batch_size";
 pub const PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION: &str =
     "restate.partition.handle_action_batch_duration.seconds";
 pub const PARTITION_HANDLE_INVOKER_EFFECT_COMMAND: &str =
     "restate.partition.handle_invoker_effect.seconds";
+pub const PARTITION_RPC_QUEUE_UTILIZATION_PERCENT: &str =
+    "restate.partition.rpc_queue.utilization.percent";
+pub const PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS: &str =
+    "restate.partition.rpc_queue.outstanding_requests";
+pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
+    "restate.partition.record_committed_to_read_latency.seconds";
 
-pub const PARTITION_LABEL: &str = "partition";
+// to calculate read rates
+pub const PARTITION_RECORD_READ_COUNT: &str = "restate.partition.record_read_count";
 
 pub(crate) fn describe_metrics() {
     describe_histogram!(
@@ -58,12 +69,12 @@ pub(crate) fn describe_metrics() {
         "Storage transactions committed by applying partition state machine commands"
     );
     describe_histogram!(
-        PP_APPLY_COMMAND_DURATION,
+        PARTITION_APPLY_COMMAND_DURATION,
         Unit::Seconds,
         "Time spent processing a single bifrost message"
     );
     describe_histogram!(
-        PP_APPLY_COMMAND_BATCH_SIZE,
+        PARTITION_APPLY_COMMAND_BATCH_SIZE,
         Unit::Count,
         "Size of the applied command batch"
     );
@@ -81,6 +92,12 @@ pub(crate) fn describe_metrics() {
         PARTITION_HANDLE_INVOKER_EFFECT_COMMAND,
         Unit::Seconds,
         "Time spent handling an invoker effect command"
+    );
+
+    describe_histogram!(
+        PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS,
+        Unit::Seconds,
+        "Duration between the record commit time to read time"
     );
 
     describe_gauge!(
@@ -114,6 +131,12 @@ pub(crate) fn describe_metrics() {
     );
 
     describe_gauge!(
+        PARTITION_LAST_APPLIED_LSN_LAG,
+        Unit::Count,
+        "Number of records between last applied lsn and the log tail"
+    );
+
+    describe_gauge!(
         PARTITION_LAST_PERSISTED_LOG_LSN,
         Unit::Count,
         "Raw value of the LSN that can be trimmed"
@@ -123,5 +146,23 @@ pub(crate) fn describe_metrics() {
         PARTITION_TIME_SINCE_LAST_RECORD,
         Unit::Seconds,
         "Number of seconds since the last record was applied"
+    );
+
+    describe_gauge!(
+        PARTITION_RPC_QUEUE_UTILIZATION_PERCENT,
+        Unit::Percent,
+        "Partition processor requests queue utilization, 0 to 100%"
+    );
+
+    describe_gauge!(
+        PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS,
+        Unit::Count,
+        "Number of outstanding requests in the partition processor request queue"
+    );
+
+    describe_counter!(
+        PARTITION_RECORD_READ_COUNT,
+        Unit::Count,
+        "Number of read records from bifrost",
     );
 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -17,7 +17,7 @@ use anyhow::Context;
 use assert2::let_assert;
 use enumset::EnumSet;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt as _};
-use metrics::histogram;
+use metrics::{SharedString, counter, gauge, histogram};
 use restate_bifrost::loglet::FindTailOptions;
 use tokio::sync::{mpsc, watch};
 use tokio::time::MissedTickBehavior;
@@ -66,8 +66,10 @@ use restate_wal_protocol::control::AnnounceLeader;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
 
 use crate::metric_definitions::{
-    PARTITION_LABEL, PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION, PP_APPLY_COMMAND_BATCH_SIZE,
-    PP_APPLY_COMMAND_DURATION,
+    PARTITION_APPLY_COMMAND_BATCH_SIZE, PARTITION_APPLY_COMMAND_DURATION, PARTITION_LABEL,
+    PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION,
+    PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, PARTITION_RECORD_READ_COUNT,
+    PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS, PARTITION_RPC_QUEUE_UTILIZATION_PERCENT,
 };
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
 use crate::partition::leadership::{LeadershipState, PartitionProcessorMetadata};
@@ -346,6 +348,7 @@ where
                     %last_applied_lsn,
                     "Processor has caught up with the log tail."
                 );
+                self.status.target_tail_lsn = None;
                 self.status.replay_status = ReplayStatus::Active;
             }
         } else {
@@ -371,8 +374,20 @@ where
             );
         }
 
+        // Telemetry setup
+        let partition_id_str = SharedString::from(self.partition_id.to_string());
+        let apply_command_latency = histogram!(PARTITION_APPLY_COMMAND_DURATION, PARTITION_LABEL => partition_id_str.clone());
+        let record_actions_latency = histogram!(PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION);
+        let record_write_to_read_latencty = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, PARTITION_LABEL => partition_id_str.clone());
+        let command_batch_size = histogram!(PARTITION_APPLY_COMMAND_BATCH_SIZE, PARTITION_LABEL => partition_id_str.clone());
+        let command_read_count =
+            counter!(PARTITION_RECORD_READ_COUNT, PARTITION_LABEL => partition_id_str.clone());
+        let rpc_queue_utilization = gauge!(PARTITION_RPC_QUEUE_UTILIZATION_PERCENT, PARTITION_LABEL => partition_id_str.clone());
+        let rpc_queue_len =
+            gauge!(PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS, PARTITION_LABEL => partition_id_str);
         // Start reading after the last applied lsn
         let key_query = KeyFilter::Within(self.partition_key_range.clone());
+
         let mut record_stream = self
             .bifrost
             .create_reader(
@@ -386,6 +401,9 @@ where
                     trace!(?entry, "Read entry");
                     let lsn = entry.sequence_number();
                     if entry.is_data_record() {
+                        entry.as_record().inspect(|record| {
+                            record_write_to_read_latencty.record(record.created_at().elapsed());
+                        });
                         entry
                             .try_decode_arc::<Envelope>()
                             .map(|envelope| Ok((lsn, envelope?)))
@@ -415,20 +433,18 @@ where
             tokio::time::interval(Duration::from_millis(500 + rand::random::<u64>() % 524));
         status_update_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        let partition_id_str = self.partition_id.to_string();
-        // Telemetry setup
-        let apply_command_latency =
-            histogram!(PP_APPLY_COMMAND_DURATION, PARTITION_LABEL => partition_id_str.clone());
-        let record_actions_latency = histogram!(PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION);
-        let command_batch_size =
-            histogram!(PP_APPLY_COMMAND_BATCH_SIZE, PARTITION_LABEL => partition_id_str.clone());
-
         let mut action_collector = ActionCollector::default();
         let mut command_buffer = Vec::with_capacity(self.max_command_batch_size);
 
         info!("Partition {} started", self.partition_id);
 
         loop {
+            let utilization =
+                (self.rpc_rx.len() as f64 * 100.0) / self.rpc_rx.max_capacity() as f64;
+
+            rpc_queue_utilization.set(utilization);
+            rpc_queue_len.set(self.rpc_rx.len() as f64);
+
             tokio::select! {
                 Some(command) = self.control_rx.recv() => {
                     if let Err(err) = self.on_command(command).await {
@@ -448,6 +464,7 @@ where
                     // check that reading has succeeded
                     operation?;
 
+                    command_read_count.increment(u64::try_from(command_buffer.len()).expect("usize fit in u64"));
                     command_batch_size.record(command_buffer.len() as f64);
 
                     let mut transaction = partition_store.transaction();
@@ -785,6 +802,7 @@ where
             {
                 // finished catching up
                 self.status.replay_status = ReplayStatus::Active;
+                self.status.target_tail_lsn = None;
             }
             _ => {}
         };

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -151,6 +151,7 @@ pub async fn list_partitions(
         "PERSISTED-LSN",
         "SKIPPED-RECORDS",
         "ARCHIVED-LSN",
+        "LSN-LAG",
         "LAST-UPDATE",
     ]);
 
@@ -284,6 +285,17 @@ pub async fn list_partitions(
                         .status
                         .last_archived_log_lsn
                         .map(|x| x.to_string())
+                        .unwrap_or("-".to_owned()),
+                ),
+                Cell::new(
+                    processor
+                        .status
+                        .target_tail_lsn
+                        .zip(processor.status.last_applied_log_lsn)
+                        .map(|(tail, applied)| {
+                            // (tail - 1) - applied_lsn = tail - (applied_lsn + 1)
+                            tail.value.saturating_sub(applied.value + 1).to_string()
+                        })
                         .unwrap_or("-".to_owned()),
                 ),
                 render_as_duration(processor.status.updated_at, Tense::Past),


### PR DESCRIPTION
Improve invoker observability

Add few extra metrics to measure number of queued commands,
and number of in flight invocation tasks

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2779).
* __->__ #2779
* #2755