### PR TITLE
Increase retry count for StartedNode::provision_cluster

### DIFF
--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -68,6 +68,7 @@ async fn replicated_loglet() -> googletest::Result<()> {
         replication_property: ReplicationProperty::new(NonZeroU8::new(2).expect("to be non-zero")),
     };
 
+    info!("Provisioning the cluster");
     cluster.nodes[0]
         .provision_cluster(
             None,


### PR DESCRIPTION
In order to deal with slower test infrastructure, we increase the retry count for StartedNode::provision_cluster to ~60s. If the node does not allow to provision the cluster within this duration, the operation will fail.

This fixes #3052.