### PR TITLE
Jitter scheduled snapshot creation by 0-10s

### DIFF
--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use tracing::{debug, info, instrument, warn};
 
@@ -37,12 +37,7 @@ pub struct SnapshotPartitionTask {
 
 impl SnapshotPartitionTask {
     #[instrument(level = "info", skip_all, fields(snapshot_id = %self.snapshot_id, partition_id = %self.partition_id))]
-    pub async fn run(
-        self,
-        jitter_start: Duration,
-    ) -> Result<PartitionSnapshotMetadata, SnapshotError> {
-        tokio::time::sleep(jitter_start).await;
-
+    pub async fn run(self) -> Result<PartitionSnapshotMetadata, SnapshotError> {
         debug!("Creating partition snapshot");
         let result = self.create_snapshot_inner().await;
 

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::path::PathBuf;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use tracing::{debug, info, instrument, warn};
 
@@ -37,9 +37,13 @@ pub struct SnapshotPartitionTask {
 
 impl SnapshotPartitionTask {
     #[instrument(level = "info", skip_all, fields(snapshot_id = %self.snapshot_id, partition_id = %self.partition_id))]
-    pub async fn run(self) -> Result<PartitionSnapshotMetadata, SnapshotError> {
-        debug!("Creating partition snapshot");
+    pub async fn run(
+        self,
+        jitter_start: Duration,
+    ) -> Result<PartitionSnapshotMetadata, SnapshotError> {
+        tokio::time::sleep(jitter_start).await;
 
+        debug!("Creating partition snapshot");
         let result = self.create_snapshot_inner().await;
 
         result

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -23,6 +23,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::gauge;
 use rand::Rng;
 use rand::seq::SliceRandom;
+use restate_types::retries::with_jitter;
 use tokio::sync::oneshot;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinSet;
@@ -245,7 +246,8 @@ impl PartitionProcessorManager {
         let mut logs_version_watcher = metadata.watch(MetadataKind::Logs);
         let mut partition_table_version_watcher = metadata.watch(MetadataKind::PartitionTable);
 
-        let mut latest_snapshot_check_interval = tokio::time::interval(Duration::from_secs(5));
+        let mut latest_snapshot_check_interval =
+            tokio::time::interval(with_jitter(Duration::from_secs(1), 0.1));
         latest_snapshot_check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         let mut update_target_tail_lsns = tokio::time::interval(Duration::from_secs(1));

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1002,7 +1002,7 @@ impl PartitionProcessorManager {
                     snapshot_repository,
                 };
 
-                let jitter_start = if sender.is_some() {
+                let jitter = if sender.is_some() {
                     Duration::ZERO
                 } else {
                     Duration::from_millis(rand::rng().random_range(0..10_000))
@@ -1010,7 +1010,10 @@ impl PartitionProcessorManager {
                 let spawn_task_result = TaskCenter::spawn_unmanaged(
                     TaskKind::PartitionSnapshotProducer,
                     "create-snapshot",
-                    create_snapshot_task.run(jitter_start),
+                    async move {
+                        tokio::time::sleep(jitter).await;
+                        create_snapshot_task.run().await
+                    },
                 );
 
                 match spawn_task_result {


### PR DESCRIPTION
This commit also limits the maximum number of in-flight _scheduled_ snapshot requests to 4.

This PR precedes https://github.com/restatedev/restate/pull/3061, see for testing notes.