### PR TITLE
Revert "Set the default concurrent_invocations_limit to None"

### DIFF
--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -231,9 +231,7 @@ impl Default for InvokerOptions {
             message_size_warning: NonZeroUsize::new(10_000_000).unwrap(), // 10MB
             message_size_limit: None,
             tmp_dir: None,
-            // Let users configure a limit once they hit a problem with the number of concurrent
-            // invocations.
-            concurrent_invocations_limit: None,
+            concurrent_invocations_limit: Some(NonZeroUsize::new(100).unwrap()),
             disable_eager_state: false,
         }
     }


### PR DESCRIPTION
This reverts commit 33fd35e7ee877f216896200af6aa817142dd3eb6.