### PR TITLE
Assign task names to JoinSet tasks

### DIFF
--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -166,7 +166,11 @@ impl Watchdog {
         trace!("Shutting down live bifrost providers");
         let mut providers = JoinSet::new();
         for provider in self.live_providers {
-            providers.spawn(async move { provider.shutdown().await });
+            providers
+                .build_task()
+                .name("shutdown-loglet-provider")
+                .spawn(async move { provider.shutdown().await })
+                .expect("to spawn provider shutdown");
         }
 
         debug!(

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -355,12 +355,15 @@ mod task_orchestrator {
             );
             let task_id = self
                 .tasks
+                .build_task()
+                .name("kafka-consumer")
                 .spawn({
                     let consumer_task_clone = consumer_task_clone.clone();
                     consumer_task_clone
                         .run(rx)
                         .in_current_tc_as_task(TaskKind::Kafka, "kafka-consumer-task")
                 })
+                .expect("to spawn kafka consumer task")
                 .id();
 
             self.running_tasks_to_subscriptions


### PR DESCRIPTION
Assign task names to JoinSet tasks. Unfortunately, it does not solve the problem of init tasks being reported as continuously polled via tokio-console but it's an improvement anyway.