### PR TITLE
fix: make invoker-impl compile with all-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,7 +7024,6 @@ name = "restate-invoker-impl"
 version = "1.3.1-dev"
 dependencies = [
  "anyhow",
- "assert2",
  "bytes",
  "bytestring",
  "codederror",

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -20,13 +20,12 @@ restate-futures-util = { workspace = true }
 restate-invoker-api = { workspace = true }
 restate-queue = { workspace = true }
 restate-service-client = { workspace = true }
-restate-service-protocol = { workspace = true, features = ["message"] }
+restate-service-protocol = { workspace = true, features = ["message", "codec"] }
 restate-service-protocol-v4 = { workspace = true, features = ["message-codec", "entry-codec"] }
 restate-timer-queue = { workspace = true }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }
-assert2 = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
@@ -50,7 +49,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }
 restate-invoker-api = { workspace = true, features = ["test-util"] }
-restate-service-protocol = { workspace = true, features = ["codec"] }
+restate-service-protocol = { workspace = true }
 restate-test-util = { workspace = true }
 restate-types = { workspace = true }
 


### PR DESCRIPTION
Ref: https://github.com/restatedev/restate/issues/3036

```
cargo clippy --manifest-path crates/invoker-impl/Cargo.toml --all-features

29 | use restate_service_protocol::codec::ProtobufRawEntryCodec;
   |                               ^^^^^ could not find `codec` in `restate_service_protocol`
   |
note: found an item that was configured out
```