### PR TITLE
Remove `ExperimentalFeature::DisableIdempotencyTable`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,24 +111,6 @@ jobs:
     with:
       restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  sdk-java-disable-idempotency-table:
-    name: Run SDK-Java integration tests with DisableIdempotencyTable
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      actions: read
-    secrets: inherit
-    needs: docker
-    uses: restatedev/sdk-java/.github/workflows/integration.yaml@main
-    with:
-      restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
-      envVars: |
-        RESTATE_WORKER__EXPERIMENTAL_FEATURE_DISABLE_IDEMPOTENCY_TABLE=true
-        RUST_LOG=info,restate_invoker=trace,restate_ingress_http=trace,restate_bifrost=trace,restate_log_server=trace,restate_core::partitions=trace,restate=debug
-      testArtifactOutput: sdk-java-disable-idempotency-table-integration-test-report
-
   sdk-java-invocation-status-killed:
     name: Run SDK-Java integration tests with InvocationStatusKilled
     permissions:

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -49,9 +49,6 @@ pub struct WorkerOptions {
     cleanup_interval: humantime::Duration,
 
     #[cfg_attr(feature = "schemars", schemars(skip))]
-    experimental_feature_disable_idempotency_table: bool,
-
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     experimental_feature_invocation_status_killed: bool,
 
     pub storage: StorageOptions,
@@ -90,10 +87,6 @@ impl WorkerOptions {
         self.cleanup_interval.into()
     }
 
-    pub fn experimental_feature_disable_idempotency_table(&self) -> bool {
-        self.experimental_feature_disable_idempotency_table
-    }
-
     pub fn experimental_feature_invocation_status_killed(&self) -> bool {
         self.experimental_feature_invocation_status_killed
     }
@@ -105,7 +98,6 @@ impl Default for WorkerOptions {
             internal_queue_length: NonZeroUsize::new(1000).expect("Non zero number"),
             num_timers_in_memory_limit: None,
             cleanup_interval: Duration::from_secs(60 * 60).into(),
-            experimental_feature_disable_idempotency_table: false,
             experimental_feature_invocation_status_killed: false,
             storage: StorageOptions::default(),
             invoker: Default::default(),

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -55,7 +55,7 @@ async fn start_and_complete_idempotent_invocation() {
         }))
     );
 
-    // Assert idempotency key mapping exists only with idempotency table writes enabled
+    // Assert we don't write idempotency metadata, the table is deprecated
     assert_that!(
         test_env
             .storage()
@@ -144,7 +144,7 @@ async fn start_and_complete_idempotent_invocation_neo_table() {
         }))
     );
 
-    // Assert idempotency key mapping exists only with idempotency table writes enabled
+    // Assert we don't write idempotency metadata, the table is deprecated
     assert_that!(
         test_env
             .storage()

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -24,14 +24,9 @@ use restate_types::invocation::{
 use rstest::*;
 use std::time::Duration;
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn start_and_complete_idempotent_invocation(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn start_and_complete_idempotent_invocation() {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let retention = Duration::from_secs(60) * 60 * 24;
@@ -61,28 +56,14 @@ async fn start_and_complete_idempotent_invocation(
     );
 
     // Assert idempotency key mapping exists only with idempotency table writes enabled
-    if experimental_features.contains(ExperimentalFeature::DisableIdempotencyTable) {
-        assert_that!(
-            test_env
-                .storage()
-                .get_idempotency_metadata(&idempotency_id)
-                .await
-                .unwrap(),
-            none()
-        );
-    } else {
-        assert_that!(
-            test_env
-                .storage()
-                .get_idempotency_metadata(&idempotency_id)
-                .await
-                .unwrap()
-                .unwrap(),
-            pat!(IdempotencyMetadata {
-                invocation_id: eq(invocation_id),
-            })
-        );
-    }
+    assert_that!(
+        test_env
+            .storage()
+            .get_idempotency_metadata(&idempotency_id)
+            .await
+            .unwrap(),
+        none()
+    );
 
     // Send output, then end
     let response_bytes = Bytes::from_static(b"123");
@@ -132,14 +113,9 @@ async fn start_and_complete_idempotent_invocation(
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn start_and_complete_idempotent_invocation_neo_table(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn start_and_complete_idempotent_invocation_neo_table() {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let retention = Duration::from_secs(60) * 60 * 24;
@@ -169,28 +145,14 @@ async fn start_and_complete_idempotent_invocation_neo_table(
     );
 
     // Assert idempotency key mapping exists only with idempotency table writes enabled
-    if experimental_features.contains(ExperimentalFeature::DisableIdempotencyTable) {
-        assert_that!(
-            test_env
-                .storage()
-                .get_idempotency_metadata(&idempotency_id)
-                .await
-                .unwrap(),
-            none()
-        );
-    } else {
-        assert_that!(
-            test_env
-                .storage()
-                .get_idempotency_metadata(&idempotency_id)
-                .await
-                .unwrap()
-                .unwrap(),
-            pat!(IdempotencyMetadata {
-                invocation_id: eq(invocation_id),
-            })
-        );
-    }
+    assert_that!(
+        test_env
+            .storage()
+            .get_idempotency_metadata(&idempotency_id)
+            .await
+            .unwrap(),
+        none()
+    );
 
     // Send output, then end
     let response_bytes = Bytes::from_static(b"123");
@@ -244,14 +206,9 @@ async fn start_and_complete_idempotent_invocation_neo_table(
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn complete_already_completed_invocation(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn complete_already_completed_invocation() {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let invocation_target = InvocationTarget::mock_virtual_object();
@@ -307,14 +264,9 @@ async fn complete_already_completed_invocation(
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn attach_with_service_invocation_command_while_executing(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn attach_with_service_invocation_command_while_executing() {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let retention = Duration::from_secs(60) * 60 * 24;
@@ -405,16 +357,11 @@ async fn attach_with_service_invocation_command_while_executing(
 }
 
 #[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into(), true)]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into(), false)]
-#[case(EnumSet::empty(), true)]
-#[case(EnumSet::empty(), false)]
+#[case(true)]
+#[case(false)]
 #[restate_core::test]
-async fn attach_with_send_service_invocation(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-    #[case] use_same_request_id: bool,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn attach_with_send_service_invocation(#[case] use_same_request_id: bool) {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let retention = Duration::from_secs(60) * 60 * 24;
@@ -530,14 +477,9 @@ async fn attach_with_send_service_invocation(
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn attach_inboxed_with_send_service_invocation(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn attach_inboxed_with_send_service_invocation() {
+    let mut test_env = TestEnv::create().await;
 
     let invocation_target = InvocationTarget::mock_virtual_object();
     let request_id_1 = PartitionProcessorRpcRequestId::default();
@@ -631,12 +573,9 @@ async fn attach_inboxed_with_send_service_invocation(
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn attach_command(#[case] experimental_features: EnumSet<ExperimentalFeature>) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn attach_command() {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let completion_retention = Duration::from_secs(60) * 60 * 24;
@@ -784,14 +723,9 @@ async fn attach_command_without_blocking_inflight() {
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn purge_completed_idempotent_invocation(
-    #[case] experimental_features: EnumSet<ExperimentalFeature>,
-) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn purge_completed_idempotent_invocation() {
+    let mut test_env = TestEnv::create().await;
 
     let idempotency_key = ByteString::from_static("my-idempotency-key");
     let invocation_target = InvocationTarget::mock_virtual_object();

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -16,15 +16,11 @@ use restate_types::errors::WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR;
 use restate_types::invocation::{
     AttachInvocationRequest, InvocationQuery, InvocationTarget, PurgeInvocationRequest,
 };
-use rstest::*;
 use std::time::Duration;
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn start_workflow_method(#[case] experimental_features: EnumSet<ExperimentalFeature>) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn start_workflow_method() {
+    let mut test_env = TestEnv::create().await;
 
     let invocation_target = InvocationTarget::mock_workflow();
     let invocation_id = InvocationId::mock_generate(&invocation_target);
@@ -52,25 +48,14 @@ async fn start_workflow_method(#[case] experimental_features: EnumSet<Experiment
     );
 
     // Assert service is locked only if we enable the idempotency table
-    if experimental_features.contains(ExperimentalFeature::DisableIdempotencyTable) {
-        assert_that!(
-            test_env
-                .storage()
-                .get_virtual_object_status(&invocation_target.as_keyed_service_id().unwrap())
-                .await
-                .unwrap(),
-            eq(VirtualObjectStatus::Unlocked)
-        );
-    } else {
-        assert_that!(
-            test_env
-                .storage()
-                .get_virtual_object_status(&invocation_target.as_keyed_service_id().unwrap())
-                .await
-                .unwrap(),
-            eq(VirtualObjectStatus::Locked(invocation_id))
-        );
-    }
+    assert_that!(
+        test_env
+            .storage()
+            .get_virtual_object_status(&invocation_target.as_keyed_service_id().unwrap())
+            .await
+            .unwrap(),
+        eq(VirtualObjectStatus::Unlocked)
+    );
 
     // Sending another invocation won't re-execute
     let actions = test_env
@@ -183,12 +168,9 @@ async fn start_workflow_method(#[case] experimental_features: EnumSet<Experiment
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn attach_by_workflow_key(#[case] experimental_features: EnumSet<ExperimentalFeature>) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn attach_by_workflow_key() {
+    let mut test_env = TestEnv::create().await;
 
     let invocation_target = InvocationTarget::mock_workflow();
     let invocation_id = InvocationId::mock_generate(&invocation_target);
@@ -321,12 +303,9 @@ async fn attach_by_workflow_key(#[case] experimental_features: EnumSet<Experimen
     test_env.shutdown().await;
 }
 
-#[rstest]
-#[case(ExperimentalFeature::DisableIdempotencyTable.into())]
-#[case(EnumSet::empty())]
 #[restate_core::test]
-async fn purge_completed_workflow(#[case] experimental_features: EnumSet<ExperimentalFeature>) {
-    let mut test_env = TestEnv::create_with_experimental_features(experimental_features).await;
+async fn purge_completed_workflow() {
+    let mut test_env = TestEnv::create().await;
 
     let invocation_target = InvocationTarget::mock_workflow();
     let invocation_id = InvocationId::mock_random();

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -47,7 +47,7 @@ async fn start_workflow_method() {
         }))
     );
 
-    // Assert service is locked only if we enable the idempotency table
+    // Assert we don't write virtual object status anymore for locking.
     assert_that!(
         test_env
             .storage()


### PR DESCRIPTION
With this PR it should still be possible to skip from 1.1 straight to 1.3, but it won't allow 1.3 to be rolled back to 1.1 because it would break idempotent requests created in 1.3