### PR TITLE
Efficiently pack metadata versions in network structs

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -150,13 +150,9 @@ fn serialize_store_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> {
 
     let message = Message {
         header: Some(restate_core::network::protobuf::network::Header {
-            my_nodes_config_version: Some(5),
-            my_logs_version: None,
-            my_schema_version: None,
-            my_partition_table_version: None,
+            my_nodes_config_version: 5,
             msg_id: random(),
-            in_response_to: None,
-            span_context: None,
+            ..Default::default()
         }),
         body: Some(body),
     };
@@ -188,13 +184,9 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
 
     let message = Message {
         header: Some(restate_core::network::protobuf::network::Header {
-            my_nodes_config_version: Some(5),
-            my_logs_version: None,
-            my_schema_version: None,
-            my_partition_table_version: None,
+            my_nodes_config_version: 5,
             msg_id: random(),
-            in_response_to: None,
-            span_context: None,
+            ..Default::default()
         }),
         body: Some(body),
     };

--- a/crates/core/protobuf/restate/network.proto
+++ b/crates/core/protobuf/restate/network.proto
@@ -39,17 +39,17 @@ message Header {
   uint64 msg_id = 1;
 
   // **DEPRECATED** fabric v2 uses in-message id instead.
-  // The msg_id at which we are responding to. Unset if this not to be
-  // considered a response. Note: If this is set, it's the responsibility of
+  // The msg_id at which we are responding to. Unset(0) if this not to be
+  // considered a response. Note: If this is non-zero, it's the responsibility of
   // the message producer to ensure that the response is sent to the original
   // producer (generational node id).
   // Using raw value to be as compact as possible.
-  optional uint64 in_response_to = 2;
+  uint64 in_response_to = 2;
 
-  optional uint32 my_nodes_config_version = 3;
-  optional uint32 my_logs_version = 4;
-  optional uint32 my_schema_version = 5;
-  optional uint32 my_partition_table_version = 6;
+  uint32 my_nodes_config_version = 3;
+  uint32 my_logs_version = 4;
+  uint32 my_schema_version = 5;
+  uint32 my_partition_table_version = 6;
   optional SpanContext span_context = 7;
 }
 

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -713,10 +713,7 @@ mod tests {
             direction: ConnectionDirection::Bidirectional.into(),
             swimlane: Swimlane::default().into(),
         };
-        let hello = Message::new(
-            Header::new(metadata.nodes_config_version(), None, None, None, None),
-            hello,
-        );
+        let hello = Message::new(Header::default(), hello);
         tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
@@ -741,10 +738,7 @@ mod tests {
             direction: ConnectionDirection::Bidirectional.into(),
             swimlane: Swimlane::default().into(),
         };
-        let hello = Message::new(
-            Header::new(metadata.nodes_config_version(), None, None, None, None),
-            hello,
-        );
+        let hello = Message::new(Header::default(), hello);
         tx.send(hello).await?;
 
         let connections = ConnectionManager::default();
@@ -779,10 +773,7 @@ mod tests {
             ConnectionDirection::Bidirectional,
             Swimlane::default(),
         );
-        let hello = Message::new(
-            Header::new(metadata.nodes_config_version(), None, None, None, None),
-            hello,
-        );
+        let hello = Message::new(Header::default(), hello);
         tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
@@ -847,13 +838,11 @@ mod tests {
 
         let request = GetNodeState::default();
         let partition_table_version = metadata.partition_table_version().next();
-        let header = Header::new(
-            metadata.nodes_config_version(),
-            None,
-            None,
-            Some(partition_table_version),
-            None,
-        );
+        let header = Header {
+            my_nodes_config_version: metadata.nodes_config_version().into(),
+            my_partition_table_version: partition_table_version.into(),
+            ..Default::default()
+        };
 
         let permit = connection.conn.reserve().await.unwrap();
 

--- a/crates/core/src/network/io/egress_stream.rs
+++ b/crates/core/src/network/io/egress_stream.rs
@@ -308,28 +308,25 @@ impl EgressStream {
     }
 
     fn fill_header(&mut self, header: &mut Header, span: Option<Span>) {
-        header.my_nodes_config_version = Some(
-            self.metadata_cache
-                .nodes_config
-                .live_load()
-                .version()
-                .into(),
-        );
-        header.my_schema_version = Some(self.metadata_cache.schema.live_load().version().into());
-        header.my_partition_table_version = Some(
-            self.metadata_cache
-                .partition_table
-                .live_load()
-                .version()
-                .into(),
-        );
-        header.my_logs_version = Some(
-            self.metadata_cache
-                .logs_metadata
-                .live_load()
-                .version()
-                .into(),
-        );
+        header.my_nodes_config_version = self
+            .metadata_cache
+            .nodes_config
+            .live_load()
+            .version()
+            .into();
+        header.my_schema_version = self.metadata_cache.schema.live_load().version().into();
+        header.my_partition_table_version = self
+            .metadata_cache
+            .partition_table
+            .live_load()
+            .version()
+            .into();
+        header.my_logs_version = self
+            .metadata_cache
+            .logs_metadata
+            .live_load()
+            .version()
+            .into();
         if let Some(span) = span {
             let context = span.context();
             let mut span_context = SpanContext::default();

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -21,6 +21,7 @@ pub mod network {
     use opentelemetry::propagation::{Extractor, Injector};
 
     use restate_types::GenerationalNodeId;
+    use restate_types::net::metadata::MetadataKind;
 
     use restate_types::net::{
         CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION, ProtocolVersion,
@@ -74,23 +75,16 @@ pub mod network {
             self.fields.keys().map(String::as_str).collect()
         }
     }
+
     impl Header {
-        #[cfg(feature = "test-util")]
-        pub fn new(
-            nodes_config_version: restate_types::Version,
-            logs_version: Option<restate_types::Version>,
-            schema_version: Option<restate_types::Version>,
-            partition_table_version: Option<restate_types::Version>,
-            in_response_to: Option<u64>,
-        ) -> Self {
-            Self {
-                my_nodes_config_version: Some(nodes_config_version.into()),
-                my_logs_version: logs_version.map(Into::into),
-                my_schema_version: schema_version.map(Into::into),
-                my_partition_table_version: partition_table_version.map(Into::into),
-                msg_id: 0,
-                in_response_to,
-                span_context: None,
+        /// Returns the version of the metadata for the given kind.
+        #[must_use]
+        pub fn metadata_version(&self, kind: MetadataKind) -> restate_types::Version {
+            match kind {
+                MetadataKind::NodesConfiguration => self.my_nodes_config_version.into(),
+                MetadataKind::Schema => self.my_schema_version.into(),
+                MetadataKind::PartitionTable => self.my_partition_table_version.into(),
+                MetadataKind::Logs => self.my_logs_version.into(),
             }
         }
     }


### PR DESCRIPTION

Leveraging the fact the Version::INVALID is 0 to pack the metadata versions better in memory. Version needs 4 bytes (u32) while Option<Version> needs 8. `PeerMetadataVersion` now needs 16 bytes instead of 32, same for `Header`.

The other change is to let `MetadataVersions` keep track of the actual observed version of the peer as this might come handy for introspection later. This doesn't impact performance as we still only notify if the version is higher than our latest local view.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3196).
* #3200
* #3199
* __->__ #3196