### PR TITLE
[sql] Reduce the number of in-flight RecordBatches

### DIFF
--- a/crates/storage-query-datafusion/src/partition_store_scanner.rs
+++ b/crates/storage-query-datafusion/src/partition_store_scanner.rs
@@ -66,7 +66,7 @@ where
         range: RangeInclusive<PartitionKey>,
         projection: SchemaRef,
     ) -> anyhow::Result<SendableRecordBatchStream> {
-        let mut stream_builder = RecordBatchReceiverStream::builder(projection.clone(), 16);
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection.clone(), 2);
         let tx = stream_builder.tx();
         let partition_store_manager = self.partition_store_manager.clone();
         let background_task = async move {

--- a/crates/storage-query-datafusion/src/state/row.rs
+++ b/crates/storage-query-datafusion/src/state/row.rs
@@ -33,5 +33,7 @@ pub(crate) fn append_state_row(
             row.value_utf8(str);
         }
     }
-    row.value(&state_value);
+    if row.is_value_defined() {
+        row.value(&state_value);
+    }
 }


### PR DESCRIPTION
This commit sets the number of record batches that has to be kept in memory during a scan (per-partition) to 2.
With this we ensure that at most 2048 rows are materlized at a time per scanner.
One is being filled during a scan, and an other is pending to be processed by the parent operator (the consumer of the scan)