### PR TITLE
Limit scope of local-loglet feature to bifrost crate

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"
 restate-admin-rest-model = { workspace = true }
 restate-cli-util = { workspace = true }
 restate-serde-util = { workspace = true }
-restate-types = { workspace = true, features = ["local-loglet"] }
+restate-types = { workspace = true }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -12,7 +12,6 @@ default = ["replicated-loglet", "serve-web-ui"]
 clients = []
 options_schema = ["restate-service-client/options_schema"]
 memory-loglet = ["restate-bifrost/memory-loglet"]
-local-loglet = ["restate-bifrost/local-loglet", "restate-types/local-loglet"]
 replicated-loglet = ["restate-bifrost/replicated-loglet"]
 serve-web-ui = ["restate-web-ui", "mime_guess"]
 storage-query = []
@@ -22,7 +21,7 @@ metadata-api = []
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 restate-admin-rest-model = { workspace = true, features = ["schema"] }
-restate-bifrost = { workspace = true }
+restate-bifrost = { workspace = true, features = ["local-loglet"] }
 restate-core = { workspace = true, features = ["options_schema"] }
 restate-errors = { workspace = true }
 restate-fs-util = { workspace = true }

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -331,7 +331,6 @@ fn try_provisioning(
     node_set_selector_hints: impl NodeSetSelectorHints,
 ) -> Option<LogletConfiguration> {
     match logs_configuration.default_provider {
-        #[cfg(any(test, feature = "local-loglet"))]
         ProviderConfiguration::Local => {
             let log_id = LogletId::new(log_id, SegmentIndex::OLDEST);
             Some(LogletConfiguration::Local(log_id.into()))
@@ -442,7 +441,6 @@ pub fn build_new_replicated_loglet_configuration(
 enum LogletConfiguration {
     #[cfg(feature = "replicated-loglet")]
     Replicated(ReplicatedLogletParams),
-    #[cfg(feature = "local-loglet")]
     Local(u64),
     #[cfg(any(test, feature = "memory-loglet"))]
     Memory(u64),
@@ -453,7 +451,6 @@ impl LogletConfiguration {
         match self {
             #[cfg(feature = "replicated-loglet")]
             LogletConfiguration::Replicated(_) => ProviderKind::Replicated,
-            #[cfg(feature = "local-loglet")]
             LogletConfiguration::Local(_) => ProviderKind::Local,
             #[cfg(any(test, feature = "memory-loglet"))]
             LogletConfiguration::Memory(_) => ProviderKind::InMemory,
@@ -470,7 +467,6 @@ impl LogletConfiguration {
         match (self, &logs_configuration.default_provider) {
             #[cfg(any(test, feature = "memory-loglet"))]
             (Self::Memory(_), ProviderConfiguration::InMemory) => false,
-            #[cfg(feature = "local-loglet")]
             (Self::Local(_), ProviderConfiguration::Local) => false,
             #[cfg(feature = "replicated-loglet")]
             (Self::Replicated(params), ProviderConfiguration::Replicated(config)) => {
@@ -566,7 +562,6 @@ impl LogletConfiguration {
                     .serialize()
                     .map_err(|err| LogsControllerError::ConfigurationToLogletParams(err.into()))?,
             ),
-            #[cfg(feature = "local-loglet")]
             LogletConfiguration::Local(id) => LogletParams::from(id.to_string()),
             #[cfg(any(test, feature = "memory-loglet"))]
             LogletConfiguration::Memory(id) => LogletParams::from(id.to_string()),
@@ -588,7 +583,6 @@ impl LogletConfiguration {
             ProviderConfiguration::InMemory => {
                 Some(LogletConfiguration::Memory(next_loglet_id.into()))
             }
-            #[cfg(feature = "local-loglet")]
             ProviderConfiguration::Local => Some(LogletConfiguration::Local(next_loglet_id.into())),
             #[cfg(feature = "replicated-loglet")]
             ProviderConfiguration::Replicated(ref config) => {
@@ -617,7 +611,6 @@ impl LogletConfiguration {
             LogletConfiguration::Replicated(configuration) => {
                 itertools::Either::Left(configuration.nodeset.iter())
             }
-            #[cfg(feature = "local-loglet")]
             LogletConfiguration::Local(_) => itertools::Either::Right(iter::empty()),
             #[cfg(any(test, feature = "memory-loglet"))]
             LogletConfiguration::Memory(_) => itertools::Either::Right(iter::empty()),
@@ -628,7 +621,6 @@ impl LogletConfiguration {
         match self {
             #[cfg(feature = "replicated-loglet")]
             LogletConfiguration::Replicated(configuration) => Some(configuration.sequencer),
-            #[cfg(feature = "local-loglet")]
             LogletConfiguration::Local(_) => None,
             #[cfg(any(test, feature = "memory-loglet"))]
             LogletConfiguration::Memory(_) => None,
@@ -641,7 +633,6 @@ impl TryFrom<&LogletConfig> for LogletConfiguration {
 
     fn try_from(value: &LogletConfig) -> Result<Self, Self::Error> {
         match value.kind {
-            #[cfg(feature = "local-loglet")]
             ProviderKind::Local => Ok(LogletConfiguration::Local(value.params.parse()?)),
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderKind::InMemory => Ok(LogletConfiguration::Memory(value.params.parse()?)),

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -777,7 +777,6 @@ impl SealAndExtendTask {
             Some(ext) => match ext.provider_kind {
                 #[cfg(any(test, feature = "memory-loglet"))]
                 ProviderKind::InMemory => ProviderConfiguration::InMemory,
-                #[cfg(any(test, feature = "local-loglet"))]
                 ProviderKind::Local => ProviderConfiguration::Local,
                 ProviderKind::Replicated => {
                     ProviderConfiguration::Replicated(ReplicatedLogletConfig {
@@ -820,7 +819,6 @@ impl SealAndExtendTask {
                 ProviderKind::InMemory,
                 u64::from(next_loglet_id).to_string().into(),
             ),
-            #[cfg(any(test, feature = "local-loglet"))]
             ProviderConfiguration::Local => (
                 ProviderKind::Local,
                 u64::from(next_loglet_id).to_string().into(),

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = []
-local-loglet = ["dep:restate-rocksdb", "dep:rocksdb", "restate-types/local-loglet"]
+local-loglet = ["dep:restate-rocksdb", "dep:rocksdb"]
 replicated-loglet = ["auto-extend"]
 memory-loglet = ["restate-types/memory-loglet"]
 test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util"]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [features]
 default = []
 memory-loglet = ["restate-bifrost/memory-loglet", "restate-admin/memory-loglet"]
-local-loglet = ["restate-bifrost/local-loglet", "restate-admin/local-loglet", "restate-types/local-loglet"]
 replicated-loglet = ["restate-bifrost/replicated-loglet", "restate-admin/replicated-loglet"]
 options_schema = [
     "dep:schemars",
@@ -22,7 +21,7 @@ options_schema = [
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 restate-admin = { workspace = true, features = ["storage-query"]}
-restate-bifrost = { workspace = true }
+restate-bifrost = { workspace = true, features = ["local-loglet"] }
 restate-core = { workspace = true }
 restate-ingress-http = { workspace = true }
 restate-log-server = { workspace = true }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -219,7 +219,6 @@ impl Node {
 
         let bifrost_svc = BifrostService::new(metadata_manager.writer());
 
-        #[cfg(feature = "local-loglet")]
         let bifrost_svc = bifrost_svc.enable_local_loglet(&updateable_config);
 
         #[cfg(feature = "replicated-loglet")]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 default = []
 
 memory-loglet = []
-local-loglet = []
 schemars = ["dep:schemars", "restate-serde-util/schema"]
 unsafe-mutable-config = []
 test-util = ["memory-loglet", "unsafe-mutable-config", "dep:tempfile", "dep:restate-test-util"]

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -123,7 +123,6 @@ impl LookupIndex {
 pub enum ProviderConfiguration {
     #[cfg(any(test, feature = "memory-loglet"))]
     InMemory,
-    #[cfg(any(test, feature = "local-loglet"))]
     Local,
     Replicated(ReplicatedLogletConfig),
 }
@@ -142,7 +141,6 @@ impl ProviderConfiguration {
         match self {
             #[cfg(any(test, feature = "memory-loglet"))]
             Self::InMemory => ProviderKind::InMemory,
-            #[cfg(any(test, feature = "local-loglet"))]
             Self::Local => ProviderKind::Local,
             Self::Replicated(_) => ProviderKind::Replicated,
         }
@@ -166,7 +164,6 @@ impl ProviderConfiguration {
         match self {
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderConfiguration::InMemory => None,
-            #[cfg(any(test, feature = "local-loglet"))]
             ProviderConfiguration::Local => None,
             ProviderConfiguration::Replicated(config) => Some(&config.replication_property),
         }
@@ -176,7 +173,6 @@ impl ProviderConfiguration {
         match self {
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderConfiguration::InMemory => None,
-            #[cfg(any(test, feature = "local-loglet"))]
             ProviderConfiguration::Local => None,
             ProviderConfiguration::Replicated(config) => Some(config.target_nodeset_size),
         }
@@ -192,7 +188,6 @@ impl From<(ProviderKind, ReplicationProperty, NodeSetSize)> for ProviderConfigur
         ),
     ) -> Self {
         match provider_kind {
-            #[cfg(any(test, feature = "local-loglet"))]
             ProviderKind::Local => ProviderConfiguration::Local,
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderKind::InMemory => ProviderConfiguration::InMemory,
@@ -211,7 +206,6 @@ impl From<ProviderConfiguration> for crate::protobuf::cluster::BifrostProvider {
         let mut result = cluster::BifrostProvider::default();
 
         match value {
-            #[cfg(any(test, feature = "local-loglet"))]
             ProviderConfiguration::Local => result.provider = ProviderKind::Local.to_string(),
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderConfiguration::InMemory => result.provider = ProviderKind::InMemory.to_string(),
@@ -234,7 +228,6 @@ impl TryFrom<crate::protobuf::cluster::BifrostProvider> for ProviderConfiguratio
         let provider_kind: ProviderKind = value.provider.parse()?;
 
         match provider_kind {
-            #[cfg(any(test, feature = "local-loglet"))]
             ProviderKind::Local => Ok(Self::Local),
             #[cfg(any(test, feature = "memory-loglet"))]
             ProviderKind::InMemory => Ok(Self::InMemory),
@@ -540,7 +533,6 @@ impl From<&'static str> for LogletParams {
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum ProviderKind {
     /// A local rocksdb-backed loglet.
-    #[cfg(any(test, feature = "local-loglet"))]
     Local,
     /// An in-memory loglet, primarily for testing.
     #[cfg(any(test, feature = "memory-loglet"))]
@@ -555,7 +547,6 @@ impl FromStr for ProviderKind {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
-            #[cfg(any(test, feature = "local-loglet"))]
             "local" => Ok(Self::Local),
             #[cfg(any(test, feature = "memory-loglet"))]
             "in-memory" | "in_memory" | "memory" => Ok(Self::InMemory),
@@ -768,7 +759,6 @@ flexbuffers_storage_encode_decode!(Chain);
 /// It must generate params that uniquely identify the new loglet instance on every call.
 pub fn new_single_node_loglet_params(default_provider: ProviderKind) -> LogletParams {
     match default_provider {
-        #[cfg(any(test, feature = "local-loglet"))]
         ProviderKind::Local => {
             use rand::RngCore;
             let loglet_id = rand::rng().next_u64().to_string();

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 dist = true
 
 [features]
-default = ["local-loglet", "replicated-loglet", "no-trace-logging"]
+default = ["replicated-loglet", "no-trace-logging"]
 console = [
     "tokio/full",
     "tokio/tracing",
@@ -29,7 +29,6 @@ options_schema = [
     "restate-types/schemars",
 ]
 memory-loglet = ["restate-node/memory-loglet", "restate-admin/memory-loglet"]
-local-loglet = ["restate-node/local-loglet", "restate-admin/local-loglet", "restate-types/local-loglet"]
 replicated-loglet = ["restate-node/replicated-loglet", "restate-admin/replicated-loglet"]
 crate_per_service = ["restate-tracing-instrumentation/service_per_crate"]
 no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"]

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -15,17 +15,16 @@ dist = true
 formula = "restatectl"
 
 [features]
-default = ["replicated-loglet", "local-loglet", "memory-loglet", "no-trace-logging"]
+default = ["replicated-loglet", "memory-loglet", "no-trace-logging"]
 replicated-loglet = [
     "restate-bifrost/replicated-loglet",
 ]
 memory-loglet = ["restate-types/memory-loglet", "restate-bifrost/memory-loglet", "restate-admin/memory-loglet"]
-local-loglet = ["restate-bifrost/local-loglet", "restate-admin/local-loglet"]
 no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
 
 [dependencies]
 restate-admin = { workspace = true, features = ["clients"] }
-restate-bifrost = { workspace = true }
+restate-bifrost = { workspace = true, features = ["local-loglet"] }
 restate-cli-util = { workspace = true }
 restate-core = { workspace = true }
 restate-log-server = { workspace = true, features = ["clients"] }


### PR DESCRIPTION
This commit simplifies how we use the local-loglet feature by limiting it to the Bifrost crate only. This has the advantage that restate-types can use ProviderKind::Local as the default value for the Bifrost provider. Moreover, it reduces the number of features that might be misconfigured which usually shows up at release time.

This fixes #3118.

@jackkleeman let me know whether this still solves the original problem you wanted to fix.