### PR TITLE
fix(3088): disable pgsql endpoint by default

### DIFF
--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -81,8 +81,6 @@ pub struct Node {
             pub fn with_random_ports(self) {
                 self.base_config.admin.bind_address =
                     random_socket_address().expect("to find a random port for the admin server");
-                self.base_config.admin.query_engine.pgsql_bind_address =
-                    random_socket_address().expect("to find a random port for the pgsql server");
                 self.base_config.ingress.bind_address =
                     random_socket_address().expect("to find a random port for the ingress server");
             }

--- a/crates/storage-query-postgres/src/service.rs
+++ b/crates/storage-query-postgres/src/service.rs
@@ -12,8 +12,6 @@ use crate::pgwire_server::{HandlerFactory, spawn_connection};
 use codederror::CodedError;
 use restate_core::cancellation_watcher;
 use restate_storage_query_datafusion::context::QueryContext;
-
-use restate_types::config::QueryEngineOptions;
 use restate_types::errors::GenericError;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
@@ -40,9 +38,9 @@ pub struct PostgresQueryService {
 }
 
 impl PostgresQueryService {
-    pub fn from_options(options: &QueryEngineOptions, query_context: QueryContext) -> Self {
+    pub fn from_options(bind_address: SocketAddr, query_context: QueryContext) -> Self {
         Self {
-            bind_address: options.pgsql_bind_address,
+            bind_address,
             query_context,
         }
     }

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -212,6 +212,12 @@ impl From<AdminOptionsShadow> for AdminOptions {
         });
 
         #[allow(deprecated)]
+        if value.query_engine.pgsql_bind_address.is_some() {
+            print_warning_deprecated_config_option("admin.query-enging.pgsql-bind-address", None);
+            eprintln!("Please make SQL queries using the CLI or with the :9070/query API.")
+        }
+
+        #[allow(deprecated)]
         Self {
             bind_address: value.bind_address,
             advertised_admin_endpoint: None,

--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -44,7 +44,11 @@ pub struct QueryEngineOptions {
     /// # Pgsql Bind address
     ///
     /// The address to bind for the psql service.
-    pub pgsql_bind_address: SocketAddr,
+    #[deprecated(
+        since = "1.4.0",
+        note = "Pgsql query engine be disable with 1.4.0, and removed with 1.5.0"
+    )]
+    pub pgsql_bind_address: Option<SocketAddr>,
 }
 
 impl QueryEngineOptions {
@@ -52,13 +56,15 @@ impl QueryEngineOptions {
         self.query_parallelism.map(Into::into)
     }
 }
+
 impl Default for QueryEngineOptions {
     fn default() -> Self {
+        #[allow(deprecated)]
         Self {
             memory_size: NonZeroUsize::new(4 * 1024 * 1024 * 1024).unwrap(), // 4GiB
             tmp_dir: None,
             query_parallelism: None,
-            pgsql_bind_address: "0.0.0.0:9071".parse().unwrap(),
+            pgsql_bind_address: None,
         }
     }
 }


### PR DESCRIPTION
Fix: https://github.com/restatedev/restate/issues/3088

when configuration it in `config.toml`, a log was printed：

```
Using the deprecated config option 'admin.query-enging.pgsql-bind-address'.
```