### PR TITLE
fix: make wal-protocol compile with no features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7793,7 +7793,6 @@ dependencies = [
  "enum-map",
  "flexbuffers",
  "googletest",
- "restate-bifrost",
  "restate-core",
  "restate-invoker-api",
  "restate-storage-api",

--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -18,7 +18,7 @@ use axum::http::StatusCode;
 use okapi_operation::*;
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
 use restate_types::invocation::{InvocationTermination, PurgeInvocationRequest};
-use restate_wal_protocol::{Command, Envelope, append_envelope_to_bifrost};
+use restate_wal_protocol::{Command, Envelope};
 use serde::Deserialize;
 use tracing::warn;
 
@@ -94,7 +94,7 @@ pub async fn delete_invocation<V>(
 
     let partition_key = invocation_id.partition_key();
 
-    let result = append_envelope_to_bifrost(
+    let result = restate_bifrost::append_to_bifrost(
         &state.bifrost,
         Arc::new(Envelope::new(create_envelope_header(partition_key), cmd)),
     )

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -27,7 +27,7 @@ use restate_errors::warn_it;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
 use restate_types::schema::service::ServiceMetadata;
 use restate_types::state_mut::ExternalStateMutation;
-use restate_wal_protocol::{Command, Envelope, append_envelope_to_bifrost};
+use restate_wal_protocol::{Command, Envelope};
 use tracing::{debug, warn};
 
 /// List services
@@ -228,7 +228,7 @@ pub async fn modify_service_state<V>(
         state: new_state,
     };
 
-    let result = append_envelope_to_bifrost(
+    let result = restate_bifrost::append_to_bifrost(
         &state.bifrost,
         Arc::new(Envelope::new(
             create_envelope_header(partition_key),

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -29,7 +29,59 @@ pub use bifrost_admin::{BifrostAdmin, SealedSegment};
 pub use error::{Error, Result};
 pub use read_stream::LogReadStream;
 pub use record::{InputRecord, LogEntry};
+use restate_core::{Metadata, ShutdownError};
+use restate_types::Version;
+use restate_types::identifiers::WithPartitionKey;
+use restate_types::logs::{LogId, Lsn};
+use restate_types::partition_table::{FindPartition, PartitionTableError};
 pub use service::BifrostService;
+use std::sync::Arc;
 pub use types::*;
 
 pub const SMALL_BATCH_THRESHOLD_COUNT: usize = 4;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AppendError {
+    #[error("partition not found: {0}")]
+    PartitionNotFound(#[from] PartitionTableError),
+    #[error(transparent)]
+    Bifrost(#[from] Error),
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
+}
+
+/// Appends the given envelope to the provided Bifrost instance. The log instance is chosen
+/// based on the envelopes partition key.
+///
+/// Important: This method must only be called in the context of a [`TaskCenter`] task because
+/// it needs access to [`metadata()`].
+///
+/// todo: This method should be removed in favor of using Appender/BackgroundAppender API in
+/// Bifrost. Additionally, the check for partition_table is probably unnecessary in the vast
+/// majority of call-sites.
+pub async fn append_to_bifrost<T>(
+    bifrost: &Bifrost,
+    envelope: Arc<T>,
+) -> Result<(LogId, Lsn), AppendError>
+where
+    T: WithPartitionKey
+        + restate_types::storage::StorageEncode
+        + restate_types::logs::HasRecordKeys,
+{
+    let partition_id = {
+        // make sure we drop pinned partition table before awaiting
+        let partition_table = Metadata::current()
+            .wait_for_partition_table(Version::MIN)
+            .await?;
+        partition_table.find_partition_id(envelope.partition_key())?
+    };
+
+    let log_id = LogId::from(*partition_id);
+    // todo: Pass the envelope as `Arc` to `append_envelope_to_bifrost` instead. Possibly use
+    // triomphe's UniqueArc for a mutable Arc during construction.
+    let lsn = bifrost
+        .append(log_id, ErrorRecoveryStrategy::default(), envelope)
+        .await?;
+
+    Ok((log_id, lsn))
+}

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -13,8 +13,6 @@ serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api
 
 [dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
-
-restate-bifrost = { workspace = true }
 restate-core = { workspace = true }
 restate-invoker-api = { workspace = true }
 restate-storage-api = { workspace = true }

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -25,9 +25,7 @@ use restate_storage_api::invocation_status_table::{
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
 use restate_types::invocation::PurgeInvocationRequest;
-use restate_wal_protocol::{
-    Command, Destination, Envelope, Header, Source, append_envelope_to_bifrost,
-};
+use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
 
 pub(super) struct Cleaner<Storage> {
     partition_id: PartitionId,
@@ -140,7 +138,7 @@ where
             };
 
             if SystemTime::now() >= expiration_time {
-                append_envelope_to_bifrost(
+                restate_bifrost::append_to_bifrost(
                     bifrost,
                     Arc::new(Envelope {
                         header: Header {

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -21,7 +21,7 @@ use restate_storage_api::deduplication_table::DedupInformation;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey};
 use restate_types::message::MessageIndex;
-use restate_wal_protocol::{Destination, Envelope, Header, Source, append_envelope_to_bifrost};
+use restate_wal_protocol::{Destination, Envelope, Header, Source};
 
 use crate::partition::shuffle::state_machine::StateMachine;
 use crate::partition::types::OutboxMessageExt;
@@ -226,7 +226,7 @@ where
             move |msg| {
                 let bifrost = bifrost.clone();
                 async move {
-                    append_envelope_to_bifrost(&bifrost, Arc::new(msg)).await?;
+                    restate_bifrost::append_to_bifrost(&bifrost, Arc::new(msg)).await?;
                     Ok(())
                 }
             },


### PR DESCRIPTION
Fix: https://github.com/restatedev/restate/issues/3036

before fix:

```
cargo clippy --manifest-path crates/wal-protocol/Cargo.toml --no-default-features

error[E0277]: the trait bound `Envelope: serde::ser::Serialize` is not satisfied
  --> crates/wal-protocol/src/lib.rs:61:1
   |
61 | flexbuffers_storage_encode_decode!(Envelope);
```