### PR TITLE
[fix] Fix `overdue` not being woken up under extreme load conditions

### DIFF
--- a/crates/futures-util/src/overdue.rs
+++ b/crates/futures-util/src/overdue.rs
@@ -189,7 +189,10 @@ where
         this.delay.as_mut().reset(new_deadline);
         // to make sure we register the waker
         let r = this.delay.poll(cx);
-        assert!(r.is_pending());
+        if !r.is_pending() {
+            // we need to wake up the future to make sure it's polled again
+            cx.waker().wake_by_ref();
+        }
         Poll::Pending
     }
 }


### PR DESCRIPTION

Under extreme load, the deadline might have already passed by the time we schedule the timer, in this case, we must wake up the task again immediately to avoid being stuck for long time.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3057).
* #3059
* #3058
* __->__ #3057