### PR TITLE
Cluster controller `query` gRPC handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,19 +194,37 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
  "arrow-csv",
- "arrow-data",
- "arrow-ipc",
+ "arrow-data 53.4.0",
+ "arrow-ipc 53.4.0",
  "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-ord 53.4.0",
+ "arrow-row 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
+ "arrow-string 53.4.0",
+]
+
+[[package]]
+name = "arrow"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
+dependencies = [
+ "arrow-arith 54.2.1",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-cast 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-ord 54.2.1",
+ "arrow-row 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
+ "arrow-string 54.2.1",
 ]
 
 [[package]]
@@ -215,12 +233,26 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31dce77d2985522288edae7206bffd5fc4996491841dda01a13a58415867e681"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
  "chrono",
  "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "chrono",
  "num",
 ]
 
@@ -231,11 +263,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
 dependencies = [
  "ahash 0.8.11",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
  "chrono",
  "chrono-tz",
+ "half",
+ "hashbrown 0.15.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "chrono",
  "half",
  "hashbrown 0.15.2",
  "num",
@@ -253,20 +301,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e899dade2c3b7f5642eb8366cfd898958bcca099cde6dfea543c7e8d3ad88d4"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
  "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
  "half",
  "lexical-core",
  "num",
@@ -279,11 +358,11 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec222848d70fea5a32af9c3602b08f5d740d5e2d33fbd76bf6fd88759b5b13a7"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
  "chrono",
  "csv",
  "csv-core",
@@ -298,8 +377,20 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f2861ffa86f107b8ab577d86cff7c7a490243eabe961ba1e1af4f27542bb79"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 53.4.0",
+ "arrow-schema 53.4.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a329fb064477c9ec5f0870d2f5130966f91055c7c5bce2b3a084f116bc28c3b"
+dependencies = [
+ "arrow-buffer 54.2.1",
+ "arrow-schema 54.2.1",
  "half",
  "num",
 ]
@@ -310,13 +401,26 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
  "flatbuffers",
  "lz4_flex",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -325,11 +429,11 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eff38eeb8a971ad3a4caf62c5d57f0cff8a48b64a55e3207c4fd696a9234aad"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
  "chrono",
  "half",
  "indexmap 2.7.1",
@@ -345,13 +449,26 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f202a879d287099139ff0d121e7f55ae5e0efe634b8cf2106ebc27a8715dee"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
 ]
 
 [[package]]
@@ -361,10 +478,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f936954991c360ba762dff23f5dda16300774fafd722353d9683abd97630ae"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "half",
 ]
 
@@ -375,16 +505,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
 
 [[package]]
+name = "arrow-schema"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85934a9d0261e0fa5d4e2a5295107d743b543a6e0484a835d4b8db2da15306f9"
+
+[[package]]
 name = "arrow-select"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "num",
 ]
 
@@ -394,11 +544,28 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72993b01cb62507b06f1fb49648d7286c8989ecfabdb7b77a750fcb54410731b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "arrow-string"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
  "memchr",
  "num",
  "regex",
@@ -411,7 +578,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b174afa840f089aa85eb50cc4502895612be563d9b251bd8c38102fe68d74bdd"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "arrow_convert_derive",
  "chrono",
  "err-derive",
@@ -2010,10 +2177,10 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014fc8c384ecacedaabb3bc8359c2a6c6e9d8f7bea65be3434eccacfc37f52d9"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-ipc 53.4.0",
+ "arrow-schema 53.4.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -2054,7 +2221,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee60d33e210ef96070377ae667ece7caa0e959c8387496773d4a1a72f1a5012e"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 53.4.0",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
@@ -2070,10 +2237,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b42b7d720fe21ed9cca2ebb635f3f13a12cfab786b41e0fba184fb2e620525b"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-schema 53.4.0",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
@@ -2108,7 +2275,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22cb02af47e756468b3cbfee7a83e3d4f2278d452deb4b033ba933c75169486"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -2127,7 +2294,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62298eadb1d15b525df1315e61a71519ffc563d41d5c3b2a30fda2d70f77b93c"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "chrono",
  "datafusion-common",
  "datafusion-doc",
@@ -2147,7 +2314,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dda7f73c5fc349251cd3dcb05773c5bf55d2505a698ef9d38dfc712161ea2f55"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "datafusion-common",
  "itertools 0.13.0",
 ]
@@ -2158,8 +2325,8 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd197f3b2975424d3a4898ea46651be855a46721a56727515dbd5c9e2fb597da"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 53.4.0",
+ "arrow-buffer 53.4.0",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -2189,8 +2356,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabbe48fba18f9981b134124381bee9e46f93518b8ad2f9721ee296cef5affb9"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-schema",
+ "arrow 53.4.0",
+ "arrow-schema 53.4.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2211,7 +2378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a3fefed9c8c11268d446d924baca8cabf52fe32f73fdaa20854bac6473590c"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
+ "arrow 53.4.0",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -2235,7 +2402,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c35c070eb705c12795dab399c3809f4dfbc290678c624d3989490ca9b8449c1"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2288,7 +2455,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b520413906f755910422b016fb73884ae6e9e1b376de4f9584b6c0e031da75"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -2307,10 +2474,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd6ddc378f6ad19af95ccd6790dec8f8e1264bc4c70e99ddc1830c1a1c78ccd"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-schema 53.4.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -2332,7 +2499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e6c05458eccd74b4c77ed6a1fe63d52434240711de7f6960034794dad1caf5"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
+ "arrow 53.4.0",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -2345,7 +2512,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dc3a82190f49c37d377f31317e07ab5d7588b837adadba8ac367baad5dc2351"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr-common",
@@ -2362,11 +2529,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6608bc9844b4ddb5ed4e687d173e6c88700b1d0482f43894617d18a1fe75da"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-ord 53.4.0",
+ "arrow-schema 53.4.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2393,9 +2560,9 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a884061c79b33d0c8e84a6f4f4be8bdc12c0f53f5af28ddf5d6d95ac0b15fdc"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-schema 53.4.0",
  "bigdecimal",
  "datafusion-common",
  "datafusion-expr",
@@ -6486,7 +6653,7 @@ version = "1.3.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",
- "arrow",
+ "arrow 53.4.0",
  "arrow_convert",
  "axum",
  "base62",
@@ -6519,7 +6686,6 @@ dependencies = [
  "jsonwebtoken",
  "octocrab",
  "open",
- "pin-project",
  "reqwest",
  "restate-admin-rest-model",
  "restate-cli-util",
@@ -7665,6 +7831,8 @@ name = "restatectl"
 version = "1.3.0-dev"
 dependencies = [
  "anyhow",
+ "arrow 54.2.1",
+ "arrow-ipc 54.2.1",
  "bytes",
  "bytesize",
  "bytestring",
@@ -10164,9 +10332,9 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "arrayvec",
- "arrow-array",
- "arrow-cast",
- "arrow-ipc",
+ "arrow-array 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-ipc 53.4.0",
  "aws-credential-types",
  "aws-runtime",
  "aws-sdk-sts",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,7 +62,6 @@ itertools = { workspace = true }
 jsonwebtoken = { version = "9.1.0" }
 octocrab = { version = "0.32.0", features = ["stream"] }
 open = "5.1.2"
-pin-project = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls-tls", "stream", "http2"] }
 ring = { version = "0.17.8" }
 serde = { workspace = true }

--- a/crates/admin/protobuf/cluster_ctrl_svc.proto
+++ b/crates/admin/protobuf/cluster_ctrl_svc.proto
@@ -37,6 +37,8 @@ service ClusterCtrlSvc {
 
   rpc SetClusterConfiguration(SetClusterConfigurationRequest)
       returns (SetClusterConfigurationResponse);
+
+  rpc Query(QueryRequest) returns (stream QueryResponse);
 }
 
 message SetClusterConfigurationResponse {}
@@ -91,11 +93,13 @@ message TrimLogRequest {
 // error with the same inputs.
 message CreatePartitionSnapshotRequest {
   uint32 partition_id = 1;
-  // Minimum LSN (inclusive) which must be covered by the snapshot; if set it is treated as a hard
-  // requirement and the operation will return an error if it cannot be met
+  // Minimum LSN (inclusive) which must be covered by the snapshot; if set it is
+  // treated as a hard requirement and the operation will return an error if it
+  // cannot be met
   optional uint64 min_target_lsn = 2;
-  // Optionally, also trim the log to the archived LSN; trim only occurs after a successful snapshot
-  // and so will honor the min_target_lsn requirement, if set to true
+  // Optionally, also trim the log to the archived LSN; trim only occurs after a
+  // successful snapshot and so will honor the min_target_lsn requirement, if
+  // set to true
   bool trim_log = 3;
 }
 
@@ -152,4 +156,14 @@ message FindTailResponse {
   uint32 segment_index = 2;
   TailState tail_state = 3;
   uint64 tail_lsn = 4;
+}
+
+message QueryRequest {
+  // SQL query
+  string query = 1;
+}
+
+message QueryResponse {
+  // arrow encoded record batch
+  bytes encoded = 1;
 }

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -9,12 +9,17 @@
 // by the Apache License, Version 2.0.
 
 use bytes::{Bytes, BytesMut};
+use datafusion::arrow::ipc::writer::StreamWriter;
+use datafusion::error::DataFusionError;
+use futures::StreamExt;
+use futures::stream::BoxStream;
 use tonic::{Request, Response, Status, async_trait};
 use tracing::info;
 
 use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{Bifrost, Error as BiforstError};
 use restate_core::{Metadata, MetadataWriter};
+use restate_storage_query_datafusion::context::QueryContext;
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::metadata::{Logs, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
@@ -32,10 +37,11 @@ use crate::cluster_controller::protobuf::{
     FindTailResponse, ListLogsRequest, ListLogsResponse, SealAndExtendChainRequest,
     SealAndExtendChainResponse, SealedSegment, TailState, TrimLogRequest,
 };
+use crate::storage_query::WriteRecordBatchStream;
 
 use super::ClusterControllerHandle;
 use super::protobuf::{
-    GetClusterConfigurationRequest, GetClusterConfigurationResponse,
+    GetClusterConfigurationRequest, GetClusterConfigurationResponse, QueryRequest, QueryResponse,
     SetClusterConfigurationRequest, SetClusterConfigurationResponse,
 };
 use super::service::ChainExtension;
@@ -44,6 +50,7 @@ pub(crate) struct ClusterCtrlSvcHandler {
     controller_handle: ClusterControllerHandle,
     bifrost: Bifrost,
     metadata_writer: MetadataWriter,
+    query_context: QueryContext,
 }
 
 impl ClusterCtrlSvcHandler {
@@ -51,11 +58,13 @@ impl ClusterCtrlSvcHandler {
         controller_handle: ClusterControllerHandle,
         bifrost: Bifrost,
         metadata_writer: MetadataWriter,
+        query_context: QueryContext,
     ) -> Self {
         Self {
             controller_handle,
             bifrost,
             metadata_writer,
+            query_context,
         }
     }
 
@@ -351,10 +360,44 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
 
         Ok(Response::new(SetClusterConfigurationResponse {}))
     }
+
+    /// Server streaming response type for the Query method.
+    type QueryStream = BoxStream<'static, Result<QueryResponse, Status>>;
+
+    async fn query(
+        &self,
+        request: Request<QueryRequest>,
+    ) -> std::result::Result<Response<Self::QueryStream>, tonic::Status> {
+        let request = request.into_inner();
+        let stream = self
+            .query_context
+            .execute(&request.query)
+            .await
+            .map_err(datafusion_error_to_status)?;
+
+        Ok(Response::new(
+            WriteRecordBatchStream::<StreamWriter<Vec<u8>>>::new(stream, request.query)
+                .map_err(datafusion_error_to_status)?
+                .map(|item| {
+                    item.map(|encoded| QueryResponse { encoded })
+                        .map_err(datafusion_error_to_status)
+                })
+                .boxed(),
+        ))
+    }
 }
 
 fn serialize_value<T: StorageEncode>(value: T) -> Bytes {
     let mut buf = BytesMut::new();
     StorageCodec::encode(&value, &mut buf).expect("We can always serialize");
     buf.freeze()
+}
+
+fn datafusion_error_to_status(err: DataFusionError) -> Status {
+    match err {
+        DataFusionError::SQL(..)
+        | DataFusionError::Execution(..)
+        | DataFusionError::SchemaError(..) => Status::invalid_argument(err.to_string()),
+        _ => Status::internal(err.to_string()),
+    }
 }

--- a/crates/admin/src/storage_query/mod.rs
+++ b/crates/admin/src/storage_query/mod.rs
@@ -15,6 +15,7 @@ mod query;
 use axum::{Router, routing::post};
 use std::sync::Arc;
 
+pub use query::{RecordBatchWriter, WriteRecordBatchStream};
 use restate_storage_query_datafusion::context::QueryContext;
 
 #[derive(Clone)]

--- a/crates/admin/src/storage_query/query.rs
+++ b/crates/admin/src/storage_query/query.rs
@@ -98,7 +98,7 @@ pub async fn query(
         .expect("content-type header is correct"))
 }
 
-trait RecordBatchWriter
+pub trait RecordBatchWriter
 where
     Self: Sized,
 {
@@ -193,7 +193,7 @@ impl RecordBatchWriter for JsonWriter {
     }
 }
 
-struct WriteRecordBatchStream<W> {
+pub struct WriteRecordBatchStream<W> {
     done: bool,
     record_batch_stream: SendableRecordBatchStream,
     stream_writer: W,
@@ -201,7 +201,7 @@ struct WriteRecordBatchStream<W> {
 }
 
 impl<W: RecordBatchWriter> WriteRecordBatchStream<W> {
-    fn new(
+    pub fn new(
         record_batch_stream: SendableRecordBatchStream,
         query: String,
     ) -> Result<Self, DataFusionError> {

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -109,15 +109,18 @@ impl<T: TransportConnect> AdminRole<T> {
         .with_query_context(query_context);
 
         let controller = if config.admin.is_cluster_controller_enabled() {
-            Some(cluster_controller::Service::new(
-                updateable_config.clone(),
-                health_status,
-                bifrost,
-                networking,
-                router_builder,
-                server_builder,
-                metadata_writer,
-            ))
+            Some(
+                cluster_controller::Service::create(
+                    updateable_config.clone(),
+                    health_status,
+                    bifrost,
+                    networking,
+                    router_builder,
+                    server_builder,
+                    metadata_writer,
+                )
+                .await?,
+            )
         } else {
             None
         };

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -20,6 +20,7 @@ mod invocation_state;
 mod invocation_status;
 mod journal;
 mod keyed_service_status;
+mod log;
 mod node;
 mod partition;
 mod partition_store_scanner;

--- a/crates/storage-query-datafusion/src/log/mod.rs
+++ b/crates/storage-query-datafusion/src/log/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub use table::register_self;

--- a/crates/storage-query-datafusion/src/log/row.rs
+++ b/crates/storage-query-datafusion/src/log/row.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::table_util::format_using;
+
+use super::schema::LogBuilder;
+use restate_types::{
+    Version,
+    logs::{
+        LogId,
+        metadata::{LogletRef, ProviderKind, Segment},
+    },
+    replicated_loglet::ReplicatedLogletParams,
+};
+
+#[inline]
+pub(crate) fn append_segment_row(
+    builder: &mut LogBuilder,
+    output: &mut String,
+    ver: Version,
+    id: LogId,
+    segment: &Segment<'_>,
+    replicated_loglet_params: Option<&LogletRef<ReplicatedLogletParams>>,
+) {
+    let mut row = builder.row();
+
+    row.metadata_ver(ver.into());
+
+    row.log_id(id.into());
+    row.segment_index(segment.config.index().into());
+    row.base_lsn(segment.base_lsn.into());
+    row.kind(format_using(output, &segment.config.kind));
+
+    if segment.config.kind == ProviderKind::Replicated {
+        if let Some(LogletRef { params, .. }) = replicated_loglet_params {
+            row.loglet_id(format_using(output, &params.loglet_id));
+            row.sequencer(format_using(output, &params.sequencer));
+            row.replication(format_using(output, &params.replication));
+            row.nodeset(format_using(output, &params.nodeset));
+        }
+    }
+}

--- a/crates/storage-query-datafusion/src/log/schema.rs
+++ b/crates/storage-query-datafusion/src/log/schema.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(dead_code)]
+
+use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
+
+define_table!(
+    log(
+        /// Log ID
+        log_id: DataType::UInt32,
+
+        /// Segment index
+        segment_index: DataType::UInt32,
+
+        /// Segment start lsn
+        base_lsn: DataType::UInt64,
+
+        /// Segment provider kind
+        kind: DataType::Utf8,
+
+        // replicated loglet specific params
+
+        /// Loglet ID
+        loglet_id: DataType::Utf8,
+
+        /// Sequencer node id
+        sequencer: DataType::Utf8,
+
+        /// Loglet replication factor
+        replication: DataType::Utf8,
+
+        /// Log server id used by the loglet.
+        nodeset: DataType::Utf8,
+
+        /// Current known metadata version
+        metadata_ver: DataType::UInt32,
+    )
+);

--- a/crates/storage-query-datafusion/src/log/table.rs
+++ b/crates/storage-query-datafusion/src/log/table.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use restate_types::Versioned;
+use restate_types::logs::LogletId;
+use tokio::sync::mpsc::Sender;
+
+use restate_core::Metadata;
+use restate_types::logs::metadata::Logs;
+
+use crate::context::QueryContext;
+use crate::table_providers::{GenericTableProvider, Scan};
+use crate::table_util::Builder;
+
+use super::row::append_segment_row;
+use super::schema::LogBuilder;
+
+pub fn register_self(ctx: &QueryContext, metadata: Metadata) -> datafusion::common::Result<()> {
+    let logs_table =
+        GenericTableProvider::new(LogBuilder::schema(), Arc::new(LogScanner(metadata)));
+    ctx.register_non_partitioned_table("logs", Arc::new(logs_table))
+}
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("DeploymentMetadataScanner")]
+struct LogScanner(Metadata);
+
+impl Scan for LogScanner {
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let schema = projection.clone();
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let tx = stream_builder.tx();
+
+        let logs = self.0.logs_snapshot();
+        stream_builder.spawn(async move {
+            for_each_log(schema, tx, logs).await;
+            Ok(())
+        });
+        stream_builder.build()
+    }
+}
+
+async fn for_each_log(
+    schema: SchemaRef,
+    tx: Sender<datafusion::common::Result<RecordBatch>>,
+    logs: Arc<Logs>,
+) {
+    let mut builder = LogBuilder::new(schema.clone());
+    let mut output = String::new();
+    for (id, chain) in logs.iter() {
+        for segment in chain.iter() {
+            let loglet_id = LogletId::new(*id, segment.index());
+            let replicated_loglet = logs.get_replicated_loglet(&loglet_id);
+
+            append_segment_row(
+                &mut builder,
+                &mut output,
+                logs.version(),
+                *id,
+                &segment,
+                replicated_loglet,
+            );
+
+            if builder.full() {
+                let batch = builder.finish();
+                if tx.send(batch).await.is_err() {
+                    // not sure what to do here?
+                    // the other side has hung up on us.
+                    // we probably don't want to panic, is it will cause the entire process to exit
+                    return;
+                }
+                builder = LogBuilder::new(schema.clone());
+            }
+        }
+    }
+
+    if !builder.empty() {
+        let result = builder.finish();
+        let _ = tx.send(result).await;
+    }
+}

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -34,6 +34,8 @@ restate-types = { workspace = true, features = ["clap"] }
 restate-wal-protocol = { workspace = true }
 
 anyhow = { workspace = true }
+arrow = { workspace = true }
+arrow-ipc = { version = "54.2.1" }
 bytes = { workspace = true }
 bytesize = { workspace = true }
 bytestring = { workspace = true }

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -21,6 +21,7 @@ use crate::commands::partition::Partitions;
 use crate::commands::provision::ProvisionOpts;
 use crate::commands::replicated_loglet::ReplicatedLoglet;
 use crate::commands::snapshot::Snapshot;
+use crate::commands::sql::SqlOpts;
 use crate::commands::status::ClusterStatusOpts;
 use crate::connection::ConnectionInfo;
 
@@ -71,6 +72,8 @@ pub enum Command {
     /// [low-level] Commands that operate on replicated loglets
     #[clap(subcommand)]
     ReplicatedLoglet(ReplicatedLoglet),
+    /// Query cluster status
+    Sql(SqlOpts),
 }
 
 fn init(common_opts: &CommonOpts) {

--- a/tools/restatectl/src/commands/mod.rs
+++ b/tools/restatectl/src/commands/mod.rs
@@ -19,4 +19,5 @@ pub mod partition;
 pub mod provision;
 pub mod replicated_loglet;
 pub mod snapshot;
+pub mod sql;
 pub mod status;

--- a/tools/restatectl/src/commands/sql.rs
+++ b/tools/restatectl/src/commands/sql.rs
@@ -1,0 +1,184 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use anyhow::Context as AnyhowContext;
+use arrow::{
+    array::RecordBatch,
+    buffer::Buffer,
+    error::ArrowError,
+    util::display::{ArrayFormatter, FormatOptions},
+};
+use arrow_ipc::reader::StreamDecoder;
+use cling::prelude::*;
+use futures::{Stream, StreamExt, ready};
+use restate_admin::cluster_controller::protobuf::{
+    QueryRequest, QueryResponse, cluster_ctrl_svc_client::ClusterCtrlSvcClient,
+};
+use restate_cli_util::{
+    _comfy_table::{Cell, Table},
+    c_eprintln, c_println,
+    ui::{
+        console::{Styled, StyledTable},
+        stylesheet::Style,
+    },
+};
+use tonic::{Status, Streaming, codec::CompressionEncoding};
+
+use crate::connection::ConnectionInfo;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "query")]
+pub struct SqlOpts {
+    query: String,
+}
+
+async fn query(connection: &ConnectionInfo, args: &SqlOpts) -> anyhow::Result<()> {
+    let channel = connection
+        .connect(&connection.address[0])
+        .await
+        .context("Failed to connect to node")?;
+
+    let start_time = Instant::now();
+    let mut client = ClusterCtrlSvcClient::new(channel)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(CompressionEncoding::Gzip);
+
+    let response = client
+        .query(QueryRequest {
+            query: args.query.clone(),
+        })
+        .await
+        .context("Failed to run query")?
+        .into_inner();
+
+    let mut stream = RecordBatchStream::from(response);
+
+    let mut table = Table::new_styled();
+
+    let format_options = FormatOptions::default().with_display_error(true);
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        if table.header().is_none() {
+            // add headers.
+            let mut headers = vec![];
+            for col in batch.schema().fields() {
+                headers.push(col.name().clone().to_uppercase());
+            }
+            table.set_styled_header(headers);
+        }
+
+        let formatters = batch
+            .columns()
+            .iter()
+            .map(|c| ArrayFormatter::try_new(c.as_ref(), &format_options))
+            .collect::<Result<Vec<_>, ArrowError>>()?;
+
+        for row in 0..batch.num_rows() {
+            let mut cells = Vec::new();
+            for formatter in &formatters {
+                cells.push(Cell::new(formatter.value(row)));
+            }
+            table.add_row(cells);
+        }
+    }
+
+    // Only print if there are actual results.
+    if table.row_count() > 0 {
+        c_println!("{}", table);
+        c_println!();
+    }
+
+    c_eprintln!(
+        "{} rows. Query took {:?}",
+        table.row_count(),
+        Styled(Style::Notice, start_time.elapsed())
+    );
+
+    Ok(())
+}
+
+pub struct RecordBatchStream {
+    inner: Streaming<QueryResponse>,
+    decoder: StreamDecoder,
+    buffer: Option<Buffer>,
+    done: bool,
+}
+
+impl RecordBatchStream {
+    fn new(inner: Streaming<QueryResponse>) -> Self {
+        Self {
+            inner,
+            decoder: StreamDecoder::new(),
+            buffer: None,
+            done: false,
+        }
+    }
+}
+
+impl From<Streaming<QueryResponse>> for RecordBatchStream {
+    fn from(value: Streaming<QueryResponse>) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Stream for RecordBatchStream {
+    type Item = Result<RecordBatch, RecordBatchStreamError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        if self.buffer.as_ref().is_none_or(|b| b.is_empty()) {
+            let item = ready!(self.inner.poll_next_unpin(cx));
+            match item {
+                None => {
+                    self.done = true;
+                    return Poll::Ready(None);
+                }
+                Some(Err(err)) => {
+                    self.done = true;
+                    return Poll::Ready(Some(Err(err.into())));
+                }
+                Some(Ok(batch)) => {
+                    self.buffer = Some(Buffer::from(batch.encoded));
+                }
+            }
+        }
+
+        let mut buffer = self.buffer.take().unwrap();
+        match self.decoder.decode(&mut buffer) {
+            Err(err) => {
+                self.done = true;
+                Poll::Ready(Some(Err(err.into())))
+            }
+            Ok(batch) => {
+                if !buffer.is_empty() {
+                    self.buffer = Some(buffer);
+                }
+                Poll::Ready(Ok(batch).transpose())
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordBatchStreamError {
+    #[error(transparent)]
+    Remote(#[from] Status),
+    #[error(transparent)]
+    Arrow(#[from] ArrowError),
+}


### PR DESCRIPTION
Cluster controller `query` gRPC handler

Summary:
- Add a `query` grpc handler for cluster controller service to query
cluster state with datafusion sql.
- Expose the functionality via the `restatectl sql` command

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2938).
* #2945
* #2944
* __->__ #2938
* #2925