### PR TITLE
Switch to jiff for parsing for human-friendly durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3476,9 +3476,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -3967,6 +3967,47 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -5546,6 +5587,15 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -7371,6 +7421,7 @@ dependencies = [
  "http-serde",
  "humantime",
  "iso8601",
+ "jiff",
  "prost",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.4"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3981,31 +3981,31 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.4"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
 ]
@@ -6685,7 +6685,6 @@ dependencies = [
  "futures",
  "http 1.2.0",
  "http-body-util",
- "humantime",
  "hyper",
  "hyper-rustls",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ hyper-rustls = { version = "0.27.2", default-features = false, features = [
 hyper-util = { version = "0.1" }
 indexmap = "2.7"
 itertools = "0.14.0"
+jiff = "0.2.4"
 jsonschema = { version = "0.28.3", default-features = false }
 metrics = { version = "0.24" }
 metrics-exporter-prometheus = { version = "0.17", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ hyper-rustls = { version = "0.27.2", default-features = false, features = [
 hyper-util = { version = "0.1" }
 indexmap = "2.7"
 itertools = "0.14.0"
-jiff = "0.2.4"
+jiff = "0.2.14"
 jsonschema = { version = "0.28.3", default-features = false }
 metrics = { version = "0.24" }
 metrics-exporter-prometheus = { version = "0.17", default-features = false, features = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,7 +55,6 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["server", "http2"] }
 hyper-rustls = { workspace = true, default-features = false, features = ["http1", "http2", "aws-lc-rs", "native-tokio", "tls12", "logging"]  }
 hyper-util = { workspace = true, features = ["client-legacy", "http2", "server", "client", "tokio"] }
-humantime = { workspace = true }
 indicatif = "0.17.7"
 indoc = { version = "2.0.4" }
 itertools = { workspace = true }

--- a/cli/src/commands/services/config/patch.rs
+++ b/cli/src/commands/services/config/patch.rs
@@ -8,18 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface};
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::Table;
 use const_format::concatcp;
+
 use restate_admin_rest_model::services::ModifyServiceRequest;
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_serde_util::DurationString;
 
-pub(super) const DURATION_EDIT_DESCRIPTION: &str = "Can be configured using the humantime format (https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) or the ISO8601.";
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+
+pub(super) const DURATION_EDIT_DESCRIPTION: &str = "Can be configured using the jiff \
+    friendly format (https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) or ISO8601.";
 pub(super) const IDEMPOTENCY_RETENTION_EDIT_DESCRIPTION: &str = concatcp!(
     super::view::IDEMPOTENCY_RETENTION,
     "\n",
@@ -122,23 +125,23 @@ pub(super) async fn apply_service_configuration_patch(
     if let Some(idempotency_retention) = &modify_request.idempotency_retention {
         table.add_kv_row(
             "Idempotent requests retention:",
-            humantime::Duration::from(*idempotency_retention),
+            DurationString::display(*idempotency_retention),
         );
     }
     if let Some(workflow_completion_retention) = &modify_request.workflow_completion_retention {
         table.add_kv_row(
             "Workflow retention time:",
-            humantime::Duration::from(*workflow_completion_retention),
+            DurationString::display(*workflow_completion_retention),
         );
     }
     if let Some(inactivity_timeout) = &modify_request.inactivity_timeout {
         table.add_kv_row(
             "Inactivity timeout:",
-            humantime::Duration::from(*inactivity_timeout),
+            DurationString::display(*inactivity_timeout),
         );
     }
     if let Some(abort_timeout) = &modify_request.abort_timeout {
-        table.add_kv_row("Abort timeout:", humantime::Duration::from(*abort_timeout));
+        table.add_kv_row("Abort timeout:", DurationString::display(*abort_timeout));
     }
     c_println!("{table}");
     confirm_or_exit("Are you sure you want to apply these changes?")?;

--- a/cli/src/commands/services/config/view.rs
+++ b/cli/src/commands/services/config/view.rs
@@ -16,6 +16,7 @@ use comfy_table::Table;
 use indoc::indoc;
 use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::{c_println, c_tip};
+use restate_serde_util::DurationString;
 use restate_types::invocation::ServiceType;
 
 // TODO we could infer this text from the OpenAPI docs!
@@ -87,7 +88,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
         let mut table = Table::new_styled();
         table.add_kv_row(
             "Idempotent requests retention:",
-            humantime::Duration::from(idempotency_retention),
+            DurationString::display(idempotency_retention),
         );
         c_println!("{table}");
         c_tip!("{}", IDEMPOTENCY_RETENTION);
@@ -98,7 +99,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
         let mut table = Table::new_styled();
         table.add_kv_row(
             "Workflow retention time:",
-            humantime::format_duration(
+            DurationString::display(
                 service
                     .workflow_completion_retention
                     .expect("Workflows must have a well defined retention"),
@@ -114,7 +115,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
         "Inactivity timeout:",
         service
             .inactivity_timeout
-            .map(|d| humantime::format_duration(d).to_string())
+            .map(DurationString::display)
             .unwrap_or("<DEFAULT>".to_string()),
     );
     c_println!("{table}");
@@ -126,7 +127,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
         "Abort timeout:",
         service
             .abort_timeout
-            .map(|d| humantime::format_duration(d).to_string())
+            .map(DurationString::display)
             .unwrap_or("<DEFAULT>".to_string()),
     );
     c_println!("{table}");

--- a/crates/admin-rest-model/src/services.rs
+++ b/crates/admin-rest-model/src/services.rs
@@ -8,10 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 
 use restate_types::schema::service::ServiceMetadata;
 
@@ -35,7 +36,7 @@ pub struct ModifyServiceRequest {
     ///
     /// Modify the retention of idempotent requests for this service.
     ///
-    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format or the ISO8601.
+    /// Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601.
     #[serde(
         default,
         with = "serde_with::As::<Option<restate_serde_util::DurationString>>"
@@ -47,7 +48,7 @@ pub struct ModifyServiceRequest {
     ///
     /// Modify the retention of the workflow completion. This can be modified only for workflow services!
     ///
-    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format or the ISO8601.
+    /// Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601.
     #[serde(
         default,
         with = "serde_with::As::<Option<restate_serde_util::DurationString>>"
@@ -64,7 +65,7 @@ pub struct ModifyServiceRequest {
     /// The 'abort timeout' is used to abort the invocation, in case it doesn't react to
     /// the request to suspend.
     ///
-    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format or the ISO8601.
+    /// Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601.
     ///
     /// This overrides the default inactivity timeout set in invoker options.
     #[serde(
@@ -84,7 +85,7 @@ pub struct ModifyServiceRequest {
     /// This timer potentially **interrupts** user code. If the user code needs longer to
     /// gracefully terminate, then this value needs to be set accordingly.
     ///
-    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format or the ISO8601.
+    /// Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601.
     ///
     /// This overrides the default abort timeout set in invoker options.
     #[serde(

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -46,8 +46,8 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper-util = { workspace = true }
-jsonschema = { workspace = true }
 itertools = { workspace = true }
+jsonschema = { workspace = true }
 mime_guess = { version = "2.0.5", optional = true }
 okapi-operation = { version = "0.3.0-rc3", features = ["axum-integration"] }
 parking_lot = { workspace = true }

--- a/crates/serde-util/Cargo.toml
+++ b/crates/serde-util/Cargo.toml
@@ -25,6 +25,7 @@ prost = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
+jiff = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/types/src/schema/service.rs
+++ b/crates/types/src/schema/service.rs
@@ -8,6 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwapOption;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_with::serde_as;
+
+use restate_serde_util::DurationString;
+
 use super::Schema;
 use super::invocation_target::InvocationTargetMetadata;
 use crate::config::Configuration;
@@ -16,13 +27,6 @@ use crate::invocation::{
     InvocationTargetType, ServiceType, VirtualObjectHandlerType, WorkflowHandlerType,
 };
 use crate::schema::openapi::ServiceOpenAPI;
-use arc_swap::ArcSwapOption;
-use serde::Deserialize;
-use serde::Serialize;
-use serde_with::serde_as;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -71,7 +75,7 @@ pub struct ServiceMetadata {
     ///
     /// The retention duration of idempotent requests for this service.
     #[serde(
-        with = "serde_with::As::<Option<restate_serde_util::DurationString>>",
+        with = "serde_with::As::<Option<DurationString>>",
         skip_serializing_if = "Option::is_none",
         default
     )]
@@ -82,7 +86,7 @@ pub struct ServiceMetadata {
     ///
     /// The retention duration of workflows. Only available on workflow services.
     #[serde(
-        with = "serde_with::As::<Option<restate_serde_util::DurationString>>",
+        with = "serde_with::As::<Option<DurationString>>",
         skip_serializing_if = "Option::is_none",
         default
     )]
@@ -96,7 +100,7 @@ pub struct ServiceMetadata {
     /// In case the request has an idempotency key, the `idempotency_retention` caps the maximum `journal_retention` time.
     /// In case the request targets a workflow handler, the `workflow_completion_retention` caps the maximum `journal_retention` time.
     #[serde(
-        with = "serde_with::As::<Option<restate_serde_util::DurationString>>",
+        with = "serde_with::As::<Option<DurationString>>",
         skip_serializing_if = "Option::is_none",
         default
     )]
@@ -112,11 +116,11 @@ pub struct ServiceMetadata {
     /// The 'abort timeout' is used to abort the invocation, in case it doesn't react to
     /// the request to suspend.
     ///
-    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format.
+    /// Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601.
     ///
     /// This overrides the default inactivity timeout set in invoker options.
     #[serde(
-        with = "serde_with::As::<Option<restate_serde_util::DurationString>>",
+        with = "serde_with::As::<Option<DurationString>>",
         skip_serializing_if = "Option::is_none",
         default
     )]
@@ -133,11 +137,11 @@ pub struct ServiceMetadata {
     /// This timer potentially **interrupts** user code. If the user code needs longer to
     /// gracefully terminate, then this value needs to be set accordingly.
     ///
-    /// Can be configured using the [`humantime`](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html) format.
+    /// Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601.
     ///
     /// This overrides the default abort timeout set in invoker options.
     #[serde(
-        with = "serde_with::As::<Option<restate_serde_util::DurationString>>",
+        with = "serde_with::As::<Option<DurationString>>",
         skip_serializing_if = "Option::is_none",
         default
     )]

--- a/crates/worker/src/partition/snapshots/repository.rs
+++ b/crates/worker/src/partition/snapshots/repository.rs
@@ -103,7 +103,7 @@ impl LatestSnapshot {
             node_name: snapshot.node_name.clone(),
             partition_id: snapshot.partition_id,
             snapshot_id: snapshot.snapshot_id,
-            created_at: snapshot.created_at.clone(),
+            created_at: snapshot.created_at,
             min_applied_lsn: snapshot.min_applied_lsn,
             path: UniqueSnapshotKey::from_metadata(snapshot).padded_key(),
         }


### PR DESCRIPTION
This commit replaces humantime with jiff::fmt::friendly to avoid ambiguous unit conversions. The result of this is that we no longer accept inputs such as `P1M`, `1 month`, `P1Y` or `1 year`. It makes sense to me to accept this tradeoff for the sake of more consistent conversions - alternatively, we could define our own conversion ratios for the number of days in a month/year as outlined here https://github.com/restatedev/restate/issues/2259#issuecomment-2726754029.

See `jiff`'s [Comparison with the `humantime` crate](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html#comparison-with-the-humantime-crate) for a more detailed discussion about the problems with its implementation.

There's an opportunity for eliminating `DurationString` in favor of using `jiff`'s serde feature directly, as well as broader adoption - I've kept this small in scope intentionally so that we can have a desired behavior discussion first.

This also opportunistically updates `humantime` to the latest (final?) available version.

Please note that `jiff` formats units of days as `d`, e.g. `30d` rather than `humantime`'s `30days`. If we choose the verbose printer, it changes the behavior for all units, so `h` becomes `hour`/`hours` etc. I prefer the denser output format but this is a change in observable behavior. Input parsing is unaffected.

Fixes: #2259

---

## Testing

```
❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' \
  -X 'PATCH' -H 'content-type: application/json' \
  --data-raw '{"idempotency_retention":"90m"}' | jq .idempotency_retention
"1h 30m"

❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' \
  -X 'PATCH' -H 'content-type: application/json' \
  --data-raw '{"idempotency_retention":"23h"}' | jq .idempotency_retention
"23h"

❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' \
  -X 'PATCH' -H 'content-type: application/json' \
  --data-raw '{"idempotency_retention":"23h 60m"}' | jq .idempotency_retention
"1d"

❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' \
  -X 'PATCH' -H 'content-type: application/json' \
  --data-raw '{"idempotency_retention":"25h"}' | jq .idempotency_retention
"1d 1h"

❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' \
  -X 'PATCH' -H 'content-type: application/json' \
  --data-raw '{"idempotency_retention":"720h"}' | jq .idempotency_retention
"30d"

❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' \
  -X 'PATCH' -H 'content-type: application/json' \
  --data-raw '{"idempotency_retention":"1month"}'
Failed to deserialize the JSON body into the target type: idempotency_retention: Please use units of days or smaller at line 1 column 34%

❯ restate services config view usersignup
 Name:          usersignup
 Service type:  Workflow

...

 Idempotent requests retention:  30d
  💡   The retention duration of idempotent requests for this service.
       The retention period starts once the invocation completes (with either success or failure).
       After the retention period, the invocation response and the idempotency key will be forgotten.

...

❯ restate services config patch --idempotency-retention P28DT54H usersignup
 Idempotent requests retention:  30d 6h
✔ Are you sure you want to apply these changes? · yes
❯ restate services config view usersignup
 Name:          usersignup
 Service type:  Workflow

...

 Idempotent requests retention:  30d 6h
  💡   The retention duration of idempotent requests for this service.
       The retention period starts once the invocation completes (with either success or failure).
       After the retention period, the invocation response and the idempotency key will be forgotten.

...

❯ curl --no-progress-meter 'http://localhost:9070/services/usersignup' | jq
{
  "name": "usersignup",
  "handlers": [
    {
      "name": "click",
      "ty": "Shared",
      "input_description": "application/json",
      "output_description": "application/json"
    },
    {
      "name": "run",
      "ty": "Workflow",
      "input_description": "application/json",
      "output_description": "application/json"
    }
  ],
  "ty": "Workflow",
  "deployment_id": "dp_16la0zp8reGBItqmP7dyxbP",
  "revision": 1,
  "public": true,
  "idempotency_retention": "30d 6h",
  "workflow_completion_retention": "1d",
  "inactivity_timeout": "30s",
  "abort_timeout": "2m"
}
```