### PR TITLE
[Core] connection manager without TransportConnect

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -628,10 +628,7 @@ enum ClusterConfigurationUpdateError {
 }
 
 #[derive(Clone)]
-struct PartitionProcessorManagerClient<N>
-where
-    N: Clone,
-{
+struct PartitionProcessorManagerClient<N> {
     network_sender: N,
     create_snapshot_router: RpcRouter<CreateSnapshotRequest>,
 }

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -16,6 +16,7 @@ use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tracing::{debug, info, instrument, trace};
 
+use restate_core::my_node_id;
 use restate_core::network::{Networking, TransportConnect};
 use restate_types::logs::metadata::{ProviderKind, SegmentIndex};
 use restate_types::logs::{
@@ -77,7 +78,7 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
         record_cache: RecordCache,
     ) -> Self {
         let known_global_tail = TailOffsetWatch::new(TailState::Open(LogletOffset::OLDEST));
-        let sequencer = if networking.my_node_id() == my_params.sequencer {
+        let sequencer = if my_node_id() == my_params.sequencer {
             debug!(
                 loglet_id = %my_params.loglet_id,
                 "We are the sequencer node for this loglet"

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -57,7 +57,6 @@ impl<T: TransportConnect> Factory<T> {
         // Handling Sequencer(s) incoming requests
         let request_pump = RequestPump::new(
             &Configuration::pinned().bifrost.replicated_loglet,
-            networking.metadata().clone(),
             router_builder,
         );
 
@@ -129,9 +128,6 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
         }
     }
 
-    pub(crate) fn networking(&self) -> &Networking<T> {
-        &self.networking
-    }
     /// Gets a loglet if it's already have been activated
     pub(crate) fn get_active_loglet(
         &self,

--- a/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
@@ -577,7 +577,7 @@ mod test {
     async fn setup<F, O>(sequencer: SequencerMockHandler, test: F)
     where
         O: Future<Output = ()>,
-        F: FnOnce(RemoteSequencer<MockConnector>) -> O,
+        F: FnOnce(RemoteSequencer<Arc<MockConnector>>) -> O,
     {
         let (connector, _receiver) = MockConnector::new(100);
         let connector = Arc::new(connector);

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/trim.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_core::TaskCenterFutureExt;
+use restate_core::{Metadata, TaskCenterFutureExt};
 use tokio::task::JoinSet;
 use tracing::{Instrument, Span, debug, instrument, trace, warn};
 
@@ -74,11 +74,12 @@ impl<'a> TrimTask<'a> {
         trim_point: LogletOffset,
         networking: Networking<T>,
     ) -> Result<(), OperationError> {
+        let metadata = Metadata::current();
         // Use the entire nodeset except for StorageState::Disabled.
         let effective_nodeset = self
             .my_params
             .nodeset
-            .to_effective(&networking.metadata().nodes_config_ref());
+            .to_effective(&metadata.nodes_config_ref());
         // caller might have already done this, but it's here for resilience against user error.
         let trim_point = trim_point.min(self.known_global_tail.latest_offset().prev_unchecked());
         if trim_point == LogletOffset::INVALID {
@@ -94,7 +95,7 @@ impl<'a> TrimTask<'a> {
 
         let mut nodeset_checker = NodeSetChecker::<bool>::new(
             &effective_nodeset,
-            &networking.metadata().nodes_config_ref(),
+            &metadata.nodes_config_ref(),
             &self.my_params.replication,
         );
 

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -351,7 +351,6 @@ pub mod test_util {
     use crate::network::NetworkError;
     use crate::network::PeerMetadataVersion;
     use crate::network::ProtocolError;
-    use crate::network::TransportConnect;
     use crate::network::handshake::negotiate_protocol_version;
     use crate::network::handshake::wait_for_hello;
 
@@ -378,11 +377,11 @@ pub mod test_util {
 
     impl MockPeerConnection {
         /// must run in task-center
-        pub async fn connect<T: TransportConnect>(
+        pub async fn connect(
             from_node_id: GenerationalNodeId,
             my_node_config_version: Version,
             my_cluster_name: String,
-            connection_manager: &ConnectionManager<T>,
+            connection_manager: &ConnectionManager,
             message_buffer: usize,
         ) -> anyhow::Result<Self> {
             let (sender, rx) = mpsc::channel(message_buffer);

--- a/crates/core/src/network/grpc/connector.rs
+++ b/crates/core/src/network/grpc/connector.rs
@@ -12,7 +12,7 @@ use futures::Stream;
 use tokio_stream::StreamExt;
 
 use restate_types::GenerationalNodeId;
-use restate_types::config::NetworkingOptions;
+use restate_types::config::Configuration;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::protobuf::node::Message;
 use tracing::trace;
@@ -22,15 +22,8 @@ use crate::network::net_util::create_tonic_channel;
 use crate::network::protobuf::core_node_svc::core_node_svc_client::CoreNodeSvcClient;
 use crate::network::{NetworkError, ProtocolError, TransportConnect};
 
-pub struct GrpcConnector {
-    networking_options: NetworkingOptions,
-}
-
-impl GrpcConnector {
-    pub fn new(networking_options: NetworkingOptions) -> Self {
-        Self { networking_options }
-    }
-}
+#[derive(Clone)]
+pub struct GrpcConnector;
 
 impl TransportConnect for GrpcConnector {
     async fn connect(
@@ -45,7 +38,7 @@ impl TransportConnect for GrpcConnector {
         let address = nodes_config.find_node_by_id(node_id)?.address.clone();
 
         trace!("Attempting to connect to node {} at {}", node_id, address);
-        let channel = create_tonic_channel(address, &self.networking_options);
+        let channel = create_tonic_channel(address, &Configuration::pinned().networking);
 
         // Establish the connection
         let mut client = CoreNodeSvcClient::new(channel)

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -16,17 +16,17 @@ use tonic::{Request, Response, Status, Streaming};
 use crate::network::protobuf::core_node_svc::core_node_svc_server::{
     CoreNodeSvc, CoreNodeSvcServer,
 };
-use crate::network::{ConnectionManager, ProtocolError, TransportConnect};
+use crate::network::{ConnectionManager, ProtocolError};
 use restate_types::protobuf::node::Message;
 
 use super::MAX_MESSAGE_SIZE;
 
-pub struct CoreNodeSvcHandler<T> {
-    connections: ConnectionManager<T>,
+pub struct CoreNodeSvcHandler {
+    connections: ConnectionManager,
 }
 
-impl<T> CoreNodeSvcHandler<T> {
-    pub fn new(connections: ConnectionManager<T>) -> Self {
+impl CoreNodeSvcHandler {
+    pub fn new(connections: ConnectionManager) -> Self {
         Self { connections }
     }
 
@@ -40,10 +40,7 @@ impl<T> CoreNodeSvcHandler<T> {
 }
 
 #[async_trait::async_trait]
-impl<T> CoreNodeSvc for CoreNodeSvcHandler<T>
-where
-    T: TransportConnect,
-{
+impl CoreNodeSvc for CoreNodeSvcHandler {
     type CreateConnectionStream = BoxStream<'static, Result<Message, Status>>;
 
     // Status codes returned in different scenarios:

--- a/crates/core/src/network/network_sender.rs
+++ b/crates/core/src/network/network_sender.rs
@@ -13,7 +13,7 @@ use restate_types::net::codec::{Targeted, WireEncode};
 use super::{NetworkSendError, NoConnection, Outgoing};
 
 /// Send NetworkMessage to nodes
-pub trait NetworkSender<S = NoConnection>: Send + Sync + Clone
+pub trait NetworkSender<S = NoConnection>: Send + Sync
 where
     S: super::private::Sealed,
 {

--- a/crates/core/src/network/partition_processor_rpc_client.rs
+++ b/crates/core/src/network/partition_processor_rpc_client.rs
@@ -134,7 +134,7 @@ pub struct PartitionProcessorRpcClient<C> {
     partition_routing: PartitionRouting,
 }
 
-impl<C> Clone for PartitionProcessorRpcClient<C> {
+impl<C: Clone> Clone for PartitionProcessorRpcClient<C> {
     fn clone(&self) -> Self {
         Self {
             networking: self.networking.clone(),

--- a/crates/ingress-http/src/rpc_request_dispatcher.rs
+++ b/crates/ingress-http/src/rpc_request_dispatcher.rs
@@ -31,7 +31,7 @@ pub struct RpcRequestDispatcher<C> {
     retry_policy: RetryPolicy,
 }
 
-impl<T> Clone for RpcRequestDispatcher<T> {
+impl<T: Clone> Clone for RpcRequestDispatcher<T> {
     fn clone(&self) -> Self {
         RpcRequestDispatcher {
             partition_processor_rpc_client: self.partition_processor_rpc_client.clone(),

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -175,7 +175,7 @@ impl Node {
         let metadata_manager =
             MetadataManager::new(metadata_builder, metadata_store_client.clone());
         let mut router_builder = MessageRouterBuilder::default();
-        let networking = Networking::new(metadata.clone(), config.networking.clone());
+        let networking = Networking::with_grpc_connector();
         metadata_manager.register_in_message_router(&mut router_builder);
         let partition_routing_refresher = PartitionRoutingRefresher::default();
 

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -15,7 +15,7 @@ use restate_core::TaskCenter;
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::network::grpc::CoreNodeSvcHandler;
 use restate_core::network::tonic_service_filter::{TonicServiceFilter, WaitForReady};
-use restate_core::network::{ConnectionManager, NetworkServerBuilder, TransportConnect};
+use restate_core::network::{ConnectionManager, NetworkServerBuilder};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::NodeCtlSvcServer;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::CommonOptions;
@@ -29,8 +29,8 @@ use crate::network_server::state::NodeCtrlHandlerStateBuilder;
 pub struct NetworkServer {}
 
 impl NetworkServer {
-    pub async fn run<T: TransportConnect>(
-        connection_manager: ConnectionManager<T>,
+    pub async fn run(
+        connection_manager: ConnectionManager,
         mut server_builder: NetworkServerBuilder,
         options: CommonOptions,
         metadata_store_client: MetadataStoreClient,


### PR DESCRIPTION

Most of the PR is mechanical, the highlights of the changes:
- Removes <T> from ConnectionManager.
- Remove redundant Metadata copies in Networking and ConnectionManager
- Use live configuration values for networking operations

This is a baby-step towards evolving this design towards a more ergonomic interface.
