### PR TITLE
[Core] WireEncode accepts a reference instead of an owned value

### DIFF
--- a/crates/core/src/network/incoming.rs
+++ b/crates/core/src/network/incoming.rs
@@ -620,7 +620,7 @@ impl<O: RpcResponse + WireEncode> Reciprocal<Oneshot<O>> {
 
     /// Fails if connection was already dropped
     pub fn try_send(self, msg: O) -> Result<(), ConnectionClosed> {
-        let reply = O::encode_to_bytes(msg, self.protocol_version);
+        let reply = O::encode_to_bytes(&msg, self.protocol_version);
         self.reply_port
             .inner
             .0
@@ -658,7 +658,7 @@ impl<O: WatchResponse + WireEncode> Reciprocal<Updates<O>> {
 
     /// Fails if connection was already dropped
     pub fn try_send(&self, msg: O) -> Result<(), ConnectionClosed> {
-        let reply = O::encode_to_bytes(msg, self.protocol_version);
+        let reply = O::encode_to_bytes(&msg, self.protocol_version);
         self.reply_port
             .inner
             .0

--- a/crates/types/src/net/codec.rs
+++ b/crates/types/src/net/codec.rs
@@ -16,11 +16,11 @@ use bytes::Bytes;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use super::{FromBilrostDto, IntoBilrostDto};
+use super::FromBilrostDto;
 use crate::protobuf::common::ProtocolVersion;
 
 pub trait WireEncode {
-    fn encode_to_bytes(self, protocol_version: ProtocolVersion) -> Bytes;
+    fn encode_to_bytes(&self, protocol_version: ProtocolVersion) -> Bytes;
 }
 
 pub trait WireDecode {
@@ -42,8 +42,8 @@ impl<T> WireEncode for Box<T>
 where
     T: WireEncode,
 {
-    fn encode_to_bytes(self, protocol_version: ProtocolVersion) -> Bytes {
-        (*self).encode_to_bytes(protocol_version)
+    fn encode_to_bytes(&self, protocol_version: ProtocolVersion) -> Bytes {
+        self.as_ref().encode_to_bytes(protocol_version)
     }
 }
 
@@ -100,17 +100,34 @@ pub fn decode_as_flexbuffers<T: DeserializeOwned>(
     flexbuffers::from_slice(buf.chunk()).context("failed decoding V1 (flexbuffers) network message")
 }
 
-pub fn encode_as_bilrost<T: IntoBilrostDto>(value: T, protocol_version: ProtocolVersion) -> Bytes {
-    use bilrost::Message;
-
+pub fn encode_as_bilrost<T: bilrost::Message>(
+    value: &T,
+    protocol_version: ProtocolVersion,
+) -> Bytes {
     assert!(
         protocol_version >= ProtocolVersion::V2,
         "bilrost encoding is supported from protocol version v2"
     );
 
-    let inner = value.into_dto();
-    inner.encode_to_bytes()
+    // commented intentionally, see the comment below.
+    // let inner = value.into_dto();
+    value.encode_to_bytes()
 }
+
+// Disabled IntoBilrostDto in favor of requiring top-level types to implement bilrost::Message
+// if this is needed, we'll need to allow into_dto to be used with references instead of owned
+// values.
+// pub fn encode_as_bilrost<T: super::IntoBilrostDto>(value: &T, protocol_version: ProtocolVersion) -> Bytes {
+//     use bilrost::Message;
+//
+//     assert!(
+//         protocol_version >= ProtocolVersion::V2,
+//         "bilrost encoding is supported from protocol version v2"
+//     );
+//
+//     // let inner = value.into_dto();
+//     value.encode_to_bytes()
+// }
 
 pub fn decode_as_bilrost<T: FromBilrostDto>(
     buf: impl Buf,

--- a/crates/types/src/net/metadata.rs
+++ b/crates/types/src/net/metadata.rs
@@ -63,11 +63,11 @@ define_rpc! {
 // -- Custom encoding logic to handle compatibility with V1 protocol
 //
 impl WireEncode for GetMetadataRequest {
-    fn encode_to_bytes(self, protocol_version: ProtocolVersion) -> Bytes {
+    fn encode_to_bytes(&self, protocol_version: ProtocolVersion) -> Bytes {
         if let ProtocolVersion::V1 = protocol_version {
             // V1 protocol sends `GetMetadataRequest` as a `MetadataMessage`
             return Bytes::from(crate::net::codec::encode_as_flexbuffers(
-                MetadataMessage::GetMetadataRequest(self),
+                MetadataMessage::GetMetadataRequest(self.clone()),
                 protocol_version,
             ));
         }
@@ -98,11 +98,11 @@ impl WireDecode for GetMetadataRequest {
 }
 
 impl WireEncode for MetadataUpdate {
-    fn encode_to_bytes(self, protocol_version: ProtocolVersion) -> Bytes {
+    fn encode_to_bytes(&self, protocol_version: ProtocolVersion) -> Bytes {
         if let ProtocolVersion::V1 = protocol_version {
             // V1 protocol sends `MetadataUpdate` as a `MetadataMessage`
             return Bytes::from(codec::encode_as_flexbuffers(
-                MetadataMessage::MetadataUpdate(self),
+                MetadataMessage::MetadataUpdate(self.clone()),
                 protocol_version,
             ));
         }

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -223,7 +223,7 @@ macro_rules! default_wire_codec {
     ) => {
         impl $crate::net::codec::WireEncode for $message {
             fn encode_to_bytes(
-                self,
+                &self,
                 protocol_version: $crate::net::ProtocolVersion,
             ) -> ::bytes::Bytes {
                 ::bytes::Bytes::from($crate::net::codec::encode_as_flexbuffers(
@@ -271,7 +271,7 @@ macro_rules! bilrost_wire_codec_with_v1_fallback {
     ) => {
         impl $crate::net::codec::WireEncode for $message {
             fn encode_to_bytes(
-                self,
+                &self,
                 protocol_version: $crate::net::ProtocolVersion,
             ) -> ::bytes::Bytes {
                 match protocol_version {
@@ -348,7 +348,7 @@ macro_rules! bilrost_wire_codec {
     ) => {
         impl $crate::net::codec::WireEncode for $message {
             fn encode_to_bytes(
-                self,
+                &self,
                 protocol_version: $crate::net::ProtocolVersion,
             ) -> ::bytes::Bytes {
                 $crate::net::codec::encode_as_bilrost(self, protocol_version)


### PR DESCRIPTION

This is necessary to allow `Box<dyn WireEncode>` to be used in the next PR. This also aligns with how most serialization libraries work, there is no need to send the owned value. I've temporarily disabled bilrost's IntoDto until we can get it to work with this design. Additionally. I didn't change the API of the send() API in network code to avoid making this as a sweeping change. If the need for passing the message by reference on that layer rises, we can change it.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3214).
* #3215
* #3213
* __->__ #3214