### PR TITLE
[Core] Enable failure detector to start earlier

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -150,13 +150,9 @@ fn serialize_store_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> {
 
     let message = Message {
         header: Some(restate_core::network::protobuf::network::Header {
-            my_nodes_config_version: Some(5),
-            my_logs_version: None,
-            my_schema_version: None,
-            my_partition_table_version: None,
+            my_nodes_config_version: 5,
             msg_id: random(),
-            in_response_to: None,
-            span_context: None,
+            ..Default::default()
         }),
         body: Some(body),
     };
@@ -188,13 +184,9 @@ fn serialize_append_message(payloads: Arc<[Record]>) -> anyhow::Result<Message> 
 
     let message = Message {
         header: Some(restate_core::network::protobuf::network::Header {
-            my_nodes_config_version: Some(5),
-            my_logs_version: None,
-            my_schema_version: None,
-            my_partition_table_version: None,
+            my_nodes_config_version: 5,
             msg_id: random(),
-            in_response_to: None,
-            span_context: None,
+            ..Default::default()
         }),
         body: Some(body),
     };

--- a/crates/core/protobuf/restate/network.proto
+++ b/crates/core/protobuf/restate/network.proto
@@ -39,17 +39,17 @@ message Header {
   uint64 msg_id = 1;
 
   // **DEPRECATED** fabric v2 uses in-message id instead.
-  // The msg_id at which we are responding to. Unset if this not to be
-  // considered a response. Note: If this is set, it's the responsibility of
+  // The msg_id at which we are responding to. Unset(0) if this not to be
+  // considered a response. Note: If this is non-zero, it's the responsibility of
   // the message producer to ensure that the response is sent to the original
   // producer (generational node id).
   // Using raw value to be as compact as possible.
-  optional uint64 in_response_to = 2;
+  uint64 in_response_to = 2;
 
-  optional uint32 my_nodes_config_version = 3;
-  optional uint32 my_logs_version = 4;
-  optional uint32 my_schema_version = 5;
-  optional uint32 my_partition_table_version = 6;
+  uint32 my_nodes_config_version = 3;
+  uint32 my_logs_version = 4;
+  uint32 my_schema_version = 5;
+  uint32 my_partition_table_version = 6;
   optional SpanContext span_context = 7;
 }
 

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -713,10 +713,7 @@ mod tests {
             direction: ConnectionDirection::Bidirectional.into(),
             swimlane: Swimlane::default().into(),
         };
-        let hello = Message::new(
-            Header::new(metadata.nodes_config_version(), None, None, None, None),
-            hello,
-        );
+        let hello = Message::new(Header::default(), hello);
         tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
@@ -741,10 +738,7 @@ mod tests {
             direction: ConnectionDirection::Bidirectional.into(),
             swimlane: Swimlane::default().into(),
         };
-        let hello = Message::new(
-            Header::new(metadata.nodes_config_version(), None, None, None, None),
-            hello,
-        );
+        let hello = Message::new(Header::default(), hello);
         tx.send(hello).await?;
 
         let connections = ConnectionManager::default();
@@ -779,10 +773,7 @@ mod tests {
             ConnectionDirection::Bidirectional,
             Swimlane::default(),
         );
-        let hello = Message::new(
-            Header::new(metadata.nodes_config_version(), None, None, None, None),
-            hello,
-        );
+        let hello = Message::new(Header::default(), hello);
         tx.send(hello).await.expect("Channel accept hello message");
 
         let connections = ConnectionManager::default();
@@ -847,13 +838,11 @@ mod tests {
 
         let request = GetNodeState::default();
         let partition_table_version = metadata.partition_table_version().next();
-        let header = Header::new(
-            metadata.nodes_config_version(),
-            None,
-            None,
-            Some(partition_table_version),
-            None,
-        );
+        let header = Header {
+            my_nodes_config_version: metadata.nodes_config_version().into(),
+            my_partition_table_version: partition_table_version.into(),
+            ..Default::default()
+        };
 
         let permit = connection.conn.reserve().await.unwrap();
 

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -283,6 +283,11 @@ impl ConnectionManager {
         )
         .await?;
 
+        // temporary until we allow connections to be established before we acquire a node id.
+        let Some(my_node_id) = metadata.my_node_id_opt() else {
+            return Err(AcceptError::NotReady);
+        };
+
         let should_register = matches!(
             hello.direction(),
             ConnectionDirection::Unknown
@@ -294,7 +299,6 @@ impl ConnectionManager {
         let mut guard = self.inner.lock();
 
         let nodes_config = metadata.nodes_config_ref();
-        let my_node_id = metadata.my_node_id();
         // NodeId **must** be generational at this layer, we may support accepting connections from
         // anonymous nodes in the future. When this happens, this restate-server release will not
         // be compatible with it.

--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -192,6 +192,8 @@ impl From<HandshakeError> for tonic::Status {
 
 #[derive(Debug, thiserror::Error)]
 pub enum AcceptError {
+    #[error("this node has not acquired a node ID yet")]
+    NotReady,
     #[error(transparent)]
     Handshake(#[from] HandshakeError),
     #[error(transparent)]
@@ -207,6 +209,7 @@ pub enum AcceptError {
 impl From<AcceptError> for tonic::Status {
     fn from(value: AcceptError) -> Self {
         match value {
+            e @ AcceptError::NotReady => tonic::Status::unavailable(e.to_string()),
             AcceptError::Handshake(handshake) => handshake.into(),
             AcceptError::OldPeerGeneration(e) => tonic::Status::already_exists(e),
             AcceptError::PreviouslyShutdown => tonic::Status::already_exists(value.to_string()),

--- a/crates/core/src/network/io/egress_stream.rs
+++ b/crates/core/src/network/io/egress_stream.rs
@@ -308,28 +308,25 @@ impl EgressStream {
     }
 
     fn fill_header(&mut self, header: &mut Header, span: Option<Span>) {
-        header.my_nodes_config_version = Some(
-            self.metadata_cache
-                .nodes_config
-                .live_load()
-                .version()
-                .into(),
-        );
-        header.my_schema_version = Some(self.metadata_cache.schema.live_load().version().into());
-        header.my_partition_table_version = Some(
-            self.metadata_cache
-                .partition_table
-                .live_load()
-                .version()
-                .into(),
-        );
-        header.my_logs_version = Some(
-            self.metadata_cache
-                .logs_metadata
-                .live_load()
-                .version()
-                .into(),
-        );
+        header.my_nodes_config_version = self
+            .metadata_cache
+            .nodes_config
+            .live_load()
+            .version()
+            .into();
+        header.my_schema_version = self.metadata_cache.schema.live_load().version().into();
+        header.my_partition_table_version = self
+            .metadata_cache
+            .partition_table
+            .live_load()
+            .version()
+            .into();
+        header.my_logs_version = self
+            .metadata_cache
+            .logs_metadata
+            .live_load()
+            .version()
+            .into();
         if let Some(span) = span {
             let context = span.context();
             let mut span_context = SpanContext::default();

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -21,6 +21,7 @@ pub mod network {
     use opentelemetry::propagation::{Extractor, Injector};
 
     use restate_types::GenerationalNodeId;
+    use restate_types::net::metadata::MetadataKind;
 
     use restate_types::net::{
         CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION, ProtocolVersion,
@@ -74,23 +75,16 @@ pub mod network {
             self.fields.keys().map(String::as_str).collect()
         }
     }
+
     impl Header {
-        #[cfg(feature = "test-util")]
-        pub fn new(
-            nodes_config_version: restate_types::Version,
-            logs_version: Option<restate_types::Version>,
-            schema_version: Option<restate_types::Version>,
-            partition_table_version: Option<restate_types::Version>,
-            in_response_to: Option<u64>,
-        ) -> Self {
-            Self {
-                my_nodes_config_version: Some(nodes_config_version.into()),
-                my_logs_version: logs_version.map(Into::into),
-                my_schema_version: schema_version.map(Into::into),
-                my_partition_table_version: partition_table_version.map(Into::into),
-                msg_id: 0,
-                in_response_to,
-                span_context: None,
+        /// Returns the version of the metadata for the given kind.
+        #[must_use]
+        pub fn metadata_version(&self, kind: MetadataKind) -> restate_types::Version {
+            match kind {
+                MetadataKind::NodesConfiguration => self.my_nodes_config_version.into(),
+                MetadataKind::Schema => self.my_schema_version.into(),
+                MetadataKind::PartitionTable => self.my_partition_table_version.into(),
+                MetadataKind::Logs => self.my_logs_version.into(),
             }
         }
     }

--- a/crates/node/src/roles/base.rs
+++ b/crates/node/src/roles/base.rs
@@ -63,8 +63,6 @@ impl Handler for GossipHandler {
     type Service = GossipService;
     async fn on_start(&mut self) {
         debug!("Gossip handler started");
-        let node_status = TaskCenter::with_current(|tc| tc.health().node_status());
-        node_status.update(NodeStatus::Alive);
     }
 
     async fn on_drain(&mut self) -> Drain {


### PR DESCRIPTION

This also removes the need for TonicServiceFilter for core networking. With the new service design, individual services will respond with SvcNotReady if they received requests before they're started. Moreover, this introduces a check when accepting connections to ensure we return ServiceUnavailable if we received connections before acquiring our node id. This is a transitional step until we can allow core networking to accept connections before the node id is acquired.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3199).
* #3200
* __->__ #3199
* #3196