### PR TITLE
Fail read-only requests that get silently dropped by Raft

### DIFF
--- a/crates/metadata-server/src/raft/kv_memory_storage.rs
+++ b/crates/metadata-server/src/raft/kv_memory_storage.rs
@@ -98,6 +98,7 @@ impl KvMemoryStorage {
     }
 
     pub fn handle_read_only_request(&mut self, request_id: Ulid) {
+        trace!("Handle read-only request: {request_id:?}");
         if let Some(read_only_request) = self.read_only_requests.remove(&request_id) {
             match read_only_request.kind {
                 ReadOnlyRequestKind::Get { key, result_tx } => {


### PR DESCRIPTION
During a leadership change a new leader might not have fully re-established what the latest commit index is. To do this, a new leader upon winning the leadership writes an empty entry. In order to avoid stale reads during this time, read-index requests are silently ignored by RawNode. If this is not correctly handled, it can lead to unanswered metadata requests. To solve the problem, we are comparing the previous pending reads and ready reads with the same values after calling RawNode::read_index. If they are still the same, then we faill the request with RequestError::Unavailable (as if we aren't the leader yet). It's then the responsibility of the client to retry the operation.

This fixes #2947.