### PR TITLE
Datafusion logs table

### DIFF
--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -20,6 +20,7 @@ mod invocation_state;
 mod invocation_status;
 mod journal;
 mod keyed_service_status;
+mod log;
 mod node;
 mod partition;
 mod partition_store_scanner;

--- a/crates/storage-query-datafusion/src/log/mod.rs
+++ b/crates/storage-query-datafusion/src/log/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub use table::register_self;

--- a/crates/storage-query-datafusion/src/log/row.rs
+++ b/crates/storage-query-datafusion/src/log/row.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::table_util::format_using;
+
+use super::schema::LogBuilder;
+use restate_types::{
+    Version,
+    logs::{
+        LogId,
+        metadata::{LogletRef, ProviderKind, Segment},
+    },
+    replicated_loglet::ReplicatedLogletParams,
+};
+
+#[inline]
+pub(crate) fn append_segment_row(
+    builder: &mut LogBuilder,
+    output: &mut String,
+    ver: Version,
+    id: LogId,
+    segment: &Segment<'_>,
+    replicated_loglet_params: Option<&LogletRef<ReplicatedLogletParams>>,
+) {
+    let mut row = builder.row();
+
+    row.metadata_ver(ver.into());
+
+    row.log_id(id.into());
+    row.segment_index(segment.config.index().into());
+    row.base_lsn(segment.base_lsn.into());
+    row.kind(format_using(output, &segment.config.kind));
+
+    if segment.config.kind == ProviderKind::Replicated {
+        if let Some(LogletRef { params, .. }) = replicated_loglet_params {
+            row.loglet_id(format_using(output, &params.loglet_id));
+            row.sequencer(format_using(output, &params.sequencer));
+            row.replication(format_using(output, &params.replication));
+            row.nodeset(format_using(output, &params.nodeset));
+        }
+    }
+}

--- a/crates/storage-query-datafusion/src/log/schema.rs
+++ b/crates/storage-query-datafusion/src/log/schema.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(dead_code)]
+
+use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
+
+define_table!(
+    log(
+        /// Log ID
+        log_id: DataType::UInt32,
+
+        /// Segment index
+        segment_index: DataType::UInt32,
+
+        /// Segment start lsn
+        base_lsn: DataType::UInt64,
+
+        /// Segment provider kind
+        kind: DataType::Utf8,
+
+        // replicated loglet specific params
+
+        /// Loglet ID
+        loglet_id: DataType::Utf8,
+
+        /// Sequencer node id
+        sequencer: DataType::Utf8,
+
+        /// Loglet replication factor
+        replication: DataType::Utf8,
+
+        /// Log server id used by the loglet.
+        nodeset: DataType::Utf8,
+
+        /// Current known metadata version
+        metadata_ver: DataType::UInt32,
+    )
+);

--- a/crates/storage-query-datafusion/src/log/table.rs
+++ b/crates/storage-query-datafusion/src/log/table.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use restate_types::Versioned;
+use restate_types::logs::LogletId;
+use tokio::sync::mpsc::Sender;
+
+use restate_core::Metadata;
+use restate_types::logs::metadata::Logs;
+
+use crate::context::QueryContext;
+use crate::table_providers::{GenericTableProvider, Scan};
+use crate::table_util::Builder;
+
+use super::row::append_segment_row;
+use super::schema::LogBuilder;
+
+pub fn register_self(ctx: &QueryContext, metadata: Metadata) -> datafusion::common::Result<()> {
+    let logs_table =
+        GenericTableProvider::new(LogBuilder::schema(), Arc::new(LogScanner(metadata)));
+    ctx.register_non_partitioned_table("logs", Arc::new(logs_table))
+}
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("DeploymentMetadataScanner")]
+struct LogScanner(Metadata);
+
+impl Scan for LogScanner {
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let schema = projection.clone();
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let tx = stream_builder.tx();
+
+        let logs = self.0.logs_snapshot();
+        stream_builder.spawn(async move {
+            for_each_log(schema, tx, logs).await;
+            Ok(())
+        });
+        stream_builder.build()
+    }
+}
+
+async fn for_each_log(
+    schema: SchemaRef,
+    tx: Sender<datafusion::common::Result<RecordBatch>>,
+    logs: Arc<Logs>,
+) {
+    let mut builder = LogBuilder::new(schema.clone());
+    let mut output = String::new();
+    for (id, chain) in logs.iter() {
+        for segment in chain.iter() {
+            let loglet_id = LogletId::new(*id, segment.index());
+            let replicated_loglet = logs.get_replicated_loglet(&loglet_id);
+
+            append_segment_row(
+                &mut builder,
+                &mut output,
+                logs.version(),
+                *id,
+                &segment,
+                replicated_loglet,
+            );
+
+            if builder.full() {
+                let batch = builder.finish();
+                if tx.send(batch).await.is_err() {
+                    // not sure what to do here?
+                    // the other side has hung up on us.
+                    // we probably don't want to panic, is it will cause the entire process to exit
+                    return;
+                }
+                builder = LogBuilder::new(schema.clone());
+            }
+        }
+    }
+
+    if !builder.empty() {
+        let result = builder.finish();
+        let _ = tx.send(result).await;
+    }
+}


### PR DESCRIPTION
Datafusion logs table

Summary:
Expose the logs metadata over datafusion

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2925).
* #2945
* #2944
* #2938
* __->__ #2925