### PR TITLE
fix: make bifrost compile with all features

### DIFF
--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 local-loglet = ["dep:restate-rocksdb", "dep:rocksdb", "restate-types/local-loglet"]
 replicated-loglet = ["auto-extend"]
 memory-loglet = ["restate-types/memory-loglet"]
-test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util"]
+test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util", "restate-core/test-util"]
 # enables bifrost to auto seal and extend. This is a transitional feature that will be removed soon.
 auto-extend = []
 


### PR DESCRIPTION
Ref: https://github.com/restatedev/restate/issues/3036

before fix:

```
cargo clippy --manifest-path crates/bifrost/Cargo.toml --all-features

error[E0599]: no variant or associated item named `TestRunner` found for enum `restate_core::TaskKind` in the current scope
   --> crates/bifrost/src/loglet/loglet_tests.rs:127:47
    |
127 |         TaskCenter::spawn_unmanaged(TaskKind::TestRunner, "read", {
    |                                               ^^^^^^^^^^ variant or associated item not found in `TaskKind`
```