### PR TITLE
Use the metadata proxy in restatectl

### DIFF
--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -8,6 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tonic::{Code, Status};
+
+use crate::metadata_store::{ReadError, WriteError};
+
 pub mod node_ctl_svc {
     use restate_types::protobuf::cluster::ClusterConfiguration;
 
@@ -35,8 +39,134 @@ pub mod node_ctl_svc {
 
 pub mod metadata_proxy_svc {
 
+    use bytestring::ByteString;
+    use tonic::{codec::CompressionEncoding, transport::Channel};
+
+    use metadata_proxy_svc_client::MetadataProxySvcClient;
+    use restate_types::{
+        Version,
+        metadata::{Precondition, VersionedValue},
+        nodes_config::NodesConfiguration,
+    };
+
+    use crate::metadata_store::{MetadataStore, ProvisionError, ReadError, WriteError};
+
+    use super::{to_read_err, to_write_err};
+
     tonic::include_proto!("restate.metadata_proxy_svc");
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("metadata_proxy_svc_descriptor");
+
+    pub struct MetadataStoreProxy {
+        client: MetadataProxySvcClient<Channel>,
+    }
+
+    impl MetadataStoreProxy {
+        pub fn new(channel: Channel) -> Self {
+            Self {
+                client: MetadataProxySvcClient::new(channel)
+                    .send_compressed(CompressionEncoding::Gzip)
+                    .accept_compressed(CompressionEncoding::Gzip),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MetadataStore for MetadataStoreProxy {
+        async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+            let mut client = self.client.clone();
+
+            let request = GetRequest {
+                key: key.to_string(),
+            };
+
+            let response = client.get(request).await.map_err(to_read_err)?.into_inner();
+
+            response
+                .value
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(ReadError::terminal)
+        }
+
+        async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+            let mut client = self.client.clone();
+
+            let request = GetRequest {
+                key: key.to_string(),
+            };
+
+            let response = client
+                .get_version(request)
+                .await
+                .map_err(to_read_err)?
+                .into_inner();
+
+            response
+                .version
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(ReadError::terminal)
+        }
+
+        async fn put(
+            &self,
+            key: ByteString,
+            value: VersionedValue,
+            precondition: Precondition,
+        ) -> Result<(), WriteError> {
+            let mut client = self.client.clone();
+
+            let request = PutRequest {
+                key: key.to_string(),
+                value: Some(value.into()),
+                precondition: Some(precondition.into()),
+            };
+
+            client.put(request).await.map_err(to_write_err)?;
+
+            Ok(())
+        }
+
+        async fn delete(
+            &self,
+            key: ByteString,
+            precondition: Precondition,
+        ) -> Result<(), WriteError> {
+            let mut client = self.client.clone();
+
+            let request = DeleteRequest {
+                key: key.to_string(),
+                precondition: Some(precondition.into()),
+            };
+
+            client.delete(request).await.map_err(to_write_err)?;
+
+            Ok(())
+        }
+
+        async fn provision(&self, _: &NodesConfiguration) -> Result<bool, ProvisionError> {
+            Err(ProvisionError::NotSupported(
+                "Provision not supported over metadata proxy".to_owned(),
+            ))
+        }
+    }
+}
+
+fn to_read_err(status: Status) -> ReadError {
+    // Currently, we treat all returned statuses as terminal errors since
+    // retryability is not encoded in the status response.
+    //
+    // Additionally, users of this proxy client (e.g., `restatectl`) are
+    // unlikely to retry on errors and will typically attempt to use
+    // another node instead.
+    ReadError::terminal(status)
+}
+
+fn to_write_err(status: Status) -> WriteError {
+    match status.code() {
+        Code::FailedPrecondition => WriteError::FailedPrecondition(status.to_string()),
+        _ => WriteError::terminal(status),
+    }
 }

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -8,20 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytestring::ByteString;
 use clap::Parser;
 use cling::{Collect, Run};
-use tracing::debug;
 
-use restate_rocksdb::RocksDbManager;
-use restate_types::config::Configuration;
-
-use crate::commands::metadata::{
-    GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts, create_metadata_store_client,
-};
+use crate::commands::metadata::MetadataCommonOpts;
 use crate::connection::ConnectionInfo;
-use crate::environment::metadata_store;
-use crate::environment::task_center::run_in_task_center;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]
@@ -36,44 +27,10 @@ pub struct GetValueOpts {
 }
 
 async fn get_value(connection: &ConnectionInfo, opts: &GetValueOpts) -> anyhow::Result<()> {
-    let value = match opts.metadata.access_mode {
-        MetadataAccessMode::Remote => get_value_remote(connection, opts).await?,
-        MetadataAccessMode::Direct => get_value_direct(opts).await?,
-    };
+    let value = super::get_value(connection, &opts.key).await?;
 
     let value = serde_json::to_string_pretty(&value).map_err(|e| anyhow::anyhow!(e))?;
     println!("{value}");
 
     Ok(())
-}
-
-async fn get_value_remote(
-    connection: &ConnectionInfo,
-    opts: &GetValueOpts,
-) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let metadata_store_client = create_metadata_store_client(connection, &opts.metadata).await?;
-
-    metadata_store_client
-        .get(ByteString::from(opts.key.as_str()))
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))
-}
-
-async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericMetadataValue>> {
-    run_in_task_center(opts.metadata.config_file.as_ref(), |config| async move {
-        let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
-        debug!("RocksDB Initialized");
-
-        let metadata_store_client = metadata_store::start_metadata_server(config.clone()).await?;
-        debug!("Metadata store client created");
-
-        let value: Option<GenericMetadataValue> = metadata_store_client
-            .get(ByteString::from(opts.key.as_str()))
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))?;
-
-        rocksdb_manager.shutdown().await;
-        anyhow::Ok(value)
-    })
-    .await
 }

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -15,11 +15,12 @@ mod put;
 use std::path::PathBuf;
 
 use cling::prelude::*;
+use tonic::codec::CompressionEncoding;
 
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_metadata_server::create_client;
-use restate_types::config::MetadataClientOptions;
-use restate_types::nodes_config::Role;
+use restate_core::protobuf::metadata_proxy_svc::GetRequest;
+use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
+use restate_types::protobuf::metadata::VersionedValue;
+use restate_types::storage::StorageCodec;
 use restate_types::{Version, Versioned, flexbuffers_storage_encode_decode};
 
 use crate::connection::ConnectionInfo;
@@ -37,19 +38,6 @@ pub enum Metadata {
 #[derive(Args, Clone, Debug)]
 #[clap()]
 pub struct MetadataCommonOpts {
-    /// Etcd store server addresses
-    #[arg(
-        short,
-        long = "etcd",
-        value_delimiter = ',',
-        required_if_eq("remote_service_type", "etcd")
-    )]
-    etcd: Vec<String>,
-
-    /// Metadata store access mode
-    #[arg(long, default_value_t)]
-    access_mode: MetadataAccessMode,
-
     /// Service type for access mode = "remote"
     #[arg(long, default_value_t)]
     remote_service_type: RemoteServiceType,
@@ -64,16 +52,6 @@ pub struct MetadataCommonOpts {
     config_file: Option<PathBuf>,
 }
 
-#[derive(clap::ValueEnum, Clone, Default, Debug, strum::Display)]
-#[strum(serialize_all = "kebab-case")]
-enum MetadataAccessMode {
-    /// Connect to a remote metadata server at the specified address
-    #[default]
-    Remote,
-    /// Open a local metadata store database directory directly
-    Direct,
-}
-
 #[derive(clap::ValueEnum, Clone, Default, Debug, strum::Display, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 enum RemoteServiceType {
@@ -84,18 +62,17 @@ enum RemoteServiceType {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GenericMetadataValue {
-    // We assume that the concrete serialized type's encoded version field is called "version".
     version: Version,
 
     #[serde(flatten)]
-    data: serde_json::Map<String, serde_json::Value>,
+    fields: serde_json::Map<String, serde_json::Value>,
 }
 
 flexbuffers_storage_encode_decode!(GenericMetadataValue);
 
 impl GenericMetadataValue {
     pub fn to_json_value(&self) -> serde_json::Value {
-        serde_json::Value::Object(self.data.clone())
+        serde_json::Value::Object(self.fields.clone())
     }
 }
 
@@ -105,30 +82,59 @@ impl Versioned for GenericMetadataValue {
     }
 }
 
-pub async fn create_metadata_store_client(
-    connection: &ConnectionInfo,
-    opts: &MetadataCommonOpts,
-) -> anyhow::Result<MetadataStoreClient> {
-    let client = match opts.remote_service_type {
-        RemoteServiceType::Restate => {
-            let nodes = connection.get_nodes_configuration().await?;
-            let addresses = nodes
-                .iter_role(Role::MetadataServer)
-                .map(|(_, node)| node.address.clone())
-                .collect();
-            restate_types::config::MetadataClientKind::Replicated { addresses }
+impl TryFrom<VersionedValue> for GenericMetadataValue {
+    type Error = anyhow::Error;
+    fn try_from(mut versioned_value: VersionedValue) -> Result<Self, Self::Error> {
+        let version: Version = versioned_value
+            .version
+            .ok_or_else(|| anyhow::anyhow!("version is required"))?
+            .into();
+
+        let value: GenericMetadataValue = StorageCodec::decode(&mut versioned_value.bytes)?;
+        if value.version != version {
+            anyhow::bail!("returned payload and metadata object versions must align");
         }
-        RemoteServiceType::Etcd => restate_types::config::MetadataClientKind::Etcd {
-            addresses: opts.etcd.clone(),
-        },
+
+        Ok(value)
+    }
+}
+
+impl TryFrom<GenericMetadataValue> for VersionedValue {
+    type Error = anyhow::Error;
+
+    fn try_from(value: GenericMetadataValue) -> Result<Self, Self::Error> {
+        let mut buf = bytes::BytesMut::new();
+        StorageCodec::encode(&value, &mut buf)?;
+
+        Ok(Self {
+            version: Some(value.version.into()),
+            bytes: buf.into(),
+        })
+    }
+}
+
+async fn get_value(
+    connection: &ConnectionInfo,
+    key: impl AsRef<str>,
+) -> anyhow::Result<Option<GenericMetadataValue>> {
+    let key = key.as_ref();
+    let response = connection
+        .try_each(None, |channel| async {
+            let mut client = MetadataProxySvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+            client
+                .get(GetRequest {
+                    key: key.to_owned(),
+                })
+                .await
+        })
+        .await?;
+
+    let response = response.into_inner();
+    let Some(value) = response.value else {
+        return Ok(None);
     };
 
-    let metadata_store_client_options = MetadataClientOptions {
-        kind: client,
-        ..MetadataClientOptions::default()
-    };
-
-    create_client(metadata_store_client_options)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))
+    Ok(Some(value.try_into()?))
 }

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -8,25 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytestring::ByteString;
+use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
 use json_patch::Patch;
 use serde_json::Value;
-use tracing::debug;
+use tonic::Code;
+use tonic::codec::CompressionEncoding;
 
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_rocksdb::RocksDbManager;
+use restate_core::protobuf::metadata_proxy_svc::PutRequest;
+use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
 use restate_types::Version;
-use restate_types::config::Configuration;
 use restate_types::metadata::Precondition;
 
-use crate::commands::metadata::{
-    GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts, create_metadata_store_client,
-};
-use crate::connection::ConnectionInfo;
-use crate::environment::metadata_store::start_metadata_server;
-use crate::environment::task_center::run_in_task_center;
+use crate::commands::metadata::MetadataCommonOpts;
+use crate::connection::{ConnectionInfo, NodeOperationError};
+
+use super::GenericMetadataValue;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]
@@ -59,10 +57,7 @@ pub(crate) async fn patch_value(
     let patch = serde_json::from_str(opts.patch.as_str())
         .map_err(|e| anyhow::anyhow!("Parsing JSON patch: {}", e))?;
 
-    let value = match opts.metadata.access_mode {
-        MetadataAccessMode::Remote => patch_value_remote(connection, opts, patch).await?,
-        MetadataAccessMode::Direct => patch_value_direct(opts, patch).await?,
-    };
+    let value = patch_value_inner(connection, opts, patch).await?;
 
     let value = serde_json::to_string_pretty(&value).map_err(|e| anyhow::anyhow!(e))?;
     println!("{value}");
@@ -70,46 +65,12 @@ pub(crate) async fn patch_value(
     Ok(())
 }
 
-async fn patch_value_remote(
+async fn patch_value_inner(
     connection: &ConnectionInfo,
     opts: &PatchValueOpts,
     patch: Patch,
-) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let metadata_store_client = create_metadata_store_client(connection, &opts.metadata).await?;
-    Ok(Some(
-        patch_value_inner(opts, &patch, &metadata_store_client).await?,
-    ))
-}
-
-async fn patch_value_direct(
-    opts: &PatchValueOpts,
-    patch: Patch,
-) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let value = run_in_task_center(opts.metadata.config_file.as_ref(), |config| async move {
-        let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
-        debug!("RocksDB Initialized");
-
-        let metadata_store_client = start_metadata_server(config.clone()).await?;
-        debug!("Metadata store client created");
-
-        let result = patch_value_inner(opts, &patch, &metadata_store_client).await;
-
-        rocksdb_manager.shutdown().await;
-        result
-    })
-    .await?;
-
-    Ok(Some(value))
-}
-
-async fn patch_value_inner(
-    opts: &PatchValueOpts,
-    patch: &Patch,
-    metadata_store_client: &MetadataStoreClient,
 ) -> anyhow::Result<GenericMetadataValue> {
-    let value: Option<GenericMetadataValue> = metadata_store_client
-        .get(ByteString::from(opts.key.as_str()))
-        .await?;
+    let value = super::get_value(connection, &opts.key).await?;
 
     let current_version = value
         .as_ref()
@@ -127,35 +88,40 @@ async fn patch_value_inner(
     }
 
     let mut document = value.map(|v| v.to_json_value()).unwrap_or(Value::Null);
-    let value = match json_patch::patch(&mut document, patch) {
-        Ok(_) => {
-            let new_value = GenericMetadataValue {
-                version: current_version.next(),
-                data: serde_json::from_value(document.clone()).map_err(|e| anyhow::anyhow!(e))?,
-            };
-            if !opts.dry_run {
-                debug!(
-                    "Updating metadata key '{}' with expected {:?} version to {:?}",
-                    opts.key, current_version, new_value.version
-                );
-                metadata_store_client
-                    .put(
-                        ByteString::from(opts.key.as_str()),
-                        &new_value,
-                        if current_version == Version::INVALID {
-                            Precondition::DoesNotExist
-                        } else {
-                            Precondition::MatchesVersion(current_version)
-                        },
-                    )
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Store update failed: {}", e))?
-            } else {
-                println!("Dry run - updated value:\n");
-            }
-            Ok(new_value)
-        }
-        Err(e) => Err(anyhow::anyhow!("Patch failed: {}", e)),
-    }?;
-    Ok(value)
+    json_patch::patch(&mut document, &patch).context("Patch failed")?;
+
+    let new_value = GenericMetadataValue {
+        version: current_version.next(),
+        fields: serde_json::from_value(document.clone()).map_err(|e| anyhow::anyhow!(e))?,
+    };
+
+    let precondition = if current_version == Version::INVALID {
+        Precondition::DoesNotExist
+    } else {
+        Precondition::MatchesVersion(current_version)
+    };
+
+    let request = PutRequest {
+        key: opts.key.clone(),
+        precondition: Some(precondition.into()),
+        value: Some(new_value.clone().try_into()?),
+    };
+
+    connection
+        .try_each(None, |channel| async {
+            let mut client = MetadataProxySvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+
+            client.put(request.clone()).await.map_err(|err| {
+                if err.code() == Code::FailedPrecondition {
+                    NodeOperationError::Terminal(err)
+                } else {
+                    NodeOperationError::RetryElsewhere(err)
+                }
+            })
+        })
+        .await?;
+
+    Ok(new_value)
 }

--- a/tools/restatectl/src/commands/node/disable_node_checker.rs
+++ b/tools/restatectl/src/commands/node/disable_node_checker.rs
@@ -37,21 +37,17 @@ pub enum DisableNodeError {
     MetadataMember,
 }
 
-pub struct DisableNodeChecker {
-    nodes_configuration: NodesConfiguration,
-    logs: Logs,
+pub struct DisableNodeChecker<'a, 'b> {
+    nodes_configuration: &'a NodesConfiguration,
+    logs: &'b Logs,
 }
 
-impl DisableNodeChecker {
-    pub fn new(nodes_configuration: NodesConfiguration, logs: Logs) -> Self {
+impl<'a, 'b> DisableNodeChecker<'a, 'b> {
+    pub fn new(nodes_configuration: &'a NodesConfiguration, logs: &'b Logs) -> Self {
         DisableNodeChecker {
             nodes_configuration,
             logs,
         }
-    }
-
-    pub fn nodes_configuration(&self) -> &NodesConfiguration {
-        &self.nodes_configuration
     }
 
     pub fn safe_to_disable_node(&self, node_id: PlainNodeId) -> Result<(), DisableNodeError> {

--- a/tools/restatectl/src/commands/node/remove_nodes.rs
+++ b/tools/restatectl/src/commands/node/remove_nodes.rs
@@ -8,20 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::commands::node::disable_node_checker::DisableNodeChecker;
-use crate::connection::ConnectionInfo;
 use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
 use itertools::Itertools;
+use tonic::codec::CompressionEncoding;
+
 use restate_cli_util::c_println;
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_metadata_server::create_client;
+use restate_core::metadata_store::serialize_value;
+use restate_core::protobuf::metadata_proxy_svc::PutRequest;
+use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
 use restate_types::PlainNodeId;
-use restate_types::config::{MetadataClientKind, MetadataClientOptions};
 use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
-use restate_types::nodes_config::{NodesConfiguration, Role};
+
+use crate::commands::node::disable_node_checker::DisableNodeChecker;
+use crate::connection::ConnectionInfo;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(alias = "rm")]
@@ -37,11 +39,10 @@ pub async fn remove_nodes(
     connection: &ConnectionInfo,
     opts: &RemoveNodesOpts,
 ) -> anyhow::Result<()> {
-    let nodes_configuration = connection.get_nodes_configuration().await?;
-    let metadata_client = create_metadata_client(&nodes_configuration).await?;
+    let mut nodes_configuration = connection.get_nodes_configuration().await?;
     let logs = connection.get_logs().await?;
 
-    let disable_node_checker = DisableNodeChecker::new(nodes_configuration, logs);
+    let disable_node_checker = DisableNodeChecker::new(&nodes_configuration, &logs);
 
     for node_id in &opts.nodes {
         disable_node_checker
@@ -49,21 +50,28 @@ pub async fn remove_nodes(
             .context("It is not safe to disable node {node_id}")?
     }
 
-    let nodes_configuration = disable_node_checker.nodes_configuration();
-    let mut updated_nodes_configuration = nodes_configuration.clone();
+    let precondition = Precondition::MatchesVersion(nodes_configuration.version());
 
     for node_id in &opts.nodes {
-        updated_nodes_configuration.remove_node_unchecked(*node_id);
+        nodes_configuration.remove_node_unchecked(*node_id);
     }
 
-    updated_nodes_configuration.increment_version();
+    nodes_configuration.increment_version();
 
-    metadata_client
-        .put(
-            NODES_CONFIG_KEY.clone(),
-            &updated_nodes_configuration,
-            Precondition::MatchesVersion(nodes_configuration.version()),
-        )
+    let request = PutRequest {
+        key: NODES_CONFIG_KEY.to_string(),
+        precondition: Some(precondition.into()),
+        value: Some(serialize_value(&nodes_configuration)?.into()),
+    };
+
+    connection
+        .try_each(None, |channel| async {
+            let mut client = MetadataProxySvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+
+            client.put(request.clone()).await
+        })
         .await?;
 
     c_println!(
@@ -72,30 +80,4 @@ pub async fn remove_nodes(
     );
 
     Ok(())
-}
-
-async fn create_metadata_client(
-    nodes_configuration: &NodesConfiguration,
-) -> anyhow::Result<MetadataStoreClient> {
-    // find metadata nodes
-    let addresses: Vec<_> = nodes_configuration
-        .iter_role(Role::MetadataServer)
-        .map(|(_, config)| config.address.clone())
-        .collect();
-    if addresses.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No nodes are configured to run metadata-server role, this command only \
-             supports replicated metadata deployment"
-        ));
-    }
-
-    // todo make this work with other metadata client kinds as well; maybe proxy through Restate server
-    let metadata_store_client_options = MetadataClientOptions {
-        kind: MetadataClientKind::Replicated { addresses },
-        ..Default::default()
-    };
-
-    create_client(metadata_store_client_options)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))
 }


### PR DESCRIPTION
Use the metadata proxy in restatectl

Summary:
Always use the metadata proxy in restatectl instead
of the metadata client. This way metadata operation
is always agnostic to the actual store kind that is
being used by the server(s)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2825).
* __->__ #2825
* #2848