### PR TITLE
Flush config file to disk before starting Restate process

### DIFF
--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -317,6 +317,10 @@ impl Node {
                 .write_all(config_dump.as_bytes())
                 .await
                 .map_err(NodeStartError::CreateConfig)?;
+            config_file
+                .flush()
+                .await
+                .map_err(NodeStartError::CreateConfig)?;
         }
 
         let node_log_filename = node_base_dir.join("restate.log");


### PR DESCRIPTION
Dropping the file alone, does not guarantee that the file content is written to disk and the file being closed immediately. If the config file is not written when starting the Restate process, then it will start with the default configuration which causes the raft_metadata_cluster_chaos_test to fail every now and then.

This fixes #2828.