### PR TITLE
Revert "Fix GenerationalNodeId should still be written."

### DIFF
--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -261,8 +261,7 @@ message ServiceInvocationResponseSink {
   }
 
   message Ingress {
-    // We just need to fill it in order to go back :(
-    GenerationalNodeId unused = 1;
+    reserved 1;
     bytes request_id = 2;
   }
 
@@ -712,8 +711,7 @@ message IdempotencyMetadata {
 
 message SubmitNotificationSink {
   message Ingress {
-    // We just need to fill it in order to go back :(
-    GenerationalNodeId unused = 1;
+    reserved 1;
     bytes request_id = 2;
   }
 

--- a/crates/partition-store/src/protobuf_types.rs
+++ b/crates/partition-store/src/protobuf_types.rs
@@ -1861,7 +1861,7 @@ pub mod v1 {
                     .ok_or(ConversionError::missing_field("notification_sink"))?
                 {
                     submit_notification_sink::NotificationSink::Ingress(
-                        submit_notification_sink::Ingress { request_id, .. },
+                        submit_notification_sink::Ingress { request_id },
                     ) => restate_types::invocation::SubmitNotificationSink::Ingress {
                         request_id:
                             restate_types::identifiers::PartitionProcessorRpcRequestId::from_slice(
@@ -1878,16 +1878,13 @@ pub mod v1 {
         impl From<restate_types::invocation::SubmitNotificationSink> for SubmitNotificationSink {
             fn from(value: restate_types::invocation::SubmitNotificationSink) -> Self {
                 let notification_sink = match value {
-                    restate_types::invocation::SubmitNotificationSink::Ingress {
-                        request_id,
-                        ..
-                    } => submit_notification_sink::NotificationSink::Ingress(
-                        submit_notification_sink::Ingress {
-                            //  In 1.1 the node number is always 1, and the generation is used to fence off responses to old process restarts. Remove in 1.3
-                            unused: Some(GenerationalNodeId::new(1, 1).into()),
-                            request_id: Bytes::copy_from_slice(&request_id.to_bytes()),
-                        },
-                    ),
+                    restate_types::invocation::SubmitNotificationSink::Ingress { request_id } => {
+                        submit_notification_sink::NotificationSink::Ingress(
+                            submit_notification_sink::Ingress {
+                                request_id: Bytes::copy_from_slice(&request_id.to_bytes()),
+                            },
+                        )
+                    }
                 };
 
                 SubmitNotificationSink {
@@ -2246,8 +2243,6 @@ pub mod v1 {
                     }),
                     Some(restate_types::invocation::ServiceInvocationResponseSink::Ingress {  request_id }) => {
                         ResponseSink::Ingress(Ingress {
-                            //  In 1.1 the node number is always 1, and the generation is used to fence off responses to old process restarts. Remove in 1.3
-                            unused: Some(GenerationalNodeId::new(1, 1).into()),
                             request_id: Bytes::copy_from_slice(&request_id.to_bytes())
                         })
                     },


### PR DESCRIPTION
Reverts restatedev/restate#2872

To merge for 1.3