### PR TITLE
Only trim multi-node clusters when Archived LSN is reported

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -920,7 +920,7 @@ mod tests {
     }
 
     #[test(restate_core::test(start_paused = true))]
-    async fn auto_log_trim() -> anyhow::Result<()> {
+    async fn auto_trim_by_archived_lsn() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
         let interval_duration = Duration::from_secs(10);
@@ -950,7 +950,7 @@ mod tests {
             block_list: BTreeSet::new(),
         });
 
-        let (node_env, bifrost, _) = create_test_env(config, |builder| {
+        let (node_env, bifrost, _) = create_test_env_with_nodes(config, 2, |builder| {
             builder
                 .add_message_handler(get_node_state_handler.clone())
                 .add_message_handler(NoOpMessageHandler::<ControlProcessors>::default())
@@ -999,7 +999,66 @@ mod tests {
     }
 
     #[test(restate_core::test(start_paused = true))]
-    async fn auto_trim_log() -> anyhow::Result<()> {
+    async fn auto_trim_log_by_persisted_lsn_single_node() -> anyhow::Result<()> {
+        const LOG_ID: LogId = LogId::new(0);
+
+        let networking = NetworkingOptions {
+            // we are using failing transport so we only want to use the mock connection we created.
+            num_concurrent_connections: NonZero::new(1).unwrap(),
+            ..Default::default()
+        };
+
+        let interval_duration = Duration::from_secs(10);
+        let admin_options = AdminOptionsBuilder::default()
+            .log_trim_check_interval(interval_duration.into())
+            .build()
+            .unwrap();
+        let config = Configuration {
+            networking,
+            admin: admin_options,
+            ..Default::default()
+        };
+
+        let applied_lsn = Arc::new(AtomicU64::new(0));
+        let persisted_lsn = Arc::new(AtomicU64::new(0));
+        let get_node_state_handler = Arc::new(MockNodeStateHandler {
+            applied_lsn: applied_lsn.clone(),
+            persisted_lsn: Arc::clone(&persisted_lsn),
+            archived_lsn: Arc::new(AtomicU64::new(0)), // not used in this test
+            block_list: BTreeSet::new(),
+        });
+        let (_, bifrost, _) = create_test_env_with_nodes(config, 1, |builder| {
+            builder
+                .add_message_handler(get_node_state_handler.clone())
+                .add_message_handler(NoOpMessageHandler::<ControlProcessors>::default())
+        })
+        .await?;
+
+        let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::default())?;
+        for i in 1..=20 {
+            let lsn = appender.append(format!("record{i}")).await?;
+            assert_eq!(Lsn::from(i), lsn);
+        }
+        applied_lsn.store(
+            bifrost.find_tail(LOG_ID).await?.offset().prev().as_u64(),
+            Ordering::Relaxed,
+        );
+        tokio::time::sleep(interval_duration * 2).await;
+        assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
+
+        persisted_lsn.store(3, Ordering::Relaxed);
+        tokio::time::sleep(interval_duration * 2).await;
+        assert_eq!(bifrost.get_trim_point(LOG_ID).await?, Lsn::from(3));
+
+        persisted_lsn.store(20, Ordering::Relaxed);
+        tokio::time::sleep(interval_duration * 2).await;
+        assert_eq!(Lsn::from(20), bifrost.get_trim_point(LOG_ID).await?);
+
+        Ok(())
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn do_not_auto_trim_by_persisted_lsn_in_clusters() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
         let networking = NetworkingOptions {
@@ -1028,7 +1087,7 @@ mod tests {
             archived_lsn: Arc::new(AtomicU64::new(0)), // not used in this test
             block_list: BTreeSet::new(),
         });
-        let (node_env, bifrost, _) = create_test_env(config, |builder| {
+        let (node_env, bifrost, _) = create_test_env_with_nodes(config, 2, |builder| {
             builder
                 .add_message_handler(get_node_state_handler.clone())
                 .add_message_handler(NoOpMessageHandler::<ControlProcessors>::default())
@@ -1063,18 +1122,13 @@ mod tests {
         tokio::time::sleep(interval_duration * 2).await;
         assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
-        persisted_lsn.store(3, Ordering::Relaxed);
+        persisted_lsn.store(10, Ordering::Relaxed);
         tokio::time::sleep(interval_duration * 2).await;
-        assert_eq!(bifrost.get_trim_point(LOG_ID).await?, Lsn::from(3));
-
-        let v = bifrost.read(LOG_ID, Lsn::from(4)).await?.unwrap();
-        assert_that!(v.sequence_number(), eq(Lsn::new(4)));
-        assert!(v.is_data_record());
-        assert_that!(v.decode_unchecked::<String>(), eq("record4".to_owned()));
+        assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
         persisted_lsn.store(20, Ordering::Relaxed);
-        tokio::time::sleep(interval_duration * 2).await;
-        assert_eq!(Lsn::from(20), bifrost.get_trim_point(LOG_ID).await?);
+        tokio::time::sleep(interval_duration * 5).await;
+        assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
         Ok(())
     }
@@ -1106,7 +1160,7 @@ mod tests {
         let applied_lsn = Arc::new(AtomicU64::new(0));
         let persisted_lsn = Arc::new(AtomicU64::new(0));
 
-        let (_node_env, bifrost, _) = create_test_env(config, |builder| {
+        let (_node_env, bifrost, _) = create_test_env_with_nodes(config, 2, |builder| {
             let block_list = builder
                 .nodes_config
                 .iter()
@@ -1172,7 +1226,7 @@ mod tests {
         let lsn = AtomicU64::new(0);
         let applied_persisted_lsn = Arc::new(lsn);
 
-        let (node_env, bifrost, cluster_state) = create_test_env(config, |builder| {
+        let (node_env, bifrost, cluster_state) = create_test_env_with_nodes(config, 2, |builder| {
             let get_node_state_handler = MockNodeStateHandler {
                 applied_lsn: applied_persisted_lsn.clone(),
                 persisted_lsn: applied_persisted_lsn.clone(),
@@ -1261,34 +1315,35 @@ mod tests {
         let persisted_lsn = Arc::new(AtomicU64::new(0));
         let archived_lsn = Arc::new(AtomicU64::new(0));
 
-        let (_node_env, bifrost, cluster_state) = create_test_env(config, |builder| {
-            assert_eq!(
-                builder.nodes_config.iter().count(),
-                2,
-                "expect two nodes in config"
-            );
+        let (_node_env, bifrost, cluster_state) =
+            create_test_env_with_nodes(config, 2, |builder| {
+                assert_eq!(
+                    builder.nodes_config.iter().count(),
+                    2,
+                    "expect two nodes in config"
+                );
 
-            let blocked_node = builder
-                .nodes_config
-                .iter()
-                .nth(1)
-                .map(|(_, node_config)| node_config.current_generation)
-                .expect("a second node in cluster");
+                let blocked_node = builder
+                    .nodes_config
+                    .iter()
+                    .nth(1)
+                    .map(|(_, node_config)| node_config.current_generation)
+                    .expect("a second node in cluster");
 
-            info!("Block list: {:?}", blocked_node);
+                info!("Block list: {:?}", blocked_node);
 
-            let get_node_state_handler = MockNodeStateHandler {
-                applied_lsn: applied_lsn.clone(),
-                persisted_lsn: persisted_lsn.clone(),
-                archived_lsn: archived_lsn.clone(),
-                block_list: [GenerationalNodeId::new(2, 2)].into(),
-            };
+                let get_node_state_handler = MockNodeStateHandler {
+                    applied_lsn: applied_lsn.clone(),
+                    persisted_lsn: persisted_lsn.clone(),
+                    archived_lsn: archived_lsn.clone(),
+                    block_list: [GenerationalNodeId::new(2, 2)].into(),
+                };
 
-            builder
-                .add_message_handler(get_node_state_handler)
-                .add_message_handler(NoOpMessageHandler::<ControlProcessors>::default())
-        })
-        .await?;
+                builder
+                    .add_message_handler(get_node_state_handler)
+                    .add_message_handler(NoOpMessageHandler::<ControlProcessors>::default())
+            })
+            .await?;
 
         let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::default())?;
         for i in 1..=20 {
@@ -1354,7 +1409,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (node_env, bifrost, cluster_state) = create_test_env(config, |builder| {
+        let (node_env, bifrost, cluster_state) = create_test_env_with_nodes(config, 2, |builder| {
             assert_eq!(
                 builder.nodes_config.iter().count(),
                 2,
@@ -1409,8 +1464,9 @@ mod tests {
         Ok(())
     }
 
-    async fn create_test_env<F>(
+    async fn create_test_env_with_nodes<F>(
         config: Configuration,
+        n: u8,
         mut modify_builder: F,
     ) -> anyhow::Result<(TestCoreEnv<FailingConnector>, Bifrost, ClusterStateWatcher)>
     where
@@ -1436,24 +1492,17 @@ mod tests {
         let cluster_state_watcher = svc.cluster_state_refresher.cluster_state_watcher();
 
         let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
-        nodes_config.upsert_node(NodeConfig::new(
-            "node-1".to_owned(),
-            GenerationalNodeId::new(1, 1),
-            NodeLocation::default(),
-            AdvertisedAddress::Uds("foobar".into()),
-            Role::Admin | Role::Worker,
-            LogServerConfig::default(),
-            MetadataServerConfig::default(),
-        ));
-        nodes_config.upsert_node(NodeConfig::new(
-            "node-2".to_owned(),
-            GenerationalNodeId::new(2, 2),
-            NodeLocation::default(),
-            AdvertisedAddress::Uds("bar".into()),
-            Role::Worker.into(),
-            LogServerConfig::default(),
-            MetadataServerConfig::default(),
-        ));
+        for i in 1..=n {
+            nodes_config.upsert_node(NodeConfig::new(
+                format!("node-{}", i),
+                GenerationalNodeId::new(i as u32, i as u32),
+                NodeLocation::default(),
+                AdvertisedAddress::Uds(format!("{}.sock", i).into()),
+                Role::Admin | Role::Worker,
+                LogServerConfig::default(),
+                MetadataServerConfig::default(),
+            ));
+        }
         let builder = modify_builder(builder.set_nodes_config(nodes_config));
 
         let node_env = builder.build().await;

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::ops::{Add, Deref};
 use std::sync::Arc;
 
@@ -22,15 +22,13 @@ use tracing::{debug, info, instrument, trace, warn};
 use restate_bifrost::Bifrost;
 use restate_core::network::TransportConnect;
 use restate_core::{Metadata, my_node_id};
-use restate_types::cluster::cluster_state::{
-    AliveNode, ClusterState, NodeState, PartitionProcessorStatus,
-};
+use restate_types::cluster::cluster_state::{AliveNode, ClusterState, PartitionProcessorStatus};
 use restate_types::config::{AdminOptions, Configuration};
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::net::metadata::MetadataKind;
 use restate_types::retries::with_jitter;
-use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+use restate_types::{GenerationalNodeId, Version};
 
 use crate::cluster_controller::cluster_state_refresher::ClusterStateWatcher;
 use crate::cluster_controller::logs_controller::{
@@ -321,28 +319,16 @@ where
             );
         }
 
-        match TrimMode::from(self.snapshots_repository_configured, &cluster_state)
-            .calculate_safe_trim_points()
-        {
-            Ok(trim_points) => {
-                trace!(?trim_points, "Calculated safe log trim points");
+        let trim_points = TrimMode::from(self.snapshots_repository_configured, &cluster_state)
+            .calculate_safe_trim_points();
+        trace!(?trim_points, "Calculated safe log trim points");
 
-                for (log_id, (trim_point, partition_id)) in trim_points {
-                    let result = self.bifrost.admin().trim(log_id, trim_point).await;
-                    if let Err(err) = result {
-                        warn!(
-                            %partition_id,
-                            "Failed to trim log {log_id}. This can lead to increased disk usage: {err}"
-                        );
-                    }
-                }
-            }
-
-            Err(TrimPointsUnavailable::UnknownPartitionStatus(blocking_nodes)) => {
+        for (log_id, (trim_point, partition_id)) in trim_points {
+            let result = self.bifrost.admin().trim(log_id, trim_point).await;
+            if let Err(err) = result {
                 warn!(
-                    ?blocking_nodes,
-                    "Log trimming is suspended until we can determine the processor state on all known cluster nodes. \
-                    Remove decommissioned nodes from the cluster and/or enable partition snapshotting to unblock log trimming"
+                    %partition_id,
+                    "Failed to trim log {log_id}. This can lead to increased disk usage: {err}"
                 );
             }
         }
@@ -367,22 +353,17 @@ fn create_log_trim_check_interval(options: &AdminOptions) -> Option<Interval> {
 }
 
 enum TrimMode {
+    /// Trim logs by the reported persisted LSN. This strategy is only appropriate for
+    /// single-node deplyments.
     PersistedLsn {
         partition_status:
             BTreeMap<PartitionId, BTreeMap<GenerationalNodeId, PartitionProcessorStatus>>,
-        blocking_nodes: BTreeSet<PlainNodeId>,
     },
+    /// Select safe trim points based on the maximum reported archived LSN per partition.
     ArchivedLsn {
         partition_status:
             BTreeMap<PartitionId, BTreeMap<GenerationalNodeId, PartitionProcessorStatus>>,
     },
-}
-
-#[derive(Debug, PartialEq)]
-enum TrimPointsUnavailable {
-    /// Trim points can not be determined because some (dead or otherwise
-    /// unreachable) nodes have not reported the state of partitions.
-    UnknownPartitionStatus(BTreeSet<PlainNodeId>),
 }
 
 impl TrimMode {
@@ -406,34 +387,31 @@ impl TrimMode {
             }
         }
 
-        if snapshots_repository_configured
-            || Self::any_processors_report_archived_lsn(cluster_state)
-        {
+        if snapshots_repository_configured || cluster_state.nodes.len() > 1 {
             TrimMode::ArchivedLsn { partition_status }
         } else {
-            TrimMode::PersistedLsn {
-                partition_status,
-                blocking_nodes: cluster_state.dead_or_suspect_nodes().copied().collect(),
-            }
+            TrimMode::PersistedLsn { partition_status }
         }
     }
 
     /// Compute the safe trim points for each log, assuming that partitions are mapped to logs 1:1.
     /// For a given cluster state, determines the set of trim points for all partitions' logs.
     ///
+    /// In clusters, determined as nodes configurations with more than 1 node, trimming is driven
+    /// exclusively by the archived LSN attribute. In other words, a snapshot repository must be
+    /// configured for automated trimming to be considered safe.
+    ///
     /// The presence of any dead or suspect nodes in the cluster state struct will prevent logs from
     /// being trimmed if archived LSN is *not* reported for all known partitions. Conversely, as long
     /// as archived LSNs are reported for all partitions, trimming can continue even in the presence of
     /// some dead nodes. This is because we assume that if those nodes are only temporarily down, they
     /// can fast-forward state from the snapshot repository when they return into service.
-    fn calculate_safe_trim_points(
-        &self,
-    ) -> Result<BTreeMap<LogId, (Lsn, PartitionId)>, TrimPointsUnavailable> {
-        if let Some(blocking_nodes) = self.get_trim_blockers() {
-            return Err(TrimPointsUnavailable::UnknownPartitionStatus(
-                blocking_nodes.clone(),
-            ));
-        }
+    fn calculate_safe_trim_points(&self) -> BTreeMap<LogId, (Lsn, PartitionId)> {
+        // if let Some(blocking_nodes) = self.get_trim_blockers() {
+        //     return Err(TrimPointsUnavailable::UnknownPartitionStatus(
+        //         blocking_nodes.clone(),
+        //     ));
+        // }
 
         let mut safe_trim_points = BTreeMap::new();
         match self {
@@ -495,41 +473,7 @@ impl TrimMode {
             }
         }
 
-        Ok(safe_trim_points)
-    }
-
-    // If any partitions are reporting an archived LSN, they must have snapshotting enabled.
-    // We use this signal as a heuristic when selecting archived LSN-based trimming in case of
-    // heterogeneous cluster node configuration.
-    fn any_processors_report_archived_lsn(cluster_state: &ClusterState) -> bool {
-        cluster_state
-            .nodes
-            .values()
-            .any(|node_state| match node_state {
-                NodeState::Alive(AliveNode { partitions, .. }) => {
-                    partitions.values().any(|partition| {
-                        // doesn't matter if it's INVALID!
-                        partition.last_archived_log_lsn.is_some()
-                    })
-                }
-                NodeState::Dead(_) | NodeState::Suspect(_) => false,
-            })
-    }
-
-    fn get_trim_blockers(&self) -> Option<&BTreeSet<PlainNodeId>> {
-        match self {
-            TrimMode::PersistedLsn {
-                blocking_nodes: dead_nodes,
-                ..
-            } => {
-                if dead_nodes.is_empty() {
-                    None
-                } else {
-                    Some(dead_nodes)
-                }
-            }
-            TrimMode::ArchivedLsn { .. } => None,
-        }
+        safe_trim_points
     }
 }
 
@@ -539,7 +483,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use crate::cluster_controller::service::state::{TrimMode, TrimPointsUnavailable};
+    use crate::cluster_controller::service::state::TrimMode;
     use RunMode::{Follower, Leader};
     use restate_types::cluster::cluster_state::{
         AliveNode, ClusterState, DeadNode, NodeState, PartitionProcessorStatus, RunMode,
@@ -551,7 +495,7 @@ mod tests {
     use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
     #[test]
-    fn safe_trim_points_no_snapshots() {
+    fn no_snapshots_no_safe_trim_points() {
         let p1 = PartitionId::from(0);
         let p2 = PartitionId::from(1);
         let p3 = PartitionId::from(2);
@@ -643,15 +587,15 @@ mod tests {
         let trim_mode = TrimMode::from(false, &cluster_state);
         let trim_points = trim_mode.calculate_safe_trim_points();
 
-        assert!(matches!(trim_mode, TrimMode::PersistedLsn { .. }));
+        assert!(matches!(trim_mode, TrimMode::ArchivedLsn { .. }));
         assert_eq!(
             trim_points,
-            Ok(BTreeMap::from([
+            BTreeMap::from([
                 (LogId::from(p1), (Lsn::INVALID, p1)),
                 (LogId::from(p2), (Lsn::INVALID, p2)),
-                (LogId::from(p3), (Lsn::new(5), p3)),
-            ])),
-            "Use min persisted LSN across the cluster as the safe point when not archiving"
+                (LogId::from(p3), (Lsn::INVALID, p3)),
+            ]),
+            "If no archived LSN reported, then it is not safe to trim in a cluster"
         );
 
         let cluster_state = Arc::new(ClusterState {
@@ -670,20 +614,66 @@ mod tests {
         let trim_mode = TrimMode::from(false, &cluster_state);
         let trim_points = trim_mode.calculate_safe_trim_points();
 
-        assert!(matches!(trim_mode, TrimMode::PersistedLsn { .. }));
+        assert!(matches!(trim_mode, TrimMode::ArchivedLsn { .. }));
         assert_eq!(
             trim_points,
-            Err(TrimPointsUnavailable::UnknownPartitionStatus(
-                [PlainNodeId::new(3)].iter().copied().collect()
-            )),
-            "Any dead nodes in cluster block trimming when using persisted LSN mode"
+            BTreeMap::from([
+                (LogId::from(p1), (Lsn::INVALID, p1)),
+                (LogId::from(p2), (Lsn::INVALID, p2)),
+                (LogId::from(p3), (Lsn::INVALID, p3)),
+            ]),
+            "Dead nodes in cluster make no difference, if no archive LSN reported we don't trim"
         );
+    }
 
-        let mut nodes = cluster_state.nodes.clone();
-        nodes.insert(PlainNodeId::new(3), dead_node());
+    #[test]
+    fn single_node_safe_trim_points() {
+        let p1 = PartitionId::from(0);
+        let p2 = PartitionId::from(1);
+        let p3 = PartitionId::from(2);
+
+        let n1 = GenerationalNodeId::new(1, 0);
+        let n1_partitions: BTreeMap<PartitionId, PartitionProcessorStatus> = [
+            (
+                p1,
+                ProcessorStatus {
+                    mode: Leader,
+                    applied: Some(Lsn::new(10)),
+                    persisted: None,
+                    archived: None,
+                }
+                .into(),
+            ),
+            (
+                p2,
+                ProcessorStatus {
+                    mode: Follower,
+                    applied: Some(Lsn::new(10)),
+                    persisted: Some(Lsn::new(5)),
+                    archived: None,
+                }
+                .into(),
+            ),
+            (
+                p3,
+                ProcessorStatus {
+                    mode: Leader,
+                    applied: Some(Lsn::new(10)),
+                    persisted: Some(Lsn::new(10)),
+                    archived: None,
+                }
+                .into(),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
         let cluster_state = Arc::new(ClusterState {
-            nodes,
-            ..*cluster_state
+            last_refreshed: None,
+            nodes_config_version: Version::MIN,
+            partition_table_version: Version::MIN,
+            logs_metadata_version: Version::MIN,
+            nodes: [(n1.as_plain(), alive_node(n1, n1_partitions.clone()))].into(),
         });
 
         let trim_mode = TrimMode::from(false, &cluster_state);
@@ -692,32 +682,12 @@ mod tests {
         assert!(matches!(trim_mode, TrimMode::PersistedLsn { .. }));
         assert_eq!(
             trim_points,
-            Err(TrimPointsUnavailable::UnknownPartitionStatus(
-                [PlainNodeId::new(3)].iter().copied().collect()
-            )),
-            "Any dead nodes in cluster block trimming when using persisted LSN mode"
-        );
-
-        let mut nodes = cluster_state.nodes.clone();
-        nodes.insert(
-            PlainNodeId::new(3),
-            suspect_node(GenerationalNodeId::new(3, 0)),
-        );
-        let cluster_state = Arc::new(ClusterState {
-            nodes,
-            ..*cluster_state
-        });
-
-        let trim_mode = TrimMode::from(false, &cluster_state);
-        let trim_points = trim_mode.calculate_safe_trim_points();
-
-        assert!(matches!(trim_mode, TrimMode::PersistedLsn { .. }));
-        assert_eq!(
-            trim_points,
-            Err(TrimPointsUnavailable::UnknownPartitionStatus(
-                [PlainNodeId::new(3)].iter().copied().collect()
-            )),
-            "Any dead nodes in cluster block trimming when using persisted LSN mode"
+            BTreeMap::from([
+                (LogId::from(p1), (Lsn::new(0), p1)),
+                (LogId::from(p2), (Lsn::new(5), p2)),
+                (LogId::from(p3), (Lsn::new(10), p3)),
+            ]),
+            "Use min persisted LSN per partition as the safe point in single-node mode when not archiving"
         );
     }
 
@@ -837,12 +807,12 @@ mod tests {
 
         assert_eq!(
             trim_points,
-            Ok(BTreeMap::from([
+            BTreeMap::from([
                 (LogId::from(p1), (Lsn::INVALID, p1)),
                 (LogId::from(p2), (Lsn::new(10), p2)),
                 (LogId::from(p3), (Lsn::new(30), p3)),
                 (LogId::from(p4), (Lsn::new(40), p4)),
-            ]))
+            ])
         );
 
         let mut nodes = cluster_state.nodes.clone();
@@ -862,12 +832,12 @@ mod tests {
 
         assert_eq!(
             trim_points,
-            Ok(BTreeMap::from([
+            BTreeMap::from([
                 (LogId::from(p1), (Lsn::INVALID, p1)),
                 (LogId::from(p2), (Lsn::new(10), p2)),
                 (LogId::from(p3), (Lsn::new(30), p3)),
                 (LogId::from(p4), (Lsn::new(40), p4)),
-            ])),
+            ]),
             "presence of dead or suspect nodes does not block trimming when archived LSN is reported"
         );
     }


### PR DESCRIPTION
This change makes it so that in Restate deployments with more than one node, a snapshot repository is a requirement for auto-trimming of logs. Previously we would have trimmed logs based on the reported persisted LSN, which isn't always safe considering that additional nodes may be added at a later time.