### PR TITLE
[LogServer] Add `rocksdb-max-wal-size` to `[log-server]` to limit WAL size

### DIFF
--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -281,8 +281,6 @@ impl RocksDbManager {
         }
 
         // no need to retain 1000 log files by default.
-        //
-        db_options.set_keep_log_file_num(2);
         if !opts.rocksdb_disable_wal() {
             // RocksDB does not support recycling wal log files if wal is disabled when writing
             db_options.set_recycle_log_file_num(4);


### PR DESCRIPTION

This adds a new option `rocksdb-max-wal-size` in `[log-server]` with hidden default (0) that controls the maximum size of the WAL in bytes. If the WAL size exceeds this limit, the server will force a flush to the SST files. This is useful to prevent the WAL from growing indefinitely and consuming disk space.
The default (0) will use 6 times the total size allocated to memtables for log-server by default.

With this change, there is no need for atomic_flushes anymore, so I've removed it.


Manually tested, old WAL files are removed as expected.
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3070).
* #3071
* #3062
* __->__ #3070