### PR TITLE
fix: make wal-protocol compile with feature options_schema

### DIFF
--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [features]
 default = ["serde"]
 serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde"]
-options_schema = ["dep:schemars"]
 
 [dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
@@ -29,7 +28,7 @@ codederror = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 enum-map = { workspace = true }
-flexbuffers = {  workspace = true }
+flexbuffers = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -85,7 +85,7 @@ pub enum Source {
         /// deprecated(v1.1): use generational_node_id instead.
         node_id: PlainNodeId,
         /// From v1.1 this is always set, but maintained to support rollback to v1.0.
-        #[serde(default)]
+        #[cfg_attr(feature = "serde", serde(default))]
         generational_node_id: Option<GenerationalNodeId>,
     },
     /// Message is sent from an ingress node


### PR DESCRIPTION
Ref: https://github.com/restatedev/restate/issues/3036

Before this pr:

```
error: cannot find attribute `serde` in this scope
  --> crates/wal-protocol/src/lib.rs:88:11
   |
88 |         #[serde(default)]
   |           ^^^^^
   |
   = note: `serde` is in scope, but it is a crate, not an attribute
```