### PR TITLE
Pin Docker version to 27.5.1

### DIFF
--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Set up Docker containerd snapshotter
         uses: crazy-max/ghaction-setup-docker@v3
         with:
+          # Docker 28.0.1 seems to fail on GHA: https://github.com/restatedev/restate/actions/runs/13562737120/job/37909085871#step:6:47
+          # todo set to latest once new Docker version that is working on GHA is released
+          version: "27.5.1"
           set-host: true
           daemon-config: |
             {

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Set up Docker containerd snapshotter
         uses: crazy-max/ghaction-setup-docker@v3
         with:
+          # Docker 28.0.1 seems to fail on GHA: https://github.com/restatedev/restate/actions/runs/13562737120/job/37909085871#step:6:47
+          # todo set to latest once new Docker version that is working on GHA is released
+          version: "27.5.1"
           daemon-config: |
             {
               "features": {


### PR DESCRIPTION
The latest Docker version 28.0.1 seems to no longer start properly on GHA https://github.com/restatedev/restate/actions/runs/13562737120/job/37909085871#step:6:47 and https://github.com/restatedev/restate/actions/runs/13549192188/job/37868461603#step:6:47

This commit fixes the version to the last known working Docker version 27.5.1. We should revert this change once Docker releases a newer version that is working again.