### PR TITLE
Bilrost fast encoding + more common helper types

### DIFF
--- a/crates/encoding/src/bilrost_as.rs
+++ b/crates/encoding/src/bilrost_as.rs
@@ -138,3 +138,67 @@ impl EmptyState for BilrostDisplayFromStr {
         self.inner.is_empty()
     }
 }
+
+/// A special adaptor that always skip the field on encode and decode the value
+/// always using [`Default::default()`]
+pub struct BilrostSkip;
+
+impl<'a, Source> BilrostAsAdaptor<'a, Source> for BilrostSkip
+where
+    Source: Default,
+{
+    fn create(_value: &'a Source) -> Self {
+        Self
+    }
+
+    fn into_inner(self) -> Result<Source, DecodeError> {
+        Ok(Source::default())
+    }
+}
+
+impl Wiretyped<General> for BilrostSkip {
+    const WIRE_TYPE: bilrost::encoding::WireType = <() as Wiretyped<General>>::WIRE_TYPE;
+}
+
+impl ValueEncoder<General> for BilrostSkip {
+    fn encode_value<B: bytes::BufMut + ?Sized>(_value: &Self, _buf: &mut B) {}
+
+    fn prepend_value<B: bilrost::buf::ReverseBuf + ?Sized>(_value: &Self, _buf: &mut B) {}
+
+    fn value_encoded_len(_value: &Self) -> usize {
+        0
+    }
+}
+
+impl ValueDecoder<General> for BilrostSkip {
+    fn decode_value<B: bytes::Buf + ?Sized>(
+        _value: &mut Self,
+        _buf: bilrost::encoding::Capped<B>,
+        _ctx: bilrost::encoding::DecodeContext,
+    ) -> Result<(), bilrost::DecodeError> {
+        Ok(())
+    }
+}
+
+impl ForOverwrite for BilrostSkip {
+    fn for_overwrite() -> Self
+    where
+        Self: Sized,
+    {
+        Self
+    }
+}
+
+impl EmptyState for BilrostSkip {
+    fn clear(&mut self) {}
+    fn empty() -> Self
+    where
+        Self: Sized,
+    {
+        Self
+    }
+
+    fn is_empty(&self) -> bool {
+        true
+    }
+}

--- a/crates/encoding/src/common.rs
+++ b/crates/encoding/src/common.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_encoding_derive::BilrostNewType;
+
+use crate::NetSerde;
+
+/// A Bilrost compatible U128 type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BilrostNewType)]
+pub struct U128((u64, u64));
+
+impl From<u128> for U128 {
+    fn from(value: u128) -> Self {
+        Self(((value >> 64) as u64, value as u64))
+    }
+}
+
+impl From<U128> for u128 {
+    fn from(value: U128) -> Self {
+        (value.0.0 as u128) << 64 | value.0.1 as u128
+    }
+}
+
+impl NetSerde for U128 {}
+
+#[cfg(test)]
+mod test {
+    use rand::random;
+
+    use super::U128;
+
+    #[test]
+    fn test_u128() {
+        (0..100).for_each(|_| {
+            let num = random::<u128>();
+            let value = U128::from(num);
+
+            assert_eq!(num, u128::from(value));
+        });
+    }
+}

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod bilrost_as;
+mod common;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -16,9 +17,9 @@ use std::collections::HashSet;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-pub use bilrost_as::{BilrostAsAdaptor, BilrostDisplayFromStr};
+pub use bilrost_as::{BilrostAsAdaptor, BilrostDisplayFromStr, BilrostSkip};
+pub use common::U128;
 pub use restate_encoding_derive::{BilrostAs, BilrostNewType, NetSerde};
-
 /// A marker trait for types that can be serialized and sent over the network.
 ///
 /// Types implementing this trait are considered eligible for wire transmission,
@@ -99,41 +100,10 @@ impl<T> NetSerde for Arc<T> where T: NetSerde {}
 impl<T> NetSerde for Arc<[T]> where T: NetSerde {}
 impl<T> NetSerde for Box<T> where T: NetSerde {}
 
-/// A Bilrost compatible U128 type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, BilrostNewType)]
-pub struct U128((u64, u64));
-
-impl From<u128> for U128 {
-    fn from(value: u128) -> Self {
-        Self(((value >> 64) as u64, value as u64))
-    }
-}
-
-impl From<U128> for u128 {
-    fn from(value: U128) -> Self {
-        (value.0.0 as u128) << 64 | value.0.1 as u128
-    }
-}
-
-impl NetSerde for U128 {}
-
 #[cfg(test)]
 mod test {
     use bilrost::{Message, OwnedMessage};
-    use rand::random;
     use restate_encoding_derive::BilrostNewType;
-
-    use super::U128;
-
-    #[test]
-    fn test_u128() {
-        (0..100).for_each(|_| {
-            let num = random::<u128>();
-            let value = U128::from(num);
-
-            assert_eq!(num, u128::from(value));
-        });
-    }
 
     #[derive(BilrostNewType)]
     struct MyId(u64);

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -905,7 +905,9 @@ macro_rules! ulid_backed_id {
                 Ord,
                 serde_with::SerializeDisplay,
                 serde_with::DeserializeFromStr,
+                ::restate_encoding::BilrostAs
             )]
+            #[bilrost_as([< $res_name IdMessage >])]
             pub struct [< $res_name Id >](pub(crate) Ulid);
 
             impl [< $res_name Id >] {
@@ -967,6 +969,21 @@ macro_rules! ulid_backed_id {
 
                 fn json_schema(g: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
                     <String as schemars::JsonSchema>::json_schema(g)
+                }
+            }
+
+            #[derive(::bilrost::Message)]
+            struct [< $res_name IdMessage >](::restate_encoding::U128);
+
+            impl From<&[< $res_name Id >]> for [< $res_name IdMessage >] {
+                fn from(value: &[< $res_name Id >]) -> Self {
+                    Self(u128::from(value.0).into())
+                }
+            }
+
+            impl From<[< $res_name IdMessage >]> for [< $res_name Id >] {
+                fn from(value: [< $res_name IdMessage >]) -> Self {
+                    Self(u128::from(value.0).into())
                 }
             }
         }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -51,6 +51,14 @@ pub mod storage;
 pub mod time;
 pub mod timer;
 
+use std::num::NonZero;
+use std::ops::RangeInclusive;
+
+use bilrost::encoding::{EmptyState, ForOverwrite, General, ValueDecoder, ValueEncoder, Wiretyped};
+use serde_with::serde_as;
+
+use restate_encoding::{BilrostAs, BilrostDisplayFromStr, NetSerde};
+
 pub use id_util::{IdDecoder, IdEncoder, IdResourceType, IdStrCursor};
 pub use node_id::*;
 pub use version::*;
@@ -72,5 +80,326 @@ impl Merge for bool {
         } else {
             false
         }
+    }
+}
+
+/// A bilrost compatible wrapper to be used instead of Option<NonZero<T>> that encodes
+/// as `zero` if is set to None.
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
+pub struct OptionNonZero<P>(Option<P>);
+
+impl<P> Default for OptionNonZero<P> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<Primitive> NetSerde for OptionNonZero<Primitive> where Primitive: NetSerde {}
+
+macro_rules! impl_option_non_zero {
+    ($t:ty) => {
+        impl From<OptionNonZero<$t>> for Option<NonZero<$t>> {
+            fn from(value: OptionNonZero<$t>) -> Self {
+                value
+                    .0
+                    .map(|v| NonZero::<$t>::try_from(v).expect("is non-zero"))
+            }
+        }
+
+        impl From<Option<NonZero<$t>>> for OptionNonZero<$t> {
+            fn from(value: Option<NonZero<$t>>) -> Self {
+                Self(value.map(|v| v.get()))
+            }
+        }
+    };
+    ($($t:ty),+) => {
+        $(impl_option_non_zero!($t);)+
+    }
+}
+
+impl_option_non_zero!(u8, u16, u32, u64, usize);
+
+impl<P> ValueEncoder<General> for OptionNonZero<P>
+where
+    P: ValueEncoder<General> + Default + Copy,
+{
+    fn encode_value<B: ::bytes::BufMut + ?Sized>(value: &Self, buf: &mut B) {
+        let value = value.0.unwrap_or_default();
+        <P as ValueEncoder<General>>::encode_value(&value, buf)
+    }
+
+    fn value_encoded_len(value: &Self) -> usize {
+        let value = value.0.unwrap_or_default();
+        <P as ValueEncoder<General>>::value_encoded_len(&value)
+    }
+
+    fn prepend_value<B: bilrost::buf::ReverseBuf + ?Sized>(value: &Self, buf: &mut B) {
+        let value = value.0.unwrap_or_default();
+        <P as ValueEncoder<General>>::prepend_value(&value, buf)
+    }
+}
+
+#[allow(clippy::all)]
+impl<P> ValueDecoder<General> for OptionNonZero<P>
+where
+    P: ValueDecoder<General> + Default + Copy + PartialEq,
+{
+    fn decode_value<B: ::bytes::Buf + ?Sized>(
+        value: &mut Self,
+        buf: ::bilrost::encoding::Capped<B>,
+        ctx: ::bilrost::encoding::DecodeContext,
+    ) -> ::std::result::Result<(), ::bilrost::DecodeError> {
+        let zero = P::default();
+        let mut inner = zero;
+        <P as ValueDecoder<General>>::decode_value(&mut inner, buf, ctx)?;
+        if inner != zero {
+            value.0 = Some(inner);
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::all)]
+impl<P> Wiretyped<General> for OptionNonZero<P>
+where
+    P: Wiretyped<General>,
+{
+    const WIRE_TYPE: ::bilrost::encoding::WireType = <P as Wiretyped<General>>::WIRE_TYPE;
+}
+
+#[allow(clippy::all)]
+impl<P> EmptyState for OptionNonZero<P> {
+    fn clear(&mut self) {
+        self.0 = None;
+    }
+    fn empty() -> Self
+    where
+        Self: Sized,
+    {
+        Self::default()
+    }
+    fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+impl<P> ForOverwrite for OptionNonZero<P> {
+    fn for_overwrite() -> Self
+    where
+        Self: Sized,
+    {
+        Self::default()
+    }
+}
+
+/// A newtype wrapper around [`enumset::EnumSet`] enabling
+/// serialization and deserialization as a Bilrost message.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    BilrostAs,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::Deref,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Display,
+)]
+#[bilrost_as(EnumSetMessage)]
+pub struct NetEnumSet<T>(enumset::EnumSet<T>)
+where
+    T: enumset::EnumSetType + 'static;
+
+impl<T> NetSerde for NetEnumSet<T> where T: NetSerde + enumset::EnumSetType {}
+
+impl<T> Default for NetEnumSet<T>
+where
+    T: enumset::EnumSetType,
+{
+    fn default() -> Self {
+        Self(enumset::EnumSet::empty())
+    }
+}
+
+#[derive(bilrost::Message)]
+struct EnumSetMessage(u64);
+
+impl<T> From<&NetEnumSet<T>> for EnumSetMessage
+where
+    T: enumset::EnumSetType,
+{
+    fn from(value: &NetEnumSet<T>) -> Self {
+        Self(value.0.as_u64())
+    }
+}
+
+impl<T> From<EnumSetMessage> for NetEnumSet<T>
+where
+    T: enumset::EnumSetType + 'static,
+{
+    fn from(value: EnumSetMessage) -> Self {
+        Self(enumset::EnumSet::<T>::from_u64_truncated(value.0))
+    }
+}
+
+impl<T> From<T> for NetEnumSet<T>
+where
+    T: enumset::EnumSetType,
+{
+    fn from(value: T) -> Self {
+        enumset::EnumSet::from(value).into()
+    }
+}
+
+/// A newtype wrapper around [`RangeInclusive<Idx>`] enabling
+/// serialization and deserialization as a Bilrost message.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BilrostAs,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::Deref,
+    derive_more::From,
+    derive_more::Into,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[bilrost_as(RangeInclusiveMessage<Idx>)]
+pub struct NetRangeInclusive<Idx>(RangeInclusive<Idx>)
+where
+    Idx: Copy + EmptyState + ValueEncoder<General> + ValueDecoder<General> + 'static;
+
+impl<Idx> Default for NetRangeInclusive<Idx>
+where
+    Idx: Copy + EmptyState + ValueEncoder<General> + ValueDecoder<General>,
+{
+    fn default() -> Self {
+        Self(RangeInclusive::new(Idx::empty(), Idx::empty()))
+    }
+}
+
+#[derive(bilrost::Message)]
+struct RangeInclusiveMessage<Idx>((Idx, Idx))
+where
+    Idx: EmptyState + ValueEncoder<General> + ValueDecoder<General>;
+
+impl<Idx> From<&NetRangeInclusive<Idx>> for RangeInclusiveMessage<Idx>
+where
+    Idx: Copy + EmptyState + ValueEncoder<General> + ValueDecoder<General>,
+{
+    fn from(value: &NetRangeInclusive<Idx>) -> Self {
+        Self((*value.0.start(), *value.0.end()))
+    }
+}
+
+impl<Idx> From<RangeInclusiveMessage<Idx>> for NetRangeInclusive<Idx>
+where
+    Idx: Copy + EmptyState + ValueEncoder<General> + ValueDecoder<General>,
+{
+    fn from(value: RangeInclusiveMessage<Idx>) -> Self {
+        Self(RangeInclusive::new(value.0.0, value.0.1))
+    }
+}
+
+/// A newtype wrapper around [`serde_json::Value`] enabling
+/// serialization and deserialization as a Bilrost message.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Deref,
+    derive_more::Display,
+    derive_more::FromStr,
+    serde::Serialize,
+    serde::Deserialize,
+    BilrostAs,
+)]
+#[bilrost_as(BilrostDisplayFromStr)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct NetJsonValue(serde_json::Value);
+
+impl Default for NetJsonValue {
+    fn default() -> Self {
+        Self(serde_json::Value::Null)
+    }
+}
+
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Deref,
+    derive_more::Display,
+    derive_more::FromStr,
+    serde::Serialize,
+    serde::Deserialize,
+    BilrostAs,
+)]
+#[bilrost_as(BilrostDisplayFromStr)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct NetHumanDuration(
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
+    humantime::Duration,
+);
+
+impl Default for NetHumanDuration {
+    fn default() -> Self {
+        Self(humantime::Duration::from(std::time::Duration::from_secs(0)))
+    }
+}
+
+impl From<std::time::Duration> for NetHumanDuration {
+    fn from(value: std::time::Duration) -> Self {
+        Self(humantime::Duration::from(value))
+    }
+}
+
+impl From<NetHumanDuration> for std::time::Duration {
+    fn from(value: NetHumanDuration) -> Self {
+        value.0.into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bilrost::{Message, OwnedMessage};
+    use bytes::BytesMut;
+
+    use crate::NetJsonValue;
+
+    #[test]
+    fn json_value() {
+        #[derive(bilrost::Message)]
+        struct Message {
+            payload: NetJsonValue,
+        }
+
+        let m = Message {
+            payload: serde_json::json!({
+                "hello": "World",
+            })
+            .into(),
+        };
+
+        let mut buf = BytesMut::new();
+        m.encode(&mut buf).unwrap();
+
+        let loaded = Message::decode(buf).unwrap();
+
+        assert_eq!(m.payload.0, loaded.payload.0);
     }
 }

--- a/crates/types/src/net/codec.rs
+++ b/crates/types/src/net/codec.rs
@@ -109,7 +109,8 @@ pub fn encode_as_bilrost<T: bilrost::Message>(
         "bilrost encoding is supported from protocol version v2"
     );
 
-    value.encode_to_bytes()
+    let buf = value.encode_fast();
+    Bytes::from(buf.into_vec())
 }
 
 pub fn decode_as_bilrost<T: OwnedMessage>(

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -6,10 +6,12 @@ This directory contains documentation relevant for Restate developers.
 
 [development-guidelines.md](development-guidelines.md) contains guidelines for the development in this repository.
 
-[local-development.md](local-development.md) contains recommendations for how to set up the local development environment. 
+[local-development.md](local-development.md) contains recommendations for how to set up the local development environment.
 
 [rust-guidelines.md](rust-guidelines.md) contains guidelines for coding Rust.
 
 [debug.md](debug.md) contains some tips for debugging the runtime.
 
 [release.md](release.md) contains explanation for how to release the runtime.
+
+[bilrost-migration-guidelines](bilrost-migration-guidelines.md) guidelines on how to create bilrost messages and how to migrate current serde messages to bilrost without breaking compatibility

--- a/docs/dev/bilrost-migration-guidelines.md
+++ b/docs/dev/bilrost-migration-guidelines.md
@@ -1,0 +1,239 @@
+# Bilrost best practice
+Over the course of integrating bilrost into our project—particularly for network serialization and storage encoding—we’ve developed a few guidelines to streamline its usage. Our primary objective has been to adopt bilrost in a way that preserves compatibility with existing serde-based structures. In some cases, our existing types were already compatible and could derive bilrost::Message directly with minimal changes.
+
+To avoid the overhead of maintaining parallel DTOs, we recommend designing new structures to be bilrost-friendly from the start. This approach simplifies serialization logic and reduces redundancy as the project evolves.
+
+## Supported types
+
+Luckily bilrost supports a wide range of built-in types and 3rd party types as well (for example `ByteString`, `Bytes` , and more) **but** it lacks support for something native like `u128` (same as protobuf btw). This makes it a bit tedious to support something like `Ulid` and all `Ulid` derived IDs.
+
+To work around this I had to create my own custom `U128` which internally stores itss value as a `(u64, u64)` but of course I need to create a DTO for every structure that uses `Ulid` driven IDs.
+
+
+
+<aside>
+💡
+
+> *Rule #1*: Avoid using u128 🤷 for network/storage types, If you must, use our `::restate_encoding::U128` type.
+
+> *Note*: All Ulid based types in restate repo already can be used in bilrost Messages with no issues. They leverage on `U128` and `BilrostAs` to serialize itself
+</aside>
+
+## Enums
+
+`bilrost` makes a clear distinction between a `numberic` enum (represented as an integer value) , and `fat` enums. This was the most annoying thing to work with due to the following
+
+### Numeric (slim) Enums
+
+```rust
+// Before
+enum MySlimEnum {
+	FirstVariant,
+	SecondVariant
+}
+```
+
+```rust
+// After
+#[derive(
+    PartialEq,
+    Eq,
+    bilrost::Enumeration
+)]
+enum MySlimEnum {
+    Unknown = 0,
+    FirstVariant = 1,
+    SecondVariant = 2,
+}
+```
+
+- Enum variants must be assigned to tags, either by the `=` sign or by using the `#[bilrost(<tag>)]` annotation on each attribute
+- Enum must have an empty state of value `zero` If this not possible then the enum has to be used as an option field
+
+```rust
+#[derive(PartialEq, Eq, bilrost::Enumeration)]
+enum MySlimEnum {
+    #[bilrost(1)]
+    FirstVariant,
+    #[bilrost(2)]
+    SecondVariant,
+}
+
+#[derive(bilrost::Message)]
+struct MyStruct {
+		// This works because although the enum has NO empty state (0)
+		// the field here is optional
+    slim: Option<MySlimEnum>,
+}
+```
+
+```rust
+#[derive(PartialEq, Eq, bilrost::Enumeration)]
+enum MySlimEnum {
+    #[bilrost(0)]
+    Unknown,
+    #[bilrost(1)]
+    FirstVariant,
+    #[bilrost(2)]
+    SecondVariant,
+}
+
+#[derive(bilrost::Message)]
+struct MyStruct {
+    // This will also work because the Enum now has EmptyState (Unknown)
+    slim: MySlimEnum,
+}
+```
+
+```rust
+#[derive(PartialEq, Eq, bilrost::Enumeration)]
+enum MySlimEnum {
+    #[bilrost(1)]
+    FirstVariant,
+    #[bilrost(2)]
+    SecondVariant,
+}
+
+#[derive(bilrost::Message)]
+struct MyStruct {
+		// This will not compile! (required field but no empty state)
+    slim: MySlimEnum,
+}
+```
+
+### Fat Enums
+
+This works completely different from above. It’s mainly because fat enums translate to a `Oneof` field (similar to protobuf `oneof`) this then enforces the following rules.
+
+- You also need to have an `EmptyState` an empty variant that carries no data, otherwise you need your field to also become `Option` (that’s where the similarity with numeric enums ends)
+- Your enum must derive `bilrost::Oneof`
+- Each variant must carry **EXACTLY** one value. Only **ONE** empty enum variant can show up at the top of the enum to work as the “empty state” AND it must be `untagged`
+
+```rust
+// Derives Oneof
+#[derive(bilrost::Oneof)]
+enum MyFatEnum {
+		// the only place where the empty state can appear
+		// and it's the only variant that is not associated with
+		// a value
+    Unknown,
+    // It will be clear why I am starting from 2 here later in this document
+    // and not from 1
+    //
+    // Also there is exactly one value (in this cause a u64)
+    #[bilrost(2)]
+    FirstVariant(u64),
+    #[bilrost(3)]
+    // this also carries a single value of type tuple(u64, u64)
+    SecondVariant((u64, u64)),
+    // this also works
+    #[bilrost(4)]
+    ThirdVariant {
+        name: String,
+    },
+    /// This one will not work
+    // FourthVariant(u64, u64)
+    /// Neither this
+    // FifthVariant{value: u64, name: String}
+}
+
+```
+
+To use this inside your struct you need to do the following
+
+```rust
+#[derive(bilrost::Message)]
+struct MyStruct {
+    #[bilrost(1)]
+    id: String,
+    #[bilrost(oneof(2, 3, 4))]
+    fat: MyFatEnum,
+}
+```
+
+You notice the following:
+
+When using your `MyFatEnum` type, you need to make sure you use the `#[bilrost(oneof(<all possible tags>))]` annotations as shown in the example.
+
+The tags **MUST** be unique inside your container message. This is why the enum variants were starting from `2` and not the logical `1` (since in my container type `MyStruct` 1 was already taken)
+
+This is mainly because the enum variant is “flattened” inside the container message.
+
+You can see how this becomes tedious task when you try to reuse your enum in another structure since now your enum tags are fixed at `2, 3, and 4` it’s now impossible to extend a struct that already has `2` assigned
+
+```rust
+// NOT POSSIBLE
+struct MyOtherStructure{
+	#[bilrost(1)]
+	id: String,
+	#[bilrost(2)]
+	value: SomeMessage
+	// This is not possible now because 2 is alread
+	// taken by the above field.
+	#[bilrost(oneof(2, 3, 4)]
+	fat: MyFatEnum,
+}
+```
+
+To work around this issue, your fat enums must be wrapped. in it’s own mesage
+
+```rust
+
+#[derive(bilrost::Message)]
+struct MyFatEnumWrapper(#[bilrost(oneof(2,3,4))] MyFatEnum);
+
+// then use it normally as a sub-message
+struct MyStruct {
+     #[bilrost(1)]
+    id: String,
+    #[bilrost(2)]
+    fat: MyFatEnumWrapper,
+}
+
+struct MyOtherStructure{
+	#[bilrost(1)]
+	id: String,
+	#[bilrost(2)]
+	value: SomeMessage
+	// This is now possible because MyFatEnumWrapper
+	// is just it's own sub-message
+	#[bilrost(3)]
+	fat: MyFatEnumWrapper,
+}
+```
+
+<aside>
+💡
+
+> *Rule #2*: If your Fat enums are reusable, they need to be wrapped in a special wrapper that can be used in all container messages.
+
+</aside>
+
+## Backward compatibility
+
+When migrating some structures/messages to Bilrost an extra care must be taken to avoid breaking compatibility with V1. This means the serde serialisation can not be changes (flexbuffer/serde) this forces us most of the time to stick with the current available structure.
+
+The problem arise when we face a type that is not serialisable with bilrost. For example (non-exhaustive list):
+
+- An enum that has incompatible variants
+
+    ```rust
+    pub enum InputContentType {
+        /// `*/*`
+        #[default]
+        Any,
+        /// `<MIME_type>/*`
+        MimeType(ByteString),
+        /// `<MIME_type>/<MIME_subtype>`
+        MimeTypeAndSubtype(ByteString, ByteString),
+    }
+    ```
+
+- Foreign types that are not serialisable with bilrost (for example `humantime::Duration`
+
+To work around this usually we have 2 solutions.
+
+- For types that is not compatible, usually a `BilrostAs` macro can become handy to fix this issue.
+    - Usage [examples](https://github.com/restatedev/restate/blob/main/crates/encoding/tests/bilrost.rs)
+- For foreign types, we normally create a `NewType` that wraps the foreign type, then use `BilrostAs`
+    - [Example](https://github.com/restatedev/restate/pull/3212/files#diff-c88bdf6293027da569d1e0b6d02a108f116197d27258b0bb4b107bbdc82472b3R163)  that creates a new type for `RangeInclusive<Idx>`


### PR DESCRIPTION
Bilrost fast encoding + more common helper types

Summary:
- Switch to Birlost fast encoding with ReverseBuffer
- Introduce changes to the BilrostAs that allows us to implement
Generic typed messages.
- Create an EnumSet wrapper type that can serialize itself as Birlost
- Create a RangeInclusive wrapper type that can serialize itself as Birlost
message.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3222).
* #3212
* __->__ #3222