### PR TITLE
New connection reactor implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,7 +4205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/core/protobuf/restate/network.proto
+++ b/crates/core/protobuf/restate/network.proto
@@ -9,9 +9,9 @@
 
 syntax = "proto3";
 
-import "restate/common.proto";
-
 package restate.network;
+
+import "restate/common.proto";
 
 //
 // # Wire Protocol Of Streaming Connections
@@ -35,7 +35,33 @@ message Header {
   optional SpanContext span_context = 7;
 }
 
-message SpanContext { map<string, string> fields = 1; }
+message SpanContext {
+  map<string, string> fields = 1;
+}
+
+// direction is defined from the lens of the connection initiator
+enum ConnectionDirection {
+  // By default, it's assumed this is a bidirectional connection to maintain
+  // compatibility with v1.2
+  ConnectionDirection_UNKNOWN = 0;
+  // Connection is declared by initiator as bidirectional. Bidirectional
+  // connections are used to send and receive rpc and unary messages by both ends
+  // of the connection.
+  BIDIRECTIONAL = 1;
+  // Connection is declared by initiator that it's used by initiator to send rpc
+  // requests and unary messages to the peer (acceptor). The acceptor side should *not*
+  // use this connection to send requests back to us. Only servicing requests. This is
+  // a typical case for a server who wants to run a side dedicated connection to a peer
+  // or for a client session connecting to a server.
+  FORWARD = 2;
+  // Connection is declared as a reverse connection by the initiator. A reverse connection
+  // is used to receive requests from peers. The acceptor can use this connection to send
+  // rpc requests to us.
+  //
+  // This can be used to initiate connections to a remote node that doesn't have
+  // network access to initiate connections back to us.
+  REVERSE = 3;
+}
 
 // First message sent to an ingress after starting the connection. The message
 // must be sent before any other message.
@@ -47,12 +73,18 @@ message Hello {
   // this is optional for future-proofing with anonymous clients using this
   // protocol
   optional restate.common.GenerationalNodeId my_node_id = 4;
+  ConnectionDirection direction = 5;
 }
 
 message Welcome {
+  reserved 1;
   restate.common.ProtocolVersion protocol_version = 2;
   // generational node id of sender
   restate.common.GenerationalNodeId my_node_id = 3;
+  // confirmation that this connection respects the direction state in the Hello message.
+  // if this is unset (UNKNOWN) then it's equivalent to if the Hello message had `BIDIRECTIONAL`
+  // for backward compatibility.
+  ConnectionDirection direction_ack = 4;
 }
 
 // Bidirectional Communication

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -30,7 +30,7 @@ use restate_types::{GenerationalNodeId, Version, Versioned};
 
 use crate::metadata::manager::Command;
 use crate::metadata_store::{MetadataStoreClient, ReadError};
-use crate::network::WeakConnection;
+use crate::network::Connection;
 use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
 
 #[derive(Debug, thiserror::Error)]
@@ -258,7 +258,7 @@ impl Metadata {
         &self,
         metadata_kind: MetadataKind,
         version: Version,
-        remote_peer: Option<WeakConnection>,
+        remote_peer: Option<Connection>,
         urgency: Urgency,
     ) {
         // check whether the version is newer than what we know
@@ -416,23 +416,23 @@ pub fn spawn_metadata_manager(metadata_manager: MetadataManager) -> Result<TaskI
 #[derive(Debug, Clone)]
 struct VersionInformation {
     version: Version,
-    remote_peer: Option<WeakConnection>,
+    peer_connection: Option<Connection>,
 }
 
 impl Default for VersionInformation {
     fn default() -> Self {
         Self {
             version: Version::INVALID,
-            remote_peer: None,
+            peer_connection: None,
         }
     }
 }
 
 impl VersionInformation {
-    fn new(version: Version, remote_peer: Option<WeakConnection>) -> Self {
+    fn new(version: Version, peer_connection: Option<Connection>) -> Self {
         Self {
             version,
-            remote_peer,
+            peer_connection,
         }
     }
 }

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -37,10 +37,10 @@ use crate::TaskKind;
 use crate::cancellation_watcher;
 use crate::is_cancellation_requested;
 use crate::metadata_store::{MetadataStoreClient, ReadError};
+use crate::network::Connection;
 use crate::network::Incoming;
 use crate::network::Outgoing;
 use crate::network::Reciprocal;
-use crate::network::WeakConnection;
 use crate::network::{MessageHandler, MessageRouterBuilder, NetworkError};
 
 pub(super) type CommandSender = mpsc::UnboundedSender<Command>;
@@ -546,7 +546,7 @@ impl MetadataManager {
 }
 
 enum UpdateTaskState {
-    FromPeer(WeakConnection),
+    FromPeer(Connection),
     Sync,
 }
 
@@ -557,7 +557,7 @@ struct UpdateTask {
 
 impl UpdateTask {
     fn from(version_information: VersionInformation) -> Self {
-        let state = if let Some(connection) = version_information.remote_peer {
+        let state = if let Some(connection) = version_information.peer_connection {
             UpdateTaskState::FromPeer(connection)
         } else {
             UpdateTaskState::Sync

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -285,6 +285,7 @@ pub mod test_util {
     use crate::network::io::DropEgressStream;
     use crate::network::io::EgressStream;
     use crate::network::io::UnboundedEgressSender;
+    use crate::network::protobuf::network::ConnectionDirection;
     use crate::network::protobuf::network::Header;
     use crate::network::protobuf::network::Hello;
     use crate::network::protobuf::network::Message;
@@ -332,7 +333,11 @@ pub mod test_util {
                 EgressStream::create(message_buffer);
             let incoming = incoming.map(Ok);
 
-            let hello = Hello::new(Some(from_node_id), my_cluster_name);
+            let hello = Hello::new(
+                Some(from_node_id),
+                my_cluster_name,
+                ConnectionDirection::Bidirectional,
+            );
             let header = Header {
                 my_nodes_config_version: Some(my_node_config_version.into()),
                 msg_id: crate::network::generate_msg_id(),
@@ -558,7 +563,7 @@ pub mod test_util {
             let selected_protocol_version = negotiate_protocol_version(&hello)?;
 
             // Enqueue the welcome message
-            let welcome = Welcome::new(my_node_id, selected_protocol_version);
+            let welcome = Welcome::new(my_node_id, selected_protocol_version, hello.direction());
 
             let header = Header::new(
                 nodes_config.version(),

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::sync::Weak;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -31,8 +29,8 @@ use super::protobuf::network::message;
 use super::protobuf::network::message::Body;
 
 pub struct OwnedSendPermit<M> {
-    _protocol_version: ProtocolVersion,
-    _permit: mpsc::OwnedPermit<EgressMessage>,
+    protocol_version: ProtocolVersion,
+    permit: mpsc::OwnedPermit<EgressMessage>,
     _phantom: std::marker::PhantomData<M>,
 }
 
@@ -66,21 +64,43 @@ where
     }
 }
 
+impl<M> OwnedSendPermit<M>
+where
+    M: WireEncode + Targeted,
+{
+    /// Sends a message over this permit.
+    ///
+    /// Note that sending messages over this permit won't use the peer information nor the connection
+    /// associated with the message.
+    pub fn send<S>(self, message: Outgoing<M, S>) {
+        let header = Header {
+            msg_id: message.msg_id(),
+            in_response_to: message.in_response_to(),
+            ..Default::default()
+        };
+
+        let target = M::TARGET.into();
+        let payload = message.into_body().encode_to_bytes(self.protocol_version);
+
+        let body = Body::Encoded(message::BinaryMessage { target, payload });
+        self.permit
+            .send(EgressMessage::Message(header, body, Some(Span::current())));
+    }
+}
+
 /// A single streaming connection with a channel to the peer. A connection can be
 /// opened by either ends of the connection and has no direction. Any connection
 /// can be used to send or receive from a peer.
-///
-/// The primary owner of a connection is the running reactor, all other components
-/// should hold a `WeakConnection` if access to a certain connection is
-/// needed.
-pub struct OwnedConnection {
+#[derive(Clone, derive_more::Debug)]
+pub struct Connection {
     pub(crate) peer: GenerationalNodeId,
     pub(crate) protocol_version: ProtocolVersion,
+    #[debug(skip)]
     pub(crate) sender: EgressSender,
     pub(crate) created: Instant,
 }
 
-impl OwnedConnection {
+impl Connection {
     pub(crate) fn new(
         peer: GenerationalNodeId,
         protocol_version: ProtocolVersion,
@@ -95,12 +115,22 @@ impl OwnedConnection {
     }
 
     #[cfg(any(test, feature = "test-util"))]
+    pub fn new_closed(peer: GenerationalNodeId) -> Self {
+        Self {
+            peer,
+            protocol_version: Default::default(),
+            sender: EgressSender::new_closed(),
+            created: Instant::now(),
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
     pub fn new_fake(
         peer: GenerationalNodeId,
         protocol_version: ProtocolVersion,
         capacity: usize,
     ) -> (
-        Arc<Self>,
+        Self,
         super::io::UnboundedEgressSender,
         super::io::EgressStream,
         super::io::DropEgressStream,
@@ -109,7 +139,7 @@ impl OwnedConnection {
 
         let (sender, unbounded_sender, egress, drop_egress) = EgressStream::create(capacity);
         (
-            Arc::new(Self::new(peer, protocol_version, sender)),
+            Self::new(peer, protocol_version, sender),
             unbounded_sender,
             egress,
             drop_egress,
@@ -144,15 +174,6 @@ impl OwnedConnection {
         self.sender.close(reason).await
     }
 
-    /// A handle that sends messages through that connection. This hides the
-    /// wire protocol from the user and guarantees order of messages.
-    pub fn downgrade(self: &Arc<Self>) -> WeakConnection {
-        WeakConnection {
-            peer: self.peer,
-            connection: Arc::downgrade(self),
-        }
-    }
-
     /// Allocates capacity to send one message on this connection. If connection is closed, this
     /// returns None.
     pub async fn reserve<M>(&self) -> Option<SendPermit<'_, M>> {
@@ -169,24 +190,24 @@ impl OwnedConnection {
     pub async fn reserve_timeout<M>(
         &self,
         timeout: Duration,
-    ) -> Result<SendPermit<'_, M>, NetworkError> {
+    ) -> Result<OwnedSendPermit<M>, NetworkError> {
         let start = Instant::now();
-        let permit = tokio::time::timeout(timeout, self.sender.reserve())
+        let permit = tokio::time::timeout(timeout, self.sender.clone().reserve_owned())
             .await
             .map_err(|_| NetworkError::Timeout(start.elapsed()))?
-            .map_err(|_| NetworkError::ConnectionClosed(self.peer))?;
-        Ok(SendPermit {
+            .map_err(|_| NetworkError::ConnectionClosed(ConnectionClosed))?;
+        Ok(OwnedSendPermit {
             permit,
             protocol_version: self.protocol_version,
             _phantom: std::marker::PhantomData,
         })
     }
 
-    pub async fn reserve_owned<M>(self) -> Option<OwnedSendPermit<M>> {
-        let permit = self.sender.reserve_owned().await.ok()?;
+    pub async fn reserve_owned<M>(&self) -> Option<OwnedSendPermit<M>> {
+        let permit = self.sender.clone().reserve_owned().await.ok()?;
         Some(OwnedSendPermit {
-            _permit: permit,
-            _protocol_version: self.protocol_version,
+            permit,
+            protocol_version: self.protocol_version,
             _phantom: std::marker::PhantomData,
         })
     }
@@ -197,7 +218,9 @@ impl OwnedConnection {
         let permit = match self.sender.try_reserve() {
             Ok(permit) => permit,
             Err(TrySendError::Full(_)) => return Err(NetworkError::Full),
-            Err(TrySendError::Closed(_)) => return Err(NetworkError::ConnectionClosed(self.peer)),
+            Err(TrySendError::Closed(_)) => {
+                return Err(NetworkError::ConnectionClosed(ConnectionClosed));
+            }
         };
 
         Ok(SendPermit {
@@ -206,60 +229,29 @@ impl OwnedConnection {
             _phantom: std::marker::PhantomData,
         })
     }
+
+    /// Tries to allocate capacity to send one message on this connection. If there is no capacity,
+    /// it will fail with [`NetworkError::Full`]. If connection is closed it returns [`NetworkError::ConnectionClosed`]
+    pub fn try_reserve_owned<M>(&self) -> Result<OwnedSendPermit<M>, NetworkError> {
+        let permit = self.sender.clone().try_reserve_owned()?;
+
+        Ok(OwnedSendPermit {
+            permit,
+            protocol_version: self.protocol_version,
+            _phantom: std::marker::PhantomData,
+        })
+    }
 }
 
-impl PartialEq for OwnedConnection {
+impl PartialEq for Connection {
     fn eq(&self, other: &Self) -> bool {
         self.sender.same_channel(&other.sender)
-    }
-}
-
-/// A handle to send messages through a connection. It's safe to hold and clone objects of this
-/// even if the connection has been dropped. Cheap to clone.
-#[derive(Clone, Debug)]
-pub struct WeakConnection {
-    pub(crate) peer: GenerationalNodeId,
-    pub(crate) connection: Weak<OwnedConnection>,
-}
-
-static_assertions::assert_impl_all!(WeakConnection: Send, Sync);
-
-impl WeakConnection {
-    pub fn new_closed(peer: GenerationalNodeId) -> Self {
-        Self {
-            peer,
-            connection: Weak::new(),
-        }
-    }
-
-    /// The node id at the other end of this connection
-    pub fn peer(&self) -> GenerationalNodeId {
-        self.peer
-    }
-
-    /// Resolves when the connection is closed
-    pub fn closed(&self) -> impl std::future::Future<Output = ()> + Send + Sync + 'static {
-        let weak_connection = self.connection.clone();
-        async move {
-            let Some(connection) = weak_connection.upgrade() else {
-                return;
-            };
-            connection.closed().await
-        }
-    }
-}
-
-impl PartialEq for WeakConnection {
-    fn eq(&self, other: &Self) -> bool {
-        self.connection.ptr_eq(&other.connection)
     }
 }
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
     use super::*;
-
-    use std::sync::Arc;
 
     use async_trait::async_trait;
     use futures::StreamExt;
@@ -340,7 +332,7 @@ pub mod test_util {
                 EgressStream::create(message_buffer);
             let incoming = incoming.map(Ok);
 
-            let hello = Hello::new(from_node_id, my_cluster_name);
+            let hello = Hello::new(Some(from_node_id), my_cluster_name);
             let header = Header {
                 my_nodes_config_version: Some(my_node_config_version.into()),
                 msg_id: crate::network::generate_msg_id(),
@@ -407,8 +399,8 @@ pub mod test_util {
         pub async fn reserve_owned<M>(self) -> Option<OwnedSendPermit<M>> {
             let permit = self.sender.reserve_owned().await.ok()?;
             Some(OwnedSendPermit {
-                _permit: permit,
-                _protocol_version: self.protocol_version,
+                permit,
+                protocol_version: self.protocol_version,
                 _phantom: std::marker::PhantomData,
             })
         }
@@ -420,7 +412,7 @@ pub mod test_util {
                 Ok(permit) => permit,
                 Err(TrySendError::Full(_)) => return Err(NetworkError::Full),
                 Err(TrySendError::Closed(_)) => {
-                    return Err(NetworkError::ConnectionClosed(self.peer));
+                    return Err(NetworkError::ConnectionClosed(ConnectionClosed));
                 }
             };
 
@@ -431,11 +423,11 @@ pub mod test_util {
             })
         }
 
-        /// Allows you to use utilities in OwnedConnection or WeakConnection.
+        /// Allows you to use utilities in Connection
         /// Reminder: Sending on this connection will cause message to arrive as incoming to the node
         /// we are connected to.
-        pub fn to_owned_connection(&self) -> OwnedConnection {
-            OwnedConnection {
+        pub fn to_owned_connection(&self) -> Connection {
+            Connection {
                 peer: self.peer,
                 protocol_version: self.protocol_version,
                 sender: self.sender.clone(),
@@ -447,7 +439,7 @@ pub mod test_util {
         pub fn process_with_message_handler<H: MessageHandler + Send + Sync + 'static>(
             self,
             handler: H,
-        ) -> anyhow::Result<(WeakConnection, TaskHandle<anyhow::Result<()>>)> {
+        ) -> anyhow::Result<(Connection, TaskHandle<anyhow::Result<()>>)> {
             let mut router = MessageRouterBuilder::default();
             router.add_message_handler(handler);
             let router = router.build();
@@ -460,7 +452,7 @@ pub mod test_util {
         pub fn process_with_message_router<R: Handler + 'static>(
             self,
             router: R,
-        ) -> anyhow::Result<(WeakConnection, TaskHandle<anyhow::Result<()>>)> {
+        ) -> anyhow::Result<(Connection, TaskHandle<anyhow::Result<()>>)> {
             let Self {
                 my_node_id,
                 peer,
@@ -472,18 +464,17 @@ pub mod test_util {
                 drop_egress,
             } = self;
 
-            let connection = Arc::new(OwnedConnection {
+            let connection = Connection {
                 peer,
                 protocol_version,
                 sender,
                 created,
-            });
+            };
 
-            let weak = connection.downgrade();
             let message_processor = MessageProcessor {
                 my_node_id,
                 router,
-                connection,
+                connection: connection.clone(),
                 tx: unbounded_sender,
                 recv_stream,
             };
@@ -492,14 +483,14 @@ pub mod test_util {
                 "test-message-processor",
                 async move { message_processor.run(drop_egress).await },
             )?;
-            Ok((weak, handle))
+            Ok((connection, handle))
         }
 
         // Allow for messages received on this connection to be forwarded to the supplied sender.
         pub fn forward_to_sender(
             self,
             sender: mpsc::Sender<(GenerationalNodeId, Incoming<BinaryMessage>)>,
-        ) -> anyhow::Result<(WeakConnection, TaskHandle<anyhow::Result<()>>)> {
+        ) -> anyhow::Result<(Connection, TaskHandle<anyhow::Result<()>>)> {
             let handler = ForwardingHandler {
                 my_node_id: self.my_node_id,
                 inner_sender: sender,
@@ -635,7 +626,7 @@ pub mod test_util {
     struct MessageProcessor<R> {
         my_node_id: GenerationalNodeId,
         router: R,
-        connection: Arc<OwnedConnection>,
+        connection: Connection,
         tx: UnboundedEgressSender,
         recv_stream: BoxStream<'static, Message>,
     }
@@ -703,7 +694,7 @@ pub mod test_util {
                         .call(
                             Incoming::from_parts(
                                 msg,
-                                self.connection.downgrade(),
+                                self.connection.clone(),
                                 header.msg_id,
                                 header.in_response_to,
                                 PeerMetadataVersion::from(header),

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -9,44 +9,34 @@
 // by the Apache License, Version 2.0.
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use ahash::HashMap;
-use enum_map::EnumMap;
-use futures::future::OptionFuture;
 use futures::{Stream, StreamExt};
-use metrics::{counter, histogram};
-use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry_sdk::propagation::TraceContextPropagator;
 use parking_lot::Mutex;
-use tokio::time::{Instant, timeout};
-use tracing::{Instrument, Span, debug, info, instrument, trace, warn};
+use tracing::{Span, debug, info, instrument, trace, warn};
 
-use restate_futures_util::overdue::OverdueLoggingExt;
 use restate_types::config::Configuration;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::NodesConfiguration;
-use restate_types::{GenerationalNodeId, Merge, NodeId, PlainNodeId, Version};
+use restate_types::{GenerationalNodeId, Merge, NodeId, PlainNodeId};
 
+use super::MessageRouter;
 use super::connection::Connection;
 use super::error::{NetworkError, ProtocolError};
 use super::handshake::wait_for_welcome;
 use super::io::{
-    DrainReason, DropEgressStream, EgressMessage, EgressStream, UnboundedEgressSender,
+    ConnectionReactor, DropEgressStream, EgressMessage, EgressStream, UnboundedEgressSender,
 };
 use super::metric_definitions::{
     self, CONNECTION_DROPPED, INCOMING_CONNECTION, OUTGOING_CONNECTION,
 };
-use super::protobuf::network::{Header, Hello, Message, Welcome, message::Body, message::Signal};
+use super::protobuf::network::ConnectionDirection;
+use super::protobuf::network::{Header, Hello, Message, Welcome};
+use super::tracking::{ConnectionTracking, PeerRouting};
 use super::transport_connector::TransportConnect;
-use super::{Handler, MessageRouter};
 use crate::metadata::Urgency;
 use crate::network::handshake::{negotiate_protocol_version, wait_for_hello};
-use crate::network::metric_definitions::{
-    NETWORK_MESSAGE_PROCESSING_DURATION, NETWORK_MESSAGE_RECEIVED, NETWORK_MESSAGE_RECEIVED_BYTES,
-};
-use crate::network::{Incoming, PeerMetadataVersion};
-use crate::{Metadata, TaskCenter, TaskContext, TaskKind, my_node_id};
+use crate::{Metadata, ShutdownError, my_node_id};
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Default)]
 struct GenStatus {
@@ -91,12 +81,6 @@ struct ConnectionManagerInner {
 }
 
 impl ConnectionManagerInner {
-    fn cleanup_stale_connections(&mut self, peer_node_id: &GenerationalNodeId) {
-        if let Some(connections) = self.connection_by_gen_id.get_mut(peer_node_id) {
-            connections.retain(|c| !c.is_closed());
-        }
-    }
-
     fn get_random_connection(
         &self,
         peer_node_id: &GenerationalNodeId,
@@ -229,8 +213,11 @@ impl ConnectionManager {
                 .outbound_queue_length
                 .get(),
         );
+
+        self.update_generation_or_preempt(peer_node_id)?;
+
         // Enqueue the welcome message
-        let welcome = Welcome::new(my_node_id, selected_protocol_version);
+        let welcome = Welcome::new(my_node_id, selected_protocol_version, hello.direction());
         unbounded_sender
             .unbounded_send(EgressMessage::Message(
                 Header::default(),
@@ -240,10 +227,23 @@ impl ConnectionManager {
             .map_err(|_| ProtocolError::PeerDropped)?;
         let connection = Connection::new(peer_node_id, selected_protocol_version, sender);
 
-        INCOMING_CONNECTION.increment(1);
+        let should_register = matches!(
+            hello.direction(),
+            ConnectionDirection::Unknown
+                | ConnectionDirection::Bidirectional
+                | ConnectionDirection::Reverse
+        );
+
         // Register the connection.
-        let _ =
-            self.start_connection_reactor(connection, unbounded_sender, incoming, drop_egress)?;
+        let _ = self.start_connection_reactor(
+            connection,
+            unbounded_sender,
+            incoming,
+            drop_egress,
+            should_register,
+        )?;
+
+        INCOMING_CONNECTION.increment(1);
 
         // Our output stream, i.e. responses.
         Ok(egress)
@@ -265,37 +265,29 @@ impl ConnectionManager {
         }
 
         // find a connection by node_id
-        let maybe_connection: Option<Connection> = {
-            let guard = self.inner.lock();
-            guard.get_random_connection(
-                &node_id,
-                Configuration::pinned()
-                    .networking
-                    .num_concurrent_connections(),
-            )
-            // lock is dropped.
-        };
-
-        if let Some(connection) = maybe_connection {
+        if let Some(connection) = self.inner.lock().get_random_connection(
+            &node_id,
+            Configuration::pinned()
+                .networking
+                .num_concurrent_connections(),
+        ) {
             return Ok(connection);
         }
 
-        let is_gone = {
-            self.inner
-                .lock()
-                .observed_generations
-                .get(&node_id.as_plain())
-                .map(|status| {
-                    node_id.generation() < status.generation
-                        || (node_id.generation() == status.generation && status.gone)
-                })
-                .unwrap_or(false)
-            // lock is dropped.
-        };
-
-        if is_gone {
+        if self
+            .inner
+            .lock()
+            .observed_generations
+            .get(&node_id.as_plain())
+            .map(|status| {
+                node_id.generation() < status.generation
+                    || (node_id.generation() == status.generation && status.gone)
+            })
+            .unwrap_or(false)
+        {
             return Err(NetworkError::NodeIsGone(node_id));
         }
+
         // We have no connection. We attempt to create a new connection.
         self.connect(node_id, transport_connector).await
     }
@@ -309,11 +301,11 @@ impl ConnectionManager {
         C: TransportConnect,
     {
         let metadata = Metadata::current();
-        if node_id == metadata.my_node_id() {
+        let my_node_id = metadata.my_node_id_opt();
+        if my_node_id.is_some_and(|my_node| my_node == node_id) {
             return self.connect_loopback();
         }
 
-        let my_node_id = metadata.my_node_id();
         let nodes_config = metadata.nodes_config_snapshot();
         let cluster_name = nodes_config.cluster_name().to_owned();
 
@@ -324,29 +316,29 @@ impl ConnectionManager {
                 .get(),
         );
 
+        let our_direction = ConnectionDirection::Bidirectional;
         // perform handshake.
-        let hello = Hello::new(Some(my_node_id), cluster_name);
-        // Prime the channel with the hello message before connecting.
-        unbounded_sender
-            .unbounded_send(EgressMessage::Message(
-                Header::default(),
-                hello.into(),
-                None,
-            ))
-            .expect("egress channel must be open");
+        unbounded_sender.unbounded_send(EgressMessage::Message(
+            Header::default(),
+            Hello::new(my_node_id, cluster_name, our_direction).into(),
+            Some(Span::current()),
+        ))?;
 
         // Establish the connection
         let mut incoming = transport_connector
             .connect(node_id, &nodes_config, egress)
             .await?;
+
         // finish the handshake
         let (_header, welcome) = wait_for_welcome(
             &mut incoming,
             Configuration::pinned().networking.handshake_timeout.into(),
         )
         .await?;
+
         let protocol_version = welcome.protocol_version();
 
+        // this should not happen if the peer follows the correct protocol negotiation
         if !protocol_version.is_supported() {
             return Err(ProtocolError::UnsupportedVersion(protocol_version.into()).into());
         }
@@ -372,8 +364,37 @@ impl ConnectionManager {
 
         let connection = Connection::new(peer_node_id, protocol_version, tx);
 
+        if self
+            .inner
+            .lock()
+            .observed_generations
+            .get(&node_id.as_plain())
+            .map(|status| {
+                node_id.generation() < status.generation
+                    || (node_id.generation() == status.generation && status.gone)
+            })
+            .unwrap_or(false)
+        {
+            return Err(NetworkError::NodeIsGone(node_id));
+        }
+
+        // if peer cannot respect our hello intent of direction, we are okay with registering
+        let should_register = matches!(
+            welcome.direction_ack(),
+            ConnectionDirection::Unknown
+                | ConnectionDirection::Bidirectional
+                | ConnectionDirection::Forward
+        );
+        let res = self.start_connection_reactor(
+            connection,
+            unbounded_sender,
+            incoming,
+            drop_egress,
+            should_register,
+        )?;
+
         OUTGOING_CONNECTION.increment(1);
-        self.start_connection_reactor(connection, unbounded_sender, incoming, drop_egress)
+        Ok(res)
     }
 
     #[instrument(skip_all)]
@@ -391,7 +412,14 @@ impl ConnectionManager {
             tx,
         );
 
-        self.start_connection_reactor(connection, unbounded_sender, egress.map(Ok), drop_egress)
+        Ok(self.start_connection_reactor(
+            connection,
+            unbounded_sender,
+            egress.map(Ok),
+            drop_egress,
+            // loopback is always registered
+            true,
+        )?)
     }
 
     fn verify_node_id(
@@ -438,460 +466,132 @@ impl ConnectionManager {
         Ok(())
     }
 
+    fn update_generation_or_preempt(
+        &self,
+        peer_node_id: GenerationalNodeId,
+    ) -> Result<(), NetworkError> {
+        // Lock is held, don't perform expensive or async operations here.
+        let mut guard = self.inner.lock();
+        let known_status = guard
+            .observed_generations
+            .get(&peer_node_id.as_plain())
+            .copied()
+            .unwrap_or(GenStatus::new(peer_node_id.generation()));
+
+        if known_status.generation > peer_node_id.generation() {
+            // This peer is _older_ than the one we have seen in the past, we cannot accept
+            // this connection. We terminate the stream immediately.
+            return Err(NetworkError::OldPeerGeneration(format!(
+                "newer generation '{}' has been observed",
+                NodeId::new_generational(peer_node_id.id(), known_status.generation)
+            )));
+        }
+
+        if known_status.generation == peer_node_id.generation() && known_status.gone {
+            // This peer was observed to have shutdown before. We cannot accept new connections from this peer.
+            return Err(NetworkError::NodeIsGone(peer_node_id));
+        }
+
+        // todo: if we have connections with an older generation, we request to drop it.
+        // However, more than one connection with the same generation is allowed.
+        // if known_status.generation < connection.peer.generation() {
+        // todo: Terminate old node's connections
+        // }
+
+        // update observed generation
+        let new_status = GenStatus::new(peer_node_id.generation());
+        guard
+            .observed_generations
+            .entry(peer_node_id.as_plain())
+            .and_modify(|status| {
+                status.merge(new_status);
+            })
+            .or_insert(new_status);
+        Ok(())
+    }
+
     fn start_connection_reactor<S>(
         &self,
         connection: Connection,
         unbounded_sender: UnboundedEgressSender,
         incoming: S,
         drop_egress: DropEgressStream,
-    ) -> Result<Connection, NetworkError>
+        should_register: bool,
+    ) -> Result<Connection, ShutdownError>
     where
         S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
     {
-        // Lock is held, don't perform expensive or async operations here.
-
-        // If we have a connection with an older generation, we request to drop it.
-        // However, more than one connection with the same generation is allowed.
-        let mut _cleanup = false;
-        let mut guard = self.inner.lock();
-        let known_status = guard
-            .observed_generations
-            .get(&connection.peer.as_plain())
-            .copied()
-            .unwrap_or(GenStatus::new(connection.peer.generation()));
-
-        if known_status.generation > connection.peer.generation() {
-            // This peer is _older_ than the one we have seen in the past, we cannot accept
-            // this connection. We terminate the stream immediately.
-            return Err(NetworkError::OldPeerGeneration(format!(
-                "newer generation '{}' has been observed",
-                NodeId::new_generational(connection.peer.id(), known_status.generation)
-            )));
-        }
-
-        if known_status.generation == connection.peer.generation() && known_status.gone {
-            // This peer was observed to have shutdown before. We cannot accept new connections from this peer.
-            return Err(NetworkError::NodeIsGone(connection.peer));
-        }
-
-        if known_status.generation < connection.peer.generation() {
-            // We have observed newer generation of the same node.
-            // TODO: Terminate old node's connection by cancelling its reactor task,
-            // and continue with this connection.
-            _cleanup = true;
-        }
-        // update observed generation
-        let new_status = GenStatus::new(connection.peer.generation());
-        guard
-            .observed_generations
-            .entry(connection.peer.as_plain())
-            .and_modify(|status| {
-                status.merge(new_status);
-            })
-            .or_insert(new_status);
-
         let peer_node_id = connection.peer;
-        let span = tracing::error_span!(parent: None, "network-reactor",
-            task_id = tracing::field::Empty,
-            peer = %peer_node_id,
-        );
-        let router = guard.router.clone();
+        let router = self.inner.lock().router.clone();
 
-        let task_id = TaskCenter::spawn_child(
-            TaskKind::ConnectionReactor,
-            "network-connection-reactor",
-            run_reactor(
-                self.inner.clone(),
-                connection.clone(),
-                unbounded_sender,
-                router,
-                incoming,
-                drop_egress,
-            )
-            .instrument(span),
-        )?;
+        let reactor = ConnectionReactor::new(connection.clone(), unbounded_sender, drop_egress);
+
         if peer_node_id != my_node_id() {
             debug!(
                 peer = %peer_node_id,
-                task_id = %task_id,
                 "Incoming connection accepted from node {}", peer_node_id
             );
         }
-        // Reactor has already started by now.
-        // clean up old connections
-        guard.cleanup_stale_connections(&peer_node_id);
-        // Add this connection.
-        guard
-            .connection_by_gen_id
-            .entry(peer_node_id)
-            .or_default()
-            .push(connection.clone());
+
+        let _ = reactor.start(
+            router,
+            self.clone(),
+            self.clone(),
+            incoming,
+            should_register,
+        )?;
+
         Ok(connection)
     }
 }
 
-async fn run_reactor<S>(
-    // todo: switch to hooks, this way we can get rid of MessageProcessor
-    connection_manager: Arc<Mutex<ConnectionManagerInner>>,
-    connection: Connection,
-    tx: UnboundedEgressSender,
-    router: impl Handler,
-    mut incoming: S,
-    drop_egress: DropEgressStream,
-) -> anyhow::Result<()>
-where
-    S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send,
-{
-    let current_task = TaskContext::current();
-    let metadata = Metadata::current();
-    Span::current().record("task_id", tracing::field::display(current_task.id()));
-    let mut cancellation = std::pin::pin!(current_task.cancellation_token().cancelled());
-    let mut seen_versions = MetadataVersions::default();
-
-    let context_propagator = TraceContextPropagator::default();
-    let mut needs_drain = false;
-    let mut is_peer_shutting_down = false;
-    // Receive loop
-    loop {
-        // read a message from the stream
-        let msg = tokio::select! {
-            biased;
-            _ = &mut cancellation => {
-                if TaskCenter::is_shutdown_requested() {
-                    // We want to make the distinction between whether we are terminating the
-                    // connection, or whether the node is shutting down.
-                    tx.unbounded_drain(DrainReason::Shutdown);
-                } else {
-                    tx.unbounded_drain(DrainReason::ConnectionDrain);
-                }
-                // we only drain the connection if we were the initiators of the termination
-                needs_drain = true;
-                break;
-            },
-            msg = incoming.next() => {
-                match msg {
-                    Some(Ok(msg)) => { msg }
-                    Some(Err(status)) => {
-                        // stream has terminated.
-                        info!("Error received: {status}, terminating stream");
-                        tx.unbounded_drain(DrainReason::ConnectionDrain);
-                        break;
-                    }
-                    None => {
-                        // peer terminated the connection
-                        // stream has terminated cleanly.
-                        needs_drain = true;
-                        tx.unbounded_drain(DrainReason::ConnectionDrain);
-                        break;
-                    }
-                }
-            }
-        };
-
-        let processing_started = Instant::now();
-
-        // body are not allowed to be empty.
-        let Some(body) = msg.body else {
-            tx.unbounded_drain(DrainReason::CodecError(
-                "Body is missing on message".to_owned(),
-            ));
-            break;
-        };
-
-        // Welcome and hello are not allowed after handshake
-        if body.is_welcome() || body.is_hello() {
-            tx.unbounded_drain(DrainReason::CodecError(
-                "Hello/Welcome are not allowed after handshake".to_owned(),
-            ));
-            break;
-        };
-
-        // if it's a control signal, handle it, otherwise, route with message router.
-        if let Body::ConnectionControl(ctrl_msg) = &body {
-            // do something
-            info!(
-                "Terminating connection based on signal from {}: {}",
-                connection.peer(),
-                ctrl_msg.message
-            );
-            if ctrl_msg.signal() == Signal::Shutdown {
-                tx.unbounded_drain(DrainReason::ConnectionDrain);
-                is_peer_shutting_down = true;
-                needs_drain = true;
-            }
-            break;
-        }
-
-        //  header is required on all messages
-        let Some(header) = msg.header else {
-            tx.unbounded_drain(DrainReason::CodecError(
-                "Header is missing on message".to_owned(),
-            ));
-            break;
-        };
-
-        seen_versions
-            .update(
-                header.my_nodes_config_version.map(Into::into),
-                header.my_partition_table_version.map(Into::into),
-                header.my_schema_version.map(Into::into),
-                header.my_logs_version.map(Into::into),
-            )
-            .into_iter()
-            .for_each(|(kind, version)| {
-                if let Some(version) = version {
-                    metadata.notify_observed_version(
-                        kind,
-                        version,
-                        Some(connection.clone()),
-                        Urgency::Normal,
-                    );
-                }
-            });
-
-        let encoded_len = body.encoded_len();
-        match body.try_as_binary_body(connection.protocol_version) {
-            Ok(msg) => {
-                let target = msg.target();
-
-                let parent_context = header
-                    .span_context
-                    .as_ref()
-                    .map(|span_ctx| context_propagator.extract(span_ctx));
-
-                // unconstrained: We want to avoid yielding if the message router has capacity,
-                // this is to improve tail latency of message processing. We still give tokio
-                // a yielding point when reading the next message but it would be excessive to
-                // introduce more than one yielding point in this reactor loop.
-                if let Err(e) = tokio::task::unconstrained(
-                    router.call(
-                        Incoming::from_parts(
-                            msg,
-                            connection.clone(),
-                            header.msg_id,
-                            header.in_response_to,
-                            PeerMetadataVersion::from(header),
-                        )
-                        .with_parent_context(parent_context),
-                        connection.protocol_version,
-                    ),
-                )
-                .await
-                {
-                    warn!(
-                        target = target.as_str_name(),
-                        "Error processing message: {e}"
-                    );
-                }
-                histogram!(NETWORK_MESSAGE_PROCESSING_DURATION, "target" => target.as_str_name())
-                    .record(processing_started.elapsed());
-                counter!(NETWORK_MESSAGE_RECEIVED, "target" => target.as_str_name()).increment(1);
-                counter!(NETWORK_MESSAGE_RECEIVED_BYTES, "target" => target.as_str_name())
-                    .increment(encoded_len as u64);
-                trace!(
-                    target = target.as_str_name(),
-                    "Processed message in {:?}",
-                    processing_started.elapsed()
-                );
-            }
-            Err(status) => {
-                // terminate the stream
-                warn!("Error processing message, reporting error to peer: {status}",);
-                tx.unbounded_drain(DrainReason::CodecError(status.to_string()));
-                break;
-            }
-        }
+impl PeerRouting for ConnectionManager {
+    fn register(&self, connection: &Connection) {
+        let peer = connection.peer;
+        let mut guard = self.inner.lock();
+        guard
+            .connection_by_gen_id
+            .entry(connection.peer)
+            .or_default()
+            .push(connection.clone());
+        debug!("connection to {} was registered", peer);
     }
 
-    // remove from active set
-    on_connection_draining(&connection, &connection_manager, is_peer_shutting_down);
-    let protocol_version = connection.protocol_version;
-    let peer_node_id = connection.peer;
-    let connection_created_at = connection.created;
-
-    let drain_start = std::time::Instant::now();
-    let mut drain_counter = 0;
-    let mut tx = Some(tx);
-    let mut drop_egress = Some(drop_egress);
-
-    if needs_drain {
-        let mut drain_timeout = std::pin::pin!(tokio::time::sleep(Duration::from_secs(15)));
-        debug!("Draining connection");
-        loop {
-            tokio::select! {
-                _ = &mut drain_timeout => {
-                    // drain timed out.
-                    debug!("Drain timed out, closing connection");
-                    drop_egress.take();
-                    drop(incoming);
-                    break;
-                },
-                msg = incoming.next() => {
-                    let Some(Ok(msg)) = msg else {
-                        break;
-                    };
-                    // Draining of incoming queue
-                    if let Some(Body::ConnectionControl(ctrl_msg)) = &msg.body {
-                        trace!(
-                            "Received signal from {} while draining: {}",
-                            peer_node_id,
-                            ctrl_msg.signal()
-                        );
-                        // No more requests/unary messages will arrive. Reactor can be closed if we don't
-                        // have waiting responses
-                        match ctrl_msg.signal() {
-                            Signal::RequestStreamDrained => {
-                                // No more requests coming, but rpc responses might still arrive.
-                                // We don't need tx anymore. We'll not create future responder
-                                // tasks.
-                                tx.take();
-                            }
-                            Signal::ResponseStreamDrained => {
-                                // No more requests coming, but rpc requests might still arrive.
-                                // Peer will terminate its sender stream once if drained its two
-                                // egress streams.
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    // ignore malformed messages
-                    let Some(header) = msg.header else {
-                        continue;
-                    };
-                    if let Some(body) = msg.body {
-                        // we ignore non-deserializable messages (serde errors, or control signals in drain)
-                        if let Ok(msg) = body.try_as_binary_body(protocol_version) {
-                            drain_counter += 1;
-                            let parent_context = header
-                                .span_context
-                                .as_ref()
-                                .map(|span_ctx| context_propagator.extract(span_ctx));
-
-                            if let Err(e) = router
-                                .call(
-                                    Incoming::from_parts(
-                                        msg,
-                                        connection.clone(),
-                                        header.msg_id,
-                                        header.in_response_to,
-                                        PeerMetadataVersion::from(header),
-                                    )
-                                    .with_parent_context(parent_context),
-                                    protocol_version,
-                                )
-                                .await
-                            {
-                                debug!(
-                                    "Error processing message while draining connection: {:?}",
-                                    e
-                                );
-                            }
-                        }
-                    }
-                },
-            }
+    fn deregister(&self, connection: &Connection) {
+        let mut guard = self.inner.lock();
+        if let Some(connections) = guard.connection_by_gen_id.get_mut(&connection.peer) {
+            connections.retain(|c| c != connection);
         }
+        trace!("connection reactor was deregistered {}", connection.peer);
     }
-    // in case we didn't drain, we still need to drop the response stream
-    tx.take();
-    drop(connection);
-
-    // Wait for egress to fully drain
-    if timeout(
-        Duration::from_secs(5),
-        OptionFuture::from(drop_egress)
-            .log_slow_after(
-                Duration::from_secs(2),
-                tracing::Level::INFO,
-                "Waiting for connection's egress to drain",
-            )
-            .with_overdue(Duration::from_secs(3), tracing::Level::WARN),
-    )
-    .await
-    .is_err()
-    {
-        info!("Connection's egress has taken too long to drain, will drop");
-    }
-    CONNECTION_DROPPED.increment(1);
-    debug!(
-        "Connection terminated, drained {} messages in {:?}, total connection age is {:?}",
-        drain_counter,
-        drain_start.elapsed(),
-        connection_created_at.elapsed()
-    );
-    Ok(())
 }
 
-fn on_connection_draining(
-    connection: &Connection,
-    inner_manager: &Mutex<ConnectionManagerInner>,
-    is_peer_shutting_down: bool,
-) {
-    let mut guard = inner_manager.lock();
-    if let Some(connections) = guard.connection_by_gen_id.get_mut(&connection.peer) {
-        // Remove this connection from connections map to reduce the chance
-        // of picking it up as connection.
-        connections.retain(|c| c != connection);
+impl ConnectionTracking for ConnectionManager {
+    fn connection_created(&self, conn: &Connection) {
+        info!("Connection reactor started: {}", conn.peer);
     }
-    if is_peer_shutting_down {
-        let mut new_status = GenStatus::new(connection.peer.generation());
+
+    fn connection_dropped(&self, conn: &Connection) {
+        debug!(
+            peer = %conn.peer,
+            "Connection terminated, total connection age is {:?}",
+            conn.created.elapsed()
+        );
+        CONNECTION_DROPPED.increment(1);
+    }
+
+    fn notify_peer_shutdown(&self, node_id: GenerationalNodeId) {
+        let mut guard = self.inner.lock();
+        let mut new_status = GenStatus::new(node_id.generation());
         new_status.gone = true;
         guard
             .observed_generations
-            .entry(connection.peer.as_plain())
+            .entry(node_id.as_plain())
             .and_modify(|status| {
                 status.merge(new_status);
             })
             .or_insert(new_status);
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, derive_more::Index, derive_more::IndexMut)]
-pub struct MetadataVersions {
-    #[index]
-    versions: EnumMap<MetadataKind, Version>,
-}
-
-impl Default for MetadataVersions {
-    fn default() -> Self {
-        Self {
-            versions: EnumMap::from_fn(|_| Version::INVALID),
-        }
-    }
-}
-
-impl MetadataVersions {
-    pub fn update(
-        &mut self,
-        nodes_config_version: Option<Version>,
-        partition_table_version: Option<Version>,
-        schema_version: Option<Version>,
-        logs_version: Option<Version>,
-    ) -> EnumMap<MetadataKind, Option<Version>> {
-        let mut result = EnumMap::default();
-        result[MetadataKind::NodesConfiguration] =
-            self.update_internal(MetadataKind::NodesConfiguration, nodes_config_version);
-        result[MetadataKind::PartitionTable] =
-            self.update_internal(MetadataKind::PartitionTable, partition_table_version);
-        result[MetadataKind::Schema] = self.update_internal(MetadataKind::Schema, schema_version);
-        result[MetadataKind::Logs] = self.update_internal(MetadataKind::Logs, logs_version);
-
-        result
-    }
-
-    fn update_internal(
-        &mut self,
-        metadata_kind: MetadataKind,
-        version: Option<Version>,
-    ) -> Option<Version> {
-        if let Some(version) = version {
-            if version > self.versions[metadata_kind] {
-                self.versions[metadata_kind] = version;
-                return Some(version);
-            }
-        }
-        None
+        info!("Node {} notified us that it is shutting down", node_id);
     }
 }
 
@@ -981,6 +681,7 @@ mod tests {
             max_protocol_version: ProtocolVersion::Unknown.into(),
             my_node_id: Some(my_node_id.into()),
             cluster_name: metadata.nodes_config_ref().cluster_name().to_owned(),
+            direction: ConnectionDirection::Bidirectional.into(),
         };
         let hello = Message::new(
             Header::new(
@@ -1016,6 +717,7 @@ mod tests {
             max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
             my_node_id: Some(my_node_id.into()),
             cluster_name: "Random-cluster".to_owned(),
+            direction: ConnectionDirection::Bidirectional.into(),
         };
         let hello = Message::new(
             Header::new(
@@ -1057,6 +759,7 @@ mod tests {
         let hello = Hello::new(
             Some(my_node_id),
             metadata.nodes_config_ref().cluster_name().to_owned(),
+            ConnectionDirection::Bidirectional,
         );
         let hello = Message::new(
             Header::new(
@@ -1096,6 +799,7 @@ mod tests {
         let hello = Hello::new(
             Some(my_node_id),
             metadata.nodes_config_ref().cluster_name().to_owned(),
+            ConnectionDirection::Bidirectional,
         );
         let hello = Message::new(
             Header::new(

--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -60,8 +60,8 @@ pub enum NetworkError {
     OldPeerGeneration(String),
     #[error("node {0} was shut down")]
     NodeIsGone(GenerationalNodeId),
-    #[error("connection lost to peer {0}")]
-    ConnectionClosed(GenerationalNodeId),
+    #[error(transparent)]
+    ConnectionClosed(#[from] ConnectionClosed),
     #[error("cannot send messages to this node: {0}")]
     Unavailable(String),
     #[error("failed syncing metadata: {0}")]

--- a/crates/core/src/network/io/mod.rs
+++ b/crates/core/src/network/io/mod.rs
@@ -10,6 +10,8 @@
 
 mod egress_sender;
 mod egress_stream;
+mod reactor;
 
 pub use egress_sender::{EgressSender, UnboundedEgressSender};
 pub use egress_stream::{DrainReason, DropEgressStream, EgressMessage, EgressStream};
+pub use reactor::ConnectionReactor;

--- a/crates/core/src/network/io/reactor.rs
+++ b/crates/core/src/network/io/reactor.rs
@@ -1,0 +1,465 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::pin::Pin;
+use std::time::Duration;
+
+use enum_map::{EnumMap, enum_map};
+use futures::future::OptionFuture;
+use futures::{Stream, StreamExt};
+use metrics::{counter, histogram};
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use prost::Message as _;
+use tokio::time::{Instant, Sleep};
+use tracing::{Instrument, Span, debug, info, trace, warn};
+
+use restate_futures_util::overdue::OverdueLoggingExt;
+use restate_types::live::Live;
+use restate_types::logs::metadata::Logs;
+use restate_types::net::metadata::MetadataKind;
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partition_table::PartitionTable;
+use restate_types::schema::Schema;
+use restate_types::{Version, Versioned};
+
+use crate::metadata::Urgency;
+use crate::network::metric_definitions::{
+    NETWORK_MESSAGE_PROCESSING_DURATION, NETWORK_MESSAGE_RECEIVED, NETWORK_MESSAGE_RECEIVED_BYTES,
+};
+use crate::network::protobuf::network::message::{Body, Signal};
+use crate::network::protobuf::network::{Header, Message};
+use crate::network::tracking::{ConnectionTracking, PeerRouting};
+use crate::network::{Connection, Handler, Incoming, PeerMetadataVersion, ProtocolError};
+use crate::{Metadata, ShutdownError, TaskCenter, TaskContext, TaskId, TaskKind};
+
+use super::{DrainReason, DropEgressStream, UnboundedEgressSender};
+
+enum Decision {
+    Continue,
+    NotifyPeerShutdown,
+    Drain(DrainReason),
+    DrainEgress,
+    Drop,
+}
+
+#[derive(derive_more::IsVariant)]
+enum State {
+    Active,
+    Draining { drain_timeout: Pin<Box<Sleep>> },
+    WaitForEgress,
+}
+
+pub struct ConnectionReactor {
+    state: State,
+    connection: Connection,
+    tx: Option<UnboundedEgressSender>,
+    drop_egress: Option<DropEgressStream>,
+    context_propagator: TraceContextPropagator,
+    seen_versions: Option<MetadataVersions>,
+}
+
+impl ConnectionReactor {
+    pub fn new(
+        connection: Connection,
+        tx: UnboundedEgressSender,
+        drop_egress: DropEgressStream,
+    ) -> Self {
+        let context_propagator = TraceContextPropagator::default();
+        Self {
+            state: State::Active,
+            connection,
+            tx: Some(tx),
+            drop_egress: Some(drop_egress),
+            context_propagator,
+            seen_versions: Default::default(),
+        }
+    }
+
+    pub fn start<S>(
+        self,
+        router: impl Handler + Sync + 'static,
+        conn_tracker: impl ConnectionTracking + Send + Sync + 'static,
+        peer_router: impl PeerRouting + Send + Sync + 'static,
+        incoming: S,
+        should_register: bool,
+    ) -> Result<TaskId, ShutdownError>
+    where
+        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
+    {
+        let span = tracing::error_span!(parent: None, "network-reactor",
+            task_id = tracing::field::Empty,
+            peer = %self.connection.peer(),
+        );
+
+        TaskCenter::spawn(
+            TaskKind::ConnectionReactor,
+            "network-connection-reactor",
+            self.run_reactor(router, incoming, conn_tracker, peer_router, should_register)
+                .instrument(span),
+        )
+    }
+
+    fn send_drain_signal(&self, reason: DrainReason) {
+        if let Some(tx) = &self.tx {
+            tx.unbounded_drain(reason)
+        }
+    }
+
+    fn notify_metadata_versions(&mut self, header: &Header) {
+        if let Some(seen) = self.seen_versions.as_mut() {
+            seen.notify(header, &self.connection);
+        }
+    }
+
+    fn switch_to_draining(&mut self, reason: DrainReason, peer_router: &impl PeerRouting) {
+        trace!("Connection is draining");
+        self.send_drain_signal(reason);
+        self.seen_versions = None;
+        self.state = State::Draining {
+            drain_timeout: Box::pin(tokio::time::sleep(Duration::from_secs(15))),
+        };
+        peer_router.deregister(&self.connection);
+    }
+
+    pub async fn run_reactor<S>(
+        mut self,
+        router: impl Handler,
+        mut incoming: S,
+        conn_tracker: impl ConnectionTracking,
+        peer_router: impl PeerRouting,
+        should_register: bool,
+    ) -> anyhow::Result<()>
+    where
+        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send,
+    {
+        let current_task = TaskContext::current();
+        let metadata = Metadata::current();
+        self.seen_versions = Some(MetadataVersions::new(metadata));
+        Span::current().record("task_id", tracing::field::display(current_task.id()));
+        let mut cancellation = std::pin::pin!(current_task.cancellation_token().cancelled());
+
+        if should_register {
+            peer_router.register(&self.connection);
+        }
+        conn_tracker.connection_created(&self.connection);
+
+        loop {
+            let decision = match self.state {
+                State::Active => {
+                    // read a message from the stream
+                    tokio::select! {
+                        biased;
+                        _ = &mut cancellation => {
+                            if TaskCenter::is_shutdown_requested() {
+                                // We want to make the distinction between whether we are terminating the
+                                // connection, or whether the node is shutting down.
+                                Decision::Drain(DrainReason::Shutdown)
+                            } else {
+                                Decision::Drain(DrainReason::ConnectionDrain)
+                            }
+                            // we only drain the connection if we were the initiators of the termination
+                        },
+                        msg = incoming.next() => {
+                            self.handle_message(msg, &router).await
+                        }
+                    }
+                }
+                State::Draining {
+                    ref mut drain_timeout,
+                } => {
+                    tokio::select! {
+                        _ = drain_timeout => {
+                            debug!("Drain timed out, closing connection");
+                            Decision::Drop
+                        },
+                        msg = incoming.next() => {
+                            self.handle_message(msg, &router).await
+                        }
+                    }
+                }
+                State::WaitForEgress => {
+                    self.tx.take();
+                    if tokio::time::timeout(
+                        Duration::from_secs(5),
+                        OptionFuture::from(self.drop_egress.take())
+                            .log_slow_after(
+                                Duration::from_secs(2),
+                                tracing::Level::INFO,
+                                "Waiting for connection's egress to drain",
+                            )
+                            .with_overdue(Duration::from_secs(3), tracing::Level::WARN),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        info!("Connection's egress has taken too long to drain, will drop");
+                    }
+                    Decision::Drop
+                }
+            };
+
+            match (&self.state, decision) {
+                (_, Decision::Continue) => {}
+                (State::Active, Decision::Drain(reason)) => {
+                    // send drain signal, and switch
+                    self.switch_to_draining(reason, &peer_router);
+                }
+                (State::Active, Decision::NotifyPeerShutdown) => {
+                    conn_tracker.notify_peer_shutdown(self.connection.peer());
+                    self.switch_to_draining(DrainReason::ConnectionDrain, &peer_router);
+                }
+                (_, Decision::DrainEgress) => {
+                    self.tx.take();
+                    self.state = State::WaitForEgress;
+                }
+                (State::Draining { .. }, Decision::NotifyPeerShutdown) => {
+                    conn_tracker.notify_peer_shutdown(self.connection.peer());
+                }
+                (State::Draining { .. }, Decision::Drain(reason)) => {
+                    // send drain signal, and switch
+                    self.send_drain_signal(reason);
+                }
+                (_, Decision::Drop) => break,
+                (State::WaitForEgress, Decision::NotifyPeerShutdown) => unreachable!(),
+                (State::WaitForEgress, Decision::Drain(_)) => unreachable!(),
+            }
+        }
+
+        // we also try to deregister here because we don't always transition to "Draining" before
+        // dropping
+        peer_router.deregister(&self.connection);
+        conn_tracker.connection_dropped(&self.connection);
+        Ok(())
+    }
+
+    async fn handle_message(
+        &mut self,
+        msg: Option<Result<Message, ProtocolError>>,
+        router: &impl Handler,
+    ) -> Decision {
+        let msg = match msg {
+            Some(Ok(msg)) => msg,
+            Some(Err(status)) => {
+                // This indicates an unrecoverable error in the underlying stream.
+                // It's very likely that we can't send or receive anything.
+                // We'll choose to drop the queued messages on the floor.
+                info!("Error received: {status}, terminating stream");
+                return Decision::Drop;
+            }
+            None if self.state.is_active() => {
+                return Decision::Drain(DrainReason::ConnectionDrain);
+            }
+            None => {
+                // Peer has terminated the connection stream cleanly.
+                // no more messages will arrive on this stream.
+                return Decision::DrainEgress;
+            }
+        };
+
+        let processing_started = Instant::now();
+        // body are not allowed to be empty.
+        let Some(body) = msg.body else {
+            return Decision::Drain(DrainReason::CodecError(
+                "Body is missing on message".to_owned(),
+            ));
+        };
+
+        //  header is required on all messages
+        let Some(header) = msg.header else {
+            warn!("Peer sent a message without header");
+            return Decision::Drop;
+        };
+
+        self.notify_metadata_versions(&header);
+
+        match body {
+            Body::ConnectionControl(ctrl_msg) => {
+                debug!(
+                    "Received control signal from peer {}. {} {}",
+                    self.connection.peer(),
+                    ctrl_msg.signal(),
+                    ctrl_msg.message,
+                );
+                match ctrl_msg.signal() {
+                    Signal::Shutdown => Decision::NotifyPeerShutdown,
+                    Signal::RequestStreamDrained => {
+                        // No more requests coming, but rpc responses might still arrive.
+                        // We don't need tx anymore. We'll not create future responder
+                        // tasks.
+                        self.tx.take();
+                        Decision::Drain(DrainReason::ConnectionDrain)
+                    }
+                    Signal::ResponseStreamDrained => {
+                        // No more responses coming, but rpc requests might still arrive.
+                        // Peer will terminate its sender stream once if drained its two
+                        // egress streams.
+                        Decision::Drain(DrainReason::ConnectionDrain)
+                    }
+                    Signal::DrainConnection => Decision::Drain(DrainReason::ConnectionDrain),
+                    Signal::CodecError => Decision::Drop,
+                    Signal::Unknown => Decision::Continue,
+                }
+            }
+            // Welcome and hello are not allowed after handshake
+            Body::Welcome(_) | Body::Hello(_) => {
+                warn!("Peer sent a welcome/hello message after handshake, terminating connection");
+                Decision::Drop
+            }
+
+            Body::Encoded(msg) => {
+                let encoded_len = msg.encoded_len();
+                let target = msg.target();
+
+                let parent_context = header
+                    .span_context
+                    .as_ref()
+                    .map(|span_ctx| self.context_propagator.extract(span_ctx));
+
+                // unconstrained: We want to avoid yielding if the message router has capacity,
+                // this is to improve tail latency of message processing. We still give tokio
+                // a yielding point when reading the next message but it would be excessive to
+                // introduce more than one yielding point in this reactor loop.
+                if let Err(e) = tokio::task::unconstrained(
+                    router.call(
+                        Incoming::from_parts(
+                            msg,
+                            self.connection.clone(),
+                            header.msg_id,
+                            header.in_response_to,
+                            PeerMetadataVersion::from(header),
+                        )
+                        .with_parent_context(parent_context),
+                        self.connection.protocol_version,
+                    ),
+                )
+                .await
+                {
+                    warn!(
+                        target = target.as_str_name(),
+                        "Error processing message: {e}"
+                    );
+                }
+                histogram!(NETWORK_MESSAGE_PROCESSING_DURATION, "target" => target.as_str_name())
+                    .record(processing_started.elapsed());
+                counter!(NETWORK_MESSAGE_RECEIVED, "target" => target.as_str_name()).increment(1);
+                counter!(NETWORK_MESSAGE_RECEIVED_BYTES, "target" => target.as_str_name())
+                    .increment(encoded_len as u64);
+                trace!(
+                    target = target.as_str_name(),
+                    "Processed message in {:?}",
+                    processing_started.elapsed()
+                );
+                Decision::Continue
+            }
+        }
+    }
+}
+
+#[derive(derive_more::Index, derive_more::IndexMut)]
+pub struct MetadataVersions {
+    #[index_mut]
+    #[index]
+    versions: EnumMap<MetadataKind, Version>,
+    metadata: Metadata,
+    nodes_config: Live<NodesConfiguration>,
+    schema: Live<Schema>,
+    partition_table: Live<PartitionTable>,
+    logs_metadata: Live<Logs>,
+}
+
+impl MetadataVersions {
+    fn new(metadata: Metadata) -> Self {
+        let mut nodes_config = metadata.updateable_nodes_config();
+        let mut schema = metadata.updateable_schema();
+        let mut partition_table = metadata.updateable_partition_table();
+        let mut logs_metadata = metadata.updateable_logs_metadata();
+
+        let versions = enum_map! {
+            MetadataKind::NodesConfiguration => nodes_config.live_load().version(),
+            MetadataKind::Schema => schema.live_load().version(),
+            MetadataKind::PartitionTable => partition_table.live_load().version(),
+            MetadataKind::Logs => logs_metadata.live_load().version(),
+        };
+
+        Self {
+            metadata,
+            versions,
+            nodes_config,
+            schema,
+            partition_table,
+            logs_metadata,
+        }
+    }
+
+    pub fn notify(&mut self, header: &Header, connection: &Connection) {
+        self.update(
+            header.my_nodes_config_version.map(Into::into),
+            header.my_partition_table_version.map(Into::into),
+            header.my_schema_version.map(Into::into),
+            header.my_logs_version.map(Into::into),
+        )
+        .into_iter()
+        .for_each(|(kind, version)| {
+            if let Some(version) = version {
+                if version > self.get_latest_version(kind) {
+                    self.metadata.notify_observed_version(
+                        kind,
+                        version,
+                        Some(connection.clone()),
+                        Urgency::Normal,
+                    );
+                }
+                // todo: store the latest if it's higher
+            }
+        });
+    }
+
+    fn get_latest_version(&mut self, kind: MetadataKind) -> Version {
+        match kind {
+            MetadataKind::NodesConfiguration => self.nodes_config.live_load().version(),
+            MetadataKind::Schema => self.schema.live_load().version(),
+            MetadataKind::PartitionTable => self.partition_table.live_load().version(),
+            MetadataKind::Logs => self.logs_metadata.live_load().version(),
+        }
+    }
+
+    fn update(
+        &mut self,
+        nodes_config_version: Option<Version>,
+        partition_table_version: Option<Version>,
+        schema_version: Option<Version>,
+        logs_version: Option<Version>,
+    ) -> EnumMap<MetadataKind, Option<Version>> {
+        let mut result = EnumMap::default();
+        result[MetadataKind::NodesConfiguration] =
+            self.update_internal(MetadataKind::NodesConfiguration, nodes_config_version);
+        result[MetadataKind::PartitionTable] =
+            self.update_internal(MetadataKind::PartitionTable, partition_table_version);
+        result[MetadataKind::Schema] = self.update_internal(MetadataKind::Schema, schema_version);
+        result[MetadataKind::Logs] = self.update_internal(MetadataKind::Logs, logs_version);
+
+        result
+    }
+
+    fn update_internal(
+        &mut self,
+        metadata_kind: MetadataKind,
+        version: Option<Version>,
+    ) -> Option<Version> {
+        if let Some(version) = version {
+            if version > self.versions[metadata_kind] {
+                self.versions[metadata_kind] = version;
+                return Some(version);
+            }
+        }
+        None
+    }
+}

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -28,7 +28,7 @@ pub mod tonic_service_filter;
 pub mod transport_connector;
 mod types;
 
-pub use connection::{OwnedConnection, WeakConnection};
+pub use connection::Connection;
 pub use connection_manager::ConnectionManager;
 pub use error::*;
 pub use grpc::GrpcConnector;

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -25,6 +25,7 @@ pub mod protobuf;
 pub mod rpc_router;
 mod server_builder;
 pub mod tonic_service_filter;
+mod tracking;
 pub mod transport_connector;
 mod types;
 

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -218,7 +218,7 @@ where
                     .serve_connection(io, service.clone()).into_owned());
 
                 TaskCenter::spawn(TaskKind::SocketHandler, task_name.clone(), async move {
-                    debug!("New connection accepted");
+                    trace!("New connection accepted");
                     if let Err(e) = connection.await {
                         if let Some(hyper_error) = e.downcast_ref::<hyper::Error>() {
                             if hyper_error.is_incomplete_message() {

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -29,8 +29,13 @@ pub mod network {
     use self::message::{BinaryMessage, ConnectionControl, Signal};
 
     impl Hello {
-        pub fn new(my_node_id: Option<GenerationalNodeId>, cluster_name: String) -> Self {
+        pub fn new(
+            my_node_id: Option<GenerationalNodeId>,
+            cluster_name: String,
+            direction: ConnectionDirection,
+        ) -> Self {
             Self {
+                direction: direction.into(),
                 min_protocol_version: MIN_SUPPORTED_PROTOCOL_VERSION.into(),
                 max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
                 my_node_id: my_node_id.map(Into::into),
@@ -77,10 +82,15 @@ pub mod network {
     }
 
     impl Welcome {
-        pub fn new(my_node_id: GenerationalNodeId, protocol_version: ProtocolVersion) -> Self {
+        pub fn new(
+            my_node_id: GenerationalNodeId,
+            protocol_version: ProtocolVersion,
+            direction_ack: ConnectionDirection,
+        ) -> Self {
             Self {
                 my_node_id: Some(my_node_id.into()),
                 protocol_version: protocol_version.into(),
+                direction_ack: direction_ack.into(),
             }
         }
     }

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -29,11 +29,11 @@ pub mod network {
     use self::message::{BinaryMessage, ConnectionControl, Signal};
 
     impl Hello {
-        pub fn new(my_node_id: GenerationalNodeId, cluster_name: String) -> Self {
+        pub fn new(my_node_id: Option<GenerationalNodeId>, cluster_name: String) -> Self {
             Self {
                 min_protocol_version: MIN_SUPPORTED_PROTOCOL_VERSION.into(),
                 max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
-                my_node_id: Some(my_node_id.into()),
+                my_node_id: my_node_id.map(Into::into),
                 cluster_name,
             }
         }

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -458,7 +458,7 @@ mod test {
     use restate_types::GenerationalNodeId;
     use restate_types::net::TargetName;
 
-    use crate::network::{PeerMetadataVersion, WeakConnection};
+    use crate::network::{Connection, PeerMetadataVersion};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct TestRequest {
@@ -540,7 +540,7 @@ mod test {
                 TestResponse {
                     text: "test".to_string(),
                 },
-                WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
+                Connection::new_closed(GenerationalNodeId::new(1, 1)),
                 1,
                 Some(42),
                 PeerMetadataVersion::default(),
@@ -553,7 +553,7 @@ mod test {
             TestResponse {
                 text: "test".to_string(),
             },
-            WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
+            Connection::new_closed(GenerationalNodeId::new(1, 1)),
             1,
             Some(42),
             PeerMetadataVersion::default(),
@@ -568,7 +568,7 @@ mod test {
                 TestResponse {
                     text: "a very real message".to_string(),
                 },
-                WeakConnection::new_closed(GenerationalNodeId::new(1, 1)),
+                Connection::new_closed(GenerationalNodeId::new(1, 1)),
                 1,
                 Some(1),
                 PeerMetadataVersion::default(),
@@ -609,7 +609,7 @@ mod test {
                     TestResponse {
                         text: format!("{idx}"),
                     },
-                    WeakConnection::new_closed(GenerationalNodeId::new(0, 0)),
+                    Connection::new_closed(GenerationalNodeId::new(0, 0)),
                     1,
                     Some(idx),
                     PeerMetadataVersion::default(),

--- a/crates/core/src/network/tracking.rs
+++ b/crates/core/src/network/tracking.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_types::GenerationalNodeId;
+
+use super::Connection;
+
+pub trait PeerRouting {
+    /// Registering a connection that can be used by others to send requests to this peer
+    fn register(&self, connection: &Connection);
+    /// Remove this connection from the pool of connections that we can use to send requests.
+    fn deregister(&self, connection: &Connection);
+}
+
+/// A trait for tracking connection lifecycle
+pub trait ConnectionTracking {
+    // a connection has been created
+    fn connection_created(&self, conn: &Connection);
+    // a node has told us that it's shutting down
+    fn notify_peer_shutdown(&self, node_id: GenerationalNodeId);
+    // connection is has dropped
+    fn connection_dropped(&self, conn: &Connection);
+}
+
+/// Null tracker
+pub struct NoopTracker;
+/// Null router
+pub struct NoopRouter;
+
+impl ConnectionTracking for NoopTracker {
+    fn connection_created(&self, _conn: &Connection) {}
+    fn notify_peer_shutdown(&self, _node_id: GenerationalNodeId) {}
+    fn connection_dropped(&self, _conn: &Connection) {}
+}
+
+impl PeerRouting for NoopRouter {
+    fn register(&self, _conn: &Connection) {}
+    fn deregister(&self, _conn: &Connection) {}
+}

--- a/crates/core/src/network/transport_connector.rs
+++ b/crates/core/src/network/transport_connector.rs
@@ -67,7 +67,7 @@ pub mod test_util {
     use crate::network::io::EgressStream;
     use crate::network::protobuf::network::Message;
     use crate::network::protobuf::network::message::BinaryMessage;
-    use crate::network::{Incoming, MockPeerConnection, PartialPeerConnection, WeakConnection};
+    use crate::network::{Connection, Incoming, MockPeerConnection, PartialPeerConnection};
     use crate::{TaskCenter, TaskHandle, TaskKind, my_node_id};
 
     #[derive(Clone)]
@@ -136,7 +136,7 @@ pub mod test_util {
     /// stream
     pub struct MessageCollectorMockConnector {
         pub mock_connector: MockConnector,
-        pub tasks: Mutex<Vec<(WeakConnection, TaskHandle<anyhow::Result<()>>)>>,
+        pub tasks: Mutex<Vec<(Connection, TaskHandle<anyhow::Result<()>>)>>,
     }
 
     impl MessageCollectorMockConnector {

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -163,7 +163,7 @@ impl TaskCenter {
     #[track_caller]
     pub fn spawn_unmanaged<F, T>(
         kind: TaskKind,
-        name: &'static str,
+        name: impl Into<SharedString>,
         future: F,
     ) -> Result<TaskHandle<T>, ShutdownError>
     where

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -618,7 +618,7 @@ mod tests {
     use googletest::prelude::*;
     use test_log::test;
 
-    use restate_core::network::OwnedConnection;
+    use restate_core::network::Connection;
     use restate_core::network::protobuf::network::message;
     use restate_core::{MetadataBuilder, TaskCenter};
     use restate_rocksdb::RocksDbManager;
@@ -672,7 +672,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -705,8 +705,8 @@ mod tests {
             payloads: payloads.clone(),
         };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1 = Incoming::for_testing(connection.clone(), msg1, None);
+        let msg2 = Incoming::for_testing(connection.clone(), msg2, None);
         let msg1_id = msg1.msg_id();
         let msg2_id = msg2.msg_id();
 
@@ -742,7 +742,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -785,10 +785,10 @@ mod tests {
             payloads: payloads.clone(),
         };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
-        let seal2 = Incoming::for_testing(connection.downgrade(), seal2, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1 = Incoming::for_testing(connection.clone(), msg1, None);
+        let seal1 = Incoming::for_testing(connection.clone(), seal1, None);
+        let seal2 = Incoming::for_testing(connection.clone(), seal2, None);
+        let msg2 = Incoming::for_testing(connection.clone(), msg2, None);
         let msg1_id = msg1.msg_id();
         let seal1_id = seal1.msg_id();
         let seal2_id = seal2.msg_id();
@@ -843,7 +843,7 @@ mod tests {
             flags: StoreFlags::empty(),
             payloads: payloads.clone(),
         };
-        let msg3 = Incoming::for_testing(connection.downgrade(), msg3, None);
+        let msg3 = Incoming::for_testing(connection.clone(), msg3, None);
         let msg3_id = msg3.msg_id();
         worker.enqueue_store(msg3).unwrap();
         let response = net_rx.next().await.unwrap();
@@ -858,7 +858,7 @@ mod tests {
         let msg = GetLogletInfo {
             header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
         };
-        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+        let msg = Incoming::for_testing(connection.clone(), msg, None);
         let msg_id = msg.msg_id();
         worker.enqueue_get_loglet_info(msg).unwrap();
 
@@ -884,9 +884,9 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
         let (repair_connection, _repair_sender, mut peer_net_rx, _egress_drop2) =
-            OwnedConnection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(PEER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -946,19 +946,19 @@ mod tests {
             payloads: payloads.clone(),
         };
 
-        let msg1 = Incoming::for_testing(connection.downgrade(), msg1, None);
-        let msg2 = Incoming::for_testing(connection.downgrade(), msg2, None);
+        let msg1 = Incoming::for_testing(connection.clone(), msg1, None);
+        let msg2 = Incoming::for_testing(connection.clone(), msg2, None);
         let repair1 = Incoming::for_testing(
-            repair_connection.downgrade(),
+            repair_connection.clone(),
             repair_message_before_local_tail,
             None,
         );
         let repair2 = Incoming::for_testing(
-            repair_connection.downgrade(),
+            repair_connection.clone(),
             repair_message_after_local_tail,
             None,
         );
-        let seal1 = Incoming::for_testing(connection.downgrade(), seal1, None);
+        let seal1 = Incoming::for_testing(connection.clone(), seal1, None);
 
         worker.enqueue_store(msg1).unwrap();
         worker.enqueue_store(msg2).unwrap();
@@ -1003,7 +1003,7 @@ mod tests {
         let msg = GetLogletInfo {
             header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
         };
-        let msg = Incoming::for_testing(connection.downgrade(), msg, None);
+        let msg = Incoming::for_testing(connection.clone(), msg, None);
         let msg_id = msg.msg_id();
         worker.enqueue_get_loglet_info(msg).unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store, loglet_state)?;
@@ -1036,7 +1036,7 @@ mod tests {
         // Note: dots mean we don't have records at those globally committed offsets.
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=1 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(2)),
@@ -1053,7 +1053,7 @@ mod tests {
 
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=4 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(5)),
@@ -1070,7 +1070,7 @@ mod tests {
 
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=9 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
@@ -1097,7 +1097,7 @@ mod tests {
         // We expect to see [2, 5]. No trim gaps, no filtered gaps.
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     // faking that offset=9 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
@@ -1133,7 +1133,7 @@ mod tests {
         // We expect to see [2, FILTERED(5), 10, 11]. No trim gaps.
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     // INVALID can be used when we don't have a reasonable value to pass in.
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
@@ -1178,7 +1178,7 @@ mod tests {
         // We expect to see [FILTERED(5), 10]. (11 is not returned due to budget)
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     // INVALID can be used when we don't have a reasonable value to pass in.
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
@@ -1232,7 +1232,7 @@ mod tests {
         const LOGLET: LogletId = LogletId::new_unchecked(1);
         let loglet_state_map = LogletStateMap::default();
         let (connection, _sender, mut net_rx, _egress_drop) =
-            OwnedConnection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
+            Connection::new_fake(SEQUENCER, CURRENT_PROTOCOL_VERSION, 10);
 
         let loglet_state = loglet_state_map.get_or_load(LOGLET, &log_store).await?;
         let worker = LogletWorker::start(LOGLET, log_store.clone(), loglet_state.clone())?;
@@ -1242,7 +1242,7 @@ mod tests {
         // The loglet has no knowledge of global commits, it shouldn't accept trims.
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::OLDEST),
                     trim_point: LogletOffset::OLDEST,
@@ -1263,7 +1263,7 @@ mod tests {
         // won't move trim point beyond its local tail.
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
                     trim_point: LogletOffset::new(9),
@@ -1283,7 +1283,7 @@ mod tests {
         // let's store some records at offsets (5, 6)
         worker
             .enqueue_store(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Store {
                     // faking that offset=9 is released
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
@@ -1307,7 +1307,7 @@ mod tests {
         // trim to 5
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
                     trim_point: LogletOffset::new(5),
@@ -1327,7 +1327,7 @@ mod tests {
         // Attempt to read. We expect to see a trim gap (1->5, 6 (data-record))
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
                     total_limit_in_bytes: None,
@@ -1369,7 +1369,7 @@ mod tests {
         // trim everything
         worker
             .enqueue_trim(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 Trim {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::new(10)),
                     trim_point: LogletOffset::new(9),
@@ -1389,7 +1389,7 @@ mod tests {
         // Attempt to read again. We expect to see a trim gap (1->6)
         worker
             .enqueue_get_records(Incoming::for_testing(
-                connection.downgrade(),
+                connection.clone(),
                 GetRecords {
                     header: LogServerRequestHeader::new(LOGLET, LogletOffset::INVALID),
                     total_limit_in_bytes: None,


### PR DESCRIPTION

This allows the reactor to be used without connection manager

Note that the mechanics of how we connect to peers will change in the future as well (including preemption).
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2907).
* __->__ #2907
* #2894