### PR TITLE
[Bifrost] auto-seal sequencers on graceful shutdown

### DIFF
--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -161,7 +161,7 @@ impl BifrostService {
 
         // We spawn the watchdog as a background long-running task
         TaskCenter::spawn(
-            TaskKind::BifrostBackgroundHighPriority,
+            TaskKind::BifrostWatchdog,
             "bifrost-watchdog",
             self.watchdog.run(),
         )?;

--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -19,7 +19,7 @@ use tracing::{debug, trace, warn};
 use restate_core::metadata_store::{
     ReadModifyWriteError, ReadWriteError, retry_on_retryable_error,
 };
-use restate_core::{TaskCenter, TaskKind, cancellation_watcher};
+use restate_core::{TaskCenter, TaskCenterFutureExt, TaskKind, cancellation_watcher};
 use restate_types::config::Configuration;
 use restate_types::logs::metadata::{Logs, ProviderKind};
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
@@ -170,7 +170,7 @@ impl Watchdog {
             providers
                 .build_task()
                 .name("shutdown-loglet-provider")
-                .spawn(async move { provider.shutdown().await })
+                .spawn(async move { provider.shutdown().await }.in_current_tc())
                 .expect("to spawn provider shutdown");
         }
 

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -811,9 +811,12 @@ impl TaskCenterInner {
         self.cancel_tasks(Some(TaskKind::PartitionProcessorManager), None)
             .await;
         self.initiate_managed_runtimes_shutdown();
+        // Ask bifrost to shutdown providers and loglets
+        self.cancel_tasks(Some(TaskKind::BifrostWatchdog), None)
+            .await;
+        self.shutdown_managed_runtimes();
         // global shutdown trigger
         self.cancel_tasks(None, None).await;
-        self.shutdown_managed_runtimes();
         // notify outer components that we have completed the shutdown.
         self.global_cancel_token.cancel();
         info!("** Shutdown completed in {:?}", start.elapsed());

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -117,6 +117,8 @@ pub enum TaskKind {
     MetadataServer,
     Background,
     // -- Bifrost Tasks
+    #[strum(props(runtime = "default"))]
+    BifrostWatchdog,
     /// A background task that the system needs for its operation. The task requires a system
     /// shutdown on errors and the system will wait for its graceful cancellation on shutdown.
     #[strum(props(runtime = "default"))]

--- a/crates/futures-util/src/overdue.rs
+++ b/crates/futures-util/src/overdue.rs
@@ -189,7 +189,10 @@ where
         this.delay.as_mut().reset(new_deadline);
         // to make sure we register the waker
         let r = this.delay.poll(cx);
-        assert!(r.is_pending());
+        if !r.is_pending() {
+            // we need to wake up the future to make sure it's polled again
+            cx.waker().wake_by_ref();
+        }
         Poll::Pending
     }
 }

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -177,7 +177,7 @@ impl<S: LogStore> LogletWorker<S> {
                     // todo: consider a draining shutdown if needed
                     // this might include sending notifications of shutdown to allow graceful
                     // handoff
-                    trace!(loglet_id = %self.loglet_id, "Loglet writer shutting down");
+                    trace!(loglet_id = %self.loglet_id, "Loglet worker shutting down");
                     break;
                 }
                 // GET_DIGEST

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -106,7 +106,7 @@ impl LogStoreWriter {
         // the backlog while we process this one.
         let (sender, receiver) = mpsc::channel(batch_size * 2);
 
-        TaskCenter::spawn_child(
+        TaskCenter::spawn(
             TaskKind::SystemService,
             "log-server-rocksdb-writer",
             async move {
@@ -124,6 +124,9 @@ impl LogStoreWriter {
                         }
                         Some(cmds) = TokioStreamExt::next(&mut receiver) => {
                                 self.handle_commands(opts.live_load(), cmds).await;
+                        }
+                        else => {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION

This PR is another step towards better graceful shutdown. We'll ask Bifrost's watchdog to shutdown before we terminate connections to give it a chance to cleanly seal all local sequencers. This also fixes a bug where the rocksdb writer might get terminated before the loglet workers, causing the loglet workers to spew errors on shutdown and not cleanly draining up.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3058).
* #3059
* __->__ #3058
* #3057