### PR TITLE
[RocksDB] Use zstd compression for all levels

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -142,12 +142,12 @@ fn cf_data_options(
         opts.set_num_levels(7);
 
         opts.set_compression_per_level(&[
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
             DBCompressionType::Zstd,
         ]);
 
@@ -192,9 +192,9 @@ fn cf_metadata_options(
         //
         opts.set_num_levels(3);
         opts.set_compression_per_level(&[
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
         ]);
         opts.set_memtable_whole_key_filtering(true);
         opts.set_max_write_buffer_number(4);

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -244,12 +244,12 @@ pub(crate) fn cf_options(
         //
         cf_options.set_num_levels(7);
         cf_options.set_compression_per_level(&[
-            DBCompressionType::None,
-            DBCompressionType::None,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
-            DBCompressionType::Lz4,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
             DBCompressionType::Zstd,
         ]);
 


### PR DESCRIPTION

In benchmarks, zstd added ~2-3% CPU but cut disk throughput by 50% and 30-40% less IOPS. It's a good trade-off for our use case. Additionally, this enables rocksdb to perform "trivial move" compactions across all levels.
