### PR TITLE
[sql] Add a max_concurrent_queries optional configuration key

### DIFF
--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -45,6 +45,11 @@ pub struct QueryEngineOptions {
     ///
     /// The address to bind for the psql service.
     pub pgsql_bind_address: SocketAddr,
+
+    /// # Default per node scan parallelism
+    ///
+    /// The number of parallel scanner to use for a query execution
+    partition_scan_parallelism: Option<NonZeroUsize>,
 }
 
 impl QueryEngineOptions {
@@ -59,6 +64,7 @@ impl Default for QueryEngineOptions {
             tmp_dir: None,
             query_parallelism: None,
             pgsql_bind_address: "0.0.0.0:9071".parse().unwrap(),
+            partition_scan_parallelism: None,
         }
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -190,6 +190,7 @@ impl Worker {
 
         let datafusion_remote_scanner = RemoteQueryScannerServer::new(
             Duration::from_secs(60),
+            config.admin.query_engine.query_parallelism(),
             storage_query_context.clone(),
             router_builder,
         );


### PR DESCRIPTION
This commit adds a new configuration key under the admin/query. With that in place, a user can set a limit to have a tighter control on the number of inflight queries.
The default is set no unlimited (None).