### PR TITLE
[RocksDb] Enable write batch insertion hints for log-servers

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -124,6 +124,7 @@ fn db_options(log_server_opts: &LogServerOptions) -> rocksdb::Options {
             .expect("fits into u64"),
     );
 
+    opts.set_enable_pipelined_write(true);
     opts.set_max_subcompactions(log_server_opts.rocksdb_max_sub_compactions());
 
     opts

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -265,6 +265,9 @@ impl LogStoreWriter {
         let mut write_opts = rocksdb::WriteOptions::new();
         write_opts.disable_wal(opts.rocksdb.rocksdb_disable_wal());
         write_opts.set_sync(!opts.rocksdb_disable_wal_fsync());
+        // hint to rocksdb to insert the memtable position hint for the batch, our writes per batch
+        // are mostly ordered.
+        write_opts.set_memtable_insert_hint_per_batch(true);
 
         trace!(
             "Committing loglet current write batch: {} items",

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -281,8 +281,6 @@ impl RocksDbManager {
         }
 
         // no need to retain 1000 log files by default.
-        //
-        db_options.set_keep_log_file_num(2);
         if !opts.rocksdb_disable_wal() {
             // RocksDB does not support recycling wal log files if wal is disabled when writing
             db_options.set_recycle_log_file_num(4);


### PR DESCRIPTION

In conjunction with pipedlined writes, this improves latency under extreme load conditions, a long-standing improvement that I had locally for some time.
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3062).
* #3071
* __->__ #3062
* #3070