### PR TITLE
[CI] Upgrade cargo-deny-action to fix rustup

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -20,7 +20,7 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check advisories
 
@@ -29,6 +29,6 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-2x
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check bans licenses sources


### PR DESCRIPTION

Rustup 1.28 has been released and it disables toolchain auto installation. See [rust-lang/rustup#3985], cargo-deny-action has released a fix on v2 at https://github.com/EmbarkStudios/cargo-deny-action/pull/92
