### PR TITLE
Harden three_logserver_seal_empty by retrying on retryable seal error

### DIFF
--- a/crates/bifrost/src/loglet/error.rs
+++ b/crates/bifrost/src/loglet/error.rs
@@ -81,3 +81,12 @@ impl From<NetworkError> for OperationError {
         }
     }
 }
+
+impl MaybeRetryableError for OperationError {
+    fn retryable(&self) -> bool {
+        match self {
+            OperationError::Shutdown(_) => false,
+            OperationError::Other(err) => err.retryable(),
+        }
+    }
+}


### PR DESCRIPTION
This fixes #2871.