### PR TITLE
Fix panic in restatectl listing nodes outside cluster

### DIFF
--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -55,7 +55,8 @@ message ProvisionClusterResponse {
 
 message IdentResponse {
   restate.common.NodeStatus status = 1;
-  restate.common.NodeId node_id = 2;
+  // node id may be unset if the node hasn't yet joined a cluster
+  optional restate.common.NodeId node_id = 2;
   string cluster_name = 3;
   // indicates which roles are enabled on this node
   repeated string roles = 4;


### PR DESCRIPTION
After fix:

```
❯ restatectl nodes ls
The cluster metadata service was unavailable but the following node(s) from the address list responded directly
 NODE  GEN  NAME  ADDRESS                 ROLES
 n/a        -     http://localhost:5122/  worker
Error: Could not retrieve cluster metadata. Has the cluster been provisioned yet?
```

Fixes #2946