### PR TITLE
Establish parent relationship between an invocation and child calls

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -739,7 +739,7 @@ where
                                 headers: cmd.headers.into_iter().map(Into::into).collect(),
                                 key: cmd.key.into(),
                                 idempotency_key: cmd.idempotency_key.map(|s| s.into()),
-                                span_relation: parent_span_context.as_linked()
+                                span_relation: parent_span_context.as_parent()
                             }
                         )
                         .map_err(|e| InvokerError::CommandPrecondition(


### PR DESCRIPTION
Child calls should be in a parent relationship with their originating invocation and not only be linked to each other. This makes the traces more meaningful.