### PR TITLE
Add basic Grafana + Prometheus cloud init script

### DIFF
--- a/scripts/loadtest-environment/README.md
+++ b/scripts/loadtest-environment/README.md
@@ -12,4 +12,6 @@ This will create a file `cdk-outputs.json` which contains some useful output par
 
 To connect to your EC2 instance, you can use `ssh -i private-key.pem -l ubuntu ${node-public-ip}` or alternatively `aws ssm start-session --target <instance-id>`. You can find some predefined load tests in the `tests` directory. You can find some standard restate-server configurations in the `config` directory.
 
+The Grafana default username / password will be `admin` / `admin`.
+
 If you want to temporarily suspend the machine, you can do so with `aws ec2 stop-instances --instance-ids <instance-id>` and later re-start it. You will still pay for the associated EBS volumes even while the instance is stopped. Note that the contents of any local NVMe devices will be wiped if you do so. Tear down the stack using `npx cdk destroy` when you are done with it.

--- a/scripts/loadtest-environment/lib/loadtest-environment-stack.ts
+++ b/scripts/loadtest-environment/lib/loadtest-environment-stack.ts
@@ -65,6 +65,7 @@ export class LoadTestEnvironmentStack extends cdk.Stack {
       description: "Restate servers",
     });
 
+    const nodes: ec2.Instance[] = [];
     const subnets = vpc.publicSubnets;
     for (let n = 1; n <= 3; n++) {
       const node = new ec2.Instance(this, `N${n}`, {
@@ -88,13 +89,6 @@ export class LoadTestEnvironmentStack extends cdk.Stack {
               volumeType: ec2.EbsDeviceVolumeType.GP2,
             }),
           },
-          // {
-          //   deviceName: "/dev/sdb",
-          //   volume: {
-          //     ebsDevice: props.ebsVolume,
-          //     virtualName: "restate-data",
-          //   },
-          // },
         ],
         userData,
         keyPair,
@@ -103,33 +97,46 @@ export class LoadTestEnvironmentStack extends cdk.Stack {
       new cdk.CfnOutput(this, `InstanceId${n}`, { value: node.instanceId });
       new cdk.CfnOutput(this, `Node${n}`, { value: node.instancePublicDnsName });
       new cdk.CfnOutput(this, `NodeInternalIpAddress${n}`, { value: node.instancePrivateIp });
+      nodes.push(node); // NB: they will be zero-based here!
     }
 
-    // todo: replace the IPs below with the NodeInternalIpAddress${N} outputs
-    /*
-      wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-      add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
-      apt update && apt install grafana prometheus
+    // Cloud init script. To run on every boot, make sure it's idempotent and change `once` to `always` below.
+    const grafanaInitScript = ec2.UserData.forLinux();
+    grafanaInitScript.addCommands(
+      "wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -",
+      'add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"',
+      "apt-get update",
+      "apt-get install --yes grafana prometheus",
+      "",
+      "cat << EOF >> /etc/prometheus/prometheus.yml",
+      "",
+      `
+  - job_name: 'restate-cluster-nodes'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['${nodes[0].instancePrivateIp}:9100']
+      - targets: ['${nodes[1].instancePrivateIp}:9100']
+      - targets: ['${nodes[2].instancePrivateIp}:9100']
 
-      cat > /etc/prometheus/prometheus.yml <<EOF
+  - job_name: 'restate-cluster-restate'
+    metrics_path: '/metrics'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['${nodes[0].instancePrivateIp}:5122']
+      - targets: ['${nodes[1].instancePrivateIp}:5122']
+      - targets: ['${nodes[2].instancePrivateIp}:5122']
+`,
+      "EOF",
+      "",
+      "systemctl restart grafana-server",
+      "systemctl restart prometheus",
+    );
 
-        - job_name: 'restate-cluster-nodes'
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['172.31.34.171:9100']
-            - targets: ['172.31.1.249:9100']
-            - targets: ['172.31.28.10:9100']
+    const grafanaCloudConfig = ec2.UserData.custom([`cloud_final_modules:`, `- [scripts-user, once]`].join("\n"));
+    const grafanaUserData = new ec2.MultipartUserData();
+    grafanaUserData.addUserDataPart(grafanaCloudConfig, "text/cloud-config");
+    grafanaUserData.addUserDataPart(grafanaInitScript, "text/x-shellscript");
 
-        - job_name: 'restate-cluster-restate'
-          metrics_path: '/metrics'
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['172.31.34.171:5122']
-            - targets: ['172.31.1.249:5122']
-            - targets: ['172.31.28.10:5122']
-      EOF
-      systemctl restart prometheus
-    */
     const grafanaInstanceType = ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.LARGE);
     const grafana = new ec2.Instance(this, `GrafanaInstance`, {
       instanceProfile,
@@ -149,9 +156,12 @@ export class LoadTestEnvironmentStack extends cdk.Stack {
           volume: ec2.BlockDeviceVolume.ebs(100),
         },
       ],
+      userData: grafanaUserData,
       keyPair,
     });
     grafana.addSecurityGroup(securityGroup);
+    new cdk.CfnOutput(this, "GrafanaNode", { value: grafana.instancePublicDnsName });
+    new cdk.CfnOutput(this, "GrafanaAddress", { value: `http://${grafana.instancePublicDnsName}:3000` });
 
     securityGroup.addIngressRule(securityGroup, ec2.Port.allTraffic());
     securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.allTraffic());


### PR DESCRIPTION
The grafana node cloud-init script doesn't work correctly, but running `/var/lib/cloud/instance/scripts/part-002` by hand once will fix it for now.