### PR TITLE
chore(*): add location args examples with newline

### DIFF
--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -63,7 +63,7 @@ pub struct CommonOptionCliOverride {
     /// - `us-west` -- the node is in the `us-west` region.
     /// - `us-west.a1` -- the node is in the `us-west` region and in the `a1` zone.
     /// - `` -- [default] the node is in the default location
-    #[clap(long, alias = "node-location", global = true)]
+    #[clap(long, alias = "node-location", global = true, verbatim_doc_comment)]
     pub location: Option<NodeLocation>,
 
     /// If set, the node insists on acquiring this node ID.


### PR DESCRIPTION
Currently when we start restate-server with `--help`，the `location` args output is:

```
## Examples - `us-west` -- the node is in the `us-west` region. - `us-west.a1` -- the node is in the `us-west` region and in the `a1` zone. - `` -- [default] the node is in the default location
```

it's `newline` is missing, add `verbatim_doc_comment` to keep it, now output is:

```
          ## Examples
          - `us-west` -- the node is in the `us-west` region.
          - `us-west.a1` -- the node is in the `us-west` region and in the `a1` zone.
          - `` -- [default] the node is in the default location
```