### PR TITLE
Use stable network identifier when starting a K8s based Restate cluster

### DIFF
--- a/charts/restate-helm/README.md
+++ b/charts/restate-helm/README.md
@@ -14,3 +14,9 @@ You can find example values for a 3-node replicated cluster in [replicated-value
 ```bash
 helm install restate oci://ghcr.io/restatedev/restate-helm --namespace restate --create-namespace -f replicated-values.yaml
 ```
+
+Note that you need to explicitly provision the Restate cluster via
+
+```bash
+kubectl exec -it restate-0 -- restatectl provision --log-provider replicated --log-replication 2 --yes
+```

--- a/charts/restate-helm/replicated-values.yaml
+++ b/charts/restate-helm/replicated-values.yaml
@@ -1,14 +1,8 @@
 replicaCount: 3
 
 env:
-  - name: POD_IP
-    valueFrom:
-      fieldRef:
-        fieldPath: "status.podIP"
-  - name: RESTATE_ADVERTISED_ADDRESS
-    value: "http://$(POD_IP):5122"
-  - name: RESTATE_ROLES
-    value: '["metadata-server", "admin", "worker", "log-server"]'
+  - name: RESTATE_LOG_FORMAT
+    value: json
   - name: RESTATE_CLUSTER_NAME
     value: helm-replicated
   - name: RESTATE_METADATA_CLIENT__ADDRESSES
@@ -16,5 +10,5 @@ env:
   - name: RESTATE_METADATA_SERVER__TYPE
     value: "replicated"
   - name: RESTATE_AUTO_PROVISION
-    # provision with `kubectl exec -it restate-0 -- restatectl provision --log-provider replicated --log-replication 2`
+    # provision with `kubectl exec -it restate-0 -- restatectl provision --log-provider replicated --log-replication 2 --yes`
     value: "false"

--- a/charts/restate-helm/templates/service.yaml
+++ b/charts/restate-helm/templates/service.yaml
@@ -2,6 +2,29 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ include "restate.fullname" . }}-cluster
+  labels:
+    {{- include "restate.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - port: 5122
+      name: node
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Restate pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  selector:
+    app: {{ include "restate.fullname" . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Service that load balances across the ready Restate pods
   name: {{ include "restate.fullname" . }}
   labels:
     {{- include "restate.labels" . | nindent 4 }}

--- a/charts/restate-helm/templates/statefulset.yaml
+++ b/charts/restate-helm/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "restate.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "restate.fullname" . }}
+  serviceName: {{ include "restate.fullname" . }}-cluster
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -44,8 +44,16 @@ spec:
             - containerPort: 5122
               name: node
           env:
-            - name: RUST_LOG
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.name"
+            - name: RESTATE_LOG_FILTER
               value: {{ .Values.logging.env_filter }}
+            - name: RESTATE_ADVERTISED_ADDRESS
+              # Use the stable network identifier (dns resolvable) provided by the stateful set. The second part is the
+              # serviceName of the stateful set.
+              value: http://$(POD_NAME).{{ include "restate.fullname" . }}-cluster:5122
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -63,6 +71,11 @@ spec:
       volumes:
         - name: tmp
           emptyDir: { }
+  # It's important to start multiple pods at the same time in case multiple pods died. Otherwise, we risk
+  # unavailability of an already configured metadata cluster
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/charts/restate-helm/values.yaml
+++ b/charts/restate-helm/values.yaml
@@ -26,13 +26,14 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 3000
 
-
 logging:
   env_filter: info
 
 env:
   - name: RESTATE_LOG_FORMAT
     value: json
+  - name: RESTATE_CLUSTER_NAME
+    value: helm-single-node
 
 service:
   type: ClusterIP


### PR DESCRIPTION
W/o stable network identifier, it is not possible that the replicated metadata cluster survives a crash of multiple pods (N/2 + 1) because they would be restarted with a different IP which makes them no longer reachable by the other nodes (based on the advertised address stored before in the NodesConfiguration). As a result, the metadata cluster would lose write availability because it can no longer form a majority quorum.

To solve this problem, we are now using the stable network identifier provided by the stateful set. It requires to run a headless service with the same name as the one configured as the serviceName in the stateful set spec. Now, all Restate pods are started with this stable network identifier as their advertised address. Additionally, we set the podManagementPolicy to parallel to enable that a metadata cluster majority quorum can form in case of a multiple pod failures. Moreover, we configure the headless service to publish the pod addresses before they are ready.