### PR TITLE
[Core] Support for sent notification for unary messages

### DIFF
--- a/crates/core/src/network/io/egress_sender.rs
+++ b/crates/core/src/network/io/egress_sender.rs
@@ -42,7 +42,7 @@ impl Future for SendToken {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(self.0.poll_unpin(cx)) {
-            Ok(_) => Poll::Ready(Ok(())),
+            Ok(()) => Poll::Ready(Ok(())),
             Err(_) => Poll::Ready(Err(ConnectionClosed)),
         }
     }

--- a/crates/core/src/network/io/mod.rs
+++ b/crates/core/src/network/io/mod.rs
@@ -15,6 +15,7 @@ mod rpc_tracker;
 
 use std::sync::Arc;
 
+pub use egress_sender::SendToken;
 pub(crate) use egress_sender::WeakUnboundedEgressSender;
 pub(super) use egress_stream::EgressMessage;
 pub(super) use egress_stream::EgressStream;

--- a/crates/core/src/network/io/reactor.rs
+++ b/crates/core/src/network/io/reactor.rs
@@ -417,7 +417,10 @@ impl ConnectionReactor {
                         }
                         Some(rpc_reply::Body::Payload(payload)) => {
                             trace!("Received RPC response with payload!");
-                            reply_sender.send(crate::network::RawRpcReply::Success(payload))
+                            reply_sender.send(crate::network::RawRpcReply::Success((
+                                self.connection.protocol_version,
+                                payload,
+                            )))
                         }
                         None => {
                             warn!(
@@ -503,8 +506,10 @@ impl ConnectionReactor {
                         // V1 doesn't support RPC statuses.
                         // todo: handle routing errors
                         trace!("Received LEGACY RPC response with payload!");
-                        let _ =
-                            reply_sender.send(crate::network::RawRpcReply::Success(msg.payload));
+                        let _ = reply_sender.send(crate::network::RawRpcReply::Success((
+                            self.connection.protocol_version,
+                            msg.payload,
+                        )));
                     }
                     // if we didn't find the original RPC, it's okay, we'll simply ignore this
                     // response. This matches the behaviour of V2.

--- a/crates/core/src/network/message_router.rs
+++ b/crates/core/src/network/message_router.rs
@@ -302,7 +302,7 @@ impl<S: Service> ServiceMessage<S> {
         use crate::network::protobuf::network::rpc_reply;
         use crate::network::{RawRpcReply, ReplyRx, RpcReplyError, RpcReplyPort};
 
-        let (reply_sender, reply_token) = ReplyRx::new(protocol_version);
+        let (reply_sender, reply_token) = ReplyRx::new();
         let payload = msg.encode_to_bytes(protocol_version);
 
         let (reply_port, reply_rx) = RpcReplyPort::new();
@@ -326,7 +326,7 @@ impl<S: Service> ServiceMessage<S> {
             match reply_rx.await {
                 Ok(envelope) => match envelope.body {
                     rpc_reply::Body::Payload(payload) => {
-                        reply_sender.send(RawRpcReply::Success(payload))
+                        reply_sender.send(RawRpcReply::Success((protocol_version, payload)))
                     }
                     rpc_reply::Body::Status(status) => {
                         reply_sender.send(RawRpcReply::Error(RpcReplyError::from(status)))


### PR DESCRIPTION

Other changes:
- Smaller EgressMessages by using static string for message names, removing span for unary messages (224 bytes -> 216 bytes)
- ReplyRx doesn't require protocol version at creation time, this will become relevant in a subsequent PR. The protocol version is now returned along with the reply when it arrives
