### PR TITLE
[Core] Decouple connector from service discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6589,6 +6589,7 @@ dependencies = [
  "prost-types",
  "rand 0.9.0",
  "restate-core-derive",
+ "restate-futures-util",
  "restate-object-store-util",
  "restate-test-util",
  "restate-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9099,6 +9099,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -10251,6 +10252,8 @@ dependencies = [
  "uuid",
  "zerocopy 0.7.35",
  "zeroize",
+ "zstd 0.13.2",
+ "zstd-safe 7.2.1",
  "zstd-sys",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,9 +15,10 @@ options_schema = ["dep:schemars"]
 [dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
-restate-types = { workspace = true }
 restate-core-derive = { workspace = true, optional = true }
+restate-futures-util = { workspace = true }
 restate-object-store-util = { workspace = true }
+restate-types = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -61,7 +61,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tokio-util = { workspace = true, features = ["net"] }
-tonic = { workspace = true, features = [ "transport", "codegen", "prost", "gzip", ] }
+tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip", "zstd"] }
 tonic-reflection = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -12,34 +12,29 @@ use std::sync::Arc;
 use std::sync::Weak;
 use std::time::Duration;
 
-use enum_map::{EnumMap, enum_map};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::time::Instant;
-use tracing::{debug, trace};
 
+use restate_types::GenerationalNodeId;
 use restate_types::net::ProtocolVersion;
 use restate_types::net::codec::Targeted;
 use restate_types::net::codec::WireEncode;
-use restate_types::net::metadata::MetadataKind;
 use restate_types::protobuf::node::Header;
-use restate_types::protobuf::node::Message;
-use restate_types::protobuf::node::message;
-use restate_types::{GenerationalNodeId, Version};
 
 use super::NetworkError;
 use super::Outgoing;
-use crate::Metadata;
+use super::io::{CloseReason, EgressMessage, EgressSender};
 
 pub struct OwnedSendPermit<M> {
     _protocol_version: ProtocolVersion,
-    _permit: mpsc::OwnedPermit<Message>,
+    _permit: mpsc::OwnedPermit<EgressMessage>,
     _phantom: std::marker::PhantomData<M>,
 }
 
 pub struct SendPermit<'a, M> {
     protocol_version: ProtocolVersion,
-    permit: mpsc::Permit<'a, Message>,
+    permit: mpsc::Permit<'a, EgressMessage>,
     _phantom: std::marker::PhantomData<M>,
 }
 
@@ -51,40 +46,18 @@ where
     ///
     /// Note that sending messages over this permit won't use the peer information nor the connection
     /// associated with the message.
-    pub fn send<S>(self, message: Outgoing<M, S>, metadata: &Metadata) {
-        let metadata_versions = HeaderMetadataVersions::from_metadata(metadata);
-        self.send_with_versions(message, metadata_versions);
-    }
+    pub fn send<S>(self, message: Outgoing<M, S>) {
+        let header = Header {
+            msg_id: message.msg_id(),
+            in_response_to: message.in_response_to(),
+            ..Default::default()
+        };
 
-    fn send_with_versions<S>(
-        self,
-        message: Outgoing<M, S>,
-        metadata_versions: HeaderMetadataVersions,
-    ) {
-        let header = Header::new(
-            metadata_versions[MetadataKind::NodesConfiguration]
-                .expect("nodes configuration version must be set"),
-            metadata_versions[MetadataKind::Logs],
-            metadata_versions[MetadataKind::Schema],
-            metadata_versions[MetadataKind::PartitionTable],
-            message.msg_id(),
-            message.in_response_to(),
-        );
         let body = message
             .into_body()
             .encode(self.protocol_version)
             .expect("message encoding infallible");
-        self.send_raw(Message::new(header, body));
-    }
-}
-
-impl<M> SendPermit<'_, M> {
-    /// Sends a raw pre-serialized message over this permit.
-    ///
-    /// Note that sending messages over this permit won't use the peer information nor the connection
-    /// associated with the message.
-    pub(crate) fn send_raw(self, raw_message: Message) {
-        self.permit.send(raw_message);
+        self.permit.send(EgressMessage::Message(header, body));
     }
 }
 
@@ -98,7 +71,7 @@ impl<M> SendPermit<'_, M> {
 pub struct OwnedConnection {
     pub(crate) peer: GenerationalNodeId,
     pub(crate) protocol_version: ProtocolVersion,
-    pub(crate) sender: mpsc::Sender<Message>,
+    pub(crate) sender: EgressSender,
     pub(crate) created: Instant,
 }
 
@@ -106,7 +79,7 @@ impl OwnedConnection {
     pub(crate) fn new(
         peer: GenerationalNodeId,
         protocol_version: ProtocolVersion,
-        sender: mpsc::Sender<Message>,
+        sender: EgressSender,
     ) -> Self {
         Self {
             peer,
@@ -116,13 +89,28 @@ impl OwnedConnection {
         }
     }
 
+    pub fn id(&self) -> u64 {
+        self.sender.cid
+    }
+
     #[cfg(any(test, feature = "test-util"))]
     pub fn new_fake(
         peer: GenerationalNodeId,
         protocol_version: ProtocolVersion,
-        sender: mpsc::Sender<Message>,
-    ) -> Arc<Self> {
-        Arc::new(Self::new(peer, protocol_version, sender))
+        capacity: usize,
+    ) -> (
+        Arc<Self>,
+        super::io::EgressStream,
+        super::io::DropEgressStream,
+    ) {
+        use super::io::EgressStream;
+
+        let (sender, egress, drop_egress) = EgressStream::create(capacity);
+        (
+            Arc::new(Self::new(peer, protocol_version, sender)),
+            egress,
+            drop_egress,
+        )
     }
 
     /// The node id at the other end of this connection
@@ -145,18 +133,8 @@ impl OwnedConnection {
         async move { sender.closed().await }
     }
 
-    /// Best-effort delivery of signals on the connection.
-    pub fn send_control_frame(&self, control: message::ConnectionControl) {
-        let signal = control.signal();
-        let msg = Message {
-            header: None,
-            body: Some(control.into()),
-        };
-
-        debug!(?msg, "Sending control frame to peer");
-        if self.sender.try_send(msg).is_ok() {
-            trace!(?signal, "Control frame was written to connection");
-        }
+    pub(crate) fn close(&self, reason: CloseReason) {
+        self.sender.close(reason)
     }
 
     /// A handle that sends messages through that connection. This hides the
@@ -223,37 +201,6 @@ impl OwnedConnection {
     }
 }
 
-#[derive(derive_more::Index)]
-pub(crate) struct HeaderMetadataVersions {
-    #[index]
-    versions: EnumMap<MetadataKind, Option<Version>>,
-}
-
-impl Default for HeaderMetadataVersions {
-    // Used primarily in tests
-    fn default() -> Self {
-        let versions = enum_map! {
-            MetadataKind::NodesConfiguration => Some(Version::MIN),
-            MetadataKind::Schema => None,
-            MetadataKind::Logs => None,
-            MetadataKind::PartitionTable => None,
-        };
-        Self { versions }
-    }
-}
-
-impl HeaderMetadataVersions {
-    pub fn from_metadata(metadata: &Metadata) -> Self {
-        let versions = enum_map! {
-            MetadataKind::NodesConfiguration => Some(metadata.nodes_config_version()),
-            MetadataKind::Schema => Some(metadata.schema_version()),
-            MetadataKind::Logs => Some(metadata.logs_version()),
-            MetadataKind::PartitionTable => Some(metadata.partition_table_version()),
-        };
-        Self { versions }
-    }
-}
-
 impl PartialEq for OwnedConnection {
     fn eq(&self, other: &Self) -> bool {
         self.sender.same_channel(&other.sender)
@@ -281,13 +228,6 @@ impl WeakConnection {
     /// The node id at the other end of this connection
     pub fn peer(&self) -> GenerationalNodeId {
         self.peer
-    }
-
-    pub fn is_closed(&self) -> bool {
-        self.connection
-            .upgrade()
-            .map(|c| c.is_closed())
-            .unwrap_or(true)
     }
 
     /// Resolves when the connection is closed
@@ -319,7 +259,6 @@ pub mod test_util {
     use futures::stream::BoxStream;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::error::TrySendError;
-    use tokio_stream::wrappers::ReceiverStream;
     use tracing::info;
     use tracing::warn;
 
@@ -336,7 +275,6 @@ pub mod test_util {
     use restate_types::protobuf::node::message;
     use restate_types::protobuf::node::message::BinaryMessage;
     use restate_types::protobuf::node::message::Body;
-    use restate_types::protobuf::node::message::ConnectionControl;
     use restate_types::{GenerationalNodeId, Version};
 
     use crate::TaskCenter;
@@ -353,6 +291,8 @@ pub mod test_util {
     use crate::network::ProtocolError;
     use crate::network::handshake::negotiate_protocol_version;
     use crate::network::handshake::wait_for_hello;
+    use crate::network::io::DropEgressStream;
+    use crate::network::io::EgressStream;
 
     // For testing
     //
@@ -368,11 +308,14 @@ pub mod test_util {
         /// The Id of the node we are connected to
         pub(crate) peer: GenerationalNodeId,
         pub protocol_version: ProtocolVersion,
-        pub sender: mpsc::Sender<Message>,
+        #[debug(skip)]
+        pub(crate) sender: EgressSender,
         pub created: Instant,
 
         #[debug(skip)]
         pub recv_stream: BoxStream<'static, Message>,
+        #[debug(skip)]
+        drop_egress: DropEgressStream,
     }
 
     impl MockPeerConnection {
@@ -384,22 +327,18 @@ pub mod test_util {
             connection_manager: &ConnectionManager,
             message_buffer: usize,
         ) -> anyhow::Result<Self> {
-            let (sender, rx) = mpsc::channel(message_buffer);
-            let incoming = ReceiverStream::new(rx).map(Ok);
+            let (sender, incoming, drop_egress) = EgressStream::create(message_buffer);
+            let incoming = incoming.map(Ok);
 
             let hello = Hello::new(from_node_id, my_cluster_name);
-            let hello = Message::new(
-                Header::new(
-                    my_node_config_version,
-                    None,
-                    None,
-                    None,
-                    crate::network::generate_msg_id(),
-                    None,
-                ),
-                hello,
-            );
-            sender.send(hello).await?;
+            let header = Header {
+                my_nodes_config_version: Some(my_node_config_version.into()),
+                msg_id: crate::network::generate_msg_id(),
+                ..Default::default()
+            };
+            sender
+                .send(EgressMessage::Message(header, hello.into()))
+                .await?;
 
             let created = Instant::now();
             let mut recv_stream = connection_manager
@@ -424,6 +363,7 @@ pub mod test_util {
                 sender,
                 recv_stream: Box::pin(recv_stream),
                 created,
+                drop_egress,
             })
         }
 
@@ -432,12 +372,16 @@ pub mod test_util {
         where
             M: WireEncode + Targeted,
         {
-            let body = message
-                .encode(self.protocol_version)
-                .expect("serde infallible");
-            let message = Message::new(header, body);
+            let message = Message {
+                header: Some(header),
+                body: Some(
+                    message
+                        .encode(self.protocol_version)
+                        .expect("serde infallible"),
+                ),
+            };
 
-            self.sender.send(message).await?;
+            self.sender.send(EgressMessage::RawMessage(message)).await?;
 
             Ok(())
         }
@@ -515,6 +459,7 @@ pub mod test_util {
                 sender,
                 created,
                 recv_stream,
+                drop_egress,
             } = self;
 
             let connection = Arc::new(OwnedConnection {
@@ -534,7 +479,7 @@ pub mod test_util {
             let handle = TaskCenter::spawn_unmanaged(
                 TaskKind::ConnectionReactor,
                 "test-message-processor",
-                async move { message_processor.run().await },
+                async move { message_processor.run(drop_egress).await },
             )?;
             Ok((weak, handle))
         }
@@ -563,11 +508,14 @@ pub mod test_util {
         pub my_node_id: GenerationalNodeId,
         /// The Id of the node id that started this connection
         pub(crate) peer: GenerationalNodeId,
-        pub sender: mpsc::Sender<Message>,
+        #[debug(skip)]
+        pub(crate) sender: EgressSender,
         pub created: Instant,
 
         #[debug(skip)]
         pub recv_stream: BoxStream<'static, Message>,
+        #[debug(skip)]
+        pub(crate) drop_egress: DropEgressStream,
     }
 
     impl PartialPeerConnection {
@@ -583,6 +531,7 @@ pub mod test_util {
                 sender,
                 created,
                 mut recv_stream,
+                drop_egress,
             } = self;
             let temp_stream = recv_stream.by_ref();
             let (header, hello) = wait_for_hello(
@@ -606,18 +555,15 @@ pub mod test_util {
             // Enqueue the welcome message
             let welcome = Welcome::new(my_node_id, selected_protocol_version);
 
-            let welcome = Message::new(
-                Header::new(
-                    nodes_config.version(),
-                    None,
-                    None,
-                    None,
-                    crate::network::generate_msg_id(),
-                    Some(header.msg_id),
-                ),
-                welcome,
+            let header = Header::new(
+                nodes_config.version(),
+                None,
+                None,
+                None,
+                crate::network::generate_msg_id(),
+                Some(header.msg_id),
             );
-            sender.try_send(welcome)?;
+            sender.try_send(EgressMessage::Message(header, welcome.into()))?;
 
             Ok(MockPeerConnection {
                 my_node_id,
@@ -626,6 +572,7 @@ pub mod test_util {
                 sender,
                 created,
                 recv_stream,
+                drop_egress,
             })
         }
     }
@@ -676,7 +623,7 @@ pub mod test_util {
     }
 
     impl<R: Handler> MessageProcessor<R> {
-        async fn run(mut self) -> anyhow::Result<()> {
+        async fn run(mut self, _drop_egress: DropEgressStream) -> anyhow::Result<()> {
             let mut cancel = std::pin::pin!(cancellation_watcher());
             loop {
                 tokio::select! {
@@ -691,8 +638,8 @@ pub mod test_util {
                         };
                         //  header is required on all messages
                         let Some(header) = msg.header else {
-                            self.connection.send_control_frame(ConnectionControl::codec_error(
-                                "Header is missing on message",
+                            self.connection.close(CloseReason::CodecError(
+                                "Header is missing on message".to_owned(),
                             ));
                             break;
                         };
@@ -700,14 +647,14 @@ pub mod test_util {
                         // body are not allowed to be empty.
                         let Some(body) = msg.body else {
                             self.connection
-                                .send_control_frame(ConnectionControl::codec_error("Body is missing on message"));
+                                .close(CloseReason::CodecError("Body is missing on message".to_owned()));
                             break;
                         };
 
                         // Welcome and hello are not allowed after handshake
                         if body.is_welcome() || body.is_hello() {
-                            self.connection.send_control_frame(ConnectionControl::codec_error(
-                                "Hello/Welcome are not allowed after handshake",
+                            self.connection.close(CloseReason::CodecError(
+                                "Hello/Welcome are not allowed after handshake".to_string(),
                             ));
                             break;
                         };
@@ -754,7 +701,7 @@ pub mod test_util {
                     // terminate the stream
                     info!("Error processing message, reporting error to peer: {status}");
                     self.connection
-                        .send_control_frame(ConnectionControl::codec_error(status.to_string()));
+                        .close(CloseReason::CodecError(status.to_string()));
                 }
             }
             Ok(())

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -316,6 +316,7 @@ impl ConnectionManager {
         let my_node_id = metadata.my_node_id();
         let nodes_config = metadata.nodes_config_snapshot();
         let cluster_name = nodes_config.cluster_name().to_owned();
+        let address = nodes_config.find_node_by_id(node_id)?.address.clone();
 
         let (tx, egress, drop_egress) = EgressStream::create(
             Configuration::pinned()
@@ -331,10 +332,9 @@ impl ConnectionManager {
             .await
             .unwrap();
 
+        trace!("Attempting to connect to node {} at {}", node_id, address);
         // Establish the connection
-        let mut incoming = transport_connector
-            .connect(node_id, &nodes_config, egress)
-            .await?;
+        let mut incoming = transport_connector.connect(address, egress).await?;
         // finish the handshake
         let (_header, welcome) = wait_for_welcome(
             &mut incoming,

--- a/crates/core/src/network/grpc/connector.rs
+++ b/crates/core/src/network/grpc/connector.rs
@@ -9,18 +9,23 @@
 // by the Apache License, Version 2.0.
 
 use futures::Stream;
+use http::Uri;
+use hyper_util::rt::TokioIo;
+use tokio::io;
+use tokio::net::UnixStream;
 use tokio_stream::StreamExt;
+use tonic::codec::CompressionEncoding;
+use tonic::transport::channel::Channel;
 
-use restate_types::GenerationalNodeId;
-use restate_types::config::Configuration;
-use restate_types::nodes_config::NodesConfiguration;
+use restate_types::config::{Configuration, NetworkingOptions};
+use restate_types::net::AdvertisedAddress;
 use restate_types::protobuf::node::Message;
-use tracing::trace;
+use tonic::transport::Endpoint;
 
 use super::MAX_MESSAGE_SIZE;
-use crate::network::net_util::create_tonic_channel;
 use crate::network::protobuf::core_node_svc::core_node_svc_client::CoreNodeSvcClient;
 use crate::network::{NetworkError, ProtocolError, TransportConnect};
+use crate::{TaskCenter, TaskKind};
 
 #[derive(Clone)]
 pub struct GrpcConnector;
@@ -28,23 +33,80 @@ pub struct GrpcConnector;
 impl TransportConnect for GrpcConnector {
     async fn connect(
         &self,
-        node_id: GenerationalNodeId,
-        nodes_config: &NodesConfiguration,
+        address: AdvertisedAddress,
         output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
     ) -> Result<
         impl Stream<Item = Result<Message, ProtocolError>> + Send + Unpin + 'static,
         NetworkError,
     > {
-        let address = nodes_config.find_node_by_id(node_id)?.address.clone();
-
-        trace!("Attempting to connect to node {} at {}", node_id, address);
-        let channel = create_tonic_channel(address, &Configuration::pinned().networking);
+        let channel = create_channel(address, &Configuration::pinned().networking);
 
         // Establish the connection
         let mut client = CoreNodeSvcClient::new(channel)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
-            .max_decoding_message_size(MAX_MESSAGE_SIZE);
+            .max_decoding_message_size(MAX_MESSAGE_SIZE)
+            // note: the order of those calls defines the priority
+            .accept_compressed(CompressionEncoding::Zstd)
+            .accept_compressed(CompressionEncoding::Gzip)
+            .send_compressed(CompressionEncoding::Zstd)
+            .send_compressed(CompressionEncoding::Gzip);
         let incoming = client.create_connection(output_stream).await?.into_inner();
         Ok(incoming.map(|x| x.map_err(ProtocolError::from)))
+    }
+}
+
+fn create_channel(address: AdvertisedAddress, options: &NetworkingOptions) -> Channel {
+    let endpoint = match &address {
+        AdvertisedAddress::Uds(_) => {
+            // dummy endpoint required to specify an uds connector, it is not used anywhere
+            Endpoint::try_from("http://127.0.0.1").expect("/ should be a valid Uri")
+        }
+        AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()).executor(TaskCenterExecutor),
+    };
+
+    let endpoint = endpoint
+        .user_agent(format!(
+            "restate/{}",
+            option_env!("CARGO_PKG_VERSION").unwrap_or("dev")
+        ))
+        .unwrap()
+        .connect_timeout(*options.connect_timeout)
+        .http2_keep_alive_interval(*options.http2_keep_alive_interval)
+        .keep_alive_timeout(*options.http2_keep_alive_timeout)
+        .http2_adaptive_window(options.http2_adaptive_window)
+        .keep_alive_while_idle(true)
+        // We have a single owner for the underlying Buffer service. Change this if we moved to
+        // sharing the channel across multiple connections/streams.
+        .buffer_size(1)
+        // this true by default, but this is to guard against any change in defaults
+        .tcp_nodelay(true);
+
+    match address {
+        AdvertisedAddress::Uds(uds_path) => {
+            endpoint.connect_with_connector_lazy(tower::service_fn(move |_: Uri| {
+                let uds_path = uds_path.clone();
+                async move {
+                    Ok::<_, io::Error>(TokioIo::new(UnixStream::connect(uds_path).await?))
+                }
+            }))
+        }
+        AdvertisedAddress::Http(_) => endpoint.connect_lazy()
+    }
+}
+
+#[derive(Clone, Default)]
+struct TaskCenterExecutor;
+
+impl<F> hyper::rt::Executor<F> for TaskCenterExecutor
+where
+    F: Future + 'static + Send,
+    F::Output: Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        let _ = TaskCenter::spawn_child(TaskKind::H2Stream, "h2stream", async move {
+            // ignore the future output
+            let _ = fut.await;
+            Ok(())
+        });
     }
 }

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -34,7 +34,10 @@ impl CoreNodeSvcHandler {
         CoreNodeSvcServer::new(self)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
             .max_encoding_message_size(MAX_MESSAGE_SIZE)
+            // note: the order of those calls defines the priority
+            .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)
+            .send_compressed(CompressionEncoding::Zstd)
             .send_compressed(CompressionEncoding::Gzip)
     }
 }

--- a/crates/core/src/network/io/egress_sender.rs
+++ b/crates/core/src/network/io/egress_sender.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
+
+use futures::FutureExt;
+use tokio::sync::{mpsc, oneshot};
+use tracing::trace;
+
+use super::{CloseReason, EgressMessage};
+
+#[derive(Debug, thiserror::Error)]
+#[error("connection closed")]
+pub struct ConnectionClosed;
+
+/// A future to track if an enqueued messages was sent over the socket or not. Note that the
+/// send operation will be attempted regardless this token was dropped or not.
+pub struct SendToken(oneshot::Receiver<()>);
+
+/// Dropped means the message was not sent and the stream was closed
+pub struct SendNotifier(oneshot::Sender<()>);
+
+impl SendNotifier {
+    pub fn create() -> (SendNotifier, SendToken) {
+        let (tx, rx) = oneshot::channel();
+        (SendNotifier(tx), SendToken(rx))
+    }
+
+    /// Notifes the receiver if not dropped
+    pub fn notify(self) {
+        let _ = self.0.send(());
+    }
+}
+
+impl Future for SendToken {
+    type Output = Result<(), ConnectionClosed>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match ready!(self.0.poll_unpin(cx)) {
+            Ok(_) => Poll::Ready(Ok(())),
+            Err(_) => Poll::Ready(Err(ConnectionClosed)),
+        }
+    }
+}
+
+#[derive(derive_more::Deref, Clone)]
+pub struct EgressSender {
+    pub(crate) cid: u64,
+    #[deref]
+    pub(crate) inner: mpsc::Sender<EgressMessage>,
+}
+
+impl EgressSender {
+    // temporary, will be replaced in future work
+    pub async fn reserve_owned(
+        self,
+    ) -> Result<mpsc::OwnedPermit<EgressMessage>, mpsc::error::SendError<()>> {
+        self.inner.reserve_owned().await
+    }
+
+    /// Starts a drain of this stream. Existing enqueued messages will be sent before
+    /// terminating but no new messages will be accepted.
+    pub fn close(&self, reason: CloseReason) {
+        if self
+            .inner
+            // todo: replace with send after moving to unbounded channel
+            .try_send(EgressMessage::Close(CloseReason::Shutdown))
+            .is_ok()
+        {
+            trace!(cid = %self.cid, ?reason, "Drain message was enqueued to egress stream");
+        }
+    }
+}

--- a/crates/core/src/network/io/egress_stream.rs
+++ b/crates/core/src/network/io/egress_stream.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
+use std::task::{Context, Poll, ready};
+
+use futures::{FutureExt, Stream};
+use tokio::sync::{mpsc, oneshot};
+
+use restate_types::Versioned;
+use restate_types::live::Live;
+use restate_types::logs::metadata::Logs;
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partition_table::PartitionTable;
+use restate_types::protobuf::node::message::ConnectionControl;
+use restate_types::protobuf::node::{Header, Message, message::Body};
+use restate_types::schema::Schema;
+
+use super::EgressSender;
+use super::egress_sender::SendNotifier;
+use crate::Metadata;
+
+/// A handle to drop the egress stream remotely, or to be notified if the egress stream has been
+/// terminated via other means.
+// todo: make pub(crate) after its usage in tests is removed
+pub struct DropEgressStream(oneshot::Receiver<Infallible>);
+
+impl DropEgressStream {
+    /// same effect as dropping, closing the egress stream and dropping any messages in the buffer
+    pub fn close(&mut self) {
+        self.0.close();
+    }
+}
+
+impl Future for DropEgressStream {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match ready!(self.0.poll_unpin(cx)) {
+            Ok(_) => unreachable!(),
+            Err(_) => Poll::Ready(()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CloseReason {
+    /// Node will shutdown and never come back
+    Shutdown,
+    /// Only this connection is terminating
+    ConnectionDrain,
+    CodecError(String),
+}
+
+impl From<CloseReason> for Body {
+    fn from(value: CloseReason) -> Self {
+        match value {
+            CloseReason::Shutdown => ConnectionControl::shutdown().into(),
+            CloseReason::ConnectionDrain => ConnectionControl::connection_reset().into(),
+            CloseReason::CodecError(e) => ConnectionControl::codec_error(e).into(),
+        }
+    }
+}
+
+// todo: make this pub(crate) when OwnedConnection::new_fake() stops needing it
+pub enum EgressMessage {
+    #[cfg(any(test, feature = "test-util"))]
+    /// An egress message to send to peer. Used only in tests, header must be populated correctly
+    /// by sender
+    RawMessage(Message),
+    /// An egress body to send to peer, header is populated by egress stream
+    Message(Header, Body),
+    /// The message that requires an ack that it was sent
+    WithNotifer(Body, SendNotifier),
+    /// A signal to close the inner stream. The inner stream cannot receive further messages but
+    /// we'll continue to drain all buffered messages before droppingx
+    Close(CloseReason),
+}
+
+struct MetadataVersionCache {
+    nodes_config: Live<NodesConfiguration>,
+    schema: Live<Schema>,
+    partition_table: Live<PartitionTable>,
+    logs_metadata: Live<Logs>,
+}
+
+impl MetadataVersionCache {
+    fn new() -> Self {
+        let metadata = Metadata::current();
+        Self {
+            nodes_config: metadata.updateable_nodes_config(),
+            schema: metadata.updateable_schema(),
+            partition_table: metadata.updateable_partition_table(),
+            logs_metadata: metadata.updateable_logs_metadata(),
+        }
+    }
+
+    fn fill_header(&mut self, header: &mut Header) {
+        header.my_nodes_config_version = Some(self.nodes_config.live_load().version().into());
+        header.my_schema_version = Some(self.schema.live_load().version().into());
+        header.my_partition_table_version = Some(self.partition_table.live_load().version().into());
+        header.my_logs_version = Some(self.logs_metadata.live_load().version().into());
+    }
+}
+
+/// Egress stream is the egress side of the message fabric. The stream is driven externally
+/// (currently tonic/hyper) to stream messages to a peer. In the normal case, it populates the
+/// appropriate headers by efficiently fetching latest metadata versions. It also provides a
+/// mechanism to externally drain or force-terminate.
+///
+/// This stream will also handle outgoing rpc call mapping in future changes.
+// todo: make pub(crate) after its usage in tests is removed
+pub struct EgressStream {
+    // connection identifier, local to this node, used to tie egress with ingress streams and
+    // identify the connection in logs.
+    #[allow(dead_code)]
+    cid: u64,
+    inner: Option<mpsc::Receiver<EgressMessage>>,
+    /// The sole purpose of this channel, is to force drop the egress channel even if the inner stream's
+    /// didn't wake us up. For instance, if there is no available space on the socket's sendbuf and
+    /// we still want to drop this stream. We'll signal this receiver instead of the inline
+    /// PoisonPill. This results a wake-up to drop all buffered messages and releasing the inner
+    /// stream.
+    drop_notification: Option<oneshot::Sender<Infallible>>,
+    metadata_cache: MetadataVersionCache,
+}
+
+impl EgressStream {
+    pub fn create(capacity: usize) -> (EgressSender, Self, DropEgressStream) {
+        static NEXT_CID: AtomicU64 = const { AtomicU64::new(1) };
+
+        let cid = NEXT_CID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let (tx, rx) = mpsc::channel(capacity);
+        let (drop_tx, drop_rx) = oneshot::channel();
+        (
+            EgressSender { cid, inner: tx },
+            Self {
+                cid,
+                inner: Some(rx),
+                drop_notification: Some(drop_tx),
+                metadata_cache: MetadataVersionCache::new(),
+            },
+            DropEgressStream(drop_rx),
+        )
+    }
+}
+
+impl EgressStream {
+    fn terminate_stream(&mut self) {
+        self.inner.take();
+        self.drop_notification.take();
+    }
+}
+
+impl Stream for EgressStream {
+    type Item = Message;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.drop_notification {
+            // This is a terminated stream already
+            None => {
+                self.terminate_stream();
+                return Poll::Ready(None);
+            }
+            Some(ref mut drop_notification) => {
+                match drop_notification.poll_closed(cx) {
+                    Poll::Ready(()) => {
+                        // drop has been requested, we'll immediately drop the inner sender and
+                        // terminate this stream
+                        self.terminate_stream();
+                        return Poll::Ready(None);
+                    }
+                    // fall-through to read the inner stream
+                    Poll::Pending => {}
+                }
+            }
+        }
+
+        match self.inner {
+            Some(ref mut inner) => {
+                match ready!(inner.poll_recv(cx)) {
+                    #[cfg(any(test, feature = "test-util"))]
+                    Some(EgressMessage::RawMessage(msg)) => Poll::Ready(Some(msg)),
+                    Some(EgressMessage::Message(mut header, body)) => {
+                        self.metadata_cache.fill_header(&mut header);
+                        let msg = Message {
+                            header: Some(header),
+                            body: Some(body),
+                        };
+                        Poll::Ready(Some(msg))
+                    }
+                    Some(EgressMessage::WithNotifer(body, notifier)) => {
+                        let mut header = Header::default();
+                        self.metadata_cache.fill_header(&mut header);
+                        let msg = Message {
+                            header: Some(header),
+                            body: Some(body),
+                        };
+                        notifier.notify();
+                        Poll::Ready(Some(msg))
+                    }
+                    Some(EgressMessage::Close(reason)) => {
+                        // No new messages can be enqueued, and we'll continue to drain
+                        // already enqueued messages.
+                        //
+                        // reactor will only know when the stream is terminated.
+                        inner.close();
+                        let mut header = Header::default();
+                        self.metadata_cache.fill_header(&mut header);
+                        let msg = Message {
+                            header: Some(header),
+                            body: Some(reason.into()),
+                        };
+                        Poll::Ready(Some(msg))
+                    }
+                    None => {
+                        self.terminate_stream();
+                        Poll::Ready(None)
+                    }
+                }
+            }
+            None => {
+                self.terminate_stream();
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.inner {
+            Some(ref inner) => (inner.len(), None),
+            None => (0, None),
+        }
+    }
+}

--- a/crates/core/src/network/io/mod.rs
+++ b/crates/core/src/network/io/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod egress_sender;
+mod egress_stream;
+
+pub use egress_sender::EgressSender;
+pub use egress_stream::{CloseReason, DropEgressStream, EgressMessage, EgressStream};

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -13,6 +13,7 @@ mod connection_manager;
 mod error;
 pub mod grpc;
 mod handshake;
+mod io;
 mod message_router;
 pub(crate) mod metric_definitions;
 mod multiplex;

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -40,7 +40,7 @@ pub fn create_tonic_channel<T: CommonClientConnectionOptions + Send + Sync + ?Si
             // dummy endpoint required to specify an uds connector, it is not used anywhere
             Endpoint::try_from("http://127.0.0.1").expect("/ should be a valid Uri")
         }
-        AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()),
+        AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()).executor(TaskCenterExecutor),
     };
 
     let endpoint = apply_options(endpoint, options);
@@ -189,6 +189,7 @@ where
     let mut configuration = Configuration::updateable();
     let mut shutdown = std::pin::pin!(cancellation_watcher());
     let graceful_shutdown = GracefulShutdown::new();
+    let task_name: Arc<str> = Arc::from(format!("{}-socket", server_name));
     loop {
         tokio::select! {
             biased;
@@ -215,7 +216,7 @@ where
                 let connection = graceful_shutdown.watch(builder
                     .serve_connection(io, service.clone()).into_owned());
 
-                TaskCenter::spawn(TaskKind::SocketHandler, server_name, async move {
+                TaskCenter::spawn(TaskKind::SocketHandler, task_name.clone(), async move {
                     debug!("New connection accepted");
                     if let Err(e) = connection.await {
                         if let Some(hyper_error) = e.downcast_ref::<hyper::Error>() {

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -40,7 +40,7 @@ pub fn create_tonic_channel<T: CommonClientConnectionOptions + Send + Sync + ?Si
             // dummy endpoint required to specify an uds connector, it is not used anywhere
             Endpoint::try_from("http://127.0.0.1").expect("/ should be a valid Uri")
         }
-        AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()).executor(TaskCenterExecutor),
+        AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()),
     };
 
     let endpoint = apply_options(endpoint, options);

--- a/crates/core/src/network/streams.rs
+++ b/crates/core/src/network/streams.rs
@@ -1,0 +1,267 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
+use std::task::{Context, Poll, ready};
+
+use futures::{FutureExt, Stream};
+use tokio::sync::{mpsc, oneshot};
+use tracing::trace;
+
+use restate_types::Versioned;
+use restate_types::live::Live;
+use restate_types::logs::metadata::Logs;
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partition_table::PartitionTable;
+use restate_types::protobuf::node::message::ConnectionControl;
+use restate_types::protobuf::node::{Header, Message, message::Body};
+use restate_types::schema::Schema;
+
+use crate::Metadata;
+
+/// A handle to drop the egress stream remotely, or to be notified if the egress stream has been
+/// terminated via other means.
+// todo: make pub(crate) after its usage in tests is removed
+pub struct DropEgressStream(oneshot::Receiver<Infallible>);
+
+impl DropEgressStream {
+    /// same effect as dropping, closing the egress stream and dropping any messages in the buffer
+    pub fn close(&mut self) {
+        self.0.close();
+    }
+}
+
+impl Future for DropEgressStream {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match ready!(self.0.poll_unpin(cx)) {
+            Ok(_) => unreachable!(),
+            Err(_) => Poll::Ready(()),
+        }
+    }
+}
+
+pub enum DrainReason {
+    /// Node will shutdown and never come back
+    Shutdown,
+    /// Only this connection is terminating
+    ConnectionReset,
+}
+
+impl From<DrainReason> for Body {
+    fn from(value: DrainReason) -> Self {
+        match value {
+            DrainReason::Shutdown => ConnectionControl::shutdown().into(),
+            DrainReason::ConnectionReset => ConnectionControl::connection_reset().into(),
+        }
+    }
+}
+
+// todo: make this pub(crate) when OwnedConnection::new_fake() stops needing it.
+pub enum EgressMessage {
+    #[cfg(any(test, feature = "test-util"))]
+    /// An egress message to send to peer. Used only in tests, header must be populated correctly
+    /// by sender.
+    RawMessage(Message),
+    /// An egress body to send to peer, header is populated by egress stream
+    Message(Header, Body),
+    /// The message that requires an ack that it was sent. The sender part of this channel can use
+    /// `closed` to wait for the notification.
+    #[allow(dead_code)]
+    MessageWithAck(Header, Body, oneshot::Receiver<Infallible>),
+    /// A signal to close the inner stream. The inner stream cannot receive further messages but
+    /// we'll continue to drain all buffered messages before dropping.
+    #[allow(dead_code)]
+    Drain(DrainReason),
+}
+
+struct MetadataVersionCache {
+    nodes_config: Live<NodesConfiguration>,
+    schema: Live<Schema>,
+    partition_table: Live<PartitionTable>,
+    logs_metadata: Live<Logs>,
+}
+
+impl MetadataVersionCache {
+    fn new() -> Self {
+        let metadata = Metadata::current();
+        Self {
+            nodes_config: metadata.updateable_nodes_config(),
+            schema: metadata.updateable_schema(),
+            partition_table: metadata.updateable_partition_table(),
+            logs_metadata: metadata.updateable_logs_metadata(),
+        }
+    }
+
+    fn fill_header(&mut self, header: &mut Header) {
+        header.my_nodes_config_version = Some(self.nodes_config.live_load().version().into());
+        header.my_schema_version = Some(self.schema.live_load().version().into());
+        header.my_partition_table_version = Some(self.partition_table.live_load().version().into());
+        header.my_logs_version = Some(self.logs_metadata.live_load().version().into());
+    }
+}
+
+#[derive(derive_more::Deref, Clone)]
+pub struct EgressSender {
+    pub(crate) cid: u64,
+    #[deref]
+    pub(crate) inner: mpsc::Sender<EgressMessage>,
+}
+
+impl EgressSender {
+    pub async fn reserve_owned(
+        self,
+    ) -> Result<mpsc::OwnedPermit<EgressMessage>, mpsc::error::SendError<()>> {
+        self.inner.reserve_owned().await
+    }
+}
+
+/// Egress stream is the egress side of the message fabric. The stream is driven externally
+/// (currently tonic/hyper) to stream messages to a peer. In the normal case, it populates the
+/// appropriate headers by efficiently fetching latest metadata versions. It also provides a
+/// mechanism to externally drain or force-terminate.
+///
+/// This stream will also handle outgoing rpc call mapping in future changes.
+// todo: make pub(crate) after its usage in tests is removed
+pub struct EgressStream {
+    // connection identifier, local to this node, used to tie egress with ingress streams and
+    // identify the connection in logs.
+    cid: u64,
+    inner: Option<mpsc::Receiver<EgressMessage>>,
+    /// The sole purpose of this channel, is to force drop the egress channel even if the inner stream's
+    /// didn't wake us up. For instance, if there is no available space on the socket's sendbuf and
+    /// we still want to drop this stream. We'll signal this receiver instead of the inline
+    /// PoisonPill. This results a wake-up to drop all buffered messages and releasing the inner
+    /// stream.
+    drop_notification: Option<oneshot::Sender<Infallible>>,
+    metadata_cache: MetadataVersionCache,
+}
+
+impl EgressStream {
+    pub fn create(capacity: usize) -> (EgressSender, Self, DropEgressStream) {
+        static NEXT_CID: AtomicU64 = const { AtomicU64::new(1) };
+
+        let cid = NEXT_CID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let (tx, rx) = mpsc::channel(capacity);
+        let (drop_tx, drop_rx) = oneshot::channel();
+        (
+            EgressSender { cid, inner: tx },
+            Self {
+                cid,
+                inner: Some(rx),
+                drop_notification: Some(drop_tx),
+                metadata_cache: MetadataVersionCache::new(),
+            },
+            DropEgressStream(drop_rx),
+        )
+    }
+}
+
+impl EgressStream {
+    fn terminate_stream(&mut self) {
+        self.inner.take();
+        self.drop_notification.take();
+    }
+}
+
+impl Stream for EgressStream {
+    type Item = Message;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.drop_notification {
+                // This is a terminated stream already
+                None => {
+                    self.terminate_stream();
+                    trace!(cid = %self.cid, "Egress stream was already terminated (drop_rx)");
+                    return Poll::Ready(None);
+                }
+                Some(ref mut drop_notification) => {
+                    match drop_notification.poll_closed(cx) {
+                        Poll::Ready(()) => {
+                            // drop has been requested, we'll immediately drop the inner sender and
+                            // terminate this stream
+                            trace!(cid = %self.cid, "Egress stream was terminated via drop_rx");
+                            self.terminate_stream();
+                            return Poll::Ready(None);
+                        }
+                        // fall-through to read the inner stream
+                        Poll::Pending => {}
+                    }
+                }
+            }
+
+            match self.inner {
+                Some(ref mut inner) => {
+                    match ready!(inner.poll_recv(cx)) {
+                        #[cfg(any(test, feature = "test-util"))]
+                        Some(EgressMessage::RawMessage(msg)) => {
+                            return Poll::Ready(Some(msg));
+                        }
+                        Some(EgressMessage::Message(mut header, body)) => {
+                            self.metadata_cache.fill_header(&mut header);
+                            let msg = Message {
+                                header: Some(header),
+                                body: Some(body),
+                            };
+                            return Poll::Ready(Some(msg));
+                        }
+                        Some(EgressMessage::MessageWithAck(mut header, body, _notify)) => {
+                            self.metadata_cache.fill_header(&mut header);
+                            let msg = Message {
+                                header: Some(header),
+                                body: Some(body),
+                            };
+                            // _notify is auto-dropped after we return the result, this sender side will
+                            // be notified then.
+                            return Poll::Ready(Some(msg));
+                        }
+                        Some(EgressMessage::Drain(reason)) => {
+                            // No new messages can be enqueued, and we'll continue to drain
+                            // already enqueued messages.
+                            //
+                            // reactor will only know when the stream is terminated.
+                            inner.close();
+                            trace!(cid = %self.cid, "Egress stream was requested to drain");
+                            let mut header = Header::default();
+                            self.metadata_cache.fill_header(&mut header);
+                            let msg = Message {
+                                header: Some(header),
+                                body: Some(reason.into()),
+                            };
+                            return Poll::Ready(Some(msg));
+                        }
+                        None => {
+                            trace!(cid = %self.cid, "Egress stream is drained");
+                            self.terminate_stream();
+                            return Poll::Ready(None);
+                        }
+                    }
+                }
+                None => {
+                    trace!(cid = %self.cid, "Egress stream was already terminated (inner)");
+                    self.terminate_stream();
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.inner {
+            Some(ref inner) => (inner.len(), None),
+            None => (0, None),
+        }
+    }
+}

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -58,7 +58,6 @@ pub mod test_util {
     use parking_lot::Mutex;
     use tokio::sync::mpsc;
     use tokio::time::Instant;
-    use tokio_stream::wrappers::ReceiverStream;
     use tracing::info;
 
     use restate_types::GenerationalNodeId;
@@ -67,6 +66,7 @@ pub mod test_util {
     use restate_types::protobuf::node::message::BinaryMessage;
 
     use super::{NetworkError, ProtocolError};
+    use crate::network::io::EgressStream;
     use crate::network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection};
     use crate::{TaskCenter, TaskHandle, TaskKind, my_node_id};
 
@@ -107,7 +107,7 @@ pub mod test_util {
                 node_id, current_generation
             );
 
-            let (sender, rx) = mpsc::channel(self.sendbuf);
+            let (sender, egress, drop_egress) = EgressStream::create(self.sendbuf);
 
             let peer_connection = PartialPeerConnection {
                 my_node_id: node_id,
@@ -115,6 +115,7 @@ pub mod test_util {
                 sender,
                 recv_stream: output_stream.boxed(),
                 created: Instant::now(),
+                drop_egress,
             };
 
             let peer_connection = peer_connection.handshake(nodes_config).await.unwrap();
@@ -125,8 +126,7 @@ pub mod test_util {
                     "MockConnector has been terminated, cannot connect to {node_id}"
                 )));
             }
-            let incoming = ReceiverStream::new(rx).map(Ok);
-            Ok(incoming)
+            Ok(egress.map(Ok))
         }
     }
 

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -12,8 +12,7 @@ use std::future::Future;
 
 use futures::Stream;
 
-use restate_types::GenerationalNodeId;
-use restate_types::nodes_config::NodesConfiguration;
+use restate_types::net::AdvertisedAddress;
 use restate_types::protobuf::node::Message;
 
 use super::{NetworkError, ProtocolError};
@@ -21,8 +20,7 @@ use super::{NetworkError, ProtocolError};
 pub trait TransportConnect: Clone + Send + Sync + 'static {
     fn connect(
         &self,
-        node_id: GenerationalNodeId,
-        nodes_config: &NodesConfiguration,
+        address: AdvertisedAddress,
         output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
     ) -> impl Future<
         Output = Result<
@@ -35,8 +33,7 @@ pub trait TransportConnect: Clone + Send + Sync + 'static {
 impl<T: TransportConnect> TransportConnect for std::sync::Arc<T> {
     fn connect(
         &self,
-        node_id: GenerationalNodeId,
-        nodes_config: &NodesConfiguration,
+        address: AdvertisedAddress,
         output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
     ) -> impl Future<
         Output = Result<
@@ -44,141 +41,135 @@ impl<T: TransportConnect> TransportConnect for std::sync::Arc<T> {
             NetworkError,
         >,
     > + Send {
-        (**self).connect(node_id, nodes_config, output_stream)
+        (**self).connect(address, output_stream)
     }
 }
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
     use super::*;
+    //
+    // use std::sync::Arc;
+    //
+    use futures::Stream;
+    // use futures::StreamExt;
+    // use parking_lot::Mutex;
+    // use tokio::sync::mpsc;
+    // use tokio::time::Instant;
+    // use tracing::info;
+    //
+    // use restate_types::GenerationalNodeId;
+    // use restate_types::nodes_config::NodesConfiguration;
+    // use restate_types::protobuf::node::Message;
+    // use restate_types::protobuf::node::message::BinaryMessage;
+    //
+    // use super::{NetworkError, ProtocolError};
+    // use crate::network::io::EgressStream;
+    // use crate::network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection};
+    // use crate::{TaskCenter, TaskHandle, TaskKind, my_node_id};
 
-    use std::sync::Arc;
-
-    use futures::{Stream, StreamExt};
-    use parking_lot::Mutex;
-    use tokio::sync::mpsc;
-    use tokio::time::Instant;
-    use tracing::info;
-
-    use restate_types::GenerationalNodeId;
-    use restate_types::nodes_config::NodesConfiguration;
-    use restate_types::protobuf::node::Message;
-    use restate_types::protobuf::node::message::BinaryMessage;
-
-    use super::{NetworkError, ProtocolError};
-    use crate::network::io::EgressStream;
-    use crate::network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection};
-    use crate::{TaskCenter, TaskHandle, TaskKind, my_node_id};
-
-    #[derive(Clone)]
-    pub struct MockConnector {
-        pub sendbuf: usize,
-        pub new_connection_sender: mpsc::UnboundedSender<MockPeerConnection>,
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    impl MockConnector {
-        pub fn new(sendbuf: usize) -> (Self, mpsc::UnboundedReceiver<MockPeerConnection>) {
-            let (new_connection_sender, rx) = mpsc::unbounded_channel();
-            (
-                Self {
-                    sendbuf,
-                    new_connection_sender,
-                },
-                rx,
-            )
-        }
-    }
-
-    impl TransportConnect for MockConnector {
-        async fn connect(
-            &self,
-            node_id: GenerationalNodeId,
-            nodes_config: &NodesConfiguration,
-            output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
-        ) -> Result<
-            impl Stream<Item = Result<Message, ProtocolError>> + Send + Unpin + 'static,
-            NetworkError,
-        > {
-            // validates that the node is known in the config
-            let current_generation = nodes_config.find_node_by_id(node_id)?.current_generation;
-            info!(
-                "Attempting to fake a connection to node {} and current_generation is {}",
-                node_id, current_generation
-            );
-
-            let (sender, egress, drop_egress) = EgressStream::create(self.sendbuf);
-
-            let peer_connection = PartialPeerConnection {
-                my_node_id: node_id,
-                peer: my_node_id(),
-                sender,
-                recv_stream: output_stream.boxed(),
-                created: Instant::now(),
-                drop_egress,
-            };
-
-            let peer_connection = peer_connection.handshake(nodes_config).await.unwrap();
-
-            if self.new_connection_sender.send(peer_connection).is_err() {
-                // receiver has closed, cannot accept connections
-                return Err(NetworkError::Unavailable(format!(
-                    "MockConnector has been terminated, cannot connect to {node_id}"
-                )));
-            }
-            Ok(egress.map(Ok))
-        }
-    }
-
-    /// Accepts all connections, performs handshake and sends all received messages to a single
-    /// stream
-    pub struct MessageCollectorMockConnector {
-        pub mock_connector: MockConnector,
-        pub tasks: Mutex<Vec<(WeakConnection, TaskHandle<anyhow::Result<()>>)>>,
-    }
-
-    impl MessageCollectorMockConnector {
-        pub fn new(
-            sendbuf: usize,
-            sender: mpsc::Sender<(GenerationalNodeId, Incoming<BinaryMessage>)>,
-        ) -> Arc<Self> {
-            let (mock_connector, mut new_connections) = MockConnector::new(sendbuf);
-            let connector = Arc::new(Self {
-                mock_connector,
-                tasks: Default::default(),
-            });
-
-            // start acceptor
-            TaskCenter::spawn(TaskKind::Disposable, "test-connection-acceptor", {
-                let connector = connector.clone();
-                async move {
-                    while let Some(connection) = new_connections.recv().await {
-                        let (connection, task) = connection.forward_to_sender(sender.clone())?;
-                        connector.tasks.lock().push((connection, task));
-                    }
-                    Ok(())
-                }
-            })
-            .unwrap();
-            connector
-        }
-    }
-
-    impl TransportConnect for Arc<MessageCollectorMockConnector> {
-        async fn connect(
-            &self,
-            node_id: GenerationalNodeId,
-            nodes_config: &NodesConfiguration,
-            output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
-        ) -> Result<
-            impl Stream<Item = Result<Message, ProtocolError>> + Send + Unpin + 'static,
-            NetworkError,
-        > {
-            self.mock_connector
-                .connect(node_id, nodes_config, output_stream)
-                .await
-        }
-    }
+    // #[derive(Clone)]
+    // pub struct MockConnector {
+    //     pub sendbuf: usize,
+    //     pub new_connection_sender: mpsc::UnboundedSender<MockPeerConnection>,
+    // }
+    //
+    // #[cfg(any(test, feature = "test-util"))]
+    // impl MockConnector {
+    //     pub fn new(sendbuf: usize) -> (Self, mpsc::UnboundedReceiver<MockPeerConnection>) {
+    //         let (new_connection_sender, rx) = mpsc::unbounded_channel();
+    //         (
+    //             Self {
+    //                 sendbuf,
+    //                 new_connection_sender,
+    //             },
+    //             rx,
+    //         )
+    //     }
+    // }
+    //
+    // impl TransportConnect for MockConnector {
+    //     async fn connect(
+    //         &self,
+    //         address: AdvertisedAddress,
+    //         output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
+    //     ) -> Result<
+    //         impl Stream<Item = Result<Message, ProtocolError>> + Send + Unpin + 'static,
+    //         NetworkError,
+    //     > {
+    //         // validates that the node is known in the config
+    //         let (sender, egress, drop_egress) = EgressStream::create(self.sendbuf);
+    //
+    //         let peer_connection = PartialPeerConnection {
+    //             my_node_id: node_id,
+    //             peer: my_node_id(),
+    //             sender,
+    //             recv_stream: output_stream.boxed(),
+    //             created: Instant::now(),
+    //             drop_egress,
+    //         };
+    //
+    //         let peer_connection = peer_connection.handshake(nodes_config).await.unwrap();
+    //
+    //         if self.new_connection_sender.send(peer_connection).is_err() {
+    //             // receiver has closed, cannot accept connections
+    //             return Err(NetworkError::Unavailable(format!(
+    //                 "MockConnector has been terminated, cannot connect to {node_id}"
+    //             )));
+    //         }
+    //         Ok(egress.map(Ok))
+    //     }
+    // }
+    //
+    // /// Accepts all connections, performs handshake and sends all received messages to a single
+    // /// stream
+    // pub struct MessageCollectorMockConnector {
+    //     pub mock_connector: MockConnector,
+    //     pub tasks: Mutex<Vec<(WeakConnection, TaskHandle<anyhow::Result<()>>)>>,
+    // }
+    //
+    // impl MessageCollectorMockConnector {
+    //     pub fn new(
+    //         sendbuf: usize,
+    //         sender: mpsc::Sender<(GenerationalNodeId, Incoming<BinaryMessage>)>,
+    //     ) -> Arc<Self> {
+    //         let (mock_connector, mut new_connections) = MockConnector::new(sendbuf);
+    //         let connector = Arc::new(Self {
+    //             mock_connector,
+    //             tasks: Default::default(),
+    //         });
+    //
+    //         // start acceptor
+    //         TaskCenter::spawn(TaskKind::Disposable, "test-connection-acceptor", {
+    //             let connector = connector.clone();
+    //             async move {
+    //                 while let Some(connection) = new_connections.recv().await {
+    //                     let (connection, task) = connection.forward_to_sender(sender.clone())?;
+    //                     connector.tasks.lock().push((connection, task));
+    //                 }
+    //                 Ok(())
+    //             }
+    //         })
+    //         .unwrap();
+    //         connector
+    //     }
+    // }
+    //
+    // impl TransportConnect for Arc<MessageCollectorMockConnector> {
+    //     async fn connect(
+    //         &self,
+    //         node_id: GenerationalNodeId,
+    //         nodes_config: &NodesConfiguration,
+    //         output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
+    //     ) -> Result<
+    //         impl Stream<Item = Result<Message, ProtocolError>> + Send + Unpin + 'static,
+    //         NetworkError,
+    //     > {
+    //         self.mock_connector
+    //             .connect(node_id, nodes_config, output_stream)
+    //             .await
+    //     }
+    // }
 
     /// Transport that fails all outgoing connections
     #[derive(Default, Clone)]
@@ -188,8 +179,7 @@ pub mod test_util {
     impl TransportConnect for FailingConnector {
         async fn connect(
             &self,
-            _node_id: GenerationalNodeId,
-            _nodes_config: &NodesConfiguration,
+            _address: AdvertisedAddress,
             _output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
         ) -> Result<
             impl Stream<Item = Result<Message, ProtocolError>> + Send + Unpin + 'static,

--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -22,8 +22,6 @@ use restate_types::net::codec::{Targeted, WireEncode};
 use restate_types::protobuf::node::Header;
 use restate_types::{GenerationalNodeId, NodeId, Version};
 
-use crate::Metadata;
-
 use super::connection::OwnedConnection;
 use super::{NetworkError, NetworkSendError, WeakConnection};
 
@@ -423,9 +421,7 @@ impl<M: Targeted + WireEncode> Outgoing<M, HasConnection> {
             NetworkError::ConnectionClosed(connection.peer())
         );
 
-        Metadata::with_current(|metadata| {
-            permit.send(self, metadata);
-        });
+        permit.send(self);
         Ok(())
     }
 
@@ -439,9 +435,7 @@ impl<M: Targeted + WireEncode> Outgoing<M, HasConnection> {
             Err(e) => return Err(NetworkSendError::new(self, e)),
         };
 
-        Metadata::with_current(|metadata| {
-            permit.send(self, metadata);
-        });
+        permit.send(self);
         Ok(())
     }
 
@@ -453,9 +447,7 @@ impl<M: Targeted + WireEncode> Outgoing<M, HasConnection> {
         let connection = bail_on_error!(self, self.try_upgrade());
         let permit = bail_on_error!(self, connection.try_reserve());
 
-        Metadata::with_current(|metadata| {
-            permit.send(self, metadata);
-        });
+        permit.send(self);
 
         Ok(())
     }

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -134,7 +134,11 @@ impl TaskCenter {
 
     /// Launch a new task
     #[track_caller]
-    pub fn spawn<F>(kind: TaskKind, name: &'static str, future: F) -> Result<TaskId, ShutdownError>
+    pub fn spawn<F>(
+        kind: TaskKind,
+        name: impl Into<SharedString>,
+        future: F,
+    ) -> Result<TaskId, ShutdownError>
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -656,8 +656,8 @@ mod tests {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let (connection, mut net_rx, _egress_drop) =
+            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -699,7 +699,7 @@ mod tests {
         worker.enqueue_store(msg1).unwrap();
         worker.enqueue_store(msg2).unwrap();
         // wait for response (in test-env, it's safe to assume that responses will arrive in order)
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg1_id));
         let stored: Stored = response
@@ -710,7 +710,7 @@ mod tests {
         assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
         // response 2
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg2_id));
         let stored: Stored = response
@@ -732,8 +732,8 @@ mod tests {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let (connection, mut net_rx, _egress_drop) =
+            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -787,7 +787,7 @@ mod tests {
 
         worker.enqueue_store(msg1).unwrap();
         // first store is successful
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg1_id));
         let stored: Stored = response
@@ -803,7 +803,7 @@ mod tests {
         // observe Status::Sealing
         worker.enqueue_store(msg2).unwrap();
         // sealing
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg2_id));
         let stored: Stored = response
@@ -815,7 +815,7 @@ mod tests {
         // seal responses can come at any order, but we'll consume waiters queue before we process
         // store messages.
         // sealed
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
         let sealed: Sealed = response
@@ -826,7 +826,7 @@ mod tests {
         assert_that!(sealed.local_tail, eq(LogletOffset::new(3)));
 
         // sealed2
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), any!(eq(seal1_id), eq(seal2_id)));
         let sealed: Sealed = response
@@ -849,7 +849,7 @@ mod tests {
         let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
         let msg3_id = msg3.msg_id();
         worker.enqueue_store(msg3).unwrap();
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg3_id));
         let stored: Stored = response
@@ -868,7 +868,7 @@ mod tests {
         let msg_id = msg.msg_id();
         worker.enqueue_get_loglet_info(msg).unwrap();
 
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg_id));
         let info: LogletInfo = response
@@ -892,12 +892,10 @@ mod tests {
         const PEER: GenerationalNodeId = GenerationalNodeId::new(2, 2);
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
-
-        let (peer_net_tx, mut peer_net_rx) = mpsc::channel(10);
-        let repair_connection =
-            OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, peer_net_tx);
+        let (connection, mut net_rx, _egress_drop1) =
+            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+        let (repair_connection, mut peer_net_rx, _egress_drop2) =
+            OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -974,7 +972,7 @@ mod tests {
         worker.enqueue_store(msg1).unwrap();
         worker.enqueue_store(msg2).unwrap();
         // first store is successful
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let stored: Stored = response
             .body
             .unwrap()
@@ -984,7 +982,7 @@ mod tests {
         assert_that!(stored.local_tail, eq(LogletOffset::new(3)));
 
         // 10, 11
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let stored: Stored = response
             .body
             .unwrap()
@@ -997,7 +995,7 @@ mod tests {
         // seal responses can come at any order, but we'll consume waiters queue before we process
         // store messages.
         // sealed
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let sealed: Sealed = response
             .body
             .unwrap()
@@ -1007,7 +1005,7 @@ mod tests {
 
         // repair store (before local tail, local tail won't move)
         worker.enqueue_store(repair1).unwrap();
-        let response = peer_net_rx.recv().await.unwrap();
+        let response = peer_net_rx.next().await.unwrap();
         let stored: Stored = response
             .body
             .unwrap()
@@ -1016,7 +1014,7 @@ mod tests {
         assert_that!(stored.local_tail, eq(LogletOffset::new(12)));
 
         worker.enqueue_store(repair2).unwrap();
-        let response = peer_net_rx.recv().await.unwrap();
+        let response = peer_net_rx.next().await.unwrap();
         let stored: Stored = response
             .body
             .unwrap()
@@ -1033,7 +1031,7 @@ mod tests {
         let msg_id = msg.msg_id();
         worker.enqueue_get_loglet_info(msg).unwrap();
 
-        let response = net_rx.recv().await.unwrap();
+        let response = net_rx.next().await.unwrap();
         let header = response.header.unwrap();
         assert_that!(header.in_response_to(), eq(msg_id));
         let info: LogletInfo = response
@@ -1055,8 +1053,8 @@ mod tests {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let (connection, mut net_rx, _egress_drop) =
+            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -1117,7 +1115,7 @@ mod tests {
         // Wait for stores to complete.
         for _ in 0..3 {
             let stored: Stored = net_rx
-                .recv()
+                .next()
                 .await
                 .unwrap()
                 .body
@@ -1144,7 +1142,7 @@ mod tests {
             .unwrap();
 
         let mut records: Records = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1184,7 +1182,7 @@ mod tests {
             .unwrap();
 
         let mut records: Records = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1232,7 +1230,7 @@ mod tests {
             .unwrap();
 
         let mut records: Records = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1272,8 +1270,8 @@ mod tests {
         const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
-        let (net_tx, mut net_rx) = mpsc::channel(10);
-        let connection = OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, net_tx);
+        let (connection, mut net_rx, _egress_drop) =
+            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store.clone(), loglet_state.clone())?;
@@ -1293,7 +1291,7 @@ mod tests {
             .unwrap();
 
         let trimmed: Trimmed = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1317,7 +1315,7 @@ mod tests {
             .unwrap();
 
         let trimmed: Trimmed = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1345,7 +1343,7 @@ mod tests {
             ))
             .unwrap();
         let stored: Stored = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1367,7 +1365,7 @@ mod tests {
             .unwrap();
 
         let trimmed: Trimmed = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1394,7 +1392,7 @@ mod tests {
             .unwrap();
 
         let mut records: Records = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1435,7 +1433,7 @@ mod tests {
             .unwrap();
 
         let trimmed: Trimmed = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body
@@ -1462,7 +1460,7 @@ mod tests {
             .unwrap();
 
         let mut records: Records = net_rx
-            .recv()
+            .next()
             .await
             .unwrap()
             .body

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -106,7 +106,7 @@ tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io-util", "net", "rt"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.22", features = ["serde"] }
-tonic = { version = "0.12", features = ["gzip", "tls-roots"] }
+tonic = { version = "0.12", features = ["gzip", "tls-roots", "zstd"] }
 tower-9fbad63c4bcf4a8f = { package = "tower", version = "0.4", features = ["balance", "buffer", "limit", "retry", "timeout", "util"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["limit", "load-shed", "log", "make", "util"] }
 tower-http = { version = "0.6", default-features = false, features = ["cors", "normalize-path", "trace"] }
@@ -119,6 +119,8 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4", "v7"] }
 zerocopy = { version = "0.7", features = ["derive", "simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
 
 [build-dependencies]
@@ -216,7 +218,7 @@ tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io-util", "net", "rt"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.22", features = ["serde"] }
-tonic = { version = "0.12", features = ["gzip", "tls-roots"] }
+tonic = { version = "0.12", features = ["gzip", "tls-roots", "zstd"] }
 tower-9fbad63c4bcf4a8f = { package = "tower", version = "0.4", features = ["balance", "buffer", "limit", "retry", "timeout", "util"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["limit", "load-shed", "log", "make", "util"] }
 tower-http = { version = "0.6", default-features = false, features = ["cors", "normalize-path", "trace"] }
@@ -229,6 +231,8 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4", "v7"] }
 zerocopy = { version = "0.7", features = ["derive", "simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]


### PR DESCRIPTION

Also:
- Enable zstd compression for message fabric networking
- Decouple fabric clients from using common options, this is a highly specialised use-case and should not be mixed with normal grpc clients
- Let normal grpc clients use the "current" runtime, and while pinning message fabric clients to "default" runtime

Tests that use MockConnector et. al. are disabled temporarily until a replacement is in place.
