### PR TITLE
Avoid unnecessary log rewrites

### DIFF
--- a/crates/types/src/logs/builder.rs
+++ b/crates/types/src/logs/builder.rs
@@ -151,23 +151,26 @@ impl ChainBuilder<'_> {
         };
 
         let remaining = self.inner.chain.split_off(&found_base_lsn);
-        for loglet_config in self.inner.chain.values() {
-            if let ProviderKind::Replicated = loglet_config.kind {
-                // if it was inserted correctly before, we shouldn't fail to deserialize it.
-                // validation happens at original insert time.
-                let params =
-                    ReplicatedLogletParams::deserialize_from(loglet_config.params.as_bytes())
-                        .expect("params should be deserializable");
-                self.lookup_index.rm_replicated_loglet_reference(
-                    self.log_id,
-                    loglet_config.index(),
-                    params.loglet_id,
-                );
+        if !self.inner.chain.is_empty() {
+            *self.modified = true;
+
+            for loglet_config in self.inner.chain.values() {
+                if let ProviderKind::Replicated = loglet_config.kind {
+                    // if it was inserted correctly before, we shouldn't fail to deserialize it.
+                    // validation happens at original insert time.
+                    let params =
+                        ReplicatedLogletParams::deserialize_from(loglet_config.params.as_bytes())
+                            .expect("params should be deserializable");
+                    self.lookup_index.rm_replicated_loglet_reference(
+                        self.log_id,
+                        loglet_config.index(),
+                        params.loglet_id,
+                    );
+                }
             }
         }
 
         self.inner.chain = remaining;
-        *self.modified = true;
     }
 
     /// `base_lsn` must be higher than all previous base_lsns.


### PR DESCRIPTION
Currently we can thrash the log version when trying to trim the same lsn repeatedly; as long as that lsn is inside an untrimmed segment, we will keep doing bifrost_config writes, with the same data.

~As another nice to have, lets use ordered map for the logs, so that the serialised logs is an ordered array instead of a random array on every update.~