### PR TITLE
Treat invalid HTTP S3 endpoint overrides as a startup configuration error

### DIFF
--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -102,13 +102,23 @@ pub async fn create_object_store_client(
         } else {
             builder
         };
-        let builder = if let Some(endpoint_url) = &options.aws_endpoint_url {
+        let env_endpoint_url = std::env::var("AWS_ENDPOINT_URL_S3")
+            .ok()
+            .or_else(|| std::env::var("AWS_ENDPOINT_URL").ok());
+        let builder = if let Some(endpoint_url) = options
+            .aws_endpoint_url
+            .as_ref()
+            .or(env_endpoint_url.as_ref())
+        {
             builder.with_endpoint(endpoint_url)
         } else {
             builder
         };
-        let builder = if let Some(allow_http) = &options.aws_allow_http {
-            builder.with_allow_http(*allow_http)
+        let env_allow_http = std::env::var("AWS_ALLOW_HTTP")
+            .ok()
+            .map(|s| s.trim().eq_ignore_ascii_case("true"));
+        let builder = if let Some(allow_http) = options.aws_allow_http.or(env_allow_http) {
+            builder.with_allow_http(allow_http)
         } else {
             builder
         };

--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -102,23 +102,37 @@ pub async fn create_object_store_client(
         } else {
             builder
         };
-        let env_endpoint_url = std::env::var("AWS_ENDPOINT_URL_S3")
-            .ok()
-            .or_else(|| std::env::var("AWS_ENDPOINT_URL").ok());
-        let builder = if let Some(endpoint_url) = options
-            .aws_endpoint_url
-            .as_ref()
-            .or(env_endpoint_url.as_ref())
-        {
-            builder.with_endpoint(endpoint_url)
-        } else {
-            builder
-        };
         let env_allow_http = std::env::var("AWS_ALLOW_HTTP")
             .ok()
             .map(|s| s.trim().eq_ignore_ascii_case("true"));
-        let builder = if let Some(allow_http) = options.aws_allow_http.or(env_allow_http) {
+        let allow_insecure_http = options.aws_allow_http.or(env_allow_http);
+        let builder = if let Some(allow_http) = allow_insecure_http {
             builder.with_allow_http(allow_http)
+        } else {
+            builder
+        };
+        let env_endpoint_url = std::env::var("AWS_ENDPOINT_URL_S3")
+            .ok()
+            .or_else(|| std::env::var("AWS_ENDPOINT_URL").ok());
+        let s3_endpoint = options
+            .aws_endpoint_url
+            .as_ref()
+            .or(env_endpoint_url.as_ref());
+        if !env_allow_http.unwrap_or_default()
+            && s3_endpoint.is_some_and(|endpoint| {
+                Url::parse(endpoint).is_ok_and(|url| url.scheme().eq_ignore_ascii_case("http"))
+            })
+        {
+            anyhow::bail!(
+                "Misconfiguration detected: an HTTP endpoint URL \"{}\" override is set for object \
+                store destination \"{}\", but plain HTTP is not allowed. Please set 'aws-allow-http' \
+                to `true` to enable this destination",
+                s3_endpoint.expect("is some"),
+                destination
+            );
+        }
+        let builder = if let Some(endpoint_url) = s3_endpoint {
+            builder.with_endpoint(endpoint_url)
         } else {
             builder
         };


### PR DESCRIPTION
It's easy to miss a warning in the startup logs; since this could lead to data loss, I thought it's better to complain loudly and stop:

```
~/restate/restate chore/support-global-aws-env-defaults* ❯ AWS_ENDPOINT_URL_S3=http://minio:9000 RESTATE_WORKER__SNAPSHOTS__DESTINATION=s3://bucket/snapshots restate-server --default-num-partitions 1

...

2025-03-10T12:18:32.403583Z INFO restate_server
  Starting Restate Server 1.2.2-dev (debug) (7eeb6143c aarch64-apple-darwin 2025-03-10)
    node_name: "Pavels-MacBook-Pro-2.local"
    config_source: [default]
    base_dir: /Users/pavel/restate/restate/restate-data/Pavels-MacBook-Pro-2.local/
on main
2025-03-10T12:18:32.591063Z ERROR restate_server
  Restate application failed
    error: building worker failed: failed creating worker: failed constructing partition snapshot repository: Misconfiguration detected: an HTTP endpoint URL http://minio:9000 override is set for object store destination s3://bucket/snapshots, but plain HTTP is not allowed. Please set allow HTTP to `true` to continue
    restate.error.code: None
    Visit https://docs.restate.dev/references/errors#None for more info about this error.
on main
```

Additionally, this PR also enables some standard AWS SDK environment variables to be used as fallback defaults - see https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html.

It might be useful at some point to propagate the dev/production profile into a hidden field in the `CommonOptions` struct so that we can make better config decisions on the fly deeper into the server construction. WDYT?