### PR TITLE
Set an upper bound of 180s for the runtime tests to complete

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 3 }


### PR DESCRIPTION
This will help us debug hanging local cluster tests because it will force the printing of stderr/logs of the node processes when terminating the tests.

This PR should help us debug #2862.