### PR TITLE
Add support for removing/adding metadata server nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7223,6 +7223,7 @@ dependencies = [
  "futures",
  "googletest",
  "http 1.2.0",
+ "humantime",
  "indexmap 2.7.1",
  "itertools 0.14.0",
  "metrics",

--- a/crates/metadata-server/Cargo.toml
+++ b/crates/metadata-server/Cargo.toml
@@ -29,6 +29,7 @@ derive_more = { workspace = true }
 flexbuffers = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+humantime = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }

--- a/crates/metadata-server/proto/metadata_server_network_svc.proto
+++ b/crates/metadata-server/proto/metadata_server_network_svc.proto
@@ -18,7 +18,7 @@ service MetadataServerNetworkSvc {
   rpc ConnectTo(stream NetworkMessage) returns (stream NetworkMessage);
 
   // Try to join an existing metadata store cluster
-  rpc JoinCluster(JoinClusterRequest) returns (google.protobuf.Empty);
+  rpc JoinCluster(JoinClusterRequest) returns (JoinClusterResponse);
 }
 
 message NetworkMessage {
@@ -28,5 +28,10 @@ message NetworkMessage {
 message JoinClusterRequest {
   uint32 node_id = 1;
   int64 created_at_millis = 2;
+}
+
+message JoinClusterResponse {
+  // might be none if talking to Restate <= 1.3.0
+  optional uint32 nodes_config_version = 1;
 }
 

--- a/crates/metadata-server/proto/metadata_server_svc.proto
+++ b/crates/metadata-server/proto/metadata_server_svc.proto
@@ -34,6 +34,12 @@ service MetadataServerSvc {
 
   // Returns the status of the metadata store svc
   rpc Status(google.protobuf.Empty) returns (StatusResponse);
+
+  // Instructs the node to join the metadata cluster
+  rpc AddNode(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // Remove the given node from the metadata cluster. This operation can only be executed by the leader.
+  rpc RemoveNode(RemoveNodeRequest) returns (google.protobuf.Empty);
 }
 
 message GetRequest { string key = 1; }
@@ -56,6 +62,12 @@ message GetVersionResponse { optional restate.common.Version version = 1; }
 message ProvisionRequest { bytes nodes_configuration = 1; }
 
 message ProvisionResponse { bool newly_provisioned = 1; }
+
+message RemoveNodeRequest {
+  uint32 plain_node_id = 1;
+  // optional field to uniquely identify a given cluster member
+  optional int64 created_at_millis = 2;
+}
 
 message StatusResponse {
   restate.common.MetadataServerStatus status = 1;

--- a/crates/metadata-server/src/raft/mod.rs
+++ b/crates/metadata-server/src/raft/mod.rs
@@ -23,9 +23,9 @@ use network::NetworkMessage;
 use protobuf::Message as ProtobufMessage;
 use restate_core::metadata_store::MetadataStoreClient;
 use restate_core::network::net_util::CommonClientConnectionOptions;
-use restate_types::PlainNodeId;
 use restate_types::net::AdvertisedAddress;
 use restate_types::retries::RetryPolicy;
+use restate_types::{PlainNodeId, Version};
 pub use server::RaftMetadataServer;
 use std::sync::Arc;
 
@@ -53,6 +53,8 @@ impl NetworkMessage for raft::prelude::Message {
 enum RaftServerState {
     Member {
         my_member_id: MemberId,
+        // field is introduced with 1.3.1 and therefore needs to be optional
+        min_expected_nodes_config_version: Option<Version>,
     },
     #[default]
     Standby,

--- a/crates/metadata-server/src/raft/storage/rocksdb.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb.rs
@@ -645,6 +645,11 @@ impl<'a> Transaction<'a> {
         Ok(())
     }
 
+    pub fn delete_raft_server_state(&mut self) -> Result<(), Error> {
+        self.delete_metadata_cf(RAFT_SERVER_STATE_KEY);
+        Ok(())
+    }
+
     pub fn store_snapshot(&mut self, snapshot: &Snapshot) -> Result<(), Error> {
         self.put_value_ref_metadata_cf(SNAPSHOT_KEY, snapshot)
     }
@@ -720,6 +725,12 @@ impl<'a> Transaction<'a> {
     fn put_bytes_metadata_cf(&mut self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) {
         let mut write_batch = mem::take(&mut self.write_batch);
         write_batch.put_cf(&self.storage.metadata_cf(), key.as_ref(), value.as_ref());
+        self.write_batch = write_batch;
+    }
+
+    fn delete_metadata_cf(&mut self, key: impl AsRef<[u8]>) {
+        let mut write_batch = mem::take(&mut self.write_batch);
+        write_batch.delete_cf(&self.storage.metadata_cf(), key);
         self.write_batch = write_batch;
     }
 }

--- a/tools/restatectl/src/app.rs
+++ b/tools/restatectl/src/app.rs
@@ -16,6 +16,7 @@ use restate_cli_util::CommonOpts;
 use crate::commands::config::ConfigOpts;
 use crate::commands::log::Logs;
 use crate::commands::metadata::Metadata;
+use crate::commands::metadata_server::MetadataServer;
 use crate::commands::node::Nodes;
 use crate::commands::partition::Partitions;
 use crate::commands::provision::ProvisionOpts;
@@ -72,6 +73,9 @@ pub enum Command {
     /// [low-level] Commands that operate on replicated loglets
     #[clap(subcommand)]
     ReplicatedLoglet(ReplicatedLoglet),
+    /// Command that operate on the replicated metadata servers
+    #[clap(subcommand)]
+    MetadataServer(MetadataServer),
     /// Query cluster status
     Sql(SqlOpts),
 }

--- a/tools/restatectl/src/commands/metadata_server/list_servers.rs
+++ b/tools/restatectl/src/commands/metadata_server/list_servers.rs
@@ -11,6 +11,8 @@
 use std::collections::BTreeMap;
 
 use bytesize::ByteSize;
+use clap::Parser;
+use cling::{Collect, Run};
 use futures::future::join_all;
 use itertools::Itertools;
 use tonic::{IntoRequest, Status};
@@ -26,7 +28,15 @@ use restate_types::{PlainNodeId, Version};
 
 use crate::connection::ConnectionInfo;
 
-pub async fn list_metadata_servers(connection: &ConnectionInfo) -> anyhow::Result<()> {
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "list_metadata_servers")]
+#[clap(visible_alias = "ls")]
+pub struct ListMetadataServers {}
+
+pub async fn list_metadata_servers(
+    connection: &ConnectionInfo,
+    _list_metadata_servers: &ListMetadataServers,
+) -> anyhow::Result<()> {
     debug!("Gathering metadata server status information");
 
     let nodes_configuration = connection.get_nodes_configuration().await?;

--- a/tools/restatectl/src/commands/metadata_server/mod.rs
+++ b/tools/restatectl/src/commands/metadata_server/mod.rs
@@ -8,4 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub mod status;
+use crate::commands::metadata_server::list_servers::ListMetadataServers;
+use crate::commands::metadata_server::nodes::{AddNodeOpts, RemoveNodeOpts};
+use clap::Subcommand;
+use cling::Run;
+
+pub mod list_servers;
+mod nodes;
+
+#[derive(Run, Subcommand, Clone)]
+#[clap(visible_alias = "ms")]
+pub enum MetadataServer {
+    /// Add a node to the metadata store cluster
+    AddNode(AddNodeOpts),
+    /// Remove a node from the metadata store cluster
+    RemoveNode(RemoveNodeOpts),
+    /// List metadata server status
+    ListServers(ListMetadataServers),
+}

--- a/tools/restatectl/src/commands/metadata_server/nodes.rs
+++ b/tools/restatectl/src/commands/metadata_server/nodes.rs
@@ -1,0 +1,126 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::connection::ConnectionInfo;
+use anyhow::Context;
+use clap::Parser;
+use cling::{Collect, Run};
+use restate_cli_util::c_println;
+use restate_metadata_server::grpc::RemoveNodeRequest;
+use restate_metadata_server::grpc::metadata_server_svc_client::MetadataServerSvcClient;
+use restate_types::PlainNodeId;
+use restate_types::nodes_config::{MetadataServerState, Role};
+use tracing::debug;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap(visible_alias = "add")]
+#[cling(run = "add_node")]
+pub struct AddNodeOpts {
+    /// A node-id or a list of node-ids (comma-separated) to add
+    #[arg(required = true, value_delimiter = ',')]
+    nodes: Vec<PlainNodeId>,
+}
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[clap(visible_alias = "rm")]
+#[cling(run = "remove_node")]
+pub struct RemoveNodeOpts {
+    /// A node-id or a list of node-ids (comma-separated) to remove
+    #[arg(required = true, value_delimiter = ',')]
+    nodes: Vec<PlainNodeId>,
+}
+
+async fn add_node(
+    add_node_opts: &AddNodeOpts,
+    connection_info: &ConnectionInfo,
+) -> anyhow::Result<()> {
+    let nodes_configuration = connection_info.get_nodes_configuration().await?;
+
+    for node_to_add in &add_node_opts.nodes {
+        let node_config = nodes_configuration
+            .find_node_by_id(*node_to_add)
+            .context(format!(
+                "failed to add unknown node {node_to_add} to the metadata cluster"
+            ))?;
+
+        // todo proxy request through an arbitrary Restate node to avoid requiring access to all metadata server nodes
+        let channel = connection_info
+            .connect(&node_config.address)
+            .await
+            .context(format!("failed connecting to node {node_to_add}"))?;
+        let mut client = MetadataServerSvcClient::new(channel);
+        // todo think about whether to run these calls in parallel
+        client.add_node(()).await.context(format!(
+            "failed adding node {node_to_add} to metadata cluster"
+        ))?;
+
+        c_println!("Added node '{node_to_add}' to the metadata cluster",);
+    }
+
+    Ok(())
+}
+
+async fn remove_node(
+    remove_node_opts: &RemoveNodeOpts,
+    connection_info: &ConnectionInfo,
+) -> anyhow::Result<()> {
+    let nodes_configuration = connection_info.get_nodes_configuration().await?;
+
+    for node_to_remove in &remove_node_opts.nodes {
+        let mut success = false;
+
+        // check that we know the specified node
+        let _ = nodes_configuration
+            .find_node_by_id(*node_to_remove)
+            .context(format!(
+                "failed to remove unknown node {node_to_remove} from the metadata cluster"
+            ))?;
+
+        // todo try to figure out who's the current leader and directly reach out to the leader
+        //  based on the metadata server status call
+        for node_config in nodes_configuration
+            .iter_role(Role::MetadataServer)
+            .map(|(_, node_config)| node_config)
+        {
+            if node_config.metadata_server_config.metadata_server_state
+                == MetadataServerState::Member
+            {
+                let channel = connection_info.connect(&node_config.address).await?;
+
+                let mut client = MetadataServerSvcClient::new(channel);
+                // todo think about whether to run these calls in parallel
+
+                match client
+                    .remove_node(RemoveNodeRequest {
+                        plain_node_id: u32::from(*node_to_remove),
+                        created_at_millis: None,
+                    })
+                    .await
+                {
+                    Ok(_response) => {
+                        success = true;
+                        break;
+                    }
+                    Err(err) => {
+                        debug!(%err, "Failed removing node from the metadata cluster. Trying different metadata server.")
+                    }
+                }
+            }
+        }
+
+        if success {
+            c_println!("Removed node '{node_to_remove}' from the metadata cluster");
+        } else {
+            c_println!("Failed removing node '{node_to_remove}' from the metadata cluster");
+        }
+    }
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -31,14 +31,14 @@ use restate_types::protobuf::cluster::{AliveNode, RunMode};
 use restate_types::{GenerationalNodeId, NodeId};
 
 use crate::commands::log::list_logs::{ListLogsOpts, list_logs};
-use crate::commands::metadata_server::status::list_metadata_servers;
+use crate::commands::metadata_server::list_servers::{ListMetadataServers, list_metadata_servers};
 use crate::commands::node::list_nodes::{ListNodesOpts, list_nodes, list_nodes_lite};
 use crate::commands::partition::list::{ListPartitionsOpts, list_partitions};
 use crate::connection::{ConnectionInfo, ConnectionInfoError};
 use crate::util::grpc_channel;
 
 use super::log::deserialize_replicated_log_params;
-use super::metadata_server::status::render_metadata_server_status;
+use super::metadata_server::list_servers::render_metadata_server_status;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "cluster_status")]
@@ -84,7 +84,7 @@ async fn cluster_status(
     list_partitions(connection, &ListPartitionsOpts::default()).await?;
     c_println!();
 
-    list_metadata_servers(connection).await?;
+    list_metadata_servers(connection, &ListMetadataServers {}).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This commit adds restatectl metadata-server add-node/remove-node to add and remove nodes to and from the metadata cluster. Internally, an add command instructs the joining node to reach out to the leader to ask for a reconfiguration. A remove command is sent to the leader where it triggers a reconfiguration to remove the given node. To also stop removed metadata cluster members that have missed the configuration change, we are using the MetadataServerState stored in the NodesConfiguration as an additional signal. If a node detects that its MetadataServerState is set to Standby while it is running as a Member, then it will step down. Likewise, if a Standby node detects that its MetadataServerState is Member, then it will try to join the cluster because it might mean that it tried joining before but failed just before receiving the response.

This fixes #2994.