### PR TITLE
Default bind port to 5122 when inferring from ambiguous advertised-address

### DIFF
--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -18,7 +18,7 @@ use restate_core::network::net_util::create_tonic_channel;
 use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest as ProtoProvisionClusterRequest;
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvcClient;
-use restate_types::config::{MetadataServerKind, RaftOptions};
+use restate_types::config::{InvalidConfigurationError, MetadataServerKind, RaftOptions};
 use restate_types::logs::metadata::ProviderConfiguration;
 use restate_types::partition_table::PartitionReplication;
 use restate_types::protobuf::common::MetadataServerStatus;
@@ -118,6 +118,8 @@ pub enum NodeStartError {
     CreateConfig(io::Error),
     #[error("Failed to create or append to node log file: {0}")]
     CreateLog(io::Error),
+    #[error(transparent)]
+    DeriveBindAddress(#[from] InvalidConfigurationError),
     #[error("Failed to dump config to bytes: {0}")]
     DumpConfig(GenericError),
     #[error("Failed to spawn restate-server: {0}")]
@@ -258,7 +260,7 @@ impl Node {
                 self.base_config
                     .common
                     .advertised_address
-                    .derive_bind_address(),
+                    .derive_bind_address()?,
             );
         }
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -21,8 +21,8 @@ use serde_with::serde_as;
 use restate_serde_util::{NonZeroByteCount, SerdeableHeaderHashMap};
 
 use super::{
-    AwsOptions, HttpOptions, ObjectStoreOptions, PerfStatsLevel, RocksDbOptions,
-    print_warning_deprecated_config_option,
+    AwsOptions, HttpOptions, InvalidConfigurationError, ObjectStoreOptions, PerfStatsLevel,
+    RocksDbOptions, print_warning_deprecated_config_option,
 };
 use crate::PlainNodeId;
 use crate::locality::NodeLocation;
@@ -387,11 +387,12 @@ impl CommonOptions {
     }
 
     /// set derived values if they are not configured to reduce verbose configurations
-    pub fn set_derived_values(&mut self) {
+    pub fn set_derived_values(&mut self) -> Result<(), InvalidConfigurationError> {
         // Only derive bind_address if it is not explicitly set
         if self.bind_address.is_none() {
-            self.bind_address = Some(self.advertised_address.derive_bind_address());
+            self.bind_address = Some(self.advertised_address.derive_bind_address()?);
         }
+        Ok(())
     }
 }
 

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -269,6 +269,8 @@ pub enum InvalidConfigurationError {
         "force-node-id can not be 0 since it is a reserved value. Please choose a non-zero value or unset this option. Existing clusters will be auto-migrated"
     )]
     ForceNodeIdZero,
+    #[error("could not derive bind address: {0}")]
+    DeriveBindAddress(String),
 }
 
 /// Used to deserialize the [`Configuration`] in backwards compatible way which allows to specify

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -66,7 +66,7 @@ impl ConfigLoader {
 
         let mut config: Configuration = figment.extract()?;
 
-        config.common.set_derived_values();
+        config.common.set_derived_values()?;
         config.admin.set_derived_values();
         config.ingress.set_derived_values();
 


### PR DESCRIPTION
This change updates the implied bind-address logic to default to 5122 if only a hostname is
specified, without a protocol or port.

In cases where a protocol is specified, the specific protocol determines the actual bind port - we
print a startup warning when this happens as this might be surprising. HTTPS is an exception since
restate-server does not natively support this; it's not an error to advertise an https:// address
but it's probably a misconfiguration not to specify a bind-address also.
  
Fixes #2940

---

Tests are a bit ugly but I think this is much more sane now:

```toml
advertised-address = "127.0.0.1"               # will bind to :5122
advertised-address = "localhost"               # will bind to :5122
advertised-address = "http://127.0.0.1"        # will bind to :80 - and print a warning on stderr
advertised-address = "https://nodename"        # fail without a bind-address
advertised-address = "http://127.0.0.1:35122"  # will bind to :35122
```

When started with `advertised-address = "http://127.0.0.1"`:

```
❯ restate-server --config-file ../config-snippets/bind-address.toml --log-format compact
The advertised address is configured with scheme http:// and no explicit port, implying port 80
...
2025-03-19T19:51:25.459507Z  INFO server: restate_core::network::net_util: Server listening server_name=node-rpc-server net.host.addr="0.0.0.0" net.host.port=80
...
```

When started with `advertised-address = "https://nodename"` (and no `bind-address`):

```
❯ restate-server --config-file ../config-snippets/bind-address.toml --log-format compact
The advertised address is configured with scheme https:// and no explicit port, implying port 443
[RT0002] invalid configuration: could not derive bind address: Restate does not support HTTPS. If you are using a TLS-terminating reverse proxy, please set bind-address explicitly.
```
