### PR TITLE
[Bifrost] Set default record cache to 250MB

### DIFF
--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -66,7 +66,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip"] }
+tonic = { workspace = true, features = ["transport", "codegen", "prost", "gzip", "zstd"] }
 tower = { workspace = true, features = ["load-shed", "limit"] }
 tracing = { workspace = true }
 xxhash-rust = { workspace = true }

--- a/crates/admin/src/cluster_controller/protobuf.rs
+++ b/crates/admin/src/cluster_controller/protobuf.rs
@@ -8,7 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tonic::codec::CompressionEncoding;
+use tonic::transport::Channel;
+
+use restate_core::network::grpc::DEFAULT_GRPC_COMPRESSION;
+
 tonic::include_proto!("restate.cluster_ctrl");
 
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("cluster_ctrl_svc_descriptor");
+
+/// Creates a new ClusterCtrlSvcClient with appropriate configuration
+pub fn new_cluster_ctrl_client(
+    channel: Channel,
+) -> cluster_ctrl_svc_client::ClusterCtrlSvcClient<Channel> {
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient::new(channel)
+        // note: the order of those calls defines the priority
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(DEFAULT_GRPC_COMPRESSION)
+}

--- a/crates/admin/src/rest_api/cluster_health.rs
+++ b/crates/admin/src/rest_api/cluster_health.rs
@@ -11,10 +11,10 @@
 use axum::Json;
 use http::StatusCode;
 use okapi_operation::openapi;
+use restate_core::protobuf::node_ctl_svc::new_node_ctl_client;
 
 use crate::rest_api::error::GenericRestError;
 use restate_core::network::net_util::create_tonic_channel;
-use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::{Metadata, my_node_id};
 use restate_types::config::Configuration;
 use restate_types::{NodeId, PlainNodeId};
@@ -37,7 +37,7 @@ pub async fn cluster_health() -> Result<Json<ClusterHealthResponse>, GenericRest
             )
         })?;
 
-    let mut node_ctl_svc_client = NodeCtlSvcClient::new(create_tonic_channel(
+    let mut node_ctl_svc_client = new_node_ctl_client(create_tonic_channel(
         node_config.address.clone(),
         &Configuration::pinned().networking,
     ));

--- a/crates/core/src/network/grpc/connector.rs
+++ b/crates/core/src/network/grpc/connector.rs
@@ -23,6 +23,7 @@ use tonic::transport::Endpoint;
 use tracing::debug;
 
 use super::MAX_MESSAGE_SIZE;
+use crate::network::grpc::DEFAULT_GRPC_COMPRESSION;
 use crate::network::protobuf::core_node_svc::core_node_svc_client::CoreNodeSvcClient;
 use crate::network::protobuf::network::Message;
 use crate::network::transport_connector::find_node;
@@ -60,7 +61,7 @@ impl TransportConnect for GrpcConnector {
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)
-            .send_compressed(CompressionEncoding::Gzip);
+            .send_compressed(DEFAULT_GRPC_COMPRESSION);
         let incoming = client.create_connection(output_stream).await?.into_inner();
         Ok(incoming.map_while(|x| x.ok()))
     }

--- a/crates/core/src/network/grpc/mod.rs
+++ b/crates/core/src/network/grpc/mod.rs
@@ -13,7 +13,12 @@ mod svc_handler;
 
 pub use connector::GrpcConnector;
 pub use svc_handler::CoreNodeSvcHandler;
+use tonic::codec::CompressionEncoding;
 
 /// The maximum size for a grpc message for core networking service.
 /// This impacts the buffer limit for prost codec.
-const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+pub const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
+/// Default send compression for grpc clients
+// todo: change this to zstd in v1.4
+pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -37,6 +37,9 @@ impl CoreNodeSvcHandler {
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)
+            // note: the order of those calls defines the priority
+            // deflate/gzip has significantly higher CPU overhead according to our CPU profiling,
+            // so we prefer zstd over gzip.
             .send_compressed(CompressionEncoding::Zstd)
             .send_compressed(CompressionEncoding::Gzip)
     }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -15,9 +15,10 @@ use futures::{FutureExt, Stream, StreamExt, TryStreamExt, stream};
 use itertools::Itertools;
 use regex::{Regex, RegexSet};
 use restate_core::network::net_util::create_tonic_channel;
-use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest as ProtoProvisionClusterRequest;
-use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
-use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvcClient;
+use restate_core::protobuf::node_ctl_svc::{
+    ProvisionClusterRequest as ProtoProvisionClusterRequest, new_node_ctl_client,
+};
+use restate_metadata_server::grpc::new_metadata_server_client;
 use restate_types::config::{InvalidConfigurationError, MetadataServerKind, RaftOptions};
 use restate_types::logs::metadata::ProviderConfiguration;
 use restate_types::partition_table::PartitionReplication;
@@ -795,7 +796,7 @@ impl StartedNode {
 
     /// Check to see if the metadata server has joined the metadata cluster.
     pub async fn metadata_server_joined_cluster(&self) -> bool {
-        let mut metadata_server_client = MetadataServerSvcClient::new(create_tonic_channel(
+        let mut metadata_server_client = new_metadata_server_client(create_tonic_channel(
             self.config().common.advertised_address.clone(),
             &self.config().networking,
         ));
@@ -848,7 +849,7 @@ impl StartedNode {
             Some(10),
             Some(Duration::from_secs(1)),
         );
-        let client = NodeCtlSvcClient::new(channel);
+        let client = new_node_ctl_client(channel);
 
         let response = retry_policy
             .retry(|| {

--- a/crates/log-server/src/protobuf.rs
+++ b/crates/log-server/src/protobuf.rs
@@ -8,7 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tonic::codec::CompressionEncoding;
+use tonic::transport::Channel;
+
+use restate_core::network::grpc::{DEFAULT_GRPC_COMPRESSION, MAX_MESSAGE_SIZE};
+
 tonic::include_proto!("restate.log_server");
 
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("log_server_svc_descriptor");
+
+/// Creates a new ClusterCtrlSvcClient with appropriate configuration
+pub fn new_log_server_client(
+    channel: Channel,
+) -> log_server_svc_client::LogServerSvcClient<Channel> {
+    log_server_svc_client::LogServerSvcClient::new(channel)
+        .max_decoding_message_size(MAX_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_MESSAGE_SIZE)
+        // note: the order of those calls defines the priority
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(DEFAULT_GRPC_COMPRESSION)
+}

--- a/crates/metadata-server/src/grpc/client.rs
+++ b/crates/metadata-server/src/grpc/client.rs
@@ -30,10 +30,11 @@ use restate_types::{PlainNodeId, Version};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
-use tonic::codec::CompressionEncoding;
 use tonic::transport::Channel;
 use tonic::{Code, Status};
 use tracing::{debug, instrument};
+
+use super::new_metadata_server_client;
 
 const MAX_RETRY_ATTEMPTS: usize = 3;
 
@@ -48,9 +49,7 @@ struct MetadataServerSvcClientWithAddress {
 impl MetadataServerSvcClientWithAddress {
     fn new(channel: ChannelWithAddress) -> Self {
         Self {
-            client: MetadataServerSvcClient::new(channel.channel.clone())
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip),
+            client: new_metadata_server_client(channel.channel.clone()),
             address: channel.address,
         }
     }

--- a/crates/metadata-server/src/grpc/mod.rs
+++ b/crates/metadata-server/src/grpc/mod.rs
@@ -8,11 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tonic::codec::CompressionEncoding;
+use tonic::transport::Channel;
+
+use restate_core::network::grpc::DEFAULT_GRPC_COMPRESSION;
+
 pub mod client;
 pub(crate) mod handler;
 
 tonic::include_proto!("restate.metadata_server_svc");
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("metadata_server_svc");
+
+/// Creates a new MetadataServerSvcClient with appropriate configuration
+pub fn new_metadata_server_client(
+    channel: Channel,
+) -> metadata_server_svc_client::MetadataServerSvcClient<Channel> {
+    metadata_server_svc_client::MetadataServerSvcClient::new(channel)
+        // note: the order of those calls defines the priority
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(DEFAULT_GRPC_COMPRESSION)
+}
 
 pub mod pb_conversions {
     use restate_types::Version;

--- a/crates/metadata-server/src/raft/network/grpc_svc.rs
+++ b/crates/metadata-server/src/raft/network/grpc_svc.rs
@@ -8,7 +8,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_core::network::grpc::DEFAULT_GRPC_COMPRESSION;
+use tonic::codec::CompressionEncoding;
+use tonic::transport::Channel;
+
 tonic::include_proto!("restate.metadata_server_network_svc");
 
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("metadata_server_network_svc");
+
+/// Creates a new MetadataServerNetworkSvcClient with appropriate configuration
+pub fn new_metadata_server_network_client(
+    channel: Channel,
+) -> metadata_server_network_svc_client::MetadataServerNetworkSvcClient<Channel> {
+    metadata_server_network_svc_client::MetadataServerNetworkSvcClient::new(channel)
+        // note: the order of those calls defines the priority
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .send_compressed(DEFAULT_GRPC_COMPRESSION)
+}

--- a/crates/metadata-server/src/raft/network/networking.rs
+++ b/crates/metadata-server/src/raft/network/networking.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::raft::network::connection_manager::ConnectionManager;
+use crate::raft::network::grpc_svc::new_metadata_server_network_client;
 use crate::raft::network::{PEER_METADATA_KEY, grpc_svc};
 use bytes::{Buf, BufMut, BytesMut};
 use futures::FutureExt;
@@ -22,7 +23,6 @@ use std::collections::hash_map::Entry;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::IntoStreamingRequest;
-use tonic::codec::CompressionEncoding;
 use tonic::metadata::MetadataValue;
 use tracing::{debug, trace};
 
@@ -162,8 +162,7 @@ where
                 let channel = net_util::create_tonic_channel(address.clone(), networking_options);
 
                 async move {
-                    let mut network_client = grpc_svc::metadata_server_network_svc_client::MetadataServerNetworkSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip)
-                        .send_compressed(CompressionEncoding::Gzip);
+                    let mut network_client = new_metadata_server_network_client(channel);
                     let (outgoing_tx, outgoing_rx) = mpsc::channel(128);
 
                     let mut request = ReceiverStream::new(outgoing_rx).into_streaming_request();

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["gzip", "zstd"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -10,8 +10,6 @@
 
 use axum::Json;
 use axum::routing::{MethodFilter, get, on};
-use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_server::MetadataProxySvcServer;
-use tonic::codec::CompressionEncoding;
 
 use restate_core::Identification;
 use restate_core::TaskCenter;
@@ -19,7 +17,6 @@ use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::network::grpc::CoreNodeSvcHandler;
 use restate_core::network::tonic_service_filter::{TonicServiceFilter, WaitForReady};
 use restate_core::network::{ConnectionManager, NetworkServerBuilder};
-use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::NodeCtlSvcServer;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::CommonOptions;
 use restate_types::protobuf::common::NodeStatus;
@@ -71,16 +68,12 @@ impl NetworkServer {
         });
 
         server_builder.register_grpc_service(
-            NodeCtlSvcServer::new(NodeCtlSvcHandler::new(metadata_store_client.clone()))
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip),
+            NodeCtlSvcHandler::new(metadata_store_client.clone()).into_server(),
             restate_core::protobuf::node_ctl_svc::FILE_DESCRIPTOR_SET,
         );
 
         server_builder.register_grpc_service(
-            MetadataProxySvcServer::new(MetadataProxySvcHandler::new(metadata_store_client))
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip),
+            MetadataProxySvcHandler::new(metadata_store_client).into_server(),
             restate_core::protobuf::metadata_proxy_svc::FILE_DESCRIPTOR_SET,
         );
 

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -352,7 +352,7 @@ impl RocksDbManager {
         block_opts.set_index_block_restart_interval(4);
         block_opts.set_cache_index_and_filter_blocks(true);
         block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
-        block_opts.set_block_size(32 * 1024);
+        block_opts.set_block_size(opts.rocksdb_block_size().get());
 
         block_opts.set_block_cache(&self.cache);
         cf_options.set_block_based_table_factory(&block_opts);

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -81,7 +81,7 @@ pub struct BifrostOptions {
     ///
     /// Optional size of record cache in bytes.
     /// If set to 0, record cache will be disabled.
-    /// Defaults: 20M
+    /// Defaults: 250MB
     #[cfg_attr(feature = "schemars", schemars(with = "ByteCount"))]
     pub record_cache_memory_size: ByteCount,
 }
@@ -114,7 +114,7 @@ impl Default for BifrostOptions {
             append_retry_max_interval: Duration::from_secs(1).into(),
             auto_recovery_interval: Duration::from_secs(3).into(),
             seal_retry_interval: Duration::from_secs(2).into(),
-            record_cache_memory_size: 20_000_000u64.into(), // 20MB
+            record_cache_memory_size: 250_000_000u64.into(), // 20MB
         }
     }
 }

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -161,12 +161,12 @@ impl RocksDbOptions {
     }
 
     pub fn rocksdb_disable_direct_io_for_reads(&self) -> bool {
-        self.rocksdb_disable_direct_io_for_reads.unwrap_or(false)
+        self.rocksdb_disable_direct_io_for_reads.unwrap_or(true)
     }
 
     pub fn rocksdb_disable_direct_io_for_flush_and_compaction(&self) -> bool {
         self.rocksdb_disable_direct_io_for_flush_and_compactions
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     pub fn rocksdb_disable_statistics(&self) -> bool {

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -98,6 +98,16 @@ pub struct RocksDbOptions {
     /// Default: 64MB
     #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
     rocksdb_log_max_file_size: Option<NonZeroByteCount>,
+
+    /// # RocksDB block size
+    ///
+    /// Uncompressed block size
+    ///
+    /// Default: 64KB
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<NonZeroByteCount>")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
+    rocksdb_block_size: Option<NonZeroUsize>,
 }
 
 /// Verbosity of the LOG.
@@ -154,6 +164,9 @@ impl RocksDbOptions {
         if self.rocksdb_log_max_file_size.is_none() {
             self.rocksdb_log_max_file_size = Some(common.rocksdb_log_max_file_size());
         }
+        if self.rocksdb_block_size.is_none() {
+            self.rocksdb_block_size = Some(common.rocksdb_block_size());
+        }
     }
 
     pub fn rocksdb_disable_wal(&self) -> bool {
@@ -205,6 +218,11 @@ impl RocksDbOptions {
             .unwrap_or(NonZeroByteCount::new(
                 NonZeroUsize::new(64_000_000).expect("is valid size"),
             ))
+    }
+
+    pub fn rocksdb_block_size(&self) -> NonZeroUsize {
+        self.rocksdb_block_size
+            .unwrap_or(NonZeroUsize::new(64 * 1024).unwrap())
     }
 }
 

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -16,14 +16,13 @@ use futures_util::StreamExt;
 use googletest::fail;
 use tempfile::TempDir;
 use tokio::sync::oneshot;
-use tonic::codec::CompressionEncoding;
 use tonic::transport::Channel;
 use tracing::{error, info};
 use url::Url;
 
 use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
 use restate_admin::cluster_controller::protobuf::{
-    ClusterStateRequest, CreatePartitionSnapshotRequest,
+    ClusterStateRequest, CreatePartitionSnapshotRequest, new_cluster_ctrl_client,
 };
 use restate_core::network::net_util::{CommonClientConnectionOptions, create_tonic_channel};
 use restate_local_cluster_runner::{
@@ -82,11 +81,10 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
     tokio::time::timeout(Duration::from_secs(10), worker_1_ready.next()).await?;
     tokio::time::timeout(Duration::from_secs(10), worker_2_ready.next()).await?;
 
-    let mut client = ClusterCtrlSvcClient::new(create_tonic_channel(
+    let mut client = new_cluster_ctrl_client(create_tonic_channel(
         cluster.nodes[0].node_address().clone(),
         &TestNetworkOptions::default(),
-    ))
-    .accept_compressed(CompressionEncoding::Gzip);
+    ));
 
     tokio::time::timeout(Duration::from_secs(5), any_partition_active(&mut client)).await??;
 

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -63,7 +63,7 @@ strum = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true, features = ["transport", "prost"] }
+tonic = { workspace = true, features = ["transport", "prost", "zstd"] }
 tracing = { workspace = true }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 

--- a/tools/restatectl/src/commands/config/get.rs
+++ b/tools/restatectl/src/commands/config/get.rs
@@ -10,11 +10,9 @@
 
 use clap::Parser;
 use cling::{Collect, Run};
-use tonic::codec::CompressionEncoding;
+use restate_admin::cluster_controller::protobuf::new_cluster_ctrl_client;
 
-use restate_admin::cluster_controller::protobuf::{
-    GetClusterConfigurationRequest, cluster_ctrl_svc_client::ClusterCtrlSvcClient,
-};
+use restate_admin::cluster_controller::protobuf::GetClusterConfigurationRequest;
 use restate_cli_util::c_println;
 use restate_types::nodes_config::Role;
 
@@ -28,10 +26,7 @@ pub struct ConfigGetOpts {}
 async fn config_get(connection: &ConnectionInfo, _get_opts: &ConfigGetOpts) -> anyhow::Result<()> {
     let response = connection
         .try_each(Some(Role::Admin), |channel| async {
-            let mut client =
-                ClusterCtrlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
-
-            client
+            new_cluster_ctrl_client(channel)
                 .get_cluster_configuration(GetClusterConfigurationRequest {})
                 .await
         })

--- a/tools/restatectl/src/commands/log/reconfigure.rs
+++ b/tools/restatectl/src/commands/log/reconfigure.rs
@@ -12,11 +12,11 @@ use std::num::NonZeroU32;
 
 use anyhow::{Context, bail};
 use cling::prelude::*;
-use tonic::codec::CompressionEncoding;
 use tracing::error;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::{ChainExtension, SealAndExtendChainRequest};
+use restate_admin::cluster_controller::protobuf::{
+    ChainExtension, SealAndExtendChainRequest, new_cluster_ctrl_client,
+};
 use restate_cli_util::{c_eprintln, c_println};
 use restate_types::logs::LogId;
 use restate_types::logs::metadata::{Logs, ProviderKind, Segment};
@@ -129,10 +129,9 @@ async fn inner_reconfigure(
 
     let response = connection
         .try_each(Some(Role::Admin), |channel| async {
-            let mut client =
-                ClusterCtrlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
-
-            client.seal_and_extend_chain(request.clone()).await
+            new_cluster_ctrl_client(channel)
+                .seal_and_extend_chain(request.clone())
+                .await
         })
         .await?
         .into_inner();

--- a/tools/restatectl/src/commands/log/trim_log.rs
+++ b/tools/restatectl/src/commands/log/trim_log.rs
@@ -10,11 +10,9 @@
 
 use anyhow::Context;
 use cling::prelude::*;
-use tonic::codec::CompressionEncoding;
 use tracing::error;
 
-use restate_admin::cluster_controller::protobuf::TrimLogRequest;
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
+use restate_admin::cluster_controller::protobuf::{TrimLogRequest, new_cluster_ctrl_client};
 use restate_cli_util::c_println;
 use restate_types::nodes_config::Role;
 
@@ -56,10 +54,9 @@ async fn trim_log_inner(
 
     connection
         .try_each(Some(Role::Admin), |channel| async {
-            let mut client =
-                ClusterCtrlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
-
-            client.trim_log(trim_request).await
+            new_cluster_ctrl_client(channel)
+                .trim_log(trim_request)
+                .await
         })
         .await
         .with_context(|| "failed to submit trim request")?

--- a/tools/restatectl/src/commands/metadata/mod.rs
+++ b/tools/restatectl/src/commands/metadata/mod.rs
@@ -15,10 +15,8 @@ mod put;
 use std::path::PathBuf;
 
 use cling::prelude::*;
-use tonic::codec::CompressionEncoding;
 
-use restate_core::protobuf::metadata_proxy_svc::GetRequest;
-use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
+use restate_core::protobuf::metadata_proxy_svc::{GetRequest, new_metadata_proxy_client};
 use restate_types::protobuf::metadata::VersionedValue;
 use restate_types::storage::StorageCodec;
 use restate_types::{Version, Versioned, flexbuffers_storage_encode_decode};
@@ -120,10 +118,7 @@ async fn get_value(
     let key = key.as_ref();
     let response = connection
         .try_each(None, |channel| async {
-            let mut client = MetadataProxySvcClient::new(channel)
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip);
-            client
+            new_metadata_proxy_client(channel)
                 .get(GetRequest {
                     key: key.to_owned(),
                 })

--- a/tools/restatectl/src/commands/metadata_server/status.rs
+++ b/tools/restatectl/src/commands/metadata_server/status.rs
@@ -12,14 +12,13 @@ use std::collections::BTreeMap;
 
 use futures::future::join_all;
 use itertools::Itertools;
-use tonic::codec::CompressionEncoding;
 use tonic::{IntoRequest, Status};
 use tracing::debug;
 
 use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
-use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvcClient;
+use restate_metadata_server::grpc::new_metadata_server_client;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::{PlainNodeId, Version};
@@ -61,11 +60,10 @@ pub async fn list_metadata_servers(connection: &ConnectionInfo) -> anyhow::Resul
                         }
                     };
 
-                    let mut metadata_client = MetadataServerSvcClient::new(channel)
-                        .accept_compressed(CompressionEncoding::Gzip);
-
                     debug!("Querying metadata service status on node {address}");
-                    let metadata_store_status = metadata_client.status(().into_request()).await;
+                    let metadata_store_status = new_metadata_server_client(channel)
+                        .status(().into_request())
+                        .await;
 
                     (node_id, metadata_store_status)
                 }

--- a/tools/restatectl/src/commands/node/list_nodes.rs
+++ b/tools/restatectl/src/commands/node/list_nodes.rs
@@ -16,15 +16,13 @@ use chrono::TimeDelta;
 use cling::prelude::*;
 use itertools::Itertools;
 use tokio::task::JoinSet;
-use tonic::codec::CompressionEncoding;
 use tracing::{info, warn};
 
 use restate_cli_util::_comfy_table::{Cell, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::ui::{Tense, duration_to_human_rough};
-use restate_core::protobuf::node_ctl_svc::IdentResponse;
-use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
+use restate_core::protobuf::node_ctl_svc::{IdentResponse, new_node_ctl_client};
 use restate_types::health::MetadataServerStatus;
 use restate_types::net::AdvertisedAddress;
 use restate_types::nodes_config::NodesConfiguration;
@@ -219,8 +217,7 @@ async fn fetch_extra_info(
         let address = node_config.address.clone();
         let get_ident = async move {
             let channel = grpc_channel(address.clone());
-            let mut node_ctl_svc_client =
-                NodeCtlSvcClient::new(channel).accept_compressed(CompressionEncoding::Gzip);
+            let mut node_ctl_svc_client = new_node_ctl_client(channel);
 
             let ident_response = node_ctl_svc_client.get_ident(()).await?.into_inner();
             Ok((address, ident_response))

--- a/tools/restatectl/src/commands/node/remove_nodes.rs
+++ b/tools/restatectl/src/commands/node/remove_nodes.rs
@@ -12,12 +12,10 @@ use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
 use itertools::Itertools;
-use tonic::codec::CompressionEncoding;
 
 use restate_cli_util::c_println;
 use restate_core::metadata_store::serialize_value;
-use restate_core::protobuf::metadata_proxy_svc::PutRequest;
-use restate_core::protobuf::metadata_proxy_svc::metadata_proxy_svc_client::MetadataProxySvcClient;
+use restate_core::protobuf::metadata_proxy_svc::{PutRequest, new_metadata_proxy_client};
 use restate_types::PlainNodeId;
 use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
@@ -66,11 +64,9 @@ pub async fn remove_nodes(
 
     connection
         .try_each(None, |channel| async {
-            let mut client = MetadataProxySvcClient::new(channel)
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip);
-
-            client.put(request.clone()).await
+            new_metadata_proxy_client(channel)
+                .put(request.clone())
+                .await
         })
         .await?;
 

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -13,17 +13,17 @@ use std::collections::{BTreeMap, HashMap};
 
 use cling::prelude::*;
 use itertools::Itertools;
-use restate_types::nodes_config::Role;
-use tonic::codec::CompressionEncoding;
 
-use restate_admin::cluster_controller::protobuf::cluster_ctrl_svc_client::ClusterCtrlSvcClient;
-use restate_admin::cluster_controller::protobuf::{ClusterStateRequest, ListLogsRequest};
+use restate_admin::cluster_controller::protobuf::{
+    ClusterStateRequest, ListLogsRequest, new_cluster_ctrl_client,
+};
 use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::Tense;
 use restate_cli_util::ui::console::StyledTable;
 use restate_types::logs::metadata::{Chain, Logs};
 use restate_types::logs::{LogId, Lsn};
+use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
     DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode, SuspectNode, node_state,
 };
@@ -73,11 +73,7 @@ pub async fn list_partitions(
 ) -> anyhow::Result<()> {
     let cluster_state = connection
         .try_each(Some(Role::Admin), |channel| async {
-            let mut client = ClusterCtrlSvcClient::new(channel)
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip);
-
-            client
+            new_cluster_ctrl_client(channel)
                 .get_cluster_state(ClusterStateRequest::default())
                 .await
         })
@@ -89,11 +85,9 @@ pub async fn list_partitions(
     // we need the logs to show the current sequencer for each partition's log
     let list_logs_response = connection
         .try_each(Some(Role::Admin), |channel| async {
-            let mut client = ClusterCtrlSvcClient::new(channel)
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip);
-
-            client.list_logs(ListLogsRequest::default()).await
+            new_cluster_ctrl_client(channel)
+                .list_logs(ListLogsRequest::default())
+                .await
         })
         .await?
         .into_inner();

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -15,13 +15,11 @@ use clap::Parser;
 use cling::{Collect, Run};
 use restate_cli_util::ui::console::confirm_or_exit;
 use restate_cli_util::{c_error, c_println, c_warn};
-use restate_core::protobuf::node_ctl_svc::ProvisionClusterRequest;
-use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
+use restate_core::protobuf::node_ctl_svc::{ProvisionClusterRequest, new_node_ctl_client};
 use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind};
 use restate_types::replication::ReplicationProperty;
 use std::cmp::Ordering;
 use tonic::Code;
-use tonic::codec::CompressionEncoding;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "provision_cluster")]
@@ -70,9 +68,7 @@ async fn provision_cluster(
 
     let channel = grpc_channel(address.clone());
 
-    let mut client = NodeCtlSvcClient::new(channel)
-        .accept_compressed(CompressionEncoding::Gzip)
-        .send_compressed(CompressionEncoding::Gzip);
+    let mut client = new_node_ctl_client(channel);
 
     let request = ProvisionClusterRequest {
         dry_run: true,

--- a/tools/restatectl/src/commands/replicated_loglet/info.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/info.rs
@@ -17,8 +17,7 @@ use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::{Styled, StyledTable};
 use restate_cli_util::ui::stylesheet::Style;
-use restate_log_server::protobuf::GetLogletInfoRequest;
-use restate_log_server::protobuf::log_server_svc_client::LogServerSvcClient;
+use restate_log_server::protobuf::{GetLogletInfoRequest, new_log_server_client};
 use restate_types::PlainNodeId;
 use restate_types::logs::LogletId;
 use restate_types::logs::metadata::{LogletRef, Logs};
@@ -122,7 +121,7 @@ async fn get_info(connection: &ConnectionInfo, opts: &InfoOpts) -> anyhow::Resul
             );
             continue;
         }
-        let mut client = LogServerSvcClient::new(grpc_channel(node.address.clone()));
+        let mut client = new_log_server_client(grpc_channel(node.address.clone()));
         let Ok(Some(loglet_info)) = client
             .get_loglet_info(GetLogletInfoRequest {
                 loglet_id: opts.loglet_id.into(),

--- a/tools/restatectl/src/commands/sql.rs
+++ b/tools/restatectl/src/commands/sql.rs
@@ -25,7 +25,7 @@ use arrow_ipc::reader::StreamDecoder;
 use cling::prelude::*;
 use futures::{Stream, StreamExt, ready};
 use restate_admin::cluster_controller::protobuf::{
-    QueryRequest, QueryResponse, cluster_ctrl_svc_client::ClusterCtrlSvcClient,
+    QueryRequest, QueryResponse, new_cluster_ctrl_client,
 };
 use restate_cli_util::{
     _comfy_table::{Cell, Table},
@@ -35,7 +35,7 @@ use restate_cli_util::{
         stylesheet::Style,
     },
 };
-use tonic::{Status, Streaming, codec::CompressionEncoding};
+use tonic::{Status, Streaming};
 
 use crate::connection::ConnectionInfo;
 
@@ -52,9 +52,7 @@ async fn query(connection: &ConnectionInfo, args: &SqlOpts) -> anyhow::Result<()
         .context("Failed to connect to node")?;
 
     let start_time = Instant::now();
-    let mut client = ClusterCtrlSvcClient::new(channel)
-        .accept_compressed(CompressionEncoding::Gzip)
-        .send_compressed(CompressionEncoding::Gzip);
+    let mut client = new_cluster_ctrl_client(channel);
 
     let response = client
         .query(QueryRequest {

--- a/tools/restatectl/src/connection.rs
+++ b/tools/restatectl/src/connection.rs
@@ -15,14 +15,14 @@ use std::{cmp::Ordering, fmt::Display, sync::Arc};
 use cling::{Collect, prelude::Parser};
 use itertools::{Either, Itertools, Position};
 use rand::{rng, seq::SliceRandom};
-use restate_metadata_server::ReadModifyWriteError;
 use tokio::sync::{Mutex, MutexGuard};
-use tonic::{Code, Status, codec::CompressionEncoding, transport::Channel};
+use tonic::{Code, Status, transport::Channel};
 use tracing::{debug, info};
 
 use restate_core::protobuf::node_ctl_svc::{
-    GetMetadataRequest, IdentResponse, node_ctl_svc_client::NodeCtlSvcClient,
+    GetMetadataRequest, IdentResponse, new_node_ctl_client,
 };
+use restate_metadata_server::ReadModifyWriteError;
 use restate_types::{
     Version, Versioned,
     logs::metadata::Logs,
@@ -180,9 +180,7 @@ impl ConnectionInfo {
                 grpc_channel(address.clone())
             });
 
-            let mut client = NodeCtlSvcClient::new(channel.clone())
-                .accept_compressed(CompressionEncoding::Gzip)
-                .send_compressed(CompressionEncoding::Gzip);
+            let mut client = new_node_ctl_client(channel.clone());
 
             let response = match client.get_ident(()).await {
                 Ok(response) => response.into_inner(),


### PR DESCRIPTION

The current default is very small, 250MB gives more room and we'll review this value again in the future.
```
// intentionally empty
```
