### PR TITLE
Automatically switch using the replicated metadata store after successful migration

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -22,7 +22,7 @@ use restate_rocksdb::RocksDbManager;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::{
     BifrostOptionsBuilder, CommonOptionsBuilder, Configuration, ConfigurationBuilder,
-    MetadataServerKind, MetadataServerOptionsBuilder, RaftOptions, WorkerOptionsBuilder,
+    MetadataServerKind, MetadataServerOptionsBuilder, WorkerOptionsBuilder,
 };
 use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::live::Constant;
@@ -168,7 +168,7 @@ pub fn restate_configuration() -> Configuration {
         .expect("building worker options should work");
 
     let metadata_server_options = MetadataServerOptionsBuilder::default()
-        .kind(Some(MetadataServerKind::Raft(RaftOptions::default())))
+        .kind(Some(MetadataServerKind::Raft))
         .build()
         .expect("building metadata server options should work");
 

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -20,7 +20,7 @@ use restate_core::protobuf::node_ctl_svc::{
     ProvisionClusterRequest as ProtoProvisionClusterRequest, new_node_ctl_client,
 };
 use restate_metadata_server::grpc::new_metadata_server_client;
-use restate_types::config::{InvalidConfigurationError, MetadataServerKind, RaftOptions};
+use restate_types::config::{InvalidConfigurationError, MetadataServerKind};
 use restate_types::logs::metadata::ProviderConfiguration;
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::replication::ReplicationProperty;
@@ -185,15 +185,12 @@ impl Node {
         base_config.common.auto_provision = false;
         base_config.common.log_disable_ansi_codes = true;
         if roles.contains(Role::MetadataServer)
-            && !matches!(
-                base_config.metadata_server.kind(),
-                MetadataServerKind::Raft(_)
-            )
+            && !matches!(base_config.metadata_server.kind(), MetadataServerKind::Raft)
         {
             info!("Setting the metadata server to replicated");
             base_config
                 .metadata_server
-                .set_kind(MetadataServerKind::Raft(RaftOptions::default()));
+                .set_kind(MetadataServerKind::Raft);
         }
 
         for node_id in 1..=size {

--- a/crates/metadata-server/Cargo.toml
+++ b/crates/metadata-server/Cargo.toml
@@ -20,7 +20,6 @@ restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
-assert2 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }

--- a/crates/metadata-server/Cargo.toml
+++ b/crates/metadata-server/Cargo.toml
@@ -20,6 +20,7 @@ restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
+assert2 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }

--- a/crates/metadata-server/src/local/mod.rs
+++ b/crates/metadata-server/src/local/mod.rs
@@ -12,7 +12,7 @@ mod server;
 
 use crate::local::storage::RocksDbStorage;
 use std::path::PathBuf;
-pub use {server::LocalMetadataServer, server::migrate_nodes_configuration};
+pub use {server::BuildError, server::LocalMetadataServer, server::migrate_nodes_configuration};
 
 pub mod storage;
 #[cfg(test)]

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -638,7 +638,7 @@ impl Member {
         // todo remove additional indirection from Arc
         connection_manager.store(Some(Arc::new(new_connection_manager)));
 
-        let raft_options = Configuration::pinned().metadata_server.raft_options();
+        let raft_options = &Configuration::pinned().metadata_server.raft_options;
 
         let mut config = Config {
             id: to_raft_id(my_member_id.node_id),

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -52,9 +52,7 @@ use restate_core::{
     Metadata, MetadataWriter, ShutdownError, TaskCenter, TaskKind, cancellation_watcher,
 };
 use restate_rocksdb::RocksError;
-use restate_types::config::{
-    Configuration, MetadataServerKind, MetadataServerOptions, RaftOptions, RocksDbOptions,
-};
+use restate_types::config::{Configuration, MetadataServerOptions, RocksDbOptions};
 use restate_types::errors::{ConversionError, GenericError};
 use restate_types::health::HealthStatus;
 use restate_types::live::{BoxedLiveLoad, Constant};
@@ -640,19 +638,7 @@ impl Member {
         // todo remove additional indirection from Arc
         connection_manager.store(Some(Arc::new(new_connection_manager)));
 
-        let raft_options = match Configuration::pinned().metadata_server.kind() {
-            MetadataServerKind::Local => {
-                warn!(
-                    "The replicated metadata server was not configured. This indicates that the \
-                system switched automatically after a successful migration. Using the default \
-                options for the replicated metadata server. Please configure \
-                'metadata-server.type = \"replicated\"' explicitly to control the respective \
-                options."
-                );
-                RaftOptions::default()
-            }
-            MetadataServerKind::Raft(raft_options) => raft_options,
-        };
+        let raft_options = Configuration::pinned().metadata_server.raft_options();
 
         let mut config = Config {
             id: to_raft_id(my_member_id.node_id),

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -44,7 +44,8 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
 
     configuration
         .metadata_server
-        .set_kind(MetadataServerKind::Raft(raft_options));
+        .set_kind(MetadataServerKind::Raft);
+    configuration.metadata_server.set_raft_options(raft_options);
     set_current_config(configuration);
 
     let uds = tempfile::tempdir()?.into_path().join("server.sock");

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -24,7 +24,8 @@ use crate::{
 };
 
 use super::{
-    QueryEngineOptions, print_warning_deprecated_config_option, print_warning_deprecated_value,
+    QueryEngineOptions, print_warning_deprecated_config_option,
+    print_warning_deprecated_value_using_default,
 };
 
 /// # Admin server options
@@ -205,7 +206,7 @@ impl From<AdminOptionsShadow> for AdminOptions {
 
             match value {
                 PartitionReplication::Everywhere => {
-                    print_warning_deprecated_value(
+                    print_warning_deprecated_value_using_default(
                         "admin.default-partition-replication",
                         "everywhere",
                     );

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -647,8 +647,7 @@ impl MetadataClientKind {
     rename_all = "kebab-case",
     rename_all_fields = "kebab-case"
 )]
-// TODO(azmy): Remove this Shadow struct once we no longer support
-// the `address` configuration param.
+// TODO(azmy): Remove this Shadow struct once we no longer support the `address` configuration param.
 enum MetadataClientKindShadow {
     #[serde(alias = "embedded")]
     Replicated {

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -59,16 +59,17 @@ pub struct MetadataServerOptions {
     ///
     /// The type of metadata server to start when running the metadata store role.
     // defined as Option<_> for backward compatibility with version < v1.2
-    #[serde(flatten)]
+    // todo remove when removing the local metadata server
+    #[serde(rename = "type")]
     kind: Option<MetadataServerKind>,
+
+    // defined as Option<_> for backward compatibility with version < v1.2
+    #[serde(flatten)]
+    raft_options: Option<RaftOptions>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, derive_more::Display)]
-#[serde(
-    tag = "type",
-    rename_all = "kebab-case",
-    rename_all_fields = "kebab-case"
-)]
+#[serde(rename_all = "kebab-case", rename_all_fields = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MetadataServerKind {
     #[default]
@@ -77,7 +78,7 @@ pub enum MetadataServerKind {
     // make the Raft based metadata server primarily known as the replicated metadata server
     #[serde(rename = "replicated")]
     #[display("replicated")]
-    Raft(RaftOptions),
+    Raft,
 }
 
 impl MetadataServerOptions {
@@ -87,6 +88,14 @@ impl MetadataServerOptions {
 
     pub fn set_kind(&mut self, kind: MetadataServerKind) {
         self.kind = Some(kind);
+    }
+
+    pub fn raft_options(&self) -> RaftOptions {
+        self.raft_options.clone().unwrap_or_default()
+    }
+
+    pub fn set_raft_options(&mut self, raft_options: RaftOptions) {
+        self.raft_options = Some(raft_options);
     }
 
     pub fn apply_common(&mut self, common: &CommonOptions) {
@@ -134,6 +143,7 @@ impl Default for MetadataServerOptions {
             rocksdb_memory_ratio: 0.01,
             rocksdb,
             kind: Some(MetadataServerKind::default()),
+            raft_options: Some(RaftOptions::default()),
         }
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -327,6 +327,12 @@ fn print_warning_deprecated_config_option(deprecated: &str, replacement: Option<
     }
 }
 
-fn print_warning_deprecated_value(option: &str, value: &str) {
-    eprintln!("Option {option} does no longer support config value {value}. Using default value");
+fn print_warning_deprecated_value_using_default(option: &str, value: &str) {
+    eprintln!(
+        "Config option '{option}' does no longer support the value '{value}'. Using the default value instead."
+    );
+}
+
+fn print_warning_deprecated_value(option: &str, value: &str, help_msg: &str) {
+    eprintln!("Value '{value}' of config option '{option}' is deprecated: {help_msg}")
 }

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -95,11 +95,12 @@ async fn cluster_chaos_test() -> googletest::Result<()> {
     let mut base_config = Configuration::default();
     base_config
         .metadata_server
-        .set_kind(MetadataServerKind::Raft(RaftOptions {
-            raft_election_tick: NonZeroUsize::new(5).expect("5 to be non zero"),
-            raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
-            ..RaftOptions::default()
-        }));
+        .set_kind(MetadataServerKind::Raft);
+    base_config.metadata_server.set_raft_options(RaftOptions {
+        raft_election_tick: NonZeroUsize::new(5).expect("5 to be non zero"),
+        raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
+        ..RaftOptions::default()
+    });
     base_config.common.default_num_partitions = 4;
     base_config.bifrost.default_provider = ProviderKind::Replicated;
     base_config.common.log_filter = "warn,restate=debug".to_owned();

--- a/server/tests/raft_metadata_cluster.rs
+++ b/server/tests/raft_metadata_cluster.rs
@@ -142,11 +142,12 @@ async fn raft_metadata_cluster_chaos_test() -> googletest::Result<()> {
     let mut base_config = Configuration::default();
     base_config
         .metadata_server
-        .set_kind(MetadataServerKind::Raft(RaftOptions {
-            raft_election_tick: NonZeroUsize::new(5).expect("5 to be non zero"),
-            raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
-            ..RaftOptions::default()
-        }));
+        .set_kind(MetadataServerKind::Raft);
+    base_config.metadata_server.set_raft_options(RaftOptions {
+        raft_election_tick: NonZeroUsize::new(5).expect("5 to be non zero"),
+        raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
+        ..RaftOptions::default()
+    });
 
     let nodes = Node::new_test_nodes(
         base_config,


### PR DESCRIPTION
With this commit we are going to automatically switch to use the replicated metadata server
if we detect that the local metadata server has been sealed (migrated).