### PR TITLE
Add support for configuring object store access retry policies

### DIFF
--- a/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
+++ b/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
@@ -17,7 +17,6 @@ use tracing::info;
 use url::Url;
 
 use restate_object_store_util::create_object_store_client;
-use restate_types::retries::RetryPolicy;
 
 use crate::metadata_store::providers::objstore::version_repository::{
     Tag, TaggedValue, VersionRepository, VersionRepositoryError,
@@ -34,7 +33,12 @@ impl ObjectStoreVersionRepository {
     pub(crate) async fn from_configuration(
         configuration: MetadataClientKind,
     ) -> anyhow::Result<Self> {
-        let MetadataClientKind::ObjectStore { path, object_store } = configuration else {
+        let MetadataClientKind::ObjectStore {
+            path,
+            object_store,
+            object_store_retry_policy,
+        } = configuration
+        else {
             anyhow::bail!("unexpected configuration value");
         };
 
@@ -49,9 +53,10 @@ impl ObjectStoreVersionRepository {
         }
         let prefix = Path::from(url.path());
 
-        let object_store = create_object_store_client(url, &object_store, &RetryPolicy::None)
-            .await
-            .map_err(|e| anyhow::anyhow!("Unable to build an S3 object store: {}", e))?;
+        let object_store =
+            create_object_store_client(url, &object_store, &object_store_retry_policy)
+                .await
+                .map_err(|e| anyhow::anyhow!("Unable to build an S3 object store: {}", e))?;
 
         Ok(Self {
             object_store: Box::new(object_store),

--- a/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
+++ b/crates/core/src/metadata_store/providers/objstore/object_store_version_repository.rs
@@ -13,9 +13,11 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use object_store::path::{Path, PathPart};
 use object_store::{Error, ObjectStore, PutMode, PutOptions, PutPayload, UpdateVersion};
-use restate_object_store_util::create_object_store_client;
 use tracing::info;
 use url::Url;
+
+use restate_object_store_util::create_object_store_client;
+use restate_types::retries::RetryPolicy;
 
 use crate::metadata_store::providers::objstore::version_repository::{
     Tag, TaggedValue, VersionRepository, VersionRepositoryError,
@@ -47,7 +49,7 @@ impl ObjectStoreVersionRepository {
         }
         let prefix = Path::from(url.path());
 
-        let object_store = create_object_store_client(url, &object_store)
+        let object_store = create_object_store_client(url, &object_store, &RetryPolicy::None)
             .await
             .map_err(|e| anyhow::anyhow!("Unable to build an S3 object store: {}", e))?;
 

--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
+use std::usize;
 
 use anyhow::Context;
 use aws_config::default_provider::region::DefaultRegionChain;
@@ -180,9 +181,8 @@ fn from_retry_policy(retry_policy: &RetryPolicy) -> RetryConfig {
             interval,
             max_attempts,
         } => RetryConfig {
-            // retry policy with unset max retries creates infinite retries; we use the ObjectStore default instead
             max_retries: max_attempts
-                .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                .unwrap_or(NonZeroUsize::new(usize::MAX).expect("non-zero"))
                 .into(),
             backoff: BackoffConfig {
                 init_backoff: (*interval).into(),
@@ -203,23 +203,22 @@ fn from_retry_policy(retry_policy: &RetryPolicy) -> RetryConfig {
             max_attempts,
             max_interval,
         } => RetryConfig {
-            // retry policy with unset max retries creates infinite retries; we use the ObjectStore default instead
             max_retries: max_attempts
-                .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                .unwrap_or(NonZeroUsize::new(usize::MAX).expect("non-zero"))
                 .into(),
             backoff: BackoffConfig {
                 init_backoff: (*initial_interval).into(),
                 max_backoff: max_interval
-                    .unwrap_or_else(|| Duration::from_secs(15).into())
+                    .unwrap_or_else(|| Duration::from_secs(10).into())
                     .into(),
                 base: f64::from(*factor),
             },
             retry_timeout: max_interval
                 .map(|interval| interval.into())
-                .unwrap_or_else(|| Duration::from_secs(15))
+                .unwrap_or_else(|| Duration::from_secs(10))
                 * u32::try_from(
                     max_attempts
-                        .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                        .unwrap_or(NonZeroUsize::new(usize::MAX).expect("non-zero"))
                         .get(),
                 )
                 .expect("explicit max attempts fits in u32"),

--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -212,7 +212,7 @@ fn from_retry_policy(retry_policy: &RetryPolicy) -> RetryConfig {
                 max_backoff: max_interval
                     .unwrap_or_else(|| Duration::from_secs(15).into())
                     .into(),
-                base: f64::from(f32::from(*factor)),
+                base: f64::from(*factor),
             },
             retry_timeout: max_interval
                 .map(|interval| interval.into())

--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,14 +19,17 @@ use aws_config::{BehaviorVersion, Region};
 use aws_smithy_runtime_api::client::identity::ResolveCachedIdentity;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
 use futures::FutureExt;
-use object_store::ObjectStore;
 use object_store::aws::{AmazonS3Builder, S3ConditionalPut};
+use object_store::{BackoffConfig, ObjectStore, RetryConfig};
 use tracing::debug;
 use url::Url;
+
+use restate_types::retries::RetryPolicy;
 
 pub async fn create_object_store_client(
     destination: Url,
     options: &restate_types::config::ObjectStoreOptions,
+    retry_policy: &RetryPolicy,
 ) -> anyhow::Result<Arc<dyn ObjectStore>> {
     // We use the AWS SDK configuration and credentials provider so that the conventional AWS
     // environment variables and config files work as expected. The object_store crate has its
@@ -155,15 +159,7 @@ pub async fn create_object_store_client(
         let builder = builder
             .with_url(destination)
             .with_conditional_put(S3ConditionalPut::ETagMatch)
-            .with_retry(object_store::RetryConfig {
-                max_retries: 8,
-                retry_timeout: Duration::from_secs(60),
-                backoff: object_store::BackoffConfig {
-                    init_backoff: Duration::from_millis(100),
-                    max_backoff: Duration::from_secs(5),
-                    base: 2.,
-                },
-            });
+            .with_retry(from_retry_policy(retry_policy));
 
         Arc::new(builder.build()?)
     } else {
@@ -171,6 +167,64 @@ pub async fn create_object_store_client(
         object_store::parse_url(&destination)?.0.into()
     };
     Ok(object_store)
+}
+
+/// Convert Restate [RetryPolicy] into [object_store::RetryConfig].
+fn from_retry_policy(retry_policy: &RetryPolicy) -> RetryConfig {
+    match retry_policy {
+        RetryPolicy::None => RetryConfig {
+            max_retries: 0, // zero disables retries in object_store::RetryConfig
+            ..Default::default()
+        },
+        RetryPolicy::FixedDelay {
+            interval,
+            max_attempts,
+        } => RetryConfig {
+            // retry policy with unset max retries creates infinite retries; we use the ObjectStore default instead
+            max_retries: max_attempts
+                .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                .into(),
+            backoff: BackoffConfig {
+                init_backoff: (*interval).into(),
+                max_backoff: (*interval).into(),
+                base: 1.,
+            },
+            retry_timeout: Into::<std::time::Duration>::into(*interval)
+                * u32::try_from(
+                    max_attempts
+                        .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                        .get(),
+                )
+                .expect("explicit max attempts fits in u32"),
+        },
+        RetryPolicy::Exponential {
+            initial_interval,
+            factor,
+            max_attempts,
+            max_interval,
+        } => RetryConfig {
+            // retry policy with unset max retries creates infinite retries; we use the ObjectStore default instead
+            max_retries: max_attempts
+                .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                .into(),
+            backoff: BackoffConfig {
+                init_backoff: (*initial_interval).into(),
+                max_backoff: max_interval
+                    .unwrap_or_else(|| Duration::from_secs(15).into())
+                    .into(),
+                base: f64::from(f32::from(*factor)),
+            },
+            retry_timeout: max_interval
+                .map(|interval| interval.into())
+                .unwrap_or_else(|| Duration::from_secs(15))
+                * u32::try_from(
+                    max_attempts
+                        .unwrap_or(NonZeroUsize::new(10).expect("non-zero"))
+                        .get(),
+                )
+                .expect("explicit max attempts fits in u32"),
+        },
+    }
 }
 
 #[derive(Debug)]

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -648,6 +648,8 @@ enum MetadataClientKindShadow {
         path: String,
         #[serde(flatten)]
         object_store: ObjectStoreOptions,
+        #[serde(default = "MetadataClientKind::default_object_store_retry_policy")]
+        object_store_retry_policy: RetryPolicy,
     },
     // Fallback to support not having to specify the type field
     #[serde(untagged)]
@@ -662,10 +664,14 @@ impl TryFrom<MetadataClientKindShadow> for MetadataClientKind {
     type Error = &'static str;
     fn try_from(value: MetadataClientKindShadow) -> Result<Self, Self::Error> {
         let result = match value {
-            MetadataClientKindShadow::ObjectStore { path, object_store } => Self::ObjectStore {
+            MetadataClientKindShadow::ObjectStore {
                 path,
                 object_store,
-                object_store_retry_policy: RetryPolicy::None,
+                object_store_retry_policy,
+            } => Self::ObjectStore {
+                path,
+                object_store,
+                object_store_retry_policy,
             },
             MetadataClientKindShadow::Etcd { addresses } => Self::Etcd { addresses },
             MetadataClientKindShadow::Replicated { address, addresses }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -560,6 +560,7 @@ impl Default for MetadataClientOptions {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
 #[serde(
     tag = "type",
@@ -579,6 +580,7 @@ pub enum MetadataClientKind {
     /// Store metadata on the replicated metadata store that runs on nodes with the metadata-server role.
     #[display("replicated")]
     Replicated {
+        /// # Restate metadata server address list
         #[cfg_attr(feature = "schemars", schemars(with = "Vec<String>"))]
         addresses: Vec<AdvertisedAddress>,
     },
@@ -587,6 +589,7 @@ pub enum MetadataClientKind {
     /// The addresses are formatted as `host:port`
     #[display("etcd")]
     Etcd {
+        /// # Etcd cluster node address list
         #[cfg_attr(feature = "schemars", schemars(with = "String"))]
         addresses: Vec<String>,
     },
@@ -605,7 +608,22 @@ pub enum MetadataClientKind {
 
         #[serde(flatten)]
         object_store: ObjectStoreOptions,
+
+        /// # Error retry policy
+        #[serde(default = "MetadataClientKind::default_object_store_retry_policy")]
+        object_store_retry_policy: RetryPolicy,
     },
+}
+
+impl MetadataClientKind {
+    fn default_object_store_retry_policy() -> RetryPolicy {
+        RetryPolicy::exponential(
+            Duration::from_millis(100),
+            2.,
+            Some(10),
+            Some(Duration::from_secs(10)),
+        )
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -644,9 +662,11 @@ impl TryFrom<MetadataClientKindShadow> for MetadataClientKind {
     type Error = &'static str;
     fn try_from(value: MetadataClientKindShadow) -> Result<Self, Self::Error> {
         let result = match value {
-            MetadataClientKindShadow::ObjectStore { path, object_store } => {
-                Self::ObjectStore { path, object_store }
-            }
+            MetadataClientKindShadow::ObjectStore { path, object_store } => Self::ObjectStore {
+                path,
+                object_store,
+                object_store_retry_policy: RetryPolicy::None,
+            },
             MetadataClientKindShadow::Etcd { addresses } => Self::Etcd { addresses },
             MetadataClientKindShadow::Replicated { address, addresses }
             | MetadataClientKindShadow::Fallback { address, addresses } => {

--- a/crates/types/src/config/object_store.rs
+++ b/crates/types/src/config/object_store.rs
@@ -18,6 +18,8 @@ use serde_with::serde_as;
 #[serde(rename_all = "kebab-case")]
 #[builder(default)]
 pub struct ObjectStoreOptions {
+    /// # AWS profile
+    ///
     /// The AWS configuration profile to use for S3 object store destinations. If you use
     /// named profiles in your AWS configuration, you can replace all the other settings with
     /// a single profile reference. See the [AWS documentation on profiles]
@@ -25,6 +27,8 @@ pub struct ObjectStoreOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_profile: Option<String>,
 
+    /// # AWS region
+    ///
     /// AWS region to use with S3 object store destinations. This may be inferred from the
     /// environment, for example the current region when running in EC2. Because of the
     /// request signing algorithm this must have a value. For Minio, you can generally
@@ -32,27 +36,36 @@ pub struct ObjectStoreOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_region: Option<String>,
 
-    /// AWS access key (or username in Minio / S3-compatible stores).
+    /// # AWS access key
+    ///
+    /// Username for Minio, or consult the service documentation for other S3-compatible stores.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_access_key_id: Option<String>,
 
-    /// AWS secret key (or password in Minio / S3-compatible stores).
+    /// # AWS secret key
+    ///
+    /// Password for Minio, or consult the service documentation for other S3-compatible stores.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_secret_access_key: Option<String>,
 
-    /// AWS session token, needed with short-term STS session credentials.
+    /// # AWS session token
+    ///
+    /// This is only needed with short-term STS session credentials.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_session_token: Option<String>,
 
-    /// Endpoint URL override. When you use Amazon S3, this is typically inferred from the region
-    /// and there is no need to set it. With other object stores, you will have to provide
-    /// an appropriate HTTP(S) endpoint. If *not* using HTTPS, also set `aws-allow-http` to
-    /// `true`.
+    /// # Object store API endpoint URL override
+    ///
+    /// When you use Amazon S3, this is typically inferred from the region and there is no need to
+    /// set it. With other object stores, you will have to provide an appropriate HTTP(S) endpoint.
+    /// If *not* using HTTPS, also set `aws-allow-http` to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_endpoint_url: Option<String>,
 
-    /// Allow plain HTTP to be used with the object store endpoint. Required when the
-    /// endpoint URL that isn't using HTTPS.
+    /// # Allow insecure HTTP
+    ///
+    /// Allow plain HTTP to be used with the object store endpoint. Required when the endpoint URL
+    /// that isn't using HTTPS.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aws_allow_http: Option<bool>,
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -367,7 +367,10 @@ impl Default for StorageOptions {
 #[serde(rename_all = "kebab-case")]
 #[builder(default)]
 pub struct SnapshotsOptions {
+    /// # Snapshot destination URL
+    ///
     /// Base URL for cluster snapshots. Supports `s3://` and `file://` protocol scheme.
+    /// S3-compatible object stores must support ETag-based conditional writes.
     ///
     /// Default: `None`
     pub destination: Option<String>,
@@ -383,12 +386,13 @@ pub struct SnapshotsOptions {
     ///
     /// This setting does not influence explicitly requested snapshots triggered using `restatectl`.
     ///
-    /// Default: `None` - automatic snapshots are disabled by default
+    /// Default: `None` - automatic snapshots are disabled
     pub snapshot_interval_num_records: Option<NonZeroU64>,
 
     #[serde(flatten)]
     pub object_store: ObjectStoreOptions,
 
+    /// # Error retry policy
     #[serde(default = "SnapshotsOptions::default_retry_policy")]
     pub object_store_retry_policy: RetryPolicy,
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -389,6 +389,8 @@ pub struct SnapshotsOptions {
 
     #[serde(flatten)]
     pub object_store: ObjectStoreOptions,
+
+    pub object_store_retry_policy: RetryPolicy,
 }
 
 fn is_default_snapshots_options(opts: &SnapshotsOptions) -> bool {

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -393,7 +393,8 @@ pub struct SnapshotsOptions {
     pub object_store: ObjectStoreOptions,
 
     /// # Error retry policy
-    #[serde(default = "SnapshotsOptions::default_retry_policy")]
+    ///
+    /// A retry policy for dealing with retryable object store errors.
     pub object_store_retry_policy: RetryPolicy,
 }
 

--- a/crates/types/src/retries.rs
+++ b/crates/types/src/retries.rs
@@ -54,7 +54,7 @@ const DEFAULT_JITTER_MULTIPLIER: f32 = 0.3;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
@@ -103,7 +103,7 @@ pub enum RetryPolicy {
         /// # Factor
         ///
         /// The factor to use to compute the next retry attempt.
-        factor: ExponentiationFactor,
+        factor: f32,
 
         /// # Max attempts
         ///
@@ -143,7 +143,7 @@ impl RetryPolicy {
         // y = \sum_{n=0}^{x} \min \left( max_interval,\ initial_interval \cdot factor x \right)
         Self::Exponential {
             initial_interval: initial_interval.into(),
-            factor: factor.into(),
+            factor,
             max_attempts: max_attempts.map(|m| NonZeroUsize::new(m).expect("non-zero")),
             max_interval: max_interval.map(Into::into),
         }
@@ -283,7 +283,7 @@ impl Iterator for RetryIter<'_> {
                     None
                 } else if self.last_retry.is_some() {
                     let new_retry = cmp::min(
-                        self.last_retry.unwrap().mul_f32(factor.0),
+                        self.last_retry.unwrap().mul_f32(*factor),
                         max_interval.map(Into::into).unwrap_or(Duration::MAX),
                     );
                     self.last_retry = Some(new_retry);
@@ -331,24 +331,6 @@ pub fn with_jitter(duration: Duration, max_multiplier: f32) -> Duration {
 }
 
 impl ExactSizeIterator for RetryIter<'_> {}
-
-#[derive(
-    Debug, Copy, Clone, derive_more::Into, derive_more::From, serde::Serialize, serde::Deserialize,
-)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct ExponentiationFactor(f32);
-
-impl PartialEq for ExponentiationFactor {
-    fn eq(&self, other: &Self) -> bool {
-        if self.0.is_nan() && other.0.is_nan() {
-            true
-        } else {
-            self.0 == other.0
-        }
-    }
-}
-
-impl Eq for ExponentiationFactor {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Expose the object store retry policy to be configurable via Restate config.

This change also revises the default object store max attempts from 8 to 10, to be more in line with ObjectStore's own defaults. We may want to use different defaults for different parts of the config however - e.g. the default snapshot retry policy might be quite different from metadata or other use cases.

This was [recently exposed by our e2e tests failing](https://github.com/restatedev/e2e-verification-runner/actions/runs/13578683032/job/37960529900#step:5:305) due to slow minio startup; the default retry policy gives up very quickly: 

> Error after 8 retries in 1.726268511s, max_retries:8, 

---

**Testing**

Defaults:

```
% restate-server --dump-config

...

[worker.snapshots.object-store-retry-policy]
type = "exponential"
initial-interval = "100ms"
factor = 2.0
max-attempts = 10
max-interval = "10s"
```

By default, the `metadata-client` type is `replicated` - which doesn't have a retry-policy. However if you set the client type to be `object-store`, the appropriate retry config becomes relevant. If we have the following server config:

```metadata-client-s3.config.toml
[metadata-client]
type = "object-store"
path = "s3://metadata-bucket"
```

```
% restate-server --dump-config --config-file ../config-snippets/metadata-client-s3.config.toml

...

[metadata-client.object-store-retry-policy]
type = "exponential"
initial-interval = "100ms"
factor = 2.0
max-attempts = 10
max-interval = "10s"
```

Tested the Object Store-backed metadata client with an Docker Compose cluster simulating the above test case scenario where Minio startup was delayed by 5 and 10s, all working as expected.

---

**S3 failure testing**

For good measure, I added a new nemesis to the Jepsen suite which blocks S3 access and tested this with both the S3 snapshotting and metadata-on-S3 workloads; depending on the S3 blocking policy (drop vs. reject), we can see that the default metadata client retry policy kicks in (notice the different latency cutoff with reject, vs ongoing 10s operation timeouts when the drop policy is in place):

Workload `set-mds-s3` with S3 nemesis (drop packets policy):

![image](https://github.com/user-attachments/assets/81ba0425-a98d-46b9-990c-585d0c5715aa)