### PR TITLE
fix: make restatectl compile with feature no-tracing-logging

### DIFF
--- a/tools/restatectl/src/commands/config/set.rs
+++ b/tools/restatectl/src/commands/config/set.rs
@@ -75,7 +75,11 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
 
     set_opts.log_provider.inspect(|provider| {
         match provider {
-            ProviderKind::InMemory | ProviderKind::Local => {
+            #[cfg(feature = "memory-loglet")]
+            ProviderKind::InMemory => {
+                c_warn!("You are about to reconfigure your cluster with a Bifrost provider that only supports a single node cluster.");
+            }
+            ProviderKind::Local => {
                 c_warn!("You are about to reconfigure your cluster with a Bifrost provider that only supports a single node cluster.");
             }
             ProviderKind::Replicated => {

--- a/tools/restatectl/src/commands/node/disable_node_checker.rs
+++ b/tools/restatectl/src/commands/node/disable_node_checker.rs
@@ -102,7 +102,16 @@ impl<'a, 'b> DisableNodeChecker<'a, 'b> {
         // given node because it is included in the implicit node set
         if matches!(
             self.logs.configuration().default_provider.kind(),
-            ProviderKind::Local | ProviderKind::InMemory
+            ProviderKind::Local
+        ) {
+            return Err(DisableNodeError::DefaultLogletProvider(
+                self.logs.configuration().default_provider.kind(),
+            ));
+        }
+        #[cfg(feature = "memory-loglet")]
+        if matches!(
+            self.logs.configuration().default_provider.kind(),
+            ProviderKind::InMemory
         ) {
             return Err(DisableNodeError::DefaultLogletProvider(
                 self.logs.configuration().default_provider.kind(),
@@ -115,7 +124,15 @@ impl<'a, 'b> DisableNodeChecker<'a, 'b> {
                 match segment.config.kind {
                     // we assume that the given node runs the local and memory loglet and, therefore,
                     // cannot be disabled
-                    ProviderKind::Local | ProviderKind::InMemory => {
+                    #[cfg(feature = "memory-loglet")]
+                    ProviderKind::InMemory => {
+                        return Err(DisableNodeError::LocalLoglet {
+                            provider_kind: segment.config.kind,
+                            loglet_id: LogletId::new(*log_id, segment.index()),
+                            node_id,
+                        });
+                    }
+                    ProviderKind::Local => {
                         return Err(DisableNodeError::LocalLoglet {
                             provider_kind: segment.config.kind,
                             loglet_id: LogletId::new(*log_id, segment.index()),

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -105,7 +105,13 @@ async fn provision_cluster(
         let default_provider = ProviderConfiguration::try_from(default_provider.clone())?;
 
         match default_provider {
-            ProviderConfiguration::InMemory | ProviderConfiguration::Local => {
+            #[cfg(feature = "memory-loglet")]
+            ProviderConfiguration::InMemory => {
+                c_warn!(
+                    "You are about to provision a cluster with a Bifrost provider that only supports a single node cluster."
+                );
+            }
+            ProviderConfiguration::Local => {
                 c_warn!(
                     "You are about to provision a cluster with a Bifrost provider that only supports a single node cluster."
                 );


### PR DESCRIPTION
Ref: https://github.com/restatedev/restate/issues/3036

before fix:

```
cargo clippy --manifest-path tools/restatectl/Cargo.toml --no-default-features --features no-trace-logging
error[E0599]: no variant or associated item named InMemory found for enum restate_types::logs::metadata::ProviderKind in the current scope
  --> tools/restatectl/src/commands/config/set.rs:78:27
   |
78 |             ProviderKind::InMemory | ProviderKind::Local => {
   |                           ^^^^^^^^ variant or associated item not found in ProviderKind
```

cc @tillrohrmann 