### PR TITLE
Move `PartitionProcessorRpcClient` in `restate_types`, and rename it `InvocationClient`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6998,12 +6998,10 @@ name = "restate-ingress-http"
 version = "1.3.3-dev"
 dependencies = [
  "anyhow",
- "assert2",
  "bytes",
  "bytestring",
  "chrono",
  "codederror",
- "derive_builder",
  "futures",
  "googletest",
  "http 1.2.0",

--- a/crates/core/src/worker_api/mod.rs
+++ b/crates/core/src/worker_api/mod.rs
@@ -9,5 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod partition_processor_manager;
+mod partition_processor_rpc_client;
 
 pub use partition_processor_manager::*;
+pub use partition_processor_rpc_client::*;

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -21,12 +21,10 @@ restate-tracing-instrumentation = { workspace = true }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }
-assert2 = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 chrono = { workspace = true }
 codederror = { workspace = true }
-derive_builder = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -8,21 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
-use http::{Method, Request, Response};
-use http_body_util::Full;
-use tracing::warn;
-
 use super::Handler;
 use super::HandlerError;
 use super::path_parsing::{InvocationRequestType, InvocationTargetType, TargetType};
+
 use crate::RequestDispatcher;
-use crate::partition_processor_rpc_client::{
-    AttachInvocationResponse, GetInvocationOutputResponse,
-};
+use bytes::Bytes;
+use http::{Method, Request, Response};
+use http_body_util::Full;
 use restate_types::identifiers::IdempotencyId;
 use restate_types::invocation::InvocationQuery;
+use restate_types::invocation::client::{AttachInvocationResponse, GetInvocationOutputResponse};
 use restate_types::schema::invocation_target::InvocationTargetResolver;
+use tracing::warn;
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
 where

--- a/crates/ingress-http/src/handler/tests.rs
+++ b/crates/ingress-http/src/handler/tests.rs
@@ -24,14 +24,15 @@ use tracing_test::traced_test;
 use restate_core::TestCoreEnv;
 use restate_test_util::{assert, assert_eq};
 use restate_types::identifiers::{IdempotencyId, InvocationId, ServiceId, WithInvocationId};
+use restate_types::invocation::client::{
+    AttachInvocationResponse, GetInvocationOutputResponse, InvocationOutput,
+    InvocationOutputResponse, SubmittedInvocationNotification,
+};
 use restate_types::invocation::{
     InvocationQuery, InvocationTarget, InvocationTargetType, VirtualObjectHandlerType,
     WorkflowHandlerType,
 };
 use restate_types::live::Live;
-use restate_types::net::partition_processor::{
-    IngressResponseResult, InvocationOutput, SubmittedInvocationNotification,
-};
 use restate_types::schema::invocation_target::{
     InputContentType, InputRules, InputValidationRule, InvocationTargetMetadata,
     OutputContentTypeRule, OutputRules,
@@ -44,9 +45,6 @@ use super::mocks::*;
 use super::service_handler::*;
 use crate::MockRequestDispatcher;
 use crate::handler::responses::X_RESTATE_ID;
-use crate::partition_processor_rpc_client::{
-    AttachInvocationResponse, GetInvocationOutputResponse,
-};
 
 #[restate_core::test]
 #[traced_test]
@@ -84,7 +82,7 @@ async fn call_service() {
                 request_id: Default::default(),
                 invocation_id: Some(invocation_request.invocation_id()),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     InvocationTarget::service("greeter.Greeter", "greet"),
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -130,7 +128,7 @@ async fn call_service_with_get() {
                 request_id: Default::default(),
                 invocation_id: Some(InvocationId::mock_random()),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     invocation_request.header.target,
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -200,7 +198,7 @@ async fn call_virtual_object() {
                 request_id: Default::default(),
                 invocation_id: Some(InvocationId::mock_random()),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     invocation_request.header.target,
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -405,7 +403,7 @@ async fn idempotency_key_parsing() {
                 request_id: Default::default(),
                 invocation_id: Some(InvocationId::mock_random()),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     invocation_request.header.target,
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -577,7 +575,7 @@ async fn attach_with_invocation_id() {
                 request_id: Default::default(),
                 invocation_id: Some(invocation_id),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     InvocationTarget::service("greeter.Greeter", "greet"),
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -633,7 +631,7 @@ async fn attach_with_idempotency_id_to_unkeyed_service() {
                 request_id: Default::default(),
                 invocation_id: Some(invocation_id),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     InvocationTarget::service("greeter.Greeter", "greet"),
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -691,7 +689,7 @@ async fn attach_with_idempotency_id_to_keyed_service() {
                 request_id: Default::default(),
                 invocation_id: Some(invocation_id),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     InvocationTarget::virtual_object(
                         "greeter.Greeter",
                         "mygreet",
@@ -750,7 +748,7 @@ async fn get_output_with_invocation_id() {
                 request_id: Default::default(),
                 invocation_id: Some(invocation_id),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     InvocationTarget::service("greeter.Greeter", "greet"),
                     serde_json::to_vec(&GreetingResponse {
                         greeting: "Igal".to_string(),
@@ -807,7 +805,7 @@ async fn get_output_with_workflow_key() {
                 request_id: Default::default(),
                 invocation_id: None,
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     InvocationTarget::workflow(
                         service_id.service_name,
                         service_id.key,
@@ -1098,7 +1096,7 @@ fn expect_invocation_and_reply_with_empty() -> MockRequestDispatcher {
                 request_id: Default::default(),
                 completion_expiry_time: None,
                 invocation_id: Some(invocation_request.invocation_id()),
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     invocation_request.header.target,
                     Bytes::new(),
                 ),
@@ -1118,7 +1116,7 @@ fn expect_invocation_and_reply_with_non_empty() -> MockRequestDispatcher {
                 request_id: Default::default(),
                 invocation_id: Some(invocation_request.invocation_id()),
                 completion_expiry_time: None,
-                response: IngressResponseResult::Success(
+                response: InvocationOutputResponse::Success(
                     invocation_request.header.target,
                     Bytes::from_static(b"123"),
                 ),

--- a/crates/ingress-http/src/handler/workflow.rs
+++ b/crates/ingress-http/src/handler/workflow.rs
@@ -8,22 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
-use http::{Method, Request, Response};
-use http_body_util::Full;
-use tracing::{info, warn};
-
-use restate_types::identifiers::ServiceId;
-use restate_types::invocation::InvocationQuery;
-use restate_types::schema::invocation_target::InvocationTargetResolver;
-
 use super::Handler;
 use super::HandlerError;
 use super::path_parsing::WorkflowRequestType;
+
 use crate::RequestDispatcher;
-use crate::partition_processor_rpc_client::{
-    AttachInvocationResponse, GetInvocationOutputResponse,
-};
+use bytes::Bytes;
+use http::{Method, Request, Response};
+use http_body_util::Full;
+use restate_types::identifiers::ServiceId;
+use restate_types::invocation::InvocationQuery;
+use restate_types::invocation::client::{AttachInvocationResponse, GetInvocationOutputResponse};
+use restate_types::schema::invocation_target::InvocationTargetResolver;
+use tracing::{info, warn};
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
 where

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -11,21 +11,23 @@
 mod handler;
 mod layers;
 mod metric_definitions;
-pub mod partition_processor_rpc_client;
-pub mod rpc_request_dispatcher;
+mod rpc_request_dispatcher;
 mod server;
 
+pub use rpc_request_dispatcher::InvocationClientRequestDispatcher;
 pub use server::{HyperServerIngress, IngressServerError, StartSignal};
 
 use bytes::Bytes;
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 
-use partition_processor_rpc_client::{AttachInvocationResponse, GetInvocationOutputResponse};
 use restate_types::identifiers::InvocationId;
+use restate_types::invocation::client::{
+    AttachInvocationResponse, GetInvocationOutputResponse, InvocationOutput,
+    SubmittedInvocationNotification,
+};
 use restate_types::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use restate_types::journal_v2::Signal;
-use restate_types::net::partition_processor::{InvocationOutput, SubmittedInvocationNotification};
 
 /// Client connection information for a given RPC request
 #[derive(Clone, Copy, Debug)]
@@ -101,7 +103,6 @@ mod mocks {
     use restate_types::invocation::{
         InvocationQuery, InvocationTargetType, ServiceType, VirtualObjectHandlerType,
     };
-    use restate_types::net::partition_processor::InvocationOutput;
     use restate_types::schema::invocation_target::test_util::MockInvocationTargetResolver;
     use restate_types::schema::invocation_target::{
         DEFAULT_IDEMPOTENCY_RETENTION, InvocationTargetMetadata, InvocationTargetResolver,

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -253,7 +253,7 @@ mod tests {
     use restate_types::health::Health;
     use restate_types::identifiers::WithInvocationId;
     use restate_types::invocation::InvocationTarget;
-    use restate_types::net::partition_processor::IngressResponseResult;
+    use restate_types::invocation::client::InvocationOutputResponse;
     use serde::{Deserialize, Serialize};
     use std::future::ready;
     use std::net::SocketAddr;
@@ -293,7 +293,7 @@ mod tests {
                     request_id: Default::default(),
                     invocation_id: Some(invocation_request.invocation_id()),
                     completion_expiry_time: None,
-                    response: IngressResponseResult::Success(
+                    response: InvocationOutputResponse::Success(
                         InvocationTarget::service("greeter.Greeter", "greet"),
                         serde_json::to_vec(&GreetingResponse {
                             greeting: "Igal".to_string(),

--- a/crates/types/src/invocation/client.rs
+++ b/crates/types/src/invocation/client.rs
@@ -1,0 +1,151 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::errors::InvocationError;
+use crate::identifiers::{InvocationId, PartitionProcessorRpcRequestId};
+use crate::invocation::{InvocationQuery, InvocationRequest, InvocationResponse, InvocationTarget};
+use crate::journal_v2::Signal;
+use crate::time::MillisSinceEpoch;
+use bytes::Bytes;
+use std::error::Error;
+use std::fmt;
+
+pub struct InvocationClientError {
+    is_safe_to_retry: bool,
+    inner: anyhow::Error,
+}
+
+impl InvocationClientError {
+    pub fn new(inner: impl Into<anyhow::Error>, is_safe_to_retry: bool) -> Self {
+        Self {
+            is_safe_to_retry,
+            inner: inner.into(),
+        }
+    }
+
+    pub fn is_safe_to_retry(&self) -> bool {
+        self.is_safe_to_retry
+    }
+
+    pub fn into_inner(self) -> anyhow::Error {
+        self.inner
+    }
+}
+
+impl fmt::Debug for InvocationClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl fmt::Display for InvocationClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl Error for InvocationClientError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.inner.source()
+    }
+
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    #[allow(deprecated)]
+    fn cause(&self) -> Option<&dyn Error> {
+        self.inner.cause()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SubmittedInvocationNotification {
+    pub request_id: PartitionProcessorRpcRequestId,
+    pub execution_time: Option<MillisSinceEpoch>,
+    /// If true, this request_id created a "fresh invocation",
+    /// otherwise the invocation was previously submitted.
+    pub is_new_invocation: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InvocationOutput {
+    pub request_id: PartitionProcessorRpcRequestId,
+    pub invocation_id: Option<InvocationId>,
+    pub completion_expiry_time: Option<MillisSinceEpoch>,
+    pub response: InvocationOutputResponse,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum InvocationOutputResponse {
+    Success(InvocationTarget, Bytes),
+    Failure(InvocationError),
+}
+
+#[derive(Debug, Clone)]
+pub enum AttachInvocationResponse {
+    NotFound,
+    /// Returned when the invocation hasn't an idempotency key, nor it's a workflow run.
+    NotSupported,
+    Ready(InvocationOutput),
+}
+
+#[derive(Debug, Clone)]
+pub enum GetInvocationOutputResponse {
+    NotFound,
+    /// The invocation was found, but it's still processing and a result is not ready yet.
+    NotReady,
+    /// Returned when the invocation hasn't an idempotency key, nor it's a workflow run.
+    NotSupported,
+    Ready(InvocationOutput),
+}
+
+/// This trait provides the functionalities to interact with Restate invocations.
+pub trait InvocationClient {
+    /// Append the invocation to the log, waiting for the submit notification emitted by the PartitionProcessor.
+    fn append_invocation_and_wait_submit_notification(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_request: InvocationRequest,
+    ) -> impl Future<Output = Result<SubmittedInvocationNotification, InvocationClientError>> + Send;
+
+    /// Append the invocation and wait for its output.
+    fn append_invocation_and_wait_output(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_request: InvocationRequest,
+    ) -> impl Future<Output = Result<InvocationOutput, InvocationClientError>> + Send;
+
+    fn attach_invocation(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_query: InvocationQuery,
+    ) -> impl Future<Output = Result<AttachInvocationResponse, InvocationClientError>> + Send;
+
+    fn get_invocation_output(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_query: InvocationQuery,
+    ) -> impl Future<Output = Result<GetInvocationOutputResponse, InvocationClientError>> + Send;
+
+    fn append_invocation_response(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_response: InvocationResponse,
+    ) -> impl Future<Output = Result<(), InvocationClientError>> + Send;
+
+    fn append_signal(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_id: InvocationId,
+        signal: Signal,
+    ) -> impl Future<Output = Result<(), InvocationClientError>> + Send;
+}

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -10,6 +10,8 @@
 
 //! This module contains all the core types representing a service invocation.
 
+pub mod client;
+
 use crate::GenerationalNodeId;
 use crate::errors::InvocationError;
 use crate::identifiers::{

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -8,16 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::errors::InvocationError;
 use crate::identifiers::{
     InvocationId, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
-use crate::invocation::{InvocationQuery, InvocationRequest, InvocationResponse, InvocationTarget};
+use crate::invocation::client::{InvocationOutput, SubmittedInvocationNotification};
+use crate::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use crate::journal_v2::Signal;
 use crate::net::ServiceTag;
 use crate::net::{default_wire_codec, define_rpc, define_service};
-use crate::time::MillisSinceEpoch;
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 pub struct PartitionLeaderService;
@@ -114,27 +112,4 @@ pub enum PartitionProcessorRpcResponse {
     NotSupported,
     Submitted(SubmittedInvocationNotification),
     Output(InvocationOutput),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct SubmittedInvocationNotification {
-    pub request_id: PartitionProcessorRpcRequestId,
-    pub execution_time: Option<MillisSinceEpoch>,
-    /// If true, this request_id created a "fresh invocation",
-    /// otherwise the invocation was previously submitted.
-    pub is_new_invocation: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct InvocationOutput {
-    pub request_id: PartitionProcessorRpcRequestId,
-    pub invocation_id: Option<InvocationId>,
-    pub completion_expiry_time: Option<MillisSinceEpoch>,
-    pub response: IngressResponseResult,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum IngressResponseResult {
-    Success(InvocationTarget, Bytes),
-    Failure(InvocationError),
 }

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -27,9 +27,9 @@ use restate_types::identifiers::{
     InvocationId, LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
     WithPartitionKey,
 };
+use restate_types::invocation::client::{InvocationOutput, SubmittedInvocationNotification};
 use restate_types::net::partition_processor::{
-    InvocationOutput, PartitionProcessorRpcError, PartitionProcessorRpcResponse,
-    SubmittedInvocationNotification,
+    PartitionProcessorRpcError, PartitionProcessorRpcResponse,
 };
 use restate_types::time::MillisSinceEpoch;
 use restate_wal_protocol::Command;

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -47,6 +47,7 @@ use restate_types::identifiers::{
     LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
 use restate_types::invocation;
+use restate_types::invocation::client::{InvocationOutput, InvocationOutputResponse};
 use restate_types::invocation::{
     AttachInvocationRequest, InvocationQuery, InvocationTarget, InvocationTargetType,
     NotifySignalRequest, ResponseResult, ServiceInvocation, ServiceInvocationResponseSink,
@@ -56,9 +57,9 @@ use restate_types::logs::MatchKeyQuery;
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
 use restate_types::net::RpcRequest;
 use restate_types::net::partition_processor::{
-    AppendInvocationReplyOn, GetInvocationOutputResponseMode, IngressResponseResult,
-    InvocationOutput, PartitionLeaderService, PartitionProcessorRpcError,
-    PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner, PartitionProcessorRpcResponse,
+    AppendInvocationReplyOn, GetInvocationOutputResponseMode, PartitionLeaderService,
+    PartitionProcessorRpcError, PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner,
+    PartitionProcessorRpcResponse,
 };
 use restate_types::storage::StorageDecodeError;
 use restate_types::time::MillisSinceEpoch;
@@ -749,9 +750,9 @@ where
                     request_id,
                     response: match completed.response_result.clone() {
                         ResponseResult::Success(res) => {
-                            IngressResponseResult::Success(completed.invocation_target, res)
+                            InvocationOutputResponse::Success(completed.invocation_target, res)
                         }
-                        ResponseResult::Failure(err) => IngressResponseResult::Failure(err),
+                        ResponseResult::Failure(err) => InvocationOutputResponse::Failure(err),
                     },
                     invocation_id: Some(invocation_id),
                     completion_expiry_time,

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -12,12 +12,12 @@ use restate_invoker_api::InvokeInputJournal;
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::timer_table::TimerKey;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId};
+use restate_types::invocation::client::InvocationOutputResponse;
 use restate_types::invocation::{InvocationEpoch, InvocationTarget};
 use restate_types::journal::Completion;
 use restate_types::journal_v2::CommandIndex;
 use restate_types::journal_v2::raw::RawNotification;
 use restate_types::message::MessageIndex;
-use restate_types::net::partition_processor::IngressResponseResult;
 use restate_types::time::MillisSinceEpoch;
 use restate_wal_protocol::timer::TimerKeyValue;
 use std::time::Duration;
@@ -64,7 +64,7 @@ pub enum Action {
         request_id: PartitionProcessorRpcRequestId,
         invocation_id: Option<InvocationId>,
         completion_expiry_time: Option<MillisSinceEpoch>,
-        response: IngressResponseResult,
+        response: InvocationOutputResponse,
     },
     IngressSubmitNotification {
         request_id: PartitionProcessorRpcRequestId,

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -107,12 +107,12 @@ mod tests {
     use restate_types::deployment::PinnedDeployment;
     use restate_types::errors::CANCELED_INVOCATION_ERROR;
     use restate_types::identifiers::{DeploymentId, InvocationId, PartitionProcessorRpcRequestId};
+    use restate_types::invocation::client::InvocationOutputResponse;
     use restate_types::invocation::{
         InvocationTarget, InvocationTermination, JournalCompletionTarget, NotifySignalRequest,
         ResponseResult, ServiceInvocation, ServiceInvocationResponseSink,
     };
     use restate_types::journal_v2::CANCEL_SIGNAL;
-    use restate_types::net::partition_processor::IngressResponseResult;
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::time::MillisSinceEpoch;
     use restate_wal_protocol::Command;
@@ -240,7 +240,7 @@ mod tests {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(rpc_id),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Failure(CANCELED_INVOCATION_ERROR))
+                response: eq(InvocationOutputResponse::Failure(CANCELED_INVOCATION_ERROR))
             }))
         );
 

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -59,6 +59,7 @@ use restate_types::identifiers::{
     PartitionProcessorRpcRequestId, ServiceId,
 };
 use restate_types::identifiers::{IdempotencyId, WithPartitionKey};
+use restate_types::invocation::client::InvocationOutputResponse;
 use restate_types::invocation::{
     AttachInvocationRequest, InvocationEpoch, InvocationQuery, InvocationResponse,
     InvocationTarget, InvocationTargetType, InvocationTermination, JournalCompletionTarget,
@@ -83,7 +84,6 @@ use restate_types::journal_v2::{
     CommandType, CompletionId, EntryMetadata, NotificationId, Signal, SignalResult,
 };
 use restate_types::message::MessageIndex;
-use restate_types::net::partition_processor::IngressResponseResult;
 use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_types::state_mut::StateMutationVersion;
@@ -2040,7 +2040,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     invocation_id,
                     completion_expiry_time,
                     match result.clone() {
-                        ResponseResult::Success(res) => IngressResponseResult::Success(
+                        ResponseResult::Success(res) => InvocationOutputResponse::Success(
                             invocation_target
                                 .expect(
                                     "For success responses, there must be an invocation target!",
@@ -2048,7 +2048,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                                 .clone(),
                             res,
                         ),
-                        ResponseResult::Failure(err) => IngressResponseResult::Failure(err),
+                        ResponseResult::Failure(err) => InvocationOutputResponse::Failure(err),
                     },
                 ),
             }
@@ -3297,17 +3297,17 @@ impl<S> StateMachineApplyContext<'_, S> {
         request_id: PartitionProcessorRpcRequestId,
         invocation_id: Option<InvocationId>,
         completion_expiry_time: Option<MillisSinceEpoch>,
-        response: IngressResponseResult,
+        response: InvocationOutputResponse,
     ) {
         match &response {
-            IngressResponseResult::Success(_, _) => {
+            InvocationOutputResponse::Success(_, _) => {
                 debug_if_leader!(
                     self.is_leader,
                     "Send response to ingress with request id '{:?}': Success",
                     request_id
                 )
             }
-            IngressResponseResult::Failure(e) => {
+            InvocationOutputResponse::Failure(e) => {
                 debug_if_leader!(
                     self.is_leader,
                     "Send response to ingress with request id '{:?}': Failure({})",

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -93,7 +93,7 @@ async fn start_and_complete_idempotent_invocation() {
         contains(pat!(Action::IngressResponse {
             request_id: eq(request_id),
             invocation_id: some(eq(invocation_id)),
-            response: eq(IngressResponseResult::Success(
+            response: eq(InvocationOutputResponse::Success(
                 invocation_target.clone(),
                 response_bytes.clone()
             ))
@@ -184,7 +184,7 @@ async fn start_and_complete_idempotent_invocation_neo_table() {
         contains(pat!(Action::IngressResponse {
             request_id: eq(request_id),
             invocation_id: some(eq(invocation_id)),
-            response: eq(IngressResponseResult::Success(
+            response: eq(InvocationOutputResponse::Success(
                 invocation_target.clone(),
                 response_bytes.clone()
             ))
@@ -259,7 +259,7 @@ async fn complete_already_completed_invocation() {
         contains(pat!(Action::IngressResponse {
             request_id: eq(request_id),
             invocation_id: some(eq(invocation_id)),
-            response: eq(IngressResponseResult::Success(
+            response: eq(InvocationOutputResponse::Success(
                 invocation_target.clone(),
                 response_bytes.clone()
             ))
@@ -344,7 +344,7 @@ async fn attach_with_service_invocation_command_while_executing() {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_1),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -352,7 +352,7 @@ async fn attach_with_service_invocation_command_while_executing() {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_1),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -458,7 +458,7 @@ async fn attach_with_send_service_invocation(#[case] use_same_request_id: bool) 
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_1),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -471,7 +471,7 @@ async fn attach_with_send_service_invocation(#[case] use_same_request_id: bool) 
                 contains(pat!(Action::IngressResponse {
                     request_id: eq(request_id_1),
                     invocation_id: some(eq(invocation_id)),
-                    response: eq(IngressResponseResult::Success(
+                    response: eq(InvocationOutputResponse::Success(
                         invocation_target.clone(),
                         response_bytes.clone()
                     ))
@@ -658,7 +658,7 @@ async fn attach_command() {
             contains(pat!(Action::IngressResponse {
                 invocation_id: some(eq(invocation_id)),
                 request_id: eq(request_id_1),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -666,7 +666,7 @@ async fn attach_command() {
             contains(pat!(Action::IngressResponse {
                 invocation_id: some(eq(invocation_id)),
                 request_id: eq(request_id_2),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -146,10 +146,12 @@ async fn terminate_scheduled_invocation(
         contains(pat!(Action::IngressResponse {
             request_id: eq(rpc_id),
             invocation_id: some(eq(invocation_id)),
-            response: eq(IngressResponseResult::Failure(match termination_flavor {
-                TerminationFlavor::Kill => KILLED_INVOCATION_ERROR,
-                TerminationFlavor::Cancel => CANCELED_INVOCATION_ERROR,
-            }))
+            response: eq(InvocationOutputResponse::Failure(
+                match termination_flavor {
+                    TerminationFlavor::Kill => KILLED_INVOCATION_ERROR,
+                    TerminationFlavor::Cancel => CANCELED_INVOCATION_ERROR,
+                }
+            ))
         }))
     );
 

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -53,6 +53,7 @@ use restate_types::identifiers::{
     AwakeableIdentifier, InvocationId, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
     ServiceId,
 };
+use restate_types::invocation::client::InvocationOutputResponse;
 use restate_types::invocation::{
     Header, InvocationResponse, InvocationTarget, InvocationTermination, ResponseResult,
     ServiceInvocation, ServiceInvocationResponseSink, Source, VirtualObjectHandlerType,
@@ -950,21 +951,21 @@ async fn send_ingress_response_to_multiple_targets() -> TestResult {
         all!(
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_1),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
             })),
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_2),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
             })),
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_3),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -79,7 +79,7 @@ async fn start_workflow_method() {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_2),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Failure(
+                response: eq(InvocationOutputResponse::Failure(
                     WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR
                 ))
             }))
@@ -115,7 +115,7 @@ async fn start_workflow_method() {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_1),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -124,7 +124,7 @@ async fn start_workflow_method() {
             not(contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_2),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -162,7 +162,7 @@ async fn start_workflow_method() {
         contains(pat!(Action::IngressResponse {
             request_id: eq(request_id_3),
             invocation_id: some(eq(invocation_id)),
-            response: eq(IngressResponseResult::Failure(
+            response: eq(InvocationOutputResponse::Failure(
                 WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR
             ))
         }))
@@ -252,7 +252,7 @@ async fn attach_by_workflow_key() {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_1),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -260,7 +260,7 @@ async fn attach_by_workflow_key() {
             contains(pat!(Action::IngressResponse {
                 request_id: eq(request_id_2),
                 invocation_id: some(eq(invocation_id)),
-                response: eq(IngressResponseResult::Success(
+                response: eq(InvocationOutputResponse::Success(
                     invocation_target.clone(),
                     response_bytes.clone()
                 ))
@@ -298,7 +298,7 @@ async fn attach_by_workflow_key() {
         contains(pat!(Action::IngressResponse {
             request_id: eq(request_id_3),
             invocation_id: some(eq(invocation_id)),
-            response: eq(IngressResponseResult::Success(
+            response: eq(InvocationOutputResponse::Success(
                 invocation_target.clone(),
                 response_bytes.clone()
             ))


### PR DESCRIPTION
The `InvocationClient` should be completely orthogonal from the transport, and should be easy to mock.

We're gonna use this same client in the Admin API soon for #3186 followups, for propagating errors in the admin api.