### PR TITLE
fix(2236): support insecure skip tls verify in cli

### DIFF
--- a/cli/src/clients/admin_client.rs
+++ b/cli/src/clients/admin_client.rs
@@ -128,6 +128,7 @@ impl AdminClient {
                 std::env::consts::ARCH,
             ))
             .connect_timeout(CliContext::get().connect_timeout())
+            .danger_accept_invalid_certs(CliContext::get().insecure_skip_tls_verify())
             .build()?;
 
         let base_url = env.admin_base_url()?.clone();

--- a/crates/cli-util/src/context.rs
+++ b/crates/cli-util/src/context.rs
@@ -156,6 +156,10 @@ impl CliContext {
         Duration::from_millis(self.network.request_timeout)
     }
 
+    pub fn insecure_skip_tls_verify(&self) -> bool {
+        self.network.insecure_skip_tls_verify
+    }
+
     pub fn loaded_dotenv(&self) -> Option<&Path> {
         self.loaded_dotenv.as_deref()
     }

--- a/crates/cli-util/src/opts.rs
+++ b/crates/cli-util/src/opts.rs
@@ -86,6 +86,10 @@ pub struct NetworkOpts {
     /// Overall request timeout for network calls, in milliseconds.
     #[arg(long, default_value_t = DEFAULT_REQUEST_TIMEOUT, global = true)]
     pub request_timeout: u64,
+    /// If true, the server's certificate will not be checked for validity. This will make your HTTPS connections
+    /// insecure
+    #[arg[long = "insecure", short = 'k', default_value_t = false, global = true]]
+    pub insecure_skip_tls_verify: bool,
 }
 
 impl CommonClientConnectionOptions for NetworkOpts {


### PR DESCRIPTION
Fix: https://github.com/restatedev/restate/issues/2236