### PR TITLE
Harden tests that depend on mock service endpoint

### DIFF
--- a/tools/mock-service-endpoint/src/listener.rs
+++ b/tools/mock-service-endpoint/src/listener.rs
@@ -23,8 +23,12 @@ use tracing::error;
 
 use crate::handler::serve;
 
-pub async fn run_listener(address: SocketAddr) -> Result<(), Box<dyn Error + Send + Sync>> {
+pub async fn run_listener(
+    address: SocketAddr,
+    on_bind: impl FnOnce(),
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     let listener = TcpListener::bind(address).await?;
+    on_bind();
 
     loop {
         tokio::select! {

--- a/tools/mock-service-endpoint/src/main.rs
+++ b/tools/mock-service-endpoint/src/main.rs
@@ -30,6 +30,5 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let addr: SocketAddr = ([127, 0, 0, 1], 9080).into();
 
-    info!("Listening on http://{}", addr);
-    run_listener(addr).await
+    run_listener(addr, || info!("Listening on http://{}", addr)).await
 }


### PR DESCRIPTION
This commit hardens the tests that depend on the mock service endpoint by adding a callback to await until the mock service endpoint has bound to a socket address.