### PR TITLE
feat(1764): add locked key threshold seconds option

### DIFF
--- a/cli/src/commands/services/status/agg_status.rs
+++ b/cli/src/commands/services/status/agg_status.rs
@@ -62,7 +62,12 @@ pub async fn run_aggregated_status(
     // Render Locked Keys
     if !locked_keys.is_empty() {
         c_title!("📨", "Active Keys");
-        render_locked_keys(locked_keys, opts.locked_keys_limit).await?;
+        render_locked_keys(
+            locked_keys,
+            opts.locked_keys_limit,
+            opts.locked_key_held_threshold_second,
+        )
+        .await?;
     }
     Ok(())
 }

--- a/cli/src/commands/services/status/detailed_status.rs
+++ b/cli/src/commands/services/status/detailed_status.rs
@@ -55,7 +55,12 @@ pub async fn run_detailed_status(
         let locked_keys = get_locked_keys_status(&sql_client, vec![service_name]).await?;
         if !locked_keys.is_empty() {
             c_title!("📨", "Active Keys");
-            render_locked_keys(locked_keys, opts.locked_keys_limit).await?;
+            render_locked_keys(
+                locked_keys,
+                opts.locked_keys_limit,
+                opts.locked_key_held_threshold_second,
+            )
+            .await?;
         }
     }
 


### PR DESCRIPTION
fix: https://github.com/restatedev/restate/issues/1764

```
Arguments:
  [SERVICE]
          Service name, prints all services if omitted

Options:
      --locked-keys-limit <LOCKED_KEYS_LIMIT>
          [default: 5]

  -v, --verbose...
          Increase logging verbosity

      --locked-key-held-threshold-second <LOCKED_KEY_HELD_THRESHOLD_SECOND>
          [default: 5]
```