### PR TITLE
[chore] Use latest RocksDB table format version

### DIFF
--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -347,8 +347,8 @@ impl RocksDbManager {
         let mut block_opts = BlockBasedOptions::default();
         block_opts.set_bloom_filter(10.0, true);
         // use the latest Rocksdb table format.
-        // https://github.com/facebook/rocksdb/blob/f059c7d9b96300091e07429a60f4ad55dac84859/include/rocksdb/table.h#L275
-        block_opts.set_format_version(5);
+        // https://github.com/facebook/rocksdb/blob/56359da69132d769e97f0a7cc89681d3500e166d/include/rocksdb/table.h#L571
+        block_opts.set_format_version(6);
         block_opts.set_optimize_filters_for_memory(true);
         block_opts.set_index_block_restart_interval(4);
         block_opts.set_cache_index_and_filter_blocks(true);


### PR DESCRIPTION
This has been the default in RocksDB for over a year now:

https://github.com/facebook/rocksdb/commit/bfd00bba9c75fffc95d53c741c6939c2ba5223f3
