### PR TITLE
Bail when a non-native remote metadata client is configured on a meta…

### DIFF
--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -226,30 +226,21 @@ pub async fn create_metadata_server_and_client(
             RaftMetadataServer::create(rocksdb_options, health_status, server_builder)
                 .await
                 .map_err(anyhow::Error::from)
-                .and_then(|server| {
+                .map(|server| {
                     let metadata_client_options = config.common.metadata_client.clone();
                     let backoff_policy = metadata_client_options.backoff_policy.clone();
-
-                    let MetadataClientKind::Replicated { addresses } =
-                        config.common.metadata_client.kind.clone()
-                    else {
-                        anyhow::bail!(
-                            "Detected a possible misconfiguration of the cluster. The \
-                        cluster runs a replicated metadata server but not the replicated metadata \
-                        client. If you don't want to run a metadata server, then remove the \
-                        metadata-server role. If you want to run the replicated metadata server, \
-                        then configure metadata-client.type = \"replicated\""
-                        );
-                    };
-
-                    Ok((
+                    let_assert!(
+                        MetadataClientKind::Replicated { addresses } =
+                            config.common.metadata_client.kind.clone()
+                    );
+                    (
                         server.boxed(),
                         create_replicated_metadata_client(
                             addresses,
                             Some(backoff_policy),
                             Arc::new(metadata_client_options),
                         ),
-                    ))
+                    )
                 })
         }
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -149,6 +149,20 @@ impl Node {
         let is_provisioned =
             cluster_marker::validate_and_update_cluster_marker(config.common.cluster_name())?;
 
+        if !matches!(
+            &config.common.metadata_client.kind,
+            restate_types::config::MetadataClientKind::Replicated { .. }
+        ) && config.has_role(Role::MetadataServer)
+        {
+            return Err(BuildError::InvalidConfiguration(anyhow::anyhow!(
+                "Detected possible misconfiguration. This node runs a replicated metadata \
+                server but is not configured to use the replicated metadata client. If you \
+                don't want to run a metadata server, remove the metadata-server role. If you \
+                want to use the replicated metadata server, then set \
+                metadata-client.type = \"replicated\""
+            )));
+        };
+
         let (metadata_store_role, metadata_store_client) = if config.has_role(Role::MetadataServer)
         {
             restate_metadata_server::create_metadata_server_and_client(


### PR DESCRIPTION
…data-server node

This prevents mixing up any remote metadata store clients (including etcd, object-store) with the local metadata server. Previously, we correctly detected the misconfiguration of a local metadata server with a remote metadata client, but would completely ignore the remote client configuration if the node has the `metadata-server` role.