### PR TITLE
fix(2955): report err when cannot connect to admin service

### DIFF
--- a/cli/src/commands/whoami.rs
+++ b/cli/src/commands/whoami.rs
@@ -194,8 +194,8 @@ pub async fn run(State(env): State<CliEnv>) {
 
     c_println!();
     // Get admin client, don't fail completely if we can't get one!
-    if let Ok(client) = crate::clients::AdminClient::new(&env).await {
-        match client.health().await {
+    match crate::clients::AdminClient::new(&env).await {
+        Ok(client) => match client.health().await {
             Ok(envelope) if envelope.status_code().is_success() => {
                 c_success!("Admin Service '{}' is healthy!", client.base_url);
                 if let Some(advertised_ingress_address) = client.advertised_ingress_address {
@@ -220,6 +220,10 @@ pub async fn run(State(env): State<CliEnv>) {
                 c_error!("Admin Service '{}' is unhealthy:", client.base_url);
                 c_eprintln!("   >> {}", e);
             }
+        },
+        Err(e) => {
+            c_error!("Could not connect to Admin Service:");
+            c_eprintln!("   >> {}", e);
         }
     }
 


### PR DESCRIPTION
Fix: https://github.com/restatedev/restate/issues/2955

After fix:

```
 Git SHA              9c28cba6
 Git Commit Date      2025-03-20
 Git Commit Branch    fix-2955

❌ Maybe cannot connect to Admin Service 'http://localhost:9070/':
   >> Unable to connect to the Restate server 'http://localhost:9070/'. Please make sure that it is running and reachable.
```