### PR TITLE
Bilrost `Metadata` messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ checksum = "815ed941f4e34d221bda5ac688ff1f80f579ca0c1b062d381347be6d53786e02"
 dependencies = [
  "bilrost-derive",
  "bytes",
+ "bytestring",
  "thin-vec",
 ]
 
@@ -7864,6 +7865,7 @@ dependencies = [
  "anyhow",
  "assert2",
  "async-trait",
+ "bilrost",
  "bytes",
  "bytestring",
  "codederror",
@@ -7872,8 +7874,10 @@ dependencies = [
  "enum-map",
  "flexbuffers",
  "googletest",
+ "prost",
  "restate-core",
  "restate-invoker-api",
+ "restate-partition-store",
  "restate-storage-api",
  "restate-test-util",
  "restate-types",
@@ -10389,9 +10393,11 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "axum-core",
+ "bilrost",
  "bitflags 2.8.0",
  "byteorder",
  "bytes",
+ "bytestring",
  "bzip2-sys",
  "cc",
  "chrono",

--- a/crates/admin-rest-model/src/deployments.rs
+++ b/crates/admin-rest-model/src/deployments.rs
@@ -67,6 +67,7 @@ pub enum Deployment {
 impl From<DeploymentMetadata> for Deployment {
     fn from(value: DeploymentMetadata) -> Self {
         match value.ty {
+            DeploymentType::Unknown => unreachable!("unknown deployment type"),
             DeploymentType::Http {
                 address,
                 protocol_type,

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -666,7 +666,7 @@ mod tests {
                         .parse()
                         .unwrap(),
                 ),
-                Role::Worker.into(),
+                Role::Worker,
                 LogServerConfig::default(),
                 MetadataServerConfig::default(),
             );

--- a/crates/admin/src/schema_registry/updater.rs
+++ b/crates/admin/src/schema_registry/updater.rs
@@ -297,8 +297,12 @@ impl SchemaUpdater {
                     existing_deployment
                         .metadata
                         .supported_protocol_versions
-                        .clone(),
-                    deployment_metadata.supported_protocol_versions.clone(),
+                        .clone()
+                        .into(),
+                    deployment_metadata
+                        .supported_protocol_versions
+                        .clone()
+                        .into(),
                 ),
             ));
         };

--- a/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/replication/checker.rs
@@ -267,7 +267,7 @@ impl<Attr: Eq + Hash + Clone + std::fmt::Debug> NodeSetChecker<Attr> {
             .get(&node_id)
             .copied()
             .unwrap_or(StorageState::Disabled);
-        if storage_state.empty() {
+        if storage_state.is_empty() {
             return;
         }
         let old_attribute = self.node_to_attr.insert(node_id, attribute.clone());
@@ -294,7 +294,7 @@ impl<Attr: Eq + Hash + Clone + std::fmt::Debug> NodeSetChecker<Attr> {
             .get(&node_id)
             .copied()
             .unwrap_or(StorageState::Disabled);
-        if storage_state.empty() {
+        if storage_state.is_empty() {
             return;
         }
         let existing = self.node_to_attr.get(&node_id);
@@ -421,7 +421,7 @@ impl<Attr: Eq + Hash + Clone + std::fmt::Debug> NodeSetChecker<Attr> {
         location: &NodeLocation,
     ) {
         // we only consider nodes that might have data, everything else is ignored.
-        if storage_state.empty() {
+        if storage_state.is_empty() {
             return;
         }
         self.node_to_storage_state.insert(node_id, storage_state);
@@ -796,7 +796,7 @@ mod tests {
             GenerationalNodeId::new(id.into(), 1),
             location.parse().unwrap(),
             format!("unix:/tmp/my_socket-{id}").parse().unwrap(),
-            Role::LogServer.into(),
+            Role::LogServer,
             LogServerConfig { storage_state },
             MetadataServerConfig::default(),
         )

--- a/crates/bifrost/src/providers/replicated_loglet/test_util.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/test_util.rs
@@ -23,7 +23,7 @@ pub fn generate_logserver_node(
         GenerationalNodeId::new(id.into(), 1),
         format!("region-{id}").parse().unwrap(),
         format!("unix:/tmp/my_socket-{id}").parse().unwrap(),
-        Role::LogServer.into(),
+        Role::LogServer,
         LogServerConfig { storage_state },
         MetadataServerConfig::default(),
     )

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -153,6 +153,7 @@ impl Metadata {
 
     pub fn version(&self, metadata_kind: MetadataKind) -> Version {
         match metadata_kind {
+            MetadataKind::Unknown => Version::INVALID,
             MetadataKind::NodesConfiguration => self.nodes_config_version(),
             MetadataKind::Schema => self.schema_version(),
             MetadataKind::PartitionTable => self.partition_table_version(),
@@ -277,6 +278,7 @@ impl MetadataInner {
 
     fn version(&self, metadata_kind: MetadataKind) -> Version {
         match metadata_kind {
+            MetadataKind::Unknown => Version::INVALID,
             MetadataKind::NodesConfiguration => self.nodes_config.load().version(),
             MetadataKind::Schema => self.schema.load().version(),
             MetadataKind::PartitionTable => self.partition_table.load().version(),
@@ -290,6 +292,7 @@ impl MetadataInner {
         T: GlobalMetadata + metadata::Extraction<Output = T>,
     {
         let container = match metadata_kind {
+            MetadataKind::Unknown => unreachable!(),
             MetadataKind::NodesConfiguration => self.nodes_config.load_full().into_container(),
             MetadataKind::Schema => self.schema.load_full().into_container(),
             MetadataKind::PartitionTable => self.partition_table.load_full().into_container(),

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -234,6 +234,7 @@ impl MetadataManager {
         callback: Option<oneshot::Sender<Version>>,
     ) {
         match value {
+            MetadataContainer::Unknown => {}
             MetadataContainer::NodesConfiguration(value) => {
                 let _ = updaters
                     .nodes_config
@@ -264,6 +265,9 @@ impl MetadataManager {
         min_version: Option<Version>,
     ) {
         match metadata_kind {
+            MetadataKind::Unknown => {
+                // drop silently
+            }
             MetadataKind::NodesConfiguration => self.send_nodes_config(to, min_version),
             MetadataKind::PartitionTable => self.send_partition_table(to, min_version),
             MetadataKind::Logs => self.send_logs(to, min_version),

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -808,7 +808,7 @@ mod tests {
             node_id,
             NodeLocation::default(),
             AdvertisedAddress::Uds("foobar1".into()),
-            Role::Worker.into(),
+            Role::Worker,
             LogServerConfig::default(),
             MetadataServerConfig::default(),
         );

--- a/crates/core/src/network/io/reactor.rs
+++ b/crates/core/src/network/io/reactor.rs
@@ -789,6 +789,7 @@ impl MetadataVersions {
         let logs_metadata = metadata.updateable_logs_metadata();
 
         let versions = enum_map! {
+            MetadataKind::Unknown => Version::INVALID,
             MetadataKind::NodesConfiguration => Version::INVALID,
             MetadataKind::Schema => Version::INVALID,
             MetadataKind::PartitionTable => Version::INVALID,
@@ -813,6 +814,7 @@ impl MetadataVersions {
 
     fn get_latest_version(&mut self, kind: MetadataKind) -> Version {
         match kind {
+            MetadataKind::Unknown => Version::INVALID,
             MetadataKind::NodesConfiguration => self.nodes_config.live_load().version(),
             MetadataKind::Schema => self.schema.live_load().version(),
             MetadataKind::PartitionTable => self.partition_table.live_load().version(),

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -20,8 +20,8 @@ pub mod network {
 
     use opentelemetry::propagation::{Extractor, Injector};
 
-    use restate_types::GenerationalNodeId;
     use restate_types::net::metadata::MetadataKind;
+    use restate_types::{GenerationalNodeId, Version};
 
     use restate_types::net::{
         CURRENT_PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION, ProtocolVersion,
@@ -81,6 +81,7 @@ pub mod network {
         #[must_use]
         pub fn metadata_version(&self, kind: MetadataKind) -> restate_types::Version {
             match kind {
+                MetadataKind::Unknown => Version::INVALID,
                 MetadataKind::NodesConfiguration => self.my_nodes_config_version.into(),
                 MetadataKind::Schema => self.my_schema_version.into(),
                 MetadataKind::PartitionTable => self.my_partition_table_version.into(),

--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -83,6 +83,7 @@ impl PeerMetadataVersion {
     /// Get the metadata version for a given kind
     pub fn get(&self, kind: MetadataKind) -> Version {
         match kind {
+            MetadataKind::Unknown => Version::INVALID,
             MetadataKind::Logs => self.logs,
             MetadataKind::NodesConfiguration => self.nodes_config,
             MetadataKind::PartitionTable => self.partition_table,

--- a/crates/encoding/derive/src/lib.rs
+++ b/crates/encoding/derive/src/lib.rs
@@ -24,7 +24,7 @@ pub fn bilrost_as(input: TokenStream) -> TokenStream {
     bilrost::bilrost_as(input)
 }
 
-#[proc_macro_derive(NetSerde)]
+#[proc_macro_derive(NetSerde, attributes(net_serde))]
 pub fn network_message(item: TokenStream) -> TokenStream {
     net::net_serde(item)
 }

--- a/crates/encoding/derive/src/net.rs
+++ b/crates/encoding/derive/src/net.rs
@@ -12,19 +12,30 @@ use std::collections::HashSet;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields};
+use syn::{
+    Attribute, Data, DeriveInput, Fields, Ident,
+    parse::{Parse, ParseStream},
+};
 
 pub fn net_serde(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as DeriveInput);
-
+    match net_serde_inner(input) {
+        Ok(stream) => stream,
+        Err(err) => err.into_compile_error().into(),
+    }
+}
+pub fn net_serde_inner(input: DeriveInput) -> Result<TokenStream, syn::Error> {
     let name = input.ident;
 
     let field_types = match input.data {
-        Data::Struct(data_struct) => collect_field_types(data_struct.fields),
+        Data::Struct(data_struct) => collect_field_types(data_struct.fields)?,
         Data::Enum(data_enum) => {
             let mut field_types = HashSet::new();
             for variant in data_enum.variants {
-                field_types.extend(collect_field_types(variant.fields));
+                if skip_type(&variant.attrs)? {
+                    continue;
+                }
+                field_types.extend(collect_field_types(variant.fields)?);
             }
             field_types
         }
@@ -41,15 +52,58 @@ pub fn net_serde(item: TokenStream) -> TokenStream {
         impl ::restate_encoding::NetSerde for #name where #(#where_clauses),* {}
     };
 
-    TokenStream::from(expanded)
+    Ok(TokenStream::from(expanded))
 }
 
-fn collect_field_types(fields: Fields) -> HashSet<syn::Type> {
+fn collect_field_types(fields: Fields) -> Result<HashSet<syn::Type>, syn::Error> {
+    let mut set = HashSet::new();
     match fields {
-        Fields::Named(fields_named) => fields_named.named.into_iter().map(|f| f.ty).collect(),
-        Fields::Unnamed(fields_unnamed) => {
-            fields_unnamed.unnamed.into_iter().map(|f| f.ty).collect()
+        Fields::Named(fields_named) => {
+            for field in fields_named.named {
+                if skip_type(&field.attrs)? {
+                    continue;
+                }
+                set.insert(field.ty);
+            }
         }
-        Fields::Unit => HashSet::default(),
+        Fields::Unnamed(fields_unnamed) => {
+            for field in fields_unnamed.unnamed {
+                if skip_type(&field.attrs)? {
+                    continue;
+                }
+                set.insert(field.ty);
+            }
+        }
+        Fields::Unit => {}
+    };
+
+    Ok(set)
+}
+
+struct NetSerdeAttrArgs {
+    idents: Vec<Ident>,
+}
+
+impl Parse for NetSerdeAttrArgs {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        let mut idents = Vec::new();
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            idents.push(ident);
+            if !input.is_empty() {
+                let _ = input.parse::<syn::Token![,]>()?;
+            }
+        }
+        Ok(NetSerdeAttrArgs { idents })
     }
+}
+
+fn skip_type(attrs: &[Attribute]) -> Result<bool, syn::Error> {
+    let Some(attr) = attrs.iter().find(|attr| attr.path().is_ident("net_serde")) else {
+        return Ok(false);
+    };
+
+    let args: NetSerdeAttrArgs = attr.parse_args()?;
+
+    Ok(args.idents.iter().any(|a| a == "skip"))
 }

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -62,7 +62,8 @@ impl_net_serde!(
     String,
     bytes::Bytes,
     bytestring::ByteString,
-    std::time::Duration
+    std::time::Duration,
+    std::path::PathBuf
 );
 
 macro_rules! impl_net_serde_tuple {
@@ -99,6 +100,7 @@ impl<Idx> NetSerde for RangeInclusive<Idx> where Idx: NetSerde {}
 impl<T> NetSerde for Arc<T> where T: NetSerde {}
 impl<T> NetSerde for Arc<[T]> where T: NetSerde {}
 impl<T> NetSerde for Box<T> where T: NetSerde {}
+impl<T, const N: usize> NetSerde for [T; N] where T: NetSerde {}
 
 #[cfg(test)]
 mod test {

--- a/crates/encoding/tests/net_serde.rs
+++ b/crates/encoding/tests/net_serde.rs
@@ -20,7 +20,11 @@ struct SomeMessage {
     b: String,
     c: (bool, u64),
     d: Inner,
+    #[net_serde(skip)]
+    f: NotSendable,
 }
+
+struct NotSendable;
 
 #[allow(dead_code)]
 #[derive(NetSerde)]

--- a/crates/ingress-kafka/src/dispatcher.rs
+++ b/crates/ingress-kafka/src/dispatcher.rs
@@ -67,6 +67,9 @@ impl KafkaIngressEvent {
         };
 
         let invocation_target = match subscription.sink() {
+            Sink::Unknown => {
+                anyhow::bail!("Unknown subscription sink")
+            }
             Sink::DeprecatedService { name, handler, ty } => match ty {
                 EventReceiverServiceType::VirtualObject => InvocationTarget::virtual_object(
                     &**name,

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -121,7 +121,9 @@ impl Service {
     ) -> anyhow::Result<()> {
         let mut client_config = rdkafka::ClientConfig::new();
 
-        let Source::Kafka { cluster, topic, .. } = subscription.source();
+        let Source::Kafka { cluster, topic, .. } = subscription.source() else {
+            anyhow::bail!("Unknown subscription source");
+        };
 
         // Copy cluster options and subscription metadata into client_config
         let cluster_options = options

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -346,7 +346,11 @@ where
                     .ok_or_else(|| {
                         InvokerError::IncompatibleServiceEndpoint(
                             deployment.id,
-                            deployment.metadata.supported_protocol_versions.clone(),
+                            deployment
+                                .metadata
+                                .supported_protocol_versions
+                                .clone()
+                                .into(),
                         )
                     })
                 );

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -261,6 +261,7 @@ where
         }
 
         let address = match deployment_metadata.ty {
+            DeploymentType::Unknown => unreachable!("unknown deployment type"),
             DeploymentType::Lambda {
                 arn,
                 assume_role_arn,

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -270,6 +270,9 @@ where
         }
 
         let address = match deployment_metadata.ty {
+            DeploymentType::Unknown => {
+                unreachable!("unknown deployment type");
+            }
             DeploymentType::Lambda {
                 arn,
                 assume_role_arn,

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -70,7 +70,7 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
         PlainNodeId::from(0).with_generation(my_generation),
         NodeLocation::default(),
         advertised_address.clone(),
-        Role::MetadataServer.into(),
+        Role::MetadataServer,
         LogServerConfig::default(),
         MetadataServerConfig::default(),
     );

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -263,7 +263,7 @@ impl<'a> NodeInit<'a> {
                         }
 
                         // update node_config
-                        node_config.roles = common_opts.roles;
+                        node_config.roles = common_opts.roles.into();
                         node_config.address = common_opts.advertised_address.clone();
                         node_config.current_generation.bump_generation();
 
@@ -313,7 +313,7 @@ mod tests {
     use restate_core::TestCoreEnvBuilder;
     use restate_types::config::{Configuration, set_current_config};
     use restate_types::nodes_config::{NodeConfig, NodesConfiguration};
-    use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+    use restate_types::{GenerationalNodeId, NetEnumSet, PlainNodeId, Version};
 
     #[test_log::test(restate_core::test)]
     async fn node_id_mismatch() -> googletest::Result<()> {
@@ -330,7 +330,7 @@ mod tests {
             GenerationalNodeId::INITIAL_NODE_ID,
             Default::default(),
             "http://localhost:1337".parse().unwrap(),
-            Default::default(),
+            NetEnumSet::default(),
             Default::default(),
             Default::default(),
         );

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -551,7 +551,7 @@ impl Node {
         let _ = TaskCenter::spawn(TaskKind::Disposable, "status-report", async move {
             let health = TaskCenter::with_current(|tc| tc.health().clone());
             trace!("Node-to-node networking is ready");
-            for role in my_roles {
+            for role in my_roles.iter() {
                 match role {
                     Role::Worker => {
                         health

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -146,6 +146,7 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let mut encoded = BytesMut::new();
         match kind {
+            MetadataKind::Unknown => return Err(Status::invalid_argument("unknown metadata kind")),
             MetadataKind::NodesConfiguration => {
                 StorageCodec::encode(metadata.nodes_config_ref().as_ref(), &mut encoded)
                     .expect("We can always serialize");

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -21,7 +21,7 @@ mod owned_iter;
 mod partition_store;
 mod partition_store_manager;
 pub mod promise_table;
-mod protobuf_types;
+pub mod protobuf_types;
 pub mod scan;
 pub mod service_status_table;
 pub mod snapshots;

--- a/crates/storage-query-datafusion/src/deployment/row.rs
+++ b/crates/storage-query-datafusion/src/deployment/row.rs
@@ -22,6 +22,7 @@ pub(crate) fn append_deployment_row(
     row.id(format_using(output, &deployment.id));
 
     match deployment.metadata.ty {
+        DeploymentType::Unknown => row.ty("unknown"),
         DeploymentType::Http { .. } => {
             row.ty("http");
         }

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -237,7 +237,7 @@ where
         let range = partition.key_range.clone();
         let stream = self
             .scanner
-            .scan_partition(*partition_id, range, self.projected_schema.clone())
+            .scan_partition(*partition_id, range.into(), self.projected_schema.clone())
             .map_err(|e| DataFusionError::External(e.into()))?;
         Ok(stream)
     }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -33,7 +33,7 @@ base64 = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
-bilrost = { workspace = true }
+bilrost = { workspace = true, features = ["bytestring"] }
 bincode = { workspace = true, default-features = false, features = ["std", "serde"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"], optional = true }

--- a/crates/types/benches/assets/nodes_dump.json
+++ b/crates/types/benches/assets/nodes_dump.json
@@ -1,0 +1,90 @@
+{
+    "version": 127,
+    "cluster_fingerprint": null,
+    "cluster_name": "localcluster",
+    "name_lookup": {
+        "node-1": 1,
+        "node-2": 2,
+        "node-3": 3
+    },
+    "nodes": [
+        [
+            1,
+            {
+                "Node": {
+                    "address": "http://127.0.0.1:5122/",
+                    "current_generation": [
+                        1,
+                        40
+                    ],
+                    "location": "",
+                    "log_server_config": {
+                        "storage_state": "read-write"
+                    },
+                    "metadata_server_config": {
+                        "metadata_server_state": "member"
+                    },
+                    "name": "node-1",
+                    "roles": [
+                        "worker",
+                        "admin",
+                        "metadata-server",
+                        "log-server"
+                    ]
+                }
+            }
+        ],
+        [
+            3,
+            {
+                "Node": {
+                    "address": "http://127.0.0.1:7122/",
+                    "current_generation": [
+                        3,
+                        39
+                    ],
+                    "location": "",
+                    "log_server_config": {
+                        "storage_state": "read-write"
+                    },
+                    "metadata_server_config": {
+                        "metadata_server_state": "member"
+                    },
+                    "name": "node-3",
+                    "roles": [
+                        "worker",
+                        "admin",
+                        "metadata-server",
+                        "log-server"
+                    ]
+                }
+            }
+        ],
+        [
+            2,
+            {
+                "Node": {
+                    "address": "http://127.0.0.1:6122/",
+                    "current_generation": [
+                        2,
+                        43
+                    ],
+                    "location": "",
+                    "log_server_config": {
+                        "storage_state": "read-write"
+                    },
+                    "metadata_server_config": {
+                        "metadata_server_state": "member"
+                    },
+                    "name": "node-2",
+                    "roles": [
+                        "worker",
+                        "admin",
+                        "metadata-server",
+                        "log-server"
+                    ]
+                }
+            }
+        ]
+    ]
+}

--- a/crates/types/benches/assets/schema_dump.json
+++ b/crates/types/benches/assets/schema_dump.json
@@ -1,0 +1,403 @@
+{
+    "version": 2,
+    "deployments": [
+        [
+            "dp_14MOkJLlmEzq1PWbFU3jIJj",
+            {
+                "metadata": {
+                    "created_at": 1745652694762,
+                    "delivery_options": {
+                        "additional_headers": {}
+                    },
+                    "supported_protocol_versions": {
+                        "end": 5,
+                        "start": 5
+                    },
+                    "ty": {
+                        "Http": {
+                            "address": "http://localhost:9090/",
+                            "http_version": "HTTP/2.0",
+                            "protocol_type": "BidiStream"
+                        }
+                    }
+                },
+                "services": [
+                    {
+                        "deployment_id": "dp_14MOkJLlmEzq1PWbFU3jIJj",
+                        "handlers": [
+                            {
+                                "input_description": "JSON string",
+                                "input_json_schema": {
+                                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                    "type": "string"
+                                },
+                                "name": "Unlock",
+                                "output_description": "none",
+                                "ty": "Shared"
+                            },
+                            {
+                                "input_description": "JSON string",
+                                "input_json_schema": {
+                                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                    "type": "string"
+                                },
+                                "name": "Run",
+                                "output_description": "JSON string",
+                                "output_json_schema": {
+                                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                    "type": "string"
+                                },
+                                "ty": "Workflow"
+                            }
+                        ],
+                        "idempotency_retention": "1day",
+                        "name": "MyWorkflow",
+                        "public": true,
+                        "revision": 2,
+                        "ty": "Workflow",
+                        "workflow_completion_retention": "1day"
+                    },
+                    {
+                        "deployment_id": "dp_14MOkJLlmEzq1PWbFU3jIJj",
+                        "handlers": [
+                            {
+                                "input_description": "none",
+                                "name": "Greet",
+                                "output_description": "application/json",
+                                "output_json_schema": {
+                                    "$defs": {
+                                        "Result": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "Counter": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "Counter"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "$ref": "#/$defs/Result",
+                                    "$schema": "https://json-schema.org/draft/2020-12/schema"
+                                },
+                                "ty": "Exclusive"
+                            },
+                            {
+                                "input_description": "none",
+                                "name": "Bye",
+                                "output_description": "application/json",
+                                "output_json_schema": {
+                                    "$defs": {
+                                        "Result": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "Counter": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "Counter"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "$ref": "#/$defs/Result",
+                                    "$schema": "https://json-schema.org/draft/2020-12/schema"
+                                },
+                                "ty": "Exclusive"
+                            },
+                            {
+                                "input_description": "none",
+                                "name": "Count",
+                                "output_description": "application/json",
+                                "output_json_schema": {
+                                    "$defs": {
+                                        "Result": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "Counter": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "Counter"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "$ref": "#/$defs/Result",
+                                    "$schema": "https://json-schema.org/draft/2020-12/schema"
+                                },
+                                "ty": "Shared"
+                            }
+                        ],
+                        "idempotency_retention": "1day",
+                        "name": "Greeter",
+                        "public": true,
+                        "revision": 2,
+                        "ty": "VirtualObject"
+                    }
+                ]
+            }
+        ]
+    ],
+    "services": {
+        "Greeter": {
+            "abort_timeout": null,
+            "handlers": {
+                "Bye": {
+                    "target_meta": {
+                        "completion_retention": null,
+                        "idempotency_retention": {
+                            "nanos": 0,
+                            "secs": 86400
+                        },
+                        "input_rules": {
+                            "input_validation_rules": [
+                                "NoBodyAndContentType"
+                            ]
+                        },
+                        "output_rules": {
+                            "content_type_rule": {
+                                "Set": {
+                                    "content_type": "application/json",
+                                    "has_json_schema": true,
+                                    "set_content_type_if_empty": false
+                                }
+                            },
+                            "json_schema": {
+                                "$defs": {
+                                    "Result": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "Counter": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "Counter"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "$ref": "#/$defs/Result",
+                                "$schema": "https://json-schema.org/draft/2020-12/schema"
+                            }
+                        },
+                        "public": true,
+                        "target_ty": {
+                            "VirtualObject": "Exclusive"
+                        }
+                    }
+                },
+                "Count": {
+                    "target_meta": {
+                        "completion_retention": null,
+                        "idempotency_retention": {
+                            "nanos": 0,
+                            "secs": 86400
+                        },
+                        "input_rules": {
+                            "input_validation_rules": [
+                                "NoBodyAndContentType"
+                            ]
+                        },
+                        "output_rules": {
+                            "content_type_rule": {
+                                "Set": {
+                                    "content_type": "application/json",
+                                    "has_json_schema": true,
+                                    "set_content_type_if_empty": false
+                                }
+                            },
+                            "json_schema": {
+                                "$defs": {
+                                    "Result": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "Counter": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "Counter"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "$ref": "#/$defs/Result",
+                                "$schema": "https://json-schema.org/draft/2020-12/schema"
+                            }
+                        },
+                        "public": true,
+                        "target_ty": {
+                            "VirtualObject": "Shared"
+                        }
+                    }
+                },
+                "Greet": {
+                    "target_meta": {
+                        "completion_retention": null,
+                        "idempotency_retention": {
+                            "nanos": 0,
+                            "secs": 86400
+                        },
+                        "input_rules": {
+                            "input_validation_rules": [
+                                "NoBodyAndContentType"
+                            ]
+                        },
+                        "output_rules": {
+                            "content_type_rule": {
+                                "Set": {
+                                    "content_type": "application/json",
+                                    "has_json_schema": true,
+                                    "set_content_type_if_empty": false
+                                }
+                            },
+                            "json_schema": {
+                                "$defs": {
+                                    "Result": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "Counter": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "Counter"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "$ref": "#/$defs/Result",
+                                "$schema": "https://json-schema.org/draft/2020-12/schema"
+                            }
+                        },
+                        "public": true,
+                        "target_ty": {
+                            "VirtualObject": "Exclusive"
+                        }
+                    }
+                }
+            },
+            "idempotency_retention": {
+                "nanos": 0,
+                "secs": 86400
+            },
+            "inactivity_timeout": null,
+            "location": {
+                "latest_deployment": "dp_14MOkJLlmEzq1PWbFU3jIJj",
+                "public": true
+            },
+            "revision": 2,
+            "ty": "VirtualObject",
+            "workflow_completion_retention": null
+        },
+        "MyWorkflow": {
+            "abort_timeout": null,
+            "handlers": {
+                "Run": {
+                    "target_meta": {
+                        "completion_retention": {
+                            "nanos": 0,
+                            "secs": 86400
+                        },
+                        "idempotency_retention": {
+                            "nanos": 0,
+                            "secs": 86400
+                        },
+                        "input_rules": {
+                            "input_validation_rules": [
+                                {
+                                    "JsonValue": {
+                                        "content_type": {
+                                            "MimeTypeAndSubtype": [
+                                                "application",
+                                                "json"
+                                            ]
+                                        },
+                                        "schema": {
+                                            "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "output_rules": {
+                            "content_type_rule": {
+                                "Set": {
+                                    "content_type": "application/json",
+                                    "has_json_schema": true,
+                                    "set_content_type_if_empty": false
+                                }
+                            },
+                            "json_schema": {
+                                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                "type": "string"
+                            }
+                        },
+                        "public": true,
+                        "target_ty": {
+                            "Workflow": "Workflow"
+                        }
+                    }
+                },
+                "Unlock": {
+                    "target_meta": {
+                        "completion_retention": null,
+                        "idempotency_retention": {
+                            "nanos": 0,
+                            "secs": 86400
+                        },
+                        "input_rules": {
+                            "input_validation_rules": [
+                                {
+                                    "JsonValue": {
+                                        "content_type": {
+                                            "MimeTypeAndSubtype": [
+                                                "application",
+                                                "json"
+                                            ]
+                                        },
+                                        "schema": {
+                                            "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "output_rules": {
+                            "content_type_rule": "None",
+                            "json_schema": null
+                        },
+                        "public": true,
+                        "target_ty": {
+                            "Workflow": "Shared"
+                        }
+                    }
+                }
+            },
+            "idempotency_retention": {
+                "nanos": 0,
+                "secs": 86400
+            },
+            "inactivity_timeout": null,
+            "location": {
+                "latest_deployment": "dp_14MOkJLlmEzq1PWbFU3jIJj",
+                "public": true
+            },
+            "revision": 2,
+            "ty": "Workflow",
+            "workflow_completion_retention": {
+                "nanos": 0,
+                "secs": 86400
+            }
+        }
+    },
+    "subscriptions": []
+}

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_encoding::BilrostNewType;
 use std::any::Any;
 use std::borrow::Cow;
 use std::convert::Into;
@@ -93,7 +94,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, BilrostNewType)]
 #[serde(transparent)]
 pub struct InvocationErrorCode(u16);
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -22,7 +22,7 @@ use std::mem::size_of;
 use std::str::FromStr;
 use ulid::Ulid;
 
-use restate_encoding::{BilrostNewType, NetSerde};
+use restate_encoding::{BilrostAs, BilrostDisplayFromStr, BilrostNewType, NetSerde};
 
 use crate::base62_util::base62_encode_fixed_width;
 use crate::base62_util::base62_max_length_for_type;
@@ -199,6 +199,7 @@ pub trait ResourceId {
     Clone,
     Copy,
     Debug,
+    Default,
     Ord,
     PartialOrd,
     serde_with::SerializeDisplay,
@@ -422,7 +423,10 @@ impl Display for ServiceId {
     Ord,
     serde_with::SerializeDisplay,
     serde_with::DeserializeFromStr,
+    Default,
+    BilrostAs,
 )]
+#[bilrost_as(BilrostDisplayFromStr)]
 pub struct InvocationId {
     /// Partition key of the called service
     partition_key: PartitionKey,

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -700,12 +700,25 @@ impl WithInvocationId for JournalEntryId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde_with::SerializeDisplay, serde_with::DeserializeFromStr)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    serde_with::SerializeDisplay,
+    serde_with::DeserializeFromStr,
+    bilrost::Message,
+    NetSerde,
+)]
 pub struct LambdaARN {
+    #[bilrost(1)]
     partition: ByteString,
+    #[bilrost(2)]
     region: ByteString,
+    #[bilrost(3)]
     account_id: ByteString,
+    #[bilrost(4)]
     name: ByteString,
+    #[bilrost(5)]
     version: ByteString,
 }
 
@@ -909,10 +922,12 @@ macro_rules! ulid_backed_id {
                 Ord,
                 serde_with::SerializeDisplay,
                 serde_with::DeserializeFromStr,
-                ::restate_encoding::BilrostAs
+                ::restate_encoding::BilrostAs,
             )]
             #[bilrost_as([< $res_name IdMessage >])]
             pub struct [< $res_name Id >](pub(crate) Ulid);
+
+            impl ::restate_encoding::NetSerde for [< $res_name Id >] {}
 
             impl [< $res_name Id >] {
                 pub fn new() -> Self {

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -456,10 +456,15 @@ pub struct InvocationInput {
 }
 
 /// Target of a completion sent from another Partition Processor.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash, bilrost::Message,
+)]
 pub struct JournalCompletionTarget {
+    #[bilrost(1)]
     pub caller_id: InvocationId,
+    #[bilrost(2)]
     pub caller_completion_id: CompletionId,
+    #[bilrost(3)]
     pub caller_invocation_epoch: InvocationEpoch,
 }
 
@@ -537,13 +542,15 @@ impl From<&InvocationError> for ResponseResult {
 }
 
 // Represents a response to get invocation output
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 #[serde(
     from = "serde_hacks::GetInvocationOutputResponse",
     into = "serde_hacks::GetInvocationOutputResponse"
 )]
 pub struct GetInvocationOutputResponse {
+    #[bilrost(1)]
     pub target: JournalCompletionTarget,
+    #[bilrost(oneof(2, 3))]
     pub result: GetInvocationOutputResult,
 }
 
@@ -833,7 +840,7 @@ impl SpanRelation {
 }
 
 /// Message to terminate an invocation.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct InvocationTermination {
     pub invocation_id: InvocationId,
     pub flavor: TerminationFlavor,
@@ -856,17 +863,20 @@ impl InvocationTermination {
 }
 
 /// Flavor of the termination. Can be kill (hard stop) or graceful cancel.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Enumeration,
+)]
 pub enum TerminationFlavor {
     /// hard termination, no clean up
-    Kill,
+    Kill = 0,
     /// graceful termination allowing the invocation to clean up
-    Cancel,
+    Cancel = 1,
 }
 
 /// Message to purge an invocation.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct PurgeInvocationRequest {
+    #[bilrost(1)]
     pub invocation_id: InvocationId,
 }
 

--- a/crates/types/src/journal_v2/notification.rs
+++ b/crates/types/src/journal_v2/notification.rs
@@ -299,10 +299,12 @@ pub struct GetInvocationOutputCompletion {
     pub completion_id: CompletionId,
     pub result: GetInvocationOutputResult,
 }
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bilrost::Oneof)]
 pub enum GetInvocationOutputResult {
     Void,
+    #[bilrost(2)]
     Success(Bytes),
+    #[bilrost(3)]
     Failure(Failure),
 }
 impl_completion_accessors!(GetInvocationOutput);

--- a/crates/types/src/journal_v2/types.rs
+++ b/crates/types/src/journal_v2/types.rs
@@ -13,9 +13,11 @@
 use crate::errors::{InvocationError, InvocationErrorCode};
 use bytestring::ByteString;
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct Failure {
+    #[bilrost(1)]
     pub code: InvocationErrorCode,
+    #[bilrost(2)]
     pub message: ByteString,
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -284,6 +284,11 @@ where
     }
 }
 
+impl<Idx> NetSerde for NetRangeInclusive<Idx> where
+    Idx: Copy + EmptyState + ValueEncoder<General> + ValueDecoder<General>
+{
+}
+
 #[derive(bilrost::Message)]
 struct RangeInclusiveMessage<Idx>((Idx, Idx))
 where
@@ -322,10 +327,11 @@ where
     serde::Serialize,
     serde::Deserialize,
     BilrostAs,
+    NetSerde,
 )]
 #[bilrost_as(BilrostDisplayFromStr)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct NetJsonValue(serde_json::Value);
+pub struct NetJsonValue(#[net_serde(skip)] serde_json::Value);
 
 impl Default for NetJsonValue {
     fn default() -> Self {
@@ -347,12 +353,14 @@ impl Default for NetJsonValue {
     serde::Serialize,
     serde::Deserialize,
     BilrostAs,
+    NetSerde,
 )]
 #[bilrost_as(BilrostDisplayFromStr)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NetHumanDuration(
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+    #[net_serde(skip)]
     humantime::Duration,
 );
 

--- a/crates/types/src/locality/location_scope.rs
+++ b/crates/types/src/locality/location_scope.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_encoding::NetSerde;
+
 /// [`LocationScope`] specifies the location of a node in the cluster. The location
 /// is expressed by a set of hierarchical scopes. Restate assumes the cluster topology
 /// to be a tree-like structure.
@@ -25,6 +27,7 @@
     strum::EnumString,
     serde::Serialize,
     serde::Deserialize,
+    NetSerde,
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(ascii_case_insensitive)]

--- a/crates/types/src/locality/node_location.rs
+++ b/crates/types/src/locality/node_location.rs
@@ -11,6 +11,7 @@
 use std::str::FromStr;
 
 use itertools::Itertools;
+use restate_encoding::{BilrostAs, BilrostDisplayFromStr, NetSerde};
 
 use crate::PlainNodeId;
 
@@ -46,12 +47,21 @@ const NODE_DELIMITER: &str = ":";
 /// improve cache-friendlyness. It's a fixed-size array of labels, where each label is a highly-likely
 /// stack-inlined `SmartString`.
 #[derive(
-    Clone, Default, PartialEq, Eq, serde_with::DeserializeFromStr, serde_with::SerializeDisplay,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    serde_with::DeserializeFromStr,
+    serde_with::SerializeDisplay,
+    BilrostAs,
+    NetSerde,
 )]
+#[bilrost_as(BilrostDisplayFromStr)]
 pub struct NodeLocation {
     /// Internal storage for labels of all scopes, the order of scopes in the array
     /// is the reverse order of their type value: largest scope (i.e. Region) gets
     /// stored at index 0, and so on...
+    #[net_serde(skip)]
     labels: [SmartString; LocationScope::num_scopes()],
     /// number of (non-empty) scope labels specified
     num_defined_scopes: u8,

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -44,6 +44,8 @@ pub use tail::*;
     derive_more::Into,
     Serialize,
     Deserialize,
+    BilrostNewType,
+    NetSerde,
 )]
 #[debug("{}", _0)]
 pub struct LogId(u32);

--- a/crates/types/src/net/codec.rs
+++ b/crates/types/src/net/codec.rs
@@ -14,6 +14,7 @@ use anyhow::Context;
 use bilrost::OwnedMessage;
 use bytes::Buf;
 use bytes::Bytes;
+use restate_encoding::NetSerde;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -100,7 +101,7 @@ pub fn decode_as_flexbuffers<T: DeserializeOwned>(
     flexbuffers::from_slice(buf.chunk()).context("failed decoding V1 (flexbuffers) network message")
 }
 
-pub fn encode_as_bilrost<T: bilrost::Message>(
+pub fn encode_as_bilrost<T: bilrost::Message + NetSerde>(
     value: &T,
     protocol_version: ProtocolVersion,
 ) -> Bytes {
@@ -113,7 +114,7 @@ pub fn encode_as_bilrost<T: bilrost::Message>(
     Bytes::from(buf.into_vec())
 }
 
-pub fn decode_as_bilrost<T: OwnedMessage>(
+pub fn decode_as_bilrost<T: OwnedMessage + NetSerde>(
     buf: impl Buf,
     protocol_version: ProtocolVersion,
 ) -> Result<T, anyhow::Error> {

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -23,6 +23,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Error};
 use http::Uri;
+use restate_encoding::{BilrostAs, BilrostDisplayFromStr, NetSerde};
 
 use crate::config::InvalidConfigurationError;
 pub use crate::protobuf::common::ProtocolVersion;
@@ -40,14 +41,26 @@ pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V2;
     derive_more::Display,
     serde_with::SerializeDisplay,
     serde_with::DeserializeFromStr,
+    BilrostAs,
+    NetSerde,
 )]
+#[bilrost_as(BilrostDisplayFromStr)]
 pub enum AdvertisedAddress {
     /// Unix domain socket
     #[display("unix:{}", _0.display())]
     Uds(PathBuf),
     /// Hostname or host:port pair
     #[display("{}", _0)]
+    #[net_serde(skip)]
     Http(Uri),
+}
+
+// This default implementation is needed by bilrost
+// to have a default "empty state"
+impl Default for AdvertisedAddress {
+    fn default() -> Self {
+        Self::Uds("".into())
+    }
 }
 
 impl FromStr for AdvertisedAddress {

--- a/crates/types/src/replicated_loglet/log_nodeset.rs
+++ b/crates/types/src/replicated_loglet/log_nodeset.rs
@@ -90,7 +90,11 @@ impl EffectiveNodeSet {
         Self(
             nodeset
                 .into_iter()
-                .filter(|node_id| !nodes_config.get_log_server_storage_state(node_id).empty())
+                .filter(|node_id| {
+                    !nodes_config
+                        .get_log_server_storage_state(node_id)
+                        .is_empty()
+                })
                 .collect(),
         )
     }

--- a/crates/types/src/replicated_loglet/params.rs
+++ b/crates/types/src/replicated_loglet/params.rs
@@ -13,7 +13,7 @@ use crate::logs::LogletId;
 use crate::replication::{NodeSet, ReplicationProperty};
 
 /// Configuration parameters of a replicated loglet segment
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, bilrost::Message)]
 pub struct ReplicatedLogletParams {
     /// Unique identifier for this loglet
     pub loglet_id: LogletId,

--- a/crates/types/src/replication/nodeset.rs
+++ b/crates/types/src/replication/nodeset.rs
@@ -18,6 +18,7 @@ use ahash::AHasher;
 use itertools::Itertools;
 use rand::distr::Uniform;
 use rand::prelude::*;
+use restate_encoding::{BilrostAs, NetSerde};
 
 use crate::{Merge, PlainNodeId};
 
@@ -39,8 +40,11 @@ type IndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<AHasher>>;
     derive_more::Index,
     derive_more::IntoIterator,
     derive_more::From,
+    BilrostAs,
+    NetSerde,
 )]
-pub struct NodeSet(IndexSet<PlainNodeId>);
+#[bilrost_as(dto::NodeSet)]
+pub struct NodeSet(#[net_serde(skip)] IndexSet<PlainNodeId>);
 
 impl NodeSet {
     pub fn new() -> Self {
@@ -255,6 +259,12 @@ impl From<Vec<u32>> for NodeSet {
     }
 }
 
+impl From<Vec<PlainNodeId>> for NodeSet {
+    fn from(value: Vec<PlainNodeId>) -> Self {
+        Self(value.into_iter().collect())
+    }
+}
+
 impl From<NodeSet> for Box<[PlainNodeId]> {
     fn from(value: NodeSet) -> Self {
         value.0.into_iter().collect()
@@ -403,6 +413,24 @@ fn write_nodes<'a>(
         }
     }
     write!(f, "]")
+}
+
+mod dto {
+    use crate::PlainNodeId;
+
+    #[derive(bilrost::Message)]
+    pub(super) struct NodeSet(Vec<PlainNodeId>);
+    impl From<&super::NodeSet> for NodeSet {
+        fn from(value: &super::NodeSet) -> Self {
+            Self(value.clone().into())
+        }
+    }
+
+    impl From<NodeSet> for super::NodeSet {
+        fn from(value: NodeSet) -> Self {
+            Self::from(value.0)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/types/src/replication/nodeset_selector.rs
+++ b/crates/types/src/replication/nodeset_selector.rs
@@ -629,7 +629,7 @@ pub mod tests {
             GenerationalNodeId::new(id.into(), 1),
             location.parse().unwrap(),
             format!("unix:/tmp/my_socket-{id}").parse().unwrap(),
-            role.into(),
+            role,
             LogServerConfig { storage_state },
             MetadataServerConfig::default(),
         )

--- a/crates/types/src/schema/mod.rs
+++ b/crates/types/src/schema/mod.rs
@@ -17,6 +17,7 @@ pub mod subscriptions;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use restate_encoding::NetSerde;
 use serde_with::serde_as;
 
 use self::deployment::DeploymentSchemas;
@@ -32,15 +33,19 @@ use crate::net::metadata::MetadataKind;
 
 /// The schema information
 #[serde_as]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bilrost::Message, NetSerde)]
 pub struct Schema {
+    #[bilrost(1)]
     pub version: Version,
+    #[bilrost(2)]
     pub services: HashMap<String, ServiceSchemas>,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
+    #[bilrost(3)]
     pub deployments: HashMap<DeploymentId, DeploymentSchemas>,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
+    #[bilrost(4)]
     pub subscriptions: HashMap<SubscriptionId, Subscription>,
 }
 

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -187,7 +187,7 @@ macro_rules! flexbuffers_storage_encode_decode {
 }
 
 /// A polymorphic container of a buffer or a cached storage-encodeable object
-#[derive(Clone, derive_more::Debug, BilrostAs)]
+#[derive(Clone, derive_more::Debug, BilrostAs, NetSerde)]
 #[bilrost_as(dto::PolyBytes)]
 pub enum PolyBytes {
     /// Raw bytes backed by (Bytes), so it's cheap to clone
@@ -195,6 +195,7 @@ pub enum PolyBytes {
     Bytes(bytes::Bytes),
     /// A cached deserialized value that can be downcasted to the original type
     #[debug("Typed")]
+    #[net_serde(skip)]
     Typed(Arc<dyn StorageEncode>),
 }
 
@@ -205,8 +206,6 @@ impl Default for PolyBytes {
         Self::Bytes(bytes::Bytes::default())
     }
 }
-// implement NetSerde for PolyBytes manually
-impl NetSerde for PolyBytes {}
 
 impl PolyBytes {
     /// Returns true if we are holding raw encoded bytes

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -40,7 +40,9 @@ pub enum StorageDecodeError {
     UnsupportedCodecKind(StorageCodecKind),
 }
 
-#[derive(Debug, Copy, Clone, strum::FromRepr, derive_more::Display)]
+#[derive(
+    Debug, Copy, Clone, strum::FromRepr, derive_more::Display, PartialEq, Eq, bilrost::Enumeration,
+)]
 #[repr(u8)]
 pub enum StorageCodecKind {
     /// plain old protobuf
@@ -53,6 +55,11 @@ pub enum StorageCodecKind {
     BincodeSerde = 4,
     /// Json (no length prefix)
     Json = 5,
+    /// Bilrost (no length-prefixed)
+    Bilrost = 6,
+
+    /// Custom encoding
+    Custom = 0xff,
 }
 
 impl From<StorageCodecKind> for u8 {

--- a/crates/types/src/storage/decode.rs
+++ b/crates/types/src/storage/decode.rs
@@ -92,3 +92,7 @@ fn decode_serde_from_json<T: DeserializeOwned, B: Buf>(
     })?;
     Ok(result)
 }
+
+pub fn decode_bilrost<T: bilrost::OwnedMessage, B: Buf>(buf: B) -> Result<T, StorageDecodeError> {
+    T::decode(buf).map_err(|err| StorageDecodeError::DecodeValue(err.into()))
+}

--- a/crates/types/src/storage/encode.rs
+++ b/crates/types/src/storage/encode.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 use std::mem;
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::Serialize;
 
 use super::{StorageCodecKind, StorageEncodeError};
@@ -77,4 +77,9 @@ fn encode_serde_as_json<T: Serialize>(
     serde_json::to_writer(buf.writer(), value)?;
 
     Ok(())
+}
+
+/// Utility method to encode a [`bilrost::Message`] type
+pub fn encode_bilrost<T: bilrost::Message>(value: &T) -> Bytes {
+    value.encode_fast().into_vec().into()
 }

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_encoding::{BilrostNewType, NetSerde};
+
 /// A type used for versioned metadata.
 #[derive(
     Clone,
@@ -23,7 +25,8 @@
     derive_more::AddAssign,
     serde::Serialize,
     serde::Deserialize,
-    restate_encoding::BilrostNewType,
+    BilrostNewType,
+    NetSerde,
 )]
 #[display("v{}", _0)]
 #[debug("v{}", _0)]

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -15,6 +15,7 @@ serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 restate-core = { workspace = true }
 restate-invoker-api = { workspace = true }
+restate-partition-store = { workspace = true }
 restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 
@@ -22,6 +23,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+bilrost = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
@@ -32,6 +34,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
+prost = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -819,7 +819,7 @@ impl PartitionProcessorManager {
                     debug!(%partition_id, "Starting new partition processor to run as {}", control_processor.command);
                     let starting_task = self.create_start_partition_processor_task(
                         partition_id,
-                        partition_key_range.clone(),
+                        partition_key_range.clone().into(),
                     );
 
                     self.asynchronous_operations

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -30,8 +30,10 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
+bilrost = { version = "0.1012", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
+bytestring = { version = "1", default-features = false, features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", default-features = false, features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
@@ -145,8 +147,10 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
+bilrost = { version = "0.1012", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
+bytestring = { version = "1", default-features = false, features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Bilrost `Metadata` messages

Migration of all metadata objects and messages to Bilrost

Note from the benchmark
- This is only testing with schema metadata
- Flexbuffer buffer size is 4346 bytes
- Bilrost buffer size is only 2527 bytes (improvement around 41%)
- Slight increase in serialization speed (around 9%)
- Big increase in deserialization speed (around 41%)

Benchmarking
```
Flexbuffers Message Size: 4346
flexbuffers-schema-metadata-serialize
                        time:   [22.560 µs 22.569 µs 22.578 µs]
                        change: [+2.7422% +2.8679% +2.9815%] (p = 0.00 < 0.05)
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

flexbuffers-schema-metadata-deserialize
                        time:   [24.026 µs 24.073 µs 24.126 µs]
                        change: [+0.1556% +0.2826% +0.4065%] (p = 0.00 < 0.05)
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild
  6 (6.00%) high severe

Bilrost Message Size: 2527
bilrost-schema-metadata-serialize
                        time:   [20.632 µs 20.687 µs 20.787 µs]
                        change: [-1.4008% -1.0478% -0.7141%] (p = 0.00 < 0.05)
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

bilrost-schema-metadata-deserialize
                        time:   [14.454 µs 14.480 µs 14.526 µs]
                        change: [+3.6280% +3.7771% +3.9767%] (p = 0.00 < 0.05)
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3212).
* __->__ #3212
* #3261
* #3242