### PR TITLE
[Core] Allow unknown/future nodes to connect to us

### DIFF
--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -30,7 +30,7 @@ use restate_types::{GenerationalNodeId, Version, Versioned};
 
 use crate::metadata::manager::Command;
 use crate::metadata_store::{MetadataStoreClient, ReadError};
-use crate::network::Connection;
+use crate::network::UnboundedConnectionRef;
 use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
 
 #[derive(Debug, thiserror::Error)]
@@ -258,7 +258,7 @@ impl Metadata {
         &self,
         metadata_kind: MetadataKind,
         version: Version,
-        remote_peer: Option<Connection>,
+        remote_peer: Option<UnboundedConnectionRef>,
         urgency: Urgency,
     ) {
         // check whether the version is newer than what we know
@@ -416,7 +416,7 @@ pub fn spawn_metadata_manager(metadata_manager: MetadataManager) -> Result<TaskI
 #[derive(Debug, Clone)]
 struct VersionInformation {
     version: Version,
-    peer_connection: Option<Connection>,
+    peer_connection: Option<UnboundedConnectionRef>,
 }
 
 impl Default for VersionInformation {
@@ -429,7 +429,7 @@ impl Default for VersionInformation {
 }
 
 impl VersionInformation {
-    fn new(version: Version, peer_connection: Option<Connection>) -> Self {
+    fn new(version: Version, peer_connection: Option<UnboundedConnectionRef>) -> Self {
         Self {
             version,
             peer_connection,

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -37,10 +37,9 @@ use crate::TaskKind;
 use crate::cancellation_watcher;
 use crate::is_cancellation_requested;
 use crate::metadata_store::{MetadataStoreClient, ReadError};
-use crate::network::Connection;
 use crate::network::Incoming;
-use crate::network::Outgoing;
 use crate::network::Reciprocal;
+use crate::network::UnboundedConnectionRef;
 use crate::network::{MessageHandler, MessageRouterBuilder, NetworkError};
 
 pub(super) type CommandSender = mpsc::UnboundedSender<Command>;
@@ -495,22 +494,19 @@ impl MetadataManager {
                 match task.state {
                     UpdateTaskState::FromPeer(connection) => {
                         trace!(
-                            "Attempting to get '{}' metadata from {}",
+                            "Attempting to get '{}' metadata from {:?}",
                             metadata_kind,
                             connection.peer()
                         );
-                        let outgoing = Outgoing::new(
-                            connection.peer(),
-                            MetadataMessage::GetMetadataRequest(GetMetadataRequest {
-                                metadata_kind,
-                                min_version: Some(task.version),
-                            }),
-                        )
-                        .assign_connection(connection);
-
                         // Best-effort send. We'll sync from metadata store if we couldn't send or
                         // if we have not heard a response before the next tick.
-                        let _ = outgoing.try_send();
+                        let _ = connection.encode_and_send(MetadataMessage::GetMetadataRequest(
+                            GetMetadataRequest {
+                                metadata_kind,
+                                min_version: Some(task.version),
+                            },
+                        ));
+
                         task.state = UpdateTaskState::Sync;
                         update_task = Some(task);
                     }
@@ -548,7 +544,7 @@ impl MetadataManager {
 }
 
 enum UpdateTaskState {
-    FromPeer(Connection),
+    FromPeer(UnboundedConnectionRef),
     Sync,
 }
 

--- a/crates/core/src/network/io/egress_sender.rs
+++ b/crates/core/src/network/io/egress_sender.rs
@@ -129,4 +129,21 @@ impl UnboundedEgressSender {
     pub fn unbounded_drain(&self, reason: DrainReason) {
         let _ = self.inner.send(EgressMessage::Close(reason));
     }
+
+    pub fn downgrade(&self) -> WeakUnboundedEgressSender {
+        WeakUnboundedEgressSender {
+            inner: self.inner.downgrade(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct WeakUnboundedEgressSender {
+    inner: mpsc::WeakUnboundedSender<EgressMessage>,
+}
+
+impl WeakUnboundedEgressSender {
+    pub fn upgrade(&self) -> Option<UnboundedEgressSender> {
+        self.inner.upgrade().map(UnboundedEgressSender::new)
+    }
 }

--- a/crates/core/src/network/io/mod.rs
+++ b/crates/core/src/network/io/mod.rs
@@ -12,6 +12,8 @@ mod egress_sender;
 mod egress_stream;
 mod reactor;
 
+pub(crate) use egress_sender::WeakUnboundedEgressSender;
+
 pub use egress_sender::{EgressSender, UnboundedEgressSender};
 pub use egress_stream::{DrainReason, DropEgressStream, EgressMessage, EgressStream};
 pub use reactor::ConnectionReactor;

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -29,7 +29,7 @@ mod tracking;
 pub mod transport_connector;
 mod types;
 
-pub use connection::Connection;
+pub use connection::{Connection, UnboundedConnectionRef};
 pub use connection_manager::ConnectionManager;
 pub use error::*;
 pub use grpc::GrpcConnector;

--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -26,6 +26,7 @@ use super::{Connection, ConnectionClosed, NetworkSendError};
 static NEXT_MSG_ID: AtomicU64 = const { AtomicU64::new(1) };
 
 /// Address of a peer in the network. It can be a specific node or an anonymous peer.
+#[derive(Debug, Clone)]
 pub enum PeerAddress {
     ServerNode(NodeId),
     Anonymous,


### PR DESCRIPTION

This removes the validation on the "accept" path. At the moment we reject connections from node ids that we don't fully recognize. This removes this check in favour of:

1. Rejecting connections from nodes at which we believe have been preempted in the past (either from nodes config, or from our observations)
2. Letting nodes send us their version of nodes configuration via metadata sync mechanism

With this change, we'll use the metadata version information exchanged in hello/welcome message to initiate the metadata sync from this peer. The change to use `UnboundedEgressSender` ensures that we won't lose those requests if the bounded channel is too small. Additionally, it's aligned with upcoming changes in network API design.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2961).
* #2860
* __->__ #2961