### PR TITLE
Don't let Tokio tasks inherit span of spawning task

### DIFF
--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, instrument};
+use tracing::instrument;
 
 use restate_types::SharedString;
 use restate_types::health::{Health, NodeStatus};
@@ -147,7 +147,7 @@ impl Handle {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        self.inner.spawn_child(kind, name, future.in_current_span())
+        self.inner.spawn_child(kind, name, future)
     }
 
     pub fn spawn_unmanaged<F, T>(
@@ -161,8 +161,7 @@ impl Handle {
         T: Send + 'static,
     {
         let name = name.into();
-        self.inner
-            .spawn_unmanaged(kind, &name, future.in_current_span())
+        self.inner.spawn_unmanaged(kind, &name, future)
     }
 
     /// Must be called within a Localset-scoped task, not from a normal spawned task.
@@ -177,8 +176,7 @@ impl Handle {
         F: Future<Output = anyhow::Result<()>> + 'static,
     {
         let name = name.into();
-        self.inner
-            .spawn_local(kind, &name, future.in_current_span())
+        self.inner.spawn_local(kind, &name, future)
     }
 
     pub fn metadata(&self) -> Option<Metadata> {


### PR DESCRIPTION
Letting Tokio tasks inherit the span of the spawning task messes up the
reporting of Tokio task metrics when using tokio-console since it seems
to rely on the tracing information. That's why this commit removes the
in_current_span() instrumentation for child, unmanaged and local tasks.