### PR TITLE
Harden `local-cluster-runner`

### DIFF
--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [features]
-default = []
+default = ["clients"]
 clients = []
 test-util = []
 


### PR DESCRIPTION
Harden `local-cluster-runner`

Summary:
Make sure that metadata server checks also wait until all
members has joined

Related to #2905
