### PR TITLE
LogServer Bilrost (v2) message types

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -127,7 +127,7 @@ fn serialize_store_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> {
             loglet_id: LogletId::new(12u16.into(), 4.into()),
             known_global_tail: LogletOffset::new(55),
         },
-        payloads,
+        payloads: payloads.into(),
         timeout_at: Some(MillisSinceEpoch::now()),
         flags: StoreFlags::empty(),
         first_offset: LogletOffset::new(56),

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -377,6 +377,9 @@ impl ReadStreamTask {
                         self.add_to_cache(offset, &maybe_record);
                     } else if offset == self.read_pointer {
                         match maybe_record {
+                            MaybeRecord::Unknown => {
+                                unreachable!()
+                            }
                             MaybeRecord::TrimGap(gap) => {
                                 let permit = permits.next().expect("must have at least one permit");
                                 trace!(

--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -375,6 +375,10 @@ impl<T: TransportConnect> SequencerAppender<T> {
 
             // We had a response from this node and there is still a lot we can do
             match stored.status {
+                Status::Unknown => {
+                    warn!(peer = %node_id, "Store failed on peer. Unknown error!");
+                    self.graylist.insert(node_id);
+                }
                 Status::Ok => {
                     // only if status is okay that we remove this node
                     // from the gray list, and move to replicated list
@@ -667,7 +671,7 @@ impl<T: TransportConnect> LogServerStoreTask<T> {
             first_offset: self.first_offset,
             flags: StoreFlags::empty(),
             known_archived: LogletOffset::INVALID,
-            payloads: Arc::clone(&self.records),
+            payloads: Arc::clone(&self.records).into(),
             sequencer: *self.sequencer_shared_state.sequencer(),
             timeout_at: Some(timeout_at),
         };

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -544,7 +544,10 @@ impl<'a> FindTailOnNode<'a> {
                         // fall-through for retries
                     }
                     // unexpected statuses
-                    Status::SequencerMismatch | Status::OutOfBounds | Status::Malformed => {
+                    Status::SequencerMismatch
+                    | Status::OutOfBounds
+                    | Status::Malformed
+                    | Status::Unknown => {
                         warn!(
                             loglet_id = %self.loglet_id,
                             peer = %self.node_id,
@@ -631,7 +634,10 @@ impl WaitForTailOnNode {
                             // fall-through for retries
                         }
                         // unexpected statuses
-                        Status::SequencerMismatch | Status::OutOfBounds | Status::Malformed => {
+                        Status::SequencerMismatch
+                        | Status::OutOfBounds
+                        | Status::Malformed
+                        | Status::Unknown => {
                             error!(
                                 "Unexpected status from log-server node_id={} when waiting for tail update for loglet_id={}: {:?}",
                                 self.node_id, self.loglet_id, msg.status

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -422,6 +422,10 @@ impl<S: LogStore> LogletWorker<S> {
             // If shutdown happened, this task will be disposed of and we won't send
             // the response.
             match msg.query {
+                TailUpdateQuery::Unknown => {
+                    reciprocal.send(TailUpdated::empty().with_status(Status::Malformed));
+                    return Ok(());
+                }
                 TailUpdateQuery::LocalTail(target_offset) => {
                     local_tail_watch
                         .wait_for_offset_or_seal(target_offset)
@@ -656,7 +660,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::OLDEST,
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         // offsets 3, 4
@@ -667,7 +671,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::new(3),
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         let (msg1, msg1_reply) =
@@ -717,7 +721,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::OLDEST,
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         let seal1 = Seal {
@@ -738,7 +742,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::new(3),
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         let (msg1, msg1_reply) =
@@ -785,7 +789,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::new(3),
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
         let (msg3, msg3_reply) =
             ServiceMessage::fake_rpc(msg3, Some(LOGLET.into()), SEQUENCER, None);
@@ -838,7 +842,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::OLDEST,
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         // offsets 10, 11
@@ -849,7 +853,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::new(10),
             flags: StoreFlags::empty(),
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         let seal1 = Seal {
@@ -865,7 +869,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::new(5),
             flags: StoreFlags::IgnoreSeal,
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         // 16, 17
@@ -876,7 +880,7 @@ mod tests {
             known_archived: LogletOffset::INVALID,
             first_offset: LogletOffset::new(16),
             flags: StoreFlags::IgnoreSeal,
-            payloads: payloads.clone(),
+            payloads: payloads.clone().into(),
         };
 
         let (msg1, msg1_reply) =

--- a/crates/types/src/logs/loglet.rs
+++ b/crates/types/src/logs/loglet.rs
@@ -11,6 +11,8 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
+use restate_encoding::{BilrostNewType, NetSerde};
+
 use crate::logs::LogId;
 use crate::logs::metadata::SegmentIndex;
 
@@ -34,6 +36,8 @@ use crate::logs::metadata::SegmentIndex;
     derive_more::From,
     derive_more::Deref,
     derive_more::Into,
+    BilrostNewType,
+    NetSerde,
 )]
 #[serde(transparent)]
 #[repr(transparent)]

--- a/crates/types/src/logs/record.rs
+++ b/crates/types/src/logs/record.rs
@@ -11,6 +11,7 @@
 use std::sync::Arc;
 
 use bytes::BytesMut;
+use restate_encoding::NetSerde;
 use serde::{Deserialize, Serialize};
 
 use crate::storage::{
@@ -20,7 +21,7 @@ use crate::time::NanosSinceEpoch;
 
 use super::{KeyFilter, Keys, MatchKeyQuery};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, bilrost::Message, NetSerde)]
 pub struct Record {
     created_at: NanosSinceEpoch,
     #[serde(with = "serde_with::As::<EncodedPolyBytes>")]

--- a/crates/types/src/time.rs
+++ b/crates/types/src/time.rs
@@ -131,7 +131,18 @@ impl From<MillisSinceEpoch> for SystemTime {
 /// accurate when used on the same node. This roughly maps to std::time::Instant except that the
 /// value is portable across nodes.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    BilrostNewType,
+    NetSerde,
 )]
 #[serde(transparent)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]


### PR DESCRIPTION
LogServer Bilrost (v2) message types

Move log server messages to Bilrost v2 by either derive bilrost::Message
or implement a DTO

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3176).
* #3222
* __->__ #3176