### PR TITLE
Back out "Set replicated loglet and replicate metadata server as the defaults for 1.3.0"

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -168,7 +168,7 @@ pub fn restate_configuration() -> Configuration {
         .expect("building worker options should work");
 
     let metadata_server_options = MetadataServerOptionsBuilder::default()
-        .kind(MetadataServerKind::Raft(RaftOptions::default()))
+        .kind(Some(MetadataServerKind::Raft(RaftOptions::default())))
         .build()
         .expect("building metadata server options should work");
 

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -36,7 +36,7 @@ use super::{
 pub struct BifrostOptions {
     /// # The default kind of loglet to be used
     ///
-    /// Default: Replicated
+    /// Default: Local
     pub default_provider: ProviderKind,
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     /// Configuration of local loglet provider
@@ -107,7 +107,7 @@ impl BifrostOptions {
 impl Default for BifrostOptions {
     fn default() -> Self {
         Self {
-            default_provider: ProviderKind::Replicated,
+            default_provider: ProviderKind::Local,
             replicated_loglet: ReplicatedLogletOptions::default(),
             local: LocalLogletOptions::default(),
             read_retry_policy: RetryPolicy::exponential(

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -58,13 +58,12 @@ pub struct MetadataServerOptions {
     /// Type of metadata server to start
     ///
     /// The type of metadata server to start when running the metadata store role.
-    ///
-    /// Default: replicated
+    // defined as Option<_> for backward compatibility with version < v1.2
     #[serde(flatten)]
-    kind: MetadataServerKind,
+    kind: Option<MetadataServerKind>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, derive_more::Display)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, derive_more::Display)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
@@ -72,6 +71,7 @@ pub struct MetadataServerOptions {
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MetadataServerKind {
+    #[default]
     #[display("local")]
     Local,
     // make the Raft based metadata server primarily known as the replicated metadata server
@@ -82,11 +82,11 @@ pub enum MetadataServerKind {
 
 impl MetadataServerOptions {
     pub fn kind(&self) -> MetadataServerKind {
-        self.kind.clone()
+        self.kind.clone().unwrap_or_default()
     }
 
     pub fn set_kind(&mut self, kind: MetadataServerKind) {
-        self.kind = kind;
+        self.kind = Some(kind);
     }
 
     pub fn apply_common(&mut self, common: &CommonOptions) {
@@ -133,7 +133,7 @@ impl Default for MetadataServerOptions {
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.01,
             rocksdb,
-            kind: MetadataServerKind::Raft(RaftOptions::default()),
+            kind: Some(MetadataServerKind::default()),
         }
     }
 }


### PR DESCRIPTION

Original commit changeset: 8c2b8592a508
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3101).
* #3102
* __->__ #3101