### PR TITLE
Avoid AWS lambda retries

### DIFF
--- a/crates/service-client/src/lambda.rs
+++ b/crates/service-client/src/lambda.rs
@@ -105,6 +105,10 @@ impl LambdaClient {
 
             let lambda_client_builder = aws_sdk_lambda::config::Builder::from(&config);
 
+            // Restate has its own retry mechanisms, and the built in retry policy in this library could just confuse things
+            let lambda_client_builder =
+                lambda_client_builder.retry_config(aws_config::retry::RetryConfig::disabled());
+
             let lambda_client =
                 aws_sdk_lambda::Client::from_conf(lambda_client_builder.clone().build());
 


### PR DESCRIPTION
Currently there are multiple layers of retries, one inside the service client, then again at the invocation level. This differs from HTTP and is unnecessary.