### PR TITLE
MetadataStoreProxy implementation

### DIFF
--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -8,6 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tonic::{Code, Status};
+
+use crate::metadata_store::{ReadError, WriteError};
+
 pub mod node_ctl_svc {
     use restate_types::protobuf::cluster::ClusterConfiguration;
 
@@ -35,8 +39,134 @@ pub mod node_ctl_svc {
 
 pub mod metadata_proxy_svc {
 
+    use bytestring::ByteString;
+    use tonic::{codec::CompressionEncoding, transport::Channel};
+
+    use metadata_proxy_svc_client::MetadataProxySvcClient;
+    use restate_types::{
+        Version,
+        metadata::{Precondition, VersionedValue},
+        nodes_config::NodesConfiguration,
+    };
+
+    use crate::metadata_store::{MetadataStore, ProvisionError, ReadError, WriteError};
+
+    use super::{to_read_err, to_write_err};
+
     tonic::include_proto!("restate.metadata_proxy_svc");
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("metadata_proxy_svc_descriptor");
+
+    pub struct MetadataStoreProxy {
+        client: MetadataProxySvcClient<Channel>,
+    }
+
+    impl MetadataStoreProxy {
+        pub fn new(channel: Channel) -> Self {
+            Self {
+                client: MetadataProxySvcClient::new(channel)
+                    .send_compressed(CompressionEncoding::Gzip)
+                    .accept_compressed(CompressionEncoding::Gzip),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MetadataStore for MetadataStoreProxy {
+        async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+            let mut client = self.client.clone();
+
+            let request = GetRequest {
+                key: key.to_string(),
+            };
+
+            let response = client.get(request).await.map_err(to_read_err)?.into_inner();
+
+            response
+                .value
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(ReadError::terminal)
+        }
+
+        async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+            let mut client = self.client.clone();
+
+            let request = GetRequest {
+                key: key.to_string(),
+            };
+
+            let response = client
+                .get_version(request)
+                .await
+                .map_err(to_read_err)?
+                .into_inner();
+
+            response
+                .version
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(ReadError::terminal)
+        }
+
+        async fn put(
+            &self,
+            key: ByteString,
+            value: VersionedValue,
+            precondition: Precondition,
+        ) -> Result<(), WriteError> {
+            let mut client = self.client.clone();
+
+            let request = PutRequest {
+                key: key.to_string(),
+                value: Some(value.into()),
+                precondition: Some(precondition.into()),
+            };
+
+            client.put(request).await.map_err(to_write_err)?;
+
+            Ok(())
+        }
+
+        async fn delete(
+            &self,
+            key: ByteString,
+            precondition: Precondition,
+        ) -> Result<(), WriteError> {
+            let mut client = self.client.clone();
+
+            let request = DeleteRequest {
+                key: key.to_string(),
+                precondition: Some(precondition.into()),
+            };
+
+            client.delete(request).await.map_err(to_write_err)?;
+
+            Ok(())
+        }
+
+        async fn provision(&self, _: &NodesConfiguration) -> Result<bool, ProvisionError> {
+            Err(ProvisionError::NotSupported(
+                "Provision not supported over metadata proxy".to_owned(),
+            ))
+        }
+    }
+}
+
+fn to_read_err(status: Status) -> ReadError {
+    // Currently, we treat all returned statuses as terminal errors since
+    // retryability is not encoded in the status response.
+    //
+    // Additionally, users of this proxy client (e.g., `restatectl`) are
+    // unlikely to retry on errors and will typically attempt to use
+    // another node instead.
+    ReadError::terminal(status)
+}
+
+fn to_write_err(status: Status) -> WriteError {
+    match status.code() {
+        Code::FailedPrecondition => WriteError::FailedPrecondition(status.to_string()),
+        _ => WriteError::terminal(status),
+    }
 }


### PR DESCRIPTION
MetadataStoreProxy implementation

Summary:
Implement MetadataStore for the MetadataProxySvcClient

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2848).
* #2825
* __->__ #2848