### PR TITLE
Only update metadata manager if metadata was actually written to the metadata store

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -348,7 +348,7 @@ impl<T: TransportConnect> Service<T> {
                 },
                 Ok(cluster_state) = cluster_state_watcher.next_cluster_state() => {
                     self.observed_cluster_state.update(&cluster_state);
-                    trace!("Observed cluster state updated");
+                    trace!(observed_cluster_state = ?self.observed_cluster_state, "Observed cluster state updated");
                     // todo quarantine this cluster controller if errors re-occur too often so that
                     //  another cluster controller can take over
                     if let Err(err) = state.update(&self) {

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -54,7 +54,7 @@ enum UpdateError {
     Network(#[from] NetworkError),
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, derive_more::Display)]
 pub enum TargetVersion {
     Latest,
     Version(Version),
@@ -342,6 +342,8 @@ impl MetadataManager {
         if self.has_target_version(metadata_kind, target_version) {
             return Ok(());
         }
+
+        trace!(%metadata_kind, %target_version, "Sync metadata");
 
         match metadata_kind {
             MetadataKind::NodesConfiguration => {

--- a/crates/core/src/network/partition_processor_rpc_client.rs
+++ b/crates/core/src/network/partition_processor_rpc_client.rs
@@ -378,8 +378,9 @@ where
 
         if rpc_result.is_err() && rpc_result.as_ref().unwrap_err().likely_stale_route() {
             trace!(
-                ?partition_id,
-                ?node_id,
+                %partition_id,
+                %node_id,
+                %request_id,
                 "Received Partition Processor error indicating possible stale route"
             );
             self.partition_routing.request_refresh();

--- a/crates/core/src/partitions.rs
+++ b/crates/core/src/partitions.rs
@@ -174,8 +174,9 @@ impl PartitionRoutingRefresher {
                     }
                 }
                 _ = partition_table_watch.changed() => {
-                    trace!("Refreshing routing information...");
-                    let routing = PartitionToNodesRoutingTable::from(Metadata::with_current(|m| m.partition_table_ref()));
+                    let partition_table = Metadata::with_current(|m| m.partition_table_ref());
+                    debug!("Refreshing routing information based on partition table {}...", partition_table.version());
+                    let routing = PartitionToNodesRoutingTable::from(partition_table);
                     self.inner.store(Arc::new(routing));
                 }
             }


### PR DESCRIPTION
The Scheduler updates the PartitionTable whenever it updates the partition placement. Once it decides on a new PartitionTable, it tries to store it in the metadata store. If the write fails because of a precondition violation, we were accidentally publishing the rejected PartitionTable. This can lead to cluster nodes operating on different partition tables. One symptom of it is that an ingress becomes unresponsive because the CC selected a different leader than what the ingress believes is the current leader. Therefore, the ingress sends the ingress invocation to the wrong partition processor where it gets rejected.

Additionally, to speed up convergence when detecting a concurrent write to the partition table, we are trying to sync the metadata based on the expected version + 1 instead of the new version + 1 which might not have been written at this point.

This commit also includes a few logging improvements which helped while debugging the above-described problem.

This fixes #2959.