### PR TITLE
Introduce an optional cluster_id to fingerprint snapshots

### DIFF
--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -247,9 +247,8 @@ impl<'a> NodeInit<'a> {
                         });
                     }
 
-                    // it is only safe to write this if all current and future cluster nodes
-                    // run a version that is cluster id aware; older versions may clobber the id
-                    // on joining, creating a huge mess!
+                    // it is only safe to write this if all current and future cluster nodes are
+                    // cluster-id aware, as older versions will clobber the existing id on joining!
                     match nodes_config.cluster_id() {
                         Some(cluster_id) => {
                             debug!(cluster_id = ?cluster_id, "Joining cluster");

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -17,7 +17,7 @@ use serde_with::hex::Hex;
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
 
 use restate_core::worker_api::SnapshotCreated;
-use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId};
+use restate_types::identifiers::{ClusterId, PartitionId, PartitionKey, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -34,12 +34,10 @@ pub enum SnapshotFormatVersion {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PartitionSnapshotMetadata {
+    pub snapshot_id: SnapshotId,
     pub version: SnapshotFormatVersion,
-
-    /// Restate cluster name which produced the snapshot.
     pub cluster_name: String,
-
-    /// Restate partition id.
+    pub cluster_id: Option<ClusterId>,
     pub partition_id: PartitionId,
 
     /// Node that produced this snapshot.
@@ -48,9 +46,6 @@ pub struct PartitionSnapshotMetadata {
     /// Local node time when the snapshot was created.
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     pub created_at: humantime::Timestamp,
-
-    /// Snapshot id.
-    pub snapshot_id: SnapshotId,
 
     /// The partition key range that the partition processor which generated this snapshot was
     /// responsible for, at the time the snapshot was generated.

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -16,7 +16,7 @@ use tempfile::tempdir;
 use restate_storage_api::Transaction;
 use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
 use restate_types::config::WorkerOptions;
-use restate_types::identifiers::{PartitionKey, SnapshotId};
+use restate_types::identifiers::{ClusterId, PartitionKey, SnapshotId};
 use restate_types::live::Live;
 use restate_types::logs::{LogId, Lsn};
 use restate_types::time::MillisSinceEpoch;
@@ -40,6 +40,7 @@ pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_stor
     let snapshot_meta = PartitionSnapshotMetadata {
         version: SnapshotFormatVersion::V1,
         cluster_name: "cluster_name".to_string(),
+        cluster_id: Some(ClusterId::new()),
         partition_id,
         node_name: "node".to_string(),
         created_at: humantime::Timestamp::from(SystemTime::from(MillisSinceEpoch::new(0))),

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -289,6 +289,15 @@ pub struct CommonOptions {
     /// Restate uses Scarf to collect anonymous usage data to help us understand how the software is being used.
     /// You can set this flag to true to disable this collection. It can also be set with the environment variable DO_NOT_TRACK=1.
     pub disable_telemetry: bool,
+
+    /// # Experimental feature to enable unique cluster ids
+    ///
+    /// This feature is experimental and should be used with caution. It enables a safety feature
+    /// which persists a unique cluster fingerprint which can be used to detect misconfigurations
+    /// such as importing snapshots from the wrong cluster. Enabling it is only safe if all current
+    /// and future member nodes are guaranteed to run Restate version >= 1.2.3.
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    pub experimental_feature_enable_cluster_ids: bool,
 }
 
 impl CommonOptions {
@@ -444,6 +453,7 @@ impl Default for CommonOptions {
             ),
             initialization_timeout: Duration::from_secs(5 * 60).into(),
             disable_telemetry: false,
+            experimental_feature_enable_cluster_ids: false,
         }
     }
 }
@@ -836,6 +846,7 @@ pub struct CommonOptionsShadow {
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     initialization_timeout: humantime::Duration,
     disable_telemetry: bool,
+    experimental_feature_enable_cluster_ids: bool,
 
     metadata_client: MetadataClientOptions,
     // todo drop in version 1.3
@@ -963,6 +974,7 @@ impl From<CommonOptionsShadow> for CommonOptions {
             network_error_retry_policy: value.network_error_retry_policy,
             initialization_timeout: value.initialization_timeout,
             disable_telemetry: value.disable_telemetry,
+            experimental_feature_enable_cluster_ids: value.experimental_feature_enable_cluster_ids,
 
             auto_provision,
             default_num_partitions,

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -41,6 +41,7 @@ prefixed_ids! {
     /// follow the same encoding scheme according to the [default] version.
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub enum IdResourceType {
+        Cluster("restate"),
         Invocation("inv"),
         Deployment("dp"),
         Subscription("sub"),

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -41,7 +41,7 @@ prefixed_ids! {
     /// follow the same encoding scheme according to the [default] version.
     #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub enum IdResourceType {
-        Cluster("restate"),
+        Cluster("clust"),
         Invocation("inv"),
         Deployment("dp"),
         Subscription("sub"),

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -967,10 +967,6 @@ ulid_backed_id!(Subscription @with_resource_id);
 ulid_backed_id!(PartitionProcessorRpcRequest);
 ulid_backed_id!(Snapshot @with_resource_id);
 
-impl ClusterId {
-    pub const UNINITIALIZED: ClusterId = ClusterId::from_parts(0, 0);
-}
-
 #[derive(
     Debug, Clone, PartialEq, Eq, serde_with::SerializeDisplay, serde_with::DeserializeFromStr,
 )]

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -961,10 +961,15 @@ macro_rules! ulid_backed_id {
     };
 }
 
+ulid_backed_id!(Cluster @with_resource_id);
 ulid_backed_id!(Deployment @with_resource_id);
 ulid_backed_id!(Subscription @with_resource_id);
 ulid_backed_id!(PartitionProcessorRpcRequest);
 ulid_backed_id!(Snapshot @with_resource_id);
+
+impl ClusterId {
+    pub const UNINITIALIZED: ClusterId = ClusterId::from_parts(0, 0);
+}
 
 #[derive(
     Debug, Clone, PartialEq, Eq, serde_with::SerializeDisplay, serde_with::DeserializeFromStr,

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -11,6 +11,7 @@
 use enumset::{EnumSet, EnumSetType};
 use serde_with::serde_as;
 
+use crate::identifiers::ClusterId;
 use crate::locality::NodeLocation;
 use crate::net::AdvertisedAddress;
 use crate::{GenerationalNodeId, NodeId, PlainNodeId, flexbuffers_storage_encode_decode};
@@ -59,6 +60,7 @@ pub enum Role {
 pub struct NodesConfiguration {
     version: Version,
     cluster_name: String,
+    cluster_id: Option<ClusterId>,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
     nodes: HashMap<PlainNodeId, MaybeNode>,
@@ -71,6 +73,7 @@ impl Default for NodesConfiguration {
         Self {
             version: Version::INVALID,
             cluster_name: "Unspecified".to_owned(),
+            cluster_id: None,
             nodes: Default::default(),
             name_lookup: Default::default(),
         }
@@ -128,6 +131,7 @@ impl NodesConfiguration {
         Self {
             version,
             cluster_name,
+            cluster_id: None,
             nodes: HashMap::default(),
             name_lookup: HashMap::default(),
         }
@@ -143,6 +147,20 @@ impl NodesConfiguration {
 
     pub fn cluster_name(&self) -> &str {
         &self.cluster_name
+    }
+
+    pub fn cluster_id(&self) -> Option<ClusterId> {
+        self.cluster_id
+    }
+
+    pub fn set_cluster_id(&mut self, cluster_id: ClusterId) {
+        assert!(
+            self.cluster_id.is_none(),
+            "Attempt to re-initialize cluster id from {} to {}!",
+            self.cluster_id.unwrap_or(ClusterId::UNINITIALIZED),
+            cluster_id,
+        );
+        self.cluster_id = Some(cluster_id);
     }
 
     pub fn increment_version(&mut self) {

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -156,8 +156,8 @@ impl NodesConfiguration {
     pub fn set_cluster_id(&mut self, cluster_id: ClusterId) {
         assert!(
             self.cluster_id.is_none(),
-            "Attempt to re-initialize cluster id from {} to {}!",
-            self.cluster_id.unwrap_or(ClusterId::UNINITIALIZED),
+            "attempt to set cluster-id on already-initialized configuration with id {:?} to new id: {}",
+            self.cluster_id,
             cluster_id,
         );
         self.cluster_id = Some(cluster_id);

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -150,7 +150,6 @@ impl Worker {
         }
 
         let partition_processor_manager = PartitionProcessorManager::new(
-            metadata.nodes_config_ref().cluster_id(),
             health_status,
             updateable_config.clone(),
             metadata_store_client,

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -150,6 +150,7 @@ impl Worker {
         }
 
         let partition_processor_manager = PartitionProcessorManager::new(
+            metadata.nodes_config_ref().cluster_id(),
             health_status,
             updateable_config.clone(),
             metadata_store_client,

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -18,7 +18,7 @@ use restate_partition_store::PartitionStoreManager;
 use restate_partition_store::snapshots::{
     LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion,
 };
-use restate_types::identifiers::{PartitionId, SnapshotId};
+use restate_types::identifiers::{ClusterId, PartitionId, SnapshotId};
 use restate_types::logs::Lsn;
 
 use crate::partition::snapshots::SnapshotRepository;
@@ -31,6 +31,7 @@ pub struct SnapshotPartitionTask {
     pub snapshot_base_path: PathBuf,
     pub partition_store_manager: PartitionStoreManager,
     pub cluster_name: String,
+    pub cluster_id: Option<ClusterId>,
     pub node_name: String,
     pub snapshot_repository: SnapshotRepository,
 }
@@ -84,6 +85,7 @@ impl SnapshotPartitionTask {
         PartitionSnapshotMetadata {
             version: SnapshotFormatVersion::V1,
             cluster_name: self.cluster_name.clone(),
+            cluster_id: self.cluster_id,
             node_name: self.node_name.clone(),
             partition_id: self.partition_id,
             created_at: humantime::Timestamp::from(created_at),

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -49,7 +49,7 @@ use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
 use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::health::HealthStatus;
-use restate_types::identifiers::{ClusterId, SnapshotId};
+use restate_types::identifiers::SnapshotId;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
 use restate_types::live::Live;
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
@@ -83,7 +83,6 @@ use crate::partition_processor_manager::processor_state::{
 use crate::partition_processor_manager::spawn_processor_task::SpawnPartitionProcessorTask;
 
 pub struct PartitionProcessorManager {
-    cluster_id: Option<ClusterId>,
     health_status: HealthStatus<WorkerStatus>,
     updateable_config: Live<Configuration>,
     processor_states: BTreeMap<PartitionId, ProcessorState>,
@@ -175,7 +174,6 @@ impl StatusHandle for MultiplexedInvokerStatusReader {
 impl PartitionProcessorManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        cluster_id: Option<ClusterId>,
         health_status: HealthStatus<WorkerStatus>,
         updateable_config: Live<Configuration>,
         metadata_store_client: MetadataStoreClient,
@@ -189,7 +187,6 @@ impl PartitionProcessorManager {
 
         let (tx, rx) = mpsc::channel(updateable_config.pinned().worker.internal_queue_length());
         Self {
-            cluster_id,
             health_status,
             updateable_config,
             processor_states: BTreeMap::default(),
@@ -992,7 +989,7 @@ impl PartitionProcessorManager {
                     snapshot_base_path,
                     partition_store_manager: self.partition_store_manager.clone(),
                     cluster_name: config.common.cluster_name().into(),
-                    cluster_id: self.cluster_id,
+                    cluster_id: Metadata::current().nodes_config_ref().cluster_id(),
                     node_name: config.common.node_name().into(),
                     snapshot_repository,
                 };
@@ -1153,7 +1150,7 @@ mod tests {
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::{CommonOptions, Configuration, RocksDbOptions, StorageOptions};
     use restate_types::health::HealthStatus;
-    use restate_types::identifiers::{ClusterId, PartitionId, PartitionKey};
+    use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::live::{Constant, Live};
     use restate_types::locality::NodeLocation;
     use restate_types::net::AdvertisedAddress;
@@ -1203,7 +1200,6 @@ mod tests {
         .await?;
 
         let partition_processor_manager = PartitionProcessorManager::new(
-            Some(ClusterId::new()),
             health_status,
             Live::from_value(Configuration::default()),
             env_builder.metadata_store_client.clone(),


### PR DESCRIPTION
A step towards resolving #2783.

This PR introduces an optional unique cluster-id and which is used to track snapshot provenance. This can be useful to prevent mishaps when if cluster names are reused. This is behind an experimental feature flag, as it is only safe to activate if all cluster members are aware of cluster-ids.

An opt-in feature flag allows users to enable this early; the earliest safe point to enable this by default will be the 1.4.0 release.

As a follow-up, we can also update the network handshake to use this if available - I haven't yet made an attempt to wire it in there.

---

## Testing

With the feature enabled:

```
% cat xp-enable-cluster-ids.toml
experimental-feature-enable-cluster-ids = true
```

```
% restate-server --log-format compact --log-filter restate_node=debug,info --config-file xp-enable-cluster-ids.toml
...
2025-03-17T16:54:14.710796Z  DEBUG restate_node::init: Initializing cluster id cluster_id=restate_14P7xhDLRYnUhebnimUVPC9
```

On subsequent startup, even with it disabled:

```
% restate-server --log-format compact --log-filter restate_node=debug,info
...
2025-03-17T16:57:04.472219Z DEBUG restate_node::init: Joining cluster cluster_id=restate_14P7xhDLRYnUhebnimUVPC9
```
