### PR TITLE
Move metadata common (protobuf) types to restate_types

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -12,6 +12,7 @@ use futures::future;
 use futures::never::Never;
 use rand::prelude::IteratorRandom;
 use rand::rng;
+use restate_types::metadata::Precondition;
 use std::collections::HashMap;
 use std::iter;
 use std::ops::Deref;
@@ -22,7 +23,7 @@ use tokio::task::JoinSet;
 use tracing::{Instrument, Level, debug, enabled, error, info, trace_span};
 
 use restate_bifrost::{Bifrost, Error as BifrostError};
-use restate_core::metadata_store::{Precondition, WriteError};
+use restate_core::metadata_store::WriteError;
 use restate_core::{
     Metadata, MetadataKind, MetadataWriter, ShutdownError, TargetVersion, TaskCenterFutureExt,
 };

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -14,9 +14,10 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
+use restate_types::metadata::Precondition;
 use tracing::{Level, debug, enabled, info, instrument, trace};
 
-use restate_core::metadata_store::{Precondition, ReadError, ReadWriteError, WriteError};
+use restate_core::metadata_store::{ReadError, ReadWriteError, WriteError};
 use restate_core::network::{NetworkSender, Networking, Outgoing, TransportConnect};
 use restate_core::{
     Metadata, MetadataKind, MetadataWriter, ShutdownError, SyncError, TargetVersion, TaskCenter,

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -603,6 +603,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
 
     use googletest::prelude::*;
+    use restate_types::metadata::Precondition;
     use test_log::test;
     use tokio::time::Duration;
     use tracing::info;
@@ -855,7 +856,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                Precondition::MatchesVersion(old_version),
             )
             .await?;
 

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -452,6 +452,7 @@ mod tests {
     use restate_types::live::{Constant, Live};
     use restate_types::logs::metadata::{ProviderKind, new_single_node_loglet_params};
     use restate_types::logs::{KeyFilter, SequenceNumber};
+    use restate_types::metadata::Precondition;
     use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 
     use crate::{BifrostService, ErrorRecoveryStrategy};
@@ -738,7 +739,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                Precondition::MatchesVersion(old_version),
             )
             .await?;
 
@@ -936,7 +937,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                Precondition::MatchesVersion(old_version),
             )
             .await?;
 

--- a/crates/core/src/metadata_store.rs
+++ b/crates/core/src/metadata_store.rs
@@ -15,9 +15,10 @@ use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::{Bytes, BytesMut};
+use bytes::BytesMut;
 use bytestring::ByteString;
 use metrics::{counter, histogram};
+use restate_types::metadata::{Precondition, VersionedValue};
 use tokio::time::Instant;
 use tracing::debug;
 
@@ -28,7 +29,7 @@ use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::retries::RetryPolicy;
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode, StorageEncodeError};
-use restate_types::{Version, Versioned, flexbuffers_storage_encode_decode};
+use restate_types::{Version, Versioned};
 
 #[cfg(any(test, feature = "test-util"))]
 use crate::metadata_store::test_util::InMemoryMetadataStore;
@@ -136,32 +137,6 @@ impl MaybeRetryableError for ProvisionError {
             ProvisionError::NotSupported(_) => false,
         }
     }
-}
-
-#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct VersionedValue {
-    pub version: Version,
-    #[debug(skip)]
-    pub value: Bytes,
-}
-
-impl VersionedValue {
-    pub fn new(version: Version, value: Bytes) -> Self {
-        Self { version, value }
-    }
-}
-
-flexbuffers_storage_encode_decode!(VersionedValue);
-
-/// Preconditions for the write operations of the [`MetadataStore`].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
-pub enum Precondition {
-    /// No precondition
-    None,
-    /// Key-value pair must not exist for the write operation to succeed.
-    DoesNotExist,
-    /// Key-value pair must have the provided [`Version`] for the write operation to succeed.
-    MatchesVersion(Version),
 }
 
 /// Metadata store abstraction. The metadata store implementations need to support linearizable

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -17,6 +17,7 @@ use futures::Stream;
 use restate_types::config::NetworkingOptions;
 use restate_types::locality::NodeLocation;
 use restate_types::logs::metadata::{ProviderKind, bootstrap_logs_metadata};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY,
 };
@@ -31,7 +32,7 @@ use restate_types::protobuf::node::Message;
 use restate_types::{GenerationalNodeId, Version};
 
 use crate::TaskCenter;
-use crate::metadata_store::{MetadataStoreClient, Precondition};
+use crate::metadata_store::MetadataStoreClient;
 use crate::network::{
     ConnectionManager, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder,
     NetworkError, Networking, ProtocolError, TransportConnect,

--- a/crates/metadata-server/build.rs
+++ b/crates/metadata-server/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
+        .extern_path(".restate.metadata", "::restate_types::protobuf::metadata")
         .compile_protos(
             &["./proto/metadata_server_svc.proto"],
             &["proto", "../types/protobuf"],

--- a/crates/metadata-server/proto/metadata_server_svc.proto
+++ b/crates/metadata-server/proto/metadata_server_svc.proto
@@ -11,6 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "restate/common.proto";
+import "restate/metadata.proto";
 
 package restate.metadata_server_svc;
 
@@ -39,38 +40,18 @@ message GetRequest { string key = 1; }
 
 message PutRequest {
   string key = 1;
-  VersionedValue value = 2;
-  Precondition precondition = 3;
+  restate.metadata.VersionedValue value = 2;
+  restate.metadata.Precondition precondition = 3;
 }
 
 message DeleteRequest {
   string key = 1;
-  Precondition precondition = 2;
+  restate.metadata.Precondition precondition = 2;
 }
 
-message VersionedValue {
-  Version version = 1;
-  bytes bytes = 2;
-}
+message GetResponse { optional restate.metadata.VersionedValue value = 1; }
 
-message GetResponse { optional VersionedValue value = 1; }
-
-message Version { uint32 value = 1; }
-
-message GetVersionResponse { optional Version version = 1; }
-
-enum PreconditionKind {
-  PreconditionKind_UNKNOWN = 0;
-  NONE = 1;
-  DOES_NOT_EXIST = 2;
-  MATCHES_VERSION = 3;
-}
-
-message Precondition {
-  PreconditionKind kind = 1;
-  // needs to be set in case of PreconditionKind::MATCHES_VERSION
-  optional Version version = 2;
-}
+message GetVersionResponse { optional restate.common.Version version = 1; }
 
 message ProvisionRequest { bytes nodes_configuration = 1; }
 
@@ -121,14 +102,14 @@ message WriteRequest {
   Ulid request_id = 1;
   WriteRequestKind kind = 2;
   bytes key = 3;
-  Precondition precondition = 4;
+  restate.metadata.Precondition precondition = 4;
   // value is only required if WriteRequestKind is set to PUT
-  optional VersionedValue value = 7;
+  optional restate.metadata.VersionedValue value = 7;
 }
 
 message KvEntry {
   bytes key = 1;
-  VersionedValue value = 2;
+  restate.metadata.VersionedValue value = 2;
 }
 
 message MetadataServerSnapshot {

--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -10,19 +10,18 @@
 
 use crate::KnownLeader;
 use crate::grpc::metadata_server_svc_client::MetadataServerSvcClient;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc::{DeleteRequest, GetRequest, ProvisionRequest, PutRequest};
 use async_trait::async_trait;
 use bytes::BytesMut;
 use bytestring::ByteString;
 use parking_lot::Mutex;
 use rand::prelude::IteratorRandom;
-use restate_core::metadata_store::{
-    MetadataStore, Precondition, ProvisionError, ReadError, VersionedValue, WriteError,
-};
+use restate_core::metadata_store::{MetadataStore, ProvisionError, ReadError, WriteError};
 use restate_core::network::net_util::{CommonClientConnectionOptions, create_tonic_channel};
 use restate_core::{Metadata, TaskCenter, TaskKind, cancellation_watcher};
 use restate_types::config::Configuration;
+use restate_types::errors::ConversionError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::net::AdvertisedAddress;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration, Role};

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -12,18 +12,19 @@ use std::ops::Deref;
 
 use async_trait::async_trait;
 use metrics::{counter, histogram};
+use restate_types::errors::ConversionError;
+use restate_types::metadata::Precondition;
 use tokio::sync::{oneshot, watch};
 use tokio::time::Instant;
 use tonic::{Request, Response, Status};
 
-use restate_core::metadata_store::{Precondition, serialize_value};
+use restate_core::metadata_store::serialize_value;
 use restate_types::config::Configuration;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;
 
 use crate::grpc::metadata_server_svc_server::MetadataServerSvc;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc::{
     DeleteRequest, GetRequest, GetResponse, GetVersionResponse,
     ProvisionRequest as ProtoProvisionRequest, ProvisionResponse, PutRequest, StatusResponse,

--- a/crates/metadata-server/src/grpc/mod.rs
+++ b/crates/metadata-server/src/grpc/mod.rs
@@ -15,30 +15,11 @@ tonic::include_proto!("restate.metadata_server_svc");
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("metadata_server_svc");
 
 pub mod pb_conversions {
-    use crate::grpc::{
-        GetResponse, GetVersionResponse, PreconditionKind, Ulid, WriteRequest, WriteRequestKind,
-    };
+    use crate::grpc::{GetResponse, GetVersionResponse, Ulid, WriteRequest, WriteRequestKind};
     use crate::{MetadataServerSummary, grpc};
-    use restate_core::metadata_store::{Precondition, VersionedValue};
     use restate_types::Version;
-
-    #[derive(Debug, thiserror::Error)]
-    pub enum ConversionError {
-        #[error("missing field '{0}'")]
-        MissingField(&'static str),
-        #[error("invalid data '{0}'")]
-        InvalidData(&'static str),
-    }
-
-    impl ConversionError {
-        pub fn missing_field(field: &'static str) -> Self {
-            ConversionError::MissingField(field)
-        }
-
-        pub fn invalid_data(field: &'static str) -> Self {
-            ConversionError::InvalidData(field)
-        }
-    }
+    use restate_types::errors::ConversionError;
+    use restate_types::metadata::VersionedValue;
 
     impl TryFrom<GetResponse> for Option<VersionedValue> {
         type Error = ConversionError;
@@ -52,82 +33,9 @@ pub mod pb_conversions {
         }
     }
 
-    impl TryFrom<grpc::VersionedValue> for VersionedValue {
-        type Error = ConversionError;
-
-        fn try_from(value: grpc::VersionedValue) -> Result<Self, Self::Error> {
-            let version = value
-                .version
-                .ok_or_else(|| ConversionError::missing_field("version"))?;
-            Ok(VersionedValue::new(version.into(), value.bytes))
-        }
-    }
-
     impl From<GetVersionResponse> for Option<Version> {
         fn from(value: GetVersionResponse) -> Self {
             value.version.map(Into::into)
-        }
-    }
-
-    impl From<VersionedValue> for grpc::VersionedValue {
-        fn from(value: VersionedValue) -> Self {
-            grpc::VersionedValue {
-                version: Some(value.version.into()),
-                bytes: value.value,
-            }
-        }
-    }
-
-    impl From<grpc::Version> for Version {
-        fn from(value: grpc::Version) -> Self {
-            Version::from(value.value)
-        }
-    }
-
-    impl From<Version> for grpc::Version {
-        fn from(value: Version) -> Self {
-            grpc::Version {
-                value: value.into(),
-            }
-        }
-    }
-
-    impl From<Precondition> for grpc::Precondition {
-        fn from(value: Precondition) -> Self {
-            match value {
-                Precondition::None => grpc::Precondition {
-                    kind: PreconditionKind::None.into(),
-                    version: None,
-                },
-                Precondition::DoesNotExist => grpc::Precondition {
-                    kind: PreconditionKind::DoesNotExist.into(),
-                    version: None,
-                },
-                Precondition::MatchesVersion(version) => grpc::Precondition {
-                    kind: PreconditionKind::MatchesVersion.into(),
-                    version: Some(version.into()),
-                },
-            }
-        }
-    }
-
-    impl TryFrom<grpc::Precondition> for Precondition {
-        type Error = ConversionError;
-
-        fn try_from(value: grpc::Precondition) -> Result<Self, Self::Error> {
-            match value.kind() {
-                PreconditionKind::Unknown => {
-                    Err(ConversionError::invalid_data("unknown precondition kind"))
-                }
-                PreconditionKind::None => Ok(Precondition::None),
-                PreconditionKind::DoesNotExist => Ok(Precondition::DoesNotExist),
-                PreconditionKind::MatchesVersion => Ok(Precondition::MatchesVersion(
-                    value
-                        .version
-                        .ok_or_else(|| ConversionError::missing_field("version"))?
-                        .into(),
-                )),
-            }
         }
     }
 

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -20,25 +20,24 @@ use crate::raft::{RaftMetadataServer, create_replicated_metadata_client};
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
-use grpc::pb_conversions::ConversionError;
 use itertools::Itertools;
 use prost::Message;
 use raft_proto::eraftpb::Snapshot;
-use restate_core::metadata_store::VersionedValue;
 use restate_core::metadata_store::providers::{
     EtcdMetadataStore, create_object_store_based_meta_store,
 };
 pub use restate_core::metadata_store::{
-    MetadataStoreClient, Precondition, ReadError, ReadModifyWriteError, WriteError,
+    MetadataStoreClient, ReadError, ReadModifyWriteError, WriteError,
 };
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataWriter, ShutdownError};
 use restate_types::config::{
     Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind,
 };
-use restate_types::errors::{GenericError, MaybeRetryableError};
+use restate_types::errors::{ConversionError, GenericError, MaybeRetryableError};
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -12,14 +12,14 @@ use crate::local::storage::RocksDbStorage;
 use crate::{MetadataServer, MetadataStoreRequest, RequestError, RequestReceiver, RequestSender};
 use bytestring::ByteString;
 use restate_core::metadata_store::{
-    MetadataStoreClient, Precondition, ProvisionedMetadataStore, ReadError, VersionedValue,
-    WriteError, serialize_value,
+    MetadataStoreClient, ProvisionedMetadataStore, ReadError, WriteError, serialize_value,
 };
 use restate_core::{MetadataWriter, ShutdownError, cancellation_watcher};
 use restate_rocksdb::RocksError;
 use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration};
 use restate_types::protobuf::common::MetadataServerStatus;

--- a/crates/metadata-server/src/local/storage.rs
+++ b/crates/metadata-server/src/local/storage.rs
@@ -13,7 +13,6 @@ use crate::{PreconditionViolation, RequestError};
 use bytes::BytesMut;
 use bytestring::ByteString;
 use itertools::Itertools;
-use restate_core::metadata_store::{Precondition, VersionedValue};
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
@@ -21,6 +20,7 @@ use restate_rocksdb::{
 use restate_types::Version;
 use restate_types::config::{MetadataServerOptions, RocksDbOptions, data_dir};
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
 use rocksdb::{
     BoundColumnFamily, DBCompressionType, Error, IteratorMode, ReadOptions, WriteBatch,

--- a/crates/metadata-server/src/raft/kv_memory_storage.rs
+++ b/crates/metadata-server/src/raft/kv_memory_storage.rs
@@ -9,15 +9,15 @@
 // by the Apache License, Version 2.0.
 
 use crate::grpc::MetadataServerSnapshot;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::{
     Callback, PreconditionViolation, ReadOnlyRequest, ReadOnlyRequestKind, RequestError,
     RequestKind, WriteRequest, grpc,
 };
 use bytestring::ByteString;
 use restate_core::MetadataWriter;
-use restate_core::metadata_store::{Precondition, VersionedValue};
 use restate_types::Version;
+use restate_types::errors::ConversionError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -11,7 +11,6 @@
 use crate::grpc::MetadataServerSnapshot;
 use crate::grpc::handler::MetadataServerHandler;
 use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::local::migrate_nodes_configuration;
 use crate::metric_definitions::{
     METADATA_SERVER_REPLICATED_APPLIED_LSN, METADATA_SERVER_REPLICATED_COMMITTED_LSN,
@@ -50,7 +49,7 @@ use raft_proto::ConfChangeI;
 use raft_proto::eraftpb::{ConfChangeSingle, ConfChangeType, Snapshot, SnapshotMetadata};
 use rand::prelude::IteratorRandom;
 use rand::rng;
-use restate_core::metadata_store::{Precondition, serialize_value};
+use restate_core::metadata_store::serialize_value;
 use restate_core::network::NetworkServerBuilder;
 use restate_core::network::net_util::create_tonic_channel;
 use restate_core::{
@@ -59,9 +58,10 @@ use restate_core::{
 use restate_types::config::{
     Configuration, MetadataServerKind, MetadataServerOptions, RocksDbOptions,
 };
-use restate_types::errors::GenericError;
+use restate_types::errors::{ConversionError, GenericError};
 use restate_types::health::HealthStatus;
 use restate_types::live::{BoxedLiveLoad, Constant};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration, Role};

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -16,7 +16,7 @@ use futures::TryFutureExt;
 use googletest::IntoTestResult;
 use rand::RngCore;
 use rand::distr::{Alphanumeric, SampleString};
-use restate_core::metadata_store::{Precondition, serialize_value};
+use restate_core::metadata_store::serialize_value;
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataBuilder, TaskCenter, TaskKind, cancellation_token};
 use restate_rocksdb::RocksDbManager;
@@ -27,6 +27,7 @@ use restate_types::config::{
 use restate_types::health::Health;
 use restate_types::live::Constant;
 use restate_types::locality::NodeLocation;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 use restate_types::nodes_config::{

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,6 +16,7 @@ mod roles;
 use anyhow::Context;
 use bytestring::ByteString;
 use prost_dto::IntoProst;
+use restate_types::metadata::Precondition;
 use std::num::NonZeroU16;
 use tracing::{debug, error, info, trace, warn};
 
@@ -25,9 +26,7 @@ use crate::network_server::NetworkServer;
 use crate::roles::{AdminRole, BaseRole, IngressRole, WorkerRole};
 use codederror::CodedError;
 use restate_bifrost::BifrostService;
-use restate_core::metadata_store::{
-    Precondition, ReadWriteError, WriteError, retry_on_retryable_error,
-};
+use restate_core::metadata_store::{ReadWriteError, WriteError, retry_on_retryable_error};
 use restate_core::network::{
     GrpcConnector, MessageRouterBuilder, NetworkServerBuilder, Networking,
 };

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -113,6 +113,7 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
         .compile_protos(
             &[
                 "./protobuf/restate/common.proto",
+                "./protobuf/restate/metadata.proto",
                 "./protobuf/restate/cluster.proto",
                 "./protobuf/restate/log_server_common.proto",
                 "./protobuf/restate/node.proto",

--- a/crates/types/protobuf/restate/metadata.proto
+++ b/crates/types/protobuf/restate/metadata.proto
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+package restate.metadata;
+
+import "google/protobuf/empty.proto";
+import "restate/common.proto";
+
+message VersionedValue {
+  restate.common.Version version = 1;
+  bytes bytes = 2;
+}
+
+enum PreconditionKind {
+  PreconditionKind_UNKNOWN = 0;
+  NONE = 1;
+  DOES_NOT_EXIST = 2;
+  MATCHES_VERSION = 3;
+}
+
+message Precondition {
+  PreconditionKind kind = 1;
+  // needs to be set in case of PreconditionKind::MATCHES_VERSION
+  optional restate.common.Version version = 2;
+}

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -338,3 +338,21 @@ pub enum ThreadJoinError {
     #[error("thread terminated unexpectedly")]
     UnexpectedTermination,
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConversionError {
+    #[error("missing field '{0}'")]
+    MissingField(&'static str),
+    #[error("invalid data '{0}'")]
+    InvalidData(&'static str),
+}
+
+impl ConversionError {
+    pub fn missing_field(field: &'static str) -> Self {
+        ConversionError::MissingField(field)
+    }
+
+    pub fn invalid_data(field: &'static str) -> Self {
+        ConversionError::InvalidData(field)
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -34,6 +34,7 @@ pub mod live;
 pub mod locality;
 pub mod logs;
 pub mod message;
+pub mod metadata;
 pub mod metadata_store;
 pub mod net;
 pub mod nodes_config;

--- a/crates/types/src/metadata.rs
+++ b/crates/types/src/metadata.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+
+use crate::{Version, flexbuffers_storage_encode_decode};
+
+#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VersionedValue {
+    pub version: Version,
+    #[debug(skip)]
+    pub value: Bytes,
+}
+
+impl VersionedValue {
+    pub fn new(version: Version, value: Bytes) -> Self {
+        Self { version, value }
+    }
+}
+
+flexbuffers_storage_encode_decode!(VersionedValue);
+
+/// Preconditions for the write operations of the [`MetadataStore`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
+pub enum Precondition {
+    /// No precondition
+    None,
+    /// Key-value pair must not exist for the write operation to succeed.
+    DoesNotExist,
+    /// Key-value pair must have the provided [`Version`] for the write operation to succeed.
+    MatchesVersion(Version),
+}

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -17,7 +17,6 @@ use googletest::internal::test_outcome::TestAssertionFailure;
 
 use restate_bifrost::{Bifrost, loglet::Loglet};
 use restate_core::TaskCenter;
-use restate_core::metadata_store::Precondition;
 use restate_core::{MetadataWriter, metadata_store::MetadataStoreClient};
 use restate_local_cluster_runner::{
     cluster::{Cluster, MaybeTempDir, StartedCluster},
@@ -27,6 +26,7 @@ use restate_rocksdb::RocksDbManager;
 use restate_types::logs::LogletId;
 use restate_types::logs::builder::LogsBuilder;
 use restate_types::logs::metadata::{Chain, LogletParams, SegmentIndex};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::{
     GenerationalNodeId, PlainNodeId,

--- a/server/tests/raft_metadata_cluster.rs
+++ b/server/tests/raft_metadata_cluster.rs
@@ -13,7 +13,7 @@ use enumset::EnumSet;
 use googletest::prelude::err;
 use googletest::{IntoTestResult, assert_that, pat};
 use rand::seq::IndexedMutRandom;
-use restate_core::metadata_store::{Precondition, WriteError};
+use restate_core::metadata_store::WriteError;
 use restate_core::{TaskCenter, TaskKind, cancellation_watcher};
 use restate_local_cluster_runner::cluster::Cluster;
 use restate_local_cluster_runner::node::{BinarySource, HealthCheck, Node};
@@ -23,6 +23,7 @@ use restate_types::Versioned;
 use restate_types::config::{
     Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind, RaftOptions,
 };
+use restate_types::metadata::Precondition;
 use std::num::NonZeroUsize;
 use std::time::{Duration, Instant};
 use tracing::info;

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use codederror::CodedError;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use restate_core::task_center::TaskCenterMonitoring;
+use restate_types::metadata::Precondition;
 use tracing::trace;
 
 use bifrost_benchpress::util::{print_prometheus_stats, print_rocksdb_stats};
@@ -25,7 +26,7 @@ use restate_core::{
     task_center,
 };
 use restate_errors::fmt::RestateCode;
-use restate_metadata_server::{MetadataStoreClient, Precondition};
+use restate_metadata_server::MetadataStoreClient;
 use restate_rocksdb::RocksDbManager;
 use restate_tracing_instrumentation::init_tracing_and_logging;
 use restate_types::config::{

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -12,10 +12,11 @@ use bytestring::ByteString;
 use clap::Parser;
 use cling::{Collect, Run};
 use json_patch::Patch;
+use restate_types::metadata::Precondition;
 use serde_json::Value;
 use tracing::debug;
 
-use restate_core::metadata_store::{MetadataStoreClient, Precondition};
+use restate_core::metadata_store::MetadataStoreClient;
 use restate_rocksdb::RocksDbManager;
 use restate_types::Version;
 use restate_types::config::Configuration;


### PR DESCRIPTION
Move metadata common (protobuf) types to restate_types

Summary:
This is a planning step to move all metadata common protobuf
type to restate_types. This way the data types can
be reused in other crates and .proto files
without a direct dependency on metadata-server crate
