### PR TITLE
Add contributor license agreement to repository

### DIFF
--- a/docs/dev/cla.md
+++ b/docs/dev/cla.md
@@ -1,0 +1,48 @@
+Restate Contributor License Agreement
+
+Thank you for your interest in the open source project(s) managed by Restate GmbH. (“Restate”). 
+In order to clarify the intellectual property license granted with Contributions from any person or entity, Restate must have a Contributor License Agreement (“CLA”) on file that has been entered into by each contributor, indicating agreement to the license terms below. 
+This license is for your protection as a contributor as well as the protection of Restate and its other contributors and users; it does not change your rights to use your own Contributions for any other purpose.
+
+You accept and agree to these terms and conditions for Your present and future Contributions submitted to Restate. 
+In return, Restate shall consider Your Contributions for addition to the official Restate open source project(s) for which they were submitted. 
+Except for the license granted herein to Restate and recipients of software distributed by Restate, You reserve all right, title, and interest in and to Your Contributions.
+
+1. Definitions.
+
+“You” (or “Your”) shall mean the copyright owner or legal entity authorized by the copyright owner that is entering into this CLA with Restate. 
+For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. 
+For the purposes of this definition, “control” means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+“Contribution” shall mean any code, documentation or other original works of authorship, including any modifications or additions to an existing work, that are intentionally submitted by You to Restate for inclusion in, or documentation of, any of the products owned or managed by Restate (the “Work”). 
+For the purposes of this definition, “submitted” means any form of electronic, verbal, or written communication sent to Restate or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Restate for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as “Not a Contribution.”
+
+2. Grant of Copyright License. 
+Subject to the terms and conditions of this CLA, You hereby grant to Restate and to recipients of software distributed by Restate a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+3. Grant of Patent License. 
+Subject to the terms and conditions of this CLA, You hereby grant to Restate and to recipients of software distributed by Restate a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) were submitted. 
+If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which You have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this CLA for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+4. Authority. 
+You represent and warrant that You are legally entitled to grant the above license. 
+If You are an individual and Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to Restate, or that Your employer has entered into a separate CLA with Restate covering Your Contributions. 
+If You are a Company, You represent further that each employee making a Contribution to Restate under the Company’s name is authorized to submit Contributions on behalf of the Company.
+
+5. Original Works. 
+You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). 
+You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+6. Disclaimer. 
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. 
+You may provide support for free, for a fee, or not at all. 
+UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, EXCEPT FOR THE WARRANTIES SET FORTH ABOVE, YOU PROVIDE YOUR CONTRIBUTIONS ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Submissions on Behalf of Others. 
+Should You wish to submit work that is not Your original creation, You may submit it to Restate separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which You are personally aware, and conspicuously marking the work as “Submitted on behalf of a third-party: [name here]”.
+
+8. Additional Facts/Circumstances. 
+You agree to notify Restate of any facts or circumstances of which You become aware that would make the above representations and warranties inaccurate in any respect.
+
+9. Authorization. 
+If You are entering into this CLA as a Company, You represent and warrant that the individual accepting this CLA is duly authorized to enter into this CLA on the Company’s behalf.


### PR DESCRIPTION
The CLA is based on the iCLA of the ASF https://www.apache.org/licenses/icla.pdf and RedPanda's CLA https://github.com/redpanda-data/redpanda/blob/dev/licenses/cla.md.

This fixes #2900.