### PR TITLE
Don't run Jepsen tests on PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,10 +180,7 @@ jobs:
         run: ./tools/scripts/verify-ui-artifact
 
   jepsen:
-    # Forks are not trusted and will break at the configure credentials step.
-    # Id tokens are not available to PRs created from fork branches; Jepsen tests on PR only
-    # works when the PR is created from a branch pushed to the restatedev/restate repo.
-    if: github.event.repository.fork == false && github.event.pull_request.head.repo.full_name == 'restatedev/restate'
+    if: github.event.repository.fork == false && github.event.pull_request.head.repo.full_name == 'restatedev/restate' && github.ref == 'refs/heads/main'
     runs-on: warp-ubuntu-latest-arm64-4x
     name: Run Jepsen tests
     env:


### PR DESCRIPTION
You can still run Jepsen using the Docker artifact produced by the PR branch via the restatev/jepsen workflow.

To trigger a Jepsen test run of an open PR, you can execute the test flow manually from https://github.com/restatedev/jepsen/actions/workflows/jepsen.yml - as long as the Docker image tarball artifact is still available, just entering the PR number will suffice.