### PR TITLE
Introduce RetryingMetadataStoreClient

### DIFF
--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -223,7 +223,7 @@ impl MetadataStore for GrpcMetadataServerClient {
                 .put(PutRequest {
                     key: key.clone().into(),
                     value: Some(value.clone().into()),
-                    precondition: Some(precondition.clone().into()),
+                    precondition: Some(precondition.into()),
                 })
                 .await
             {
@@ -253,7 +253,7 @@ impl MetadataStore for GrpcMetadataServerClient {
             return match client
                 .delete(DeleteRequest {
                     key: key.clone().into(),
-                    precondition: Some(precondition.clone().into()),
+                    precondition: Some(precondition.into()),
                 })
                 .await
             {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -21,7 +21,9 @@ use tracing::{debug, error, info, trace, warn};
 
 use codederror::CodedError;
 use restate_bifrost::BifrostService;
-use restate_core::metadata_store::{ReadWriteError, WriteError, retry_on_retryable_error};
+use restate_core::metadata_store::{
+    ReadWriteError, RetryError, RetryingMetadataStoreClient, WriteError,
+};
 use restate_core::network::{
     GrpcConnector, MessageRouterBuilder, NetworkServerBuilder, Networking,
 };
@@ -619,18 +621,17 @@ async fn provision_cluster_metadata(
     let (initial_nodes_configuration, initial_partition_table, initial_logs) =
         generate_initial_metadata(common_opts, cluster_configuration);
 
-    let result = retry_on_retryable_error(common_opts.network_error_retry_policy.clone(), || {
-        metadata_store_client.provision(&initial_nodes_configuration)
-    })
-    .await?;
+    let retrying_client =
+        metadata_store_client.with_retries(common_opts.network_error_retry_policy.clone());
+    let result = retrying_client
+        .provision(&initial_nodes_configuration)
+        .await?;
 
-    retry_on_retryable_error(common_opts.network_error_retry_policy.clone(), || {
-        write_initial_logs_dont_fail_if_it_exists(
-            metadata_store_client,
-            BIFROST_CONFIG_KEY.clone(),
-            initial_logs.clone(),
-        )
-    })
+    write_initial_logs_dont_fail_if_it_exists(
+        &retrying_client,
+        BIFROST_CONFIG_KEY.clone(),
+        initial_logs.clone(),
+    )
     .await
     .context("failed provisioning the initial logs")?;
 
@@ -638,13 +639,11 @@ async fn provision_cluster_metadata(
     // The partition table metadata must be initialized only after the bifrost (logs) metadata.
     // Otherwise, the logs controller may begin creating logs with incorrect configurations
     // initialized by bifrost.
-    retry_on_retryable_error(common_opts.network_error_retry_policy.clone(), || {
-        write_initial_value_dont_fail_if_it_exists(
-            metadata_store_client,
-            PARTITION_TABLE_KEY.clone(),
-            &initial_partition_table,
-        )
-    })
+    write_initial_value_dont_fail_if_it_exists(
+        &retrying_client,
+        PARTITION_TABLE_KEY.clone(),
+        &initial_partition_table,
+    )
     .await
     .context("failed provisioning the initial partition table")?;
 
@@ -696,52 +695,63 @@ fn generate_initial_metadata(
 }
 
 async fn write_initial_value_dont_fail_if_it_exists<T: Versioned + StorageEncode>(
-    metadata_store_client: &MetadataStoreClient,
+    metadata_store_client: &RetryingMetadataStoreClient<'_>,
     key: ByteString,
     initial_value: &T,
-) -> Result<(), WriteError> {
+) -> Result<(), RetryError<WriteError>> {
     match metadata_store_client
         .put(key, initial_value, Precondition::DoesNotExist)
         .await
     {
         Ok(_) => Ok(()),
-        Err(WriteError::FailedPrecondition(_)) => {
-            // we might have failed on a previous attempt after writing this value; so let's continue
-            Ok(())
+        Err(err) => {
+            match err.as_inner() {
+                WriteError::FailedPrecondition(_) => {
+                    // we might have failed on a previous attempt after writing this value; so let's continue
+                    Ok(())
+                }
+                _ => Err(err),
+            }
         }
-        Err(err) => Err(err),
     }
 }
 
 async fn write_initial_logs_dont_fail_if_it_exists(
-    metadata_store_client: &MetadataStoreClient,
+    metadata_store_client: &RetryingMetadataStoreClient<'_>,
     key: ByteString,
     initial_value: Logs,
-) -> Result<(), ReadWriteError> {
+) -> Result<(), RetryError<ReadWriteError>> {
     let value = metadata_store_client
         .read_modify_write(key, |current| match current {
             None => Ok(initial_value.clone()),
             Some(current_value) => {
                 if current_value.configuration() == initial_value.configuration() {
-                    Err(ReadModifyWriteError::FailedOperation(AlreadyInitialized))
+                    Err(AlreadyInitialized)
                 } else if current_value.version() == Version::MIN && current_value.num_logs() == 0 {
                     let builder = initial_value.clone().into_builder();
                     // make sure version is incremented to MIN + 1
                     Ok(builder.build())
                 } else {
-                    Err(ReadModifyWriteError::FailedOperation(AlreadyInitialized))
+                    Err(AlreadyInitialized)
                 }
             }
         })
         .await;
 
     match value {
-        Ok(_) | Err(ReadModifyWriteError::FailedOperation(_)) => Ok(()),
-        Err(ReadModifyWriteError::ReadWrite(err)) => Err(err),
+        Ok(_) => Ok(()),
+        Err(err) => match err.as_inner() {
+            ReadModifyWriteError::FailedOperation(_) => Ok(()),
+            _ => Err(err.map(|err| match err {
+                ReadModifyWriteError::ReadWrite(err) => err,
+                ReadModifyWriteError::FailedOperation(_) => unreachable!(),
+            })),
+        },
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("node has already been initialized")]
 struct AlreadyInitialized;
 
 #[cfg(not(feature = "replicated-loglet"))]

--- a/crates/types/src/metadata.rs
+++ b/crates/types/src/metadata.rs
@@ -28,7 +28,7 @@ impl VersionedValue {
 flexbuffers_storage_encode_decode!(VersionedValue);
 
 /// Preconditions for the write operations of the [`MetadataStore`].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, derive_more::Display)]
 pub enum Precondition {
     /// No precondition
     None,


### PR DESCRIPTION
The RetryingMetadataStoreClient automatically retries retryable errors according to the configured RetryPolicy.