### PR TITLE
[sql] Respect `target_partition` configuration value in PartitionedExecutionPlan

### DIFF
--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -22,7 +22,6 @@ use input_command::{InputCommand, InvokeCommand};
 use invocation_state_machine::InvocationStateMachine;
 use invocation_task::InvocationTask;
 use invocation_task::{InvocationTaskOutput, InvocationTaskOutputInner};
-use itertools::Itertools;
 use metric_definitions::{INVOKER_PENDING_TASKS, INVOKER_TASKS_IN_FLIGHT};
 use metrics::{counter, gauge};
 use restate_core::cancellation_watcher;
@@ -359,7 +358,6 @@ where
                     .registered_partitions_with_keys(keys.clone())
                     .flat_map(|partition| self.status_store.status_for_partition(partition))
                     .filter(|status| keys.contains(&status.invocation_id().partition_key()))
-                    .sorted_by_key(|e| e.invocation_id().partition_key())
                     .collect();
 
                 let _ = cmd.reply(statuses);

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -14,8 +14,6 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_invocation_state(partition_key, id));
-
 define_table!(sys_invocation_state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -209,9 +209,9 @@ impl MockQueryEngine {
 
     pub async fn execute(
         &self,
-        sql: &str,
+        sql: impl AsRef<str> + Send,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
-        self.2.execute(sql).await
+        self.2.execute(sql.as_ref()).await
     }
 }
 


### PR DESCRIPTION
This commit consults the target_partition, data fusion configuration value during planning, and would only declare that the source partition's data is sorted, if their `number is <= target_partition`.