### PR TITLE
Add support for ApiGatewayProxyResponses that don't specify headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7427,6 +7427,7 @@ dependencies = [
  "bytestring",
  "derive_builder",
  "futures",
+ "googletest",
  "h2 0.4.7",
  "http 1.2.0",
  "http-body-util",

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -56,4 +56,5 @@ aws-smithy-types = { workspace = true }
 pin-project-lite = { workspace = true }
 
 [dev-dependencies]
+googletest = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
I encountered this problem when using the `ServiceClient` for benchmarking arbitrary lambdas which seem to respond with `{"statusCode":200,"headers":null,"multiValueHeaders":null,"body":"foobar\n"}`.