### PR TITLE
Fix issue when removing a node while still alive

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -23,7 +23,7 @@ use tracing::{Instrument, Level, debug, enabled, error, info, trace_span};
 
 use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{Bifrost, Error as BifrostError};
-use restate_core::metadata_store::{Precondition, WriteError};
+use restate_core::metadata_store::WriteError;
 use restate_core::{
     Metadata, MetadataKind, MetadataWriter, ShutdownError, TargetVersion, TaskCenterFutureExt,
 };
@@ -37,6 +37,7 @@ use restate_types::logs::metadata::{
     ProviderKind, ReplicatedLogletConfig, SegmentIndex,
 };
 use restate_types::logs::{LogId, LogletId, Lsn, TailState};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, StorageState};
 use restate_types::partition_table::PartitionTable;

--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -38,6 +38,20 @@ impl ObservedClusterState {
     }
 
     pub fn update(&mut self, cluster_state: &ClusterState) {
+        // In case nodes were removed and no longer exists in the cluster_state;
+        // we make sure they are completely removed from both dead and alive sets.
+        self.alive_nodes
+            .retain(|id, _| cluster_state.nodes.contains_key(id));
+        self.dead_nodes
+            .retain(|id| cluster_state.nodes.contains_key(id));
+        self.nodes_to_partitions
+            .retain(|id, _| cluster_state.nodes.contains_key(id));
+        for partition_state in self.partitions.values_mut() {
+            partition_state
+                .partition_processors
+                .retain(|id, _| cluster_state.nodes.contains_key(id));
+        }
+
         self.update_nodes(cluster_state);
         self.update_partitions(cluster_state);
     }

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use rand::seq::IteratorRandom;
 use tracing::{Level, debug, enabled, info, instrument, trace};
 
-use restate_core::metadata_store::{Precondition, ReadError, ReadWriteError, WriteError};
+use restate_core::metadata_store::{ReadError, ReadWriteError, WriteError};
 use restate_core::network::{NetworkSender, Networking, Outgoing, TransportConnect};
 use restate_core::{
     Metadata, MetadataKind, MetadataWriter, ShutdownError, SyncError, TargetVersion, TaskCenter,
@@ -27,6 +27,7 @@ use restate_types::cluster::cluster_state::RunMode;
 use restate_types::identifiers::PartitionId;
 use restate_types::locality::LocationScope;
 use restate_types::logs::LogId;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::PARTITION_TABLE_KEY;
 use restate_types::net::partition_processor_manager::{
     ControlProcessor, ControlProcessors, ProcessorCommand,

--- a/crates/admin/src/metadata_api/mod.rs
+++ b/crates/admin/src/metadata_api/mod.rs
@@ -24,9 +24,13 @@ use axum::{
 use bytestring::ByteString;
 use http::{HeaderMap, StatusCode, header::ToStrError};
 
-use restate_core::metadata_store::{MetadataStore, VersionedValue};
-use restate_metadata_server::{MetadataStoreClient, Precondition, ReadError, WriteError};
-use restate_types::{Version, metadata_store::keys};
+use restate_core::metadata_store::MetadataStore;
+use restate_metadata_server::{MetadataStoreClient, ReadError, WriteError};
+use restate_types::{
+    Version,
+    metadata::{Precondition, VersionedValue},
+    metadata_store::keys,
+};
 
 /// ETag header.
 const HEADER_ETAG: &str = "ETag";

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -13,11 +13,11 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use enum_map::EnumMap;
-use restate_types::config::Configuration;
 use tokio::time::Instant;
 use tracing::{info, instrument, warn};
 
 use restate_core::{Metadata, MetadataKind, MetadataWriter, TargetVersion};
+use restate_types::config::Configuration;
 use restate_types::logs::metadata::{MaybeSegment, ProviderKind, Segment};
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, TailState};
 use restate_types::storage::StorageEncode;
@@ -626,6 +626,7 @@ mod tests {
     use restate_types::live::Constant;
     use restate_types::logs::SequenceNumber;
     use restate_types::logs::metadata::{SegmentIndex, new_single_node_loglet_params};
+    use restate_types::metadata::Precondition;
     use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
     use restate_types::partition_table::PartitionTable;
     use restate_types::{Version, Versioned};
@@ -886,7 +887,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                Precondition::MatchesVersion(old_version),
             )
             .await?;
 

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -452,6 +452,7 @@ mod tests {
     use restate_types::live::{Constant, Live};
     use restate_types::logs::metadata::{ProviderKind, new_single_node_loglet_params};
     use restate_types::logs::{KeyFilter, SequenceNumber};
+    use restate_types::metadata::Precondition;
     use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 
     use crate::loglet::FindTailOptions;
@@ -754,7 +755,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                Precondition::MatchesVersion(old_version),
             )
             .await?;
 
@@ -958,7 +959,7 @@ mod tests {
             .put(
                 BIFROST_CONFIG_KEY.clone(),
                 &new_metadata,
-                restate_metadata_server::Precondition::MatchesVersion(old_version),
+                Precondition::MatchesVersion(old_version),
             )
             .await?;
 

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -19,11 +19,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .file_descriptor_set_path(out_dir.join("node_ctl_svc_descriptor.bin"))
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
-        .extern_path(".restate.node", "::restate_types::protobuf::node")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
         .extern_path(".restate.cluster", "::restate_types::protobuf::cluster")
         .compile_protos(
             &["./protobuf/node_ctl_svc.proto"],
+            &["protobuf", "../types/protobuf"],
+        )?;
+
+    tonic_build::configure()
+        .bytes(["."])
+        .file_descriptor_set_path(out_dir.join("metadata_proxy_svc_descriptor.bin"))
+        // allow older protobuf compiler to be used
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .extern_path(".restate.common", "::restate_types::protobuf::common")
+        .extern_path(".restate.metadata", "::restate_types::protobuf::metadata")
+        .compile_protos(
+            &["./protobuf/metadata_proxy_svc.proto"],
             &["protobuf", "../types/protobuf"],
         )?;
 

--- a/crates/core/protobuf/metadata_proxy_svc.proto
+++ b/crates/core/protobuf/metadata_proxy_svc.proto
@@ -1,0 +1,47 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "restate/common.proto";
+import "restate/metadata.proto";
+
+package restate.metadata_proxy_svc;
+
+service MetadataProxySvc {
+  // Get a versioned kv-pair
+  rpc Get(GetRequest) returns (GetResponse);
+
+  // Get the current version for a kv-pair
+  rpc GetVersion(GetRequest) returns (GetVersionResponse);
+
+  // Puts the given kv-pair into the metadata store
+  rpc Put(PutRequest) returns (google.protobuf.Empty);
+
+  // Deletes the given kv-pair
+  rpc Delete(DeleteRequest) returns (google.protobuf.Empty);
+}
+
+message GetRequest { string key = 1; }
+
+message PutRequest {
+  string key = 1;
+  restate.metadata.VersionedValue value = 2;
+  restate.metadata.Precondition precondition = 3;
+}
+
+message DeleteRequest {
+  string key = 1;
+  restate.metadata.Precondition precondition = 2;
+}
+
+message GetResponse { optional restate.metadata.VersionedValue value = 1; }
+
+message GetVersionResponse { optional restate.common.Version version = 1; }

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -19,6 +19,7 @@ service NodeCtlSvc {
   // Get identity information from this node.
   rpc GetIdent(google.protobuf.Empty) returns (IdentResponse);
 
+  // Get metadata given the metadata kind
   rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse);
 
   // Provision the Restate cluster on this node.
@@ -42,7 +43,8 @@ message ProvisionClusterRequest {
   // if unset then the configured cluster default log replication will be used
   optional restate.cluster.ReplicationProperty log_replication = 5;
   // only used if provider = "replicated"
-  // if unset then the configured cluster default target nodeset size will be used
+  // if unset then the configured cluster default target nodeset size will be
+  // used
   optional uint32 target_nodeset_size = 6;
 }
 

--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -32,3 +32,11 @@ pub mod node_ctl_svc {
         }
     }
 }
+
+pub mod metadata_proxy_svc {
+
+    tonic::include_proto!("restate.metadata_proxy_svc");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("metadata_proxy_svc_descriptor");
+}

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -17,6 +17,7 @@ use futures::Stream;
 use restate_types::config::NetworkingOptions;
 use restate_types::locality::NodeLocation;
 use restate_types::logs::metadata::{ProviderKind, bootstrap_logs_metadata};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::{
     BIFROST_CONFIG_KEY, NODES_CONFIG_KEY, PARTITION_TABLE_KEY,
 };
@@ -31,7 +32,7 @@ use restate_types::protobuf::node::Message;
 use restate_types::{GenerationalNodeId, Version};
 
 use crate::TaskCenter;
-use crate::metadata_store::{MetadataStoreClient, Precondition};
+use crate::metadata_store::MetadataStoreClient;
 use crate::network::{
     ConnectionManager, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder,
     NetworkError, Networking, ProtocolError, TransportConnect,

--- a/crates/metadata-server/build.rs
+++ b/crates/metadata-server/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".restate.common", "::restate_types::protobuf::common")
+        .extern_path(".restate.metadata", "::restate_types::protobuf::metadata")
         .compile_protos(
             &["./proto/metadata_server_svc.proto"],
             &["proto", "../types/protobuf"],

--- a/crates/metadata-server/proto/metadata_server_svc.proto
+++ b/crates/metadata-server/proto/metadata_server_svc.proto
@@ -11,6 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "restate/common.proto";
+import "restate/metadata.proto";
 
 package restate.metadata_server_svc;
 
@@ -39,38 +40,18 @@ message GetRequest { string key = 1; }
 
 message PutRequest {
   string key = 1;
-  VersionedValue value = 2;
-  Precondition precondition = 3;
+  restate.metadata.VersionedValue value = 2;
+  restate.metadata.Precondition precondition = 3;
 }
 
 message DeleteRequest {
   string key = 1;
-  Precondition precondition = 2;
+  restate.metadata.Precondition precondition = 2;
 }
 
-message VersionedValue {
-  Version version = 1;
-  bytes bytes = 2;
-}
+message GetResponse { optional restate.metadata.VersionedValue value = 1; }
 
-message GetResponse { optional VersionedValue value = 1; }
-
-message Version { uint32 value = 1; }
-
-message GetVersionResponse { optional Version version = 1; }
-
-enum PreconditionKind {
-  PreconditionKind_UNKNOWN = 0;
-  NONE = 1;
-  DOES_NOT_EXIST = 2;
-  MATCHES_VERSION = 3;
-}
-
-message Precondition {
-  PreconditionKind kind = 1;
-  // needs to be set in case of PreconditionKind::MATCHES_VERSION
-  optional Version version = 2;
-}
+message GetVersionResponse { optional restate.common.Version version = 1; }
 
 message ProvisionRequest { bytes nodes_configuration = 1; }
 
@@ -121,14 +102,14 @@ message WriteRequest {
   Ulid request_id = 1;
   WriteRequestKind kind = 2;
   bytes key = 3;
-  Precondition precondition = 4;
+  restate.metadata.Precondition precondition = 4;
   // value is only required if WriteRequestKind is set to PUT
-  optional VersionedValue value = 7;
+  optional restate.metadata.VersionedValue value = 7;
 }
 
 message KvEntry {
   bytes key = 1;
-  VersionedValue value = 2;
+  restate.metadata.VersionedValue value = 2;
 }
 
 message MetadataServerSnapshot {

--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -10,19 +10,18 @@
 
 use crate::KnownLeader;
 use crate::grpc::metadata_server_svc_client::MetadataServerSvcClient;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc::{DeleteRequest, GetRequest, ProvisionRequest, PutRequest};
 use async_trait::async_trait;
 use bytes::BytesMut;
 use bytestring::ByteString;
 use parking_lot::Mutex;
 use rand::prelude::IteratorRandom;
-use restate_core::metadata_store::{
-    MetadataStore, Precondition, ProvisionError, ReadError, VersionedValue, WriteError,
-};
+use restate_core::metadata_store::{MetadataStore, ProvisionError, ReadError, WriteError};
 use restate_core::network::net_util::{CommonClientConnectionOptions, create_tonic_channel};
 use restate_core::{Metadata, TaskCenter, TaskKind, cancellation_watcher};
 use restate_types::config::Configuration;
+use restate_types::errors::ConversionError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::net::AdvertisedAddress;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration, Role};

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -16,14 +16,15 @@ use tokio::sync::{oneshot, watch};
 use tokio::time::Instant;
 use tonic::{Request, Response, Status};
 
-use restate_core::metadata_store::{Precondition, serialize_value};
+use restate_core::metadata_store::serialize_value;
 use restate_types::config::Configuration;
+use restate_types::errors::ConversionError;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;
 
 use crate::grpc::metadata_server_svc_server::MetadataServerSvc;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::grpc::{
     DeleteRequest, GetRequest, GetResponse, GetVersionResponse,
     ProvisionRequest as ProtoProvisionRequest, ProvisionResponse, PutRequest, StatusResponse,

--- a/crates/metadata-server/src/grpc/mod.rs
+++ b/crates/metadata-server/src/grpc/mod.rs
@@ -15,30 +15,12 @@ tonic::include_proto!("restate.metadata_server_svc");
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("metadata_server_svc");
 
 pub mod pb_conversions {
-    use crate::grpc::{
-        GetResponse, GetVersionResponse, PreconditionKind, Ulid, WriteRequest, WriteRequestKind,
-    };
-    use crate::{MetadataServerSummary, grpc};
-    use restate_core::metadata_store::{Precondition, VersionedValue};
     use restate_types::Version;
+    use restate_types::errors::ConversionError;
+    use restate_types::metadata::VersionedValue;
 
-    #[derive(Debug, thiserror::Error)]
-    pub enum ConversionError {
-        #[error("missing field '{0}'")]
-        MissingField(&'static str),
-        #[error("invalid data '{0}'")]
-        InvalidData(&'static str),
-    }
-
-    impl ConversionError {
-        pub fn missing_field(field: &'static str) -> Self {
-            ConversionError::MissingField(field)
-        }
-
-        pub fn invalid_data(field: &'static str) -> Self {
-            ConversionError::InvalidData(field)
-        }
-    }
+    use crate::grpc::{GetResponse, GetVersionResponse, Ulid, WriteRequest, WriteRequestKind};
+    use crate::{MetadataServerSummary, grpc};
 
     impl TryFrom<GetResponse> for Option<VersionedValue> {
         type Error = ConversionError;
@@ -52,82 +34,9 @@ pub mod pb_conversions {
         }
     }
 
-    impl TryFrom<grpc::VersionedValue> for VersionedValue {
-        type Error = ConversionError;
-
-        fn try_from(value: grpc::VersionedValue) -> Result<Self, Self::Error> {
-            let version = value
-                .version
-                .ok_or_else(|| ConversionError::missing_field("version"))?;
-            Ok(VersionedValue::new(version.into(), value.bytes))
-        }
-    }
-
     impl From<GetVersionResponse> for Option<Version> {
         fn from(value: GetVersionResponse) -> Self {
             value.version.map(Into::into)
-        }
-    }
-
-    impl From<VersionedValue> for grpc::VersionedValue {
-        fn from(value: VersionedValue) -> Self {
-            grpc::VersionedValue {
-                version: Some(value.version.into()),
-                bytes: value.value,
-            }
-        }
-    }
-
-    impl From<grpc::Version> for Version {
-        fn from(value: grpc::Version) -> Self {
-            Version::from(value.value)
-        }
-    }
-
-    impl From<Version> for grpc::Version {
-        fn from(value: Version) -> Self {
-            grpc::Version {
-                value: value.into(),
-            }
-        }
-    }
-
-    impl From<Precondition> for grpc::Precondition {
-        fn from(value: Precondition) -> Self {
-            match value {
-                Precondition::None => grpc::Precondition {
-                    kind: PreconditionKind::None.into(),
-                    version: None,
-                },
-                Precondition::DoesNotExist => grpc::Precondition {
-                    kind: PreconditionKind::DoesNotExist.into(),
-                    version: None,
-                },
-                Precondition::MatchesVersion(version) => grpc::Precondition {
-                    kind: PreconditionKind::MatchesVersion.into(),
-                    version: Some(version.into()),
-                },
-            }
-        }
-    }
-
-    impl TryFrom<grpc::Precondition> for Precondition {
-        type Error = ConversionError;
-
-        fn try_from(value: grpc::Precondition) -> Result<Self, Self::Error> {
-            match value.kind() {
-                PreconditionKind::Unknown => {
-                    Err(ConversionError::invalid_data("unknown precondition kind"))
-                }
-                PreconditionKind::None => Ok(Precondition::None),
-                PreconditionKind::DoesNotExist => Ok(Precondition::DoesNotExist),
-                PreconditionKind::MatchesVersion => Ok(Precondition::MatchesVersion(
-                    value
-                        .version
-                        .ok_or_else(|| ConversionError::missing_field("version"))?
-                        .into(),
-                )),
-            }
         }
     }
 

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -20,25 +20,24 @@ use crate::raft::{RaftMetadataServer, create_replicated_metadata_client};
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
-use grpc::pb_conversions::ConversionError;
 use itertools::Itertools;
 use prost::Message;
 use raft_proto::eraftpb::Snapshot;
-use restate_core::metadata_store::VersionedValue;
 use restate_core::metadata_store::providers::{
     EtcdMetadataStore, create_object_store_based_meta_store,
 };
 pub use restate_core::metadata_store::{
-    MetadataStoreClient, Precondition, ReadError, ReadModifyWriteError, WriteError,
+    MetadataStoreClient, ReadError, ReadModifyWriteError, WriteError,
 };
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataWriter, ShutdownError};
 use restate_types::config::{
     Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind,
 };
-use restate_types::errors::{GenericError, MaybeRetryableError};
+use restate_types::errors::{ConversionError, GenericError, MaybeRetryableError};
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,

--- a/crates/metadata-server/src/local/server.rs
+++ b/crates/metadata-server/src/local/server.rs
@@ -12,14 +12,14 @@ use crate::local::storage::RocksDbStorage;
 use crate::{MetadataServer, MetadataStoreRequest, RequestError, RequestReceiver, RequestSender};
 use bytestring::ByteString;
 use restate_core::metadata_store::{
-    MetadataStoreClient, Precondition, ProvisionedMetadataStore, ReadError, VersionedValue,
-    WriteError, serialize_value,
+    MetadataStoreClient, ProvisionedMetadataStore, ReadError, WriteError, serialize_value,
 };
 use restate_core::{MetadataWriter, ShutdownError, cancellation_watcher};
 use restate_rocksdb::RocksError;
 use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::health::HealthStatus;
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration};
 use restate_types::protobuf::common::MetadataServerStatus;

--- a/crates/metadata-server/src/local/storage.rs
+++ b/crates/metadata-server/src/local/storage.rs
@@ -13,7 +13,6 @@ use crate::{PreconditionViolation, RequestError};
 use bytes::BytesMut;
 use bytestring::ByteString;
 use itertools::Itertools;
-use restate_core::metadata_store::{Precondition, VersionedValue};
 use restate_rocksdb::{
     CfName, CfPrefixPattern, DbName, DbSpecBuilder, IoMode, Priority, RocksDb, RocksDbManager,
     RocksError,
@@ -21,6 +20,7 @@ use restate_rocksdb::{
 use restate_types::Version;
 use restate_types::config::{MetadataServerOptions, RocksDbOptions, data_dir};
 use restate_types::live::BoxedLiveLoad;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::storage::{StorageCodec, StorageDecode, StorageEncode};
 use rocksdb::{
     BoundColumnFamily, DBCompressionType, Error, IteratorMode, ReadOptions, WriteBatch,

--- a/crates/metadata-server/src/raft/kv_memory_storage.rs
+++ b/crates/metadata-server/src/raft/kv_memory_storage.rs
@@ -9,15 +9,15 @@
 // by the Apache License, Version 2.0.
 
 use crate::grpc::MetadataServerSnapshot;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::{
     Callback, PreconditionViolation, ReadOnlyRequest, ReadOnlyRequestKind, RequestError,
     RequestKind, WriteRequest, grpc,
 };
 use bytestring::ByteString;
 use restate_core::MetadataWriter;
-use restate_core::metadata_store::{Precondition, VersionedValue};
 use restate_types::Version;
+use restate_types::errors::ConversionError;
+use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -11,7 +11,6 @@
 use crate::grpc::MetadataServerSnapshot;
 use crate::grpc::handler::MetadataServerHandler;
 use crate::grpc::metadata_server_svc_server::MetadataServerSvcServer;
-use crate::grpc::pb_conversions::ConversionError;
 use crate::local::migrate_nodes_configuration;
 use crate::metric_definitions::{
     METADATA_SERVER_REPLICATED_APPLIED_LSN, METADATA_SERVER_REPLICATED_COMMITTED_LSN,
@@ -50,7 +49,7 @@ use raft_proto::ConfChangeI;
 use raft_proto::eraftpb::{ConfChangeSingle, ConfChangeType, Snapshot, SnapshotMetadata};
 use rand::prelude::IteratorRandom;
 use rand::rng;
-use restate_core::metadata_store::{Precondition, serialize_value};
+use restate_core::metadata_store::serialize_value;
 use restate_core::network::NetworkServerBuilder;
 use restate_core::network::net_util::create_tonic_channel;
 use restate_core::{
@@ -59,9 +58,10 @@ use restate_core::{
 use restate_types::config::{
     Configuration, MetadataServerKind, MetadataServerOptions, RocksDbOptions,
 };
-use restate_types::errors::GenericError;
+use restate_types::errors::{ConversionError, GenericError};
 use restate_types::health::HealthStatus;
 use restate_types::live::{BoxedLiveLoad, Constant};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::{MetadataServerState, NodesConfiguration, Role};

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -16,7 +16,7 @@ use futures::TryFutureExt;
 use googletest::IntoTestResult;
 use rand::RngCore;
 use rand::distr::{Alphanumeric, SampleString};
-use restate_core::metadata_store::{Precondition, serialize_value};
+use restate_core::metadata_store::serialize_value;
 use restate_core::network::NetworkServerBuilder;
 use restate_core::{MetadataBuilder, TaskCenter, TaskKind, cancellation_token};
 use restate_rocksdb::RocksDbManager;
@@ -27,6 +27,7 @@ use restate_types::config::{
 use restate_types::health::Health;
 use restate_types::live::Constant;
 use restate_types::locality::NodeLocation;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::net::{AdvertisedAddress, BindAddress};
 use restate_types::nodes_config::{

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -21,9 +21,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use codederror::CodedError;
 use restate_bifrost::BifrostService;
-use restate_core::metadata_store::{
-    Precondition, ReadWriteError, WriteError, retry_on_retryable_error,
-};
+use restate_core::metadata_store::{ReadWriteError, WriteError, retry_on_retryable_error};
 use restate_core::network::{
     GrpcConnector, MessageRouterBuilder, NetworkServerBuilder, Networking,
 };
@@ -41,6 +39,7 @@ use restate_types::live::Live;
 #[cfg(feature = "replicated-loglet")]
 use restate_types::logs::RecordCache;
 use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfiguration};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::{BIFROST_CONFIG_KEY, PARTITION_TABLE_KEY};
 use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, NodeConfig, NodesConfiguration, Role,

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -113,6 +113,7 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
         .compile_protos(
             &[
                 "./protobuf/restate/common.proto",
+                "./protobuf/restate/metadata.proto",
                 "./protobuf/restate/cluster.proto",
                 "./protobuf/restate/log_server_common.proto",
                 "./protobuf/restate/node.proto",

--- a/crates/types/protobuf/restate/metadata.proto
+++ b/crates/types/protobuf/restate/metadata.proto
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+package restate.metadata;
+
+import "google/protobuf/empty.proto";
+import "restate/common.proto";
+
+message VersionedValue {
+  restate.common.Version version = 1;
+  bytes bytes = 2;
+}
+
+enum PreconditionKind {
+  PreconditionKind_UNKNOWN = 0;
+  NONE = 1;
+  DOES_NOT_EXIST = 2;
+  MATCHES_VERSION = 3;
+}
+
+message Precondition {
+  PreconditionKind kind = 1;
+  // needs to be set in case of PreconditionKind::MATCHES_VERSION
+  optional restate.common.Version version = 2;
+}

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -338,3 +338,21 @@ pub enum ThreadJoinError {
     #[error("thread terminated unexpectedly")]
     UnexpectedTermination,
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConversionError {
+    #[error("missing field '{0}'")]
+    MissingField(&'static str),
+    #[error("invalid data '{0}'")]
+    InvalidData(&'static str),
+}
+
+impl ConversionError {
+    pub fn missing_field(field: &'static str) -> Self {
+        ConversionError::MissingField(field)
+    }
+
+    pub fn invalid_data(field: &'static str) -> Self {
+        ConversionError::InvalidData(field)
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -34,6 +34,7 @@ pub mod live;
 pub mod locality;
 pub mod logs;
 pub mod message;
+pub mod metadata;
 pub mod metadata_store;
 pub mod net;
 pub mod nodes_config;

--- a/crates/types/src/metadata.rs
+++ b/crates/types/src/metadata.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+
+use crate::{Version, flexbuffers_storage_encode_decode};
+
+#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VersionedValue {
+    pub version: Version,
+    #[debug(skip)]
+    pub value: Bytes,
+}
+
+impl VersionedValue {
+    pub fn new(version: Version, value: Bytes) -> Self {
+        Self { version, value }
+    }
+}
+
+flexbuffers_storage_encode_decode!(VersionedValue);
+
+/// Preconditions for the write operations of the [`MetadataStore`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
+pub enum Precondition {
+    /// No precondition
+    None,
+    /// Key-value pair must not exist for the write operation to succeed.
+    DoesNotExist,
+    /// Key-value pair must have the provided [`Version`] for the write operation to succeed.
+    MatchesVersion(Version),
+}

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -17,7 +17,6 @@ use googletest::internal::test_outcome::TestAssertionFailure;
 
 use restate_bifrost::{Bifrost, loglet::Loglet};
 use restate_core::TaskCenter;
-use restate_core::metadata_store::Precondition;
 use restate_core::{MetadataWriter, metadata_store::MetadataStoreClient};
 use restate_local_cluster_runner::{
     cluster::{Cluster, MaybeTempDir, StartedCluster},
@@ -28,6 +27,7 @@ use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::logs::LogletId;
 use restate_types::logs::builder::LogsBuilder;
 use restate_types::logs::metadata::{Chain, LogletParams, SegmentIndex};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 use restate_types::{
     GenerationalNodeId, PlainNodeId,

--- a/server/tests/raft_metadata_cluster.rs
+++ b/server/tests/raft_metadata_cluster.rs
@@ -13,7 +13,7 @@ use enumset::EnumSet;
 use googletest::prelude::err;
 use googletest::{IntoTestResult, assert_that, pat};
 use rand::seq::IndexedMutRandom;
-use restate_core::metadata_store::{Precondition, WriteError};
+use restate_core::metadata_store::WriteError;
 use restate_core::{TaskCenter, TaskKind, cancellation_watcher};
 use restate_local_cluster_runner::cluster::Cluster;
 use restate_local_cluster_runner::node::{BinarySource, HealthCheck, Node};
@@ -23,6 +23,7 @@ use restate_types::Versioned;
 use restate_types::config::{
     Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind, RaftOptions,
 };
+use restate_types::metadata::Precondition;
 use std::num::NonZeroUsize;
 use std::time::{Duration, Instant};
 use tracing::info;

--- a/tools/bifrost-benchpress/src/main.rs
+++ b/tools/bifrost-benchpress/src/main.rs
@@ -14,18 +14,18 @@ use std::time::Duration;
 use clap::Parser;
 use codederror::CodedError;
 use metrics_exporter_prometheus::PrometheusBuilder;
-use restate_core::task_center::TaskCenterMonitoring;
 use tracing::trace;
 
 use bifrost_benchpress::util::{print_prometheus_stats, print_rocksdb_stats};
 use bifrost_benchpress::{Arguments, Command, append_latency, write_to_read};
 use restate_bifrost::{Bifrost, BifrostService};
+use restate_core::task_center::TaskCenterMonitoring;
 use restate_core::{
     MetadataBuilder, MetadataManager, TaskCenter, TaskCenterBuilder, spawn_metadata_manager,
     task_center,
 };
 use restate_errors::fmt::RestateCode;
-use restate_metadata_server::{MetadataStoreClient, Precondition};
+use restate_metadata_server::MetadataStoreClient;
 use restate_rocksdb::RocksDbManager;
 use restate_tracing_instrumentation::init_tracing_and_logging;
 use restate_types::config::{
@@ -33,6 +33,7 @@ use restate_types::config::{
 };
 use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::live::Live;
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::BIFROST_CONFIG_KEY;
 
 // Configure jemalloc similar to mimic restate server

--- a/tools/restatectl/src/commands/metadata/get.rs
+++ b/tools/restatectl/src/commands/metadata/get.rs
@@ -8,20 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytestring::ByteString;
 use clap::Parser;
 use cling::{Collect, Run};
-use tracing::debug;
 
-use restate_rocksdb::RocksDbManager;
-use restate_types::config::Configuration;
-
-use crate::commands::metadata::{
-    GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts, create_metadata_store_client,
-};
+use crate::commands::metadata::MetadataCommonOpts;
 use crate::connection::ConnectionInfo;
-use crate::environment::metadata_store;
-use crate::environment::task_center::run_in_task_center;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]
@@ -36,44 +27,10 @@ pub struct GetValueOpts {
 }
 
 async fn get_value(connection: &ConnectionInfo, opts: &GetValueOpts) -> anyhow::Result<()> {
-    let value = match opts.metadata.access_mode {
-        MetadataAccessMode::Remote => get_value_remote(connection, opts).await?,
-        MetadataAccessMode::Direct => get_value_direct(opts).await?,
-    };
+    let value = super::get_value(connection, &opts.key).await?;
 
     let value = serde_json::to_string_pretty(&value).map_err(|e| anyhow::anyhow!(e))?;
     println!("{value}");
 
     Ok(())
-}
-
-async fn get_value_remote(
-    connection: &ConnectionInfo,
-    opts: &GetValueOpts,
-) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let metadata_store_client = create_metadata_store_client(connection, &opts.metadata).await?;
-
-    metadata_store_client
-        .get(ByteString::from(opts.key.as_str()))
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))
-}
-
-async fn get_value_direct(opts: &GetValueOpts) -> anyhow::Result<Option<GenericMetadataValue>> {
-    run_in_task_center(opts.metadata.config_file.as_ref(), |config| async move {
-        let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
-        debug!("RocksDB Initialized");
-
-        let metadata_store_client = metadata_store::start_metadata_server(config.clone()).await?;
-        debug!("Metadata store client created");
-
-        let value: Option<GenericMetadataValue> = metadata_store_client
-            .get(ByteString::from(opts.key.as_str()))
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get value: {}", e))?;
-
-        rocksdb_manager.shutdown().await;
-        anyhow::Ok(value)
-    })
-    .await
 }

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -15,11 +15,12 @@ mod put;
 use std::path::PathBuf;
 
 use cling::prelude::*;
+use tonic::codec::CompressionEncoding;
 
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_metadata_server::create_client;
-use restate_types::config::MetadataClientOptions;
-use restate_types::nodes_config::Role;
+use restate_core::protobuf::metadata_proxy_svc::GetRequest;
+use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
+use restate_types::protobuf::metadata::VersionedValue;
+use restate_types::storage::StorageCodec;
 use restate_types::{Version, Versioned, flexbuffers_storage_encode_decode};
 
 use crate::connection::ConnectionInfo;
@@ -37,19 +38,6 @@ pub enum Metadata {
 #[derive(Args, Clone, Debug)]
 #[clap()]
 pub struct MetadataCommonOpts {
-    /// Etcd store server addresses
-    #[arg(
-        short,
-        long = "etcd",
-        value_delimiter = ',',
-        required_if_eq("remote_service_type", "etcd")
-    )]
-    etcd: Vec<String>,
-
-    /// Metadata store access mode
-    #[arg(long, default_value_t)]
-    access_mode: MetadataAccessMode,
-
     /// Service type for access mode = "remote"
     #[arg(long, default_value_t)]
     remote_service_type: RemoteServiceType,
@@ -64,16 +52,6 @@ pub struct MetadataCommonOpts {
     config_file: Option<PathBuf>,
 }
 
-#[derive(clap::ValueEnum, Clone, Default, Debug, strum::Display)]
-#[strum(serialize_all = "kebab-case")]
-enum MetadataAccessMode {
-    /// Connect to a remote metadata server at the specified address
-    #[default]
-    Remote,
-    /// Open a local metadata store database directory directly
-    Direct,
-}
-
 #[derive(clap::ValueEnum, Clone, Default, Debug, strum::Display, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 enum RemoteServiceType {
@@ -84,18 +62,17 @@ enum RemoteServiceType {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GenericMetadataValue {
-    // We assume that the concrete serialized type's encoded version field is called "version".
     version: Version,
 
     #[serde(flatten)]
-    data: serde_json::Map<String, serde_json::Value>,
+    fields: serde_json::Map<String, serde_json::Value>,
 }
 
 flexbuffers_storage_encode_decode!(GenericMetadataValue);
 
 impl GenericMetadataValue {
     pub fn to_json_value(&self) -> serde_json::Value {
-        serde_json::Value::Object(self.data.clone())
+        serde_json::Value::Object(self.fields.clone())
     }
 }
 
@@ -105,30 +82,59 @@ impl Versioned for GenericMetadataValue {
     }
 }
 
-pub async fn create_metadata_store_client(
-    connection: &ConnectionInfo,
-    opts: &MetadataCommonOpts,
-) -> anyhow::Result<MetadataStoreClient> {
-    let client = match opts.remote_service_type {
-        RemoteServiceType::Restate => {
-            let nodes = connection.get_nodes_configuration().await?;
-            let addresses = nodes
-                .iter_role(Role::MetadataServer)
-                .map(|(_, node)| node.address.clone())
-                .collect();
-            restate_types::config::MetadataClientKind::Replicated { addresses }
+impl TryFrom<VersionedValue> for GenericMetadataValue {
+    type Error = anyhow::Error;
+    fn try_from(mut versioned_value: VersionedValue) -> Result<Self, Self::Error> {
+        let version: Version = versioned_value
+            .version
+            .ok_or_else(|| anyhow::anyhow!("version is required"))?
+            .into();
+
+        let value: GenericMetadataValue = StorageCodec::decode(&mut versioned_value.bytes)?;
+        if value.version != version {
+            anyhow::bail!("returned payload and metadata object versions must align");
         }
-        RemoteServiceType::Etcd => restate_types::config::MetadataClientKind::Etcd {
-            addresses: opts.etcd.clone(),
-        },
+
+        Ok(value)
+    }
+}
+
+impl TryFrom<GenericMetadataValue> for VersionedValue {
+    type Error = anyhow::Error;
+
+    fn try_from(value: GenericMetadataValue) -> Result<Self, Self::Error> {
+        let mut buf = bytes::BytesMut::new();
+        StorageCodec::encode(&value, &mut buf)?;
+
+        Ok(Self {
+            version: Some(value.version.into()),
+            bytes: buf.into(),
+        })
+    }
+}
+
+async fn get_value(
+    connection: &ConnectionInfo,
+    key: impl AsRef<str>,
+) -> anyhow::Result<Option<GenericMetadataValue>> {
+    let key = key.as_ref();
+    let response = connection
+        .try_each(None, |channel| async {
+            let mut client = MetadataProxySvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+            client
+                .get(GetRequest {
+                    key: key.to_owned(),
+                })
+                .await
+        })
+        .await?;
+
+    let response = response.into_inner();
+    let Some(value) = response.value else {
+        return Ok(None);
     };
 
-    let metadata_store_client_options = MetadataClientOptions {
-        kind: client,
-        ..MetadataClientOptions::default()
-    };
-
-    create_client(metadata_store_client_options)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))
+    Ok(Some(value.try_into()?))
 }

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -8,25 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytestring::ByteString;
+use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
 use json_patch::Patch;
 use serde_json::Value;
-use tracing::debug;
+use tonic::Code;
+use tonic::codec::CompressionEncoding;
 
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_rocksdb::RocksDbManager;
+use restate_core::protobuf::metadata_proxy_svc::PutRequest;
+use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
 use restate_types::Version;
-use restate_types::config::Configuration;
 use restate_types::metadata::Precondition;
 
-use crate::commands::metadata::{
-    GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts, create_metadata_store_client,
-};
-use crate::connection::ConnectionInfo;
-use crate::environment::metadata_store::start_metadata_server;
-use crate::environment::task_center::run_in_task_center;
+use crate::commands::metadata::MetadataCommonOpts;
+use crate::connection::{ConnectionInfo, NodeOperationError};
+
+use super::GenericMetadataValue;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap()]
@@ -59,10 +57,7 @@ pub(crate) async fn patch_value(
     let patch = serde_json::from_str(opts.patch.as_str())
         .map_err(|e| anyhow::anyhow!("Parsing JSON patch: {}", e))?;
 
-    let value = match opts.metadata.access_mode {
-        MetadataAccessMode::Remote => patch_value_remote(connection, opts, patch).await?,
-        MetadataAccessMode::Direct => patch_value_direct(opts, patch).await?,
-    };
+    let value = patch_value_inner(connection, opts, patch).await?;
 
     let value = serde_json::to_string_pretty(&value).map_err(|e| anyhow::anyhow!(e))?;
     println!("{value}");
@@ -70,46 +65,12 @@ pub(crate) async fn patch_value(
     Ok(())
 }
 
-async fn patch_value_remote(
+async fn patch_value_inner(
     connection: &ConnectionInfo,
     opts: &PatchValueOpts,
     patch: Patch,
-) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let metadata_store_client = create_metadata_store_client(connection, &opts.metadata).await?;
-    Ok(Some(
-        patch_value_inner(opts, &patch, &metadata_store_client).await?,
-    ))
-}
-
-async fn patch_value_direct(
-    opts: &PatchValueOpts,
-    patch: Patch,
-) -> anyhow::Result<Option<GenericMetadataValue>> {
-    let value = run_in_task_center(opts.metadata.config_file.as_ref(), |config| async move {
-        let rocksdb_manager = RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
-        debug!("RocksDB Initialized");
-
-        let metadata_store_client = start_metadata_server(config.clone()).await?;
-        debug!("Metadata store client created");
-
-        let result = patch_value_inner(opts, &patch, &metadata_store_client).await;
-
-        rocksdb_manager.shutdown().await;
-        result
-    })
-    .await?;
-
-    Ok(Some(value))
-}
-
-async fn patch_value_inner(
-    opts: &PatchValueOpts,
-    patch: &Patch,
-    metadata_store_client: &MetadataStoreClient,
 ) -> anyhow::Result<GenericMetadataValue> {
-    let value: Option<GenericMetadataValue> = metadata_store_client
-        .get(ByteString::from(opts.key.as_str()))
-        .await?;
+    let value = super::get_value(connection, &opts.key).await?;
 
     let current_version = value
         .as_ref()
@@ -127,35 +88,40 @@ async fn patch_value_inner(
     }
 
     let mut document = value.map(|v| v.to_json_value()).unwrap_or(Value::Null);
-    let value = match json_patch::patch(&mut document, patch) {
-        Ok(_) => {
-            let new_value = GenericMetadataValue {
-                version: current_version.next(),
-                data: serde_json::from_value(document.clone()).map_err(|e| anyhow::anyhow!(e))?,
-            };
-            if !opts.dry_run {
-                debug!(
-                    "Updating metadata key '{}' with expected {:?} version to {:?}",
-                    opts.key, current_version, new_value.version
-                );
-                metadata_store_client
-                    .put(
-                        ByteString::from(opts.key.as_str()),
-                        &new_value,
-                        if current_version == Version::INVALID {
-                            Precondition::DoesNotExist
-                        } else {
-                            Precondition::MatchesVersion(current_version)
-                        },
-                    )
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Store update failed: {}", e))?
-            } else {
-                println!("Dry run - updated value:\n");
-            }
-            Ok(new_value)
-        }
-        Err(e) => Err(anyhow::anyhow!("Patch failed: {}", e)),
-    }?;
-    Ok(value)
+    json_patch::patch(&mut document, &patch).context("Patch failed")?;
+
+    let new_value = GenericMetadataValue {
+        version: current_version.next(),
+        fields: serde_json::from_value(document.clone()).map_err(|e| anyhow::anyhow!(e))?,
+    };
+
+    let precondition = if current_version == Version::INVALID {
+        Precondition::DoesNotExist
+    } else {
+        Precondition::MatchesVersion(current_version)
+    };
+
+    let request = PutRequest {
+        key: opts.key.clone(),
+        precondition: Some(precondition.into()),
+        value: Some(new_value.clone().try_into()?),
+    };
+
+    connection
+        .try_each(None, |channel| async {
+            let mut client = MetadataProxySvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+
+            client.put(request.clone()).await.map_err(|err| {
+                if err.code() == Code::FailedPrecondition {
+                    NodeOperationError::Terminal(err)
+                } else {
+                    NodeOperationError::Retryable(err)
+                }
+            })
+        })
+        .await?;
+
+    Ok(new_value)
 }

--- a/tools/restatectl/src/commands/metadata/patch.rs
+++ b/tools/restatectl/src/commands/metadata/patch.rs
@@ -15,10 +15,11 @@ use json_patch::Patch;
 use serde_json::Value;
 use tracing::debug;
 
-use restate_core::metadata_store::{MetadataStoreClient, Precondition};
+use restate_core::metadata_store::MetadataStoreClient;
 use restate_rocksdb::RocksDbManager;
 use restate_types::Version;
 use restate_types::config::Configuration;
+use restate_types::metadata::Precondition;
 
 use crate::commands::metadata::{
     GenericMetadataValue, MetadataAccessMode, MetadataCommonOpts, create_metadata_store_client,

--- a/tools/restatectl/src/commands/node/remove_nodes.rs
+++ b/tools/restatectl/src/commands/node/remove_nodes.rs
@@ -15,10 +15,11 @@ use clap::Parser;
 use cling::{Collect, Run};
 use itertools::Itertools;
 use restate_cli_util::c_println;
-use restate_core::metadata_store::{MetadataStoreClient, Precondition};
+use restate_core::metadata_store::MetadataStoreClient;
 use restate_metadata_server::create_client;
 use restate_types::PlainNodeId;
 use restate_types::config::{MetadataClientKind, MetadataClientOptions};
+use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{NodesConfiguration, Role};
 

--- a/tools/restatectl/src/commands/node/remove_nodes.rs
+++ b/tools/restatectl/src/commands/node/remove_nodes.rs
@@ -9,19 +9,20 @@
 // by the Apache License, Version 2.0.
 
 use crate::commands::node::disable_node_checker::DisableNodeChecker;
-use crate::connection::ConnectionInfo;
+use crate::connection::{ConnectionInfo, NodeOperationError};
 use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
 use itertools::Itertools;
 use restate_cli_util::c_println;
-use restate_core::metadata_store::MetadataStoreClient;
-use restate_metadata_server::create_client;
+use restate_core::metadata_store::serialize_value;
+use restate_core::protobuf::metadata_proxy_svc::PutRequest;
+use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
 use restate_types::PlainNodeId;
-use restate_types::config::{MetadataClientKind, MetadataClientOptions};
 use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
-use restate_types::nodes_config::{NodesConfiguration, Role};
+use tonic::Code;
+use tonic::codec::CompressionEncoding;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[clap(alias = "rm")]
@@ -38,7 +39,6 @@ pub async fn remove_nodes(
     opts: &RemoveNodesOpts,
 ) -> anyhow::Result<()> {
     let nodes_configuration = connection.get_nodes_configuration().await?;
-    let metadata_client = create_metadata_client(&nodes_configuration).await?;
     let logs = connection.get_logs().await?;
 
     let disable_node_checker = DisableNodeChecker::new(nodes_configuration, logs);
@@ -58,12 +58,30 @@ pub async fn remove_nodes(
 
     updated_nodes_configuration.increment_version();
 
-    metadata_client
-        .put(
-            NODES_CONFIG_KEY.clone(),
-            &updated_nodes_configuration,
-            Precondition::MatchesVersion(nodes_configuration.version()),
-        )
+    let request = PutRequest {
+        key: NODES_CONFIG_KEY.to_string(),
+        value: Some(
+            serialize_value(&updated_nodes_configuration)
+                .context("Failed to serialize logs")?
+                .into(),
+        ),
+        precondition: Some(Precondition::MatchesVersion(nodes_configuration.version()).into()),
+    };
+
+    connection
+        .try_each(None, |channel| async {
+            let mut client = MetadataProxySvcClient::new(channel)
+                .accept_compressed(CompressionEncoding::Gzip)
+                .send_compressed(CompressionEncoding::Gzip);
+
+            client.put(request.clone()).await.map_err(|err| {
+                if err.code() == Code::FailedPrecondition {
+                    NodeOperationError::Terminal(err)
+                } else {
+                    NodeOperationError::Retryable(err)
+                }
+            })
+        })
         .await?;
 
     c_println!(
@@ -72,30 +90,4 @@ pub async fn remove_nodes(
     );
 
     Ok(())
-}
-
-async fn create_metadata_client(
-    nodes_configuration: &NodesConfiguration,
-) -> anyhow::Result<MetadataStoreClient> {
-    // find metadata nodes
-    let addresses: Vec<_> = nodes_configuration
-        .iter_role(Role::MetadataServer)
-        .map(|(_, config)| config.address.clone())
-        .collect();
-    if addresses.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No nodes are configured to run metadata-server role, this command only \
-             supports replicated metadata deployment"
-        ));
-    }
-
-    // todo make this work with other metadata client kinds as well; maybe proxy through Restate server
-    let metadata_store_client_options = MetadataClientOptions {
-        kind: MetadataClientKind::Replicated { addresses },
-        ..Default::default()
-    };
-
-    create_client(metadata_store_client_options)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create metadata store client: {}", e))
 }


### PR DESCRIPTION
Fix issue when removing a node while still alive

Summary:
If a node was removed from the cluster while it's actually still up and
reachable, the cluster admin will keep trying to schedule partitions on that
node but will fail eventually in the network layer and spam the logs with
errors

```
Caused by:
    0: unknown node: node N3 has been permanently deleted from config
    1: node N3 has been permanently deleted from config kind=Disposable name="send-control-processors-to-node"
2025-03-05T10:39:54.671755Z ERROR restate_core::task_center: Task 3359 failed with: send error: unknown node: node N3 has been permanently deleted from config
```

By making sure nodes that do not exist anymore (are not in the cluster_state) are also removed accordingly
from the ObserverClusterState
