### PR TITLE
Use round-robin for next metadata server selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7155,6 +7155,7 @@ dependencies = [
  "futures",
  "googletest",
  "http 1.2.0",
+ "indexmap 2.7.1",
  "itertools 0.14.0",
  "metrics",
  "parking_lot",

--- a/crates/metadata-server/Cargo.toml
+++ b/crates/metadata-server/Cargo.toml
@@ -28,6 +28,7 @@ derive_more = { workspace = true }
 flexbuffers = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 parking_lot = { workspace = true}


### PR DESCRIPTION
Non-determinism can cause us to take longer to discover the current leader.

Repeated attempts to talk to non-leaders may have been the cause of this failure to bootstrap a cluster: https://github.com/restatedev/jepsen/actions/runs/14048540740