### PR TITLE
Increase log level of cluster_chaos_test to restate=debug

### DIFF
--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -101,6 +101,7 @@ async fn cluster_chaos_test() -> googletest::Result<()> {
         }));
     base_config.common.default_num_partitions = 4;
     base_config.bifrost.default_provider = ProviderKind::Replicated;
+    base_config.common.log_filter = "warn,restate=debug".to_owned();
 
     let nodes = Node::new_test_nodes(
         base_config,


### PR DESCRIPTION
Increasing the log level of the cluster_chaos_test to restate=debug allows us hopefully to find out why the test got stuck (concretely why a newly started process did not go beyond the "Starting Restate Server" log statement.

This fixes #3072.