### PR TITLE
[Restate UI] Update to v0.0.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7812,8 +7812,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.60"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.60#23e100fafff917a47262df64c5db4cf6a3b28457"
+version = "0.0.63"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.63#28c18574bbbecaffeb5935a490d1072138ec246d"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -32,7 +32,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true, features = ["schemars"] }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.60", tag = "v0.0.60" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.63", tag = "v0.0.63" }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.63
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.63/ui-v0.0.63.zip