### PR TITLE
Set reusable cluster bucket for destroy-cluster step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,3 +246,4 @@ jobs:
         if: always()
         with:
           clusterName: ${{ env.CLUSTER_NAME }}
+          bucketName: "restate-jepsen-test-clusters-us-east-1"


### PR DESCRIPTION
This avoids the dynamic bucket showing up in the stack as to-be-deleted, even though it was never created by us.