### PR TITLE
Datafusion partitions table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7330,6 +7330,7 @@ dependencies = [
  "enumset",
  "futures",
  "googletest",
+ "itertools 0.14.0",
  "paste",
  "prost",
  "restate-core",

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -34,6 +34,7 @@ datafusion-functions-json = { version = "0.44.2" }
 derive_more = { workspace = true }
 enumset = { workspace = true }
 futures = { workspace = true }
+itertools = { workspace = true }
 paste = { workspace = true }
 prost = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -203,7 +203,8 @@ pub struct ClusterTables;
 impl RegisterTable for ClusterTables {
     async fn register(&self, ctx: &QueryContext) -> Result<(), BuildError> {
         let metadata = Metadata::current();
-        crate::node::register_self(ctx, metadata)?;
+        crate::node::register_self(ctx, metadata.clone())?;
+        crate::partition::register_self(ctx, metadata)?;
 
         Ok(())
     }

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -21,6 +21,7 @@ mod invocation_status;
 mod journal;
 mod keyed_service_status;
 mod node;
+mod partition;
 mod partition_store_scanner;
 mod physical_optimizer;
 mod promise;

--- a/crates/storage-query-datafusion/src/partition/mod.rs
+++ b/crates/storage-query-datafusion/src/partition/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub use table::register_self;

--- a/crates/storage-query-datafusion/src/partition/row.rs
+++ b/crates/storage-query-datafusion/src/partition/row.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::table_util::format_using;
+
+use super::schema::PartitionBuilder;
+use itertools::{Itertools, Position};
+use restate_types::{Version, partition_table::Partition};
+
+#[inline]
+pub(crate) fn append_partition_rows(
+    builder: &mut PartitionBuilder,
+    output: &mut String,
+    ver: Version,
+    partition: &Partition,
+) {
+    for (position, node_id) in partition.placement.iter().cloned().with_position() {
+        let mut row = builder.row();
+        row.metadata_ver(ver.into());
+
+        row.partition_id(partition.partition_id.into());
+        row.plain_node_id(format_using(output, &node_id));
+        row.start_key(*partition.key_range.start());
+        row.end_key(*partition.key_range.end());
+
+        match position {
+            Position::First | Position::Only => {
+                row.target_mode("LEADER");
+            }
+            _ => {
+                row.target_mode("FOLLOWER");
+            }
+        }
+    }
+}

--- a/crates/storage-query-datafusion/src/partition/schema.rs
+++ b/crates/storage-query-datafusion/src/partition/schema.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(dead_code)]
+
+use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
+
+define_table!(
+    /// Partition placements and their target running mode
+    partition(
+        /// Partition ID
+        partition_id: DataType::UInt32,
+
+        /// Plain node ID where the partition is running
+        plain_node_id: DataType::Utf8,
+
+        /// Target run mode of partition (LEADER, FOLLOWER)
+        target_mode: DataType::Utf8,
+
+        /// Partition start key
+        start_key: DataType::UInt64,
+
+        /// Partition end key
+        end_key: DataType::UInt64,
+
+        /// Current known metadata version
+        metadata_ver: DataType::UInt32,
+    )
+);

--- a/crates/storage-query-datafusion/src/partition/table.rs
+++ b/crates/storage-query-datafusion/src/partition/table.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use tokio::sync::mpsc::Sender;
+
+use restate_core::Metadata;
+use restate_types::partition_table::PartitionTable;
+
+use crate::context::QueryContext;
+use crate::table_providers::{GenericTableProvider, Scan};
+use crate::table_util::Builder;
+
+use super::row::append_partition_rows;
+use super::schema::PartitionBuilder;
+
+pub fn register_self(ctx: &QueryContext, metadata: Metadata) -> datafusion::common::Result<()> {
+    let partitions_table = GenericTableProvider::new(
+        PartitionBuilder::schema(),
+        Arc::new(PartitionScanner(metadata)),
+    );
+    ctx.register_non_partitioned_table("partitions", Arc::new(partitions_table))
+}
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("DeploymentMetadataScanner")]
+struct PartitionScanner(Metadata);
+
+impl Scan for PartitionScanner {
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let schema = projection.clone();
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let tx = stream_builder.tx();
+
+        let partition_table = self.0.partition_table_snapshot();
+        stream_builder.spawn(async move {
+            for_each_partition(schema, tx, partition_table).await;
+            Ok(())
+        });
+        stream_builder.build()
+    }
+}
+
+async fn for_each_partition(
+    schema: SchemaRef,
+    tx: Sender<datafusion::common::Result<RecordBatch>>,
+    partition_table: Arc<PartitionTable>,
+) {
+    let mut builder = PartitionBuilder::new(schema.clone());
+
+    let mut output = String::new();
+    for (_, partition) in partition_table.partitions() {
+        append_partition_rows(
+            &mut builder,
+            &mut output,
+            partition_table.version(),
+            partition,
+        );
+
+        if builder.full() {
+            let batch = builder.finish();
+            if tx.send(batch).await.is_err() {
+                // not sure what to do here?
+                // the other side has hung up on us.
+                // we probably don't want to panic, is it will cause the entire process to exit
+                return;
+            }
+            builder = PartitionBuilder::new(schema.clone());
+        }
+    }
+
+    if !builder.empty() {
+        let result = builder.finish();
+        let _ = tx.send(result).await;
+    }
+}


### PR DESCRIPTION
Datafusion partitions table

Summary:
Expose the partitions metadata over datafusion

> NOTE: This does not show the status of the partitions yet (observed partition status)
which will be eventually added as a sepaerate table

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2924).
* #2945
* #2944
* #2938
* #2925
* __->__ #2924