### PR TITLE
Specify default memory settings as multiples of 1024

### DIFF
--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -120,7 +120,7 @@ impl Default for BifrostOptions {
             append_retry_max_interval: Duration::from_secs(1).into(),
             auto_recovery_interval: Duration::from_secs(3).into(),
             seal_retry_interval: Duration::from_secs(2).into(),
-            record_cache_memory_size: 250_000_000u64.into(),
+            record_cache_memory_size: ByteCount::from(250u64 * 1024 * 1024), // 250 MiB
         }
     }
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -442,7 +442,7 @@ impl Default for CommonOptions {
             storage_high_priority_bg_threads: None,
             storage_low_priority_bg_threads: None,
             rocksdb_total_memtables_ratio: 0.5, // (50% of rocksdb-total-memory-size)
-            rocksdb_total_memory_size: NonZeroUsize::new(6_000_000_000).unwrap(), // 4GB
+            rocksdb_total_memory_size: NonZeroUsize::new(6 * 1024 * 1024 * 1024).unwrap(), // 6GiB
             rocksdb_bg_threads: None,
             rocksdb_high_priority_bg_threads: NonZeroU32::new(2).unwrap(),
             rocksdb_write_stall_threshold: Duration::from_secs(3).into(),

--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -55,7 +55,7 @@ impl QueryEngineOptions {
 impl Default for QueryEngineOptions {
     fn default() -> Self {
         Self {
-            memory_size: NonZeroUsize::new(4_000_000_000).unwrap(), // 4GB
+            memory_size: NonZeroUsize::new(4 * 1024 * 1024 * 1024).unwrap(), // 4GiB
             tmp_dir: None,
             query_parallelism: None,
             pgsql_bind_address: "0.0.0.0:9071".parse().unwrap(),

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -211,7 +211,7 @@ impl Default for InvokerOptions {
             in_memory_queue_length_limit: NonZeroUsize::new(66_049).unwrap(),
             inactivity_timeout: Duration::from_secs(60).into(),
             abort_timeout: Duration::from_secs(60).into(),
-            message_size_warning: NonZeroUsize::new(10_000_000).unwrap(), // 10MB
+            message_size_warning: NonZeroUsize::new(10 * 1024 * 1024).unwrap(), // 10MiB
             message_size_limit: None,
             tmp_dir: None,
             concurrent_invocations_limit: Some(NonZeroUsize::new(100).unwrap()),


### PR DESCRIPTION
Since we are displaying the memory configuration using IEC units, not using 1024 as the base will lead to odd round numbers (6 GB -> 5.6 GiB, 250 MB -> 238.4 MiB). Technically, the defaults can break user setups if they are on a very tight memory budget. That's the downside :-(

See here for example: https://github.com/restatedev/documentation/pull/577/files#diff-fac2d41f5b9f923d09879e40d88a10626dc6fa7c47b5388d6ccb9a9f7c7fe9b3R110.