### PR TITLE
[invoker] Stop retrying when the invocation is not there anymore.

### DIFF
--- a/crates/invoker-api/src/invocation_reader.rs
+++ b/crates/invoker-api/src/invocation_reader.rs
@@ -72,9 +72,9 @@ pub trait InvocationReaderTransaction {
     type StateIter: Iterator<Item = (Bytes, Bytes)> + Send + 'static;
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// Read the journal and the journal metadata for the given invocation id.
+    /// Read the journal for the given invocation id.
     ///
-    /// When Option is none, no journal was found for the given invocation id.
+    /// Returns `None` when either the invocation was not found, or the invocation is not in `Invoked` state.
     fn read_journal<'a>(
         &'a mut self,
         fid: &'a InvocationId,

--- a/crates/invoker-api/src/invocation_reader.rs
+++ b/crates/invoker-api/src/invocation_reader.rs
@@ -73,10 +73,12 @@ pub trait InvocationReaderTransaction {
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Read the journal and the journal metadata for the given invocation id.
+    ///
+    /// When Option is none, no journal was found for the given invocation id.
     fn read_journal<'a>(
         &'a mut self,
         fid: &'a InvocationId,
-    ) -> impl Future<Output = Result<(JournalMetadata, Self::JournalStream), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<(JournalMetadata, Self::JournalStream)>, Self::Error>> + Send;
 
     /// Read the state for the given service id.
     fn read_state<'a>(

--- a/crates/invoker-api/src/lib.rs
+++ b/crates/invoker-api/src/lib.rs
@@ -64,8 +64,8 @@ pub mod test_util {
         async fn read_journal(
             &mut self,
             _fid: &InvocationId,
-        ) -> Result<(JournalMetadata, Self::JournalStream), Self::Error> {
-            Ok((
+        ) -> Result<Option<(JournalMetadata, Self::JournalStream)>, Self::Error> {
+            Ok(Some((
                 JournalMetadata::new(
                     0,
                     ServiceInvocationSpanContext::empty(),
@@ -73,7 +73,7 @@ pub mod test_util {
                     MillisSinceEpoch::UNIX_EPOCH,
                 ),
                 futures::stream::empty(),
-            ))
+            )))
         }
 
         async fn read_state(

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -99,9 +99,9 @@ pub(crate) enum InvokerError {
     #[error("error when trying to read the journal: {0}")]
     #[code(restate_errors::RT0006)]
     JournalReader(anyhow::Error),
-    #[error("error when trying to read the journal: no journal present")]
+    #[error("error when trying to read the journal: not invoked")]
     #[code(unknown)]
-    NoJournalPresent,
+    NotInvoked,
     #[error("error when trying to read the service instance state: {0}")]
     #[code(restate_errors::RT0006)]
     StateReader(anyhow::Error),
@@ -176,13 +176,13 @@ impl InvokerError {
     }
 
     pub(crate) fn is_transient(&self) -> bool {
-        !matches!(self, InvokerError::NoJournalPresent)
+        !matches!(self, InvokerError::NotInvoked)
     }
 
     pub(crate) fn should_bump_start_message_retry_count_since_last_stored_entry(&self) -> bool {
         !matches!(
             self,
-            InvokerError::NoJournalPresent
+            InvokerError::NotInvoked
                 | InvokerError::JournalReader(_)
                 | InvokerError::StateReader(_)
                 | InvokerError::NoDeploymentForService

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -99,6 +99,9 @@ pub(crate) enum InvokerError {
     #[error("error when trying to read the journal: {0}")]
     #[code(restate_errors::RT0006)]
     JournalReader(anyhow::Error),
+    #[error("error when trying to read the journal: no journal present")]
+    #[code(unknown)]
+    NoJournalPresent,
     #[error("error when trying to read the service instance state: {0}")]
     #[code(restate_errors::RT0006)]
     StateReader(anyhow::Error),
@@ -173,13 +176,14 @@ impl InvokerError {
     }
 
     pub(crate) fn is_transient(&self) -> bool {
-        true
+        !matches!(self, InvokerError::NoJournalPresent)
     }
 
     pub(crate) fn should_bump_start_message_retry_count_since_last_stored_entry(&self) -> bool {
         !matches!(
             self,
-            InvokerError::JournalReader(_)
+            InvokerError::NoJournalPresent
+                | InvokerError::JournalReader(_)
                 | InvokerError::StateReader(_)
                 | InvokerError::NoDeploymentForService
                 | InvokerError::BadNegotiatedServiceProtocolVersion(_)

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -276,7 +276,7 @@ where
                         txn.read_journal(&self.invocation_id)
                             .await
                             .map_err(|e| InvokerError::JournalReader(e.into()))
-                            .and_then(|opt| opt.ok_or_else(|| InvokerError::NoJournalPresent))
+                            .and_then(|opt| opt.ok_or_else(|| InvokerError::NotInvoked))
                     );
                     (journal_meta, future::Either::Left(journal_stream))
                 }

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -276,6 +276,7 @@ where
                         txn.read_journal(&self.invocation_id)
                             .await
                             .map_err(|e| InvokerError::JournalReader(e.into()))
+                            .and_then(|opt| opt.ok_or_else(|| InvokerError::NoJournalPresent))
                     );
                     (journal_meta, future::Either::Left(journal_stream))
                 }

--- a/crates/worker/src/partition/invoker_storage_reader.rs
+++ b/crates/worker/src/partition/invoker_storage_reader.rs
@@ -26,8 +26,6 @@ use std::vec::IntoIter;
 
 #[derive(Debug, thiserror::Error)]
 pub enum InvokerStorageReaderError {
-    #[error("not invoked")]
-    NotInvoked,
     #[error(transparent)]
     Storage(#[from] restate_storage_api::StorageError),
 }
@@ -77,7 +75,7 @@ where
     async fn read_journal(
         &mut self,
         invocation_id: &InvocationId,
-    ) -> Result<(JournalMetadata, Self::JournalStream), Self::Error> {
+    ) -> Result<Option<(JournalMetadata, Self::JournalStream)>, Self::Error> {
         let invocation_status = self.txn.get_invocation_status(invocation_id).await?;
 
         if let InvocationStatus::Invoked(invoked_status) = invocation_status {
@@ -136,9 +134,9 @@ where
                 .await?
             };
 
-            Ok((journal_metadata, stream::iter(journal_stream)))
+            Ok(Some((journal_metadata, stream::iter(journal_stream))))
         } else {
-            Err(InvokerStorageReaderError::NotInvoked)
+            Ok(None)
         }
     }
 


### PR DESCRIPTION
This is safe under the following assumptions:

* For a given invocation instance, the invocation id doesn't change. This means that there's two possible situations:
  * Either the invocation is present -> in this case the invocation instance must be always the same.
  * Or the invocation is absent -> in this case the invocation either:
    * Was removed -> the bug we wanna fix here
    * not yet written. But this case cannot happen, because of another invariant: invoker gets the invoke command iff the rocksdb transaction was committed for that invocation instance.  