### PR TITLE
Add FindTailAttr for configurable find_tail behavior

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -12,6 +12,7 @@ use bytes::{Bytes, BytesMut};
 use tonic::{Request, Response, Status, async_trait};
 use tracing::info;
 
+use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{Bifrost, Error as BiforstError};
 use restate_core::{Metadata, MetadataWriter};
 use restate_types::identifiers::PartitionId;
@@ -279,7 +280,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             })?;
 
         let tail_state = writable_loglet
-            .find_tail()
+            .find_tail(FindTailOptions::default())
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -21,6 +21,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tracing::{Instrument, Level, debug, enabled, error, info, trace_span};
 
+use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{Bifrost, Error as BifrostError};
 use restate_core::metadata_store::{Precondition, WriteError};
 use restate_core::{
@@ -1093,7 +1094,7 @@ impl LogsController {
                     }
 
                     debug!(%log_id, segment_index=%writeable_loglet.segment_index(), "Attempting to find tail for loglet");
-                    let found_tail = match writeable_loglet.find_tail().await {
+                    let found_tail = match writeable_loglet.find_tail(FindTailOptions::ConsistentRead).await {
                         Ok(tail) => tail,
                         Err(err) => {
                             debug!(error=%err, %log_id, segment_index=%writeable_loglet.segment_index(), "Failed to find tail for loglet");

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -813,6 +813,7 @@ mod tests {
     use tracing::{debug, info, warn};
 
     use crate::cluster_controller::cluster_state_refresher::ClusterStateWatcher;
+    use restate_bifrost::loglet::FindTailOptions;
     use restate_bifrost::providers::memory_loglet;
     use restate_bifrost::{Bifrost, BifrostService, ErrorRecoveryStrategy};
     use restate_core::network::{
@@ -980,7 +981,12 @@ mod tests {
             assert_eq!(Lsn::from(i), lsn);
         }
         applied_lsn.store(
-            bifrost.find_tail(LOG_ID).await?.offset().prev().as_u64(),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+                .prev()
+                .as_u64(),
             Ordering::Relaxed,
         );
 
@@ -1057,7 +1063,12 @@ mod tests {
             assert_eq!(Lsn::from(i), lsn);
         }
         applied_lsn.store(
-            bifrost.find_tail(LOG_ID).await?.offset().prev().as_u64(),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+                .prev()
+                .as_u64(),
             Ordering::Relaxed,
         );
         tokio::time::sleep(interval_duration * 2).await;
@@ -1134,7 +1145,12 @@ mod tests {
             assert_eq!(Lsn::from(i), lsn);
         }
         applied_lsn.store(
-            bifrost.find_tail(LOG_ID).await?.offset().prev().as_u64(),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+                .prev()
+                .as_u64(),
             Ordering::Relaxed,
         );
         tokio::time::sleep(interval_duration * 10).await;
@@ -1214,7 +1230,12 @@ mod tests {
             assert_eq!(Lsn::from(i), lsn);
         }
         applied_persisted_lsn.store(
-            bifrost.find_tail(LOG_ID).await?.offset().prev().as_u64(),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+                .prev()
+                .as_u64(),
             Ordering::Relaxed,
         );
 
@@ -1296,7 +1317,12 @@ mod tests {
             assert_eq!(Lsn::from(i), lsn);
         }
         applied_lsn.store(
-            bifrost.find_tail(LOG_ID).await?.offset().prev().as_u64(),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+                .prev()
+                .as_u64(),
             Ordering::Relaxed,
         );
         tokio::time::sleep(interval_duration * 2).await;

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -24,7 +24,7 @@ use restate_types::storage::StorageEncode;
 
 use crate::appender::Appender;
 use crate::background_appender::BackgroundAppender;
-use crate::loglet::{LogletProvider, OperationError};
+use crate::loglet::{FindTailOptions, LogletProvider, OperationError};
 use crate::loglet_wrapper::LogletWrapper;
 use crate::watchdog::{WatchdogCommand, WatchdogSender};
 use crate::{BifrostAdmin, Error, InputRecord, LogReadStream, Result};
@@ -198,6 +198,7 @@ impl Bifrost {
     ///
     /// ```no_run
     /// use restate_bifrost::{Bifrost, LogReadStream};
+    /// use restate_bifrost::loglet::FindTailOptions;
     /// use restate_types::logs::{KeyFilter, LogId, SequenceNumber};
     ///
     /// async fn reader(bifrost: &Bifrost, log_id: LogId) -> LogReadStream {
@@ -205,7 +206,7 @@ impl Bifrost {
     ///        log_id,
     ///        KeyFilter::Any,
     ///        bifrost.get_trim_point(log_id).await.unwrap(),
-    ///        bifrost.find_tail(log_id).await.unwrap().offset().prev(),
+    ///        bifrost.find_tail(log_id, FindTailOptions::default()).await.unwrap().offset().prev(),
     ///     ).unwrap()
     /// }
     /// ```
@@ -261,16 +262,22 @@ impl Bifrost {
     /// If the log is empty, it returns TailState::Open(Lsn::OLDEST).
     /// This should never return Err(Error::LogSealed). Sealed state is represented as
     /// TailState::Sealed(..)
-    pub async fn find_tail(&self, log_id: LogId) -> Result<TailState> {
+    pub async fn find_tail(&self, log_id: LogId, opts: FindTailOptions) -> Result<TailState> {
         self.inner.fail_if_shutting_down()?;
-        Ok(self.inner.find_tail(log_id).await?.1)
+        Ok(self.inner.find_tail(log_id, opts).await?.1)
     }
 
     // Get the loglet currently serving the tail of the chain, for use in integration tests.
     #[cfg(any(test, feature = "test-util"))]
     pub async fn find_tail_loglet(&self, log_id: LogId) -> Result<Arc<dyn crate::loglet::Loglet>> {
         self.inner.fail_if_shutting_down()?;
-        Ok(self.inner.find_tail(log_id).await?.0.inner().clone())
+        Ok(self
+            .inner
+            .find_tail(log_id, FindTailOptions::default())
+            .await?
+            .0
+            .inner()
+            .clone())
     }
 
     /// The lsn of the slot **before** the first readable record (if it exists), or the offset
@@ -290,7 +297,7 @@ impl Bifrost {
 
         self.inner.fail_if_shutting_down()?;
 
-        let current_tail = self.find_tail(log_id).await?;
+        let current_tail = self.find_tail(log_id, FindTailOptions::default()).await?;
 
         if current_tail.offset() <= Lsn::OLDEST {
             return Ok(Vec::default());
@@ -368,7 +375,7 @@ impl BifrostInner {
         from: Lsn,
     ) -> Result<Option<crate::LogEntry>> {
         use futures::StreamExt;
-        let (_, tail_state) = self.find_tail(log_id).await?;
+        let (_, tail_state) = self.find_tail(log_id, FindTailOptions::default()).await?;
         if from >= tail_state.offset() {
             // Can't use this function to read future records.
             return Ok(None);
@@ -385,7 +392,11 @@ impl BifrostInner {
         stream.next().await.transpose()
     }
 
-    pub async fn find_tail(&self, log_id: LogId) -> Result<(LogletWrapper, TailState)> {
+    pub async fn find_tail(
+        &self,
+        log_id: LogId,
+        opts: FindTailOptions,
+    ) -> Result<(LogletWrapper, TailState)> {
         let loglet = self.writeable_loglet(log_id).await?;
         let start = Instant::now();
         // uses the same retry policy as reads to not add too many configuration keys
@@ -396,7 +407,7 @@ impl BifrostInner {
             .clone()
             .into_iter();
         loop {
-            match loglet.find_tail().await {
+            match loglet.find_tail(opts).await {
                 Ok(tail) => {
                     if logged {
                         info!(
@@ -682,7 +693,9 @@ mod tests {
         assert_eq!(max_lsn + Lsn::from(1), lsn);
         max_lsn = lsn;
 
-        let tail = bifrost.find_tail(LogId::new(0)).await?;
+        let tail = bifrost
+            .find_tail(LogId::new(0), FindTailOptions::default())
+            .await?;
         assert_eq!(max_lsn.next(), tail.offset());
 
         // Initiate shutdown
@@ -727,7 +740,13 @@ mod tests {
 
         let bifrost = Bifrost::init_local(node_env.metadata_writer).await;
 
-        assert_eq!(Lsn::OLDEST, bifrost.find_tail(LOG_ID).await?.offset());
+        assert_eq!(
+            Lsn::OLDEST,
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+        );
 
         assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
@@ -739,7 +758,9 @@ mod tests {
 
         bifrost.admin().trim(LOG_ID, Lsn::from(5)).await?;
 
-        let tail = bifrost.find_tail(LOG_ID).await?;
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?;
         assert_eq!(tail.offset(), Lsn::from(11));
         assert!(!tail.is_sealed());
         assert_eq!(Lsn::from(5), bifrost.get_trim_point(LOG_ID).await?);
@@ -761,7 +782,13 @@ mod tests {
         // trimming beyond the release point will fall back to the release point
         bifrost.admin().trim(LOG_ID, Lsn::MAX).await?;
 
-        assert_eq!(Lsn::from(11), bifrost.find_tail(LOG_ID).await?.offset());
+        assert_eq!(
+            Lsn::from(11),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+        );
         let new_trim_point = bifrost.get_trim_point(LOG_ID).await?;
         assert_eq!(Lsn::from(10), new_trim_point);
 
@@ -805,7 +832,9 @@ mod tests {
 
         // not sealed, tail is what we expect
         assert_that!(
-            bifrost.find_tail(LOG_ID).await?,
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?,
             pat!(TailState::Open(eq(Lsn::new(6))))
         );
 
@@ -823,7 +852,9 @@ mod tests {
 
         // sealed, tail is what we expect
         assert_that!(
-            bifrost.find_tail(LOG_ID).await?,
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?,
             pat!(TailState::Sealed(eq(Lsn::new(6))))
         );
 
@@ -875,7 +906,9 @@ mod tests {
         // find_tail() on the underlying loglet returns (6) but for bifrost it should be (5) after
         // the new segment was created at tail of the chain with base_lsn=5
         assert_that!(
-            bifrost.find_tail(LOG_ID).await?,
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?,
             pat!(TailState::Open(eq(Lsn::new(5))))
         );
 
@@ -890,13 +923,15 @@ mod tests {
 
         // tail is now 8 and open.
         assert_that!(
-            bifrost.find_tail(LOG_ID).await?,
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?,
             pat!(TailState::Open(eq(Lsn::new(8))))
         );
 
         // validating that segment 1 is still sealed and has its own tail at Lsn (6)
         assert_that!(
-            segment_1.find_tail().await?,
+            segment_1.find_tail(FindTailOptions::default()).await?,
             pat!(TailState::Sealed(eq(Lsn::new(6))))
         );
 
@@ -910,7 +945,7 @@ mod tests {
 
         // segment 2 is open and at 8 as previously validated through bifrost interface
         assert_that!(
-            segment_2.find_tail().await?,
+            segment_2.find_tail(FindTailOptions::default()).await?,
             pat!(TailState::Open(eq(Lsn::new(8))))
         );
 

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -22,6 +22,7 @@ use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 
 use crate::bifrost::BifrostInner;
 use crate::error::AdminError;
+use crate::loglet::FindTailOptions;
 use crate::loglet_wrapper::LogletWrapper;
 use crate::{Error, Result};
 
@@ -187,7 +188,7 @@ impl<'a> BifrostAdmin<'a> {
                 }
             }
         }
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
 
         Ok(SealedSegment {
             segment_index: loglet.segment_index(),

--- a/crates/bifrost/src/loglet/loglet_tests.rs
+++ b/crates/bifrost/src/loglet/loglet_tests.rs
@@ -25,7 +25,7 @@ use restate_types::logs::metadata::{LogletConfig, SegmentIndex};
 use restate_types::logs::{KeyFilter, Lsn, SequenceNumber, TailState};
 
 use super::Loglet;
-use crate::loglet::AppendError;
+use crate::loglet::{AppendError, FindTailOptions};
 use crate::loglet_wrapper::LogletWrapper;
 
 async fn wait_for_trim(loglet: &LogletWrapper, required_trim_point: Lsn) -> anyhow::Result<()> {
@@ -63,7 +63,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -76,7 +76,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
         assert_eq!(Lsn::new(i), offset);
         assert_eq!(None, loglet.get_trim_point().await?);
         {
-            let tail = loglet.find_tail().await?;
+            let tail = loglet.find_tail(FindTailOptions::default()).await?;
             assert_eq!(Lsn::new(i + 1), tail.offset());
             assert!(!tail.is_sealed());
         }
@@ -114,7 +114,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
     // trim point and tail didn't change
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::new(end), tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -168,7 +168,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
     assert_eq!(Lsn::new(4), offset);
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::new(5), tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -191,7 +191,10 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
     assert!(res.is_err());
     assert!(start.elapsed() >= Duration::from_secs(10));
     // Tail didn't change.
-    assert_eq!(Lsn::new(5), loglet.find_tail().await?.offset());
+    assert_eq!(
+        Lsn::new(5),
+        loglet.find_tail(FindTailOptions::default()).await?.offset()
+    );
 
     // trim the loglet to and including 3
     loglet.trim(Lsn::new(3)).await?;
@@ -199,7 +202,7 @@ pub async fn gapless_loglet_smoke_test(loglet: Arc<dyn Loglet>) -> googletest::R
 
     // tail didn't change
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::new(5), tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -242,7 +245,7 @@ pub async fn single_loglet_readstream(loglet: Arc<dyn Loglet>) -> googletest::Re
 
     {
         // no records have been written yet.
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -314,7 +317,7 @@ pub async fn single_loglet_readstream_with_trims(
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -327,7 +330,10 @@ pub async fn single_loglet_readstream_with_trims(
     // Lsn(5) is trimmed, 5 records left [6..10]
     loglet.trim(Lsn::new(5)).await?;
 
-    assert_eq!(Lsn::new(11), loglet.find_tail().await?.offset());
+    assert_eq!(
+        Lsn::new(11),
+        loglet.find_tail(FindTailOptions::default()).await?.offset()
+    );
     // retry if loglet needs time to perform the trim.
     wait_for_trim(&loglet, Lsn::new(5))
         .await
@@ -361,7 +367,7 @@ pub async fn single_loglet_readstream_with_trims(
 
     // tail didn't move.
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::new(11), tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -375,7 +381,7 @@ pub async fn single_loglet_readstream_with_trims(
         .into_test_result()?;
     // tail is not impacted by the trim operation
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::new(11), tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -435,7 +441,7 @@ pub async fn append_after_seal(loglet: Arc<dyn Loglet>) -> googletest::Result<()
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -453,7 +459,7 @@ pub async fn append_after_seal(loglet: Arc<dyn Loglet>) -> googletest::Result<()
         assert_that!(res, err(pat!(AppendError::Sealed)));
     }
 
-    let tail = loglet.find_tail().await?;
+    let tail = loglet.find_tail(FindTailOptions::default()).await?;
     // Seal must be applied after commit index 5 since it has been acknowledged (tail is 6 or higher)
     assert_that!(tail, pat!(TailState::Sealed(gt(Lsn::new(5)))));
 
@@ -477,7 +483,7 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -534,7 +540,10 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
         let loglet = loglet.clone();
         async move {
             loop {
-                let res = loglet.find_tail().await.expect("find_tail succeeds");
+                let res = loglet
+                    .find_tail(FindTailOptions::default())
+                    .await
+                    .expect("find_tail succeeds");
                 if res.is_sealed() {
                     return res.offset();
                 }
@@ -560,7 +569,7 @@ pub async fn append_after_seal_concurrent(loglet: Arc<dyn Loglet>) -> googletest
         err(pat!(AppendError::Sealed))
     );
 
-    let tail = loglet.find_tail().await?;
+    let tail = loglet.find_tail(FindTailOptions::default()).await?;
     assert!(tail.is_sealed());
     let first_observed_seal = first_observed_seal.await?;
     println!("Sealed tail={tail:?}, first observed seal at={first_observed_seal}");
@@ -616,7 +625,7 @@ pub async fn seal_empty(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
 
     assert_eq!(None, loglet.get_trim_point().await?);
     {
-        let tail = loglet.find_tail().await?;
+        let tail = loglet.find_tail(FindTailOptions::default()).await?;
         assert_eq!(Lsn::OLDEST, tail.offset());
         assert!(!tail.is_sealed());
     }
@@ -633,7 +642,7 @@ pub async fn seal_empty(loglet: Arc<dyn Loglet>) -> googletest::Result<()> {
     }
 
     loglet.seal().await?;
-    let tail = loglet.find_tail().await?;
+    let tail = loglet.find_tail(FindTailOptions::default()).await?;
     assert_eq!(Lsn::OLDEST, tail.offset());
     assert!(tail.is_sealed());
 

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -39,7 +39,9 @@ use self::metric_definitions::{BIFROST_LOCAL_APPEND, BIFROST_LOCAL_APPEND_DURATI
 use self::read_stream::LocalLogletReadStream;
 use crate::Result;
 use crate::loglet::util::TailOffsetWatch;
-use crate::loglet::{Loglet, LogletCommit, OperationError, SendableLogletReadStream};
+use crate::loglet::{
+    FindTailOptions, Loglet, LogletCommit, OperationError, SendableLogletReadStream,
+};
 use crate::providers::local_loglet::metric_definitions::{
     BIFROST_LOCAL_TRIM, BIFROST_LOCAL_TRIM_LENGTH,
 };
@@ -203,7 +205,10 @@ impl Loglet for LocalLoglet {
         Ok(LogletCommit::resolved(offset))
     }
 
-    async fn find_tail(&self) -> Result<TailState<LogletOffset>, OperationError> {
+    async fn find_tail(
+        &self,
+        _: FindTailOptions,
+    ) -> Result<TailState<LogletOffset>, OperationError> {
         // `fetch_add(0)` with Release ordering to enforce using last_committed_offset as a memory
         // barrier and synchronization point with other threads.
         let last_committed =

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -33,8 +33,8 @@ use crate::LogEntry;
 use crate::Result;
 use crate::loglet::util::TailOffsetWatch;
 use crate::loglet::{
-    Loglet, LogletCommit, LogletProvider, LogletProviderFactory, LogletReadStream, OperationError,
-    SendableLogletReadStream,
+    FindTailOptions, Loglet, LogletCommit, LogletProvider, LogletProviderFactory, LogletReadStream,
+    OperationError, SendableLogletReadStream,
 };
 
 #[derive(Default)]
@@ -370,7 +370,10 @@ impl Loglet for MemoryLoglet {
         Ok(LogletCommit::resolved(last_committed_offset))
     }
 
-    async fn find_tail(&self) -> Result<TailState<LogletOffset>, OperationError> {
+    async fn find_tail(
+        &self,
+        _: FindTailOptions,
+    ) -> Result<TailState<LogletOffset>, OperationError> {
         let _guard = self.log.lock().unwrap();
         let committed =
             LogletOffset::new(self.last_committed_offset.load(Ordering::Relaxed)).next();

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -30,7 +30,7 @@ use restate_types::net::replicated_loglet::{
 };
 
 use super::error::ReplicatedLogletError;
-use super::loglet::{FindTailOptions, ReplicatedLoglet};
+use super::loglet::{FindTailFlags, ReplicatedLoglet};
 use super::provider::ReplicatedLogletProvider;
 use crate::loglet::util::TailOffsetWatch;
 use crate::loglet::{AppendError, Loglet, LogletCommit, OperationError};
@@ -161,10 +161,7 @@ impl RequestPump {
 
         if msg.force_seal_check {
             let _ = TaskCenter::spawn(TaskKind::Disposable, "remote-check-seal", async move {
-                match loglet
-                    .find_tail_inner(FindTailOptions::ForceSealCheck)
-                    .await
-                {
+                match loglet.find_tail_inner(FindTailFlags::ForceSealCheck).await {
                     Ok(tail) => {
                         let sequencer_state = SequencerState {
                             header: CommonResponseHeader {

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -35,7 +35,7 @@ use super::rpc_routers::{LogServersRpc, SequencersRpc};
 use crate::Error;
 use crate::loglet::{Loglet, LogletProvider, LogletProviderFactory, OperationError};
 use crate::providers::replicated_loglet::error::ReplicatedLogletError;
-use crate::providers::replicated_loglet::loglet::FindTailOptions;
+use crate::providers::replicated_loglet::loglet::FindTailFlags;
 use crate::providers::replicated_loglet::tasks::PeriodicTailChecker;
 
 pub struct Factory<T> {
@@ -193,10 +193,10 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
                             .replicated_loglet
                             .sequencer_inactivity_timeout
                             .into(),
-                        FindTailOptions::ForceSealCheck,
+                        FindTailFlags::ForceSealCheck,
                     )
                 } else {
-                    (Duration::from_secs(2), FindTailOptions::Default)
+                    (Duration::from_secs(2), FindTailFlags::Default)
                 };
                 let _ = TaskCenter::spawn(
                     TaskKind::BifrostBackgroundLowPriority,

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -26,7 +26,7 @@ use restate_types::replicated_loglet::{LogNodeSetExt, ReplicatedLogletParams};
 
 use super::{NodeTailStatus, RepairTail, RepairTailResult, SealTask};
 use crate::loglet::util::TailOffsetWatch;
-use crate::providers::replicated_loglet::loglet::FindTailOptions;
+use crate::providers::replicated_loglet::loglet::FindTailFlags;
 use crate::providers::replicated_loglet::replication::NodeSetChecker;
 use crate::providers::replicated_loglet::rpc_routers::{LogServersRpc, SequencersRpc};
 
@@ -92,7 +92,7 @@ impl<T: TransportConnect> FindTailTask<T> {
     }
 
     #[instrument(skip_all)]
-    pub async fn run(self, opts: FindTailOptions) -> FindTailResult {
+    pub async fn run(self, opts: FindTailFlags) -> FindTailResult {
         // Special case:
         // If all nodes in the nodeset is in "provisioning", we can confidently short-circuit
         // the result to LogletOffset::Oldest and the loglet is definitely unsealed.
@@ -118,7 +118,7 @@ impl<T: TransportConnect> FindTailTask<T> {
                 segment_index: self.segment_index,
                 loglet_id: self.my_params.loglet_id,
             },
-            force_seal_check: opts == FindTailOptions::ForceSealCheck,
+            force_seal_check: opts == FindTailFlags::ForceSealCheck,
         };
 
         // todo: use cluster-state information when this becomes node-level available to avoid

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/periodic_tail_checker.rs
@@ -20,7 +20,7 @@ use restate_core::network::TransportConnect;
 use restate_types::logs::LogletId;
 
 use crate::loglet::OperationError;
-use crate::providers::replicated_loglet::loglet::{FindTailOptions, ReplicatedLoglet};
+use crate::providers::replicated_loglet::loglet::{FindTailFlags, ReplicatedLoglet};
 
 pub struct PeriodicTailChecker {}
 
@@ -30,7 +30,7 @@ impl PeriodicTailChecker {
         loglet_id: LogletId,
         loglet: Weak<ReplicatedLoglet<T>>,
         duration: Duration,
-        opts: FindTailOptions,
+        opts: FindTailFlags,
     ) -> anyhow::Result<()> {
         debug!(
             %loglet_id,

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -454,6 +454,7 @@ mod tests {
     use restate_types::logs::{KeyFilter, SequenceNumber};
     use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 
+    use crate::loglet::FindTailOptions;
     use crate::{BifrostService, ErrorRecoveryStrategy};
 
     #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
@@ -478,7 +479,9 @@ mod tests {
         let mut reader = bifrost.create_reader(LOG_ID, KeyFilter::Any, read_from, Lsn::MAX)?;
         let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::Wait)?;
 
-        let tail = bifrost.find_tail(LOG_ID).await?;
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?;
         // no records have been written
         assert!(!tail.is_sealed());
         assert_eq!(Lsn::OLDEST, tail.offset());
@@ -567,7 +570,13 @@ mod tests {
         // [1..5] trimmed. trim_point = 5
         bifrost.admin().trim(LOG_ID, Lsn::from(5)).await?;
 
-        assert_eq!(Lsn::from(11), bifrost.find_tail(LOG_ID).await?.offset());
+        assert_eq!(
+            Lsn::from(11),
+            bifrost
+                .find_tail(LOG_ID, FindTailOptions::default())
+                .await?
+                .offset()
+        );
         assert_eq!(Lsn::from(5), bifrost.get_trim_point(LOG_ID).await?);
 
         let mut read_stream =
@@ -584,7 +593,10 @@ mod tests {
         assert!(!read_stream.is_terminated());
         assert_eq!(Lsn::from(8), read_stream.read_pointer());
 
-        let tail = bifrost.find_tail(LOG_ID).await?.offset();
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?
+            .offset();
         // trimming beyond the release point will fall back to the release point
         bifrost.admin().trim(LOG_ID, Lsn::from(u64::MAX)).await?;
         let trim_point = bifrost.get_trim_point(LOG_ID).await?;
@@ -654,7 +666,9 @@ mod tests {
             pat!(Poll::Pending)
         );
 
-        let tail = bifrost.find_tail(LOG_ID).await?;
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?;
         // no records have been written
         assert!(!tail.is_sealed());
         assert_eq!(Lsn::OLDEST, tail.offset());
@@ -716,7 +730,9 @@ mod tests {
             pat!(Poll::Pending)
         );
 
-        let tail = bifrost.find_tail(LOG_ID).await?;
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?;
 
         assert!(tail.is_sealed());
         assert_eq!(Lsn::from(11), tail.offset());
@@ -803,7 +819,9 @@ mod tests {
 
         let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::Wait)?;
 
-        let tail = bifrost.find_tail(LOG_ID).await?;
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?;
         // no records have been written
         assert!(!tail.is_sealed());
         assert_eq!(Lsn::OLDEST, tail.offset());
@@ -827,7 +845,9 @@ mod tests {
             )
             .await?;
 
-        let tail = bifrost.find_tail(LOG_ID).await?;
+        let tail = bifrost
+            .find_tail(LOG_ID, FindTailOptions::default())
+            .await?;
 
         assert!(!tail.is_sealed());
         assert_eq!(Lsn::from(11), tail.offset());
@@ -851,7 +871,9 @@ mod tests {
             .unwrap();
 
         assert_that!(
-            segment_1_loglet.find_tail().await?,
+            segment_1_loglet
+                .find_tail(FindTailOptions::default())
+                .await?,
             pat!(TailState::Sealed(eq(Lsn::from(11))))
         );
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -18,6 +18,7 @@ use assert2::let_assert;
 use enumset::EnumSet;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt as _};
 use metrics::histogram;
+use restate_bifrost::loglet::FindTailOptions;
 use tokio::sync::{mpsc, watch};
 use tokio::time::MissedTickBehavior;
 use tracing::{Span, debug, error, info, instrument, trace, warn};
@@ -328,7 +329,10 @@ where
         // propagate errors and let the PPM handle error retries
         let current_tail = self
             .bifrost
-            .find_tail(LogId::from(self.partition_id))
+            .find_tail(
+                LogId::from(self.partition_id),
+                FindTailOptions::ConsistentRead,
+            )
             .await?;
 
         debug!(

--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -21,11 +21,14 @@ mod tests {
 
     use futures_util::StreamExt;
     use googletest::prelude::*;
-    use restate_bifrost::{ErrorRecoveryStrategy, loglet::AppendError};
     use test_log::test;
     use tokio::task::{JoinHandle, JoinSet};
     use tokio_util::sync::CancellationToken;
 
+    use restate_bifrost::{
+        ErrorRecoveryStrategy,
+        loglet::{AppendError, FindTailOptions},
+    };
     use restate_core::{Metadata, TaskCenterFutureExt};
     use restate_types::{
         GenerationalNodeId, Version,
@@ -68,7 +71,7 @@ mod tests {
                 assert_that!(offset, eq(LogletOffset::new(3)));
                 let offset = env.loglet.enqueue_batch(batch.clone()).await?.await?;
                 assert_that!(offset, eq(LogletOffset::new(6)));
-                let tail = env.loglet.find_tail().await?;
+                let tail = env.loglet.find_tail(FindTailOptions::default()).await?;
                 assert_that!(tail, eq(TailState::Open(LogletOffset::new(7))));
 
                 Ok(())
@@ -95,7 +98,7 @@ mod tests {
                 assert_that!(offset, eq(LogletOffset::new(3)));
                 let offset = env.loglet.enqueue_batch(batch.clone()).await?.await?;
                 assert_that!(offset, eq(LogletOffset::new(6)));
-                let tail = env.loglet.find_tail().await?;
+                let tail = env.loglet.find_tail(FindTailOptions::default()).await?;
                 assert_that!(tail, eq(TailState::Open(LogletOffset::new(7))));
 
                 env.loglet.seal().await?;
@@ -106,7 +109,7 @@ mod tests {
                 .into();
                 let not_appended = env.loglet.enqueue_batch(batch).await?.await;
                 assert_that!(not_appended, err(pat!(AppendError::Sealed)));
-                let tail = env.loglet.find_tail().await?;
+                let tail = env.loglet.find_tail(FindTailOptions::default()).await?;
                 assert_that!(tail, eq(TailState::Sealed(LogletOffset::new(7))));
 
                 Ok(())

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -17,6 +17,7 @@ use futures_util::StreamExt;
 use tracing::{debug, info};
 
 use restate_bifrost::BifrostService;
+use restate_bifrost::loglet::FindTailOptions;
 use restate_core::network::MessageRouterBuilder;
 use restate_core::{MetadataBuilder, MetadataManager, TaskCenter, TaskKind};
 use restate_rocksdb::RocksDbManager;
@@ -98,7 +99,9 @@ async fn dump_log(opts: &DumpLogOpts) -> anyhow::Result<()> {
 
         let log_id = LogId::from(opts.log_id);
         debug!("Finding log tail");
-        let tail = bifrost.find_tail(log_id).await?;
+        let tail = bifrost
+            .find_tail(log_id, FindTailOptions::default())
+            .await?;
         debug!("Log tail is {:?}", tail);
         let trim_point = bifrost.get_trim_point(log_id).await?;
         debug!("Trim point is {:?}", trim_point);


### PR DESCRIPTION
Add FindTailAttr for configurable find_tail behavior

Summary:
FindTailAttr allows find_tail users to adjust durability and accuracy. Currently, two modes are supported:

Approximate: A fast check that usually returns immediately with the last known tail.
Durable (default): Ensures a reliable tail find.

Loglet implementations can choose to always run Durable find_tail.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2781).
* #2779
* #2755
* __->__ #2781