### PR TITLE
Add missing column `invoked_by_subscription_id` to `sys_invocation` view

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -51,6 +51,7 @@ const SYS_INVOCATION_VIEW: &str = "CREATE VIEW sys_invocation as SELECT
             ss.invoked_by,
             ss.invoked_by_service_name,
             ss.invoked_by_id,
+            ss.invoked_by_subscription_id,
             ss.invoked_by_target,
             ss.pinned_deployment_id,
             ss.pinned_service_protocol_version,

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use std::borrow::Cow;
 
-/// List of available table docs. Whenever you add aa new table, add its table docs to
+/// List of available table docs. Whenever you add a new table, add its table docs to
 /// this array. This will ensure that the table docs will be included in the automatic
 /// table docs generation process.
 pub const ALL_TABLE_DOCS: &[StaticTableDocs] = &[

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -413,7 +413,7 @@ macro_rules! define_table {
         $table_name: ident (
         $(
             $(#[doc = $doc:expr])*
-            $element:ident: $ty:expr
+            $element:ident: $ty:ty
         ),+ $(,)?)
     ) => (paste::paste! {
 


### PR DESCRIPTION
Add missing column `invoked_by_subscription_id` to `sys_invocation` view

Fix discrepancy between the view docs and actual view columns
