### PR TITLE
Add jq to our docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,7 @@ FROM upload-$UPLOAD_DEBUGINFO AS upload
 # We do not need the Rust toolchain to run the server binary!
 FROM debian:bookworm-slim AS runtime
 # useful for health checks
-RUN apt-get update && apt-get install --no-install-recommends -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y jq curl && rm -rf /var/lib/apt/lists/*
 COPY --from=upload /restate/NOTICE /NOTICE
 COPY --from=upload /restate/LICENSE /LICENSE
 # copy OS roots

--- a/docker/debug.Dockerfile
+++ b/docker/debug.Dockerfile
@@ -67,6 +67,6 @@ COPY --from=builder /restate/LICENSE /LICENSE
 # copy OS roots
 COPY --from=builder /etc/ssl /etc/ssl
 # useful for health checks
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y jq curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/restate-server"]


### PR DESCRIPTION
JQ is helpful for health checks and parsing ECS task metadata