### PR TITLE
[Core] Remove WeakConnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,7 +4205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -30,7 +30,7 @@ use restate_types::{GenerationalNodeId, Version, Versioned};
 
 use crate::metadata::manager::Command;
 use crate::metadata_store::{MetadataStoreClient, ReadError};
-use crate::network::WeakConnection;
+use crate::network::Connection;
 use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
 
 #[derive(Debug, thiserror::Error)]
@@ -258,7 +258,7 @@ impl Metadata {
         &self,
         metadata_kind: MetadataKind,
         version: Version,
-        remote_peer: Option<WeakConnection>,
+        remote_peer: Option<Connection>,
         urgency: Urgency,
     ) {
         // check whether the version is newer than what we know
@@ -416,23 +416,23 @@ pub fn spawn_metadata_manager(metadata_manager: MetadataManager) -> Result<TaskI
 #[derive(Debug, Clone)]
 struct VersionInformation {
     version: Version,
-    remote_peer: Option<WeakConnection>,
+    peer_connection: Option<Connection>,
 }
 
 impl Default for VersionInformation {
     fn default() -> Self {
         Self {
             version: Version::INVALID,
-            remote_peer: None,
+            peer_connection: None,
         }
     }
 }
 
 impl VersionInformation {
-    fn new(version: Version, remote_peer: Option<WeakConnection>) -> Self {
+    fn new(version: Version, peer_connection: Option<Connection>) -> Self {
         Self {
             version,
-            remote_peer,
+            peer_connection,
         }
     }
 }

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -37,10 +37,10 @@ use crate::TaskKind;
 use crate::cancellation_watcher;
 use crate::is_cancellation_requested;
 use crate::metadata_store::{MetadataStoreClient, ReadError};
+use crate::network::Connection;
 use crate::network::Incoming;
 use crate::network::Outgoing;
 use crate::network::Reciprocal;
-use crate::network::WeakConnection;
 use crate::network::{MessageHandler, MessageRouterBuilder, NetworkError};
 
 pub(super) type CommandSender = mpsc::UnboundedSender<Command>;
@@ -546,7 +546,7 @@ impl MetadataManager {
 }
 
 enum UpdateTaskState {
-    FromPeer(WeakConnection),
+    FromPeer(Connection),
     Sync,
 }
 
@@ -557,7 +557,7 @@ struct UpdateTask {
 
 impl UpdateTask {
     fn from(version_information: VersionInformation) -> Self {
-        let state = if let Some(connection) = version_information.remote_peer {
+        let state = if let Some(connection) = version_information.peer_connection {
             UpdateTaskState::FromPeer(connection)
         } else {
             UpdateTaskState::Sync

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::sync::Weak;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -31,8 +29,8 @@ use super::protobuf::network::message;
 use super::protobuf::network::message::Body;
 
 pub struct OwnedSendPermit<M> {
-    _protocol_version: ProtocolVersion,
-    _permit: mpsc::OwnedPermit<EgressMessage>,
+    protocol_version: ProtocolVersion,
+    permit: mpsc::OwnedPermit<EgressMessage>,
     _phantom: std::marker::PhantomData<M>,
 }
 
@@ -66,21 +64,43 @@ where
     }
 }
 
+impl<M> OwnedSendPermit<M>
+where
+    M: WireEncode + Targeted,
+{
+    /// Sends a message over this permit.
+    ///
+    /// Note that sending messages over this permit won't use the peer information nor the connection
+    /// associated with the message.
+    pub fn send<S>(self, message: Outgoing<M, S>) {
+        let header = Header {
+            msg_id: message.msg_id(),
+            in_response_to: message.in_response_to(),
+            ..Default::default()
+        };
+
+        let target = M::TARGET.into();
+        let payload = message.into_body().encode_to_bytes(self.protocol_version);
+
+        let body = Body::Encoded(message::BinaryMessage { target, payload });
+        self.permit
+            .send(EgressMessage::Message(header, body, Some(Span::current())));
+    }
+}
+
 /// A single streaming connection with a channel to the peer. A connection can be
 /// opened by either ends of the connection and has no direction. Any connection
 /// can be used to send or receive from a peer.
-///
-/// The primary owner of a connection is the running reactor, all other components
-/// should hold a `WeakConnection` if access to a certain connection is
-/// needed.
-pub struct OwnedConnection {
+#[derive(Clone, derive_more::Debug)]
+pub struct Connection {
     pub(crate) peer: GenerationalNodeId,
     pub(crate) protocol_version: ProtocolVersion,
+    #[debug(skip)]
     pub(crate) sender: EgressSender,
     pub(crate) created: Instant,
 }
 
-impl OwnedConnection {
+impl Connection {
     pub(crate) fn new(
         peer: GenerationalNodeId,
         protocol_version: ProtocolVersion,
@@ -95,12 +115,22 @@ impl OwnedConnection {
     }
 
     #[cfg(any(test, feature = "test-util"))]
+    pub fn new_closed(peer: GenerationalNodeId) -> Self {
+        Self {
+            peer,
+            protocol_version: Default::default(),
+            sender: EgressSender::new_closed(),
+            created: Instant::now(),
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
     pub fn new_fake(
         peer: GenerationalNodeId,
         protocol_version: ProtocolVersion,
         capacity: usize,
     ) -> (
-        Arc<Self>,
+        Self,
         super::io::UnboundedEgressSender,
         super::io::EgressStream,
         super::io::DropEgressStream,
@@ -109,7 +139,7 @@ impl OwnedConnection {
 
         let (sender, unbounded_sender, egress, drop_egress) = EgressStream::create(capacity);
         (
-            Arc::new(Self::new(peer, protocol_version, sender)),
+            Self::new(peer, protocol_version, sender),
             unbounded_sender,
             egress,
             drop_egress,
@@ -144,15 +174,6 @@ impl OwnedConnection {
         self.sender.close(reason).await
     }
 
-    /// A handle that sends messages through that connection. This hides the
-    /// wire protocol from the user and guarantees order of messages.
-    pub fn downgrade(self: &Arc<Self>) -> WeakConnection {
-        WeakConnection {
-            peer: self.peer,
-            connection: Arc::downgrade(self),
-        }
-    }
-
     /// Allocates capacity to send one message on this connection. If connection is closed, this
     /// returns None.
     pub async fn reserve<M>(&self) -> Option<SendPermit<'_, M>> {
@@ -169,24 +190,24 @@ impl OwnedConnection {
     pub async fn reserve_timeout<M>(
         &self,
         timeout: Duration,
-    ) -> Result<SendPermit<'_, M>, NetworkError> {
+    ) -> Result<OwnedSendPermit<M>, NetworkError> {
         let start = Instant::now();
-        let permit = tokio::time::timeout(timeout, self.sender.reserve())
+        let permit = tokio::time::timeout(timeout, self.sender.clone().reserve_owned())
             .await
             .map_err(|_| NetworkError::Timeout(start.elapsed()))?
-            .map_err(|_| NetworkError::ConnectionClosed(self.peer))?;
-        Ok(SendPermit {
+            .map_err(|_| NetworkError::ConnectionClosed(ConnectionClosed))?;
+        Ok(OwnedSendPermit {
             permit,
             protocol_version: self.protocol_version,
             _phantom: std::marker::PhantomData,
         })
     }
 
-    pub async fn reserve_owned<M>(self) -> Option<OwnedSendPermit<M>> {
-        let permit = self.sender.reserve_owned().await.ok()?;
+    pub async fn reserve_owned<M>(&self) -> Option<OwnedSendPermit<M>> {
+        let permit = self.sender.clone().reserve_owned().await.ok()?;
         Some(OwnedSendPermit {
-            _permit: permit,
-            _protocol_version: self.protocol_version,
+            permit,
+            protocol_version: self.protocol_version,
             _phantom: std::marker::PhantomData,
         })
     }
@@ -197,7 +218,9 @@ impl OwnedConnection {
         let permit = match self.sender.try_reserve() {
             Ok(permit) => permit,
             Err(TrySendError::Full(_)) => return Err(NetworkError::Full),
-            Err(TrySendError::Closed(_)) => return Err(NetworkError::ConnectionClosed(self.peer)),
+            Err(TrySendError::Closed(_)) => {
+                return Err(NetworkError::ConnectionClosed(ConnectionClosed));
+            }
         };
 
         Ok(SendPermit {
@@ -206,60 +229,29 @@ impl OwnedConnection {
             _phantom: std::marker::PhantomData,
         })
     }
+
+    /// Tries to allocate capacity to send one message on this connection. If there is no capacity,
+    /// it will fail with [`NetworkError::Full`]. If connection is closed it returns [`NetworkError::ConnectionClosed`]
+    pub fn try_reserve_owned<M>(&self) -> Result<OwnedSendPermit<M>, NetworkError> {
+        let permit = self.sender.clone().try_reserve_owned()?;
+
+        Ok(OwnedSendPermit {
+            permit,
+            protocol_version: self.protocol_version,
+            _phantom: std::marker::PhantomData,
+        })
+    }
 }
 
-impl PartialEq for OwnedConnection {
+impl PartialEq for Connection {
     fn eq(&self, other: &Self) -> bool {
         self.sender.same_channel(&other.sender)
-    }
-}
-
-/// A handle to send messages through a connection. It's safe to hold and clone objects of this
-/// even if the connection has been dropped. Cheap to clone.
-#[derive(Clone, Debug)]
-pub struct WeakConnection {
-    pub(crate) peer: GenerationalNodeId,
-    pub(crate) connection: Weak<OwnedConnection>,
-}
-
-static_assertions::assert_impl_all!(WeakConnection: Send, Sync);
-
-impl WeakConnection {
-    pub fn new_closed(peer: GenerationalNodeId) -> Self {
-        Self {
-            peer,
-            connection: Weak::new(),
-        }
-    }
-
-    /// The node id at the other end of this connection
-    pub fn peer(&self) -> GenerationalNodeId {
-        self.peer
-    }
-
-    /// Resolves when the connection is closed
-    pub fn closed(&self) -> impl std::future::Future<Output = ()> + Send + Sync + 'static {
-        let weak_connection = self.connection.clone();
-        async move {
-            let Some(connection) = weak_connection.upgrade() else {
-                return;
-            };
-            connection.closed().await
-        }
-    }
-}
-
-impl PartialEq for WeakConnection {
-    fn eq(&self, other: &Self) -> bool {
-        self.connection.ptr_eq(&other.connection)
     }
 }
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
     use super::*;
-
-    use std::sync::Arc;
 
     use async_trait::async_trait;
     use futures::StreamExt;
@@ -340,7 +332,7 @@ pub mod test_util {
                 EgressStream::create(message_buffer);
             let incoming = incoming.map(Ok);
 
-            let hello = Hello::new(from_node_id, my_cluster_name);
+            let hello = Hello::new(Some(from_node_id), my_cluster_name);
             let header = Header {
                 my_nodes_config_version: Some(my_node_config_version.into()),
                 msg_id: crate::network::generate_msg_id(),
@@ -407,8 +399,8 @@ pub mod test_util {
         pub async fn reserve_owned<M>(self) -> Option<OwnedSendPermit<M>> {
             let permit = self.sender.reserve_owned().await.ok()?;
             Some(OwnedSendPermit {
-                _permit: permit,
-                _protocol_version: self.protocol_version,
+                permit,
+                protocol_version: self.protocol_version,
                 _phantom: std::marker::PhantomData,
             })
         }
@@ -420,7 +412,7 @@ pub mod test_util {
                 Ok(permit) => permit,
                 Err(TrySendError::Full(_)) => return Err(NetworkError::Full),
                 Err(TrySendError::Closed(_)) => {
-                    return Err(NetworkError::ConnectionClosed(self.peer));
+                    return Err(NetworkError::ConnectionClosed(ConnectionClosed));
                 }
             };
 
@@ -431,11 +423,11 @@ pub mod test_util {
             })
         }
 
-        /// Allows you to use utilities in OwnedConnection or WeakConnection.
+        /// Allows you to use utilities in Connection
         /// Reminder: Sending on this connection will cause message to arrive as incoming to the node
         /// we are connected to.
-        pub fn to_owned_connection(&self) -> OwnedConnection {
-            OwnedConnection {
+        pub fn to_owned_connection(&self) -> Connection {
+            Connection {
                 peer: self.peer,
                 protocol_version: self.protocol_version,
                 sender: self.sender.clone(),
@@ -447,7 +439,7 @@ pub mod test_util {
         pub fn process_with_message_handler<H: MessageHandler + Send + Sync + 'static>(
             self,
             handler: H,
-        ) -> anyhow::Result<(WeakConnection, TaskHandle<anyhow::Result<()>>)> {
+        ) -> anyhow::Result<(Connection, TaskHandle<anyhow::Result<()>>)> {
             let mut router = MessageRouterBuilder::default();
             router.add_message_handler(handler);
             let router = router.build();
@@ -460,7 +452,7 @@ pub mod test_util {
         pub fn process_with_message_router<R: Handler + 'static>(
             self,
             router: R,
-        ) -> anyhow::Result<(WeakConnection, TaskHandle<anyhow::Result<()>>)> {
+        ) -> anyhow::Result<(Connection, TaskHandle<anyhow::Result<()>>)> {
             let Self {
                 my_node_id,
                 peer,
@@ -472,18 +464,17 @@ pub mod test_util {
                 drop_egress,
             } = self;
 
-            let connection = Arc::new(OwnedConnection {
+            let connection = Connection {
                 peer,
                 protocol_version,
                 sender,
                 created,
-            });
+            };
 
-            let weak = connection.downgrade();
             let message_processor = MessageProcessor {
                 my_node_id,
                 router,
-                connection,
+                connection: connection.clone(),
                 tx: unbounded_sender,
                 recv_stream,
             };
@@ -492,14 +483,14 @@ pub mod test_util {
                 "test-message-processor",
                 async move { message_processor.run(drop_egress).await },
             )?;
-            Ok((weak, handle))
+            Ok((connection, handle))
         }
 
         // Allow for messages received on this connection to be forwarded to the supplied sender.
         pub fn forward_to_sender(
             self,
             sender: mpsc::Sender<(GenerationalNodeId, Incoming<BinaryMessage>)>,
-        ) -> anyhow::Result<(WeakConnection, TaskHandle<anyhow::Result<()>>)> {
+        ) -> anyhow::Result<(Connection, TaskHandle<anyhow::Result<()>>)> {
             let handler = ForwardingHandler {
                 my_node_id: self.my_node_id,
                 inner_sender: sender,
@@ -635,7 +626,7 @@ pub mod test_util {
     struct MessageProcessor<R> {
         my_node_id: GenerationalNodeId,
         router: R,
-        connection: Arc<OwnedConnection>,
+        connection: Connection,
         tx: UnboundedEgressSender,
         recv_stream: BoxStream<'static, Message>,
     }
@@ -703,7 +694,7 @@ pub mod test_util {
                         .call(
                             Incoming::from_parts(
                                 msg,
-                                self.connection.downgrade(),
+                                self.connection.clone(),
                                 header.msg_id,
                                 header.in_response_to,
                                 PeerMetadataVersion::from(header),

--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -60,8 +60,8 @@ pub enum NetworkError {
     OldPeerGeneration(String),
     #[error("node {0} was shut down")]
     NodeIsGone(GenerationalNodeId),
-    #[error("connection lost to peer {0}")]
-    ConnectionClosed(GenerationalNodeId),
+    #[error(transparent)]
+    ConnectionClosed(#[from] ConnectionClosed),
     #[error("cannot send messages to this node: {0}")]
     Unavailable(String),
     #[error("failed syncing metadata: {0}")]

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -28,7 +28,7 @@ pub mod tonic_service_filter;
 pub mod transport_connector;
 mod types;
 
-pub use connection::{OwnedConnection, WeakConnection};
+pub use connection::Connection;
 pub use connection_manager::ConnectionManager;
 pub use error::*;
 pub use grpc::GrpcConnector;

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -29,11 +29,11 @@ pub mod network {
     use self::message::{BinaryMessage, ConnectionControl, Signal};
 
     impl Hello {
-        pub fn new(my_node_id: GenerationalNodeId, cluster_name: String) -> Self {
+        pub fn new(my_node_id: Option<GenerationalNodeId>, cluster_name: String) -> Self {
             Self {
                 min_protocol_version: MIN_SUPPORTED_PROTOCOL_VERSION.into(),
                 max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
-                my_node_id: Some(my_node_id.into()),
+                my_node_id: my_node_id.map(Into::into),
                 cluster_name,
             }
         }

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -458,7 +458,7 @@ mod test {
     use restate_types::GenerationalNodeId;
     use restate_types::net::TargetName;
 
-    use crate::network::{PeerMetadataVersion, WeakConnection};
+    use crate::network::{Connection, PeerMetadataVersion};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct TestRequest {
@@ -540,7 +540,7 @@ mod test {
                 TestResponse {
                     text: "test".to_string(),
                 },
-                WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
+                Connection::new_closed(GenerationalNodeId::new(1, 1)),
                 1,
                 Some(42),
                 PeerMetadataVersion::default(),
@@ -553,7 +553,7 @@ mod test {
             TestResponse {
                 text: "test".to_string(),
             },
-            WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
+            Connection::new_closed(GenerationalNodeId::new(1, 1)),
             1,
             Some(42),
             PeerMetadataVersion::default(),
@@ -568,7 +568,7 @@ mod test {
                 TestResponse {
                     text: "a very real message".to_string(),
                 },
-                WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
+                Connection::new_closed(GenerationalNodeId::new(1, 1)),
                 1,
                 Some(1),
                 PeerMetadataVersion::default(),
@@ -609,7 +609,7 @@ mod test {
                     TestResponse {
                         text: format!("{idx}"),
                     },
-                    WeakConnection::new_closed(GenerationalNodeId::new(0, 0)),
+                    Connection::new_closed(GenerationalNodeId::new(0, 0)),
                     1,
                     Some(idx),
                     PeerMetadataVersion::default(),

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -67,7 +67,7 @@ pub mod test_util {
     use crate::network::io::EgressStream;
     use crate::network::protobuf::network::Message;
     use crate::network::protobuf::network::message::BinaryMessage;
-    use crate::network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection};
+    use crate::network::{Connection, Incoming, MockPeerConnection, PartialPeerConnection};
     use crate::{TaskCenter, TaskHandle, TaskKind, my_node_id};
 
     #[derive(Clone)]
@@ -136,7 +136,7 @@ pub mod test_util {
     /// stream
     pub struct MessageCollectorMockConnector {
         pub mock_connector: MockConnector,
-        pub tasks: Mutex<Vec<(WeakConnection, TaskHandle<anyhow::Result<()>>)>>,
+        pub tasks: Mutex<Vec<(Connection, TaskHandle<anyhow::Result<()>>)>>,
     }
 
     impl MessageCollectorMockConnector {

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -618,7 +618,7 @@ mod tests {
     use googletest::prelude::*;
     use test_log::test;
 
-    use restate_core::network::OwnedConnection;
+    use restate_core::network::Connection;
     use restate_core::network::protobuf::network::message;
     use restate_core::{MetadataBuilder, TaskCenter};
     use restate_rocksdb::RocksDbManager;
@@ -672,7 +672,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -705,8 +705,8 @@ mod tests {
             payloads: payloads.clone(),
         };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1 = Incoming::for_testing(connection.clone(), msg1, None);
+        let msg2 = Incoming::for_testing(connection.clone(), msg2, None);
         let msg1_id = msg1.msg_id();
         let msg2_id = msg2.msg_id();
 
@@ -742,7 +742,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -785,10 +785,10 @@ mod tests {
             payloads: payloads.clone(),
         };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
-        let seal2 = Incoming::for_testing(connection.downgrade(), seal2, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1 = Incoming::for_testing(connection.clone(), msg1, None);
+        let seal1 = Incoming::for_testing(connection.clone(), seal1, None);
+        let seal2 = Incoming::for_testing(connection.clone(), seal2, None);
+        let msg2 = Incoming::for_testing(connection.clone(), msg2, None);
         let msg1_id = msg1.msg_id();
         let seal1_id = seal1.msg_id();
         let seal2_id = seal2.msg_id();
@@ -843,7 +843,7 @@ mod tests {
             flags: StoreFlags::empty(),
             payloads: payloads.clone(),
         };
-        let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
+        let msg3 = Incoming::for_testing(connection.clone(), msg3, None);
         let msg3_id = msg3.msg_id();
         worker.enqueue_store(msg3).unwrap();
         let response = net_rx.next().await.unwrap();
@@ -858,7 +858,7 @@ mod tests {
         let msg = GetLogletInfo {
             header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
         };
-        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+        let msg = Incoming::for_testing(connection.clone(), msg, None);
         let msg_id = msg.msg_id();
         worker.enqueue_get_loglet_info(msg).unwrap();
 
@@ -884,9 +884,9 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
         let (repair_connection, _repair_sender, mut peer_net_rx, _egress_drop2) =
-            OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -946,19 +946,19 @@ mod tests {
             payloads: payloads.clone(),
         };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1 = Incoming::for_testing(connection.clone(), msg1, None);
+        let msg2 = Incoming::for_testing(connection.clone(), msg2, None);
         let repair1 = Incoming::for_testing(
-            repair_connection.downgrade(),
+            repair_connection.clone(),
             repair_message_before_local_tail,
             None,
         );
         let repair2 = Incoming::for_testing(
-            repair_connection.downgrade(),
+            repair_connection.clone(),
             repair_message_after_local_tail,
             None,
         );
-        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
+        let seal1 = Incoming::for_testing(connection.clone(), seal1, None);
 
         worker.enqueue_store(msg1).unwrap();
         worker.enqueue_store(msg2).unwrap();
@@ -1003,7 +1003,7 @@ mod tests {
         let msg = GetLogletInfo {
             header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
         };
-        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+        let msg = Incoming::for_testing(connection.clone(), msg, None);
         let msg_id = msg.msg_id();
         worker.enqueue_get_loglet_info(msg).unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -1036,7 +1036,7 @@ mod tests {
         // Note: dots mean we don't have records at those globally committed offsets.
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=1 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(2)),
@@ -1053,7 +1053,7 @@ mod tests {
 
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=4 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(5)),
@@ -1070,7 +1070,7 @@ mod tests {
 
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=9 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
@@ -1097,7 +1097,7 @@ mod tests {
         // We expect to see [2, 5]. No trim gaps, no filtered gaps.
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     // faking that offset=9 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
@@ -1133,7 +1133,7 @@ mod tests {
         // We expect to see [2, FILTERED(5), 10, 11]. No trim gaps.
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     // INVALID can be used when we don't have a reasonable value to pass in.
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
@@ -1178,7 +1178,7 @@ mod tests {
         // We expect to see [FILTERED(5), 10]. (11 is not returned due to budget)
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     // INVALID can be used when we don't have a reasonable value to pass in.
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
@@ -1232,7 +1232,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store.clone(), loglet_state.clone())?;
@@ -1242,7 +1242,7 @@ mod tests {
         // The loglet has no knowledge of global commits, it shouldn't accept trims.
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::OLDEST),
                     trim_point: LogletOffset::OLDEST,
@@ -1263,7 +1263,7 @@ mod tests {
         // won't move trim point beyond its local tail.
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
                     trim_point: LogletOffset::new(9),
@@ -1283,7 +1283,7 @@ mod tests {
         // let's store some records at offsets (5, 6)
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=9 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
@@ -1307,7 +1307,7 @@ mod tests {
         // trim to 5
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
                     trim_point: LogletOffset::new(5),
@@ -1327,7 +1327,7 @@ mod tests {
         // Attempt to read. We expect to see a trim gap (1->5, 6 (data-record))
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
                     total_limit_in_bytes: None,
@@ -1369,7 +1369,7 @@ mod tests {
         // trim everything
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
                     trim_point: LogletOffset::new(9),
@@ -1389,7 +1389,7 @@ mod tests {
         // Attempt to read again. We expect to see a trim gap (1->6)
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
                     total_limit_in_bytes: None,


### PR DESCRIPTION

Removes WeakConnection as it's not needed after having tighter control over the egress sender's lifecycle. This is a critical step towards simpler interfaces. It also gets us closer to the ability of sending responses/messages during drain. The behaviour of the reactor and drain will change in the next set of PRs.

- Removes extra indirections, upgrades, etc.
- Minor changes to the MessageRouter, more to come.
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2894).
* #2907
* __->__ #2894