### PR TITLE
Update TaskCenter::run_sync docs to reflect panic conditions

### DIFF
--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -86,6 +86,10 @@ impl Handle {
 
     /// Sets the current task_center but doesn't create a task. Use this when you need to run a
     /// closure within task_center scope.
+    ///
+    /// # Panics
+    /// If your closure tries to spawn tasks with [`TaskKind`] that inherit the runtime, then you
+    /// need to call this method from within a Tokio runtime. Otherwise, this method panics.
     pub fn run_sync<F, O>(&self, f: F) -> O
     where
         F: FnOnce() -> O,


### PR DESCRIPTION
When using TaskCenter::run_sync it can happen that we are not running in a Tokio task. In that case tokio::runtime::Handle::current panics. Therefore, we use the default Tokio runtime when there is no current handle. This fixes the partition-store benchmarks.