### PR TITLE
Default global replication property

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
-use tracing::{Level, debug, enabled, info, instrument, trace};
+use tracing::{Level, debug, enabled, info, instrument, trace, warn};
 
 use restate_core::metadata_store::{ReadError, ReadWriteError, WriteError};
 use restate_core::network::{NetworkSender, Networking, Outgoing, TransportConnect};
@@ -296,11 +296,9 @@ impl<T: TransportConnect> Scheduler<T> {
                 target_state.node_set.extend(alive_workers.iter().cloned());
             }
             PartitionReplication::Limit(replication_factor) => {
-                assert_eq!(
-                    replication_factor.greatest_defined_scope(),
-                    LocationScope::Node,
-                    "Location aware partition replication is not supported yet"
-                );
+                if replication_factor.greatest_defined_scope() > LocationScope::Node {
+                    warn!("Location aware partition replication is not supported yet");
+                }
 
                 let replication_factor = usize::from(replication_factor.num_copies());
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -596,7 +596,15 @@ impl ClusterConfiguration {
     pub fn from_configuration(configuration: &Configuration) -> Self {
         ClusterConfiguration {
             num_partitions: configuration.common.default_num_partitions,
-            partition_replication: configuration.admin.default_partition_replication.clone(),
+            partition_replication: {
+                #[allow(deprecated)]
+                configuration
+                    .admin
+                    .default_partition_replication
+                    .clone()
+                    .unwrap_or_else(|| configuration.common.default_replication.clone())
+                    .into()
+            },
             bifrost_provider: ProviderConfiguration::from_configuration(configuration),
         }
     }

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -98,11 +98,13 @@ impl NodeCtlSvcHandler {
             .map(ReplicationProperty::try_from)
             .transpose()?
             .unwrap_or_else(|| {
+                #[allow(deprecated)]
                 config
                     .bifrost
                     .replicated_loglet
                     .default_log_replication
                     .clone()
+                    .unwrap_or_else(|| config.common.default_replication.clone())
             });
 
         let provider_configuration =

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -226,7 +226,7 @@ impl Configuration {
 
     pub fn apply_cascading_values(mut self) -> Self {
         self.worker.storage.apply_common(&self.common);
-        self.bifrost.local.apply_common(&self.common);
+        self.bifrost.apply_common(&self.common);
         self.metadata_server.apply_common(&self.common);
         self.log_server.apply_common(&self.common);
         self
@@ -325,4 +325,8 @@ fn print_warning_deprecated_config_option(deprecated: &str, replacement: Option<
     } else {
         eprintln!("Using the deprecated config option '{deprecated}'.");
     }
+}
+
+fn print_warning_deprecated_value(option: &str, value: &str) {
+    eprintln!("Option {option} does no longer support config value {value}. Using default value");
 }

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -152,11 +152,13 @@ impl ProviderConfiguration {
     pub fn from_configuration(configuration: &Configuration) -> Self {
         ProviderConfiguration::from((
             configuration.bifrost.default_provider,
+            #[allow(deprecated)]
             configuration
                 .bifrost
                 .replicated_loglet
                 .default_log_replication
-                .clone(),
+                .clone()
+                .unwrap_or_else(|| configuration.common.default_replication.clone()),
             configuration.bifrost.replicated_loglet.default_nodeset_size,
         ))
     }

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -49,21 +49,26 @@ impl From<KeyRange> for RangeInclusive<PartitionKey> {
 
 /// Specified how partitions are replicated across the cluster.
 #[serde_as]
-#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PartitionReplication {
     /// All partitions are replicated on all nodes in the cluster.
-    #[default]
+    ///
+    /// #[deprecated]
+    ///
+    /// Note: It's only kept for backward compatibility with older metadata
+    /// but users can't select this value directly.
     Everywhere,
     /// Replication of partitions is limited to the specified replication property.
     /// for example a replication property of `{node: 2}` will run
     /// each partition on maximum of two nodes (one leader, and one follower)
-    Limit(
-        #[serde_as(
-            as = "serde_with::PickFirst<(serde_with::DisplayFromStr, crate::replication::ReplicationPropertyFromNonZeroU8)>"
-        )]
-        ReplicationProperty,
-    ),
+    Limit(#[serde_as(as = "crate::replication::ReplicationPropertyFromTo")] ReplicationProperty),
+}
+
+impl From<ReplicationProperty> for PartitionReplication {
+    fn from(value: ReplicationProperty) -> Self {
+        Self::Limit(value)
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -86,7 +91,7 @@ impl Default for PartitionTable {
             version: Version::INVALID,
             partitions: BTreeMap::default(),
             partition_key_index: BTreeMap::default(),
-            replication: PartitionReplication::default(),
+            replication: PartitionReplication::Limit(ReplicationProperty::new_unchecked(1)),
         }
     }
 }
@@ -497,7 +502,9 @@ impl TryFrom<PartitionTableShadow> for PartitionTable {
     fn try_from(value: PartitionTableShadow) -> Result<Self, Self::Error> {
         let mut builder = PartitionTableBuilder::new(value.version);
         // replication strategy is unset if data has been written with version <= v1.1.3
-        builder.set_partition_replication(value.replication.unwrap_or_default());
+        builder.set_partition_replication(value.replication.unwrap_or(
+            PartitionReplication::Limit(ReplicationProperty::new_unchecked(1)),
+        ));
 
         match value.partitions {
             Some(partitions) => {

--- a/tools/restatectl/src/main.rs
+++ b/tools/restatectl/src/main.rs
@@ -64,8 +64,9 @@ mod tests {
         config.common.default_num_partitions = 1.try_into()?;
         config.common.auto_provision = true;
         config.bifrost.default_provider = ProviderKind::Replicated;
-        config.bifrost.replicated_loglet.default_log_replication =
+        config.common.default_replication =
             ReplicationProperty::new(NonZeroU8::new(1).expect("non-zero"));
+
         let roles = *config.roles();
 
         let mut cluster = Cluster::builder()


### PR DESCRIPTION
Default global replication property

Summary:
A default global replication property can be used for both
logs and partition replication.

The user still can fine tune his replication property for both logs
and partition as needed

We also deprecation the option to set partitin replication to `everywhere`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3025).
* #3001
* __->__ #3025