### PR TITLE
Set replicated loglet and replicate metadata server as the defaults for 1.3.0

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -169,7 +169,7 @@ pub fn restate_configuration() -> Configuration {
         .expect("building worker options should work");
 
     let metadata_server_options = MetadataServerOptionsBuilder::default()
-        .kind(Some(MetadataServerKind::Raft(RaftOptions::default())))
+        .kind(MetadataServerKind::Raft(RaftOptions::default()))
         .build()
         .expect("building metadata server options should work");
 

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -34,7 +34,7 @@ use super::{CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
 pub struct BifrostOptions {
     /// # The default kind of loglet to be used
     ///
-    /// Default: Local
+    /// Default: Replicated
     pub default_provider: ProviderKind,
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     /// Configuration of local loglet provider
@@ -101,7 +101,7 @@ impl BifrostOptions {
 impl Default for BifrostOptions {
     fn default() -> Self {
         Self {
-            default_provider: ProviderKind::Local,
+            default_provider: ProviderKind::Replicated,
             replicated_loglet: ReplicatedLogletOptions::default(),
             local: LocalLogletOptions::default(),
             read_retry_policy: RetryPolicy::exponential(

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -58,12 +58,13 @@ pub struct MetadataServerOptions {
     /// Type of metadata server to start
     ///
     /// The type of metadata server to start when running the metadata store role.
-    // defined as Option<_> for backward compatibility with version < v1.2
+    ///
+    /// Default: replicated
     #[serde(flatten)]
-    kind: Option<MetadataServerKind>,
+    kind: MetadataServerKind,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, derive_more::Display)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, derive_more::Display)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
@@ -71,7 +72,6 @@ pub struct MetadataServerOptions {
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MetadataServerKind {
-    #[default]
     #[display("local")]
     Local,
     // make the Raft based metadata server primarily known as the replicated metadata server
@@ -82,11 +82,11 @@ pub enum MetadataServerKind {
 
 impl MetadataServerOptions {
     pub fn kind(&self) -> MetadataServerKind {
-        self.kind.clone().unwrap_or_default()
+        self.kind.clone()
     }
 
     pub fn set_kind(&mut self, kind: MetadataServerKind) {
-        self.kind = Some(kind);
+        self.kind = kind;
     }
 
     pub fn apply_common(&mut self, common: &CommonOptions) {
@@ -133,7 +133,7 @@ impl Default for MetadataServerOptions {
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.01,
             rocksdb,
-            kind: Some(MetadataServerKind::default()),
+            kind: MetadataServerKind::Raft(RaftOptions::default()),
         }
     }
 }


### PR DESCRIPTION
This commit changes the default loglet provider from local to replicated. Moreover, it changes the default metadata server kind from local to replicated as well.

This fixes #2970.