### PR TITLE
[bifrost] Limit readahead records to u16 in configuration

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -460,7 +460,7 @@ impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
 mod tests {
     use super::*;
 
-    use std::num::{NonZeroU8, NonZeroUsize};
+    use std::num::{NonZeroU8, NonZeroU16};
 
     use googletest::prelude::*;
     use test_log::test;
@@ -681,7 +681,7 @@ mod tests {
         let mut config = Configuration::default();
         // disable read-ahead to avoid reading records from log-servers before the trim taking
         // place.
-        config.bifrost.replicated_loglet.readahead_records = NonZeroUsize::new(1).unwrap();
+        config.bifrost.replicated_loglet.readahead_records = NonZeroU16::new(1).unwrap();
         config.bifrost.replicated_loglet.readahead_trigger_ratio = 1.0;
         let record_cache = RecordCache::new(0);
         run_in_test_env(config, params, record_cache, |env| {

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -105,7 +105,7 @@ impl ReadStreamTask {
                 .bifrost
                 .replicated_loglet
                 .readahead_records
-                .into(),
+                .get() as usize,
         );
         // Reading from INVALID resets to OLDEST.
         let from_offset = from_offset.max(LogletOffset::OLDEST);

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU16, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -270,7 +270,7 @@ pub struct ReplicatedLogletOptions {
     /// The number of records bifrost will attempt to prefetch from replicated loglet's log-servers
     /// for every loglet reader (e.g. partition processor). Note that this mainly impacts readers
     /// that are not co-located with the loglet sequencer (i.e. partition processor followers).
-    pub readahead_records: NonZeroUsize,
+    pub readahead_records: NonZeroU16,
 
     /// Trigger to prefetch more records
     ///
@@ -349,7 +349,7 @@ impl Default for ReplicatedLogletOptions {
                 Some(3),
                 Some(Duration::from_millis(2000)),
             ),
-            readahead_records: NonZeroUsize::new(100).unwrap(),
+            readahead_records: NonZeroU16::new(100).unwrap(),
             readahead_trigger_ratio: 0.5,
             default_nodeset_size: NodeSetSize::default(),
             default_log_replication: None,
@@ -375,7 +375,7 @@ pub struct ReplicatedLogletOptionsShadow {
     #[serde_as(as = "serde_with::DisplayFromStr")]
     log_server_rpc_timeout: humantime::Duration,
     log_server_retry_policy: RetryPolicy,
-    readahead_records: NonZeroUsize,
+    readahead_records: NonZeroU16,
     readahead_trigger_ratio: f32,
     #[serde_as(as = "Option<crate::replication::ReplicationPropertyFromTo>")]
     default_log_replication: Option<ReplicationProperty>,

--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -13,7 +13,7 @@ mod common;
 mod tests {
     use std::{
         collections::BTreeSet,
-        num::{NonZeroU8, NonZeroUsize},
+        num::{NonZeroU8, NonZeroU16},
         sync::Arc,
         time::Duration,
     };
@@ -153,7 +153,7 @@ mod tests {
         let mut config = Configuration::default();
         // disable read-ahead to avoid reading records from log-servers before the trim taking
         // place.
-        config.bifrost.replicated_loglet.readahead_records = NonZeroUsize::new(1).unwrap();
+        config.bifrost.replicated_loglet.readahead_records = NonZeroU16::new(1).unwrap();
         config.bifrost.replicated_loglet.readahead_trigger_ratio = 1.0;
         config.bifrost.record_cache_memory_size = 0_u64.into();
         run_in_test_env(


### PR DESCRIPTION

We have an assertion for it in debug, but better change the config parsing to reflect this.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3163).
* #3164
* #3162
* #3159
* #3165
* #3167
* __->__ #3163