### PR TITLE
introduce BilrostAs derive macro

### DIFF
--- a/crates/encoding/derive/src/bilrost.rs
+++ b/crates/encoding/derive/src/bilrost.rs
@@ -10,7 +10,10 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::{DeriveInput, parse_macro_input, spanned::Spanned};
 use syn::{Fields, ItemStruct};
+
+const BILROST_AS_ATTR_NAME: &str = "bilrost_as";
 
 pub fn new_type(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as ItemStruct);
@@ -99,4 +102,96 @@ pub fn new_type(item: TokenStream) -> TokenStream {
     };
 
     output.into()
+}
+
+pub fn bilrost_as(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let adaptor = match extract_bilorst_as_attr(&input) {
+        Ok(adaptor) => adaptor,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    let name = &input.ident;
+
+    let output = quote! {
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General> for #name {
+            fn encode_value<B: ::bytes::BufMut + ?Sized>(value: &Self, buf: &mut B) {
+                let adaptor = <#adaptor as ::restate_encoding::BilrostAsAdaptor<_>>::create(value);
+                <#adaptor as ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General>>::encode_value(&adaptor, buf)
+            }
+
+            fn value_encoded_len(value: &Self) -> usize {
+                let adaptor = <#adaptor as ::restate_encoding::BilrostAsAdaptor<_>>::create(value);
+                <#adaptor as ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General>>::value_encoded_len(&adaptor)
+            }
+
+            fn prepend_value<B: bilrost::buf::ReverseBuf + ?Sized>(value: &Self, buf: &mut B) {
+                let adaptor = <#adaptor as ::restate_encoding::BilrostAsAdaptor<_>>::create(value);
+                <#adaptor as ::bilrost::encoding::ValueEncoder<::bilrost::encoding::General>>::prepend_value(&adaptor, buf);
+            }
+        }
+
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::ValueDecoder<::bilrost::encoding::General> for #name {
+            fn decode_value<B: ::bytes::Buf + ?Sized>(
+                value: &mut Self,
+                buf: ::bilrost::encoding::Capped<B>,
+                ctx: ::bilrost::encoding::DecodeContext,
+            ) -> ::std::result::Result<(), ::bilrost::DecodeError> {
+                let mut adaptor = <#adaptor as ::bilrost::encoding::ForOverwrite>::for_overwrite();
+                <#adaptor as ::bilrost::encoding::ValueDecoder<::bilrost::encoding::General>>::decode_value(&mut adaptor, buf, ctx)?;
+                *value = <#adaptor as ::restate_encoding::BilrostAsAdaptor<_>>::into_inner(adaptor)?;
+                Ok(())
+            }
+        }
+
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::Wiretyped<::bilrost::encoding::General> for #name {
+            const WIRE_TYPE: ::bilrost::encoding::WireType = <#adaptor as ::bilrost::encoding::Wiretyped<::bilrost::encoding::General>>::WIRE_TYPE;
+        }
+
+        #[allow(clippy::all)]
+        impl ::bilrost::encoding::EmptyState for #name where #name: Default {
+            fn clear(&mut self) {
+                *self = Self::empty();
+            }
+            fn empty() -> Self
+            where
+                Self: Sized,
+            {
+                #name::default()
+            }
+
+            fn is_empty(&self) -> bool {
+                let adaptor = <#adaptor as ::restate_encoding::BilrostAsAdaptor<_>>::create(self);
+                <#adaptor as ::bilrost::encoding::EmptyState>::is_empty(&adaptor)
+            }
+        }
+
+        impl ::bilrost::encoding::ForOverwrite for #name where #name: Default {
+            fn for_overwrite() -> Self
+            where
+                Self: Sized,
+            {
+                #name::default()
+            }
+        }
+    };
+
+    output.into()
+}
+
+fn extract_bilorst_as_attr(input: &DeriveInput) -> Result<syn::Type, syn::Error> {
+    for attr in &input.attrs {
+        if attr.meta.path().is_ident(BILROST_AS_ATTR_NAME) {
+            return attr.parse_args();
+        }
+    }
+
+    Err(syn::Error::new(
+        input.span(),
+        "Missing bilrost_as attribute",
+    ))
 }

--- a/crates/encoding/derive/src/lib.rs
+++ b/crates/encoding/derive/src/lib.rs
@@ -19,6 +19,11 @@ pub fn bilrost_new_type(item: TokenStream) -> TokenStream {
     bilrost::new_type(item)
 }
 
+#[proc_macro_derive(BilrostAs, attributes(bilrost_as))]
+pub fn bilrost_as(input: TokenStream) -> TokenStream {
+    bilrost::bilrost_as(input)
+}
+
 #[proc_macro_derive(NetSerde)]
 pub fn network_message(item: TokenStream) -> TokenStream {
     net::net_serde(item)

--- a/crates/encoding/src/bilrost_as.rs
+++ b/crates/encoding/src/bilrost_as.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{fmt::Display, str::FromStr};
+
+use bilrost::{
+    DecodeError, DecodeErrorKind,
+    encoding::{EmptyState, ForOverwrite, General, ValueDecoder, ValueEncoder, Wiretyped},
+};
+
+/// Adaptor trait used by the `BilrostAs` derive macro. The macro will
+/// create an instance of the adaptor to be able to convert from the original
+/// type to the `As` type.
+///
+/// Any [`bilrost::Message`] that implements `From<T> for As`
+/// and `From<As> for T` will automatically implement the Adaptor trait.
+/// Hence is possible to do something like
+///
+/// ```ignore
+/// #[derive(Default, Clone, BilrostAs)]
+/// #[bilrost_as(Wire)]
+/// struct Inner{
+///
+/// }
+///
+/// #[derive(bilrost::Message)]
+/// struct Wire{
+/// }
+///
+/// // impl From<Inner> for Wire{ .. }
+/// // impl From<Wire> for Inner{ .. }
+/// ```
+pub trait BilrostAsAdaptor<V> {
+    fn create(value: &V) -> Self;
+    fn into_inner(self) -> Result<V, DecodeError>;
+}
+
+impl<D, V> BilrostAsAdaptor<V> for D
+where
+    D: bilrost::Message,
+    V: Clone,
+    D: From<V>,
+    V: From<D>,
+{
+    fn create(value: &V) -> Self {
+        D::from(value.clone())
+    }
+
+    fn into_inner(self) -> Result<V, DecodeError> {
+        Ok(V::from(self))
+    }
+}
+
+/// An adaptor that serializes the type as String using its
+/// `Display` and `FromStr` implementation
+pub struct BilrostDisplayFromStr {
+    inner: String,
+}
+
+impl<V> BilrostAsAdaptor<V> for BilrostDisplayFromStr
+where
+    V: Display,
+    V: FromStr,
+{
+    fn create(value: &V) -> Self {
+        Self {
+            inner: value.to_string(),
+        }
+    }
+
+    fn into_inner(self) -> Result<V, DecodeError> {
+        self.inner
+            .parse()
+            .map_err(|_| DecodeError::new(DecodeErrorKind::InvalidValue))
+    }
+}
+
+impl Wiretyped<General> for BilrostDisplayFromStr {
+    const WIRE_TYPE: bilrost::encoding::WireType = <String as Wiretyped<General>>::WIRE_TYPE;
+}
+
+impl ValueEncoder<General> for BilrostDisplayFromStr {
+    fn encode_value<B: bytes::BufMut + ?Sized>(value: &Self, buf: &mut B) {
+        <String as ValueEncoder<General>>::encode_value(&value.inner, buf)
+    }
+
+    fn prepend_value<B: bilrost::buf::ReverseBuf + ?Sized>(value: &Self, buf: &mut B) {
+        <String as ValueEncoder<General>>::prepend_value(&value.inner, buf)
+    }
+
+    fn value_encoded_len(value: &Self) -> usize {
+        <String as ValueEncoder<General>>::value_encoded_len(&value.inner)
+    }
+}
+
+impl ValueDecoder<General> for BilrostDisplayFromStr {
+    fn decode_value<B: bytes::Buf + ?Sized>(
+        value: &mut Self,
+        buf: bilrost::encoding::Capped<B>,
+        ctx: bilrost::encoding::DecodeContext,
+    ) -> Result<(), bilrost::DecodeError> {
+        <String as ValueDecoder<General>>::decode_value(&mut value.inner, buf, ctx)
+    }
+}
+
+impl ForOverwrite for BilrostDisplayFromStr {
+    fn for_overwrite() -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            inner: String::default(),
+        }
+    }
+}
+
+impl EmptyState for BilrostDisplayFromStr {
+    fn clear(&mut self) {
+        self.inner = String::default();
+    }
+    fn empty() -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            inner: String::default(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -8,12 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod bilrost_as;
+
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
 
-pub use restate_encoding_derive::BilrostNewType;
-pub use restate_encoding_derive::NetSerde;
+pub use bilrost_as::{BilrostAsAdaptor, BilrostDisplayFromStr};
+pub use restate_encoding_derive::{BilrostAs, BilrostNewType, NetSerde};
 
 /// A marker trait for types that can be serialized and sent over the network.
 ///
@@ -90,6 +94,9 @@ where
 }
 
 impl<V> NetSerde for HashSet<V> where V: NetSerde {}
+impl<Idx> NetSerde for RangeInclusive<Idx> where Idx: NetSerde {}
+impl<T> NetSerde for Arc<T> where T: NetSerde {}
+impl<T> NetSerde for Arc<[T]> where T: NetSerde {}
 
 /// A Bilrost compatible U128 type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, BilrostNewType)]

--- a/crates/encoding/tests/net_serde.rs
+++ b/crates/encoding/tests/net_serde.rs
@@ -1,6 +1,10 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap, fmt::Display, num::ParseIntError, ops::RangeInclusive, str::FromStr,
+};
 
-use restate_encoding::NetSerde;
+use bilrost::{Message, OwnedMessage};
+use bytes::BytesMut;
+use restate_encoding::{BilrostAs, BilrostDisplayFromStr, NetSerde};
 use static_assertions::assert_impl_all;
 
 #[allow(dead_code)]
@@ -17,3 +21,99 @@ struct SomeMessage {
 struct Inner(HashMap<u64, String>);
 
 assert_impl_all!(SomeMessage: NetSerde);
+
+#[derive(Default, BilrostAs)]
+#[bilrost_as(BilrostDisplayFromStr)]
+struct Stringer {
+    inner: u64,
+}
+
+impl Display for Stringer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl FromStr for Stringer {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner: u64 = s.parse()?;
+        Ok(Self { inner })
+    }
+}
+
+#[derive(Debug, Default, Clone, BilrostAs)]
+#[bilrost_as(AMessage)]
+struct NotAMessage {
+    range: Option<RangeInclusive<u64>>,
+}
+
+#[derive(bilrost::Message)]
+struct AMessage {
+    inner: Option<(u64, u64)>,
+}
+
+impl From<NotAMessage> for AMessage {
+    fn from(value: NotAMessage) -> Self {
+        Self {
+            inner: value.range.map(|r| (*r.start(), *r.end())),
+        }
+    }
+}
+
+impl From<AMessage> for NotAMessage {
+    fn from(value: AMessage) -> Self {
+        Self {
+            range: value.inner.map(|v| v.0..=v.1),
+        }
+    }
+}
+
+#[test]
+fn test_as_string() {
+    #[derive(bilrost::Message)]
+    struct Container {
+        #[bilrost(1)]
+        stringer: Stringer,
+    }
+
+    #[derive(bilrost::Message)]
+    struct ContainerButWithString {
+        #[bilrost(1)]
+        stringer: String,
+    }
+
+    let src = Container {
+        stringer: Stringer { inner: 42 },
+    };
+
+    let mut buf = BytesMut::new();
+    src.encode(&mut buf).expect("encodes");
+
+    let dst = ContainerButWithString::decode(buf.freeze()).expect("decodes");
+
+    assert_eq!(dst.stringer, "42");
+}
+
+#[test]
+fn test_as_from_into() {
+    #[derive(bilrost::Message)]
+    struct Container {
+        #[bilrost(1)]
+        inner: NotAMessage,
+    }
+
+    let src = Container {
+        inner: NotAMessage {
+            range: Some(0..=100),
+        },
+    };
+
+    let mut buf = BytesMut::new();
+    src.encode(&mut buf).expect("encodes");
+
+    let dst = Container::decode(buf.freeze()).expect("decodes");
+
+    assert!(matches!(dst.inner.range, Some(range) if *range.start() == 0 && *range.end() == 100));
+}


### PR DESCRIPTION
introduce BilrostAs derive macro

Summary:
Although it now only supports a FromInto adaptor this can be
later extended to support more conversion mechanics (for example from/to string)
