### PR TITLE
[Core] Connection throttling and coalescing

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -148,7 +148,7 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
                                             .await,
                                     )
                                 }
-                                Err(network_error) => (node_id, Err(network_error)),
+                                Err(network_error) => (node_id, Err(network_error.into())),
                             }
                         }
                         .in_current_tc_as_task(TaskKind::InPlace, "get-nodes-state"),

--- a/crates/bifrost/src/loglet/error.rs
+++ b/crates/bifrost/src/loglet/error.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use restate_core::{ShutdownError, network::NetworkError};
+use restate_core::ShutdownError;
 use restate_types::errors::{IntoMaybeRetryable, MaybeRetryableError};
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -68,16 +68,6 @@ impl From<OperationError> for AppendError {
         match value {
             OperationError::Shutdown(s) => AppendError::Shutdown(s),
             OperationError::Other(o) => AppendError::Other(o),
-        }
-    }
-}
-
-impl From<NetworkError> for OperationError {
-    fn from(value: NetworkError) -> Self {
-        match value {
-            NetworkError::Shutdown(err) => OperationError::Shutdown(err),
-            // todo(azmy): are all network errors retryable?
-            _ => OperationError::retryable(value),
         }
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
@@ -176,9 +176,9 @@ impl<Attr: Eq + Hash + Clone + std::fmt::Debug> NodeSetChecker<Attr> {
                     // (nodeset is newer).
                     checker.add_node(*node_id, StorageState::Provisioning, &NodeLocation::new());
                 }
-                Err(
-                    NodesConfigError::InvalidUri(_) | NodesConfigError::GenerationMismatch { .. },
-                ) => unreachable!("impossible nodes-configuration errors"),
+                Err(NodesConfigError::GenerationMismatch { .. }) => {
+                    unreachable!("impossible nodes-configuration errors")
+                }
             }
         }
 

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -47,6 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(::derive_more::IsVariant, ::derive_more::From)]",
         )
         .enum_attribute("Body", "#[derive(::derive_more::From)]")
+        .enum_attribute("ConnectionDirection", "#[derive(::derive_more::Display)]")
         .file_descriptor_set_path(out_dir.join("core_node_svc_descriptor.bin"))
         // allow older protobuf compiler to be used
         .protoc_arg("--experimental_allow_proto3_optional")

--- a/crates/core/src/network/connection/throttle.rs
+++ b/crates/core/src/network/connection/throttle.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::hash_map;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use ahash::HashMap;
+use parking_lot::RwLock;
+use restate_types::retries::{RetryIter, RetryPolicy};
+use tokio::time::Instant;
+use tracing::trace;
+
+use crate::network::{ConnectError, Destination};
+
+#[cfg(any(test, feature = "test-util"))]
+const MAX_DELAY: Duration = Duration::from_secs(1);
+#[cfg(not(any(test, feature = "test-util")))]
+const MAX_DELAY: Duration = Duration::from_secs(5);
+
+const INITIAL_DELAY: Duration = Duration::from_millis(250);
+
+static THROTTLE: LazyLock<ConnectThrottle> = LazyLock::new(ConnectThrottle::new);
+
+struct State {
+    down_until: Instant,
+    retry_iter: RetryIter<'static>,
+}
+
+pub struct ConnectThrottle {
+    destination_state: RwLock<HashMap<Destination, State>>,
+}
+
+impl ConnectThrottle {
+    fn new() -> Self {
+        Self {
+            destination_state: RwLock::new(HashMap::default()),
+        }
+    }
+
+    /// Checks if a connection to the given destination is allowed.
+    pub fn may_connect(dest: &Destination) -> Result<(), ConnectError> {
+        let failures = THROTTLE.destination_state.read();
+        if let Some(state) = failures.get(dest) {
+            let now = Instant::now();
+            let remaining = state.down_until.saturating_duration_since(now);
+            if !remaining.is_zero() {
+                // Immediately reject if we're still within the throttle window
+                return Err(ConnectError::Throttled(remaining));
+            }
+        }
+        Ok(())
+    }
+
+    /// If the connection fails, record the time so we reject attempts for a while, and
+    /// it resets the deadline to zero if connection was successful.
+    pub fn note_connect_status(dest: &Destination, success: bool) {
+        let mut last_failures = THROTTLE.destination_state.write();
+        if success {
+            if last_failures.remove(dest).is_some() {
+                trace!(
+                    "Connection succeeded to {}; resetting throttling window",
+                    dest,
+                );
+            }
+            return;
+        }
+
+        let now = Instant::now();
+        match last_failures.entry(dest.clone()) {
+            hash_map::Entry::Occupied(entry) => {
+                let state = entry.into_mut();
+                state.down_until = now + state.retry_iter.next().unwrap_or(MAX_DELAY);
+                trace!(
+                    "Connection failed to {}; re-setting throttling window to {:?}",
+                    dest,
+                    state.retry_iter.last_retry().unwrap(),
+                );
+            }
+            hash_map::Entry::Vacant(entry) => {
+                let mut retry_iter =
+                    RetryPolicy::exponential(INITIAL_DELAY, 2.0, None, Some(MAX_DELAY)).into_iter();
+                let down_until = now + retry_iter.next().unwrap_or(MAX_DELAY);
+                let state = entry.insert(State {
+                    down_until,
+                    retry_iter,
+                });
+                trace!(
+                    "connection failed to {}; setting throttling window to {:?}, next attempt in {:?}",
+                    dest,
+                    state.retry_iter.last_retry().unwrap_or(MAX_DELAY),
+                    state.down_until.saturating_duration_since(now),
+                );
+            }
+        }
+    }
+}

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -11,32 +11,32 @@
 use std::sync::Arc;
 
 use ahash::HashMap;
-use futures::{Stream, StreamExt};
+use futures::future::{BoxFuture, Shared};
+use futures::{FutureExt, Stream};
 use parking_lot::Mutex;
-use tracing::{Span, debug, info, instrument, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 
 use restate_types::config::Configuration;
 use restate_types::net::metadata::MetadataKind;
-use restate_types::nodes_config::NodesConfiguration;
+use restate_types::nodes_config::{NodesConfigError, NodesConfiguration};
 use restate_types::{GenerationalNodeId, Merge, NodeId, PlainNodeId};
 
-use super::MessageRouter;
 use super::connection::Connection;
-use super::error::{NetworkError, ProtocolError};
-use super::handshake::wait_for_welcome;
 use super::io::{
     ConnectionReactor, DropEgressStream, EgressMessage, EgressStream, UnboundedEgressSender,
 };
-use super::metric_definitions::{
-    self, CONNECTION_DROPPED, INCOMING_CONNECTION, OUTGOING_CONNECTION,
-};
+use super::metric_definitions::{self, CONNECTION_DROPPED, INCOMING_CONNECTION};
 use super::protobuf::network::ConnectionDirection;
-use super::protobuf::network::{Header, Hello, Message, Welcome};
+use super::protobuf::network::{Header, Message, Welcome};
 use super::tracking::{ConnectionTracking, PeerRouting};
-use super::transport_connector::TransportConnect;
+use super::transport_connector::{TransportConnect, find_node};
+use super::{
+    AcceptError, ConnectError, Destination, DiscoveryError, HandshakeError, MessageRouter,
+};
 use crate::metadata::Urgency;
+use crate::network::connection::ConnectThrottle;
 use crate::network::handshake::{negotiate_protocol_version, wait_for_hello};
-use crate::{Metadata, ShutdownError, my_node_id};
+use crate::{Metadata, ShutdownError, TaskId, TaskKind, my_node_id};
 
 #[derive(Copy, Clone, PartialOrd, PartialEq, Default)]
 struct GenStatus {
@@ -112,9 +112,14 @@ impl Default for ConnectionManagerInner {
     }
 }
 
+/// A future of an in-flight connection attempt.
+type SharedConnectionAttempt =
+    Shared<BoxFuture<'static, Result<(Connection, TaskId), ConnectError>>>;
+
 #[derive(Clone, Default)]
 pub struct ConnectionManager {
     inner: Arc<Mutex<ConnectionManagerInner>>,
+    in_flight_connects: Arc<Mutex<HashMap<Destination, SharedConnectionAttempt>>>,
 }
 
 impl ConnectionManager {
@@ -129,9 +134,9 @@ impl ConnectionManager {
     pub async fn accept_incoming_connection<S>(
         &self,
         mut incoming: S,
-    ) -> Result<EgressStream, NetworkError>
+    ) -> Result<EgressStream, AcceptError>
     where
-        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
+        S: Stream<Item = Message> + Unpin + Send + 'static,
     {
         let metadata = Metadata::current();
         // Perform the handshake inline before creating the reactor. This allows
@@ -167,18 +172,18 @@ impl ConnectionManager {
         // NodeId **must** be generational at this layer, we may support accepting connections from
         // anonymous nodes in the future. When this happens, this restate-server release will not
         // be compatible with it.
-        let peer_node_id = hello.my_node_id.ok_or(ProtocolError::HandshakeFailed(
-            "GenerationalNodeId is not set in the Hello message",
+        let peer_node_id = hello.my_node_id.ok_or(HandshakeError::Failed(
+            "GenerationalNodeId is not set in the Hello message".to_owned(),
         ))?;
 
         // we don't allow node-id 0 in this version.
         if peer_node_id.id == 0 {
-            return Err(ProtocolError::HandshakeFailed("Peer cannot have node Id of 0").into());
+            return Err(HandshakeError::Failed("Peer cannot have node Id of 0".to_owned()).into());
         }
 
         if peer_node_id.generation == 0 {
             return Err(
-                ProtocolError::HandshakeFailed("NodeId has invalid generation number").into(),
+                HandshakeError::Failed("NodeId has invalid generation number".to_owned()).into(),
             );
         }
 
@@ -188,15 +193,16 @@ impl ConnectionManager {
         // Sanity check. Nodes must not connect to themselves from other generations.
         if my_node_id.is_same_but_different(&peer_node_id) {
             // My node ID but different generations!
-            return Err(ProtocolError::HandshakeFailed(
-                "cannot accept a connection to the same NodeID from a different generation",
+            return Err(HandshakeError::Failed(
+                "cannot accept a connection to the same NodeID from a different generation"
+                    .to_owned(),
             )
             .into());
         }
 
         // Are we both from the same cluster?
         if hello.cluster_name != nodes_config.cluster_name() {
-            return Err(ProtocolError::HandshakeFailed("cluster name mismatch").into());
+            return Err(HandshakeError::Failed("cluster name mismatch".to_owned()).into());
         }
 
         let selected_protocol_version = negotiate_protocol_version(&hello)?;
@@ -224,7 +230,7 @@ impl ConnectionManager {
                 welcome.into(),
                 None,
             ))
-            .map_err(|_| ProtocolError::PeerDropped)?;
+            .map_err(|_| HandshakeError::PeerDropped)?;
         let connection = Connection::new(peer_node_id, selected_protocol_version, sender);
 
         let should_register = matches!(
@@ -235,13 +241,21 @@ impl ConnectionManager {
         );
 
         // Register the connection.
-        let _ = self.start_connection_reactor(
+        let task_id = self.start_connection_reactor(
+            TaskKind::ConnectionReactor,
             connection,
             unbounded_sender,
             incoming,
             drop_egress,
             should_register,
         )?;
+
+        info!(
+            direction_at_peer = %hello.direction(),
+            task_id = %task_id,
+            peer = %peer_node_id,
+            "Incoming connection accepted from node {}", peer_node_id
+        );
 
         INCOMING_CONNECTION.increment(1);
 
@@ -253,15 +267,29 @@ impl ConnectionManager {
     /// multiple connections already exist, it returns a random one.
     pub async fn get_or_connect<C>(
         &self,
-        node_id: GenerationalNodeId,
+        node_id: impl Into<NodeId>,
         transport_connector: &C,
-    ) -> Result<Connection, NetworkError>
+    ) -> Result<Connection, ConnectError>
     where
         C: TransportConnect,
     {
+        let my_node_id_opt = Metadata::with_current(|m| m.my_node_id_opt());
+        let node_id = node_id.into();
+        // find latest generation if this is not generational node id
+        let node_id = match node_id.as_generational() {
+            Some(id) => id,
+            None => {
+                find_node(
+                    &Metadata::with_current(|metadata| metadata.nodes_config_ref()),
+                    node_id,
+                )?
+                .current_generation
+            }
+        };
+
         // fail fast if we are connecting to our previous self
-        if my_node_id().is_same_but_different(&node_id) {
-            return Err(NetworkError::NodeIsGone(node_id));
+        if my_node_id_opt.is_some_and(|m| m.is_same_but_different(&node_id)) {
+            return Err(DiscoveryError::NodeIsGone(node_id.into()).into());
         }
 
         // find a connection by node_id
@@ -274,96 +302,10 @@ impl ConnectionManager {
             return Ok(connection);
         }
 
-        if self
-            .inner
-            .lock()
-            .observed_generations
-            .get(&node_id.as_plain())
-            .map(|status| {
-                node_id.generation() < status.generation
-                    || (node_id.generation() == status.generation && status.gone)
-            })
-            .unwrap_or(false)
-        {
-            return Err(NetworkError::NodeIsGone(node_id));
-        }
-
-        // We have no connection. We attempt to create a new connection.
-        self.connect(node_id, transport_connector).await
-    }
-
-    async fn connect<C>(
-        &self,
-        node_id: GenerationalNodeId,
-        transport_connector: &C,
-    ) -> Result<Connection, NetworkError>
-    where
-        C: TransportConnect,
-    {
-        let metadata = Metadata::current();
-        let my_node_id = metadata.my_node_id_opt();
-        if my_node_id.is_some_and(|my_node| my_node == node_id) {
+        if my_node_id_opt.is_some_and(|my_node| my_node == node_id) {
             return self.connect_loopback();
         }
 
-        let nodes_config = metadata.nodes_config_snapshot();
-        let cluster_name = nodes_config.cluster_name().to_owned();
-
-        let (tx, unbounded_sender, egress, drop_egress) = EgressStream::create(
-            Configuration::pinned()
-                .networking
-                .outbound_queue_length
-                .get(),
-        );
-
-        let our_direction = ConnectionDirection::Bidirectional;
-        // perform handshake.
-        unbounded_sender.unbounded_send(EgressMessage::Message(
-            Header::default(),
-            Hello::new(my_node_id, cluster_name, our_direction).into(),
-            Some(Span::current()),
-        ))?;
-
-        // Establish the connection
-        let mut incoming = transport_connector
-            .connect(node_id, &nodes_config, egress)
-            .await?;
-
-        // finish the handshake
-        let (_header, welcome) = wait_for_welcome(
-            &mut incoming,
-            Configuration::pinned().networking.handshake_timeout.into(),
-        )
-        .await?;
-
-        let protocol_version = welcome.protocol_version();
-
-        // this should not happen if the peer follows the correct protocol negotiation
-        if !protocol_version.is_supported() {
-            return Err(ProtocolError::UnsupportedVersion(protocol_version.into()).into());
-        }
-
-        // sanity checks
-        // In this version, we don't allow anonymous connections.
-        let peer_node_id: GenerationalNodeId = welcome
-            .my_node_id
-            .ok_or(ProtocolError::HandshakeFailed(
-                "Peer must set my_node_id in Welcome message",
-            ))?
-            .into();
-
-        // we expect the node to identify itself as the same NodeId
-        // we think we are connecting to
-        if peer_node_id != node_id {
-            // Node claims that it's someone else!
-            return Err(ProtocolError::HandshakeFailed(
-                "Node returned an unexpected GenerationalNodeId in Welcome message.",
-            )
-            .into());
-        }
-
-        let connection = Connection::new(peer_node_id, protocol_version, tx);
-
         if self
             .inner
             .lock()
@@ -375,31 +317,78 @@ impl ConnectionManager {
             })
             .unwrap_or(false)
         {
-            return Err(NetworkError::NodeIsGone(node_id));
+            return Err(DiscoveryError::NodeIsGone(node_id.into()).into());
         }
 
-        // if peer cannot respect our hello intent of direction, we are okay with registering
-        let should_register = matches!(
-            welcome.direction_ack(),
-            ConnectionDirection::Unknown
-                | ConnectionDirection::Bidirectional
-                | ConnectionDirection::Forward
-        );
-        let res = self.start_connection_reactor(
-            connection,
-            unbounded_sender,
-            incoming,
-            drop_egress,
-            should_register,
-        )?;
+        // We have no connection. We attempt to create a new connection or latch onto an
+        // existing attempt.
+        self.create_forward_shared_connection(Destination::Node(node_id), transport_connector)
+            .await
+    }
 
-        OUTGOING_CONNECTION.increment(1);
-        Ok(res)
+    async fn create_forward_shared_connection<C>(
+        &self,
+        dest: Destination,
+        transport_connector: &C,
+    ) -> Result<Connection, ConnectError>
+    where
+        C: TransportConnect,
+    {
+        // 1) Check if there's already a future in flight for this address
+        let maybe_connect = {
+            let mut in_flight = self.in_flight_connects.lock();
+
+            // If yes, clone that shared future so multiple callers coalesce
+            if let Some(existing) = in_flight.get(&dest) {
+                existing.clone()
+            } else {
+                // 2) Not in flight. Check the throttle window for recent failures
+                ConnectThrottle::may_connect(&dest)?;
+
+                // 3) If we pass the throttle check, create a brand-new future
+                let fut = {
+                    let dest = dest.clone();
+                    let transport_connector = transport_connector.clone();
+                    let router = self.inner.lock().router.clone();
+                    let conn_tracker = self.clone();
+                    let peer_router = self.clone();
+                    async move {
+                        // Actually attempt/force to connect. We checked throttling before creating this
+                        // future.
+                        Connection::force_connect(
+                            dest,
+                            transport_connector,
+                            ConnectionDirection::Forward,
+                            TaskKind::ConnectionReactor,
+                            router,
+                            conn_tracker,
+                            peer_router,
+                        )
+                        .await
+                    }
+                    .boxed()
+                    .shared()
+                };
+
+                // Put it in the map so other concurrent callers share the same future
+                in_flight.insert(dest.clone(), fut.clone());
+                fut
+            }
+        };
+
+        // 4) Await the shared future (outside the lock)
+        let maybe_connection = maybe_connect.await;
+
+        // 5) Remove the completed future so subsequent calls can attempt a fresh connect
+        let mut in_flight = self.in_flight_connects.lock();
+        in_flight.remove(&dest);
+
+        Ok(maybe_connection?.0)
     }
 
     #[instrument(skip_all)]
-    fn connect_loopback(&self) -> Result<Connection, NetworkError> {
-        trace!("Creating an express path connection to self");
+    fn connect_loopback(&self) -> Result<Connection, ConnectError> {
+        debug!("Creating an express path connection to self");
         let (tx, unbounded_sender, egress, drop_egress) = EgressStream::create(
             Configuration::pinned()
                 .networking
@@ -412,14 +401,17 @@ impl ConnectionManager {
             tx,
         );
 
-        Ok(self.start_connection_reactor(
-            connection,
+        self.start_connection_reactor(
+            TaskKind::LocalReactor,
+            connection.clone(),
             unbounded_sender,
-            egress.map(Ok),
+            egress,
             drop_egress,
             // loopback is always registered
             true,
-        )?)
+        )?;
+
+        Ok(connection)
     }
 
     fn verify_node_id(
@@ -428,7 +420,7 @@ impl ConnectionManager {
         header: &Header,
         nodes_config: &NodesConfiguration,
         metadata: &Metadata,
-    ) -> Result<(), NetworkError> {
+    ) -> Result<(), NodesConfigError> {
         if let Err(e) = nodes_config.find_node_by_id(peer_node_id) {
             // If nodeId is unrecognized and peer is at higher nodes configuration version,
             // then we have to update our NodesConfiguration
@@ -460,7 +452,7 @@ impl ConnectionManager {
                 );
             }
 
-            return Err(NetworkError::UnknownNode(e));
+            return Err(e);
         }
 
         Ok(())
@@ -469,7 +461,7 @@ impl ConnectionManager {
     fn update_generation_or_preempt(
         &self,
         peer_node_id: GenerationalNodeId,
-    ) -> Result<(), NetworkError> {
+    ) -> Result<(), AcceptError> {
         // Lock is held, don't perform expensive or async operations here.
         let mut guard = self.inner.lock();
         let known_status = guard
@@ -481,7 +473,7 @@ impl ConnectionManager {
         if known_status.generation > peer_node_id.generation() {
             // This peer is _older_ than the one we have seen in the past, we cannot accept
             // this connection. We terminate the stream immediately.
-            return Err(NetworkError::OldPeerGeneration(format!(
+            return Err(AcceptError::OldPeerGeneration(format!(
                 "newer generation '{}' has been observed",
                 NodeId::new_generational(peer_node_id.id(), known_status.generation)
             )));
@@ -489,7 +481,7 @@ impl ConnectionManager {
 
         if known_status.generation == peer_node_id.generation() && known_status.gone {
             // This peer was observed to have shutdown before. We cannot accept new connections from this peer.
-            return Err(NetworkError::NodeIsGone(peer_node_id));
+            return Err(AcceptError::PreviouslyShutdown);
         }
 
         // todo: if we have connections with an older generation, we request to drop it.
@@ -512,28 +504,22 @@ impl ConnectionManager {
 
     fn start_connection_reactor<S>(
         &self,
+        task_kind: TaskKind,
         connection: Connection,
         unbounded_sender: UnboundedEgressSender,
         incoming: S,
         drop_egress: DropEgressStream,
         should_register: bool,
-    ) -> Result<Connection, ShutdownError>
+    ) -> Result<TaskId, ShutdownError>
     where
-        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
+        S: Stream<Item = Message> + Unpin + Send + 'static,
     {
-        let peer_node_id = connection.peer;
         let router = self.inner.lock().router.clone();
 
-        let reactor = ConnectionReactor::new(connection.clone(), unbounded_sender, drop_egress);
+        let reactor = ConnectionReactor::new(connection, unbounded_sender, drop_egress);
 
-        if peer_node_id != my_node_id() {
-            debug!(
-                peer = %peer_node_id,
-                "Incoming connection accepted from node {}", peer_node_id
-            );
-        }
-
-        let _ = reactor.start(
+        let task_id = reactor.start(
+            task_kind,
             router,
             self.clone(),
             self.clone(),
@@ -541,7 +527,7 @@ impl ConnectionManager {
             should_register,
         )?;
 
-        Ok(connection)
+        Ok(task_id)
     }
 }
 
@@ -554,27 +540,31 @@ impl PeerRouting for ConnectionManager {
             .entry(connection.peer)
             .or_default()
             .push(connection.clone());
-        debug!("connection to {} was registered", peer);
+        trace!("connection to {} was registered", peer);
     }
 
     fn deregister(&self, connection: &Connection) {
         let mut guard = self.inner.lock();
-        if let Some(connections) = guard.connection_by_gen_id.get_mut(&connection.peer) {
-            connections.retain(|c| c != connection);
+        let peer = connection.peer;
+        trace!("connection reactor was deregistered {}", peer);
+        if let Some(connections) = guard.connection_by_gen_id.get_mut(&peer) {
+            let len_before = connections.len();
+            connections.retain(|c| c != connection && !c.is_closed());
+            if len_before > 0 && connections.is_empty() {
+                info!(%peer, "All registered connections to this node were terminated");
+            }
         }
-        trace!("connection reactor was deregistered {}", connection.peer);
     }
 }
 
 impl ConnectionTracking for ConnectionManager {
     fn connection_created(&self, conn: &Connection) {
-        info!("Connection reactor started: {}", conn.peer);
+        trace!("Connection reactor started: {}", conn.peer);
     }
 
     fn connection_dropped(&self, conn: &Connection) {
-        debug!(
-            peer = %conn.peer,
-            "Connection terminated, total connection age is {:?}",
+        info!(
+            "Connection terminated, connection lived for {:?}",
             conn.created.elapsed()
         );
         CONNECTION_DROPPED.increment(1);
@@ -582,6 +572,15 @@ impl ConnectionTracking for ConnectionManager {
 
     fn notify_peer_shutdown(&self, node_id: GenerationalNodeId) {
         let mut guard = self.inner.lock();
+        // current status
+        let is_already_gone = guard
+            .observed_generations
+            .get(&node_id.as_plain())
+            .map(|status| {
+                node_id.generation() < status.generation
+                    || (node_id.generation() == status.generation && status.gone)
+            })
+            .unwrap_or(false);
         let mut new_status = GenStatus::new(node_id.generation());
         new_status.gone = true;
         guard
@@ -591,7 +590,9 @@ impl ConnectionTracking for ConnectionManager {
                 status.merge(new_status);
             })
             .or_insert(new_status);
-        info!("Node {} notified us that it is shutting down", node_id);
+        if !is_already_gone {
+            info!(peer = %node_id, "Peer shutdown notification received");
+        }
     }
 }
 
@@ -621,6 +622,7 @@ mod tests {
         LogServerConfig, MetadataServerConfig, NodeConfig, NodesConfigError, NodesConfiguration,
         Role,
     };
+    use tokio_stream::StreamExt;
 
     use crate::network::MockPeerConnection;
     use crate::network::protobuf::network::message::Body;
@@ -660,9 +662,7 @@ mod tests {
         assert!(resp.is_err());
         assert!(matches!(
             resp,
-            Err(NetworkError::ProtocolError(
-                ProtocolError::HandshakeTimeout(_)
-            ))
+            Err(AcceptError::Handshake(HandshakeError::Timeout(_)))
         ));
         assert!(&start.elapsed() >= net_opts.handshake_timeout.as_ref());
         Ok(())
@@ -694,9 +694,7 @@ mod tests {
             ),
             hello,
         );
-        tx.send(Ok(hello))
-            .await
-            .expect("Channel accept hello message");
+        tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
         let incoming = ReceiverStream::new(rx);
@@ -704,8 +702,8 @@ mod tests {
         assert!(resp.is_err());
         assert!(matches!(
             resp,
-            Err(NetworkError::ProtocolError(
-                ProtocolError::UnsupportedVersion(proto_version)
+            Err(AcceptError::Handshake(
+                HandshakeError::UnsupportedVersion(proto_version)
             )) if proto_version == ProtocolVersion::Unknown as i32
         ));
 
@@ -730,7 +728,7 @@ mod tests {
             ),
             hello,
         );
-        tx.send(Ok(hello)).await?;
+        tx.send(hello).await?;
 
         let connections = ConnectionManager::default();
         let incoming = ReceiverStream::new(rx);
@@ -739,10 +737,12 @@ mod tests {
             .await
             .err()
             .unwrap();
-        assert!(matches!(
+        assert_that!(
             err,
-            NetworkError::ProtocolError(ProtocolError::HandshakeFailed("cluster name mismatch"))
-        ));
+            pat!(AcceptError::Handshake(pat!(HandshakeError::Failed(eq(
+                "cluster name mismatch"
+            )))))
+        );
         Ok(())
     }
 
@@ -772,9 +772,7 @@ mod tests {
             ),
             hello,
         );
-        tx.send(Ok(hello))
-            .await
-            .expect("Channel accept hello message");
+        tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
 
@@ -785,12 +783,12 @@ mod tests {
             .err()
             .unwrap();
 
-        assert!(matches!(
+        assert_that!(
             err,
-            NetworkError::ProtocolError(ProtocolError::HandshakeFailed(
+            pat!(AcceptError::Handshake(pat!(HandshakeError::Failed(eq(
                 "cannot accept a connection to the same NodeID from a different generation",
-            ))
-        ));
+            )))))
+        );
 
         // Unrecognized node Id
         let (tx, rx) = mpsc::channel(1);
@@ -812,9 +810,7 @@ mod tests {
             ),
             hello,
         );
-        tx.send(Ok(hello))
-            .await
-            .expect("Channel accept hello message");
+        tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
 
@@ -824,10 +820,12 @@ mod tests {
             .await
             .err()
             .unwrap();
-        assert!(matches!(
+        assert_that!(
             err,
-            NetworkError::UnknownNode(NodesConfigError::UnknownNodeId(_))
-        ));
+            pat!(AcceptError::NodesConfig(pat!(
+                NodesConfigError::UnknownNodeId(_)
+            )))
+        );
         Ok(())
     }
 

--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -12,11 +12,11 @@ use std::time::Duration;
 
 use tonic::Code;
 
-use restate_types::GenerationalNodeId;
+use restate_types::NodeId;
 use restate_types::net::MIN_SUPPORTED_PROTOCOL_VERSION;
 use restate_types::nodes_config::NodesConfigError;
 
-use crate::{ShutdownError, SyncError};
+use crate::ShutdownError;
 
 #[derive(Debug, thiserror::Error)]
 #[error("connection closed")]
@@ -46,53 +46,84 @@ impl<M> NetworkSendError<M> {
 
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkError {
-    #[error("unknown node: {0}")]
-    UnknownNode(#[from] NodesConfigError),
     #[error("operation aborted, node is shutting down")]
     Shutdown(#[from] ShutdownError),
     #[error("exceeded deadline after spending {0:?}")]
     Timeout(Duration),
-    #[error("protocol error: {0}")]
-    ProtocolError(#[from] ProtocolError),
-    #[error("cannot connect: {} {}", tonic::Status::code(.0), tonic::Status::message(.0))]
-    ConnectError(tonic::Status),
-    #[error("new node generation exists: {0}")]
-    OldPeerGeneration(String),
-    #[error("node {0} was shut down")]
-    NodeIsGone(GenerationalNodeId),
+    #[error(transparent)]
+    Discovery(#[from] DiscoveryError),
     #[error(transparent)]
     ConnectionClosed(#[from] ConnectionClosed),
     #[error("cannot send messages to this node: {0}")]
-    Unavailable(String),
-    #[error("failed syncing metadata: {0}")]
-    Metadata(#[from] SyncError),
+    ConnectionFailed(String),
     #[error("remote metadata version mismatch: {0}")]
     // todo(azmy): A temporary error that should be removed
     // after relaxing the restrictions on node ids in upcoming change
     RemoteVersionMismatch(String),
-    #[error("network channel is full and sending would block")]
-    Full,
 }
 
-impl From<tonic::Status> for NetworkError {
-    fn from(value: tonic::Status) -> Self {
-        if value.code() == Code::FailedPrecondition {
-            Self::RemoteVersionMismatch(value.message().into())
-        } else {
-            Self::ConnectError(value)
+impl From<ConnectError> for NetworkError {
+    fn from(value: ConnectError) -> Self {
+        match value {
+            ConnectError::RemoteMetadataVersionMismatch(e) => {
+                NetworkError::RemoteVersionMismatch(e)
+            }
+            ConnectError::Handshake(_) => NetworkError::ConnectionFailed(value.to_string()),
+            ConnectError::Throttled(_) => NetworkError::ConnectionFailed(value.to_string()),
+            ConnectError::Transport(e) => NetworkError::ConnectionFailed(e),
+            ConnectError::Discovery(e) => NetworkError::Discovery(e),
+            ConnectError::Shutdown(e) => NetworkError::Shutdown(e),
         }
     }
 }
-#[derive(Debug, thiserror::Error)]
-pub enum ProtocolError {
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum DiscoveryError {
+    #[error("node {0} was shut down or removed")]
+    NodeIsGone(NodeId),
+    #[error("node {0} was not found in config")]
+    UnknownNodeId(NodeId),
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum ConnectError {
+    #[error("remote metadata version mismatch: {0}")]
+    // todo(azmy): A temporary error that should be removed
+    // after relaxing the restrictions on node ids in upcoming change
+    RemoteMetadataVersionMismatch(String),
+    #[error(transparent)]
+    Handshake(#[from] HandshakeError),
+    #[error("connect throttled; {0:?} left in throttling window")]
+    Throttled(Duration),
+    #[error("transport error: {0}")]
+    Transport(String),
+    #[error(transparent)]
+    Discovery(#[from] DiscoveryError),
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
+}
+
+impl From<tonic::Status> for ConnectError {
+    fn from(value: tonic::Status) -> Self {
+        match value.code() {
+            Code::Ok => unreachable!(),
+            Code::DeadlineExceeded => {
+                Self::Handshake(HandshakeError::Timeout(value.message().to_owned()))
+            }
+            Code::FailedPrecondition => Self::RemoteMetadataVersionMismatch(value.message().into()),
+            _ => Self::Handshake(HandshakeError::Failed(value.message().to_owned())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum HandshakeError {
     #[error("handshake failed: {0}")]
-    HandshakeFailed(&'static str),
+    Failed(String),
     #[error("handshake timeout: {0}")]
-    HandshakeTimeout(&'static str),
-    #[error("peer dropped connection")]
+    Timeout(String),
+    #[error("peer dropped connection during handshake")]
     PeerDropped,
-    #[error("grpc error: {0}")]
-    GrpcError(#[from] tonic::Status),
     #[error(
         "peer has unsupported protocol version {0}, minimum supported is '{p}'",
         p = MIN_SUPPORTED_PROTOCOL_VERSION as i32
@@ -100,33 +131,44 @@ pub enum ProtocolError {
     UnsupportedVersion(i32),
 }
 
-impl From<ProtocolError> for tonic::Status {
-    fn from(value: ProtocolError) -> Self {
+impl From<HandshakeError> for tonic::Status {
+    fn from(value: HandshakeError) -> Self {
         match value {
-            ProtocolError::HandshakeFailed(e) => tonic::Status::invalid_argument(e),
-            ProtocolError::HandshakeTimeout(e) => tonic::Status::deadline_exceeded(e),
-            ProtocolError::PeerDropped => tonic::Status::cancelled("peer dropped"),
-            ProtocolError::UnsupportedVersion(_) => {
+            HandshakeError::Failed(e) => tonic::Status::invalid_argument(e),
+            HandshakeError::Timeout(e) => tonic::Status::deadline_exceeded(e),
+            HandshakeError::PeerDropped => tonic::Status::cancelled("peer dropped"),
+            HandshakeError::UnsupportedVersion(_) => {
                 tonic::Status::invalid_argument(value.to_string())
             }
-            ProtocolError::GrpcError(s) => s,
         }
     }
 }
 
-impl From<NetworkError> for tonic::Status {
-    fn from(value: NetworkError) -> Self {
+#[derive(Debug, thiserror::Error)]
+pub enum AcceptError {
+    #[error(transparent)]
+    Handshake(#[from] HandshakeError),
+    #[error(transparent)]
+    NodesConfig(#[from] NodesConfigError),
+    #[error("new node generation exists: {0}")]
+    OldPeerGeneration(String),
+    #[error("node was previously observed as shutting down")]
+    PreviouslyShutdown,
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
+}
+
+impl From<AcceptError> for tonic::Status {
+    fn from(value: AcceptError) -> Self {
         match value {
-            NetworkError::Shutdown(_) => tonic::Status::unavailable(value.to_string()),
-            NetworkError::ProtocolError(e) => e.into(),
-            NetworkError::Timeout(_) => tonic::Status::deadline_exceeded(value.to_string()),
-            NetworkError::OldPeerGeneration(e) => tonic::Status::already_exists(e),
-            NetworkError::NodeIsGone(_) => tonic::Status::already_exists(value.to_string()),
-            NetworkError::ConnectError(s) => s,
-            NetworkError::UnknownNode(err @ NodesConfigError::GenerationMismatch { .. }) => {
+            AcceptError::Handshake(handshake) => handshake.into(),
+            AcceptError::OldPeerGeneration(e) => tonic::Status::already_exists(e),
+            AcceptError::PreviouslyShutdown => tonic::Status::already_exists(value.to_string()),
+            AcceptError::NodesConfig(err @ NodesConfigError::GenerationMismatch { .. }) => {
                 tonic::Status::failed_precondition(err.to_string())
             }
-            e => tonic::Status::internal(e.to_string()),
+            AcceptError::NodesConfig(err) => tonic::Status::invalid_argument(err.to_string()),
+            AcceptError::Shutdown(e) => tonic::Status::aborted(e.to_string()),
         }
     }
 }

--- a/crates/core/src/network/io/egress_sender.rs
+++ b/crates/core/src/network/io/egress_sender.rs
@@ -14,7 +14,7 @@ use std::task::{Context, Poll, ready};
 use futures::FutureExt;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::network::{ConnectionClosed, NetworkError};
+use crate::network::ConnectionClosed;
 
 use super::{DrainReason, EgressMessage};
 
@@ -72,13 +72,10 @@ impl EgressSender {
         self.inner.reserve_owned().await
     }
 
-    pub fn try_reserve_owned(self) -> Result<mpsc::OwnedPermit<EgressMessage>, NetworkError> {
+    pub fn try_reserve_owned(self) -> Option<mpsc::OwnedPermit<EgressMessage>> {
         match self.inner.try_reserve_owned() {
-            Ok(permit) => Ok(permit),
-            Err(mpsc::error::TrySendError::Full(_)) => Err(NetworkError::Full),
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                Err(NetworkError::ConnectionClosed(ConnectionClosed))
-            }
+            Ok(permit) => Some(permit),
+            Err(_) => None,
         }
     }
 

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -36,6 +36,7 @@ pub use grpc::GrpcConnector;
 pub use message_router::*;
 pub use network_sender::*;
 pub use networking::Networking;
+pub use protobuf::network::ConnectionDirection;
 pub use server_builder::NetworkServerBuilder;
 pub use transport_connector::TransportConnect;
 pub use types::*;

--- a/crates/core/src/network/rpc_router.rs
+++ b/crates/core/src/network/rpc_router.rs
@@ -311,10 +311,9 @@ where
     ) -> Result<Incoming<T::ResponseMessage>, ConnectionAwareRpcError<Outgoing<T, HasConnection>>>
     {
         let peer = peer.into();
-        let connection = networking
-            .node_connection(peer)
-            .await
-            .map_err(|e| ConnectionAwareRpcError::CannotEstablishConnectionToPeer(peer, e))?;
+        let connection = networking.node_connection(peer).await.map_err(|e| {
+            ConnectionAwareRpcError::CannotEstablishConnectionToPeer(peer, e.into())
+        })?;
         let connection_closed = connection.closed();
         let outgoing = Outgoing::new(peer, msg).assign_connection(connection);
 

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -102,11 +102,16 @@ pub enum TaskKind {
     /// Kafka ingestion related task
     Kafka,
     PartitionProcessor,
+    #[strum(props(runtime = "default"))]
+    PartitionProcessorManager,
     /// Low-priority tasks responsible for partition snapshot-related I/O.
     #[strum(props(OnCancel = "abort", OnError = "log"))]
     PartitionSnapshotProducer,
     #[strum(props(OnError = "log", runtime = "default"))]
     ConnectionReactor,
+    /// connection reactor for loopback connections
+    #[strum(props(OnError = "log", runtime = "default"))]
+    LocalReactor,
     Shuffle,
     Cleaner,
     MetadataServer,

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -33,8 +33,8 @@ use crate::TaskCenter;
 use crate::metadata_store::MetadataStoreClient;
 use crate::network::protobuf::network::Message;
 use crate::network::{
-    FailingConnector, Incoming, MessageHandler, MessageRouterBuilder, NetworkError, Networking,
-    ProtocolError, TransportConnect,
+    AcceptError, FailingConnector, Incoming, MessageHandler, MessageRouterBuilder, Networking,
+    TransportConnect,
 };
 use crate::{Metadata, MetadataManager, MetadataWriter};
 use crate::{MetadataBuilder, TaskId, spawn_metadata_manager};
@@ -217,9 +217,9 @@ impl<T: TransportConnect> TestCoreEnv<T> {
     pub async fn accept_incoming_connection<S>(
         &self,
         incoming: S,
-    ) -> Result<impl Stream<Item = Message> + Unpin + Send + 'static, NetworkError>
+    ) -> Result<impl Stream<Item = Message> + Unpin + Send + 'static, AcceptError>
     where
-        S: Stream<Item = Result<Message, ProtocolError>> + Unpin + Send + 'static,
+        S: Stream<Item = Message> + Unpin + Send + 'static,
     {
         self.networking
             .connection_manager()

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -191,10 +191,10 @@ impl<S: LogStore> LogletWorker<S> {
                     self.loglet_state.notify_known_global_tail(msg.body().header.known_global_tail);
                     // drop response if connection is lost/congested
                     let peer = msg.peer();
-                    if let Err(e) = msg.to_rpc_response(LogletInfo::new(self.loglet_state.local_tail(), self.loglet_state.trim_point(), self.loglet_state.known_global_tail())).try_send() {
-                        debug!(?e.source, peer = %peer, "Failed to respond to GetLogletInfo message due to peer channel capacity being full");
-                    } else {
+                    if msg.to_rpc_response(LogletInfo::new(self.loglet_state.local_tail(), self.loglet_state.trim_point(), self.loglet_state.known_global_tail())).try_send() {
                         tracing::trace!(%peer, %self.loglet_id, local_tail = ?self.loglet_state.local_tail(), known_global_tail = %self.loglet_state.known_global_tail(), "GetLogletInfo response");
+                    } else {
+                        debug!(peer = %peer, "Failed to respond to GetLogletInfo message");
                     }
                 }
                 Some(_) = in_flight_stores.next() => {}

--- a/crates/log-server/src/network.rs
+++ b/crates/log-server/src/network.rs
@@ -238,54 +238,60 @@ impl RequestPump {
 
     fn on_get_digest(worker: &LogletWorkerHandle, msg: Incoming<GetDigest>) {
         if let Err(msg) = worker.enqueue_get_digest(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(Digest::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to GetDigest message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(Digest::empty()).try_send() {
+                debug!(%peer, "Failed to respond to GetDigest message with status Disabled");
             }
         }
     }
 
     fn on_wait_for_tail(worker: &LogletWorkerHandle, msg: Incoming<WaitForTail>) {
         if let Err(msg) = worker.enqueue_wait_for_tail(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(TailUpdated::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to WaitForTail message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(TailUpdated::empty()).try_send() {
+                debug!(%peer, "Failed to respond to WaitForTail message with status Disabled");
             }
         }
     }
 
     fn on_store(worker: &LogletWorkerHandle, msg: Incoming<Store>) {
         if let Err(msg) = worker.enqueue_store(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(Stored::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to Store message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(Stored::empty()).try_send() {
+                debug!(%peer, "Failed to respond to Store message with status Disabled");
             }
         }
     }
 
     fn on_release(worker: &LogletWorkerHandle, msg: Incoming<Release>) {
         if let Err(msg) = worker.enqueue_release(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(Released::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to Release message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(Released::empty()).try_send() {
+                debug!(%peer, "Failed to respond to Release message with status Disabled");
             }
         }
     }
 
     fn on_seal(worker: &LogletWorkerHandle, msg: Incoming<Seal>) {
         if let Err(msg) = worker.enqueue_seal(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(Sealed::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to Seal message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(Sealed::empty()).try_send() {
+                debug!(%peer, "Failed to respond to Seal message with status Disabled");
             }
         }
     }
 
     fn on_get_loglet_info(worker: &LogletWorkerHandle, msg: Incoming<GetLogletInfo>) {
         if let Err(msg) = worker.enqueue_get_loglet_info(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(LogletInfo::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to GetLogletInfo message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(LogletInfo::empty()).try_send() {
+                debug!(%peer, "Failed to respond to GetLogletInfo message with status Disabled");
             }
         }
     }
@@ -293,18 +299,20 @@ impl RequestPump {
     fn on_get_records(worker: &LogletWorkerHandle, msg: Incoming<GetRecords>) {
         if let Err(msg) = worker.enqueue_get_records(msg) {
             let next_offset = msg.body().from_offset;
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(Records::empty(next_offset)).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to GetRecords message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(Records::empty(next_offset)).try_send() {
+                debug!(%peer, "Failed to respond to GetRecords message with status Disabled");
             }
         }
     }
 
     fn on_trim(worker: &LogletWorkerHandle, msg: Incoming<Trim>) {
         if let Err(msg) = worker.enqueue_trim(msg) {
+            let peer = msg.peer();
             // worker has crashed or shutdown in progress. Notify the sender and drop the message.
-            if let Err(e) = msg.to_rpc_response(Trimmed::empty()).try_send() {
-                debug!(?e.source, peer = %e.original.peer(), "Failed to respond to Trim message with status Disabled due to peer channel capacity being full");
+            if !msg.to_rpc_response(Trimmed::empty()).try_send() {
+                debug!(%peer, "Failed to respond to Trim message with status Disabled");
             }
         }
     }

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -25,8 +25,6 @@ pub enum NodesConfigError {
     Deleted(NodeId),
     #[error("node was found but has a mismatching generation (expected={expected} found={found})")]
     GenerationMismatch { expected: NodeId, found: NodeId },
-    #[error("node config has an invalid URI: {0}")]
-    InvalidUri(#[from] http::uri::InvalidUri),
 }
 
 // PartialEq+Eq+Clone+Copy are implemented by EnumSetType

--- a/crates/types/src/retries.rs
+++ b/crates/types/src/retries.rs
@@ -253,6 +253,10 @@ impl RetryIter<'_> {
     pub fn remaining_attempts(&self) -> usize {
         self.max_attempts() - self.attempts()
     }
+
+    pub fn last_retry(&self) -> Option<Duration> {
+        self.last_retry
+    }
 }
 
 impl Iterator for RetryIter<'_> {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -241,7 +241,7 @@ impl Worker {
         )?;
 
         TaskCenter::spawn_child(
-            TaskKind::SystemService,
+            TaskKind::PartitionProcessorManager,
             "partition-processor-manager",
             self.partition_processor_manager.run(),
         )?;

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -150,7 +150,9 @@ impl SpawnPartitionProcessorTask {
                     )
                     .await?;
 
-                    TaskCenter::spawn_child(
+                    // invoker needs to outlive the partition processor when shutdown signal is
+                    // received. This is why it's not spawned as a "child".
+                    TaskCenter::spawn(
                         TaskKind::SystemService,
                         invoker_name,
                         invoker.run(invoker_config),

--- a/tools/restatectl/src/commands/node/disable_node_checker.rs
+++ b/tools/restatectl/src/commands/node/disable_node_checker.rs
@@ -57,8 +57,7 @@ impl<'a, 'b> DisableNodeChecker<'a, 'b> {
             Err(NodesConfigError::UnknownNodeId(_)) | Err(NodesConfigError::Deleted(_)) => {
                 return Ok(());
             }
-            Err(NodesConfigError::GenerationMismatch { .. })
-            | Err(NodesConfigError::InvalidUri(_)) => {
+            Err(NodesConfigError::GenerationMismatch { .. }) => {
                 unreachable!("impossible nodes config errors")
             }
         };


### PR DESCRIPTION

- Connection attempt throttling with exponential backoff
- In-flight connection attempts are auto-coalesced for (managed) connections
- Major cleanup of network error types
- Uses Forward connections by default (1.2 will treat this as bidirectional which is okay)
- Reduces default number of connections to 3 (since we'll have 3 in each direction)
- Better logging of connection lifecycle events
- Uses `NodeIsGone` state in situations where we know the node is never coming back (node was superceeded or deleted)


```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2939).
* #2961
* __->__ #2939