### PR TITLE
[BACKPORT] Set default values for deprecated options 

### DIFF
--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -15,14 +15,14 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use enumset::EnumSet;
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{DeserializeAs, serde_as};
 
 use restate_serde_util::{NonZeroByteCount, SerdeableHeaderHashMap};
 
 use super::{
-    AwsOptions, HttpOptions, ObjectStoreOptions, PerfStatsLevel, RocksDbOptions,
-    print_warning_deprecated_config_option,
+    AwsOptions, Configuration, HttpOptions, ObjectStoreOptions, PerfStatsLevel, RocksDbOptions,
+    StructWithDefaults, print_warning_deprecated_config_option,
 };
 use crate::PlainNodeId;
 use crate::locality::NodeLocation;
@@ -499,7 +499,7 @@ pub enum LogFormat {
 
 /// # Metadata client options
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(
     feature = "schemars",
@@ -560,7 +560,7 @@ impl Default for MetadataClientOptions {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
@@ -809,6 +809,7 @@ pub struct CommonOptionsShadow {
 
     metadata_client: MetadataClientOptions,
     // todo drop in version 1.3
+    #[serde_as(as = "Option<MetadataClientOptionsWithConfigurationDefaults>")]
     metadata_store_client: Option<MetadataClientOptions>,
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     // todo drop in version 1.3
@@ -940,10 +941,26 @@ impl From<CommonOptionsShadow> for CommonOptions {
     }
 }
 
+/// Deserializer for [`MetadataClientOptions`] that uses the [`Configuration`] defaults.
+struct MetadataClientOptionsWithConfigurationDefaults;
+
+impl<'de> DeserializeAs<'de, MetadataClientOptions>
+    for MetadataClientOptionsWithConfigurationDefaults
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<MetadataClientOptions, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let struct_with_defaults =
+            StructWithDefaults::new(Configuration::default().common.metadata_client);
+        deserializer.deserialize_map(struct_with_defaults)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::CommonOptions;
-    use crate::config::MetadataClientKind;
+    use crate::config::{MetadataClientKind, MetadataClientOptions};
     use crate::config_loader::ConfigLoaderBuilder;
     use crate::net::AdvertisedAddress;
     use crate::nodes_config::Role;
@@ -1032,13 +1049,16 @@ mod tests {
             .build()?;
         let configuration = config_loader.load_once()?;
 
-        assert_that!(
-            configuration.common.metadata_client.kind,
-            pat!(MetadataClientKind::Replicated {
-                addresses: elements_are![eq(AdvertisedAddress::Http(Uri::from_static(
-                    "http://127.0.0.1:15123/"
-                )))]
-            })
+        assert_eq!(
+            configuration.common.metadata_client,
+            MetadataClientOptions {
+                kind: MetadataClientKind::Replicated {
+                    addresses: vec![AdvertisedAddress::Http(Uri::from_static(
+                        "http://127.0.0.1:15123/"
+                    ))]
+                },
+                ..MetadataClientOptions::default()
+            }
         );
 
         let config_path_addresses = temp_dir.path().join("config2.toml");

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -8,15 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{DeserializeAs, serde_as};
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use restate_serde_util::NonZeroByteCount;
 use tracing::warn;
 
-use super::{CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
+use super::{
+    CommonOptions, Configuration, RocksDbOptions, RocksDbOptionsBuilder, StructWithDefaults,
+};
 
 /// # Metadata store options
 #[serde_as]
@@ -116,12 +118,17 @@ impl MetadataServerOptions {
     pub fn request_queue_length(&self) -> usize {
         self.request_queue_length.get()
     }
+
+    fn rocksdb_defaults() -> RocksDbOptionsBuilder {
+        let mut builder = RocksDbOptionsBuilder::default();
+        builder.rocksdb_disable_wal(Some(false));
+        builder
+    }
 }
 
 impl Default for MetadataServerOptions {
     fn default() -> Self {
-        let rocksdb = RocksDbOptionsBuilder::default()
-            .rocksdb_disable_wal(Some(false))
+        let rocksdb = Self::rocksdb_defaults()
             .build()
             .expect("valid RocksDbOptions");
         Self {
@@ -178,5 +185,119 @@ impl Default for RaftOptions {
             raft_tick_interval: Duration::from_millis(100).into(),
             status_update_interval: Duration::from_secs(5).into(),
         }
+    }
+}
+
+/// Deserializer for [`MetadataServerOptions`] that uses the [`Configuration`] defaults.
+pub struct MetadataServerOptionsWithConfigurationDefaults;
+
+impl<'de> DeserializeAs<'de, MetadataServerOptions>
+    for MetadataServerOptionsWithConfigurationDefaults
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<MetadataServerOptions, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let struct_with_defaults =
+            StructWithDefaults::new(Configuration::default().metadata_server);
+        deserializer.deserialize_map(struct_with_defaults)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{Configuration, MetadataServerKind, MetadataServerOptions};
+    use crate::config_loader::ConfigLoaderBuilder;
+    use std::fs;
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn metadata_server_backwards_compatibility() -> googletest::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path_address = temp_dir.path().join("config1.toml");
+        let config_file_address = r#"
+        [metadata-store]
+        type = "local"
+        "#;
+
+        fs::write(config_path_address.clone(), config_file_address)?;
+
+        let config_loader = ConfigLoaderBuilder::default()
+            .path(Some(config_path_address))
+            .disable_apply_cascading_values(true)
+            .build()?;
+        let configuration = config_loader.load_once()?;
+
+        assert_eq!(
+            configuration.metadata_server,
+            MetadataServerOptions {
+                kind: Some(MetadataServerKind::Local),
+                ..Configuration::default().metadata_server
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_server_precedence() -> googletest::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path_address = temp_dir.path().join("config1.toml");
+        let config_file_address = r#"
+        [metadata-server]
+        request-queue-length = 1337
+
+        [metadata-store]
+        type = "local"
+        "#;
+
+        fs::write(config_path_address.clone(), config_file_address)?;
+
+        let config_loader = ConfigLoaderBuilder::default()
+            .path(Some(config_path_address))
+            .disable_apply_cascading_values(true)
+            .build()?;
+        let configuration = config_loader.load_once()?;
+
+        assert_eq!(
+            configuration.metadata_server,
+            MetadataServerOptions {
+                request_queue_length: NonZeroUsize::new(1337).unwrap(),
+                ..Configuration::default().metadata_server
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_store_sub_field_does_not_clear_defaults() -> googletest::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path_address = temp_dir.path().join("config1.toml");
+        let config_file_address = r#"
+        [metadata-store]
+        rocksdb-disable-direct-io-for-reads = false
+        "#;
+
+        fs::write(config_path_address.clone(), config_file_address)?;
+
+        let config_loader = ConfigLoaderBuilder::default()
+            .path(Some(config_path_address))
+            .disable_apply_cascading_values(true)
+            .build()?;
+        let configuration = config_loader.load_once()?;
+        let mut rocksdb_defaults = MetadataServerOptions::rocksdb_defaults();
+        rocksdb_defaults.rocksdb_disable_direct_io_for_reads(Some(false));
+        let rocksdb = rocksdb_defaults.build().expect("should build");
+
+        assert_eq!(
+            configuration.metadata_server,
+            MetadataServerOptions {
+                rocksdb,
+                ..Configuration::default().metadata_server
+            }
+        );
+
+        Ok(())
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -274,6 +274,7 @@ pub enum InvalidConfigurationError {
 /// Used to deserialize the [`Configuration`] in backwards compatible way which allows to specify
 /// a `metadata_store` field instead of `metadata_server`. Can be removed once we drop support for
 /// `metadata_store`.
+#[serde_as]
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConfigurationShadow {
@@ -285,6 +286,8 @@ pub struct ConfigurationShadow {
     bifrost: BifrostOptions,
     metadata_server: MetadataServerOptions,
     // previous name of metadata server options; kept for backwards compatibility
+    // todo remove with 1.4.0
+    #[serde_as(as = "Option<metadata_server::MetadataServerOptionsWithConfigurationDefaults>")]
     metadata_store: Option<MetadataServerOptions>,
     networking: NetworkingOptions,
     log_server: LogServerOptions,

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -157,7 +157,7 @@ impl RocksDbOptions {
     }
 
     pub fn rocksdb_disable_wal(&self) -> bool {
-        self.rocksdb_disable_wal.unwrap_or(true)
+        self.rocksdb_disable_wal.unwrap_or(false)
     }
 
     pub fn rocksdb_disable_direct_io_for_reads(&self) -> bool {

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -41,6 +41,8 @@ pub struct ConfigLoader {
     #[builder(setter(strip_option))]
     cli_override: Option<crate::config::CommonOptionCliOverride>,
     disable_watch: bool,
+    #[cfg(test)]
+    disable_apply_cascading_values: bool,
 }
 
 impl ConfigLoader {
@@ -70,6 +72,14 @@ impl ConfigLoader {
         config.admin.set_derived_values();
         config.ingress.set_derived_values();
 
+        #[cfg(test)]
+        let config = if !self.disable_apply_cascading_values {
+            config.apply_cascading_values()
+        } else {
+            config
+        };
+
+        #[cfg(not(test))]
         let config = config.apply_cascading_values();
 
         config.validate()?;

--- a/crates/types/src/retries.rs
+++ b/crates/types/src/retries.rs
@@ -54,7 +54,7 @@ const DEFAULT_JITTER_MULTIPLIER: f32 = 0.3;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",

--- a/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
+++ b/crates/worker/src/partition_processor_manager/persisted_lsn_watchdog.rs
@@ -162,7 +162,7 @@ mod tests {
     use restate_rocksdb::RocksDbManager;
     use restate_storage_api::Transaction;
     use restate_storage_api::fsm_table::FsmTable;
-    use restate_types::config::{CommonOptions, RocksDbOptions, StorageOptions};
+    use restate_types::config::{CommonOptions, StorageOptions};
     use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::live::Constant;
     use restate_types::logs::{Lsn, SequenceNumber};
@@ -177,14 +177,13 @@ mod tests {
     async fn persisted_log_lsn_watchdog_detects_applied_lsns() -> anyhow::Result<()> {
         let _node_env = TestCoreEnv::create_with_single_node(1, 1).await;
         let storage_options = StorageOptions::default();
-        let rocksdb_options = RocksDbOptions::default();
 
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
         let all_partition_keys = RangeInclusive::new(0, PartitionKey::MAX);
         let partition_store_manager = PartitionStoreManager::create(
             Constant::new(storage_options.clone()).boxed(),
-            Constant::new(rocksdb_options.clone()).boxed(),
+            Constant::new(storage_options.rocksdb.clone()).boxed(),
             &[(PartitionId::MIN, all_partition_keys.clone())],
         )
         .await?;
@@ -194,7 +193,7 @@ mod tests {
                 PartitionId::MIN,
                 all_partition_keys,
                 OpenMode::CreateIfMissing,
-                &rocksdb_options,
+                &storage_options.rocksdb,
             )
             .await
             .expect("partition store present");


### PR DESCRIPTION
This is a backport of #3153 to `release/1.2`.