### PR TITLE
fix(2492): report error when resource id is too long

### DIFF
--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -864,6 +864,10 @@ macro_rules! ulid_backed_id {
 
                     // ulid (u128)
                     let raw_ulid: u128 = decoder.cursor.decode_next()?;
+                    if decoder.cursor.remaining() > 0 {
+                        return Err(IdDecodeError::Length);
+                    }
+
                     Ok(Self::from(raw_ulid))
                 }
             }


### PR DESCRIPTION
Fix: https://github.com/restatedev/restate/issues/2492

After fix:

```
curl "http://localhost:9070/deployments/dp_11nGQpCRmau6ypL82KH2TnP"
{"message":"The requested deployment 'dp_11nGQpCRmau6ypL82KH2TnP' does not exist","restate_code":null}

curl "http://localhost:9070/deployments/dp_11nGQpCRmau6ypL82KH2TnP123456"
Invalid URL: bad length
```