### PR TITLE
[LogServer] Introduce "Gone" storage state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9345,6 +9345,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -10497,6 +10498,8 @@ dependencies = [
  "uuid",
  "zerocopy 0.7.35",
  "zeroize",
+ "zstd 0.13.2",
+ "zstd-safe 7.2.1",
  "zstd-sys",
 ]
 

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -340,6 +340,7 @@ pub fn logserver_candidate_filter(_node_id: PlainNodeId, config: &NodeConfig) ->
         StorageState::Provisioning
         | StorageState::Disabled
         | StorageState::ReadOnly
+        | StorageState::Gone
         | StorageState::DataLoss => false,
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,7 +62,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tokio-util = { workspace = true, features = ["net"] }
-tonic = { workspace = true, features = [ "transport", "codegen", "prost", "gzip", ] }
+tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip", "zstd"] }
 tonic-reflection = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -240,11 +240,6 @@ impl Connection {
         conn_tracker: impl ConnectionTracking + Send + Sync + 'static,
         peer_router: impl PeerRouting + Clone + Send + Sync + 'static,
     ) -> Result<(Connection, TaskId), ConnectError> {
-        let Destination::Node(node_id) = destination else {
-            unimplemented!("connecting to anonymous nodes is not supported yet");
-        };
-
-        debug!(%direction, "Connecting to {}", node_id);
         let metadata = Metadata::current();
         let my_node_id = metadata.my_node_id_opt();
         let nodes_config = metadata.nodes_config_snapshot();
@@ -267,9 +262,7 @@ impl Connection {
             .unwrap();
 
         // Establish the connection
-        let mut incoming = transport_connector
-            .connect(node_id, &nodes_config, egress)
-            .await?;
+        let mut incoming = transport_connector.connect(&destination, egress).await?;
 
         // finish the handshake
         let (header, welcome) = wait_for_welcome(
@@ -295,12 +288,14 @@ impl Connection {
             .into();
 
         // we expect the node to identify itself as the same NodeId we think we are connecting to.
-        if peer_node_id != node_id {
-            // Node claims that it's someone else!
-            return Err(HandshakeError::Failed(
-                "Node returned an unexpected GenerationalNodeId in Welcome message.".to_owned(),
-            )
-            .into());
+        if let Destination::Node(destination_node_id) = destination {
+            if peer_node_id != destination_node_id {
+                // Node claims that it's someone else!
+                return Err(HandshakeError::Failed(
+                    "Node returned an unexpected GenerationalNodeId in Welcome message.".to_owned(),
+                )
+                .into());
+            }
         }
 
         let connection = Connection::new(peer_node_id, protocol_version, tx);
@@ -707,7 +702,6 @@ pub mod test_util {
 
     // Represents a partially connected peer connection in test environment. A connection must be
     // handshaken in order to be converted into MockPeerConnection.
-    //
     // This is used to represent an outgoing connection from (`peer` to `my_node_id`)
     #[derive(derive_more::Debug)]
     pub struct PartialPeerConnection {

--- a/crates/core/src/network/grpc/connector.rs
+++ b/crates/core/src/network/grpc/connector.rs
@@ -9,42 +9,113 @@
 // by the Apache License, Version 2.0.
 
 use futures::Stream;
+use http::Uri;
+use hyper_util::rt::TokioIo;
+use tokio::io;
+use tokio::net::UnixStream;
 use tokio_stream::StreamExt;
+use tonic::codec::CompressionEncoding;
+use tonic::transport::channel::Channel;
 
-use restate_types::GenerationalNodeId;
-use restate_types::config::Configuration;
-use restate_types::nodes_config::NodesConfiguration;
-use tracing::trace;
+use restate_types::config::{Configuration, NetworkingOptions};
+use restate_types::net::AdvertisedAddress;
+use tonic::transport::Endpoint;
+use tracing::debug;
 
 use super::MAX_MESSAGE_SIZE;
-use crate::network::net_util::create_tonic_channel;
 use crate::network::protobuf::core_node_svc::core_node_svc_client::CoreNodeSvcClient;
 use crate::network::protobuf::network::Message;
 use crate::network::transport_connector::find_node;
-use crate::network::{ConnectError, TransportConnect};
+use crate::network::{ConnectError, Destination, TransportConnect};
+use crate::{Metadata, TaskCenter, TaskKind};
 
 #[derive(Clone, Default)]
 pub struct GrpcConnector {
+    // todo: cache channels for the same address
     _private: (),
 }
 
 impl TransportConnect for GrpcConnector {
     async fn connect(
         &self,
-        node_id: GenerationalNodeId,
-        nodes_config: &NodesConfiguration,
+        destination: &Destination,
         output_stream: impl Stream<Item = Message> + Send + Unpin + 'static,
     ) -> Result<impl Stream<Item = Message> + Send + Unpin + 'static, ConnectError> {
-        let address = find_node(nodes_config, node_id)?.address.clone();
+        let address = match destination {
+            Destination::Node(node_id) => {
+                find_node(&Metadata::with_current(|m| m.nodes_config_ref()), *node_id)?
+                    .address
+                    .clone()
+            }
+            Destination::Address(address) => address.clone(),
+        };
 
-        trace!("Attempting to connect to node {} at {}", node_id, address);
-        let channel = create_tonic_channel(address, &Configuration::pinned().networking);
+        debug!("Connecting to {} at {}", destination, address);
+        let channel = create_channel(address, &Configuration::pinned().networking);
 
         // Establish the connection
         let mut client = CoreNodeSvcClient::new(channel)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
-            .max_decoding_message_size(MAX_MESSAGE_SIZE);
+            .max_decoding_message_size(MAX_MESSAGE_SIZE)
+            // note: the order of those calls defines the priority
+            .accept_compressed(CompressionEncoding::Zstd)
+            .accept_compressed(CompressionEncoding::Gzip)
+            .send_compressed(CompressionEncoding::Zstd)
+            .send_compressed(CompressionEncoding::Gzip);
         let incoming = client.create_connection(output_stream).await?.into_inner();
         Ok(incoming.map_while(|x| x.ok()))
+    }
+}
+
+fn create_channel(address: AdvertisedAddress, options: &NetworkingOptions) -> Channel {
+    let endpoint = match &address {
+        AdvertisedAddress::Uds(_) => {
+            // dummy endpoint required to specify an uds connector, it is not used anywhere
+            Endpoint::try_from("http://127.0.0.1").expect("/ should be a valid Uri")
+        }
+        AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()).executor(TaskCenterExecutor),
+    };
+
+    let endpoint = endpoint
+        .user_agent(format!(
+            "restate/{}",
+            option_env!("CARGO_PKG_VERSION").unwrap_or("dev")
+        ))
+        .unwrap()
+        .connect_timeout(*options.connect_timeout)
+        .http2_keep_alive_interval(*options.http2_keep_alive_interval)
+        .keep_alive_timeout(*options.http2_keep_alive_timeout)
+        .http2_adaptive_window(options.http2_adaptive_window)
+        .keep_alive_while_idle(true)
+        // this true by default, but this is to guard against any change in defaults
+        .tcp_nodelay(true);
+
+    match address {
+        AdvertisedAddress::Uds(uds_path) => {
+            endpoint.connect_with_connector_lazy(tower::service_fn(move |_: Uri| {
+                let uds_path = uds_path.clone();
+                async move {
+                    Ok::<_, io::Error>(TokioIo::new(UnixStream::connect(uds_path).await?))
+                }
+            }))
+        }
+        AdvertisedAddress::Http(_) => endpoint.connect_lazy()
+    }
+}
+
+#[derive(Clone, Default)]
+struct TaskCenterExecutor;
+
+impl<F> hyper::rt::Executor<F> for TaskCenterExecutor
+where
+    F: Future + 'static + Send,
+    F::Output: Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        let _ = TaskCenter::spawn_child(TaskKind::H2Stream, "h2stream", async move {
+            // ignore the future output
+            let _ = fut.await;
+            Ok(())
+        });
     }
 }

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -34,7 +34,10 @@ impl CoreNodeSvcHandler {
         CoreNodeSvcServer::new(self)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
             .max_encoding_message_size(MAX_MESSAGE_SIZE)
+            // note: the order of those calls defines the priority
+            .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)
+            .send_compressed(CompressionEncoding::Zstd)
             .send_compressed(CompressionEncoding::Gzip)
     }
 }

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -40,7 +40,6 @@ pub fn create_tonic_channel<T: CommonClientConnectionOptions + Send + Sync + ?Si
             // dummy endpoint required to specify an uds connector, it is not used anywhere
             Endpoint::try_from("http://127.0.0.1").expect("/ should be a valid Uri")
         }
-        // todo: running this on TaskCenterExecutor was previously removed due to use in restatectl (#2919)
         AdvertisedAddress::Http(uri) => Channel::builder(uri.clone()),
     };
 

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -229,7 +229,7 @@ impl LogServerService {
                     my_node_id.as_plain(),
                 ));
             }
-            StorageState::ReadWrite | StorageState::ReadOnly => {}
+            StorageState::ReadWrite | StorageState::ReadOnly | StorageState::Gone => {}
         }
 
         debug!("My storage state: {:?}", my_storage_state);

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -377,6 +377,14 @@ pub enum StorageState {
     ReadOnly,
 
     // [authoritative]
+    /// Gone is logically equivalent to ReadOnly but it signifies that the node has been
+    /// permanently lost along with all the data it might have had.
+    /// Future versions of restate can decide to not even attempt to read from Gone nodes.
+    ///
+    /// - new node sets: **excluded**
+    Gone,
+
+    // [authoritative]
     /// Can be picked up in new write sets and accepts writes in existing write sets.
     ///
     /// - should read from: **yes**
@@ -401,7 +409,7 @@ impl StorageState {
     pub fn can_write_to(&self) -> bool {
         use StorageState::*;
         match self {
-            Provisioning | Disabled | ReadOnly | DataLoss => false,
+            Provisioning | Disabled | ReadOnly | Gone | DataLoss => false,
             ReadWrite => true,
         }
     }
@@ -410,7 +418,7 @@ impl StorageState {
     pub fn can_read_from(&self) -> bool {
         use StorageState::*;
         match self {
-            Provisioning | ReadOnly | ReadWrite | DataLoss => true,
+            Provisioning | ReadOnly | Gone | ReadWrite | DataLoss => true,
             Disabled => false,
         }
     }
@@ -419,7 +427,7 @@ impl StorageState {
         use StorageState::*;
         match self {
             DataLoss => false,
-            Disabled | Provisioning | ReadOnly | ReadWrite => true,
+            Disabled | Provisioning | ReadOnly | Gone | ReadWrite => true,
         }
     }
 

--- a/tools/restatectl/src/commands/node/disable_node_checker.rs
+++ b/tools/restatectl/src/commands/node/disable_node_checker.rs
@@ -92,7 +92,10 @@ impl<'a, 'b> DisableNodeChecker<'a, 'b> {
             // it's safe to disable a disabled node
             StorageState::Disabled => return Ok(()),
             // we need to check whether this node is no longer part of any known node sets
-            StorageState::ReadOnly | StorageState::DataLoss | StorageState::Provisioning => {}
+            StorageState::ReadOnly
+            | StorageState::Gone
+            | StorageState::DataLoss
+            | StorageState::Provisioning => {}
         }
 
         // if the default provider kind is local or in-memory than it is not safe to disable the

--- a/tools/restatectl/src/commands/replicated_loglet/mod.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/mod.rs
@@ -36,6 +36,7 @@ fn render_storage_state(state: StorageState) -> Cell {
     match state {
         StorageState::ReadWrite => cell.fg(Color::Green),
         StorageState::ReadOnly => cell.fg(Color::Yellow),
+        StorageState::Gone => cell.fg(Color::Yellow),
         StorageState::DataLoss => cell.fg(Color::Red),
         StorageState::Provisioning => cell.fg(Color::Reset),
         StorageState::Disabled => cell.fg(Color::Grey),

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -107,7 +107,7 @@ tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io-util", "net", "rt"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.22", features = ["serde"] }
-tonic = { version = "0.12", features = ["gzip", "tls-roots"] }
+tonic = { version = "0.12", features = ["gzip", "tls-roots", "zstd"] }
 tower-9fbad63c4bcf4a8f = { package = "tower", version = "0.4", features = ["balance", "buffer", "limit", "retry", "timeout", "util"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["limit", "load-shed", "log", "make", "util"] }
 tower-http = { version = "0.6", default-features = false, features = ["cors", "normalize-path", "trace"] }
@@ -120,6 +120,8 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4", "v7"] }
 zerocopy = { version = "0.7", features = ["derive", "simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
 
 [build-dependencies]
@@ -218,7 +220,7 @@ tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io-util", "net", "rt"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.22", features = ["serde"] }
-tonic = { version = "0.12", features = ["gzip", "tls-roots"] }
+tonic = { version = "0.12", features = ["gzip", "tls-roots", "zstd"] }
 tower-9fbad63c4bcf4a8f = { package = "tower", version = "0.4", features = ["balance", "buffer", "limit", "retry", "timeout", "util"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["limit", "load-shed", "log", "make", "util"] }
 tower-http = { version = "0.6", default-features = false, features = ["cors", "normalize-path", "trace"] }
@@ -231,6 +233,8 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4", "v7"] }
 zerocopy = { version = "0.7", features = ["derive", "simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]


### PR DESCRIPTION

This introduces a new storage state "gone" that's logically equivalent to read-only in this release. It's not meant to be used until v1.4 is released, so avoid clobbering by previous versions.
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/2984).
* #2993
* __->__ #2984
* #2860