### PR TITLE
Forward compatibility support for cluster_fingerprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,11 +1270,12 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "serde",
+ "unty",
 ]
 
 [[package]]
@@ -7733,6 +7734,7 @@ dependencies = [
  "arc-swap",
  "base62",
  "base64 0.22.1",
+ "bincode",
  "bitflags 2.8.0",
  "bytes",
  "bytestring",
@@ -9887,6 +9889,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ aws-smithy-async = {version = "1.2.5", default-features = false}
 aws-smithy-runtime-api = "1.7.4"
 aws-smithy-types = "1.3.0"
 base64 = "0.22"
+bincode = { version = "2.0.1", default-features = false }
 bitflags = { version = "2.6.0" }
 bytes = { version = "1.7", features = ["serde"] }
 bytes-utils = "0.1.3"

--- a/crates/queue/Cargo.toml
+++ b/crates/queue/Cargo.toml
@@ -12,7 +12,7 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 restate-fs-util = { workspace = true }
 
-bincode = { version = "2.0.0-rc", default-features = false, features = ["std", "serde"] }
+bincode = { workspace = true, default-features = false, features = ["std", "serde"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -32,6 +32,7 @@ base64 = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+bincode = { workspace = true, default-features = false, features = ["std", "serde"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"], optional = true }
 codederror = { workspace = true }

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZero;
+
 use enumset::{EnumSet, EnumSetType};
 use serde_with::serde_as;
 
@@ -55,10 +57,14 @@ pub enum Role {
 }
 
 #[serde_as]
-#[derive(derive_more::Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NodesConfiguration {
     version: Version,
     cluster_name: String,
+    // a unique fingerprint for this cluster. Introduced in v1.3 for forward compatibility. Will be
+    // used to uniquely identify this cluster instance in future versions.
+    #[serde(default)]
+    cluster_fingerprint: Option<NonZero<u64>>,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
     nodes: HashMap<PlainNodeId, MaybeNode>,
@@ -70,6 +76,7 @@ impl Default for NodesConfiguration {
     fn default() -> Self {
         Self {
             version: Version::INVALID,
+            cluster_fingerprint: None,
             cluster_name: "Unspecified".to_owned(),
             nodes: Default::default(),
             name_lookup: Default::default(),
@@ -127,6 +134,7 @@ impl NodesConfiguration {
     pub fn new(version: Version, cluster_name: String) -> Self {
         Self {
             version,
+            cluster_fingerprint: None,
             cluster_name,
             nodes: HashMap::default(),
             name_lookup: HashMap::default(),

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -8,15 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub mod decode;
+pub mod encode;
+
 use std::mem;
 use std::sync::Arc;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use chrono::Utc;
 use downcast_rs::{DowncastSync, impl_downcast};
-use serde::de::{DeserializeOwned, Error as DeserializationError};
-use serde::ser::Error as SerializationError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::error;
 
 use crate::errors::GenericError;
@@ -37,15 +38,19 @@ pub enum StorageDecodeError {
     UnsupportedCodecKind(StorageCodecKind),
 }
 
-#[derive(Debug, strum::FromRepr, derive_more::Display)]
+#[derive(Debug, Copy, Clone, strum::FromRepr, derive_more::Display)]
 #[repr(u8)]
 pub enum StorageCodecKind {
-    // plain old protobuf
+    /// plain old protobuf
     Protobuf = 1,
-    // flexbuffers + serde
+    /// flexbuffers + serde (length-prefixed)
     FlexbuffersSerde = 2,
-    // length-prefixed raw-bytes. length is u32
+    /// length-prefixed raw-bytes. length is u32
     LengthPrefixedRawBytes = 3,
+    /// bincode (with serde compatibility mode, no length prefix)
+    BincodeSerde = 4,
+    /// Json (no length prefix)
+    Json = 5,
 }
 
 impl From<StorageCodecKind> for u8 {
@@ -150,8 +155,7 @@ macro_rules! flexbuffers_storage_encode_decode {
                 &self,
                 buf: &mut ::bytes::BytesMut,
             ) -> Result<(), $crate::storage::StorageEncodeError> {
-                $crate::storage::encode_as_flexbuffers(self, buf)
-                    .map_err(|err| $crate::storage::StorageEncodeError::EncodeValue(err.into()))
+                $crate::storage::encode::encode_serde(self, buf, self.default_codec())
             }
         }
 
@@ -163,17 +167,11 @@ macro_rules! flexbuffers_storage_encode_decode {
             where
                 Self: Sized,
             {
-                match kind {
-                    $crate::storage::StorageCodecKind::FlexbuffersSerde => {
-                        $crate::storage::decode_from_flexbuffers(buf).map_err(|err| {
-                            ::tracing::error!(%err, "Flexbuffers decode failure (decoding {})", stringify!($name));
-                            $crate::storage::StorageDecodeError::DecodeValue(err.into())
-                        })
-                    }
-                    codec => Err($crate::storage::StorageDecodeError::UnsupportedCodecKind(
-                        codec,
-                    )),
-                }
+                $crate::storage::decode::decode_serde(buf, kind).map_err(|err| {
+                    ::tracing::error!(%err, "{} decode failure (decoding {})", kind, stringify!($name));
+                    err
+                })
+
             }
         }
     };
@@ -338,70 +336,6 @@ impl StorageEncode for bytes::Bytes {
         }
         buf.put_slice(&self[..]);
         Ok(())
-    }
-}
-
-/// Utility method to encode a [`Serialize`] type as flexbuffers using serde.
-pub fn encode_as_flexbuffers<T: Serialize, B: BufMut>(
-    value: T,
-    buf: &mut B,
-) -> Result<(), flexbuffers::SerializationError> {
-    let vec = flexbuffers::to_vec(value)?;
-
-    let required_buffer_bytes = vec.len() + mem::size_of::<u32>();
-    if buf.remaining_mut() < required_buffer_bytes {
-        return Err(flexbuffers::SerializationError::custom(format!(
-            "not enough buffer space to serialize value; required {} bytes but free capacity was {}",
-            required_buffer_bytes,
-            buf.remaining_mut()
-        )));
-    }
-
-    // write the length
-    buf.put_u32_le(u32::try_from(vec.len()).map_err(|_| {
-        flexbuffers::SerializationError::custom("only support serializing types of size <= 4GB")
-    })?);
-    buf.put(&vec[..]);
-    Ok(())
-}
-
-/// Utility method to decode a [`DeserializeOwned`] type from flexbuffers using serde.
-pub fn decode_from_flexbuffers<T: DeserializeOwned, B: Buf>(
-    buf: &mut B,
-) -> Result<T, flexbuffers::DeserializationError> {
-    if buf.remaining() < mem::size_of::<u32>() {
-        return Err(flexbuffers::DeserializationError::custom(format!(
-            "insufficient data: expecting {} bytes for length",
-            mem::size_of::<u32>()
-        )));
-    }
-    let length = usize::try_from(buf.get_u32_le()).expect("u32 to fit into usize");
-
-    if buf.remaining() < length {
-        return Err(flexbuffers::DeserializationError::custom(format!(
-            "insufficient data: expecting {length} bytes for flexbuffers"
-        )));
-    }
-
-    if buf.chunk().len() >= length {
-        let deserializer = flexbuffers::Reader::get_root(buf.chunk())?;
-        // todo: inject the path into the error message and propagate upwards
-        let result = serde_path_to_error::deserialize(deserializer).map_err(|err| {
-            error!(%err, "Flexbuffers error at field {}", err.path());
-            err.into_inner()
-        })?;
-        buf.advance(length);
-        Ok(result)
-    } else {
-        // need to allocate contiguous buffer of length for flexbuffers
-        let bytes = buf.copy_to_bytes(length);
-        let deserializer = flexbuffers::Reader::get_root(bytes.chunk())?;
-        // todo: inject the path into the error message and propagate upwards
-        let result = serde_path_to_error::deserialize(deserializer).map_err(|err| {
-            error!(%err, "Flexbuffers error at field {}", err.path());
-            err.into_inner()
-        })?;
-        Ok(result)
     }
 }
 

--- a/crates/types/src/storage/decode.rs
+++ b/crates/types/src/storage/decode.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::mem;
+
+use bytes::Buf;
+use serde::de::{DeserializeOwned, Error as DeserializationError};
+use tracing::error;
+
+use super::{StorageCodecKind, StorageDecodeError};
+
+/// Decode a [`DeserializeOwned`] type from a buffer using serde if it is supported by the codec.
+pub fn decode_serde<T: DeserializeOwned, B: Buf>(
+    buf: &mut B,
+    codec: StorageCodecKind,
+) -> Result<T, StorageDecodeError> {
+    match codec {
+        StorageCodecKind::FlexbuffersSerde => decode_serde_from_flexbuffers(buf)
+            .map_err(|err| StorageDecodeError::DecodeValue(err.into())),
+        StorageCodecKind::BincodeSerde => decode_serde_from_bincode(buf)
+            .map_err(|err| StorageDecodeError::DecodeValue(err.into())),
+        StorageCodecKind::Json => {
+            decode_serde_from_json(buf).map_err(|err| StorageDecodeError::DecodeValue(err.into()))
+        }
+        codec => Err(StorageDecodeError::UnsupportedCodecKind(codec)),
+    }
+}
+
+/// Utility method to decode a [`DeserializeOwned`] type from flexbuffers using serde.
+fn decode_serde_from_flexbuffers<T: DeserializeOwned, B: Buf>(
+    buf: &mut B,
+) -> Result<T, flexbuffers::DeserializationError> {
+    if buf.remaining() < mem::size_of::<u32>() {
+        return Err(flexbuffers::DeserializationError::custom(format!(
+            "insufficient data: expecting {} bytes for length",
+            mem::size_of::<u32>()
+        )));
+    }
+    let length = usize::try_from(buf.get_u32_le()).expect("u32 to fit into usize");
+
+    if buf.remaining() < length {
+        return Err(flexbuffers::DeserializationError::custom(format!(
+            "insufficient data: expecting {length} bytes for flexbuffers"
+        )));
+    }
+
+    if buf.chunk().len() >= length {
+        let deserializer = flexbuffers::Reader::get_root(&buf.chunk()[..length])?;
+        let result = serde_path_to_error::deserialize(deserializer).map_err(|err| {
+            error!(%err, "Flexbuffers error at field {}", err.path());
+            err.into_inner()
+        })?;
+        buf.advance(length);
+        Ok(result)
+    } else {
+        // need to allocate contiguous buffer of length for flexbuffers
+        let bytes = buf.copy_to_bytes(length);
+        let deserializer = flexbuffers::Reader::get_root(bytes.chunk())?;
+        let result = serde_path_to_error::deserialize(deserializer).map_err(|err| {
+            error!(%err, "Flexbuffers error at field {}", err.path());
+            err.into_inner()
+        })?;
+        Ok(result)
+    }
+}
+
+/// Utility method to decode a [`DeserializeOwned`] type from bincode using serde.
+fn decode_serde_from_bincode<T: DeserializeOwned, B: Buf>(
+    buf: &mut B,
+) -> Result<T, bincode::error::DecodeError> {
+    let (result, length) =
+        bincode::serde::decode_from_slice(buf.chunk(), bincode::config::standard())?;
+    buf.advance(length);
+    Ok(result)
+}
+
+/// Utility method to decode a [`DeserializeOwned`] type from Json using serde.
+fn decode_serde_from_json<T: DeserializeOwned, B: Buf>(
+    buf: &mut B,
+) -> Result<T, serde_json::Error> {
+    let deserializer = &mut serde_json::Deserializer::from_reader(buf.reader());
+    let result = serde_path_to_error::deserialize(deserializer).map_err(|err| {
+        error!(%err, "Json error at field {}", err.path());
+        err.into_inner()
+    })?;
+    Ok(result)
+}

--- a/crates/types/src/storage/encode.rs
+++ b/crates/types/src/storage/encode.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+use std::mem;
+
+use bytes::{BufMut, BytesMut};
+use serde::Serialize;
+
+use super::{StorageCodecKind, StorageEncodeError};
+
+/// Encode a [`Serialize`] type to a buffer using serde if it is supported by the codec.
+pub fn encode_serde<T: Serialize>(
+    value: &T,
+    buf: &mut BytesMut,
+    codec: StorageCodecKind,
+) -> Result<(), StorageEncodeError> {
+    match codec {
+        StorageCodecKind::FlexbuffersSerde => encode_serde_as_flexbuffers(value, buf)
+            .map_err(|err| StorageEncodeError::EncodeValue(err.into())),
+        StorageCodecKind::BincodeSerde => encode_serde_as_bincode(value, buf)
+            .map_err(|err| StorageEncodeError::EncodeValue(err.into())),
+        StorageCodecKind::Json => encode_serde_as_json(value, buf)
+            .map_err(|err| StorageEncodeError::EncodeValue(err.into())),
+        codec => Err(StorageEncodeError::EncodeValue(
+            anyhow::anyhow!("Cannot encode serde type with codec {}", codec).into(),
+        )),
+    }
+}
+
+/// Utility method to encode a [`Serialize`] type as flexbuffers using serde.
+fn encode_serde_as_flexbuffers<T: Serialize>(
+    value: T,
+    buf: &mut BytesMut,
+) -> Result<(), flexbuffers::SerializationError> {
+    let vec = flexbuffers::to_vec(value)?;
+    let size_tag = u32::try_from(vec.len())
+        .map_err(|_| serde::ser::Error::custom("only support serializing types of size <= 4GB"))?;
+
+    buf.reserve(vec.len() + mem::size_of::<u32>());
+    // write the length
+    buf.put_u32_le(size_tag);
+    // write the data
+    buf.put_slice(&vec);
+    Ok(())
+}
+
+/// Utility method to encode a [`Serialize`] type as bincode using serde.
+fn encode_serde_as_bincode<T: Serialize>(
+    value: &T,
+    buf: &mut BytesMut,
+) -> Result<(), bincode::error::EncodeError> {
+    struct BytesWriter<'a>(&'a mut BytesMut);
+
+    impl bincode::enc::write::Writer for BytesWriter<'_> {
+        fn write(&mut self, bytes: &[u8]) -> Result<(), bincode::error::EncodeError> {
+            self.0.put_slice(bytes);
+            Ok(())
+        }
+    }
+    // write the data
+    bincode::serde::encode_into_writer(value, BytesWriter(buf), bincode::config::standard())?;
+
+    Ok(())
+}
+
+/// Utility method to encode a [`Serialize`] type as json using serde.
+fn encode_serde_as_json<T: Serialize>(
+    value: &T,
+    buf: &mut BytesMut,
+) -> Result<(), serde_json::error::Error> {
+    serde_json::to_writer(buf.writer(), value)?;
+
+    Ok(())
+}


### PR DESCRIPTION

This is the bare minimum to allow v1.3 from clobbering by future versions' RMW nodes config updates. The fingerprint will be a simple non-zero random numeric value. Zero is reserved to indicate that the value is unset/none without occupying extra space for the tag.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3029).
* #3031
* #3030
* __->__ #3029
* #3028
* #3007