### PR TITLE
Add support for protocol version Bilrost (v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bilrost"
+version = "0.1012.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815ed941f4e34d221bda5ac688ff1f80f579ca0c1b062d381347be6d53786e02"
+dependencies = [
+ "bilrost-derive",
+ "bytes",
+ "thin-vec",
+]
+
+[[package]]
+name = "bilrost-derive"
+version = "0.1012.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7460f57756524d00acaca4d8c1af4188667739d10b9a2911fd430f6b2857d2d6"
+dependencies = [
+ "eyre",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3037,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,6 +3906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,7 +4451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6884,6 +6924,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-encoding"
+version = "1.3.3-dev"
+dependencies = [
+ "bilrost",
+ "bytes",
+ "bytestring",
+ "rand 0.9.0",
+ "restate-encoding-derive",
+ "static_assertions",
+ "workspace-hack",
+]
+
+[[package]]
+name = "restate-encoding-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "workspace-hack",
+]
+
+[[package]]
 name = "restate-errors"
 version = "1.3.3-dev"
 dependencies = [
@@ -7699,6 +7762,7 @@ dependencies = [
  "arc-swap",
  "base62",
  "base64 0.22.1",
+ "bilrost",
  "bincode",
  "bitflags 2.8.0",
  "bytes",
@@ -7740,6 +7804,7 @@ dependencies = [
  "regex",
  "regress 0.10.3",
  "restate-base64-util",
+ "restate-encoding",
  "restate-errors",
  "restate-serde-util",
  "restate-test-util",
@@ -8936,6 +9001,12 @@ name = "test_bin"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
+
+[[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
@@ -10310,6 +10381,7 @@ dependencies = [
  "axum",
  "axum-core",
  "bitflags 2.8.0",
+ "byteorder",
  "bytes",
  "bzip2-sys",
  "cc",
@@ -10347,6 +10419,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.7.1",
  "itertools 0.12.1",
+ "itertools 0.14.0",
  "libc",
  "libz-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cli",
     "crates/*",
     "crates/core/derive",
+    "crates/encoding/derive",
     "crates/codederror/derive",
     "server",
     "benchmarks",
@@ -44,6 +45,7 @@ restate-bifrost = { path = "crates/bifrost" }
 restate-cli-util = { path = "crates/cli-util" }
 restate-core = { path = "crates/core" }
 restate-core-derive = { path = "crates/core/derive" }
+restate-encoding = { path = "crates/encoding" }
 restate-errors = { path = "crates/errors" }
 restate-fs-util = { path = "crates/fs-util" }
 restate-futures-util = { path = "crates/futures-util" }
@@ -91,6 +93,7 @@ aws-smithy-async = {version = "1.2.5", default-features = false}
 aws-smithy-runtime-api = "1.7.4"
 aws-smithy-types = "1.3.0"
 base64 = "0.22"
+bilrost = { version = "0.1012" }
 bincode = { version = "2.0.1", default-features = false }
 bitflags = { version = "2.6.0" }
 bytes = { version = "1.7", features = ["serde"] }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "restate-encoding"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+bilrost = { workspace = true }
+bytes = { workspace = true }
+restate-encoding-derive = { version = "0.1.0", path = "derive" }
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+bytestring = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }
+static_assertions = { workspace = true }

--- a/crates/encoding/derive/Cargo.toml
+++ b/crates/encoding/derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "restate-encoding-derive"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1"
+syn = { version = "2.0", features = ["full"] }
+workspace-hack = { version = "0.1", path = "../../../workspace-hack" }

--- a/crates/encoding/derive/src/bilrost.rs
+++ b/crates/encoding/derive/src/bilrost.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Fields, ItemStruct};
+
+pub fn new_type(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as ItemStruct);
+    let inner = match &input.fields {
+        Fields::Unnamed(inner) => {
+            if inner.unnamed.len() != 1 {
+                return syn::Error::new_spanned(
+                    input.ident,
+                    "This macro can only be used on newtype struct with exactly one field",
+                )
+                .to_compile_error()
+                .into();
+            }
+
+            &inner.unnamed[0]
+        }
+        _ => {
+            return syn::Error::new_spanned(
+                input.ident,
+                "This macro can only be used on newtype structs (e.g., `struct MyType(T);`)",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let name = &input.ident;
+    let inner_ty = &inner.ty;
+
+    let output = quote! {
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General> for #name {
+            fn encode_value<B: ::bytes::BufMut + ?Sized>(value: &Self, buf: &mut B) {
+                <#inner_ty as ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General>>::encode_value(&value.0, buf)
+            }
+
+            fn value_encoded_len(value: &Self) -> usize {
+                <#inner_ty as ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General>>::value_encoded_len(&value.0)
+            }
+
+            fn prepend_value<B: bilrost::buf::ReverseBuf + ?Sized>(value: &Self, buf: &mut B) {
+                <#inner_ty as ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General>>::prepend_value(&value.0, buf);
+            }
+        }
+
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::ValueDecoder<::bilrost::encoding::General> for #name {
+            fn decode_value<B: ::bytes::Buf + ?Sized>(
+                value: &mut Self,
+                buf: ::bilrost::encoding::Capped<B>,
+                ctx: ::bilrost::encoding::DecodeContext,
+            ) -> ::std::result::Result<(), ::bilrost::DecodeError> {
+                <#inner_ty as ::bilrost::encoding::ValueDecoder<::bilrost::encoding::General>>::decode_value(&mut value.0, buf, ctx)
+            }
+        }
+
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::Wiretyped<::bilrost::encoding::General> for #name {
+            const WIRE_TYPE: ::bilrost::encoding::WireType = <#inner_ty as ::bilrost::encoding::Wiretyped<::bilrost::encoding::General>>::WIRE_TYPE;
+        }
+
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::EmptyState for #name {
+            fn clear(&mut self) {
+                <#inner_ty as ::bilrost::encoding::EmptyState>::clear(&mut self.0);
+            }
+            fn empty() -> Self
+            where
+                Self: Sized,
+            {
+                Self(<#inner_ty as ::bilrost::encoding::EmptyState>::empty())
+            }
+            fn is_empty(&self) -> bool {
+                <#inner_ty as ::bilrost::encoding::EmptyState>::is_empty(&self.0)
+            }
+        }
+
+        impl ::bilrost::encoding::ForOverwrite for #name {
+            fn for_overwrite() -> Self
+            where
+                Self: Sized,
+            {
+                Self(<#inner_ty as ::bilrost::encoding::ForOverwrite>::for_overwrite())
+            }
+        }
+    };
+
+    output.into()
+}

--- a/crates/encoding/derive/src/lib.rs
+++ b/crates/encoding/derive/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+extern crate proc_macro;
+
+mod bilrost;
+mod net;
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(BilrostNewType)]
+pub fn bilrost_new_type(item: TokenStream) -> TokenStream {
+    bilrost::new_type(item)
+}
+
+#[proc_macro_derive(NetSerde)]
+pub fn network_message(item: TokenStream) -> TokenStream {
+    net::net_serde(item)
+}

--- a/crates/encoding/derive/src/net.rs
+++ b/crates/encoding/derive/src/net.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashSet;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields};
+
+pub fn net_serde(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as DeriveInput);
+
+    let name = input.ident;
+
+    let field_types = match input.data {
+        Data::Struct(data_struct) => collect_field_types(data_struct.fields),
+        Data::Enum(data_enum) => {
+            let mut field_types = HashSet::new();
+            for variant in data_enum.variants {
+                field_types.extend(collect_field_types(variant.fields));
+            }
+            field_types
+        }
+        _ => panic!("NetSerde can only be derived for structs or enums"),
+    };
+
+    let where_clauses = field_types.iter().map(|ty| {
+        quote! {
+            #ty: NetSerde
+        }
+    });
+
+    let expanded = quote! {
+        impl ::restate_encoding::NetSerde for #name where #(#where_clauses),* {}
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn collect_field_types(fields: Fields) -> HashSet<syn::Type> {
+    match fields {
+        Fields::Named(fields_named) => fields_named.named.into_iter().map(|f| f.ty).collect(),
+        Fields::Unnamed(fields_unnamed) => {
+            fields_unnamed.unnamed.into_iter().map(|f| f.ty).collect()
+        }
+        Fields::Unit => HashSet::default(),
+    }
+}

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -1,0 +1,153 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+pub use restate_encoding_derive::BilrostNewType;
+pub use restate_encoding_derive::NetSerde;
+
+/// A marker trait for types that can be serialized and sent over the network.
+///
+/// Types implementing this trait are considered eligible for wire transmission,
+/// typically via serialization. It is intended to be implemented automatically
+/// using the `#[derive(NetSerde)]` macro.
+///
+/// # Example
+/// ```ignore
+/// #[derive(NetSerde)]
+/// struct MyMessage {
+///     a: u64,
+///     b: String,
+/// }
+/// ```
+pub trait NetSerde {}
+
+macro_rules! impl_net_serde {
+    ($t:ty) => {
+        impl NetSerde for $t {}
+    };
+    ($($t:ty),+) => {
+        $(impl_net_serde!($t);)+
+    }
+}
+
+impl_net_serde!(
+    bool,
+    usize,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    isize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    String,
+    bytes::Bytes,
+    bytestring::ByteString,
+    std::time::Duration
+);
+
+macro_rules! impl_net_serde_tuple {
+    ($($t:ident),+) => {
+        impl<$($t),+> NetSerde for ($($t),+) where $($t: NetSerde),+ {}
+    };
+}
+
+impl_net_serde_tuple!(T0, T1);
+impl_net_serde_tuple!(T0, T1, T2);
+impl_net_serde_tuple!(T0, T1, T2, T3);
+impl_net_serde_tuple!(T0, T1, T2, T3, T4);
+impl_net_serde_tuple!(T0, T1, T2, T3, T4, T5);
+impl_net_serde_tuple!(T0, T1, T2, T3, T4, T5, T6);
+
+impl<T> NetSerde for Vec<T> where T: NetSerde {}
+impl<T> NetSerde for Option<T> where T: NetSerde {}
+impl<K, V, S> NetSerde for HashMap<K, V, S>
+where
+    K: NetSerde,
+    V: NetSerde,
+{
+}
+
+impl<K, V> NetSerde for BTreeMap<K, V>
+where
+    K: NetSerde,
+    V: NetSerde,
+{
+}
+
+impl<V> NetSerde for HashSet<V> where V: NetSerde {}
+
+/// A Bilrost compatible U128 type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BilrostNewType)]
+pub struct U128((u64, u64));
+
+impl From<u128> for U128 {
+    fn from(value: u128) -> Self {
+        Self(((value >> 64) as u64, value as u64))
+    }
+}
+
+impl From<U128> for u128 {
+    fn from(value: U128) -> Self {
+        (value.0.0 as u128) << 64 | value.0.1 as u128
+    }
+}
+
+impl NetSerde for U128 {}
+
+#[cfg(test)]
+mod test {
+    use bilrost::{Message, OwnedMessage};
+    use rand::random;
+    use restate_encoding_derive::BilrostNewType;
+
+    use super::U128;
+
+    #[test]
+    fn test_u128() {
+        (0..100).for_each(|_| {
+            let num = random::<u128>();
+            let value = U128::from(num);
+
+            assert_eq!(num, u128::from(value));
+        });
+    }
+
+    #[derive(BilrostNewType)]
+    struct MyId(u64);
+
+    #[derive(bilrost::Message)]
+    struct Nested {
+        id: MyId,
+    }
+
+    #[derive(bilrost::Message)]
+    struct Flattened {
+        id: u64,
+    }
+
+    #[test]
+    fn test_new_type() {
+        let x = Nested { id: MyId(10) };
+
+        let bytes = x.encode_to_bytes();
+
+        let y = Flattened::decode(bytes).expect("decodes");
+
+        assert_eq!(x.id.0, y.id);
+    }
+}

--- a/crates/encoding/tests/net_serde.rs
+++ b/crates/encoding/tests/net_serde.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+
+use restate_encoding::NetSerde;
+use static_assertions::assert_impl_all;
+
+#[allow(dead_code)]
+#[derive(NetSerde)]
+struct SomeMessage {
+    a: u64,
+    b: String,
+    c: (bool, u64),
+    d: Inner,
+}
+
+#[allow(dead_code)]
+#[derive(NetSerde)]
+struct Inner(HashMap<u64, String>);
+
+assert_impl_all!(SomeMessage: NetSerde);

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -21,6 +21,7 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 restate-base64-util = { workspace = true }
 restate-errors = { workspace = true }
 restate-serde-util = { workspace = true }
+restate-encoding = { workspace = true }
 restate-test-util = { workspace = true, optional = true }
 restate-utoipa = { workspace = true }
 
@@ -32,6 +33,7 @@ base64 = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+bilrost = { workspace = true }
 bincode = { workspace = true, default-features = false, features = ["std", "serde"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"], optional = true }

--- a/crates/types/src/net/codec.rs
+++ b/crates/types/src/net/codec.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+use super::{FromBilrostDto, IntoBilrostDto};
 use crate::protobuf::common::ProtocolVersion;
 
 pub trait WireEncode {
@@ -76,28 +77,52 @@ where
 /// Utility method to raw-encode a [`Serialize`] type as flexbuffers using serde without adding
 /// version tag. This must be decoded with `decode_from_untagged_flexbuffers`. This is used as the default
 /// encoding for network messages since networking has its own protocol versioning.
-pub fn encode_default<T: Serialize>(value: T, protocol_version: ProtocolVersion) -> Vec<u8> {
-    match protocol_version {
-        ProtocolVersion::V2 | ProtocolVersion::V1 => {
-            flexbuffers::to_vec(value).expect("network message serde can't fail")
-        }
-        ProtocolVersion::Unknown => {
-            unreachable!("unknown protocol version should never be set")
-        }
-    }
+pub fn encode_as_flexbuffers<T: Serialize>(value: T, protocol_version: ProtocolVersion) -> Vec<u8> {
+    assert!(
+        protocol_version >= ProtocolVersion::V1,
+        "unknown protocol version should never be set"
+    );
+
+    flexbuffers::to_vec(value).expect("network message serde can't fail")
 }
 
 /// Utility method to decode a [`DeserializeOwned`] type from flexbuffers using serde. the buffer
 /// must have the complete message and not internally chunked.
-pub fn decode_default<T: DeserializeOwned>(
+pub fn decode_as_flexbuffers<T: DeserializeOwned>(
     buf: impl Buf,
     protocol_version: ProtocolVersion,
 ) -> Result<T, anyhow::Error> {
-    match protocol_version {
-        ProtocolVersion::V2 | ProtocolVersion::V1 => flexbuffers::from_slice(buf.chunk())
-            .context("failed decoding (flexbuffers) network message"),
-        ProtocolVersion::Unknown => {
-            unreachable!("unknown protocol version should never be set")
-        }
-    }
+    assert!(
+        protocol_version >= ProtocolVersion::V1,
+        "unknown protocol version should never be set"
+    );
+
+    flexbuffers::from_slice(buf.chunk()).context("failed decoding V1 (flexbuffers) network message")
+}
+
+pub fn encode_as_bilrost<T: IntoBilrostDto>(value: T, protocol_version: ProtocolVersion) -> Bytes {
+    use bilrost::Message;
+
+    assert!(
+        protocol_version >= ProtocolVersion::V2,
+        "bilrost encoding is supported from protocol version v2"
+    );
+
+    let inner = value.into_dto();
+    inner.encode_to_bytes()
+}
+
+pub fn decode_as_bilrost<T: FromBilrostDto>(
+    buf: impl Buf,
+    protocol_version: ProtocolVersion,
+) -> Result<T, anyhow::Error> {
+    assert!(
+        protocol_version >= ProtocolVersion::V2,
+        "bilrost encoding is supported from protocol version v2"
+    );
+
+    let inner = <T::Target as bilrost::OwnedMessage>::decode(buf)
+        .context("failed decoding V2 (bilrost) network message")?;
+
+    T::from_dto(inner).context("failed to convert V2 (bilrost) value to inner type")
 }

--- a/crates/types/src/net/dto.rs
+++ b/crates/types/src/net/dto.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::convert::Infallible;
+
+use restate_encoding::NetSerde;
+
+/// A trait for converting from internal types and their DTO (Data Transfer Object)
+/// representations used for storage or wire transmission.
+///
+/// Types that need to be serialized or sent over the network should implement this trait,
+/// defining how they convert to and from a `Target` type, which is expected to implement
+/// [`bilrost::Message`]
+///
+/// For types that already implement [`bilrost::Message`], a blanket implementation is provided,
+/// allowing them to be stored or transferred directly without transformation.
+pub trait IntoBilrostDto {
+    type Target: bilrost::Message + NetSerde;
+    fn into_dto(self) -> Self::Target;
+}
+
+/// A trait for converting from DTOs (Data Transfer Object) used mainly for storage or wire transmission, and
+/// their internal types used for in memory manipulation
+///
+/// Types that need to be serialized or sent over the network should implement this trait,
+/// defining how they convert to and from a `Target` type, which is expected to implement
+/// [`bilrost::OwnedMessage`]
+///
+/// For types that already implement [`bilrost::Message`], a blanket implementation is provided,
+/// allowing them to be stored or transferred directly without transformation.
+///
+pub trait FromBilrostDto: Sized {
+    type Target: bilrost::OwnedMessage + NetSerde;
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    fn from_dto(value: Self::Target) -> Result<Self, Self::Error>;
+}
+
+impl<T> IntoBilrostDto for T
+where
+    T: bilrost::Message + NetSerde,
+{
+    type Target = T;
+
+    fn into_dto(self) -> Self::Target {
+        self
+    }
+}
+
+impl<T> FromBilrostDto for T
+where
+    T: bilrost::OwnedMessage + NetSerde,
+{
+    type Target = T;
+    type Error = Infallible;
+
+    fn from_dto(value: Self::Target) -> Result<Self, Self::Error> {
+        Ok(value)
+    }
+}

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -66,13 +66,13 @@ impl WireEncode for GetMetadataRequest {
     fn encode_to_bytes(self, protocol_version: ProtocolVersion) -> Bytes {
         if let ProtocolVersion::V1 = protocol_version {
             // V1 protocol sends `GetMetadataRequest` as a `MetadataMessage`
-            return Bytes::from(crate::net::codec::encode_default(
+            return Bytes::from(crate::net::codec::encode_as_flexbuffers(
                 MetadataMessage::GetMetadataRequest(self),
                 protocol_version,
             ));
         }
 
-        Bytes::from(codec::encode_default(self, protocol_version))
+        Bytes::from(codec::encode_as_flexbuffers(self, protocol_version))
     }
 }
 impl WireDecode for GetMetadataRequest {
@@ -87,13 +87,13 @@ impl WireDecode for GetMetadataRequest {
         if let ProtocolVersion::V1 = protocol_version {
             // V1 protocol sends `GetMetadataRequest` as a `MetadataMessage`
             let message =
-                crate::net::codec::decode_default::<MetadataMessage>(buf, protocol_version)?;
+                crate::net::codec::decode_as_flexbuffers::<MetadataMessage>(buf, protocol_version)?;
             if let MetadataMessage::GetMetadataRequest(request) = message {
                 return Ok(request);
             }
             bail!("Invalid message type");
         }
-        codec::decode_default(buf, protocol_version)
+        codec::decode_as_flexbuffers(buf, protocol_version)
     }
 }
 
@@ -101,12 +101,12 @@ impl WireEncode for MetadataUpdate {
     fn encode_to_bytes(self, protocol_version: ProtocolVersion) -> Bytes {
         if let ProtocolVersion::V1 = protocol_version {
             // V1 protocol sends `MetadataUpdate` as a `MetadataMessage`
-            return Bytes::from(codec::encode_default(
+            return Bytes::from(codec::encode_as_flexbuffers(
                 MetadataMessage::MetadataUpdate(self),
                 protocol_version,
             ));
         }
-        Bytes::from(codec::encode_default(self, protocol_version))
+        Bytes::from(codec::encode_as_flexbuffers(self, protocol_version))
     }
 }
 impl WireDecode for MetadataUpdate {
@@ -121,13 +121,13 @@ impl WireDecode for MetadataUpdate {
         if let ProtocolVersion::V1 = protocol_version {
             // V1 protocol sends `MetadataUpdate` as a `MetadataMessage`
             let message =
-                crate::net::codec::decode_default::<MetadataMessage>(buf, protocol_version)?;
+                crate::net::codec::decode_as_flexbuffers::<MetadataMessage>(buf, protocol_version)?;
             if let MetadataMessage::MetadataUpdate(update) = message {
                 return Ok(update);
             }
             bail!("Invalid message type");
         }
-        codec::decode_default(buf, protocol_version)
+        codec::decode_as_flexbuffers(buf, protocol_version)
     }
 }
 

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 pub mod codec;
+pub mod dto;
 pub mod log_server;
 pub mod metadata;
 pub mod node;
@@ -27,6 +28,7 @@ use http::Uri;
 use crate::config::InvalidConfigurationError;
 pub use crate::protobuf::common::ProtocolVersion;
 pub use crate::protobuf::common::ServiceTag;
+pub use dto::{FromBilrostDto, IntoBilrostDto};
 
 pub static MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1;
 pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V2;
@@ -224,7 +226,10 @@ macro_rules! default_wire_codec {
                 self,
                 protocol_version: $crate::net::ProtocolVersion,
             ) -> ::bytes::Bytes {
-                ::bytes::Bytes::from($crate::net::codec::encode_default(self, protocol_version))
+                ::bytes::Bytes::from($crate::net::codec::encode_as_flexbuffers(
+                    self,
+                    protocol_version,
+                ))
             }
         }
 
@@ -238,9 +243,89 @@ macro_rules! default_wire_codec {
             where
                 Self: Sized,
             {
-                $crate::net::codec::decode_default(buf, protocol_version)
+                $crate::net::codec::decode_as_flexbuffers(buf, protocol_version)
             }
         }
+    };
+}
+
+/// Implements bilrost wire codec for a type
+/// - Message type
+///
+/// Example:
+/// ```ignore
+///   bilrost_wire_codec!(IngressMessage);
+/// ```
+///
+/// Example:
+/// ```ignore
+///   bilrost_wire_codec!(IngressMessage as IngressMessageDTO);
+/// ```
+///
+/// This codec will fallback automatically to flexbuffer
+/// if remote beer is on V1.
+#[allow(unused_macros)]
+macro_rules! bilrost_wire_codec {
+    (
+        $message:ty $(as $as_type:ty)?
+    ) => {
+        impl $crate::net::codec::WireEncode for $message {
+            fn encode_to_bytes(
+                self,
+                protocol_version: $crate::net::ProtocolVersion,
+            ) -> ::bytes::Bytes {
+                match protocol_version {
+                    $crate::net::ProtocolVersion::Unknown => {
+                        unreachable!("unknown protocol version should never be set")
+                    }
+                    $crate::net::ProtocolVersion::V1 => ::bytes::Bytes::from(
+                        $crate::net::codec::encode_as_flexbuffers(self, protocol_version),
+                    ),
+                    _ => $crate::net::codec::encode_as_bilrost(self, protocol_version),
+                }
+            }
+        }
+
+        impl $crate::net::codec::WireDecode for $message {
+            type Error = anyhow::Error;
+
+            fn try_decode(
+                buf: impl bytes::Buf,
+                protocol_version: $crate::net::ProtocolVersion,
+            ) -> Result<Self, anyhow::Error>
+            where
+                Self: Sized,
+            {
+                match protocol_version {
+                    $crate::net::ProtocolVersion::Unknown => {
+                        ::anyhow::bail!("Unknown protocol version")
+                    }
+                    $crate::net::ProtocolVersion::V1 => {
+                        $crate::net::codec::decode_as_flexbuffers(buf, protocol_version)
+                    }
+                    _ => $crate::net::codec::decode_as_bilrost(buf, protocol_version),
+                }
+            }
+        }
+
+        $(
+            impl $crate::net::IntoBilrostDto for $message {
+                type Target = $as_type;
+
+                fn into_dto(self) -> $as_type {
+                    self.into()
+                }
+            }
+
+            impl $crate::net::FromBilrostDto for $message {
+                type Target = $as_type;
+                type Error = <$message as TryFrom<$as_type>>::Error;
+
+                fn from_dto(value: Self::Target) -> Result<Self, Self::Error> {
+                    value.try_into()
+                }
+            }
+        )?
     };
 }
 
@@ -321,7 +406,7 @@ macro_rules! define_rpc {
 }
 
 #[allow(unused_imports)]
-use {default_wire_codec, define_rpc, define_service, define_unary_message};
+use {bilrost_wire_codec, default_wire_codec, define_rpc, define_service, define_unary_message};
 
 #[cfg(test)]
 mod tests {

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -23,6 +23,7 @@
     derive_more::AddAssign,
     serde::Serialize,
     serde::Deserialize,
+    restate_encoding::BilrostNewType,
 )]
 #[display("v{}", _0)]
 #[debug("v{}", _0)]

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -30,6 +30,7 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
+byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -63,7 +64,8 @@ hyper-util = { version = "0.1", features = ["full"] }
 idna = { version = "1" }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["serde-1"] }
 indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["serde"] }
-itertools = { version = "0.12" }
+itertools-582f2526e08bb6a0 = { package = "itertools", version = "0.14" }
+itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 libc = { version = "0.2", features = ["extra_traits"] }
 libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
@@ -143,6 +145,7 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
+byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
@@ -178,7 +181,8 @@ hyper-util = { version = "0.1", features = ["full"] }
 idna = { version = "1" }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["serde-1"] }
 indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["serde"] }
-itertools = { version = "0.12" }
+itertools-582f2526e08bb6a0 = { package = "itertools", version = "0.14" }
+itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 libc = { version = "0.2", features = ["extra_traits"] }
 libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", default-features = false, features = ["std"] }


### PR DESCRIPTION
Add support for protocol version Bilrost (v2)

Also introduce two new derive macros:
- `BilrostNewType` to use with all ID types or any tuple with a single item. This will
effectively flatten this tuple to its inner type. Given that the inner field is bilrost serializable
- `NetworkMessage` which must be derived for each message that is going to be send over the network

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3190).
* #3176
* #3172
* __->__ #3190