### PR TITLE
[Core] Tuning failover config defaults

### DIFF
--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -118,7 +118,7 @@ impl Default for BifrostOptions {
             ),
             append_retry_min_interval: Duration::from_millis(10).into(),
             append_retry_max_interval: Duration::from_secs(1).into(),
-            auto_recovery_interval: Duration::from_secs(3).into(),
+            auto_recovery_interval: Duration::from_secs(10).into(),
             seal_retry_interval: Duration::from_secs(2).into(),
             record_cache_memory_size: ByteCount::from(250u64 * 1024 * 1024), // 250 MiB
         }

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -191,8 +191,8 @@ pub struct RaftOptions {
 impl Default for RaftOptions {
     fn default() -> Self {
         RaftOptions {
-            raft_election_tick: NonZeroUsize::new(20).expect("20 to be non zero"),
-            raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
+            raft_election_tick: NonZeroUsize::new(10).expect("be non zero"),
+            raft_heartbeat_tick: NonZeroUsize::new(2).expect("be non zero"),
             raft_tick_interval: Duration::from_millis(100).into(),
             status_update_interval: Duration::from_secs(5).into(),
         }


### PR DESCRIPTION

- Auto-recovery needs to be higher than http2 keep-alive timeout
- Shorter raft election timeout (~1-ish second)
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3165).
* #3164
* #3162
* #3159
* __->__ #3165