### PR TITLE
CI to disable protobuf-rs on cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ ignore = [
     { id = "RUSTSEC-2024-0370", reason = "crate is unmaintained. This needs `arrow_convert` to use an alternative to `err-derive`" },
     { id = "RUSTSEC-2024-0384", reason = "`instant` crate is unmaintained. The dependency comes from datafusion" },
     { id = "RUSTSEC-2024-0436", reason = "crate is unmaintained. We need to migrate to a different crate than `paste`" },
+    { id = "RUSTSEC-2024-0437", reason = "protobuf-rs stackoverflow in deep nested messages, not fixed yet" },
 ]
 
 


### PR DESCRIPTION

https://github.com/stepancheg/rust-protobuf/issues/749 No fix yet. The issue would impact our metadata-server if access by untrusted sources (stackoverflow when parsing deeply nested messages)
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2868).
* #2867
* #2860
* #2846
* __->__ #2868