### PR TITLE
Datafusion node_state table

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -253,4 +253,8 @@ impl ClusterStateWatcher {
     pub fn current(&self) -> Arc<ClusterState> {
         Arc::clone(&self.cluster_state_watcher.borrow())
     }
+
+    pub fn watch(&self) -> watch::Receiver<Arc<ClusterState>> {
+        self.cluster_state_watcher.clone()
+    }
 }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -112,8 +112,11 @@ where
         let options = configuration.live_load();
         let heartbeat_interval = Self::create_heartbeat_interval(&options.admin);
 
-        let cluster_query_context =
-            QueryContext::create(&options.admin.query_engine, ClusterTables).await?;
+        let cluster_query_context = QueryContext::create(
+            &options.admin.query_engine,
+            ClusterTables::new(cluster_state_refresher.cluster_state_watcher().watch()),
+        )
+        .await?;
 
         // Registering ClusterCtrlSvc grpc service to network server
         server_builder.register_grpc_service(

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -22,6 +22,7 @@ mod journal;
 mod keyed_service_status;
 mod log;
 mod node;
+mod node_state;
 mod partition;
 mod partition_store_scanner;
 mod physical_optimizer;

--- a/crates/storage-query-datafusion/src/node_state/mod.rs
+++ b/crates/storage-query-datafusion/src/node_state/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub use table::register_self;

--- a/crates/storage-query-datafusion/src/node_state/row.rs
+++ b/crates/storage-query-datafusion/src/node_state/row.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::table_util::format_using;
+
+use super::schema::NodeStateBuilder;
+use restate_types::{PlainNodeId, cluster::cluster_state::NodeState};
+
+#[inline]
+pub(crate) fn append_node_row(
+    builder: &mut NodeStateBuilder,
+    output: &mut String,
+    node_id: PlainNodeId,
+    node_state: &NodeState,
+) {
+    let mut row = builder.row();
+    row.plain_node_id(format_using(output, &node_id));
+    row.status(format_using(output, &node_state));
+
+    match node_state {
+        NodeState::Alive(alive) => {
+            row.uptime(alive.uptime.as_secs());
+            row.last_seen_at(alive.last_heartbeat_at.as_u64() as i64);
+            row.gen_node_id(format_using(output, &alive.generational_node_id));
+        }
+        NodeState::Dead(dead) => {
+            if let Some(ts) = dead.last_seen_alive {
+                row.last_seen_at(ts.as_u64() as i64);
+            }
+        }
+        NodeState::Suspect(suspect) => {
+            row.last_attempt_at(suspect.last_attempt.as_u64() as i64);
+            row.gen_node_id(format_using(output, &suspect.generational_node_id));
+        }
+    }
+}

--- a/crates/storage-query-datafusion/src/node_state/schema.rs
+++ b/crates/storage-query-datafusion/src/node_state/schema.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(dead_code)]
+
+use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
+
+define_table!(
+    /// Observed node status
+    node_state(
+        /// Node ID
+        plain_node_id: DataType::Utf8,
+
+        /// Current observed generation ID
+        gen_node_id: DataType::Utf8,
+
+        /// Node observed status
+        status: DataType::Utf8,
+
+        /// Node uptime (if ALIVE)
+        uptime: DataType::UInt64,
+
+        /// Node last seen timestamp
+        last_seen_at: TimestampMillisecond,
+
+        /// Last attempt to reach the node timestamp (if SUSPECT)
+        last_attempt_at: TimestampMillisecond,
+    )
+);

--- a/crates/storage-query-datafusion/src/node_state/table.rs
+++ b/crates/storage-query-datafusion/src/node_state/table.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
+
+use restate_types::cluster::cluster_state::ClusterState;
+
+use crate::context::QueryContext;
+use crate::table_providers::{GenericTableProvider, Scan};
+use crate::table_util::Builder;
+
+use super::row::append_node_row;
+use super::schema::NodeStateBuilder;
+
+pub fn register_self(
+    ctx: &QueryContext,
+    watch: watch::Receiver<Arc<ClusterState>>,
+) -> datafusion::common::Result<()> {
+    let table = GenericTableProvider::new(
+        NodeStateBuilder::schema(),
+        Arc::new(NodesStatusScanner { watch }),
+    );
+    ctx.register_non_partitioned_table("node_state", Arc::new(table))
+}
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("DeploymentMetadataScanner")]
+struct NodesStatusScanner {
+    watch: watch::Receiver<Arc<ClusterState>>,
+}
+
+impl Scan for NodesStatusScanner {
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let schema = projection.clone();
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let tx = stream_builder.tx();
+
+        let current = self.watch.borrow().clone();
+        stream_builder.spawn(async move {
+            for_each_state(schema, tx, &current).await;
+            Ok(())
+        });
+        stream_builder.build()
+    }
+}
+
+async fn for_each_state(
+    schema: SchemaRef,
+    tx: Sender<datafusion::common::Result<RecordBatch>>,
+    cluster_state: &ClusterState,
+) {
+    let mut builder = NodeStateBuilder::new(schema.clone());
+    let mut output = String::new();
+    for (id, node_state) in cluster_state.nodes.iter() {
+        append_node_row(&mut builder, &mut output, *id, node_state);
+        if builder.full() {
+            let batch = builder.finish();
+            if tx.send(batch).await.is_err() {
+                // not sure what to do here?
+                // the other side has hung up on us.
+                // we probably don't want to panic, is it will cause the entire process to exit
+                return;
+            }
+            builder = NodeStateBuilder::new(schema.clone());
+        }
+    }
+    if !builder.empty() {
+        let result = builder.finish();
+        let _ = tx.send(result).await;
+    }
+}

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -81,8 +81,9 @@ fn instant_to_proto(t: Instant) -> prost_types::Duration {
     t.elapsed().try_into().unwrap()
 }
 
-#[derive(Debug, Clone, IntoProst)]
+#[derive(Debug, Clone, IntoProst, strum::Display)]
 #[prost(target = "crate::protobuf::cluster::NodeState", oneof = "state")]
+#[strum(serialize_all = "snake_case")]
 pub enum NodeState {
     Alive(AliveNode),
     Dead(DeadNode),


### PR DESCRIPTION
Datafusion node_state table

Summary:
The `node_state` reflects the actual observed node state
as seen by this cluster controller node

A quick view of the cluster node can be retrieved as

```
restatectl sql "select n.*,s.* from nodes as n left join node_state s on n.plain_node_id=s.plain_node_id order by n.plain_node_id"
 PLAIN_NODE_ID  GEN_NODE_ID  NAME    ADDRESS                 LOCATION  HAS_ADMIN_ROLE  HAS_WORKER_ROLE  HAS_METADATA_SERVER_ROLE  HAS_LOG_SERVER_ROLE  HAS_INGRESS_ROLE  STORAGE_STATE  METADATA_SERVER_STATE  PLAIN_NODE_ID  GEN_NODE_ID  STATUS  UPTIME  LAST_SEEN_TS   LAST_ATTEMPT_TS
 N1             N1:31        node-1  http://127.0.0.1:5122/            true            true             true                      true                 false             read-write     member                 N1             N1:31        ALIVE   375     1742391116022
 N2             N2:27        node-2  http://127.0.0.1:6122/            true            true             true                      true                 false             read-write     member                 N2             N2:27        ALIVE   371     1742391116023
 N3             N3:28        node-3  http://127.0.0.1:7122/            true            true             false                     false                false                                                   N3             N3:28        ALIVE   368     1742391116024

3 rows. Query took 67.692433ms

```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2944).
* #2945
* __->__ #2944