### PR TITLE
Don't fail cloud login if we cannot open the browser

### DIFF
--- a/cli/src/commands/cloud/login.rs
+++ b/cli/src/commands/cloud/login.rs
@@ -174,7 +174,10 @@ async fn auth_flow(env: &CliEnv, _opts: &Login) -> Result<String> {
     tokio::pin!(result_fut);
 
     c_println!("Opening browser to {login_uri}");
-    open::that(login_uri.to_string())?;
+
+    if let Err(_err) = open::that(login_uri.to_string()) {
+        c_println!("Failed to open browser automatically. Please open the above URL manually.")
+    }
 
     let progress = ProgressBar::new_spinner();
     progress.set_style(indicatif::ProgressStyle::with_template("{spinner} {msg}").unwrap());


### PR DESCRIPTION
Instead of failing we are asking the user to open the URL manually.

This fixes #3179.