### PR TITLE
Add restate_version in ServiceInvocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,6 +7764,7 @@ dependencies = [
  "restate-types",
  "restate-utoipa",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ rocksdb = { version = "0.41.0", package = "rust-rocksdb", features = ["multi-thr
 rstest = "0.24.0"
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
+semver = {  version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.8"

--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -29,7 +29,7 @@ use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNu
 use restate_types::GenerationalNodeId;
 use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionProcessorRpcRequestId};
 use restate_types::invocation::{
-    InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext,
+    InvocationTarget, RestateVersion, ServiceInvocation, ServiceInvocationSpanContext,
 };
 use restate_types::journal_v2::CommandType;
 use restate_types::journal_v2::raw::{RawCommand, RawEntry, RawEntryHeader, RawEntryInner};
@@ -95,6 +95,7 @@ fn invoke_cmd() -> Command {
         submit_notification_sink: Some(
             restate_types::invocation::SubmitNotificationSink::Ingress { request_id },
         ),
+        restate_version: RestateVersion::current(),
     })
 }
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -56,7 +56,7 @@ prost-dto = { workspace = true }
 rand = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
-semver = {  version = "1.0", features = ["serde"] }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -144,6 +144,7 @@ message InvocationStatusV2 {
   repeated ServiceInvocationResponseSink response_sinks = 7;
   Duration completion_retention_duration = 11;
   Duration journal_retention_duration = 29;
+  string created_using_restate_version = 30;
 
   // Timestamps
   uint64 creation_time = 5;
@@ -333,6 +334,7 @@ message ServiceInvocation {
   optional string idempotency_key = 10;
   SubmitNotificationSink submit_notification_sink = 11;
   Duration journal_retention_duration = 12;
+  string restate_version = 13;
 }
 
 message StateMutation {

--- a/crates/partition-store/src/protobuf_types.rs
+++ b/crates/partition-store/src/protobuf_types.rs
@@ -408,6 +408,7 @@ pub mod v1 {
                     source,
                     span_context,
                     creation_time,
+                    created_using_restate_version,
                     modification_time,
                     response_sinks,
                     inboxed_transition_time,
@@ -435,6 +436,8 @@ pub mod v1 {
                 } = value;
 
                 let invocation_target = expect_or_fail!(invocation_target)?.try_into()?;
+                let created_using_restate_version =
+                    restate_version_from_pb(created_using_restate_version);
                 let timestamps =
                     restate_storage_api::invocation_status_table::StatusTimestamps::new(
                         MillisSinceEpoch::new(creation_time),
@@ -469,6 +472,7 @@ pub mod v1 {
                                         response_sinks,
                                         timestamps,
                                         invocation_target,
+                                        created_using_restate_version,
                                         argument: expect_or_fail!(argument)?,
                                         source,
                                         span_context: expect_or_fail!(span_context)?.try_into()?,
@@ -496,6 +500,7 @@ pub mod v1 {
                                         response_sinks,
                                         timestamps,
                                         invocation_target,
+                                        created_using_restate_version,
                                         argument: expect_or_fail!(argument)?,
                                         source,
                                         span_context: expect_or_fail!(span_context)?.try_into()?,
@@ -520,6 +525,7 @@ pub mod v1 {
                                 response_sinks,
                                 timestamps,
                                 invocation_target,
+                                created_using_restate_version,
                                 journal_metadata: restate_storage_api::invocation_status_table::JournalMetadata {
                                     length: journal_length,
                                     commands,
@@ -553,6 +559,7 @@ pub mod v1 {
                                 response_sinks,
                                 timestamps,
                                 invocation_target,
+                                created_using_restate_version,
                                 journal_metadata: restate_storage_api::invocation_status_table::JournalMetadata {
                                     length: journal_length,
                                     commands,
@@ -601,6 +608,7 @@ pub mod v1 {
                             restate_storage_api::invocation_status_table::CompletedInvocation {
                                 timestamps,
                                 invocation_target,
+                                created_using_restate_version,
                                 source,
                                 execution_time: execution_time.map(MillisSinceEpoch::new),
                                 idempotency_key: idempotency_key.map(ByteString::from),
@@ -642,7 +650,7 @@ pub mod v1 {
                                     response_sinks,
                                     timestamps,
                                     invocation_target,
-                                    argument,
+                                    created_using_restate_version, argument,
                                     source,
                                     span_context,
                                     headers,
@@ -658,6 +666,7 @@ pub mod v1 {
                         span_context: Some(span_context.into()),
                         // SAFETY: We're only mapping data types here
                         creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                        created_using_restate_version: created_using_restate_version.into_string(),
                         modification_time: unsafe { timestamps.modification_time() }.as_u64(),
                         inboxed_transition_time: unsafe { timestamps.inboxed_transition_time() }
                             .map(|t| t.as_u64()),
@@ -701,7 +710,7 @@ pub mod v1 {
                                     response_sinks,
                                     timestamps,
                                     invocation_target,
-                                    argument,
+                                    created_using_restate_version, argument,
                                     source,
                                     span_context,
                                     headers,
@@ -718,6 +727,7 @@ pub mod v1 {
                         span_context: Some(span_context.into()),
                         // SAFETY: We're only mapping data types here
                         creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                        created_using_restate_version: created_using_restate_version.into_string(),
                         modification_time: unsafe { timestamps.modification_time() }.as_u64(),
                         inboxed_transition_time: unsafe { timestamps.inboxed_transition_time() }
                             .map(|t| t.as_u64()),
@@ -756,7 +766,7 @@ pub mod v1 {
                     restate_storage_api::invocation_status_table::InvocationStatus::Invoked(
                         restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                             invocation_target,
-                            journal_metadata,
+                            created_using_restate_version, journal_metadata,
                             pinned_deployment,
                             response_sinks,
                             timestamps,
@@ -785,8 +795,9 @@ pub mod v1 {
                             span_context: Some(journal_metadata.span_context.into()),
                             // SAFETY: We're only mapping data types here
                             creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                            created_using_restate_version: created_using_restate_version.into_string(),
                             modification_time: unsafe { timestamps.modification_time() }.as_u64(),
-                            inboxed_transition_time: unsafe {
+                       inboxed_transition_time: unsafe {
                                 timestamps.inboxed_transition_time()
                             }
                             .map(|t| t.as_u64()),
@@ -834,7 +845,7 @@ pub mod v1 {
                         metadata:
                             restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                                 invocation_target,
-                                journal_metadata,
+                                created_using_restate_version, journal_metadata,
                                 pinned_deployment,
                                 response_sinks,
                                 timestamps,
@@ -880,6 +891,7 @@ pub mod v1 {
                             span_context: Some(journal_metadata.span_context.into()),
                             // SAFETY: We're only mapping data types here
                             creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                            created_using_restate_version: created_using_restate_version.into_string(),
                             modification_time: unsafe { timestamps.modification_time() }.as_u64(),
                             inboxed_transition_time: unsafe {
                                 timestamps.inboxed_transition_time()
@@ -928,6 +940,7 @@ pub mod v1 {
                     restate_storage_api::invocation_status_table::InvocationStatus::Completed(
                         restate_storage_api::invocation_status_table::CompletedInvocation {
                             invocation_target,
+                            created_using_restate_version,
                             source,
                             execution_time, idempotency_key,
                             timestamps,
@@ -952,24 +965,26 @@ pub mod v1 {
                             span_context: Some(journal_metadata.span_context.into()),
                             // SAFETY: We're only mapping data types here
                             creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                            created_using_restate_version: created_using_restate_version.into_string(),
                             modification_time: unsafe { timestamps.modification_time() }.as_u64(),
                             inboxed_transition_time: unsafe { timestamps.inboxed_transition_time() }
                                 .map(|t| t.as_u64()),
                             scheduled_transition_time: unsafe {
                                 timestamps.scheduled_transition_time()
                             }
-                                .map(|t| t.as_u64()),
+                            .map(|t| t.as_u64()),
                             running_transition_time: unsafe { timestamps.running_transition_time() }
                                 .map(|t| t.as_u64()),
                             completed_transition_time: unsafe {
                                 timestamps.completed_transition_time()
                             }
-                                .map(|t| t.as_u64()),
+                            .map(|t| t.as_u64()),
                             response_sinks: vec![],
                             argument: None,
                             headers: vec![],
                             execution_time: execution_time.map(|t| t.as_u64()),
-                            completion_retention_duration: Some(completion_retention_duration.into()),    journal_retention_duration: Some(journal_retention_duration.into()),
+                            completion_retention_duration: Some(completion_retention_duration.into()),
+                            journal_retention_duration: Some(journal_retention_duration.into()),
                             idempotency_key: idempotency_key.map(|key| key.to_string()),
                             inbox_sequence_number: None,
                             journal_length: journal_metadata.length,
@@ -1225,6 +1240,8 @@ pub mod v1 {
                         journal_metadata,
                         pinned_deployment,
                         response_sinks,
+                        created_using_restate_version:
+                            restate_types::invocation::RestateVersion::unknown(),
                         timestamps:
                             restate_storage_api::invocation_status_table::StatusTimestamps::new(
                                 MillisSinceEpoch::new(value.creation_time),
@@ -1343,6 +1360,8 @@ pub mod v1 {
                 Ok((
                     restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                         invocation_target,
+                        created_using_restate_version:
+                            restate_types::invocation::RestateVersion::unknown(),
                         journal_metadata,
                         pinned_deployment,
                         response_sinks,
@@ -1470,6 +1489,7 @@ pub mod v1 {
                 Ok(restate_storage_api::invocation_status_table::InboxedInvocation {
                     inbox_sequence_number: value.inbox_sequence_number,
                     metadata: restate_storage_api::invocation_status_table::PreFlightInvocationMetadata {
+                        created_using_restate_version:   restate_types::invocation::RestateVersion::unknown(),
                         response_sinks,
                         timestamps: restate_storage_api::invocation_status_table::StatusTimestamps::new(
                             MillisSinceEpoch::new(value.creation_time),
@@ -1503,6 +1523,7 @@ pub mod v1 {
                             response_sinks,
                             timestamps,
                             invocation_target,
+                            created_using_restate_version: _,
                             argument,
                             source,
                             span_context,
@@ -1558,6 +1579,8 @@ pub mod v1 {
                 Ok(
                     restate_storage_api::invocation_status_table::CompletedInvocation {
                         invocation_target,
+                        created_using_restate_version:
+                            restate_types::invocation::RestateVersion::unknown(),
                         source,
                         timestamps:
                             restate_storage_api::invocation_status_table::StatusTimestamps::new(
@@ -1591,6 +1614,7 @@ pub mod v1 {
             ) -> Self {
                 let restate_storage_api::invocation_status_table::CompletedInvocation {
                     invocation_target,
+                    created_using_restate_version: _,
                     source,
                     execution_time: _,
                     idempotency_key,
@@ -1791,6 +1815,7 @@ pub mod v1 {
                     completion_retention_duration,
                     journal_retention_duration,
                     submit_notification_sink,
+                    restate_version,
                 } = value;
 
                 let invocation_id = restate_types::identifiers::InvocationId::try_from(
@@ -1854,6 +1879,7 @@ pub mod v1 {
                     journal_retention_duration,
                     idempotency_key,
                     submit_notification_sink,
+                    restate_version: restate_version_from_pb(restate_version),
                 })
             }
         }
@@ -1879,6 +1905,7 @@ pub mod v1 {
                     journal_retention_duration: Some(value.journal_retention_duration.into()),
                     idempotency_key: value.idempotency_key.map(|s| s.to_string()),
                     submit_notification_sink: value.submit_notification_sink.map(Into::into),
+                    restate_version: value.restate_version.into_string(),
                 }
             }
         }
@@ -3904,6 +3931,16 @@ pub mod v1 {
         impl From<JournalEntryIndex> for crate::journal_table_v2::JournalEntryIndex {
             fn from(value: JournalEntryIndex) -> Self {
                 Self::from(value.entry_index)
+            }
+        }
+
+        fn restate_version_from_pb(
+            restate_version: String,
+        ) -> restate_types::invocation::RestateVersion {
+            if restate_version.is_empty() {
+                restate_types::invocation::RestateVersion::unknown()
+            } else {
+                restate_types::invocation::RestateVersion::new(restate_version)
             }
         }
     }

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::RangeInclusive;
 use std::pin::pin;
-use std::time::Duration;
 
 use futures::Stream;
 use tokio_stream::StreamExt;
@@ -85,20 +84,11 @@ async fn test_read_write() {
 
 pub(crate) fn mock_service_invocation(service_id: ServiceId) -> ServiceInvocation {
     let invocation_target = InvocationTarget::mock_from_service_id(service_id);
-    ServiceInvocation {
-        invocation_id: InvocationId::mock_generate(&invocation_target),
+    ServiceInvocation::initialize(
+        InvocationId::mock_generate(&invocation_target),
         invocation_target,
-        argument: Default::default(),
-        source: Source::Ingress(PartitionProcessorRpcRequestId::new()),
-        response_sink: None,
-        span_context: Default::default(),
-        headers: vec![],
-        execution_time: None,
-        completion_retention_duration: Duration::ZERO,
-        journal_retention_duration: Duration::ZERO,
-        idempotency_key: None,
-        submit_notification_sink: None,
-    }
+        Source::Ingress(PartitionProcessorRpcRequestId::new()),
+    )
 }
 
 pub(crate) fn mock_random_service_invocation() -> ServiceInvocation {

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -61,6 +61,7 @@ const SYS_INVOCATION_VIEW: &str = "CREATE VIEW sys_invocation as SELECT
             ss.journal_size,
             ss.journal_commands_size,
             ss.created_at,
+            ss.created_using_restate_version,
             ss.modified_at,
             ss.inboxed_at,
             ss.scheduled_at,

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -69,6 +69,9 @@ pub(crate) fn append_invocation_status_row(
     match invocation_status {
         InvocationStatus::Scheduled(scheduled) => {
             row.status("scheduled");
+            row.created_using_restate_version(
+                scheduled.metadata.created_using_restate_version.as_str(),
+            );
             fill_invoked_by(&mut row, output, scheduled.metadata.source);
             if let Some(execution_time) = scheduled.metadata.execution_time {
                 row.scheduled_start_at(execution_time.as_u64() as i64)
@@ -76,6 +79,9 @@ pub(crate) fn append_invocation_status_row(
         }
         InvocationStatus::Inboxed(inboxed) => {
             row.status("inboxed");
+            row.created_using_restate_version(
+                inboxed.metadata.created_using_restate_version.as_str(),
+            );
             fill_invoked_by(&mut row, output, inboxed.metadata.source);
             if let Some(execution_time) = inboxed.metadata.execution_time {
                 row.scheduled_start_at(execution_time.as_u64() as i64)
@@ -91,6 +97,7 @@ pub(crate) fn append_invocation_status_row(
         }
         InvocationStatus::Completed(completed) => {
             row.status("completed");
+            row.created_using_restate_version(completed.created_using_restate_version.as_str());
             fill_invoked_by(&mut row, output, completed.source);
             if let Some(execution_time) = completed.execution_time {
                 row.scheduled_start_at(execution_time.as_u64() as i64)
@@ -117,6 +124,7 @@ fn fill_in_flight_invocation_metadata(
     output: &mut String,
     meta: InFlightInvocationMetadata,
 ) {
+    row.created_using_restate_version(meta.created_using_restate_version.as_str());
     // journal_metadata and stats are filled by other functions
     if let Some(pinned_deployment) = meta.pinned_deployment {
         row.pinned_deployment_id(pinned_deployment.deployment_id.to_string());

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -91,6 +91,9 @@ define_table!(sys_invocation_status(
     /// Timestamp indicating the start of this invocation.
     created_at: TimestampMillisecond,
 
+    /// restate-server version in use when this invocation was created.
+    created_using_restate_version: DataType::LargeUtf8,
+
     /// Timestamp indicating the last invocation status transition. For example, last time the
     /// status changed from `invoked` to `suspended`.
     modified_at: TimestampMillisecond,

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -155,6 +155,9 @@ pub fn sys_invocation_table_docs() -> OwnedTableDocs {
             .remove("created_at")
             .expect("created_at should exist"),
         sys_invocation_status
+            .remove("created_using_restate_version")
+            .expect("created_using_restate_version should exist"),
+        sys_invocation_status
             .remove("modified_at")
             .expect("modified_at should exist"),
         sys_invocation_status

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -100,6 +100,7 @@ futures = { workspace = true }
 tempfile = { workspace = true }
 googletest = { workspace = true }
 rand = { workspace = true }
+semver = { workspace = true }
 test-log = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/worker/src/partition/state_machine/entries/call_commands.rs
+++ b/crates/worker/src/partition/state_machine/entries/call_commands.rs
@@ -105,13 +105,8 @@ where
 
         // Prepare the service invocation to propose
         let service_invocation = ServiceInvocation {
-            invocation_id,
-            invocation_target,
             argument: parameter,
-            source: Source::Service(
-                self.caller_invocation_id,
-                caller_invocation_metadata.invocation_target.clone(),
-            ),
+            headers,
             response_sink: self.result_notification_idx.map(|notification_idx| {
                 ServiceInvocationResponseSink::partition_processor(
                     self.caller_invocation_id,
@@ -120,12 +115,18 @@ where
                 )
             }),
             span_context: span_context.clone(),
-            headers,
             execution_time: self.execution_time,
             completion_retention_duration,
             journal_retention_duration,
             idempotency_key,
-            submit_notification_sink: None,
+            ..ServiceInvocation::initialize(
+                invocation_id,
+                invocation_target,
+                Source::Service(
+                    self.caller_invocation_id,
+                    caller_invocation_metadata.invocation_target.clone(),
+                ),
+            )
         };
 
         ctx.handle_outgoing_message(OutboxMessage::ServiceInvocation(service_invocation))

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -63,9 +63,9 @@ use restate_types::invocation::client::InvocationOutputResponse;
 use restate_types::invocation::{
     AttachInvocationRequest, InvocationEpoch, InvocationQuery, InvocationResponse,
     InvocationTarget, InvocationTargetType, InvocationTermination, JournalCompletionTarget,
-    NotifySignalRequest, ResponseResult, ServiceInvocation, ServiceInvocationResponseSink,
-    ServiceInvocationSpanContext, Source, SubmitNotificationSink, TerminationFlavor,
-    VirtualObjectHandlerType, WorkflowHandlerType,
+    NotifySignalRequest, ResponseResult, RestateVersion, ServiceInvocation,
+    ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source, SubmitNotificationSink,
+    TerminationFlavor, VirtualObjectHandlerType, WorkflowHandlerType,
 };
 use restate_types::invocation::{InvocationInput, SpanRelation};
 use restate_types::journal::Completion;
@@ -2607,6 +2607,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                         journal_retention_duration: Default::default(),
                         idempotency_key: request.idempotency_key,
                         submit_notification_sink: None,
+                        restate_version: RestateVersion::current(),
                     };
 
                     self.handle_outgoing_message(OutboxMessage::ServiceInvocation(
@@ -2673,6 +2674,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     journal_retention_duration: Default::default(),
                     idempotency_key: request.idempotency_key,
                     submit_notification_sink: None,
+                    restate_version: RestateVersion::current(),
                 };
 
                 self.handle_outgoing_message(OutboxMessage::ServiceInvocation(service_invocation))

--- a/crates/worker/src/partition/state_machine/tests/fixtures.rs
+++ b/crates/worker/src/partition/state_machine/tests/fixtures.rs
@@ -155,12 +155,11 @@ pub async fn mock_start_invocation_with_invocation_target(
     let invocation_id = InvocationId::mock_generate(&invocation_target);
 
     let actions = state_machine
-        .apply(Command::Invoke(ServiceInvocation {
+        .apply(Command::Invoke(ServiceInvocation::initialize(
             invocation_id,
-            invocation_target: invocation_target.clone(),
-            source: Source::Ingress(PartitionProcessorRpcRequestId::new()),
-            ..ServiceInvocation::mock()
-        }))
+            invocation_target.clone(),
+            Source::Ingress(PartitionProcessorRpcRequestId::new()),
+        )))
         .await;
 
     assert_that!(

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -233,10 +233,11 @@ async fn complete_already_completed_invocation() {
         &invocation_id,
         &InvocationStatus::Completed(CompletedInvocation {
             invocation_target: invocation_target.clone(),
+            created_using_restate_version: RestateVersion::current(),
             source: Source::Ingress(PartitionProcessorRpcRequestId::new()),
             execution_time: None,
             idempotency_key: Some(idempotency_key.clone()),
-            timestamps: StatusTimestamps::now(),
+            timestamps: StatusTimestamps::mock(),
             response_result: ResponseResult::Success(response_bytes.clone()),
             completion_retention_duration: Default::default(),
             journal_retention_duration: Default::default(),

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -914,13 +914,14 @@ async fn send_ingress_response_to_multiple_targets() -> TestResult {
 
     let actions = test_env
         .apply(Command::Invoke(ServiceInvocation {
-            invocation_id,
-            invocation_target: invocation_target.clone(),
-            source: Source::Ingress(request_id_1),
             response_sink: Some(ServiceInvocationResponseSink::Ingress {
                 request_id: request_id_1,
             }),
-            ..ServiceInvocation::mock()
+            ..ServiceInvocation::initialize(
+                invocation_id,
+                invocation_target.clone(),
+                Source::Ingress(request_id_1),
+            )
         }))
         .await;
     assert_that!(


### PR DESCRIPTION
Fix #3197.
This adds two metadata in sys_invocation exposing the restate version the invocation was created in, and the version it was last modified in.