### PR TITLE
Remove `experimental_feature_kafka_ingress_next`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,24 +129,6 @@ jobs:
         RUST_LOG=info,restate_invoker=trace,restate_ingress_http=trace,restate_bifrost=trace,restate_log_server=trace,restate_core::partitions=trace,restate=debug
       testArtifactOutput: sdk-java-disable-idempotency-table-integration-test-report
 
-  sdk-java-kafka-next:
-    name: Run SDK-Java integration tests with KafkaIngressNext
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      actions: read
-    secrets: inherit
-    needs: docker
-    uses: restatedev/sdk-java/.github/workflows/integration.yaml@main
-    with:
-      restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
-      envVars: |
-        RESTATE_INGRESS__EXPERIMENTAL_FEATURE_KAFKA_INGRESS_NEXT=true
-        RUST_LOG=info,restate_invoker=trace,restate_ingress_http=trace,restate_bifrost=trace,restate_log_server=trace,restate_core::partitions=trace,restate=debug
-      testArtifactOutput: sdk-java-kafka-next-gen-integration-test-report
-
   sdk-java-invocation-status-killed:
     name: Run SDK-Java integration tests with InvocationStatusKilled
     permissions:

--- a/crates/admin/src/schema_registry/error.rs
+++ b/crates/admin/src/schema_registry/error.rs
@@ -133,8 +133,6 @@ pub enum SubscriptionError {
     InvalidServiceSinkAuthority(Uri),
     #[error("invalid sink URI '{0}': cannot find service/handler specified in the sink URI.")]
     SinkServiceNotFound(Uri),
-    #[error("invalid sink URI '{0}': shared handlers cannot be used as sinks.")]
-    InvalidSinkSharedHandler(Uri),
 
     #[error(transparent)]
     #[code(unknown)]

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -79,8 +79,6 @@ pub struct SchemaRegistry<V> {
     metadata_writer: MetadataWriter,
     service_discovery: ServiceDiscovery,
     subscription_validator: V,
-
-    experimental_feature_kafka_ingress_next: bool,
 }
 
 impl<V> SchemaRegistry<V> {
@@ -88,13 +86,11 @@ impl<V> SchemaRegistry<V> {
         metadata_writer: MetadataWriter,
         service_discovery: ServiceDiscovery,
         subscription_validator: V,
-        experimental_feature_kafka_ingress_next: bool,
     ) -> Self {
         Self {
             metadata_writer,
             service_discovery,
             subscription_validator,
-            experimental_feature_kafka_ingress_next,
         }
     }
 
@@ -127,10 +123,8 @@ impl<V> SchemaRegistry<V> {
         };
 
         let (id, services) = if !apply_mode.should_apply() {
-            let mut updater = SchemaUpdater::new(
-                Metadata::with_current(|m| m.schema()).deref().clone(),
-                self.experimental_feature_kafka_ingress_next,
-            );
+            let mut updater =
+                SchemaUpdater::new(Metadata::with_current(|m| m.schema()).deref().clone());
 
             // suppress logging output in case of a dry run
             let id = tracing::subscriber::with_default(NoSubscriber::new(), || {
@@ -155,10 +149,8 @@ impl<V> SchemaRegistry<V> {
                 .read_modify_write(
                     SCHEMA_INFORMATION_KEY.clone(),
                     |schema_information: Option<Schema>| {
-                        let mut updater = SchemaUpdater::new(
-                            schema_information.unwrap_or_default(),
-                            self.experimental_feature_kafka_ingress_next,
-                        );
+                        let mut updater =
+                            SchemaUpdater::new(schema_information.unwrap_or_default());
 
                         new_deployment_id = Some(updater.add_deployment(
                             deployment_metadata.clone(),
@@ -214,10 +206,8 @@ impl<V> SchemaRegistry<V> {
         };
 
         if !apply_mode.should_apply() {
-            let mut updater = SchemaUpdater::new(
-                Metadata::with_current(|m| m.schema()).deref().clone(),
-                self.experimental_feature_kafka_ingress_next,
-            );
+            let mut updater =
+                SchemaUpdater::new(Metadata::with_current(|m| m.schema()).deref().clone());
 
             // suppress logging output in case of a dry run
             tracing::subscriber::with_default(NoSubscriber::new(), || {
@@ -239,10 +229,8 @@ impl<V> SchemaRegistry<V> {
                 .read_modify_write(
                     SCHEMA_INFORMATION_KEY.clone(),
                     |schema_information: Option<Schema>| {
-                        let mut updater = SchemaUpdater::new(
-                            schema_information.unwrap_or_default(),
-                            self.experimental_feature_kafka_ingress_next,
-                        );
+                        let mut updater =
+                            SchemaUpdater::new(schema_information.unwrap_or_default());
 
                         updater.update_deployment(
                             deployment_id,
@@ -279,10 +267,7 @@ impl<V> SchemaRegistry<V> {
                     let schema_information: Schema = schema_registry.unwrap_or_default();
 
                     if schema_information.get_deployment(&deployment_id).is_some() {
-                        let mut updater = SchemaUpdater::new(
-                            schema_information,
-                            self.experimental_feature_kafka_ingress_next,
-                        );
+                        let mut updater = SchemaUpdater::new(schema_information);
                         updater.remove_deployment(deployment_id);
                         Ok(updater.into_inner())
                     } else {
@@ -317,10 +302,7 @@ impl<V> SchemaRegistry<V> {
                         .resolve_latest_service(&service_name)
                         .is_some()
                     {
-                        let mut updater = SchemaUpdater::new(
-                            schema_information,
-                            self.experimental_feature_kafka_ingress_next,
-                        );
+                        let mut updater = SchemaUpdater::new(schema_information);
                         updater.modify_service(service_name.clone(), changes.clone())?;
                         Ok(updater.into_inner())
                     } else {
@@ -359,10 +341,7 @@ impl<V> SchemaRegistry<V> {
                         .get_subscription(subscription_id)
                         .is_some()
                     {
-                        let mut updater = SchemaUpdater::new(
-                            schema_information,
-                            self.experimental_feature_kafka_ingress_next,
-                        );
+                        let mut updater = SchemaUpdater::new(schema_information);
                         updater.remove_subscription(subscription_id);
                         Ok(updater.into_inner())
                     } else {
@@ -454,10 +433,7 @@ where
             .read_modify_write(
                 SCHEMA_INFORMATION_KEY.clone(),
                 |schema_information: Option<Schema>| {
-                    let mut updater = SchemaUpdater::new(
-                        schema_information.unwrap_or_default(),
-                        self.experimental_feature_kafka_ingress_next,
-                    );
+                    let mut updater = SchemaUpdater::new(schema_information.unwrap_or_default());
                     subscription_id = Some(updater.add_subscription(
                         None,
                         source.clone(),

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -48,7 +48,6 @@ where
         bifrost: Bifrost,
         subscription_validator: V,
         service_discovery: ServiceDiscovery,
-        experimental_feature_kafka_ingress_next: bool,
     ) -> Self {
         Self {
             bifrost,
@@ -58,7 +57,6 @@ where
                 metadata_writer,
                 service_discovery,
                 subscription_validator,
-                experimental_feature_kafka_ingress_next,
             ),
             #[cfg(feature = "storage-query")]
             query_context: None,

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -96,18 +96,13 @@ impl KafkaDeduplicationId {
 pub struct MessageSender {
     subscription: Subscription,
     dispatcher: KafkaIngressDispatcher,
-    experimental_feature_kafka_ingress_next: bool,
 
     subscription_id: String,
     ingress_request_counter: metrics::Counter,
 }
 
 impl MessageSender {
-    pub fn new(
-        subscription: Subscription,
-        dispatcher: KafkaIngressDispatcher,
-        experimental_feature_kafka_ingress_next: bool,
-    ) -> Self {
+    pub fn new(subscription: Subscription, dispatcher: KafkaIngressDispatcher) -> Self {
         Self {
             subscription_id: subscription.id().to_string(),
             ingress_request_counter: counter!(
@@ -116,7 +111,6 @@ impl MessageSender {
             ),
             subscription,
             dispatcher,
-            experimental_feature_kafka_ingress_next,
         }
     }
 
@@ -157,7 +151,6 @@ impl MessageSender {
             deduplication_id,
             deduplication_index,
             headers,
-            self.experimental_feature_kafka_ingress_next,
         )
         .map_err(|cause| Error::Event {
             topic: msg.topic().to_string(),

--- a/crates/ingress-kafka/src/dispatcher.rs
+++ b/crates/ingress-kafka/src/dispatcher.rs
@@ -14,9 +14,7 @@ use restate_bifrost::Bifrost;
 use restate_core::{Metadata, my_node_id};
 use restate_storage_api::deduplication_table::DedupInformation;
 use restate_types::GenerationalNodeId;
-use restate_types::identifiers::{
-    InvocationId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey, partitioner,
-};
+use restate_types::identifiers::{InvocationId, PartitionKey, WithPartitionKey, partitioner};
 use restate_types::invocation::{
     InvocationTarget, ServiceInvocation, SpanRelation, VirtualObjectHandlerType,
     WorkflowHandlerType,
@@ -50,7 +48,6 @@ impl KafkaIngressEvent {
         deduplication_id: KafkaDeduplicationId,
         deduplication_index: MessageIndex,
         headers: Vec<restate_types::invocation::Header>,
-        experimental_feature_kafka_ingress_next: bool,
     ) -> Result<Self, anyhow::Error> {
         // Check if we need to proxy or not
         let proxying_partition_key = if KafkaDeduplicationId::requires_proxying(subscription) {
@@ -123,11 +120,7 @@ impl KafkaIngressEvent {
         let mut service_invocation = ServiceInvocation::initialize(
             invocation_id,
             invocation_target,
-            if experimental_feature_kafka_ingress_next {
-                restate_types::invocation::Source::Subscription(subscription.id())
-            } else {
-                restate_types::invocation::Source::Ingress(PartitionProcessorRpcRequestId::new())
-            },
+            restate_types::invocation::Source::Subscription(subscription.id()),
         );
         service_invocation.with_related_span(related_span);
         service_invocation.argument = payload;

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -144,11 +144,7 @@ impl Service {
         let consumer_task = consumer_task::ConsumerTask::new(
             client_config,
             vec![topic.to_string()],
-            MessageSender::new(
-                subscription,
-                self.dispatcher.clone(),
-                options.experimental_feature_kafka_ingress_next(),
-            ),
+            MessageSender::new(subscription, self.dispatcher.clone()),
         );
 
         task_orchestrator.start(subscription_id, consumer_task);

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -105,7 +105,6 @@ impl<T: TransportConnect> AdminRole<T> {
             bifrost.clone(),
             config.ingress.clone(),
             service_discovery,
-            config.ingress.experimental_feature_kafka_ingress_next(),
         )
         .with_query_context(query_context);
 

--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -48,13 +48,6 @@ pub struct IngressOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub experimental_feature_enable_separate_ingress_role: bool,
 
-    /// Cluster of new features for the kafka ingress, including:
-    ///
-    /// * New Source::Subscription
-    /// * Shared handlers can now receive events https://github.com/restatedev/restate/issues/2100
-    #[cfg_attr(feature = "schemars", schemars(skip))]
-    experimental_feature_kafka_ingress_next: bool,
-
     /// # Ingress endpoint
     ///
     /// Ingress endpoint that the Web UI should use to interact with.
@@ -89,10 +82,6 @@ impl IngressOptions {
         )
     }
 
-    pub fn experimental_feature_kafka_ingress_next(&self) -> bool {
-        self.experimental_feature_kafka_ingress_next
-    }
-
     /// set derived values if they are not configured to reduce verbose configurations
     pub fn set_derived_values(&mut self) {
         // Only derive bind_address if it is not explicitly set
@@ -123,7 +112,6 @@ impl Default for IngressOptions {
             concurrent_api_requests_limit: None,
             kafka_clusters: Default::default(),
             experimental_feature_enable_separate_ingress_role: false,
-            experimental_feature_kafka_ingress_next: false,
             advertised_ingress_endpoint: None,
         }
     }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -114,7 +114,6 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
             ServiceClient::from_options(&config.common.service_client, AssumeRoleCacheMode::None)
                 .unwrap(),
         ),
-        false,
     );
 
     TaskCenter::spawn(


### PR DESCRIPTION
This PR should still allow to skip from 1.1 straight to 1.3 even when using kafka, but it won't allow to rollback from 1.3 to 1.2 after registering a new kafka subscription in 1.3