### PR TITLE
Support starting a cluster with an empty PartitionTable 

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -28,7 +28,6 @@ use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::live::Constant;
 use restate_types::logs::metadata::ProviderKind;
 use restate_types::retries::RetryPolicy;
-use std::num::NonZeroU16;
 use std::time::Duration;
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
@@ -160,7 +159,7 @@ pub fn flamegraph_options<'a>() -> Options<'a> {
 pub fn restate_configuration() -> Configuration {
     let common_options = CommonOptionsBuilder::default()
         .base_dir(tempfile::tempdir().expect("tempdir failed").into_path())
-        .default_num_partitions(NonZeroU16::new(10).unwrap())
+        .default_num_partitions(10)
         .build()
         .expect("building common options should work");
 

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -140,7 +140,7 @@ impl<T: TransportConnect> Scheduler<T> {
         let version = partition_table.version();
 
         // todo(azmy): avoid cloning the partition table every time by keeping
-        // the latest built always available as a field
+        //  the latest built always available as a field
         let mut builder = partition_table.clone().into_builder();
         let partition_replication = builder.partition_replication().clone();
 

--- a/crates/local-cluster-runner/examples/three_nodes.rs
+++ b/crates/local-cluster-runner/examples/three_nodes.rs
@@ -19,7 +19,6 @@ use restate_local_cluster_runner::{
 use restate_types::config::{Configuration, LogFormat};
 use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::logs::metadata::ProviderKind::Replicated;
-use std::num::NonZeroU16;
 use std::pin::pin;
 use std::time::Duration;
 use tracing::{error, info};
@@ -29,7 +28,7 @@ fn main() -> anyhow::Result<()> {
     let mut base_config = Configuration::default();
     base_config.common.log_format = LogFormat::Compact;
     base_config.common.log_filter = "warn,restate=debug".to_string();
-    base_config.common.default_num_partitions = NonZeroU16::new(4).unwrap();
+    base_config.common.default_num_partitions = 4;
     base_config.bifrost.default_provider = Replicated;
 
     let config = ConfigLoaderBuilder::default()

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,7 +16,6 @@ mod roles;
 use anyhow::Context;
 use bytestring::ByteString;
 use prost_dto::IntoProst;
-use std::num::NonZeroU16;
 use tracing::{debug, error, info, trace, warn};
 
 use codederror::CodedError;
@@ -584,15 +583,10 @@ impl Node {
 #[derive(Clone, Debug, IntoProst)]
 #[prost(target = "restate_types::protobuf::cluster::ClusterConfiguration")]
 pub struct ClusterConfiguration {
-    #[into_prost(map = "num_partitions_to_u32")]
-    pub num_partitions: NonZeroU16,
+    pub num_partitions: u16,
     pub partition_replication: PartitionReplication,
     #[prost(required)]
     pub bifrost_provider: ProviderConfiguration,
-}
-
-fn num_partitions_to_u32(num_partitions: NonZeroU16) -> u32 {
-    u32::from(num_partitions.get())
 }
 
 impl ClusterConfiguration {
@@ -676,7 +670,7 @@ fn generate_initial_metadata(
 ) -> (NodesConfiguration, PartitionTable, Logs) {
     let mut initial_partition_table_builder = PartitionTableBuilder::default();
     initial_partition_table_builder
-        .with_equally_sized_partitions(cluster_configuration.num_partitions.get())
+        .with_equally_sized_partitions(cluster_configuration.num_partitions)
         .expect("Empty partition table should not have conflicts");
     initial_partition_table_builder
         .set_partition_replication(cluster_configuration.partition_replication.clone());

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp::max_by_key;
-use std::num::NonZeroU16;
 
 use anyhow::Context;
 use bytes::BytesMut;
@@ -64,10 +63,6 @@ impl NodeCtlSvcHandler {
             .map(|num_partitions| {
                 u16::try_from(num_partitions)
                     .context("Restate only supports running up to 65535 partitions.")
-                    .and_then(|num_partitions| {
-                        NonZeroU16::try_from(num_partitions)
-                            .context("The number of partitions needs to be > 0")
-                    })
             })
             .transpose()?
             .unwrap_or(config.common.default_num_partitions);

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -12,8 +12,8 @@ use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use serde::{Deserialize, Deserializer, Serialize};
-use serde_with::{DeserializeAs, serde_as};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use restate_serde_util::{ByteCount, NonZeroByteCount};
 use tracing::warn;
@@ -295,7 +295,7 @@ pub struct ReplicatedLogletOptions {
     // Also allow to specify the replication property as non-zero u8 value to make it simpler to
     // pass it in via an env variable.
     #[serde_as(
-        as = "serde_with::PickFirst<(serde_with::DisplayFromStr, ReplicationPropertyFromNonZeroU8)>"
+        as = "serde_with::PickFirst<(serde_with::DisplayFromStr, crate::replication::ReplicationPropertyFromNonZeroU8)>"
     )]
     #[serde(default = "default_log_replication")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
@@ -316,18 +316,6 @@ pub struct ReplicatedLogletOptions {
     // hide the configuration option by excluding it from the Json schema
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub default_nodeset_size: NodeSetSize,
-}
-
-/// Helper struct to support deserializing the ReplicationProperty from a [`NonZeroU8`].
-struct ReplicationPropertyFromNonZeroU8;
-
-impl<'de> DeserializeAs<'de, ReplicationProperty> for ReplicationPropertyFromNonZeroU8 {
-    fn deserialize_as<D>(deserializer: D) -> Result<ReplicationProperty, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        NonZeroU8::deserialize(deserializer).map(ReplicationProperty::new)
-    }
 }
 
 fn nodeset_size_is_zero(i: &NodeSetSize) -> bool {

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::LazyLock;
@@ -136,7 +136,7 @@ pub struct CommonOptions {
     /// NOTE 2: This will be renamed to `default-num-partitions` by default as of v1.3+
     ///
     /// Default: 24
-    pub default_num_partitions: NonZeroU16,
+    pub default_num_partitions: u16,
 
     /// # Shutdown grace timeout
     ///
@@ -414,7 +414,7 @@ impl Default for CommonOptions {
             metadata_client: MetadataClientOptions::default(),
             bind_address: None,
             advertised_address: AdvertisedAddress::from_str(DEFAULT_ADVERTISED_ADDRESS).unwrap(),
-            default_num_partitions: NonZeroU16::new(24).expect("is not zero"),
+            default_num_partitions: 24,
             histogram_inactivity_timeout: None,
             disable_prometheus: false,
             service_client: Default::default(),
@@ -856,9 +856,9 @@ pub struct CommonOptionsShadow {
     // todo drop in version 1.3
     allow_bootstrap: Option<bool>,
 
-    default_num_partitions: NonZeroU16,
+    default_num_partitions: u16,
     // todo drop in version 1.3
-    bootstrap_num_partitions: Option<NonZeroU16>,
+    bootstrap_num_partitions: Option<u16>,
 }
 
 impl From<CommonOptionsShadow> for CommonOptions {

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -233,7 +233,7 @@ pub struct StorageOptions {
 
     /// How many partitions to divide memory across?
     ///
-    /// By default this uses the value defined in `bootstrap-num-partitions` in the common section of
+    /// By default this uses the value defined in `default-num-partitions` in the common section of
     /// the config.
     #[serde(skip_serializing_if = "Option::is_none")]
     num_partitions_to_share_memory_budget: Option<NonZeroU16>,
@@ -280,7 +280,14 @@ impl StorageOptions {
     pub fn apply_common(&mut self, common: &CommonOptions) {
         self.rocksdb.apply_common(&common.rocksdb);
         if self.num_partitions_to_share_memory_budget.is_none() {
-            self.num_partitions_to_share_memory_budget = Some(common.default_num_partitions)
+            self.num_partitions_to_share_memory_budget = Some(
+                NonZeroU16::new(common.default_num_partitions)
+                    // todo add support for configuring the memory budget after the system has
+                    //  been started.
+                    // In the absence of a configured number of default partitions, we default to
+                    // its default value of 24 partitions. This is not great :-(
+                    .unwrap_or(NonZeroU16::new(24).expect("to be non zero")),
+            )
         }
 
         // todo: move to a shared struct and deduplicate

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use std::ops::RangeInclusive;
 
-use serde_with::{DisplayFromStr, serde_as};
+use serde_with::serde_as;
 
 use crate::identifiers::{PartitionId, PartitionKey};
 use crate::logs::LogId;
@@ -58,7 +58,12 @@ pub enum PartitionReplication {
     /// Replication of partitions is limited to the specified replication property.
     /// for example a replication property of `{node: 2}` will run
     /// each partition on maximum of two nodes (one leader, and one follower)
-    Limit(#[serde_as(as = "DisplayFromStr")] ReplicationProperty),
+    Limit(
+        #[serde_as(
+            as = "serde_with::PickFirst<(serde_with::DisplayFromStr, crate::replication::ReplicationPropertyFromNonZeroU8)>"
+        )]
+        ReplicationProperty,
+    ),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/types/src/replication/replication_property.rs
+++ b/crates/types/src/replication/replication_property.rs
@@ -14,10 +14,11 @@ use std::num::NonZeroU8;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+use crate::locality::LocationScope;
 use anyhow::Context;
 use regex::Regex;
-
-use crate::locality::LocationScope;
+use serde::{Deserialize, Deserializer};
+use serde_with::DeserializeAs;
 
 static REPLICATION_PROPERTY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
@@ -221,6 +222,18 @@ impl FromStr for ReplicationProperty {
 
         replication_property
             .ok_or_else(|| anyhow::anyhow!("No replication property scopes defined"))
+    }
+}
+
+/// Helper struct to support deserializing the ReplicationProperty from a [`NonZeroU8`].
+pub struct ReplicationPropertyFromNonZeroU8;
+
+impl<'de> DeserializeAs<'de, ReplicationProperty> for ReplicationPropertyFromNonZeroU8 {
+    fn deserialize_as<D>(deserializer: D) -> Result<ReplicationProperty, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        NonZeroU8::deserialize(deserializer).map(ReplicationProperty::new)
     }
 }
 

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -30,7 +30,7 @@ use restate_types::partition_table::PartitionReplication;
 use restate_types::replication::ReplicationProperty;
 use restate_types::{config::Configuration, nodes_config::Role};
 use std::convert::Infallible;
-use std::num::{NonZeroU8, NonZeroU16, NonZeroUsize};
+use std::num::{NonZeroU8, NonZeroUsize};
 use std::time::{Duration, Instant};
 use tokio::sync::{oneshot, watch};
 use tracing::{debug, info};
@@ -42,7 +42,7 @@ async fn replicated_loglet() -> googletest::Result<()> {
     let mut base_config = Configuration::default();
     // require an explicit provision step to configure the replication property to 2
     base_config.common.auto_provision = false;
-    base_config.common.default_num_partitions = NonZeroU16::new(1).expect("1 to be non-zero");
+    base_config.common.default_num_partitions = 1;
 
     let nodes = Node::new_test_nodes(
         base_config.clone(),
@@ -100,7 +100,7 @@ async fn cluster_chaos_test() -> googletest::Result<()> {
             raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
             ..RaftOptions::default()
         }));
-    base_config.common.default_num_partitions = NonZeroU16::new(4).expect("to be non-zero");
+    base_config.common.default_num_partitions = 4;
     base_config.bifrost.default_provider = ProviderKind::Replicated;
     base_config
         .bifrost

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -20,7 +20,6 @@ use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind};
 use restate_types::replication::ReplicationProperty;
 use std::cmp::Ordering;
-use std::num::NonZeroU16;
 use tonic::Code;
 use tonic::codec::CompressionEncoding;
 
@@ -29,7 +28,7 @@ use tonic::codec::CompressionEncoding;
 pub struct ProvisionOpts {
     /// Number of partitions
     #[clap(long)]
-    num_partitions: Option<NonZeroU16>,
+    num_partitions: Option<u16>,
 
     /// Optional partition placement strategy. By default replicates
     /// partitions on all nodes. Accepts replication property
@@ -77,7 +76,7 @@ async fn provision_cluster(
 
     let request = ProvisionClusterRequest {
         dry_run: true,
-        num_partitions: provision_opts.num_partitions.map(|n| u32::from(n.get())),
+        num_partitions: provision_opts.num_partitions.map(u32::from),
         partition_replication: provision_opts.partition_replication.clone().map(Into::into),
         log_provider: provision_opts
             .log_provider


### PR DESCRIPTION
This commit allows to configure 0 partitions when starting/provisioning the
cluster. This will implicitly create an empty PartitionTable which keeps the
cluster controller from provisioning any logs and partition processors. This
will only start once the cluster is configured with a non-zero number of partitions
via restatectl config set. Note that it is not possible to change the number
of partitions after a non-zero value was configured.