### PR TITLE
[sql] Add sort information to the table schemas

### DIFF
--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -22,6 +22,7 @@ use input_command::{InputCommand, InvokeCommand};
 use invocation_state_machine::InvocationStateMachine;
 use invocation_task::InvocationTask;
 use invocation_task::{InvocationTaskOutput, InvocationTaskOutputInner};
+use itertools::Itertools;
 use metrics::counter;
 use restate_core::cancellation_watcher;
 use restate_errors::warn_it;
@@ -354,7 +355,9 @@ where
                     .registered_partitions_with_keys(keys.clone())
                     .flat_map(|partition| self.status_store.status_for_partition(partition))
                     .filter(|status| keys.contains(&status.invocation_id().partition_key()))
+                    .sorted_by_key(|e| e.invocation_id().partition_key())
                     .collect();
+
                 let _ = cmd.reply(statuses);
             },
 

--- a/crates/storage-query-datafusion/src/idempotency/schema.rs
+++ b/crates/storage-query-datafusion/src/idempotency/schema.rs
@@ -14,6 +14,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_idempotency(partition_key, service_name, service_key));
+
 define_table!(sys_idempotency(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -20,7 +20,7 @@ use restate_storage_api::StorageError;
 use restate_types::identifiers::{IdempotencyId, PartitionKey};
 
 use super::row::append_idempotency_row;
-use super::schema::SysIdempotencyBuilder;
+use super::schema::{SysIdempotencyBuilder, sys_idempotency_sort_order};
 use crate::context::{QueryContext, SelectPartitions};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
@@ -42,6 +42,7 @@ pub(crate) fn register_self(
     let table = PartitionedTableProvider::new(
         partition_selector,
         SysIdempotencyBuilder::schema(),
+        sys_idempotency_sort_order(),
         ctx.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
             .with_service_key("service_key")

--- a/crates/storage-query-datafusion/src/inbox/schema.rs
+++ b/crates/storage-query-datafusion/src/inbox/schema.rs
@@ -14,6 +14,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_inbox(partition_key, id));
+
 define_table!(sys_inbox(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -21,7 +21,7 @@ use restate_types::identifiers::PartitionKey;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::inbox::row::append_inbox_row;
-use crate::inbox::schema::SysInboxBuilder;
+use crate::inbox::schema::{SysInboxBuilder, sys_inbox_sort_order};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
@@ -43,6 +43,7 @@ pub(crate) fn register_self(
     let table = PartitionedTableProvider::new(
         partition_selector,
         SysInboxBuilder::schema(),
+        sys_inbox_sort_order(),
         ctx.create_distributed_scanner(NAME, local_partition_scanner),
         FirstMatchingPartitionKeyExtractor::default()
             .with_service_key("service_key")

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -14,6 +14,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_invocation_state(partition_key, id));
+
 define_table!(sys_invocation_state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -25,7 +25,7 @@ use restate_types::identifiers::{PartitionId, PartitionKey, WithPartitionKey};
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::invocation_state::row::append_invocation_state_row;
-use crate::invocation_state::schema::SysInvocationStateBuilder;
+use crate::invocation_state::schema::{SysInvocationStateBuilder, sys_invocation_state_sort_order};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 use crate::table_util::Builder;
@@ -55,6 +55,7 @@ pub(crate) fn register_self(
     let status_table = PartitionedTableProvider::new(
         partition_selector,
         SysInvocationStateBuilder::schema(),
+        sys_invocation_state_sort_order(),
         ctx.create_distributed_scanner(NAME, local_partition_scanner),
         FirstMatchingPartitionKeyExtractor::default().with_invocation_id("id"),
     );

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -14,6 +14,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_invocation_status(partition_key, id));
+
 define_table!(sys_invocation_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -23,7 +23,9 @@ use restate_types::identifiers::{InvocationId, PartitionKey};
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::invocation_status::row::append_invocation_status_row;
-use crate::invocation_status::schema::SysInvocationStatusBuilder;
+use crate::invocation_status::schema::{
+    SysInvocationStatusBuilder, sys_invocation_status_sort_order,
+};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
@@ -44,6 +46,7 @@ pub(crate) fn register_self(
     let status_table = PartitionedTableProvider::new(
         partition_selector,
         SysInvocationStatusBuilder::schema(),
+        sys_invocation_status_sort_order(),
         ctx.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
             .with_service_key("target_service_key")

--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -14,7 +14,9 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_table!(sys_journal(
+define_sort_order!(sys_journal(partition_key, id));
+
+define_table!(sys_journal (
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,
 

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -17,7 +17,7 @@ use tokio_stream::StreamExt;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::journal::row::{append_journal_row, append_journal_row_v2};
-use crate::journal::schema::SysJournalBuilder;
+use crate::journal::schema::{SysJournalBuilder, sys_journal_sort_order};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
@@ -43,6 +43,7 @@ pub(crate) fn register_self(
     let journal_table = PartitionedTableProvider::new(
         partition_selector,
         SysJournalBuilder::schema(),
+        sys_journal_sort_order(),
         ctx.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default().with_invocation_id("id"),
     );

--- a/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
@@ -14,6 +14,12 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_keyed_service_status(
+    partition_key,
+    service_name,
+    service_key
+));
+
 define_table!(sys_keyed_service_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/keyed_service_status/table.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/table.rs
@@ -23,7 +23,9 @@ use restate_types::identifiers::{PartitionKey, ServiceId};
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::keyed_service_status::row::append_virtual_object_status_row;
-use crate::keyed_service_status::schema::SysKeyedServiceStatusBuilder;
+use crate::keyed_service_status::schema::{
+    SysKeyedServiceStatusBuilder, sys_keyed_service_status_sort_order,
+};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
@@ -44,6 +46,7 @@ pub(crate) fn register_self(
     let status_table = PartitionedTableProvider::new(
         partition_selector,
         SysKeyedServiceStatusBuilder::schema(),
+        sys_keyed_service_status_sort_order(),
         ctx.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
             .with_service_key("service_key")

--- a/crates/storage-query-datafusion/src/promise/schema.rs
+++ b/crates/storage-query-datafusion/src/promise/schema.rs
@@ -14,6 +14,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_promise(partition_key, service_name, service_key));
+
 define_table!(sys_promise(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -20,7 +20,7 @@ use restate_storage_api::StorageError;
 use restate_types::identifiers::PartitionKey;
 
 use super::row::append_promise_row;
-use super::schema::SysPromiseBuilder;
+use super::schema::{SysPromiseBuilder, sys_promise_sort_order};
 use crate::context::{QueryContext, SelectPartitions};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
@@ -42,6 +42,7 @@ pub(crate) fn register_self(
     let table = PartitionedTableProvider::new(
         partition_selector,
         SysPromiseBuilder::schema(),
+        sys_promise_sort_order(),
         ctx.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key"),
     );

--- a/crates/storage-query-datafusion/src/state/schema.rs
+++ b/crates/storage-query-datafusion/src/state/schema.rs
@@ -14,6 +14,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(state(partition_key, service_name, service_key));
+
 define_table!(state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -24,7 +24,7 @@ use crate::context::{QueryContext, SelectPartitions};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::state::row::append_state_row;
-use crate::state::schema::StateBuilder;
+use crate::state::schema::{StateBuilder, state_sort_order};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 
 const NAME: &str = "state";
@@ -43,6 +43,7 @@ pub(crate) fn register_self(
     let table = PartitionedTableProvider::new(
         partition_selector,
         StateBuilder::schema(),
+        state_sort_order(),
         ctx.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key"),
     );

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -590,9 +590,25 @@ macro_rules! define_table {
     })
 }
 
+macro_rules! define_sort_order {
+
+    ($table_name: ident (
+        $(
+            $element:ident
+        ),+ $(,)?)
+    ) => (paste::paste! {
+
+        pub fn [< $table_name:snake _ sort_order >]() -> Vec<String> {
+           vec![ $( stringify!($element).to_string(),)+ ]
+        }
+
+        })
+}
+
 pub(crate) use define_builder;
 pub(crate) use define_data_type;
 pub(crate) use define_primitive_trait;
+pub(crate) use define_sort_order;
 pub(crate) use define_table;
 #[cfg(feature = "table_docs")]
 pub(crate) use document_type;


### PR DESCRIPTION
with this PR:

```
igal@nixos ~/w/restate (main)> ./target/debug/restate sql "explain SELECT id FROM sys_invocation order by modified_at limit 100"
 PLAN_TYPE      PLAN                                                                                                                               
                                                
 physical_plan  ProjectionExec: expr=[id@0 as id]                                                                                                  
                  SortPreservingMergeExec: [modified_at@1 ASC NULLS LAST], fetch=100                                                               
                    SortExec: TopK(fetch=100), expr=[modified_at@1 ASC NULLS LAST], preserve_partitioning=[true]                                   
                      ProjectionExec: expr=[id@1 as id, modified_at@2 as modified_at]                                                              
                        SymmetricHashJoinExec: mode=Partitioned, join_type=Left, on=[(partition_key@0, partition_key@0), (id@1, id@1)]             
                          PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_status" }) 
                          PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_state" })  
                                                                                                                                                   

2 rows. Query took 53.402081ms

```


without:

```igal@nixos ~/w/restate (add_sort_columns)> ./target/debug/restate sql "explain SELECT id FROM sys_invocation order by modified_at limit 100"
 PLAN_TYPE      PLAN                                                                                                                                     
                                                 
 physical_plan  ProjectionExec: expr=[id@0 as id]                                                                                                        
                  SortPreservingMergeExec: [modified_at@1 ASC NULLS LAST], fetch=100                                                                     
                    SortExec: TopK(fetch=100), expr=[modified_at@1 ASC NULLS LAST], preserve_partitioning=[true]                                         
                      ProjectionExec: expr=[id@1 as id, modified_at@2 as modified_at]                                                                    
                        SymmetricHashJoinExec: mode=Partitioned, join_type=Left, on=[(partition_key@0, partition_key@0), (id@1, id@1)]                   
                          SortExec: expr=[partition_key@0 ASC], preserve_partitioning=[true]                                                             
                            CoalesceBatchesExec: target_batch_size=8192                                                                                  
                              RepartitionExec: partitioning=Hash([partition_key@0, id@1], 2), input_partitions=24                                        
                                PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_status" }) 
                          SortExec: expr=[partition_key@0 ASC], preserve_partitioning=[true]                                                             
                            CoalesceBatchesExec: target_batch_size=8192                                                                                  
                              RepartitionExec: partitioning=Hash([partition_key@0, id@1], 2), input_partitions=24                                        
                                PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_state" })  


```