### PR TITLE
Remove too tight timeouts from fast_forward_over_trim_gap 

### DIFF
--- a/crates/admin/src/cluster_controller/protobuf.rs
+++ b/crates/admin/src/cluster_controller/protobuf.rs
@@ -8,9 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tonic::codec::CompressionEncoding;
-use tonic::transport::Channel;
-
 use restate_core::network::grpc::DEFAULT_GRPC_COMPRESSION;
 
 tonic::include_proto!("restate.cluster_ctrl");
@@ -21,11 +18,11 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 /// Creates a new ClusterCtrlSvcClient with appropriate configuration
 #[cfg(feature = "clients")]
 pub fn new_cluster_ctrl_client(
-    channel: Channel,
-) -> cluster_ctrl_svc_client::ClusterCtrlSvcClient<Channel> {
+    channel: tonic::transport::Channel,
+) -> cluster_ctrl_svc_client::ClusterCtrlSvcClient<tonic::transport::Channel> {
     cluster_ctrl_svc_client::ClusterCtrlSvcClient::new(channel)
         // note: the order of those calls defines the priority
-        .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
+        .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
         .send_compressed(DEFAULT_GRPC_COMPRESSION)
 }

--- a/crates/log-server/src/protobuf.rs
+++ b/crates/log-server/src/protobuf.rs
@@ -8,11 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tonic::codec::CompressionEncoding;
-use tonic::transport::Channel;
-
-use restate_core::network::grpc::{DEFAULT_GRPC_COMPRESSION, MAX_MESSAGE_SIZE};
-
 tonic::include_proto!("restate.log_server");
 
 pub const FILE_DESCRIPTOR_SET: &[u8] =
@@ -21,13 +16,14 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 /// Creates a new ClusterCtrlSvcClient with appropriate configuration
 #[cfg(feature = "clients")]
 pub fn new_log_server_client(
-    channel: Channel,
-) -> log_server_svc_client::LogServerSvcClient<Channel> {
+    channel: tonic::transport::Channel,
+) -> log_server_svc_client::LogServerSvcClient<tonic::transport::Channel> {
+    use restate_core::network::grpc::{DEFAULT_GRPC_COMPRESSION, MAX_MESSAGE_SIZE};
     log_server_svc_client::LogServerSvcClient::new(channel)
         .max_decoding_message_size(MAX_MESSAGE_SIZE)
         .max_encoding_message_size(MAX_MESSAGE_SIZE)
         // note: the order of those calls defines the priority
-        .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
+        .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
         .send_compressed(DEFAULT_GRPC_COMPRESSION)
 }


### PR DESCRIPTION
Instead of relying on fine-grained timeouts which might be wrong in constrained
environments as our CI runners, we rely on the global nextest timeout of 180s to
catch hanging tests.

This fixes https://github.com/restatedev/restate/issues/2973.