### PR TITLE
Reduce logging originating from network and loglet sealing

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/tasks/seal.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/seal.rs
@@ -10,7 +10,7 @@
 
 use tokio::task::JoinSet;
 use tokio::time::Instant;
-use tracing::{Instrument, debug, instrument, trace, warn};
+use tracing::{Instrument, debug, info, instrument, trace, warn};
 
 use restate_core::network::rpc_router::RpcRouter;
 use restate_core::network::{Incoming, Networking, TransportConnect};
@@ -142,7 +142,7 @@ impl SealTask {
             {
                 let mut nodeset_status = DecoratedNodeSet::from_iter(effective_nodeset);
                 nodeset_status.extend(&nodeset_checker);
-                tracing::info!(
+                info!(
                     loglet_id = %my_params.loglet_id,
                     replication = %my_params.replication,
                     %max_local_tail,

--- a/crates/core/src/network/connection.rs
+++ b/crates/core/src/network/connection.rs
@@ -13,7 +13,6 @@ mod throttle;
 // re-export
 pub use throttle::ConnectThrottle;
 use tracing::debug;
-use tracing::info;
 
 use std::time::Duration;
 
@@ -222,10 +221,10 @@ impl Connection {
         ConnectThrottle::note_connect_status(&destination, result.is_ok());
         match result {
             Err(ref e) => {
-                info!(%direction, "Couldn't connect to {}: {}", destination, e);
+                debug!(%direction, "Couldn't connect to {}: {}", destination, e);
             }
             Ok((_, task_id)) => {
-                info!(%direction, %task_id, "Connection established to {}", destination);
+                debug!(%direction, %task_id, "Connection established to {}", destination);
             }
         }
         result

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -250,7 +250,7 @@ impl ConnectionManager {
             Some(peer_metadata),
         )?;
 
-        info!(
+        debug!(
             direction_at_peer = %hello.direction(),
             task_id = %task_id,
             peer = %peer_node_id,
@@ -539,7 +539,7 @@ impl ConnectionTracking for ConnectionManager {
     }
 
     fn connection_dropped(&self, conn: &Connection) {
-        info!(
+        debug!(
             "Connection terminated, connection lived for {:?}",
             conn.created.elapsed()
         );


### PR DESCRIPTION
This commit reduces the log level from info to debug for most of the network related log statements as well as when loglets are sealed since the information does not seem actionable by users.