### PR TITLE
Properly handle unset partition-replication in restatectl

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -357,7 +357,8 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             .update_cluster_configuration(
                 cluster_configuration
                     .partition_replication
-                    .try_into()
+                    .map(TryInto::try_into)
+                    .transpose()
                     .map_err(|err| {
                         Status::invalid_argument(format!("invalid partition_replication: {err}"))
                     })?,

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -34,8 +34,9 @@ message ProvisionClusterRequest {
   bool dry_run = 1;
   // if unset then the configured cluster num partitions will be used
   optional uint32 num_partitions = 2;
-  // if unset partition replication will default to `everywhere`. Otherwise
-  // it's limited to the provided replication property
+  // if unset partition replication will default to
+  // `admin.default-partition-replication`. Otherwise it's limited to the
+  // provided replication property
   optional restate.cluster.ReplicationProperty partition_replication = 3;
   // if unset then the configured cluster default log provider will be used
   optional string log_provider = 4;

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -21,8 +21,8 @@ use restate_core::protobuf::node_ctl_svc::{
 use restate_metadata_server::grpc::new_metadata_server_client;
 use restate_types::config::{InvalidConfigurationError, MetadataServerKind, RaftOptions};
 use restate_types::logs::metadata::ProviderConfiguration;
-use restate_types::partition_table::PartitionReplication;
 use restate_types::protobuf::common::MetadataServerStatus;
+use restate_types::replication::ReplicationProperty;
 use restate_types::retries::RetryPolicy;
 use restate_types::{
     PlainNodeId,
@@ -817,7 +817,7 @@ impl StartedNode {
     pub async fn provision_cluster(
         &self,
         num_partitions: Option<NonZeroU16>,
-        partition_replication: PartitionReplication,
+        partition_replication: ReplicationProperty,
         provider_configuration: Option<ProviderConfiguration>,
     ) -> anyhow::Result<bool> {
         let channel = create_tonic_channel(
@@ -828,7 +828,7 @@ impl StartedNode {
         let request = ProtoProvisionClusterRequest {
             dry_run: false,
             num_partitions: num_partitions.map(|num| u32::from(num.get())),
-            partition_replication: partition_replication.into(),
+            partition_replication: Some(partition_replication.into()),
             log_provider: provider_configuration
                 .as_ref()
                 .map(|config| config.kind().to_string()),

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -114,19 +114,6 @@ pub mod cluster {
         }
     }
 
-    impl TryFrom<Option<ReplicationProperty>> for PartitionReplication {
-        type Error = anyhow::Error;
-
-        fn try_from(value: Option<ReplicationProperty>) -> Result<Self, Self::Error> {
-            Ok(value
-                .map(TryFrom::try_from)
-                .transpose()?
-                .map_or(PartitionReplication::Everywhere, |p| {
-                    PartitionReplication::Limit(p)
-                }))
-        }
-    }
-
     impl From<PartitionReplication> for Option<ReplicationProperty> {
         fn from(value: PartitionReplication) -> Self {
             match value {

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -26,7 +26,6 @@ use restate_types::config::{MetadataServerKind, RaftOptions};
 use restate_types::logs::metadata::{
     NodeSetSize, ProviderConfiguration, ProviderKind, ReplicatedLogletConfig,
 };
-use restate_types::partition_table::PartitionReplication;
 use restate_types::replication::ReplicationProperty;
 use restate_types::{config::Configuration, nodes_config::Role};
 use std::convert::Infallible;
@@ -72,7 +71,7 @@ async fn replicated_loglet() -> googletest::Result<()> {
     cluster.nodes[0]
         .provision_cluster(
             None,
-            PartitionReplication::Everywhere,
+            ReplicationProperty::new_unchecked(3),
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
         )
         .await
@@ -126,7 +125,7 @@ async fn cluster_chaos_test() -> googletest::Result<()> {
     cluster.nodes[0]
         .provision_cluster(
             None,
-            PartitionReplication::Everywhere,
+            ReplicationProperty::new_unchecked(3),
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
         )
         .await

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -15,7 +15,6 @@ use enumset::enum_set;
 use futures_util::StreamExt;
 use googletest::{IntoTestResult, fail};
 use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration, ReplicatedLogletConfig};
-use restate_types::partition_table::PartitionReplication;
 use restate_types::replication::ReplicationProperty;
 use tempfile::TempDir;
 use tokio::sync::oneshot;
@@ -83,7 +82,9 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
     cluster.nodes[0]
         .provision_cluster(
             None,
-            PartitionReplication::Everywhere,
+            // Since there is noway we can describe "everywhere" cluster replication
+            // we set the value directly to 3.
+            ReplicationProperty::new_unchecked(3),
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
         )
         .await

--- a/tools/restatectl/src/commands/config/set.rs
+++ b/tools/restatectl/src/commands/config/set.rs
@@ -70,9 +70,9 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
 
     let current_config_string = cluster_config_string(&current)?;
 
-    // todo: It's a bit confusing that not specifying the partition replication sets the partition
-    //  replication to everywhere. Everywhere should probably be an explicit value.
-    current.partition_replication = set_opts.partition_replication.clone().map(Into::into);
+    if let Some(replication_property) = &set_opts.partition_replication {
+        current.partition_replication = Some(replication_property.clone().into());
+    }
 
     set_opts.log_provider.inspect(|provider| {
         match provider {

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -28,9 +28,8 @@ pub struct ProvisionOpts {
     #[clap(long)]
     num_partitions: Option<u16>,
 
-    /// Optional partition placement strategy. By default replicates
-    /// partitions on all nodes. Accepts replication property
-    /// string as a value
+    /// Partition replication. If unset, uses
+    /// the default `admin.default-partition-replication`
     #[clap(long)]
     partition_replication: Option<ReplicationProperty>,
 


### PR DESCRIPTION
Properly handle unset partition-replication in restatectl

Summary:
Ensure correct behavior when the partition-replication flag is omitted in both provision and config set.
Previously, an unset flag defaulted to everywhere, which was incorrect.

- In provision, if the flag is omitted, the cluster defaults to the configured default-partition-replication.
 The user can override this by specifying a valid replication property.

 - In config set, omitting the flag leaves the current cluster configuration unchanged.
