### PR TITLE
Update archived LSN before taking snapshot

### DIFF
--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream::{FuturesUnordered, StreamExt};
+use itertools::{Either, Itertools};
 use metrics::gauge;
 use rand::Rng;
 use rand::seq::SliceRandom;
@@ -246,9 +247,11 @@ impl PartitionProcessorManager {
         let mut logs_version_watcher = metadata.watch(MetadataKind::Logs);
         let mut partition_table_version_watcher = metadata.watch(MetadataKind::PartitionTable);
 
-        let mut latest_snapshot_check_interval =
-            tokio::time::interval(with_jitter(Duration::from_secs(1), 0.1));
-        latest_snapshot_check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut snapshot_check_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + Duration::from_secs(rand::rng().random_range(30..60)), // delay scheduled snapshots on startup
+            with_jitter(Duration::from_secs(1), 0.1),
+        );
+        snapshot_check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         let mut update_target_tail_lsns = tokio::time::interval(Duration::from_secs(1));
         update_target_tail_lsns.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -259,7 +262,7 @@ impl PartitionProcessorManager {
                 Some(command) = self.rx.recv() => {
                     self.on_command(command);
                 }
-                _ = latest_snapshot_check_interval.tick() => {
+                _ = snapshot_check_interval.tick() => {
                     self.trigger_periodic_partition_snapshots();
                 }
                 _ = update_target_tail_lsns.tick() => {
@@ -552,6 +555,14 @@ impl PartitionProcessorManager {
                     Entry::Vacant(v) => {
                         v.insert(tail_lsn);
                     }
+                }
+            }
+            EventKind::NewArchivedLsn { archived_lsn } => {
+                if let Some(archived_lsn) = archived_lsn {
+                    self.archived_lsns
+                        .entry(partition_id)
+                        .and_modify(|lsn| *lsn = archived_lsn.max(*lsn))
+                        .or_insert(archived_lsn);
                 }
             }
         }
@@ -917,39 +928,52 @@ impl PartitionProcessorManager {
             return;
         };
 
+        let potential_snapshot_partitions =
+            self.processor_states
+                .iter()
+                .filter_map(|(partition_id, state)| {
+                    state
+                        .partition_processor_status()
+                        .filter(|status| {
+                            status.effective_mode == RunMode::Leader
+                                && status.replay_status == ReplayStatus::Active
+                        })
+                        .map(|status| (*partition_id, status))
+                });
+
+        let (mut known_archived_lsn, unknown_archived_lsn): (Vec<_>, Vec<_>) =
+            potential_snapshot_partitions.partition_map(|(partition_id, status)| {
+                match self.archived_lsns.get(&partition_id) {
+                    Some(&archived_lsn) => Either::Left((
+                        partition_id,
+                        status.last_applied_log_lsn.unwrap_or(Lsn::INVALID),
+                        archived_lsn,
+                    )),
+                    None => Either::Right(partition_id),
+                }
+            });
+
+        for partition_id in unknown_archived_lsn {
+            self.spawn_update_archived_lsn_task(partition_id, snapshot_repository.clone());
+        }
+
         // Limit the number of snapshots we schedule automatically
         const MAX_CONCURRENT_SNAPSHOTS: usize = 4;
         let limit = MAX_CONCURRENT_SNAPSHOTS.saturating_sub(self.pending_snapshots.len());
 
-        let mut snapshot_partitions: Vec<_> = self
-            .processor_states
-            .iter()
-            .filter_map(|(partition_id, state)| {
-                state
-                    .partition_processor_status()
-                    .map(|status| (*partition_id, status))
+        known_archived_lsn.shuffle(&mut rand::rng());
+        let snapshot_partitions = known_archived_lsn
+            .into_iter()
+            .filter_map(|(partition_id, applied_lsn, archived_lsn)| {
+                if applied_lsn >= archived_lsn.add(Lsn::from(records_per_snapshot.get())) {
+                    Some(partition_id)
+                } else {
+                    None
+                }
             })
-            .filter(|(partition_id, status)| {
-                status.effective_mode == RunMode::Leader
-                    && status.replay_status == ReplayStatus::Active
-                    && status.last_applied_log_lsn.unwrap_or(Lsn::INVALID)
-                        >= self
-                            .archived_lsns
-                            .get(partition_id)
-                            .copied()
-                            .unwrap_or(Lsn::INVALID)
-                            .add(Lsn::from(records_per_snapshot.get()))
-            })
-            .collect();
-        snapshot_partitions.shuffle(&mut rand::rng());
+            .take(limit);
 
-        for (partition_id, status) in snapshot_partitions.into_iter().take(limit) {
-            debug!(
-                %partition_id,
-                last_archived_lsn = %status.last_archived_log_lsn.unwrap_or(Lsn::OLDEST),
-                last_applied_lsn = %status.last_applied_log_lsn.unwrap_or(Lsn::INVALID),
-                "Creating periodic partition snapshot",
-            );
+        for partition_id in snapshot_partitions {
             self.spawn_create_snapshot_task(partition_id, None, snapshot_repository.clone(), None);
         }
     }
@@ -1046,6 +1070,33 @@ impl PartitionProcessorManager {
         }
     }
 
+    fn spawn_update_archived_lsn_task(
+        &mut self,
+        partition_id: PartitionId,
+        snapshot_repository: SnapshotRepository,
+    ) {
+        self.asynchronous_operations
+            .build_task()
+            .name(&format!("update-archived-lsn-{}", partition_id))
+            .spawn(
+                async move {
+                    let archived_lsn = snapshot_repository
+                        .get_latest_archived_lsn(partition_id)
+                        .await
+                        .inspect_err(|err| {
+                            info!(?partition_id, "Unable to get latest archived LSN: {}", err)
+                        })
+                        .unwrap_or_default();
+                    AsynchronousEvent {
+                        partition_id,
+                        inner: EventKind::NewArchivedLsn { archived_lsn },
+                    }
+                }
+                .in_current_tc(),
+            )
+            .expect("to spawn update archived LSN task");
+    }
+
     /// Creates a task that when started will spawn a new partition processor.
     ///
     /// This allows multiple partition processors to be started concurrently without holding
@@ -1129,6 +1180,9 @@ enum EventKind {
     },
     NewTargetTail {
         tail: Option<Lsn>,
+    },
+    NewArchivedLsn {
+        archived_lsn: Option<Lsn>,
     },
 }
 


### PR DESCRIPTION
This change stops partition processors from always creating a snapshot on startup regardless of how close their applied LSN is to the archived LSN.

In addition, the first round of scheduled snapshots checks only begins 30-60s after startup to avoid synchronizing with other nodes if an entire cluster starts up at the same time.

This PR is based on https://github.com/restatedev/restate/pull/3060.

---

Testing:

- Check desired startup and concurrency limit behavior via `restatectl partitions list` archived LSN output
- Test with pre-existing snapshots in repository
- Test manually requesting snapshots during the startup "quiescent" phase
- Test concurrently requesting multiple snapshots outside of scheduled snapshots