### PR TITLE
Use replication factor of `u8::MAX` as default for `everywhere`

### DIFF
--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -205,11 +205,14 @@ impl From<AdminOptionsShadow> for AdminOptions {
 
             match value {
                 PartitionReplication::Everywhere => {
+                    let replication_property = ReplicationProperty::new_unchecked(u8::MAX);
                     print_warning_deprecated_value(
                         "admin.default-partition-replication",
                         "everywhere",
+                        &replication_property,
                     );
-                    ReplicationProperty::new_unchecked(1)
+
+                    replication_property
                 }
                 PartitionReplication::Limit(replication_property) => replication_property,
             }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -45,6 +45,7 @@ pub use query_engine::*;
 pub use rocksdb::*;
 pub use worker::*;
 
+use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
 
@@ -327,6 +328,11 @@ fn print_warning_deprecated_config_option(deprecated: &str, replacement: Option<
     }
 }
 
-fn print_warning_deprecated_value(option: &str, value: &str) {
-    eprintln!("Option {option} does no longer support config value {value}. Using default value");
+fn print_warning_deprecated_value<D>(option: &str, value: &str, default: &D)
+where
+    D: Display,
+{
+    eprintln!(
+        "Option {option} does no longer support config value {value}. Using default value of {default}"
+    );
 }


### PR DESCRIPTION
Use replication factor of `u8::MAX` as default for `everywhere`

Summary:
Set default value of 255 `u8::MAX` for the "everywhere" partition
replication

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3079).
* #3082
* __->__ #3079