### PR TITLE
xtask requires `clients` feature

### DIFF
--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-restate-admin = { workspace = true, features = ["options_schema", "memory-loglet"] }
+restate-admin = { workspace = true, features = ["options_schema", "memory-loglet", "clients"] }
 restate-bifrost = { workspace = true, features = ["test-util"] }
 restate-core = { workspace = true, features = ["test-util"] }
 restate-metadata-server = { workspace = true }


### PR DESCRIPTION
xtask requires `clients` feature

Summary:
This is to fix documentation generation
