### PR TITLE
Don't panic node on incorrectly destined Raft packages

### DIFF
--- a/crates/metadata-server/src/raft/network/connection_manager.rs
+++ b/crates/metadata-server/src/raft/network/connection_manager.rs
@@ -135,7 +135,10 @@ where
 
                                     let message = M::deserialize(&mut message.payload)?;
 
-                                    assert_eq!(message.to(), self.connection_manager.identity, "Expect to only receive messages for peer '{}'", self.connection_manager.identity);
+                                    if message.to() != self.connection_manager.identity {
+                                        debug!("Sender assumes me to be node {} but I am node {}; closing the connection", message.to(), self.connection_manager.identity);
+                                        break;
+                                    }
 
                                     if self.connection_manager.router.send(message).await.is_err() {
                                         // system is shutting down


### PR DESCRIPTION
This commit prevents a node from panicking if a Raft metadata node receives messages that were destined for a different node. Instead, we are terminating the connection now. The problem can occur if one adds a new node to the cluster that is reusing an existing address.

Hopefully, we can remove the Raft specific networking component once the network stack rework has been completed.

This fixes #2963.