### PR TITLE
Add helm example for replicated cluster

### DIFF
--- a/charts/restate-helm/README.md
+++ b/charts/restate-helm/README.md
@@ -7,3 +7,10 @@ Helm chart for Restate as a single-node StatefulSet.
 ```bash
 helm install restate oci://ghcr.io/restatedev/restate-helm --namespace restate --create-namespace
 ```
+
+# Running a replicated cluster
+You can find example values for a 3-node replicated cluster in [replicated-values.yaml](./replicated-values.yaml)
+
+```bash
+helm install restate oci://ghcr.io/restatedev/restate-helm --namespace restate --create-namespace -f replicated-values.yaml
+```

--- a/charts/restate-helm/replicated-values.yaml
+++ b/charts/restate-helm/replicated-values.yaml
@@ -1,0 +1,20 @@
+replicaCount: 3
+
+env:
+  - name: POD_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: "status.podIP"
+  - name: RESTATE_ADVERTISED_ADDRESS
+    value: "http://$(POD_IP):5122"
+  - name: RESTATE_ROLES
+    value: '["metadata-server", "admin", "worker", "log-server"]'
+  - name: RESTATE_CLUSTER_NAME
+    value: helm-replicated
+  - name: RESTATE_METADATA_CLIENT__ADDRESSES
+    value: '["http://restate:5122"]'
+  - name: RESTATE_METADATA_SERVER__TYPE
+    value: "replicated"
+  - name: RESTATE_AUTO_PROVISION
+    # provision with `kubectl exec -it restate-0 -- restatectl provision --log-provider replicated --log-replication 2`
+    value: "false"

--- a/charts/restate-helm/templates/service.yaml
+++ b/charts/restate-helm/templates/service.yaml
@@ -16,9 +16,7 @@ spec:
       name: admin
     - port: 8080
       name: ingress
-    - port: 9071
-      name: storage
     - port: 5122
-      name: metrics
+      name: node
   selector:
     app: {{ include "restate.fullname" . }}

--- a/charts/restate-helm/templates/servicemonitor.yaml
+++ b/charts/restate-helm/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: node
     {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
     {{- end }}

--- a/charts/restate-helm/templates/statefulset.yaml
+++ b/charts/restate-helm/templates/statefulset.yaml
@@ -41,10 +41,8 @@ spec:
               name: admin
             - containerPort: 8080
               name: ingress
-            - containerPort: 9071
-              name: storage
             - containerPort: 5122
-              name: metrics
+              name: node
           env:
             - name: RUST_LOG
               value: {{ .Values.logging.env_filter }}
@@ -53,8 +51,8 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /health
-              port: admin
+              path: /restate/health
+              port: ingress
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
@@ -79,4 +77,3 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.size | quote }}
-


### PR DESCRIPTION
1. pods need to advertise their own ip
2. pods need a way of reaching 'another' restate server so they can bootstrap into the metadata cluster. we could hardcode restate-0 headless dns name, but http://restate:5122/ (a cluster ip that randomly picks an underlying healthy restate pod to route to) seems to work fine
3. pods need to run the logserver and metadata-server roles and have the correct metadata server type set
4. pods need to have auto provision turned off. technically its possible to have it turned on and just set up with one node before turning it off and scaling, and technically its also possible to have it be set to true for restate-0 only, but really its a lot easier if its just off.