### PR TITLE
restatectl built in lambda handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda_runtime"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "http-serde",
+ "hyper 1.6.0",
+ "hyper-util",
+ "lambda_runtime_api_client",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tracing",
+]
+
+[[package]]
+name = "lambda_runtime_api_client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90a10f094475a34a04da2be11686c4dcfe214d93413162db9ffdff3d3af293a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lazy-regex"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7850,6 +7899,7 @@ dependencies = [
  "humantime",
  "itertools 0.14.0",
  "json-patch",
+ "lambda_runtime",
  "prost-types",
  "rand 0.9.0",
  "restate-admin",

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -52,6 +52,7 @@ futures-util = { workspace = true }
 itertools = { workspace = true }
 json-patch = "2.0.0"
 humantime = { workspace = true }
+lambda_runtime = "0.13.0"
 prost-types = { workspace = true }
 rand = { workspace = true }
 rlimit = { workspace = true }

--- a/tools/restatectl/src/lambda.rs
+++ b/tools/restatectl/src/lambda.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+use lambda_runtime::LambdaEvent;
+
+#[derive(serde::Deserialize)]
+struct Request {
+    args: Vec<String>,
+    #[serde(default)]
+    env: Option<HashMap<String, String>>,
+}
+
+#[derive(serde::Serialize)]
+struct Response {
+    status: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// Turn this binary into a valid lambda bootstrap binary - if lambda environment variables are present,
+/// and the executable name is 'bootstrap' (required by lambda anyway), then instead of executing the CLI
+/// as normal, we will start a lambda handler which can then exec itself without lambda environment variables
+/// to trigger normal restatectl operations.
+///
+/// To use, simply put a restatectl binary named 'bootstrap' into a zip and upload it as a lambda.
+pub async fn handle_lambda_if_needed() {
+    if std::env::var("AWS_LAMBDA_FUNCTION_NAME").is_err() {
+        return;
+    }
+
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+
+    let Some("bootstrap") = exe.file_name().and_then(std::ffi::OsStr::to_str) else {
+        return;
+    };
+
+    let func = lambda_runtime::service_fn(|event: LambdaEvent<Request>| async {
+        eprintln!("Executing restatectl {}", event.payload.args.join(" "));
+
+        let mut cmd = tokio::process::Command::new(exe.as_os_str());
+
+        cmd.args(event.payload.args);
+
+        for (key, value) in event.payload.env.unwrap_or_default() {
+            cmd.env(key, value);
+        }
+
+        cmd.env_remove("AWS_LAMBDA_FUNCTION_NAME"); // so that we don't just hit this code path again
+
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let child = cmd.spawn()?;
+        let output = child.wait_with_output().await?;
+
+        let status = output.status.code().unwrap_or(-1);
+        let stdout = String::from_utf8_lossy(&output.stdout).into();
+        let stderr = String::from_utf8_lossy(&output.stderr).into();
+
+        eprintln!("Exit status {status}");
+        eprintln!("STDERR: {stderr}");
+        eprintln!("STDOUT: {stdout}");
+
+        Result::<Response, Error>::Ok(Response {
+            status,
+            stdout,
+            stderr,
+        })
+    });
+
+    match lambda_runtime::run(func).await {
+        Ok(()) => std::process::exit(0),
+        Err(err) => {
+            eprintln!("Failed to run lambda handler: {err}");
+            std::process::exit(1)
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
+}
+
+impl From<Error> for lambda_runtime::Diagnostic {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::IO(err) => Self {
+                error_type: "IO".into(),
+                error_message: err.to_string(),
+            },
+        }
+    }
+}

--- a/tools/restatectl/src/lib.rs
+++ b/tools/restatectl/src/lib.rs
@@ -15,3 +15,4 @@ pub use app::CliApp;
 mod build_info;
 pub(crate) mod connection;
 pub(crate) mod environment;
+pub mod lambda;

--- a/tools/restatectl/src/main.rs
+++ b/tools/restatectl/src/main.rs
@@ -17,6 +17,8 @@ use restatectl::CliApp;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> ClingFinished<CliApp> {
+    restatectl::lambda::handle_lambda_if_needed().await;
+
     let _ = ctrlc::set_handler(move || {
         // Showing cursor again if it was hidden by dialoguer.
         let mut stdout = std::io::stdout();


### PR DESCRIPTION
This makes it possible to literally use restatectl as the bootstrap binary for a lambda function, such that you can expose its operations over lambda without having to deploy any other code.