### PR TITLE
Add a global node_id metrics label to Prometheus exports when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7656,6 +7656,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "parking_lot",
  "restate-types",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,8 +4611,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+source = "git+https://github.com/pcholakov/metrics-rs?branch=mutable-global-labels#7c820d81b8def60884457b464aafa44cdeef40f4"
 dependencies = [
  "ahash 0.8.11",
  "portable-atomic",
@@ -4621,8 +4620,7 @@ dependencies = [
 [[package]]
 name = "metrics-exporter-prometheus"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+source = "git+https://github.com/pcholakov/metrics-rs?branch=mutable-global-labels#7c820d81b8def60884457b464aafa44cdeef40f4"
 dependencies = [
  "base64 0.22.1",
  "hyper-util",
@@ -4637,8 +4635,7 @@ dependencies = [
 [[package]]
 name = "metrics-util"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+source = "git+https://github.com/pcholakov/metrics-rs?branch=mutable-global-labels#7c820d81b8def60884457b464aafa44cdeef40f4"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,11 +145,9 @@ hyper-util = { version = "0.1" }
 indexmap = "2.7"
 itertools = "0.14.0"
 jsonschema = { version = "0.28.3", default-features = false }
-metrics = { version = "0.24" }
-metrics-exporter-prometheus = { version = "0.16", default-features = false, features = [
-    "async-runtime",
-] }
-metrics-util = { version = "0.19.0" }
+metrics = { version = "0.24", git = "https://github.com/pcholakov/metrics-rs", branch = "mutable-global-labels" }
+metrics-exporter-prometheus = { version = "0.16", default-features = false, features = ["async-runtime"], git = "https://github.com/pcholakov/metrics-rs", branch = "mutable-global-labels" }
+metrics-util = { version = "0.19.0", git = "https://github.com/pcholakov/metrics-rs", branch = "mutable-global-labels" }
 moka = "0.12.5"
 object_store = { version = "0.11.1", features = ["aws"] }
 opentelemetry = { version = "0.27" }

--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -188,7 +188,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
     let manager = RocksDbManager::get();
     let all_dbs = manager.get_all_dbs();
 
-    let mut labels = state.prometheus_handle.global_labels().clone();
+    let mut labels = state.prometheus_handle.global_labels();
 
     // Overall write buffer manager stats
     format_rocksdb_property_for_prometheus(

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -42,6 +42,7 @@ opentelemetry-contrib = { workspace = true, features = [ "jaeger_json_exporter",
 opentelemetry-otlp = { workspace = true, features = ["tls", "tls-roots"] }
 opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
+parking_lot = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/tracing-instrumentation/src/exporter.rs
+++ b/crates/tracing-instrumentation/src/exporter.rs
@@ -17,20 +17,9 @@ use opentelemetry::{Key, KeyValue, StringValue, Value};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::export::trace::{SpanData, SpanExporter};
 use opentelemetry_semantic_conventions::attribute::{RPC_SERVICE, SERVICE_NAME};
-use std::sync::OnceLock;
-
-use restate_types::GenerationalNodeId;
 
 /// `RPC_SERVICE` is used to override `service.name` on the `SpanBuilder`
 const RPC_SERVICE_KEY: Key = Key::from_static_str(RPC_SERVICE);
-
-static GLOBAL_NODE_ID: OnceLock<GenerationalNodeId> = OnceLock::new();
-
-pub fn set_global_node_id(node_id: GenerationalNodeId) {
-    GLOBAL_NODE_ID
-        .set(node_id)
-        .expect("Global NodeId is not set")
-}
 
 /// `UserServiceModifierSpanExporter` wraps a `opentelemetry::sdk::trace::SpanExporter` in order to allow mutating
 /// the service name which is within the resource field. As this field is set during export,
@@ -163,7 +152,7 @@ mod service_per_binary {
     };
     use opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID;
 
-    use super::GLOBAL_NODE_ID;
+    use crate::GLOBAL_NODE_ID;
 
     #[derive(Debug)]
     pub(crate) struct RuntimeModifierSpanExporter<E>
@@ -247,7 +236,7 @@ mod service_per_crate {
         CODE_NAMESPACE, SERVICE_INSTANCE_ID, SERVICE_NAME,
     };
 
-    use super::GLOBAL_NODE_ID;
+    use crate::GLOBAL_NODE_ID;
 
     const CODE_NAMESPACE_KEY: Key = Key::from_static_str(CODE_NAMESPACE);
     /// `UserServiceModifierSpanExporter` wraps a `opentelemetry::sdk::trace::SpanExporter` in order to allow mutating

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -69,7 +69,7 @@ libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 md-5 = { version = "0.10" }
 memchr = { version = "2" }
-metrics-util = { version = "0.19" }
+metrics-util = { git = "https://github.com/pcholakov/metrics-rs", branch = "mutable-global-labels" }
 nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
@@ -181,7 +181,7 @@ libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 md-5 = { version = "0.10" }
 memchr = { version = "2" }
-metrics-util = { version = "0.19" }
+metrics-util = { git = "https://github.com/pcholakov/metrics-rs", branch = "mutable-global-labels" }
 nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }


### PR DESCRIPTION
With the help of a [patched `metrics-exporter-prometheus` crate](https://github.com/metrics-rs/metrics/compare/main...pcholakov:metrics-rs:mutable-global-labels), this can work.

Do we need the ability to mutate global labels after startup, and is there an alternative? I think so; in the happy case, our node id is known relatively soon, and deferring metrics collection wouldn't be an issue. OTOH, if the node is stuck and can't confirm its node id, we'd be flying blind if we waited to install the Prometheus recorder. That will probably get caught by a health check failing anyway but it feels icky to couple metrics to joining the cluster in that way.

If we decide to put this in, it probably makes `node_name` redundant. Metric scraping job will typically add its own `instance` label anyway.

---

**Testing**

_All_ emitted metric lines have a `node_id` now 😅 

```
❯ curl --silent localhost:5122/metrics | egrep -v "^#.*|^$" | grep -v "node_id" | wc -l
0

❯ curl --silent localhost:5122/metrics | egrep -v "^#.*|^$" | head -10
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="BifrostAppender",runtime="Inherit"} 24
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="BifrostBackgroundLowPriority",runtime="Default"} 48
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="NetworkMessageHandler",runtime="Default"} 1
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="Background",runtime="Inherit"} 2
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="Cleaner",runtime="Inherit"} 24
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="LocalReactor",runtime="Default"} 13
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="PartitionProcessorManager",runtime="Default"} 1
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="LogletProvider",runtime="Inherit"} 1
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="Disposable",runtime="Inherit"} 46
restate_task_center_spawned_total{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1",kind="LogletWriter",runtime="Inherit"} 48

# Our custom pass-through RocksDB metric lines do, too:
❯ curl --silent localhost:5122/metrics | egrep -v "^#.*|^$" | grep write_buffer_manager_
restate_rocksdb_memory_write_buffer_manager_capacity_bytes{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1"} 3000000000
restate_rocksdb_memory_write_buffer_manager_usage_bytes{cluster_name="localcluster",node_name="Pavels-MacBook-Pro-2.local",node_id="N1"} 193875456
```