### PR TITLE
Removed InvocationStatus::Killed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,24 +111,6 @@ jobs:
     with:
       restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  sdk-java-invocation-status-killed:
-    name: Run SDK-Java integration tests with InvocationStatusKilled
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      actions: read
-    secrets: inherit
-    needs: docker
-    uses: restatedev/sdk-java/.github/workflows/integration.yaml@main
-    with:
-      restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
-      envVars: |
-        RESTATE_WORKER__EXPERIMENTAL_FEATURE_INVOCATION_STATUS_KILLED=true
-        RUST_LOG=info,restate_invoker=trace,restate_ingress_http=trace,restate_bifrost=trace,restate_log_server=trace,restate_core::partitions=trace,restate=debug
-      testArtifactOutput: sdk-java-invocation-status-killed-integration-test-report
-
   sdk-python:
     name: Run SDK-Python integration tests
     permissions:

--- a/cli/src/clients/datafusion_helpers/mod.rs
+++ b/cli/src/clients/datafusion_helpers/mod.rs
@@ -44,7 +44,6 @@ pub enum InvocationState {
     Running,
     Suspended,
     BackingOff,
-    Killed,
     Completed,
 }
 
@@ -59,7 +58,6 @@ impl FromStr for InvocationState {
             "suspended" => Self::Suspended,
             "backing-off" => Self::BackingOff,
             "completed" => Self::Completed,
-            "killed" => Self::Killed,
             _ => Self::Unknown,
         })
     }
@@ -75,7 +73,6 @@ impl Display for InvocationState {
             InvocationState::Running => write!(f, "running"),
             InvocationState::Suspended => write!(f, "suspended"),
             InvocationState::BackingOff => write!(f, "backing-off"),
-            InvocationState::Killed => write!(f, "killed"),
             InvocationState::Completed => write!(f, "completed"),
         }
     }

--- a/cli/src/ui/invocations.rs
+++ b/cli/src/ui/invocations.rs
@@ -122,7 +122,6 @@ pub fn invocation_status_style(status: InvocationState) -> Style {
         InvocationState::Suspended => DStyle::new().dim(),
         InvocationState::BackingOff => DStyle::new().red(),
         InvocationState::Completed => DStyle::new().blue(),
-        InvocationState::Killed => DStyle::new().red(),
     }
 }
 

--- a/crates/invoker-api/src/handle.rs
+++ b/crates/invoker-api/src/handle.rs
@@ -69,8 +69,6 @@ pub trait InvokerHandle<SR> {
         &mut self,
         partition_leader_epoch: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        // If true, acknowledge the abort. This will generate a Failed effect
-        acknowledge: bool,
     ) -> impl Future<Output = Result<(), NotRunningError>> + Send;
 
     fn register_partition(

--- a/crates/invoker-api/src/lib.rs
+++ b/crates/invoker-api/src/lib.rs
@@ -138,7 +138,6 @@ pub mod test_util {
             &mut self,
             _partition_leader_epoch: PartitionLeaderEpoch,
             _invocation_id: InvocationId,
-            _acknowledge: bool,
         ) -> Result<(), NotRunningError> {
             Ok(())
         }

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -51,7 +51,6 @@ pub(crate) enum InputCommand<SR> {
     Abort {
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        acknowledge: bool,
     },
 
     /// Command used to clean up internal state when a partition leader is going away
@@ -151,13 +150,11 @@ impl<SR: Send> restate_invoker_api::InvokerHandle<SR> for InvokerHandle<SR> {
         &mut self,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        acknowledge: bool,
     ) -> Result<(), NotRunningError> {
         self.input
             .send(InputCommand::Abort {
                 partition,
                 invocation_id,
-                acknowledge,
             })
             .map_err(|_| NotRunningError)
     }

--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -118,6 +118,7 @@ message Source {
 message InvocationStatusV2 {
 
   enum Status {
+    // This used to be the KILLED invocation status experimental feature.
     reserved 6;
     UNKNOWN_STATUS = 0;
     SCHEDULED = 1;

--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -118,12 +118,12 @@ message Source {
 message InvocationStatusV2 {
 
   enum Status {
+    reserved 6;
     UNKNOWN_STATUS = 0;
     SCHEDULED = 1;
     INBOXED = 2;
     INVOKED = 3;
     SUSPENDED = 4;
-    KILLED = 6;
     COMPLETED = 5;
   }
 

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -19,7 +19,7 @@ use futures_util::stream;
 use restate_rocksdb::RocksDbPerfGuard;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, InvocationStatusDiscriminants, InvocationStatusTable,
-    InvokedOrKilledInvocationStatusLite, ReadOnlyInvocationStatusTable,
+    InvokedInvocationStatusLite, ReadOnlyInvocationStatusTable,
 };
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
@@ -189,10 +189,10 @@ fn delete_invocation_status<S: StorageAccess>(
     storage.delete_key(&create_invocation_status_key(invocation_id))
 }
 
-fn invoked_or_killed_invocations<S: StorageAccess>(
+fn invoked_invocations<S: StorageAccess>(
     storage: &mut S,
     partition_key_range: RangeInclusive<PartitionKey>,
-) -> Result<Vec<Result<InvokedOrKilledInvocationStatusLite>>> {
+) -> Result<Vec<Result<InvokedInvocationStatusLite>>> {
     let _x = RocksDbPerfGuard::new("invoked-invocations");
     let mut invocations = storage.for_each_key_value_in_place(
         FullScanPartitionKeyRange::<InvocationStatusKeyV1>(partition_key_range.clone()),
@@ -208,7 +208,7 @@ fn invoked_or_killed_invocations<S: StorageAccess>(
     invocations.extend(storage.for_each_key_value_in_place(
         FullScanPartitionKeyRange::<InvocationStatusKey>(partition_key_range),
         |mut k, mut v| {
-            let result = read_invoked_or_killed_status_lite(&mut k, &mut v).transpose();
+            let result = read_invoked_full_invocation_id(&mut k, &mut v).transpose();
             if let Some(res) = result {
                 TableScanIterationDecision::Emit(res)
             } else {
@@ -260,37 +260,29 @@ fn all_invocation_status<S: StorageAccess>(
 fn read_invoked_v1_full_invocation_id(
     mut k: &mut &[u8],
     v: &mut &[u8],
-) -> Result<Option<InvokedOrKilledInvocationStatusLite>> {
+) -> Result<Option<InvokedInvocationStatusLite>> {
     let invocation_id = invocation_id_from_v1_key_bytes(&mut k)?;
     let invocation_status = InvocationStatusV1::decode(v)?;
     if let InvocationStatus::Invoked(invocation_meta) = invocation_status.0 {
-        Ok(Some(InvokedOrKilledInvocationStatusLite {
+        Ok(Some(InvokedInvocationStatusLite {
             invocation_id,
             invocation_target: invocation_meta.invocation_target,
-            is_invoked: true,
         }))
     } else {
         Ok(None)
     }
 }
 
-fn read_invoked_or_killed_status_lite(
+fn read_invoked_full_invocation_id(
     mut k: &mut &[u8],
     v: &mut &[u8],
-) -> Result<Option<InvokedOrKilledInvocationStatusLite>> {
+) -> Result<Option<InvokedInvocationStatusLite>> {
     let invocation_id = invocation_id_from_key_bytes(&mut k)?;
     let invocation_status = InvocationLite::decode(v)?;
     if let InvocationStatusDiscriminants::Invoked = invocation_status.status {
-        Ok(Some(InvokedOrKilledInvocationStatusLite {
+        Ok(Some(InvokedInvocationStatusLite {
             invocation_id,
             invocation_target: invocation_status.invocation_target,
-            is_invoked: true,
-        }))
-    } else if let InvocationStatusDiscriminants::Killed = invocation_status.status {
-        Ok(Some(InvokedOrKilledInvocationStatusLite {
-            invocation_id,
-            invocation_target: invocation_status.invocation_target,
-            is_invoked: false,
         }))
     } else {
         Ok(None)
@@ -306,10 +298,10 @@ impl ReadOnlyInvocationStatusTable for PartitionStore {
         get_invocation_status(self, invocation_id)
     }
 
-    fn all_invoked_or_killed_invocations(
+    fn all_invoked_invocations(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<InvokedOrKilledInvocationStatusLite>> + Send> {
-        Ok(stream::iter(invoked_or_killed_invocations(
+    ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send> {
+        Ok(stream::iter(invoked_invocations(
             self,
             self.partition_key_range().clone(),
         )?))
@@ -332,10 +324,10 @@ impl ReadOnlyInvocationStatusTable for PartitionStoreTransaction<'_> {
         try_migrate_and_get_invocation_status(self, invocation_id)
     }
 
-    fn all_invoked_or_killed_invocations(
+    fn all_invoked_invocations(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<InvokedOrKilledInvocationStatusLite>> + Send> {
-        Ok(stream::iter(invoked_or_killed_invocations(
+    ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send> {
+        Ok(stream::iter(invoked_invocations(
             self,
             self.partition_key_range().clone(),
         )?))

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -73,15 +73,6 @@ const INVOCATION_TARGET_4: InvocationTarget = InvocationTarget::VirtualObject {
 static INVOCATION_ID_4: LazyLock<InvocationId> =
     LazyLock::new(|| InvocationId::mock_generate(&INVOCATION_TARGET_4));
 
-const INVOCATION_TARGET_5: InvocationTarget = InvocationTarget::VirtualObject {
-    name: ByteString::from_static("abc"),
-    key: ByteString::from_static("5"),
-    handler: ByteString::from_static("myhandler"),
-    handler_ty: VirtualObjectHandlerType::Exclusive,
-};
-static INVOCATION_ID_5: LazyLock<InvocationId> =
-    LazyLock::new(|| InvocationId::mock_generate(&INVOCATION_TARGET_5));
-
 static RPC_REQUEST_ID: LazyLock<PartitionProcessorRpcRequestId> =
     LazyLock::new(PartitionProcessorRpcRequestId::new);
 
@@ -140,14 +131,7 @@ async fn populate_data<T: InvocationStatusTable>(txn: &mut T) {
 
     txn.put_invocation_status(
         &INVOCATION_ID_4,
-        &invoked_status(INVOCATION_TARGET_4.clone()),
-    )
-    .await
-    .unwrap();
-
-    txn.put_invocation_status(
-        &INVOCATION_ID_5,
-        &suspended_status(INVOCATION_TARGET_5.clone()),
+        &suspended_status(INVOCATION_TARGET_4.clone()),
     )
     .await
     .unwrap();
@@ -159,13 +143,6 @@ async fn verify_point_lookups<T: InvocationStatusTable>(txn: &mut T) {
             .await
             .expect("should not fail"),
         invoked_status(INVOCATION_TARGET_1.clone())
-    );
-
-    assert_eq!(
-        txn.get_invocation_status(&INVOCATION_ID_4)
-            .await
-            .expect("should not fail"),
-        invoked_status(INVOCATION_TARGET_4.clone())
     );
 }
 
@@ -186,11 +163,7 @@ async fn verify_all_svc_with_status_invoked<T: InvocationStatusTable>(txn: &mut 
             eq(InvokedInvocationStatusLite {
                 invocation_id: *INVOCATION_ID_2,
                 invocation_target: INVOCATION_TARGET_2.clone(),
-            }),
-            eq(InvokedInvocationStatusLite {
-                invocation_id: *INVOCATION_ID_4,
-                invocation_target: INVOCATION_TARGET_4.clone(),
-            }),
+            })
         ]
     );
 }

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -83,10 +83,6 @@ pub(crate) fn append_invocation_status_row(
             row.status("suspended");
             fill_in_flight_invocation_metadata(&mut row, output, metadata);
         }
-        InvocationStatus::Killed(metadata) => {
-            row.status("killed");
-            fill_in_flight_invocation_metadata(&mut row, output, metadata);
-        }
         InvocationStatus::Free => {
             row.status("free");
         }

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -23,7 +23,7 @@ define_table!(sys_invocation_status(
     /// [Invocation ID](/operate/invocation#invocation-identifier).
     id: DataType::LargeUtf8,
 
-    /// Either `inboxed` or `scheduled` or `invoked` or `suspended` or `killed` or `completed`
+    /// Either `inboxed` or `scheduled` or `invoked` or `suspended` or `completed`
     status: DataType::LargeUtf8,
 
     /// If `status = 'completed'`, this contains either `success` or `failure`

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -48,9 +48,6 @@ pub struct WorkerOptions {
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     cleanup_interval: humantime::Duration,
 
-    #[cfg_attr(feature = "schemars", schemars(skip))]
-    experimental_feature_invocation_status_killed: bool,
-
     pub storage: StorageOptions,
 
     pub invoker: InvokerOptions,
@@ -86,10 +83,6 @@ impl WorkerOptions {
     pub fn cleanup_interval(&self) -> Duration {
         self.cleanup_interval.into()
     }
-
-    pub fn experimental_feature_invocation_status_killed(&self) -> bool {
-        self.experimental_feature_invocation_status_killed
-    }
 }
 
 impl Default for WorkerOptions {
@@ -98,7 +91,6 @@ impl Default for WorkerOptions {
             internal_queue_length: NonZeroUsize::new(1000).expect("Non zero number"),
             num_timers_in_memory_limit: None,
             cleanup_interval: Duration::from_secs(60 * 60).into(),
-            experimental_feature_invocation_status_killed: false,
             storage: StorageOptions::default(),
             invoker: Default::default(),
             max_command_batch_size: NonZeroUsize::new(4).expect("Non zero number"),

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -172,7 +172,7 @@ mod tests {
     use restate_storage_api::StorageError;
     use restate_storage_api::invocation_status_table::{
         CompletedInvocation, InFlightInvocationMetadata, InvocationStatus,
-        InvokedOrKilledInvocationStatusLite,
+        InvokedInvocationStatusLite,
     };
     use restate_types::Version;
     use restate_types::identifiers::{InvocationId, InvocationUuid};
@@ -193,10 +193,10 @@ mod tests {
             std::future::pending()
         }
 
-        fn all_invoked_or_killed_invocations(
+        fn all_invoked_invocations(
             &mut self,
         ) -> std::result::Result<
-            impl Stream<Item = restate_storage_api::Result<InvokedOrKilledInvocationStatusLite>> + Send,
+            impl Stream<Item = restate_storage_api::Result<InvokedInvocationStatusLite>> + Send,
             StorageError,
         > {
             todo!();

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -390,11 +390,8 @@ impl LeaderState {
                 .notify_completion(partition_leader_epoch, invocation_id, completion)
                 .await
                 .map_err(Error::Invoker)?,
-            Action::AbortInvocation {
-                invocation_id,
-                acknowledge,
-            } => invoker_tx
-                .abort_invocation(partition_leader_epoch, invocation_id, acknowledge)
+            Action::AbortInvocation { invocation_id } => invoker_tx
+                .abort_invocation(partition_leader_epoch, invocation_id)
                 .await
                 .map_err(Error::Invoker)?,
             Action::IngressResponse {

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -72,7 +72,7 @@ use crate::metric_definitions::{
 };
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
 use crate::partition::leadership::{LeadershipState, PartitionProcessorMetadata};
-use crate::partition::state_machine::{ActionCollector, ExperimentalFeature, StateMachine};
+use crate::partition::state_machine::{ActionCollector, StateMachine};
 
 mod cleaner;
 pub mod invoker_storage_reader;
@@ -156,11 +156,8 @@ where
             ..
         } = self;
 
-        let state_machine = Self::create_state_machine(
-            &mut partition_store,
-            partition_key_range.clone(),
-        )
-        .await?;
+        let state_machine =
+            Self::create_state_machine(&mut partition_store, partition_key_range.clone()).await?;
 
         let last_seen_leader_epoch = partition_store
             .get_dedup_sequence_number(&ProducerId::self_producer())
@@ -206,14 +203,12 @@ where
         let outbox_seq_number = partition_store.get_outbox_seq_number().await?;
         let outbox_head_seq_number = partition_store.get_outbox_head_seq_number().await?;
 
-        let mut experimental_features = EnumSet::empty();
-
         let state_machine = StateMachine::new(
             inbox_seq_number,
             outbox_seq_number,
             outbox_head_seq_number,
             partition_key_range,
-            experimental_features,
+            EnumSet::empty(),
         );
 
         Ok(state_machine)

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -55,7 +55,6 @@ pub enum Action {
     },
     AbortInvocation {
         invocation_id: InvocationId,
-        acknowledge: bool,
     },
     IngressResponse {
         request_id: PartitionProcessorRpcRequestId,

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -66,14 +66,6 @@ where
                 )
                 .await?
             }
-            InvocationStatus::Killed(_) => {
-                trace!(
-                    "Received cancel command for an already killed invocation '{}'.",
-                    self.invocation_id
-                );
-                // Nothing to do here really, let's send again the abort signal to the invoker just in case
-                ctx.send_abort_invocation_to_invoker(self.invocation_id, true);
-            }
             InvocationStatus::Completed(_) => {
                 debug!(
                     "Received cancel command for completed invocation '{}'. To cleanup the invocation after it's been completed, use the purge invocation command.",
@@ -91,7 +83,7 @@ where
                 // This can happen because the invoke/resume and the abort invoker messages end up in different queues,
                 // and the abort message can overtake the invoke/resume.
                 // Consequently the invoker might have not received the abort and the user tried to send it again.
-                ctx.send_abort_invocation_to_invoker(self.invocation_id, false);
+                ctx.send_abort_invocation_to_invoker(self.invocation_id);
             }
         };
 

--- a/crates/worker/src/partition/state_machine/lifecycle/resume.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/resume.rs
@@ -29,7 +29,6 @@ impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContex
             }
             InvocationStatus::Scheduled(_)
             | InvocationStatus::Inboxed(_)
-            | InvocationStatus::Killed(_)
             | InvocationStatus::Completed(_)
             | InvocationStatus::Free => {
                 // Nothing to do here

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -105,8 +105,7 @@ use tracing::error;
 use utils::SpanExt;
 
 #[derive(Debug, Hash, enumset::EnumSetType, strum::Display)]
-pub enum ExperimentalFeature {
-}
+pub enum ExperimentalFeature {}
 
 pub struct StateMachine {
     // initialized from persistent storage
@@ -221,6 +220,7 @@ pub(crate) struct StateMachineApplyContext<'a, S> {
     outbox_head_seq_number: &'a mut Option<MessageIndex>,
     partition_key_range: RangeInclusive<PartitionKey>,
     invoker_apply_latency: &'a Histogram,
+    #[allow(dead_code)]
     experimental_features: &'a EnumSet<ExperimentalFeature>,
     is_leader: bool,
 }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -106,9 +106,6 @@ use utils::SpanExt;
 
 #[derive(Debug, Hash, enumset::EnumSetType, strum::Display)]
 pub enum ExperimentalFeature {
-    /// If true, kill should wait for end signal from invoker, in order to implement the restart functionality.
-    /// This is enabled by experimental_feature_kill_and_restart.
-    InvocationStatusKilled,
 }
 
 pub struct StateMachine {
@@ -370,17 +367,15 @@ impl<S> StateMachineApplyContext<'_, S> {
         });
     }
 
-    fn send_abort_invocation_to_invoker(&mut self, invocation_id: InvocationId, acknowledge: bool) {
+    fn send_abort_invocation_to_invoker(&mut self, invocation_id: InvocationId) {
         debug_if_leader!(
             self.is_leader,
             restate.invocation.id = %invocation_id,
             "Send abort command to invoker"
         );
 
-        self.action_collector.push(Action::AbortInvocation {
-            invocation_id,
-            acknowledge,
-        });
+        self.action_collector
+            .push(Action::AbortInvocation { invocation_id });
     }
 
     async fn on_apply(&mut self, command: Command) -> Result<(), Error>
@@ -711,16 +706,6 @@ impl<S> StateMachineApplyContext<'_, S> {
                     }
                 }
             }
-            InvocationStatus::Killed(metadata) => {
-                self.send_response_to_sinks(
-                    service_invocation.response_sink.take().into_iter(),
-                    KILLED_INVOCATION_ERROR,
-                    Some(invocation_id),
-                    None,
-                    Some(&metadata.invocation_target),
-                )
-                .await?;
-            }
             InvocationStatus::Completed(completed) => {
                 // SAFETY: We use this field to send back the notification to ingress, and not as part of the PP deterministic logic.
                 let completion_expiry_time = unsafe { completed.completion_expiry_time() };
@@ -1050,13 +1035,6 @@ impl<S> StateMachineApplyContext<'_, S> {
                 )
                 .await?
             }
-            InvocationStatus::Killed(_) => {
-                trace!(
-                    "Received kill command for an already killed invocation with id '{invocation_id}'."
-                );
-                // Nothing to do here really, let's send again the abort signal to the invoker just in case
-                self.do_send_abort_invocation_to_invoker(invocation_id, true);
-            }
             InvocationStatus::Completed(_) => {
                 debug!(
                     "Received kill command for completed invocation '{invocation_id}'. To cleanup the invocation after it's been completed, use the purge invocation command."
@@ -1070,7 +1048,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 // This can happen because the invoke/resume and the abort invoker messages end up in different queues,
                 // and the abort message can overtake the invoke/resume.
                 // Consequently the invoker might have not received the abort and the user tried to send it again.
-                self.do_send_abort_invocation_to_invoker(invocation_id, false);
+                self.do_send_abort_invocation_to_invoker(invocation_id);
             }
         };
 
@@ -1187,13 +1165,6 @@ impl<S> StateMachineApplyContext<'_, S> {
                 )
                 .await?
             }
-            InvocationStatus::Killed(_) => {
-                trace!(
-                    "Received cancel command for an already killed invocation '{invocation_id}'."
-                );
-                // Nothing to do here really, let's send again the abort signal to the invoker just in case
-                self.do_send_abort_invocation_to_invoker( invocation_id, true);
-            }
             InvocationStatus::Completed(_) => {
                 debug!("Received cancel command for completed invocation '{invocation_id}'. To cleanup the invocation after it's been completed, use the purge invocation command.");
             }
@@ -1205,7 +1176,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 // This can happen because the invoke/resume and the abort invoker messages end up in different queues,
                 // and the abort message can overtake the invoke/resume.
                 // Consequently the invoker might have not received the abort and the user tried to send it again.
-                self.do_send_abort_invocation_to_invoker(invocation_id, false);
+                self.do_send_abort_invocation_to_invoker(invocation_id);
             }
         };
 
@@ -1345,30 +1316,13 @@ impl<S> StateMachineApplyContext<'_, S> {
         self.kill_child_invocations(&invocation_id, metadata.journal_metadata.length, &metadata)
             .await?;
 
-        if self
-            .experimental_features
-            .contains(ExperimentalFeature::InvocationStatusKilled)
-        {
-            debug_if_leader!(
-                self.is_leader,
-                restate.invocation.id = %invocation_id,
-                "Effect: Store killed invocation"
-            );
-
-            self.storage
-                .put_invocation_status(&invocation_id, &InvocationStatus::Killed(metadata))
-                .await
-                .map_err(Error::Storage)?;
-            self.do_send_abort_invocation_to_invoker(invocation_id, true);
-        } else {
-            self.end_invocation(
-                invocation_id,
-                metadata,
-                Some(ResponseResult::Failure(KILLED_INVOCATION_ERROR)),
-            )
-            .await?;
-            self.do_send_abort_invocation_to_invoker(invocation_id, false);
-        }
+        self.end_invocation(
+            invocation_id,
+            metadata,
+            Some(ResponseResult::Failure(KILLED_INVOCATION_ERROR)),
+        )
+        .await?;
+        self.do_send_abort_invocation_to_invoker(invocation_id);
         Ok(())
     }
 
@@ -1391,15 +1345,13 @@ impl<S> StateMachineApplyContext<'_, S> {
         self.kill_child_invocations(&invocation_id, metadata.journal_metadata.length, &metadata)
             .await?;
 
-        // No need to go through the Killed state when we're suspended,
-        // because it means we already got a terminal state from the invoker.
         self.end_invocation(
             invocation_id,
             metadata,
             Some(ResponseResult::Failure(KILLED_INVOCATION_ERROR)),
         )
         .await?;
-        self.do_send_abort_invocation_to_invoker(invocation_id, false);
+        self.do_send_abort_invocation_to_invoker(invocation_id);
         Ok(())
     }
 
@@ -1793,21 +1745,12 @@ impl<S> StateMachineApplyContext<'_, S> {
             + journal_table_v2::JournalTable,
     {
         let is_status_invoked = matches!(invocation_status, InvocationStatus::Invoked(_));
-        let is_status_killed = matches!(invocation_status, InvocationStatus::Killed(_));
 
-        if !is_status_invoked && !is_status_killed {
+        if !is_status_invoked {
             trace!(
-                "Received invoker effect for invocation not in invoked nor killed status. Ignoring the effect."
+                "Received invoker effect for invocation not in invoked status. Ignoring the effect."
             );
-            self.do_send_abort_invocation_to_invoker(invocation_id, false);
-            return Ok(());
-        }
-        if is_status_killed
-            && !matches!(kind, InvokerEffectKind::Failed(_) | InvokerEffectKind::End)
-        {
-            warn!(
-                "Received non terminal invoker effect for killed invocation. Ignoring the effect."
-            );
+            self.do_send_abort_invocation_to_invoker(invocation_id);
             return Ok(());
         }
 
@@ -1828,7 +1771,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     entry,
                     invocation_status
                         .into_invocation_metadata()
-                        .expect("Must be present if status is killed or invoked"),
+                        .expect("Must be present if status is invoked"),
                 )
                 .await?;
             }
@@ -1855,7 +1798,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             } => {
                 let invocation_metadata = invocation_status
                     .into_invocation_metadata()
-                    .expect("Must be present if status is killed or invoked");
+                    .expect("Must be present if status is invoked");
                 debug_assert!(
                     !waiting_for_completed_entries.is_empty(),
                     "Expecting at least one entry on which the invocation {invocation_id} is waiting."
@@ -1907,13 +1850,8 @@ impl<S> StateMachineApplyContext<'_, S> {
                     invocation_id,
                     invocation_status
                         .into_invocation_metadata()
-                        .expect("Must be present if status is killed or invoked"),
-                    if is_status_killed {
-                        // It doesn't matter that the invocation successfully completed, we return failed anyway in this case.
-                        Some(ResponseResult::Failure(KILLED_INVOCATION_ERROR))
-                    } else {
-                        None
-                    },
+                        .expect("Must be present if status is invoked"),
+                    None,
                 )
                 .await?;
             }
@@ -1922,7 +1860,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     invocation_id,
                     invocation_status
                         .into_invocation_metadata()
-                        .expect("Must be present if status is killed or invoked"),
+                        .expect("Must be present if status is invoked"),
                     Some(ResponseResult::Failure(e)),
                 )
                 .await?;
@@ -3436,16 +3374,6 @@ impl<S> StateMachineApplyContext<'_, S> {
                     .await?;
                 }
             }
-            InvocationStatus::Killed(metadata) => {
-                self.send_response_to_sinks(
-                    vec![attach_invocation_request.response_sink],
-                    KILLED_INVOCATION_ERROR,
-                    Some(invocation_id),
-                    None,
-                    Some(&metadata.invocation_target),
-                )
-                .await?;
-            }
             InvocationStatus::Completed(completed) => {
                 // SAFETY: We use this field to send back the notification to ingress, and not as part of the PP deterministic logic.
                 let completion_expiry_time = unsafe { completed.completion_expiry_time() };
@@ -4123,17 +4051,11 @@ impl<S> StateMachineApplyContext<'_, S> {
         Ok(())
     }
 
-    fn do_send_abort_invocation_to_invoker(
-        &mut self,
-        invocation_id: InvocationId,
-        acknowledge: bool,
-    ) {
+    fn do_send_abort_invocation_to_invoker(&mut self, invocation_id: InvocationId) {
         debug_if_leader!(self.is_leader, restate.invocation.id = %invocation_id, "Send abort command to invoker");
 
-        self.action_collector.push(Action::AbortInvocation {
-            invocation_id,
-            acknowledge,
-        });
+        self.action_collector
+            .push(Action::AbortInvocation { invocation_id });
     }
 
     async fn do_mutate_state(&mut self, state_mutation: ExternalStateMutation) -> Result<(), Error>


### PR DESCRIPTION
This was supposed to be used for restart, but as described here https://github.com/restatedev/restate/issues/2890#issuecomment-2717274073 we now got a new solution.

First part of #2890