### PR TITLE
fix: make tracing-instrumentation compile with features prometheus

### DIFF
--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -18,10 +18,11 @@ service_per_crate = []
 options_schema = ["dep:schemars"]
 rt-tokio = ["dep:tokio"]
 prometheus = [
-  "dep:tokio",
-  "dep:metrics",
-  "dep:metrics-exporter-prometheus",
-  "dep:metrics-util",
+    "dep:tokio",
+    "dep:metrics",
+    "dep:metrics-exporter-prometheus",
+    "dep:metrics-util",
+    "tokio/tracing",
 ]
 
 [dependencies]


### PR DESCRIPTION
Ref: https://github.com/restatedev/restate/issues/3036

```
cargo clippy --manifest-path crates/tracing-instrumentation/Cargo.toml --no-default-features --features prometheus

   --> crates/tracing-instrumentation/src/prometheus_metrics.rs:87:30
    |
87  |                 tokio::task::Builder::new()
    |                              ^^^^^^^ could not find `Builder` in `task`
    |
note: found an item that was configured out
```