### PR TITLE
[restatectl] set-storage-state supports multiple nodes and safety checking

### DIFF
--- a/tools/restatectl/src/commands/replicated_loglet/list_servers.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/list_servers.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use cling::prelude::*;
+
+use itertools::Itertools;
+use restate_cli_util::_comfy_table::{Cell, Table};
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::StyledTable;
+use restate_types::Versioned;
+use restate_types::logs::metadata::ProviderKind;
+use restate_types::nodes_config::Role;
+use restate_types::replicated_loglet::ReplicatedLogletParams;
+
+use super::render_storage_state;
+use crate::connection::ConnectionInfo;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "list_servers")]
+#[clap(visible_alias = "servers", visible_alias = "nodes")]
+pub struct ListServersOpts;
+
+async fn list_servers(connection: &ConnectionInfo) -> anyhow::Result<()> {
+    let nodes_config = connection.get_nodes_configuration().await?;
+    let logs = connection.get_logs().await?;
+
+    let mut servers_table = Table::new_styled();
+    let header = vec![
+        "NODE",
+        "GEN",
+        "STORAGE-STATE",
+        "HISTORICAL LOGLETS",
+        "ACTIVE LOGLETS",
+    ];
+    servers_table.set_styled_header(header);
+    for (node_id, config) in nodes_config.iter().sorted_by(|a, b| Ord::cmp(&a.0, &b.0)) {
+        if !config.has_role(Role::LogServer)
+            && config.log_server_config.storage_state.is_provisioning()
+        {
+            continue;
+        }
+        let count_loglets = logs
+            .iter_replicated_loglets()
+            .filter(|(_, loglet)| loglet.params.nodeset.contains(node_id))
+            .count();
+        let count_active = logs
+            .iter_writeable()
+            .filter(|(_, segment)| {
+                if segment.config.kind != ProviderKind::Replicated {
+                    return false;
+                }
+                let params =
+                    ReplicatedLogletParams::deserialize_from(segment.config.params.as_bytes())
+                        .expect("loglet config is deserializable");
+                params.nodeset.contains(node_id)
+            })
+            .count();
+        servers_table.add_row(vec![
+            Cell::new(node_id.to_string()),
+            Cell::new(config.current_generation.to_string()),
+            render_storage_state(config.log_server_config.storage_state),
+            Cell::new(count_loglets),
+            Cell::new(count_active),
+        ]);
+    }
+    c_println!("Node configuration {}", nodes_config.version());
+    c_println!("Log chain {}", logs.version());
+    c_println!("{}", servers_table);
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/replicated_loglet/mod.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/mod.rs
@@ -11,9 +11,13 @@
 mod digest;
 mod digest_util;
 mod info;
+mod list_servers;
 mod storage_state;
 
 use cling::prelude::*;
+
+use restate_cli_util::_comfy_table::{Cell, Color};
+use restate_types::nodes_config::StorageState;
 
 #[derive(Run, Subcommand, Clone)]
 pub enum ReplicatedLoglet {
@@ -22,7 +26,18 @@ pub enum ReplicatedLoglet {
     /// View loglet info
     Info(info::InfoOpts),
     /// View log-server(s) state
-    ListServers(storage_state::ListServersOpts),
+    ListServers(list_servers::ListServersOpts),
     /// [dangerous] low-level unprotected log-server's storage-state manipulation
     SetStorageState(storage_state::SetOpts),
+}
+
+fn render_storage_state(state: StorageState) -> Cell {
+    let cell = Cell::new(state);
+    match state {
+        StorageState::ReadWrite => cell.fg(Color::Green),
+        StorageState::ReadOnly => cell.fg(Color::Yellow),
+        StorageState::DataLoss => cell.fg(Color::Red),
+        StorageState::Provisioning => cell.fg(Color::Reset),
+        StorageState::Disabled => cell.fg(Color::Grey),
+    }
 }

--- a/tools/restatectl/src/commands/replicated_loglet/storage_state.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/storage_state.rs
@@ -8,35 +8,32 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+
+use anyhow::Context;
 use cling::prelude::*;
 
-use restate_cli_util::_comfy_table::{Cell, Color, Table};
+use restate_bifrost::providers::replicated_loglet::logserver_candidate_filter;
+use restate_bifrost::providers::replicated_loglet::replication::NodeSetChecker;
 use restate_cli_util::c_println;
-use restate_cli_util::ui::console::StyledTable;
-use restate_core::metadata_store::{ReadWriteError, retry_on_retryable_error};
 use restate_metadata_server::{MetadataStoreClient, create_client};
-use restate_types::config::{CommonOptions, MetadataClientKind, MetadataClientOptions};
+use restate_types::config::{MetadataClientKind, MetadataClientOptions};
 use restate_types::logs::metadata::ProviderKind;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{NodesConfiguration, Role, StorageState};
-use restate_types::replicated_loglet::ReplicatedLogletParams;
-use restate_types::{GenerationalNodeId, PlainNodeId, Versioned};
+use restate_types::replication::{NodeSetSelector, NodeSetSelectorOptions};
+use restate_types::{GenerationalNodeId, PlainNodeId};
 
 use crate::connection::ConnectionInfo;
-
-#[derive(Run, Parser, Collect, Clone, Debug)]
-#[cling(run = "list_servers")]
-#[clap(visible_alias = "servers")]
-pub struct ListServersOpts;
 
 // note 1: this is until we have a way to proxy metadata requests through nodes
 // note 2: currently supports replicated metadata only, node must be one of metadata nodes
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "set_storage_state")]
 pub struct SetOpts {
-    /// The node Id of the log-server
-    #[arg(long)]
-    node_id: PlainNodeId,
+    /// A node-id or a list of node-ids (comma-separated) to update
+    #[arg(long, required = true, visible_alias = "node", value_delimiter = ',')]
+    nodes: Vec<PlainNodeId>,
     #[arg(long)]
     storage_state: StorageState,
     /// [dangerous] ignore safety checks and force the update. Note that this might cause cluster unavailability or data loss.
@@ -44,63 +41,11 @@ pub struct SetOpts {
     force: bool,
 }
 
-fn render_storage_state(state: StorageState) -> Cell {
-    let cell = Cell::new(state);
-    match state {
-        StorageState::ReadWrite => cell.fg(Color::Green),
-        StorageState::ReadOnly => cell.fg(Color::Yellow),
-        StorageState::DataLoss => cell.fg(Color::Red),
-        StorageState::Provisioning => cell.fg(Color::Reset),
-        StorageState::Disabled => cell.fg(Color::Grey),
-    }
-}
-
-async fn list_servers(connection: &ConnectionInfo) -> anyhow::Result<()> {
-    let nodes_config = connection.get_nodes_configuration().await?;
-    let logs = connection.get_logs().await?;
-
-    let mut servers_table = Table::new_styled();
-    let header = vec![
-        "NODE",
-        "GEN",
-        "STORAGE-STATE",
-        "HISTORICAL LOGLETS",
-        "ACTIVE LOGLETS",
-    ];
-    servers_table.set_styled_header(header);
-    for (node_id, config) in nodes_config.iter_role(Role::LogServer) {
-        let count_loglets = logs
-            .iter_replicated_loglets()
-            .filter(|(_, loglet)| loglet.params.nodeset.contains(node_id))
-            .count();
-        let count_active = logs
-            .iter_writeable()
-            .filter(|(_, segment)| {
-                if segment.config.kind != ProviderKind::Replicated {
-                    return false;
-                }
-                let params =
-                    ReplicatedLogletParams::deserialize_from(segment.config.params.as_bytes())
-                        .expect("loglet config is deserializable");
-                params.nodeset.contains(node_id)
-            })
-            .count();
-        servers_table.add_row(vec![
-            Cell::new(node_id.to_string()),
-            Cell::new(config.current_generation.to_string()),
-            render_storage_state(config.log_server_config.storage_state),
-            Cell::new(count_loglets),
-            Cell::new(count_active),
-        ]);
-    }
-    c_println!("Node configuration {}", nodes_config.version());
-    c_println!("Log chain {}", logs.version());
-    c_println!("{}", servers_table);
-
-    Ok(())
-}
-
 async fn set_storage_state(connection: &ConnectionInfo, opts: &SetOpts) -> anyhow::Result<()> {
+    if opts.nodes.is_empty() {
+        return Err(anyhow::anyhow!("--node/--nodes is required"));
+    }
+
     let nodes_config = connection.get_nodes_configuration().await?;
 
     // find metadata nodes
@@ -124,165 +69,168 @@ async fn set_storage_state(connection: &ConnectionInfo, opts: &SetOpts) -> anyho
         .await
         .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))?;
 
-    let node = nodes_config.find_node_by_id(opts.node_id)?;
-    let current_state = node.log_server_config.storage_state;
-    let current_generation = node.current_generation;
+    let mut current_states: HashMap<GenerationalNodeId, StorageState> =
+        HashMap::with_capacity(opts.nodes.len());
+    for node_id in opts.nodes.iter().cloned() {
+        let node = nodes_config.find_node_by_id(node_id)?;
+        let current_state = node.log_server_config.storage_state;
+        let current_generation = node.current_generation;
+        current_states.insert(current_generation, current_state);
 
-    if !opts.force {
-        if !node.has_role(Role::LogServer) {
-            return Err(anyhow::anyhow!(
-                "Node {} doesn't have `log-server` role. Its last-observed generation {} has roles: [{}]",
-                opts.node_id,
-                current_generation,
-                node.roles,
-            ));
-        }
+        if !opts.force {
+            if !node.has_role(Role::LogServer) {
+                return Err(anyhow::anyhow!(
+                    "Node {} doesn't have `log-server` role. Its last-observed generation {} has roles: [{}]",
+                    node_id,
+                    current_generation,
+                    node.roles,
+                ));
+            }
 
-        let safe = match (current_state, opts.storage_state) {
-            (from, to) if from == to => {
-                c_println!(
-                    "Node {} storage-state was already {}",
-                    opts.node_id,
-                    current_state
-                );
-                return Ok(());
-            }
-            (StorageState::Provisioning, StorageState::Disabled) => {
-                // one can do that, but the node will never be a log-server in the future
-                true
-            }
-            (StorageState::Provisioning, _) => false,
-            (StorageState::Disabled, StorageState::Provisioning) => {
-                // technically, this can be possible if the node is not in any historical nodeset,
-                // todo: perform this check to allow those operations to take place.
-                false
-            }
-            // all transitions from disable -> anything other than provisioning are not allowed.
-            (StorageState::Disabled, _) => false,
-            (StorageState::ReadOnly, StorageState::ReadWrite) => true,
-            (StorageState::ReadWrite, StorageState::ReadOnly) => {
-                // drain.
-                // We should allow this only if we won't lose ability to generate nodesets with the
-                // remaining set of writeable nodes
-                // todo (now): check if we can generate nodesets without this node.
-                true
-            }
-            (StorageState::ReadOnly, StorageState::Disabled) => {
-                // only possible if this node:
-                // - removed from all nodesets (chains trimmed)
-                false
-            }
-            (StorageState::ReadOnly, _) => false,
-            (StorageState::ReadWrite, StorageState::Provisioning) => false,
-            (StorageState::ReadWrite, _) => false,
-            (StorageState::DataLoss, StorageState::ReadWrite) => {
-                // that's only possible if we are okay with either:
-                // - declaring permanent data-loss of data on this node
-                // - the node transitioned into data-loss, but we didn't actually lose data.
-                false
-            }
-            (StorageState::DataLoss, StorageState::Provisioning) => false,
-            (StorageState::DataLoss, StorageState::ReadOnly) => {
-                // silent under-replication
-                false
-            }
-            (StorageState::DataLoss, StorageState::Disabled) => {
-                // only if data were trimmed
-                false
-            }
-            (_, _) => false,
-        };
+            let safe = match (current_state, opts.storage_state) {
+                (from, to) if from == to => true,
+                (StorageState::Provisioning, StorageState::Disabled) => {
+                    // one can do that, but the node will never be a log-server in the future
+                    true
+                }
+                (StorageState::Provisioning, _) => false,
+                (StorageState::Disabled, StorageState::Provisioning) => {
+                    // technically, this can be possible if the node is not in any historical nodeset,
+                    // todo: perform this check to allow those operations to take place.
+                    false
+                }
+                // all transitions from disable -> anything other than provisioning are not allowed.
+                (StorageState::Disabled, _) => false,
+                (StorageState::ReadOnly, StorageState::ReadWrite) => true,
+                (StorageState::ReadWrite, StorageState::ReadOnly) => {
+                    // drain.
+                    // We should allow this only if we won't lose ability to generate nodesets with the
+                    // remaining set of writeable nodes
+                    true
+                }
+                (StorageState::ReadOnly, StorageState::Disabled) => {
+                    // only possible if this node:
+                    // - removed from all nodesets (chains trimmed)
+                    false
+                }
+                (StorageState::ReadOnly, _) => false,
+                (StorageState::ReadWrite, StorageState::Provisioning) => false,
+                (StorageState::ReadWrite, _) => false,
+                (StorageState::DataLoss, StorageState::ReadWrite) => {
+                    // that's only possible if we are okay with either:
+                    // - declaring permanent data-loss of data on this node
+                    // - the node transitioned into data-loss, but we didn't actually lose data.
+                    false
+                }
+                (StorageState::DataLoss, StorageState::Provisioning) => false,
+                (StorageState::DataLoss, StorageState::ReadOnly) => {
+                    // silent under-replication
+                    false
+                }
+                (StorageState::DataLoss, StorageState::Disabled) => {
+                    // only if data were trimmed
+                    false
+                }
+                (_, _) => false,
+            };
 
-        if !safe {
-            return Err(anyhow::anyhow!(
-                "This node is currently in `{current_state}` storage-state. Transitioning into `{}` is unsafe.",
-                opts.storage_state
-            ));
+            if !safe {
+                return Err(anyhow::anyhow!(
+                    "This node is currently in `{current_state}` storage-state. Transitioning into `{}` is unsafe.",
+                    opts.storage_state
+                ));
+            }
         }
     }
 
-    let new_state = update_storage_state(
-        &metadata_client,
-        current_generation,
-        current_state,
-        opts.storage_state,
-    )
-    .await?;
-    c_println!(
-        "Node {} storage-state updated from {} to {}",
-        opts.node_id,
-        current_state,
-        new_state
-    );
+    // run safety checks
+    if !opts.force && !opts.storage_state.can_write_to() {
+        let logs = connection.get_logs().await?;
+        let provider = &logs.configuration().default_provider;
+        if let ProviderKind::Replicated = provider.kind() {
+            // any log-id would do.
+            let options = NodeSetSelectorOptions::new(0)
+                .with_target_size(provider.target_nodeset_size().unwrap());
+            let replication_property = provider.replication().unwrap();
+            let nodeset = NodeSetSelector::select(
+                &nodes_config,
+                replication_property,
+                |node_id, config| {
+                    // skip our selection of nodes from being candidate
+                    if opts.nodes.contains(&node_id) {
+                        false
+                    } else {
+                        logserver_candidate_filter(node_id, config)
+                    }
+                },
+                |_, config| {
+                    matches!(
+                        config.log_server_config.storage_state,
+                        StorageState::ReadWrite
+                    )
+                },
+                options,
+            )
+            .context("Safety-check failed: lost the ability to generate nodesets")?;
 
+            let mut checker = NodeSetChecker::new(&nodeset, &nodes_config, replication_property);
+            checker.fill_with(true);
+            if !checker.check_write_quorum(|attr| *attr) {
+                anyhow::bail!(
+                    "Safety-check failed: nodesets like {checker} will not be able to satisfy replication property"
+                );
+            }
+        }
+    }
+
+    update_storage_state(&metadata_client, &current_states, opts.storage_state).await?;
+    for (node, old_state) in current_states {
+        c_println!(
+            "{} storage-state has been updated from {} to {}",
+            node.as_plain(),
+            old_state,
+            opts.storage_state,
+        );
+    }
     Ok(())
 }
 
 async fn update_storage_state(
     metadata_client: &MetadataStoreClient,
-    my_node_id: GenerationalNodeId,
-    expected_state: StorageState,
+    nodes: &HashMap<GenerationalNodeId, StorageState>,
     target_state: StorageState,
-) -> anyhow::Result<StorageState> {
-    let retry_policy = CommonOptions::default().network_error_retry_policy;
-    let mut first_attempt = true;
-
-    retry_on_retryable_error(retry_policy, || {
-        metadata_client.read_modify_write(
+) -> anyhow::Result<()> {
+    metadata_client
+        .read_modify_write(
             NODES_CONFIG_KEY.clone(),
             move |nodes_config: Option<NodesConfiguration>| {
                 let mut nodes_config =
-                    nodes_config.ok_or(StorageStateUpdateError::MissingNodesConfiguration)?;
-                // If this fails, it means that a newer node has started somewhere else, and we
-                // should not attempt to update the storage-state. Instead, we fail.
-                let mut node = nodes_config
-                    // note that we find by the generational node id.
-                    .find_node_by_id(my_node_id)?
-                    .clone();
+                    nodes_config.ok_or(anyhow::anyhow!("Missing nodes configuration!"))?;
+                for (my_node_id, expected_state) in nodes {
+                    // If this fails, it means that a newer node has started somewhere else, and we
+                    // should not attempt to update the storage-state. Instead, we fail.
+                    let mut node = nodes_config
+                        // note that we find by the generational node id.
+                        .find_node_by_id(*my_node_id)?
+                        .clone();
 
-                if node.log_server_config.storage_state != expected_state {
-                    return if first_attempt {
+                    if node.log_server_config.storage_state != *expected_state {
                         // Something might have caused this state to change.
-                        Err(StorageStateUpdateError::NotInExpectedState(
+                        return Err(anyhow::anyhow!(
+                            "Node {} has changed it state during the update, expected={}, found={}",
+                            my_node_id,
+                            expected_state,
                             node.log_server_config.storage_state,
-                        ))
-                    } else {
-                        // If we end up here, then we must have changed the StorageState in a previous attempt.
-                        // It cannot happen that there is a newer generation of me that changed the StorageState,
-                        // because then I would have failed before when retrieving my NodeConfig with my generational
-                        // node id.
-                        Err(StorageStateUpdateError::PreviousAttemptSucceeded(
-                            nodes_config,
-                        ))
-                    };
+                        ));
+                    }
+
+                    node.log_server_config.storage_state = target_state;
+                    nodes_config.upsert_node(node);
                 }
-
-                node.log_server_config.storage_state = target_state;
-
-                first_attempt = false;
-                nodes_config.upsert_node(node);
                 nodes_config.increment_version();
                 Ok(nodes_config)
             },
         )
-    })
-    .await?;
-
-    Ok(target_state)
-}
-
-#[derive(Debug, thiserror::Error)]
-enum StorageStateUpdateError {
-    #[error("cluster must be provisioned before log-server is started")]
-    MissingNodesConfiguration,
-    #[error(transparent)]
-    NodesConfigError(#[from] restate_types::nodes_config::NodesConfigError),
-    #[error(
-        "log-server found an unexpected storage-state '{0}' in metadata store, this could mean that another node has updated it"
-    )]
-    NotInExpectedState(StorageState),
-    #[error("succeeded updating NodesConfiguration in a previous attempt")]
-    PreviousAttemptSucceeded(NodesConfiguration),
-    #[error(transparent)]
-    MetadataStore(#[from] ReadWriteError),
+        .await?;
+    Ok(())
 }


### PR DESCRIPTION

This introduces the ability to set-storage-state on multiple node-ids at once, it'll also perform safety-check when switching to a storage-state that may cause the node to be excluded from new nodesets. The safety check validates that we can still generate valid nodesets when those nodes are excluded.

Example usage in comments.
```
// intentionally empty
```
