### PR TITLE
[Core] Fix occasional shutdown lock-up due to incomplete connections being managed tasks

### DIFF
--- a/crates/core/src/network/net_util.rs
+++ b/crates/core/src/network/net_util.rs
@@ -261,7 +261,7 @@ where
     F::Output: Send + 'static,
 {
     fn execute(&self, fut: F) {
-        let _ = TaskCenter::spawn_child(TaskKind::H2Stream, "h2stream", async move {
+        let _ = TaskCenter::spawn_child(TaskKind::H2ServerStream, "h2stream", async move {
             // ignore the future output
             let _ = fut.await;
             Ok(())

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -79,8 +79,12 @@ pub enum TaskKind {
     RpcServer,
     #[strum(props(runtime = "default"))]
     SocketHandler,
+    /// An http2 stream handler created by the server-side of the connection.
     #[strum(props(OnError = "log", runtime = "default"))]
-    H2Stream,
+    H2ServerStream,
+    /// An http2 stream handler created by the client-side of the connection.
+    #[strum(props(OnError = "log", runtime = "default"))]
+    H2ClientStream,
     /// A type for ingress until we start enforcing timeouts for inflight requests. This enables us
     /// to shut down cleanly without waiting indefinitely.
     #[strum(props(OnCancel = "abort", runtime = "ingress"))]


### PR DESCRIPTION

This fixes an occasional shutdown lock-up that can happen due to task-center waiting indefinitely on a half-open connection or on a connection attempt.
