### PR TITLE
Datafusion nodes table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7327,6 +7327,7 @@ dependencies = [
  "datafusion",
  "datafusion-functions-json",
  "derive_more",
+ "enumset",
  "futures",
  "googletest",
  "paste",

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -32,6 +32,7 @@ codederror = { workspace = true }
 datafusion = { workspace = true }
 datafusion-functions-json = { version = "0.44.2" }
 derive_more = { workspace = true }
+enumset = { workspace = true }
 futures = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -198,6 +198,17 @@ where
     }
 }
 
+pub struct ClusterTables;
+
+impl RegisterTable for ClusterTables {
+    async fn register(&self, ctx: &QueryContext) -> Result<(), BuildError> {
+        let metadata = Metadata::current();
+        crate::node::register_self(ctx, metadata)?;
+
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 pub struct QueryContext {
     sql_options: SQLOptions,

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -20,6 +20,7 @@ mod invocation_state;
 mod invocation_status;
 mod journal;
 mod keyed_service_status;
+mod node;
 mod partition_store_scanner;
 mod physical_optimizer;
 mod promise;

--- a/crates/storage-query-datafusion/src/node/mod.rs
+++ b/crates/storage-query-datafusion/src/node/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub use table::register_self;

--- a/crates/storage-query-datafusion/src/node/row.rs
+++ b/crates/storage-query-datafusion/src/node/row.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::schema::NodeBuilder;
+use crate::table_util::format_using;
+use enumset::EnumSet;
+use restate_types::{
+    PlainNodeId, Version,
+    nodes_config::{NodeConfig, Role},
+};
+
+#[inline]
+pub(crate) fn append_node_row(
+    builder: &mut NodeBuilder,
+    output: &mut String,
+    ver: Version,
+    node_id: PlainNodeId,
+    node_config: &NodeConfig,
+) {
+    let mut row = builder.row();
+
+    row.metadata_ver(ver.into());
+
+    row.plain_node_id(format_using(output, &node_id));
+    row.gen_node_id(format_using(output, &node_config.current_generation));
+    row.name(format_using(output, &node_config.name));
+    row.address(format_using(output, &node_config.address));
+    row.location(format_using(output, &node_config.location));
+
+    let all: EnumSet<Role> = EnumSet::all();
+    for role in all {
+        match role {
+            Role::Admin => {
+                row.has_admin_role(node_config.has_role(role));
+            }
+            Role::Worker => {
+                row.has_worker_role(node_config.has_role(role));
+            }
+            Role::LogServer => {
+                row.has_log_server_role(node_config.has_role(role));
+                if node_config.has_role(role) {
+                    row.storage_state(format_using(
+                        output,
+                        &node_config.log_server_config.storage_state,
+                    ));
+                }
+            }
+            Role::MetadataServer => {
+                row.has_metadata_server_role(node_config.has_role(role));
+                if node_config.has_role(role) {
+                    row.metadata_server_state(format_using(
+                        output,
+                        &node_config.metadata_server_config.metadata_server_state,
+                    ));
+                }
+            }
+            Role::HttpIngress => {
+                row.has_ingress_role(node_config.has_role(role));
+            }
+        }
+    }
+}

--- a/crates/storage-query-datafusion/src/node/schema.rs
+++ b/crates/storage-query-datafusion/src/node/schema.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(dead_code)]
+
+use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
+
+define_table!(
+    /// Introspect cluster nodes.
+    node(
+        /// Node ID
+        plain_node_id: DataType::Utf8,
+
+        /// Current known generation ID
+        gen_node_id: DataType::Utf8,
+
+        /// Node Name
+        name: DataType::Utf8,
+
+        /// Node advertised address
+        address: DataType::Utf8,
+
+        /// Node location
+        location: DataType::Utf8,
+
+        /// Node has is admin
+        has_admin_role: DataType::Boolean,
+
+        /// Node has is worker
+        has_worker_role: DataType::Boolean,
+
+        /// Node is metadata server
+        has_metadata_server_role: DataType::Boolean,
+
+        /// Node has is log server
+        has_log_server_role: DataType::Boolean,
+
+        /// Node has is http-ingress
+        has_ingress_role: DataType::Boolean,
+
+        /// Node storage state. Only set of node is also a log-server
+        storage_state: DataType::Utf8,
+
+        /// Node metadata server state.
+        metadata_server_state: DataType::Utf8,
+
+        /// Current known metadata version
+        metadata_ver: DataType::UInt32,
+    )
+);

--- a/crates/storage-query-datafusion/src/node/table.rs
+++ b/crates/storage-query-datafusion/src/node/table.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use tokio::sync::mpsc::Sender;
+
+use restate_core::Metadata;
+use restate_types::nodes_config::NodesConfiguration;
+
+use crate::context::QueryContext;
+use crate::table_providers::{GenericTableProvider, Scan};
+use crate::table_util::Builder;
+
+use super::row::append_node_row;
+use super::schema::NodeBuilder;
+
+pub fn register_self(ctx: &QueryContext, metadata: Metadata) -> datafusion::common::Result<()> {
+    let nodes_table =
+        GenericTableProvider::new(NodeBuilder::schema(), Arc::new(NodesScanner(metadata)));
+    ctx.register_non_partitioned_table("nodes", Arc::new(nodes_table))
+}
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("DeploymentMetadataScanner")]
+struct NodesScanner(Metadata);
+
+impl Scan for NodesScanner {
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let schema = projection.clone();
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let tx = stream_builder.tx();
+
+        let nodes_config = self.0.nodes_config_snapshot();
+        stream_builder.spawn(async move {
+            for_each_state(schema, tx, nodes_config).await;
+            Ok(())
+        });
+        stream_builder.build()
+    }
+}
+
+async fn for_each_state(
+    schema: SchemaRef,
+    tx: Sender<datafusion::common::Result<RecordBatch>>,
+    nodes_config: Arc<NodesConfiguration>,
+) {
+    let mut builder = NodeBuilder::new(schema.clone());
+    let mut output = String::new();
+    for (id, node_config) in nodes_config.iter() {
+        append_node_row(
+            &mut builder,
+            &mut output,
+            nodes_config.version(),
+            id,
+            node_config,
+        );
+
+        if builder.full() {
+            let batch = builder.finish();
+            if tx.send(batch).await.is_err() {
+                // not sure what to do here?
+                // the other side has hung up on us.
+                // we probably don't want to panic, is it will cause the entire process to exit
+                return;
+            }
+            builder = NodeBuilder::new(schema.clone());
+        }
+    }
+    if !builder.empty() {
+        let result = builder.finish();
+        let _ = tx.send(result).await;
+    }
+}


### PR DESCRIPTION
Datafusion nodes table

Summary:
Expose nodes configuration over datafusion

> NOTE: This does not show the liveness of nodes yet (observed node status)
which will be eventually added as a separate table

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2913).
* #2945
* #2944
* #2938
* #2925
* #2924
* __->__ #2913