### PR TITLE
Make all LiveLoad implementations projectable

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -105,14 +105,14 @@ pub fn spawn_restate(config: Configuration) -> task_center::Handle {
         .into_handle();
     let mut prometheus = Prometheus::install(&config.common);
     restate_types::config::set_current_config(config.clone());
-    let updateable_config = Configuration::updateable();
+    let live_config = Configuration::live();
 
     tc.block_on(async {
         RocksDbManager::init(Constant::new(config.common));
         prometheus.start_upkeep_task();
 
         TaskCenter::spawn(TaskKind::SystemBoot, "restate", async move {
-            let node = Node::create(updateable_config, prometheus)
+            let node = Node::create(live_config, prometheus)
                 .await
                 .expect("Restate node must build");
             node.start().await

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -1405,7 +1405,7 @@ mod tests {
         let mut server_builder = NetworkServerBuilder::default();
 
         let svc = Service::create(
-            Configuration::updateable(),
+            Configuration::live(),
             HealthStatus::default(),
             bifrost.clone(),
             builder.networking.clone(),

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -76,7 +76,7 @@ where
 
     pub async fn run(
         self,
-        mut updateable_config: impl LiveLoad<AdminOptions> + Send + 'static,
+        mut updateable_config: impl LiveLoad<Live = AdminOptions>,
     ) -> anyhow::Result<()> {
         let opts = updateable_config.live_load();
 

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -43,7 +43,7 @@ impl Appender {
         error_recovery_strategy: ErrorRecoveryStrategy,
         bifrost_inner: Arc<BifrostInner>,
     ) -> Self {
-        let config = Configuration::updateable();
+        let config = Configuration::live();
         Self {
             log_id,
             config,

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -18,6 +18,7 @@ use tracing::{info, instrument, warn};
 
 use restate_core::{Metadata, MetadataWriter};
 use restate_types::config::Configuration;
+use restate_types::live::LiveLoadExt;
 use restate_types::logs::metadata::{MaybeSegment, ProviderKind, Segment};
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, TailState};
 use restate_types::storage::StorageEncode;
@@ -93,8 +94,9 @@ impl Bifrost {
 
         use crate::BifrostService;
 
-        let config = Configuration::updateable();
-        let bifrost_svc = BifrostService::new(metadata_writer).enable_local_loglet(&config);
+        let config = Configuration::live();
+        let bifrost_svc = BifrostService::new(metadata_writer)
+            .enable_local_loglet(config.map(|config| &config.bifrost.local).boxed());
         let bifrost = bifrost_svc.handle();
 
         // start bifrost service in the background

--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -17,8 +17,8 @@ use static_assertions::const_assert;
 use restate_rocksdb::{
     CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
 };
-use restate_types::config::{LocalLogletOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
+use restate_types::config::LocalLogletOptions;
+use restate_types::live::{LiveLoad, LiveLoadExt};
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 
 use super::keys::{DATA_KEY_PREFIX_LENGTH, MetadataKey, MetadataKind};
@@ -65,23 +65,23 @@ pub struct RocksDbLogStore {
 
 impl RocksDbLogStore {
     pub async fn create(
-        options: &LocalLogletOptions,
-        updateable_options: BoxedLiveLoad<RocksDbOptions>,
+        mut options: impl LiveLoad<Live = LocalLogletOptions> + 'static,
     ) -> Result<Self, LogStoreError> {
         let db_manager = RocksDbManager::get();
 
         let cfs = vec![CfName::new(DATA_CF), CfName::new(METADATA_CF)];
 
-        let data_dir = options.data_dir();
+        let opts = options.live_load();
+        let data_dir = opts.data_dir();
 
         let db_spec = DbSpecBuilder::new(DbName::new(DB_NAME), data_dir, db_options())
             .add_cf_pattern(
                 CfExactPattern::new(DATA_CF),
-                cf_data_options(options.rocksdb_memory_budget()),
+                cf_data_options(opts.rocksdb_memory_budget()),
             )
             .add_cf_pattern(
                 CfExactPattern::new(METADATA_CF),
-                cf_metadata_options(options.rocksdb_memory_budget()),
+                cf_metadata_options(opts.rocksdb_memory_budget()),
             )
             // not very important but it's to reduce the number of merges by flushing.
             // it's also a small cf so it should be quick.
@@ -89,7 +89,9 @@ impl RocksDbLogStore {
             .ensure_column_families(cfs)
             .build()
             .expect("valid spec");
-        let rocksdb = db_manager.open_db(updateable_options, db_spec).await?;
+        let rocksdb = db_manager
+            .open_db(options.map(|options| &options.rocksdb).boxed(), db_spec)
+            .await?;
         Ok(Self { rocksdb })
     }
 

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -23,7 +23,7 @@ use tracing::{debug, error, trace, warn};
 use restate_core::{ShutdownError, TaskCenter, TaskKind, cancellation_watcher};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LocalLogletOptions;
-use restate_types::live::BoxedLiveLoad;
+use restate_types::live::LiveLoad;
 use restate_types::logs::{LogletOffset, Record, SequenceNumber};
 
 use super::keys::{MetadataKey, MetadataKind, RecordKey};
@@ -77,7 +77,7 @@ impl LogStoreWriter {
     /// Must be called from task_center context
     pub fn start(
         mut self,
-        mut updateable: BoxedLiveLoad<LocalLogletOptions>,
+        mut updateable: impl LiveLoad<Live = LocalLogletOptions> + 'static,
     ) -> Result<RocksDbLogWriterHandle, ShutdownError> {
         // big enough to allows a second full batch to queue up while the existing one is being processed
         let batch_size = std::cmp::max(1, updateable.live_load().writer_batch_commit_count);

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -299,7 +299,7 @@ mod tests {
     use restate_core::{TaskCenter, TestCoreEnvBuilder};
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
-    use restate_types::live::Live;
+    use restate_types::live::{Live, LiveLoadExt};
     use restate_types::logs::Keys;
     use restate_types::logs::metadata::{LogletParams, ProviderKind};
 
@@ -330,15 +330,10 @@ mod tests {
         RocksDbManager::init(config.clone().map(|c| &c.common));
         let params = LogletParams::from("42".to_string());
 
-        let log_store = RocksDbLogStore::create(
-            &config.pinned().bifrost.local,
-            config.clone().map(|c| &c.bifrost.local.rocksdb).boxed(),
-        )
-        .await?;
+        let local_loglet_config = config.map(|config| &config.bifrost.local);
+        let log_store = RocksDbLogStore::create(local_loglet_config.clone()).await?;
 
-        let log_writer = log_store
-            .create_writer()
-            .start(config.clone().map(|c| &c.bifrost.local).boxed())?;
+        let log_writer = log_store.create_writer().start(local_loglet_config)?;
 
         let loglet = Arc::new(LocalLoglet::create(
             params
@@ -367,15 +362,10 @@ mod tests {
         let config = Live::from_value(Configuration::default());
         RocksDbManager::init(config.clone().map(|c| &c.common));
 
-        let log_store = RocksDbLogStore::create(
-            &config.pinned().bifrost.local,
-            config.clone().map(|c| &c.bifrost.local.rocksdb).boxed(),
-        )
-        .await?;
+        let local_loglet_config = config.map(|config| &config.bifrost.local);
+        let log_store = RocksDbLogStore::create(local_loglet_config.clone()).await?;
 
-        let log_writer = log_store
-            .create_writer()
-            .start(config.clone().map(|c| &c.bifrost.local).boxed())?;
+        let log_writer = log_store.create_writer().start(local_loglet_config)?;
 
         // Run the test 10 times
         for i in 1..=10 {

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -471,7 +471,7 @@ mod tests {
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::{Configuration, set_current_config};
     use restate_types::health::HealthStatus;
-    use restate_types::live::Live;
+    use restate_types::live::{Live, LiveLoadExt};
     use restate_types::logs::{Keys, LogletId};
     use restate_types::replication::{NodeSet, ReplicationProperty};
     use restate_types::{GenerationalNodeId, PlainNodeId};

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -110,7 +110,7 @@ impl<T: TransportConnect> SequencerAppender<T> {
             records,
             permit: Some(permit),
             commit_resolver: Some(commit_resolver),
-            configuration: Configuration::updateable(),
+            configuration: Configuration::live(),
             graylist: NodeSet::default(),
         }
     }

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -448,8 +448,9 @@ mod tests {
     use restate_core::{MetadataKind, TargetVersion, TaskCenter, TaskKind, TestCoreEnvBuilder};
     use restate_rocksdb::RocksDbManager;
     use restate_types::Versioned;
-    use restate_types::config::{CommonOptions, Configuration};
-    use restate_types::live::{Constant, Live};
+    use restate_types::config::CommonOptions;
+    use restate_types::config::LocalLogletOptions;
+    use restate_types::live::{Constant, LiveLoadExt};
     use restate_types::logs::metadata::{ProviderKind, new_single_node_loglet_params};
     use restate_types::logs::{KeyFilter, SequenceNumber};
     use restate_types::metadata::Precondition;
@@ -470,10 +471,10 @@ mod tests {
 
         let read_from = Lsn::from(6);
 
-        let config = Live::from_value(Configuration::default());
+        let config = Constant::new(LocalLogletOptions::default()).boxed();
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
-        let svc = BifrostService::new(env.metadata_writer).enable_local_loglet(&config);
+        let svc = BifrostService::new(env.metadata_writer).enable_local_loglet(config);
         let bifrost = svc.handle();
         svc.start().await.expect("loglet must start");
 
@@ -549,11 +550,10 @@ mod tests {
             .set_provider_kind(ProviderKind::Local)
             .build()
             .await;
-        let config = Live::from_value(Configuration::default());
+        let config = Constant::new(LocalLogletOptions::default()).boxed();
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
-        let svc =
-            BifrostService::new(node_env.metadata_writer.clone()).enable_local_loglet(&config);
+        let svc = BifrostService::new(node_env.metadata_writer.clone()).enable_local_loglet(config);
         let bifrost = svc.handle();
 
         svc.start().await.expect("loglet must start");
@@ -648,12 +648,12 @@ mod tests {
             .build()
             .await;
 
-        let config = Live::from_value(Configuration::default());
+        let config = Constant::new(LocalLogletOptions::default()).boxed();
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
         // enable both in-memory and local loglet types
         let svc = BifrostService::new(node_env.metadata_writer.clone())
-            .enable_local_loglet(&config)
+            .enable_local_loglet(config)
             .enable_in_memory_loglet();
         let bifrost = svc.handle();
         svc.start().await.expect("loglet must start");
@@ -808,12 +808,12 @@ mod tests {
             .build()
             .await;
 
-        let config = Live::from_value(Configuration::default());
+        let config = Constant::new(LocalLogletOptions::default()).boxed();
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
         // enable both in-memory and local loglet types
         let svc = BifrostService::new(node_env.metadata_writer)
-            .enable_local_loglet(&config)
+            .enable_local_loglet(config)
             .enable_in_memory_loglet();
         let bifrost = svc.handle();
         svc.start().await.expect("loglet must start");
@@ -928,12 +928,12 @@ mod tests {
             .build()
             .await;
 
-        let config = Live::from_value(Configuration::default());
+        let config = Constant::new(LocalLogletOptions::default()).boxed();
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
         // enable both in-memory and local loglet types
         let svc = BifrostService::new(node_env.metadata_writer)
-            .enable_local_loglet(&config)
+            .enable_local_loglet(config)
             .enable_in_memory_loglet();
         let bifrost = svc.handle();
         svc.start().await.expect("loglet must start");

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -17,6 +17,8 @@ use tracing::{debug, error, trace};
 use restate_core::{
     MetadataWriter, TaskCenter, TaskCenterFutureExt, TaskKind, cancellation_watcher,
 };
+use restate_types::config::LocalLogletOptions;
+use restate_types::live::BoxLiveLoad;
 use restate_types::logs::metadata::ProviderKind;
 
 use crate::bifrost::BifrostInner;
@@ -59,14 +61,8 @@ impl BifrostService {
     }
 
     #[cfg(feature = "local-loglet")]
-    pub fn enable_local_loglet(
-        mut self,
-        config: &restate_types::live::Live<restate_types::config::Configuration>,
-    ) -> Self {
-        let factory = crate::providers::local_loglet::Factory::new(
-            config.clone().map(|c| &c.bifrost.local).boxed(),
-            config.clone().map(|c| &c.bifrost.local.rocksdb).boxed(),
-        );
+    pub fn enable_local_loglet(mut self, config: BoxLiveLoad<LocalLogletOptions>) -> Self {
+        let factory = crate::providers::local_loglet::Factory::new(config);
         self.factories.insert(factory.kind(), Box::new(factory));
         self
     }

--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -186,7 +186,7 @@ where
     B::Data: Send,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
-    let mut configuration = Configuration::updateable();
+    let mut configuration = Configuration::live();
     let mut shutdown = std::pin::pin!(cancellation_watcher());
     let graceful_shutdown = GracefulShutdown::new();
     let task_name: Arc<str> = Arc::from(format!("{}-socket", server_name));

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -70,7 +70,7 @@ impl Service {
 
     pub async fn run(
         mut self,
-        mut updateable_config: impl LiveLoad<IngressOptions> + Send + 'static,
+        mut updateable_config: impl LiveLoad<Live = IngressOptions>,
     ) -> anyhow::Result<()> {
         let shutdown = cancellation_watcher();
         tokio::pin!(shutdown);

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -272,7 +272,7 @@ where
 
     pub async fn run(
         self,
-        mut updateable_options: impl LiveLoad<InvokerOptions> + Send + 'static,
+        mut updateable_options: impl LiveLoad<Live = InvokerOptions>,
     ) -> anyhow::Result<()> {
         debug!("Starting the invoker");
         let Service {

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -632,7 +632,7 @@ mod tests {
     use restate_core::{MetadataBuilder, TaskCenter};
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
-    use restate_types::live::Live;
+    use restate_types::live::{Constant, LiveLoadExt};
     use restate_types::logs::{KeyFilter, Keys, Record, RecordCache};
     use restate_types::net::CURRENT_PROTOCOL_VERSION;
     use restate_types::net::ProtocolVersion;
@@ -644,7 +644,7 @@ mod tests {
     use super::LogletWorker;
 
     async fn setup() -> Result<RocksDbLogStore> {
-        let config = Live::from_value(Configuration::default());
+        let config = Constant::new(Configuration::default());
         let common_rocks_opts = config.clone().map(|c| &c.common);
         RocksDbManager::init(common_rocks_opts);
         let metadata_builder = MetadataBuilder::default();
@@ -653,8 +653,7 @@ mod tests {
         ));
         // create logstore.
         let builder = RocksDbLogStoreBuilder::create(
-            config.clone().map(|c| &c.log_server).boxed(),
-            config.map(|c| &c.log_server.rocksdb).boxed(),
+            config.map(|config| &config.log_server),
             RecordCache::new(1_000_000),
         )
         .await?;

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -18,8 +18,8 @@ use static_assertions::const_assert;
 
 use restate_core::ShutdownError;
 use restate_rocksdb::{CfExactPattern, CfName, DbName, DbSpecBuilder, RocksDb, RocksDbManager};
-use restate_types::config::{LogServerOptions, RocksDbOptions};
-use restate_types::live::BoxedLiveLoad;
+use restate_types::config::LogServerOptions;
+use restate_types::live::{BoxLiveLoad, LiveLoad, LiveLoadExt};
 
 use super::writer::LogStoreWriter;
 use super::{DATA_CF, DB_NAME, METADATA_CF};
@@ -33,14 +33,13 @@ const_assert!(DATA_CF_BUDGET_RATIO < 1.0);
 #[derive(Clone)]
 pub struct RocksDbLogStoreBuilder {
     rocksdb: Arc<RocksDb>,
-    updateable_options: BoxedLiveLoad<LogServerOptions>,
+    updateable_options: BoxLiveLoad<LogServerOptions>,
     record_cache: RecordCache,
 }
 
 impl RocksDbLogStoreBuilder {
     pub async fn create(
-        mut updateable_options: BoxedLiveLoad<LogServerOptions>,
-        updateable_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+        mut updateable_options: impl LiveLoad<Live = LogServerOptions> + Clone + 'static,
         record_cache: RecordCache,
     ) -> Result<Self, RocksDbLogStoreError> {
         let options = updateable_options.live_load();
@@ -66,12 +65,15 @@ impl RocksDbLogStoreBuilder {
             .build()
             .expect("valid spec");
         let rocksdb = db_manager
-            .open_db(updateable_rocksdb_options, db_spec)
+            .open_db(
+                updateable_options.clone().map(|config| &config.rocksdb),
+                db_spec,
+            )
             .await?;
 
         Ok(Self {
             rocksdb,
-            updateable_options,
+            updateable_options: updateable_options.boxed(),
             record_cache,
         })
     }

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -32,7 +32,7 @@ use restate_bifrost::loglet::OperationError;
 use restate_core::{ShutdownError, TaskCenter, TaskKind, cancellation_watcher};
 use restate_rocksdb::{IoMode, Priority, RocksDb};
 use restate_types::config::LogServerOptions;
-use restate_types::live::BoxedLiveLoad;
+use restate_types::live::{BoxLiveLoad, LiveLoad};
 use restate_types::logs::{LogletId, LogletOffset, Record, RecordCache, SequenceNumber};
 
 use super::keys::{DataRecordKey, KeyPrefixKind, MetadataKey};
@@ -71,7 +71,7 @@ pub(crate) struct LogStoreWriter {
     rocksdb: Arc<RocksDb>,
     batch_acks_buf: Vec<Ack>,
     buffer: BytesMut,
-    updateable_options: BoxedLiveLoad<LogServerOptions>,
+    updateable_options: BoxLiveLoad<LogServerOptions>,
     record_cache: RecordCache,
     health_status: HealthStatus<LogServerStatus>,
 }
@@ -79,7 +79,7 @@ pub(crate) struct LogStoreWriter {
 impl LogStoreWriter {
     pub(crate) fn new(
         rocksdb: Arc<RocksDb>,
-        updateable_options: BoxedLiveLoad<LogServerOptions>,
+        updateable_options: BoxLiveLoad<LogServerOptions>,
         record_cache: RecordCache,
         health_status: HealthStatus<LogServerStatus>,
     ) -> Self {

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -21,6 +21,7 @@ use restate_types::GenerationalNodeId;
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::live::LiveLoadExt;
 use restate_types::logs::RecordCache;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{NodesConfiguration, StorageState};
@@ -58,11 +59,7 @@ impl LogServerService {
         //
         // 1. A log-store
         let log_store_builder = RocksDbLogStoreBuilder::create(
-            updateable_config.clone().map(|c| &c.log_server).boxed(),
-            updateable_config
-                .clone()
-                .map(|c| &c.log_server.rocksdb)
-                .boxed(),
+            updateable_config.clone().map(|c| &c.log_server),
             record_cache.clone(),
         )
         .await

--- a/crates/metadata-server/src/local/tests.rs
+++ b/crates/metadata-server/src/local/tests.rs
@@ -16,11 +16,9 @@ use test_log::test;
 use restate_core::network::FailingConnector;
 use restate_core::{TaskCenter, TaskKind, TestCoreEnv, TestCoreEnvBuilder};
 use restate_rocksdb::RocksDbManager;
-use restate_types::config::{
-    Configuration, MetadataServerOptions, RocksDbOptions, reset_base_temp_dir_and_retain,
-};
+use restate_types::config::{Configuration, MetadataServerOptions, reset_base_temp_dir_and_retain};
 use restate_types::health::HealthStatus;
-use restate_types::live::{BoxedLiveLoad, Live};
+use restate_types::live::{Constant, LiveLoad, LiveLoadExt};
 use restate_types::{Version, Versioned};
 
 use crate::local::{LocalMetadataServer, data_dir};
@@ -205,13 +203,8 @@ async fn durable_storage() -> anyhow::Result<()> {
     // reset RocksDbManager to allow restarting the metadata store
     RocksDbManager::get().reset().await?;
 
-    let metadata_store_opts = opts.clone();
-    let metadata_store_opts = Live::from_value(metadata_store_opts);
-    let client = start_metadata_server(
-        &metadata_store_opts.pinned(),
-        metadata_store_opts.map(|c| &c.rocksdb).boxed(),
-    )
-    .await?;
+    let metadata_store_opts = Constant::new(opts.clone());
+    let client = start_metadata_server(metadata_store_opts).await?;
 
     // validate data
     for key in 1u32..=10 {
@@ -244,29 +237,22 @@ async fn create_test_environment(
     };
 
     restate_types::config::set_current_config(config.clone());
-    let config = Live::from_value(config);
+    let config = Constant::new(config);
     let env = TestCoreEnvBuilder::with_incoming_only_connector()
         .build()
         .await;
 
     RocksDbManager::init(config.clone().map(|c| &c.common));
 
-    let client = start_metadata_server(
-        &config.pinned().metadata_server,
-        config.clone().map(|c| &c.metadata_server.rocksdb).boxed(),
-    )
-    .await?;
+    let client = start_metadata_server(config.map(|config| &config.metadata_server)).await?;
 
     Ok((client, env))
 }
 
 async fn start_metadata_server(
-    opts: &MetadataServerOptions,
-    updateables_rocksdb_options: BoxedLiveLoad<RocksDbOptions>,
+    opts: impl LiveLoad<Live = MetadataServerOptions> + Clone + 'static,
 ) -> anyhow::Result<MetadataStoreClient> {
-    let server =
-        LocalMetadataServer::create(opts, updateables_rocksdb_options, HealthStatus::default())
-            .await?;
+    let server = LocalMetadataServer::create(opts, HealthStatus::default()).await?;
 
     let client = server.client();
 

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -22,7 +22,7 @@ use restate_core::{MetadataBuilder, TaskCenter, TaskKind, cancellation_token};
 use restate_rocksdb::RocksDbManager;
 use restate_types::config::{
     CommonOptions, Configuration, MetadataClientKind, MetadataClientOptions, MetadataServerKind,
-    MetadataServerOptions, RaftOptions, RocksDbOptions, set_current_config,
+    MetadataServerOptions, RaftOptions, set_current_config,
 };
 use restate_types::health::Health;
 use restate_types::live::Constant;
@@ -55,10 +55,9 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
     RocksDbManager::init(Constant::new(CommonOptions::default()));
 
     // initialize the local storage with some data that we can migrate
-    let mut local_storage = crate::local::storage::RocksDbStorage::create(
-        &MetadataServerOptions::default(),
-        Constant::new(RocksDbOptions::default()).boxed(),
-    )
+    let mut local_storage = crate::local::storage::RocksDbStorage::create(Constant::new(
+        MetadataServerOptions::default(),
+    ))
     .await?;
 
     let my_generation = 1;
@@ -118,7 +117,7 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
     let health = Health::default();
 
     let metadata_server = RaftMetadataServer::create(
-        Constant::new(RocksDbOptions::default()).boxed(),
+        Constant::new(MetadataServerOptions::default()),
         health.metadata_server_status(),
         &mut server_builder,
     )

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -34,6 +34,7 @@ use restate_metadata_server::{
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::{CommonOptions, Configuration};
 use restate_types::live::Live;
+use restate_types::live::LiveLoadExt;
 use restate_types::logs::RecordCache;
 use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfiguration};
 use restate_types::metadata::Precondition;
@@ -214,7 +215,12 @@ impl Node {
 
         let bifrost_svc = BifrostService::new(metadata_manager.writer());
 
-        let bifrost_svc = bifrost_svc.enable_local_loglet(&updateable_config);
+        let bifrost_svc = bifrost_svc.enable_local_loglet(
+            updateable_config
+                .clone()
+                .map(|config| &config.bifrost.local)
+                .boxed(),
+        );
 
         let bifrost_svc = bifrost_svc.with_factory(replicated_loglet_factory);
 

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -32,6 +32,7 @@ use restate_types::config::Configuration;
 use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::live::LiveLoadExt;
 use restate_types::protobuf::common::AdminStatus;
 use restate_types::retries::RetryPolicy;
 

--- a/crates/node/src/roles/ingress.rs
+++ b/crates/node/src/roles/ingress.rs
@@ -16,7 +16,7 @@ use restate_ingress_http::HyperServerIngress;
 use restate_ingress_http::rpc_request_dispatcher::RpcRequestDispatcher;
 use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
-use restate_types::live::{BoxedLiveLoad, Live};
+use restate_types::live::{BoxLiveLoad, Live};
 use restate_types::partition_table::PartitionTable;
 use restate_types::protobuf::common::IngressStatus;
 use restate_types::schema::Schema;
@@ -29,7 +29,7 @@ pub struct IngressRole<T> {
 
 impl<T: TransportConnect> IngressRole<T> {
     pub fn create(
-        mut ingress_options: BoxedLiveLoad<IngressOptions>,
+        mut ingress_options: BoxLiveLoad<IngressOptions>,
         health: HealthStatus<IngressStatus>,
         networking: Networking<T>,
         schema: Live<Schema>,

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -55,8 +55,7 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
         // setup
         //
         let manager = PartitionStoreManager::create(
-            Constant::new(worker_options.storage.clone()).boxed(),
-            Constant::new(worker_options.storage.rocksdb.clone()).boxed(),
+            Constant::new(worker_options.storage.clone()),
             &[(PartitionId::MIN, RangeInclusive::new(0, PartitionKey::MAX))],
         )
         .await

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -23,7 +23,7 @@ use restate_serde_util::ByteCount;
 use restate_types::config::{
     CommonOptions, Configuration, RocksDbLogLevel, RocksDbOptions, StatisticsLevel,
 };
-use restate_types::live::{BoxedLiveLoad, LiveLoad};
+use restate_types::live::{BoxLiveLoad, LiveLoad, LiveLoadExt};
 
 use crate::background::ReadyStorageTask;
 use crate::{DbName, DbSpec, Priority, RocksAccess, RocksDb, RocksError, metric_definitions};
@@ -66,7 +66,7 @@ impl RocksDbManager {
     /// only run it once on program startup.
     ///
     /// Must run in task_center scope.
-    pub fn init(mut base_opts: impl LiveLoad<CommonOptions> + Send + 'static) -> &'static Self {
+    pub fn init(mut base_opts: impl LiveLoad<Live = CommonOptions> + 'static) -> &'static Self {
         // best-effort, it doesn't make concurrent access safe, but it's better than nothing.
         if let Some(manager) = DB_MANAGER.get() {
             return manager;
@@ -124,7 +124,7 @@ impl RocksDbManager {
         TaskCenter::spawn(
             TaskKind::SystemService,
             "db-manager",
-            DbWatchdog::run(Self::get(), watchdog_rx, base_opts),
+            DbWatchdog::run(Self::get(), watchdog_rx, base_opts.boxed()),
         )
         .expect("run db watchdog");
 
@@ -137,7 +137,7 @@ impl RocksDbManager {
 
     pub async fn open_db(
         &'static self,
-        mut updateable_opts: BoxedLiveLoad<RocksDbOptions>,
+        mut updateable_opts: impl LiveLoad<Live = RocksDbOptions> + 'static,
         mut db_spec: DbSpec,
     ) -> Result<Arc<RocksDb>, RocksError> {
         if self
@@ -167,7 +167,7 @@ impl RocksDbManager {
             .watchdog_tx
             .send(WatchdogCommand::Register(ConfigSubscription {
                 name: name.clone(),
-                updateable_rocksdb_opts: updateable_opts,
+                updateable_rocksdb_opts: updateable_opts.boxed(),
                 last_applied_opts: options,
             }))
         {
@@ -428,7 +428,7 @@ impl RocksDbManager {
 #[allow(dead_code)]
 struct ConfigSubscription {
     name: DbName,
-    updateable_rocksdb_opts: BoxedLiveLoad<RocksDbOptions>,
+    updateable_rocksdb_opts: BoxLiveLoad<RocksDbOptions>,
     last_applied_opts: RocksDbOptions,
 }
 
@@ -436,7 +436,7 @@ struct DbWatchdog {
     manager: &'static RocksDbManager,
     cache: Cache,
     watchdog_rx: mpsc::UnboundedReceiver<WatchdogCommand>,
-    updateable_common_opts: Box<dyn LiveLoad<CommonOptions> + Send>,
+    updateable_common_opts: BoxLiveLoad<CommonOptions>,
     current_common_opts: CommonOptions,
     subscriptions: Vec<ConfigSubscription>,
 }
@@ -445,14 +445,14 @@ impl DbWatchdog {
     pub async fn run(
         manager: &'static RocksDbManager,
         watchdog_rx: mpsc::UnboundedReceiver<WatchdogCommand>,
-        mut updateable_common_opts: impl LiveLoad<CommonOptions> + Send + 'static,
+        mut updateable_common_opts: BoxLiveLoad<CommonOptions>,
     ) -> anyhow::Result<()> {
         let prev_opts = updateable_common_opts.live_load().clone();
         let mut watchdog = Self {
             manager,
             cache: manager.cache.clone(),
             watchdog_rx,
-            updateable_common_opts: Box::new(updateable_common_opts),
+            updateable_common_opts,
             current_common_opts: prev_opts,
             subscriptions: Vec::new(),
         };

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -30,7 +30,7 @@ use restate_invoker_api::status_handle::test_util::MockStatusHandle;
 use restate_partition_store::{OpenMode, PartitionStore, PartitionStoreManager};
 use restate_rocksdb::RocksDbManager;
 use restate_types::NodeId;
-use restate_types::config::{CommonOptions, QueryEngineOptions, WorkerOptions};
+use restate_types::config::{CommonOptions, QueryEngineOptions, StorageOptions};
 use restate_types::errors::GenericError;
 use restate_types::identifiers::{DeploymentId, PartitionId, PartitionKey, ServiceRevision};
 use restate_types::invocation::ServiceType;
@@ -164,10 +164,9 @@ impl MockQueryEngine {
     ) -> Self {
         // Prepare Rocksdb
         RocksDbManager::init(Constant::new(CommonOptions::default()));
-        let worker_options = Live::from_value(WorkerOptions::default());
+        let storage_options = StorageOptions::default();
         let manager = PartitionStoreManager::create(
-            worker_options.clone().map(|c| &c.storage),
-            worker_options.clone().map(|c| &c.storage.rocksdb).boxed(),
+            Constant::new(storage_options.clone()),
             &[(PartitionId::MIN, RangeInclusive::new(0, PartitionKey::MAX))],
         )
         .await
@@ -177,7 +176,7 @@ impl MockQueryEngine {
                 PartitionId::MIN,
                 PartitionKey::MIN..=PartitionKey::MAX,
                 OpenMode::OpenExisting,
-                &worker_options.pinned().storage.rocksdb,
+                &storage_options.rocksdb,
             )
             .await
             .unwrap();

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -44,6 +44,7 @@ use restate_storage_query_postgres::service::PostgresQueryService;
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::live::LiveLoadExt;
 use restate_types::protobuf::common::WorkerStatus;
 
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
@@ -97,7 +98,7 @@ pub enum Error {
 }
 
 pub struct Worker {
-    updateable_config: Live<Configuration>,
+    live_config: Live<Configuration>,
     storage_query_context: QueryContext,
     storage_query_postgres: PostgresQueryService,
     datafusion_remote_scanner: RemoteQueryScannerServer,
@@ -109,7 +110,7 @@ pub struct Worker {
 impl Worker {
     #[allow(clippy::too_many_arguments)]
     pub async fn create<T: TransportConnect>(
-        updateable_config: Live<Configuration>,
+        mut live_config: Live<Configuration>,
         health_status: HealthStatus<WorkerStatus>,
         metadata: Metadata,
         partition_routing: PartitionRouting,
@@ -121,7 +122,12 @@ impl Worker {
         metric_definitions::describe_metrics();
         health_status.update(WorkerStatus::StartingUp);
 
-        let config = updateable_config.pinned();
+        let partition_store_manager =
+            PartitionStoreManager::create(live_config.clone().map(|c| &c.worker.storage), &[])
+                .await?;
+
+        let live_config_clone = live_config.clone();
+        let config = live_config.live_load();
 
         let schema = metadata.updateable_schema();
 
@@ -131,16 +137,6 @@ impl Worker {
             config.ingress.clone(),
             ingress_kafka.create_command_sender(),
         );
-
-        let partition_store_manager = PartitionStoreManager::create(
-            updateable_config.clone().map(|c| &c.worker.storage),
-            updateable_config
-                .clone()
-                .map(|c| &c.worker.storage.rocksdb)
-                .boxed(),
-            &[],
-        )
-        .await?;
 
         let snapshots_options = &config.worker.snapshots;
         if snapshots_options.snapshot_interval_num_records.is_some()
@@ -153,7 +149,7 @@ impl Worker {
 
         let partition_processor_manager = PartitionProcessorManager::new(
             health_status,
-            updateable_config.clone(),
+            live_config_clone,
             metadata_store_client,
             partition_store_manager.clone(),
             router_builder,
@@ -196,7 +192,7 @@ impl Worker {
         );
 
         Ok(Self {
-            updateable_config,
+            live_config,
             storage_query_context,
             storage_query_postgres,
             datafusion_remote_scanner,
@@ -238,7 +234,7 @@ impl Worker {
             TaskKind::SystemService,
             "kafka-ingress",
             self.ingress_kafka
-                .run(self.updateable_config.clone().map(|c| &c.ingress)),
+                .run(self.live_config.clone().map(|c| &c.ingress)),
         )?;
 
         TaskCenter::spawn_child(

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -613,7 +613,7 @@ mod tests {
     use restate_types::GenerationalNodeId;
     use restate_types::config::{CommonOptions, RocksDbOptions, StorageOptions};
     use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
-    use restate_types::live::Constant;
+    use restate_types::live::{Constant, LiveLoadExt};
     use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
     use restate_wal_protocol::control::AnnounceLeader;
     use restate_wal_protocol::{Command, Envelope};
@@ -639,7 +639,6 @@ mod tests {
 
         let partition_store_manager = PartitionStoreManager::create(
             Constant::new(storage_options.clone()).boxed(),
-            Constant::new(rocksdb_options.clone()).boxed(),
             &[(PARTITION_ID, PARTITION_KEY_RANGE)],
         )
         .await?;

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -56,6 +56,7 @@ use restate_types::health::HealthStatus;
 use restate_types::identifiers::SnapshotId;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
 use restate_types::live::Live;
+use restate_types::live::LiveLoadExt;
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::metadata::MetadataKind;
@@ -237,7 +238,8 @@ impl PartitionProcessorManager {
         let watchdog = PersistedLogLsnWatchdog::new(
             self.updateable_config
                 .clone()
-                .map(|config| &config.worker.storage),
+                .map(|config| &config.worker.storage)
+                .boxed(),
             self.partition_store_manager.clone(),
             persisted_lsns_tx,
         );
@@ -1221,7 +1223,7 @@ mod tests {
     use restate_core::{TaskCenter, TaskKind, TestCoreEnvBuilder};
     use restate_partition_store::PartitionStoreManager;
     use restate_rocksdb::RocksDbManager;
-    use restate_types::config::{CommonOptions, Configuration, RocksDbOptions, StorageOptions};
+    use restate_types::config::{CommonOptions, Configuration, StorageOptions};
     use restate_types::health::HealthStatus;
     use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::live::{Constant, Live};
@@ -1267,7 +1269,6 @@ mod tests {
 
         let partition_store_manager = PartitionStoreManager::create(
             Constant::new(StorageOptions::default()),
-            Constant::new(RocksDbOptions::default()).boxed(),
             &[(PartitionId::MIN, 0..=PartitionKey::MAX)],
         )
         .await?;

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -26,6 +26,7 @@ use restate_types::cluster::cluster_state::PartitionProcessorStatus;
 use restate_types::config::{Configuration, WorkerOptions};
 use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::live::Live;
+use restate_types::live::LiveLoadExt;
 use restate_types::logs::Lsn;
 use restate_types::schema::Schema;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -219,8 +219,7 @@ fn main() {
             );
 
             // Initialize rocksdb manager
-            let rocksdb_manager =
-                RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+            let rocksdb_manager = RocksDbManager::init(Configuration::map_live(|c| &c.common));
 
             // start config watcher
             config_loader.start();
@@ -229,7 +228,7 @@ fn main() {
             let telemetry = telemetry::Telemetry::create(&Configuration::pinned().common);
             telemetry.start();
 
-            let node = Node::create(Configuration::updateable(), prometheus).await;
+            let node = Node::create(Configuration::live(), prometheus).await;
             if let Err(err) = node {
                 handle_error(err);
             }

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -113,7 +113,7 @@ where
     // this will still respect LOCAL_CLUSTER_RUNNER_RETAIN_TEMPDIR=true
     let base_dir: MaybeTempDir = tempfile::tempdir()?.into();
 
-    RocksDbManager::init(Configuration::mapped_updateable(|c| &c.common));
+    RocksDbManager::init(Configuration::map_live(|c| &c.common));
 
     let mut cluster = Cluster::builder()
         .base_dir(base_dir.as_path().to_owned())

--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -20,11 +20,14 @@ mod tests {
 
     use futures_util::StreamExt;
     use googletest::prelude::*;
+
+    use crate::common::replicated_loglet::run_in_test_env;
     use restate_bifrost::{
         ErrorRecoveryStrategy,
         loglet::{AppendError, FindTailOptions},
     };
     use restate_core::{Metadata, TaskCenterFutureExt};
+    use restate_types::live::{LiveLoad, LiveLoadExt};
     use restate_types::{
         GenerationalNodeId, Version,
         config::Configuration,
@@ -41,8 +44,6 @@ mod tests {
     use tokio::task::{JoinHandle, JoinSet};
     use tokio_util::sync::CancellationToken;
     use tracing::info;
-
-    use super::common::replicated_loglet::run_in_test_env;
 
     fn record_from_keys(data: &str, keys: Keys) -> Record {
         Record::from_parts(


### PR DESCRIPTION
By making all LiveLoad implementations projectable, we no longer need to pass in multiple projected configurations into components if they can be derived from a common root.

This commit is extracted from #2830.