### PR TITLE
[FailureDetector] Gossip-based failure detection system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7267,6 +7267,7 @@ dependencies = [
 name = "restate-node"
 version = "1.3.3-dev"
 dependencies = [
+ "ahash 0.8.11",
  "anyhow",
  "async-trait",
  "axum",
@@ -7274,14 +7275,17 @@ dependencies = [
  "bytestring",
  "codederror",
  "derive_builder",
+ "derive_more",
  "enumset",
  "futures",
  "googletest",
  "http 1.2.0",
+ "itertools 0.14.0",
  "jemalloc_pprof",
  "metrics",
  "metrics-exporter-prometheus",
  "prost-dto",
+ "rand 0.9.0",
  "restate-admin",
  "restate-bifrost",
  "restate-core",

--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -129,7 +129,7 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
                                 network_sender
                                     .call_rpc(
                                         node_id,
-                                        Swimlane::Gossip,
+                                        Swimlane::General,
                                         GetNodeState::default(),
                                         None,
                                         Some(heartbeat_timeout),

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -961,7 +961,7 @@ mod tests {
             .connection_manager()
             .accept_fake_server_connection(
                 GenerationalNodeId::new(2, 2),
-                Swimlane::Gossip,
+                Swimlane::General,
                 ConnectionDirection::Bidirectional,
                 // let node2 receive messages and use the same message handler as node1
                 Some(router.build().into()),
@@ -1285,7 +1285,7 @@ mod tests {
             .connection_manager()
             .accept_fake_server_connection(
                 GenerationalNodeId::new(2, 2),
-                Swimlane::Gossip,
+                Swimlane::General,
                 ConnectionDirection::Bidirectional,
                 Some(router.build().into()),
             )

--- a/crates/core/src/network/connection/throttle.rs
+++ b/crates/core/src/network/connection/throttle.rs
@@ -58,6 +58,14 @@ impl ConnectThrottle {
         Ok(())
     }
 
+    /// Resets the connection throttle for the given destination.
+    pub fn reset(dest: &Destination) {
+        let mut last_failures = THROTTLE.destination_state.write();
+        if last_failures.remove(dest).is_some() {
+            trace!("Connection throttling to {} has been reset", dest);
+        }
+    }
+
     /// If the connection fails, record the time so we reject attempts for a while, and
     /// it resets the deadline to zero if connection was successful.
     pub fn note_connect_status(dest: &Destination, success: bool) {

--- a/crates/core/src/network/io/egress_stream.rs
+++ b/crates/core/src/network/io/egress_stream.rs
@@ -265,6 +265,10 @@ impl EgressStream {
         Self::new(10)
     }
 
+    pub fn with_capacity(capacity: usize) -> (EgressSender, Self, super::Shared) {
+        Self::new(capacity)
+    }
+
     fn new(capacity: usize) -> (EgressSender, Self, super::Shared) {
         let (unbounded_tx, unbounded) = mpsc::unbounded_channel();
         let (tx, rx) = mpsc::channel(capacity);

--- a/crates/core/src/network/lazy_connection.rs
+++ b/crates/core/src/network/lazy_connection.rs
@@ -149,6 +149,11 @@ impl LazyConnection {
     }
 
     #[must_use]
+    pub fn has_capacity(&self) -> bool {
+        self.is_connected() && self.sender.capacity() > 0
+    }
+
+    #[must_use]
     pub fn is_connected(&self) -> bool {
         !self.is_closed() && self.is_connected.load(Ordering::Relaxed)
     }

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -30,7 +30,7 @@ mod tracking;
 pub mod transport_connector;
 mod types;
 
-pub use connection::{Connection, UnboundedConnectionRef};
+pub use connection::{ConnectThrottle, Connection, UnboundedConnectionRef};
 pub use connection_manager::ConnectionManager;
 pub use error::*;
 pub use grpc::GrpcConnector;

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -92,6 +92,8 @@ pub enum TaskKind {
     RoleRunner,
     /// Cluster controller is the first thing that gets stopped when the server is shut down
     ClusterController,
+    #[strum(props(runtime = "default"))]
+    FailureDetector,
     SystemService,
     #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     Ingress,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -34,6 +34,7 @@ restate-tracing-instrumentation = { workspace = true, features = ["prometheus"] 
 restate-types = { workspace = true, features = ["clap"] }
 restate-worker = { workspace = true }
 
+ahash = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
@@ -41,12 +42,15 @@ bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
+derive_more = { workspace = true }
 enumset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+itertools = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 prost-dto = { workspace = true }
+rand = { workspace = true }
 rocksdb = { workspace = true }
 schemars = { workspace = true, optional = true }
 semver = {  version = "1.0", features = ["serde"] }

--- a/crates/node/src/failure_detector.rs
+++ b/crates/node/src/failure_detector.rs
@@ -8,75 +8,271 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tracing::debug;
+mod fd_state;
+mod node_state;
 
+use std::time::Duration;
+
+use metrics::counter;
+use tokio::time::Instant;
+use tokio::time::MissedTickBehavior;
+use tokio_stream::StreamExt as TokioStreamExt;
+use tracing::{debug, info, trace, warn};
+
+use restate_core::network::NetworkSender;
 use restate_core::{
-    ShutdownError, TaskCenter, TaskKind,
+    Metadata, MetadataKind, ShutdownError, TaskCenter, TaskKind,
     network::{
-        BackPressureMode, Buffered, Drain, Handler, Incoming, MessageRouterBuilder, RawSvcRpc,
-        Verdict,
+        BackPressureMode, Incoming, MessageRouterBuilder, RawSvcRpc, RawSvcUnary, ServiceMessage,
+        ServiceReceiver, Verdict,
     },
     task_center::TaskCenterMonitoring,
     worker_api::ProcessorsManagerHandle,
 };
-use restate_types::net::node::{GetNodeState, GossipService, NodeStateResponse};
-use restate_types::protobuf::common::NodeStatus;
+use restate_types::health::NodeStatus;
+use restate_types::live::LiveLoad;
+use restate_types::net::node::Gossip;
+use restate_types::net::node::GossipFlags;
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{
+    config::GossipOptions,
+    net::node::{GetNodeState, GossipService, NodeStateResponse},
+};
 
-pub struct FailureDetector {
+use crate::metric_definitions::GOSSIP_SENT;
+
+use self::fd_state::Error;
+use self::fd_state::FdState;
+
+pub struct FailureDetector<T> {
+    networking: T,
     processor_manager_handle: Option<ProcessorsManagerHandle>,
-    gossip_rx: Buffered<GossipService>,
+    gossip_svc_rx: ServiceReceiver<GossipService>,
+    gossip_interval: tokio::time::Interval,
+    last_dumped: Instant,
 }
 
-impl FailureDetector {
+impl<T: NetworkSender> FailureDetector<T> {
     pub fn new(
+        opts: &GossipOptions,
+        networking: T,
         router_builder: &mut MessageRouterBuilder,
         processor_manager_handle: Option<ProcessorsManagerHandle>,
     ) -> Self {
-        let gossip_rx = router_builder.register_buffered_service(1024, BackPressureMode::Lossy);
+        let gossip_svc_rx = router_builder.register_service(128, BackPressureMode::Lossy);
+        let mut gossip_interval = tokio::time::interval(*opts.gossip_tick_interval);
+        gossip_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         Self {
+            networking,
             processor_manager_handle,
-            gossip_rx,
+            gossip_svc_rx,
+            gossip_interval,
+            last_dumped: Instant::now(),
         }
     }
 
-    pub fn start(self) -> Result<(), ShutdownError> {
-        // gossip service is running as unmanaged task to delay its termination until the very end
-        TaskCenter::spawn_unmanaged(
-            TaskKind::SystemService,
-            "fd-network-service",
-            self.gossip_rx.run(GossipHandler {
-                processor_manager_handle: self.processor_manager_handle,
-            }),
-        )?;
+    pub fn start(
+        self,
+        opts: impl LiveLoad<Live = GossipOptions> + 'static,
+    ) -> Result<(), ShutdownError> {
+        // Note that the failure detector is an unmanaged task because we want it to continue
+        // running until the very end of the node's lifecycle. If this was spawn(), then task
+        // center will need to wait for the task to terminate before it can shutdown.
+        TaskCenter::spawn_unmanaged(TaskKind::FailureDetector, "failure-detector", async {
+            if let Err(e) = self.run(opts).await {
+                // We request shutdown of the node. FD can only fail in unrecoverable errors.
+                //
+                // The handling is manual because this is an unmanaged task.
+                TaskCenter::current().shutdown_node(&e.to_string(), 1).await;
+            }
+        })?;
+        Ok(())
+    }
+
+    pub async fn run(
+        mut self,
+        mut opts: impl LiveLoad<Live = GossipOptions> + 'static,
+    ) -> anyhow::Result<()> {
+        debug!("Failure Detector Starting");
+        let (my_node_id, mut nodes_config, mut nodes_config_watch) = Metadata::with_current(|m| {
+            (
+                m.my_node_id(),
+                m.updateable_nodes_config(),
+                m.watch(MetadataKind::NodesConfiguration),
+            )
+        });
+
+        let mut shutting_down = false;
+        let (my_node_health, cs_updater) =
+            TaskCenter::with_current(|tc| (tc.health().clone(), tc.cluster_state_updater()));
+        let mut fd_state = FdState::new(my_node_id, nodes_config.live_load(), cs_updater);
+        // We are starting up. let others know as early as possible so they can update their
+        // nodes configuration, and implicitly start the suspect timer for this node.
+        let mut my_node_status_watch = my_node_health.node_status().subscribe();
+
+        // We send the first bring-up before we enable gossip network service.
+        let node_status = *my_node_status_watch.borrow_and_update();
+        self.broadcast_bring_up(node_status, &mut fd_state);
+
+        // We should only gossip after we have fully started and stop during
+        // shutdown.
+        if !node_status.is_alive() {
+            trace!("Failure detector is waiting for the node to fully start");
+            let node_status = *my_node_status_watch
+                .wait_for(|status| *status != NodeStatus::StartingUp)
+                .await?;
+            // maybe we are shutting down.
+            if !node_status.is_alive() {
+                return Ok(());
+            }
+            // broadcast again that we have started
+            self.broadcast_bring_up(node_status, &mut fd_state);
+        }
+        info!("Failure Detector Started");
+        // Explicit reset because the interval could have been created long time ago, and we don't
+        // want to erroneously report that a stall was detected.
+        self.gossip_interval.reset_immediately();
+
+        // Start receiving gossip messages
+        let mut network_rx = self.gossip_svc_rx.take().start();
+
+        loop {
+            tokio::select! {
+                Ok(()) = my_node_status_watch.changed(), if !shutting_down => {
+                    // we should only see shutdowns.
+                    let status = *my_node_status_watch.borrow_and_update();
+                    debug_assert!(matches!(status, NodeStatus::ShuttingDown | NodeStatus::Unknown), "{status:?}");
+                    self.broadcast_failover(&mut fd_state);
+                    shutting_down = true;
+                }
+                Ok(()) = nodes_config_watch.changed() => {
+                    // can fail the task if we have been preempted
+                    fd_state.refresh_nodes_config(nodes_config.live_load())?;
+                }
+                tick_instant = self.gossip_interval.tick() => {
+                    let opts = opts.live_load();
+                    self.tick(opts, tick_instant, &mut fd_state, nodes_config.live_load())?;
+                }
+                Some(op) = network_rx.next() => {
+                    let opts = opts.live_load();
+                    match op {
+                        ServiceMessage::Unary(msg) => {
+                            self.on_gossip_message(opts, msg, &mut fd_state);
+                        }
+                        ServiceMessage::Rpc(msg) => {
+                            // V1 GetNodeState messages
+                            self.on_rpc(msg);
+                        }
+                        _ => {
+                            op.fail(Verdict::MessageUnrecognized);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// A gossip tick, most of the time happens every gossip_tick_interval unless
+    /// something else resets the interval.
+    fn tick(
+        &mut self,
+        opts: &GossipOptions,
+        tick_instant: Instant,
+        state: &mut FdState,
+        nodes_config: &NodesConfiguration,
+    ) -> Result<(), Error> {
+        state.refresh_nodes_config(nodes_config)?;
+        // Used as proxy for overload/stall detection
+        let tick_lag = tick_instant.elapsed();
+        if tick_lag >= Duration::from_secs(5) {
+            warn!(
+                "Severe lag ({:?}) was detected in failure detector internal timer, \
+                    this indicates an overload or a stall.",
+                tick_lag,
+            );
+        }
+        let interval_passed = state.gossip_tick(opts);
+
+        // If we are not stable yet, we shouldn't make state machine transitions.
+        //
+        // Note that it's still okay to send gossip messages even if we have not
+        // moved our state machines (we are not stable yet). The state machines are
+        // mainly to update our interpretation of who's alive and who's dead but it
+        // doesn't impact the information we send out to peers in the gossip message.
+        if state.is_stable(opts) {
+            state.detect_peer_failures(opts);
+        } else {
+            // If we are not stable, we still want to update our own state.
+            // `gossip_tick()` will always set our node's gossip_age to zero.
+            //
+            // We special case the standalone setup to avoid going into suspect on startup.
+            state.update_my_node_state(opts);
+        }
+
+        let sent_counter = counter!(GOSSIP_SENT);
+        // At least one interval has passed, let's send a gossip round
+        if interval_passed {
+            let mut sent = 0;
+            // todo 1: include extras every N intervals.
+            //
+            // What to do with V1 nodes? Those don't have the unary handler for
+            // GossipService so messages will be lost. It's relatively low-risk until more nodes
+            // are started up.
+            let msg = state.make_gossip_message(opts, false, nodes_config);
+            for target_node in state.select_targets_for_gossip(nodes_config, &self.networking) {
+                match target_node.send_gossip(&self.networking, msg.clone()) {
+                    Err(err) => {
+                        trace!(peer = %target_node.gen_node_id, "Couldn't send gossip to peer: {err}");
+                    }
+                    Ok(_) => {
+                        sent += 1;
+                        sent_counter.increment(1);
+                        if sent >= opts.gossip_num_peers.get() {
+                            break;
+                        }
+                    }
+                }
+            }
+            if sent == 0 && nodes_config.len() > 1 {
+                trace!(
+                    "Finished a full round of attempts without finding a suitable target node to gossip to!"
+                );
+            }
+        }
+
+        if self.last_dumped.elapsed() > Duration::from_secs(1) {
+            state.report_stats(opts);
+            self.last_dumped = Instant::now();
+        }
 
         Ok(())
     }
-}
 
-struct GossipHandler {
-    processor_manager_handle: Option<ProcessorsManagerHandle>,
-}
+    /// handle incoming gossip messages
+    fn on_gossip_message(
+        &mut self,
+        opts: &GossipOptions,
+        msg: Incoming<RawSvcUnary<GossipService>>,
+        state: &mut FdState,
+    ) {
+        let Ok(msg) = msg.try_into_typed::<Gossip>() else {
+            return;
+        };
+        let peer_nc_version = msg.metadata_version().get(MetadataKind::NodesConfiguration);
+        let peer = msg.peer();
+        let msg = msg.into_body();
 
-impl Handler for GossipHandler {
-    type Service = GossipService;
-    async fn on_start(&mut self) {
-        debug!("Gossip handler started");
+        if !state.can_admit_message(opts, peer, peer_nc_version, &msg) {
+            return;
+        }
+        trace!(%peer, "Received a gossip message {:?}", msg);
+        state.update_from_gossip_message(opts, peer, peer_nc_version, &msg);
     }
 
-    async fn on_drain(&mut self) -> Drain {
-        debug!("Gossip handler drain requested");
-        Drain::Immediate
-    }
-
-    async fn on_stop(&mut self) {
-        let node_status = TaskCenter::with_current(|tc| tc.health().node_status());
-        node_status.update(NodeStatus::Unknown);
-        debug!("Gossip handler stopped");
-    }
-
-    /// handle rpc request
-    async fn on_rpc(&mut self, message: Incoming<RawSvcRpc<Self::Service>>) {
+    /// Handle V1's GetNodeState rpc request
+    fn on_rpc(&mut self, message: Incoming<RawSvcRpc<GossipService>>) {
         let request = match message.try_into_typed::<GetNodeState>() {
             Ok(request) => request,
             Err(msg) => {
@@ -84,15 +280,59 @@ impl Handler for GossipHandler {
                 return;
             }
         };
-        let partition_state = if let Some(ref handle) = self.processor_manager_handle {
-            handle.get_state().await.ok()
-        } else {
-            None
+        let handle = self.processor_manager_handle.clone();
+        let uptime = TaskCenter::with_current(|t| t.age());
+        tokio::spawn(async move {
+            let partition_state = if let Some(handle) = handle {
+                handle.get_state().await.ok()
+            } else {
+                None
+            };
+
+            request.into_reciprocal().send(NodeStateResponse {
+                partition_processor_state: partition_state,
+                uptime,
+            });
+        });
+    }
+
+    fn broadcast_bring_up(&mut self, node_status: NodeStatus, state: &mut FdState) {
+        let mut flags = GossipFlags::Special;
+        flags |= match node_status {
+            NodeStatus::StartingUp => GossipFlags::BringUp,
+            NodeStatus::Alive => GossipFlags::ReadyToServe,
+            NodeStatus::ShuttingDown | NodeStatus::Unknown => return,
         };
 
-        request.into_reciprocal().send(NodeStateResponse {
-            partition_processor_state: partition_state,
-            uptime: TaskCenter::with_current(|t| t.age()),
-        });
+        let message = Gossip {
+            instance_ts: state.my_instance_ts,
+            sent_at: MillisSinceEpoch::now(),
+            flags,
+            nodes: Vec::new(),
+            extras: Vec::new(),
+        };
+
+        for (_, node) in state.peers() {
+            let _sent = node.send_gossip(&self.networking, message.clone());
+        }
+    }
+
+    fn broadcast_failover(&mut self, state: &mut FdState) -> bool {
+        state.set_failover();
+
+        let flags = GossipFlags::Special | GossipFlags::FailingOver;
+        let message = Gossip {
+            instance_ts: state.my_instance_ts,
+            sent_at: MillisSinceEpoch::now(),
+            flags,
+            nodes: Vec::new(),
+            extras: Vec::new(),
+        };
+
+        for (_, node) in state.peers() {
+            let _sent = node.send_gossip(&self.networking, message.clone());
+        }
+
+        true
     }
 }

--- a/crates/node/src/failure_detector/fd_state.rs
+++ b/crates/node/src/failure_detector/fd_state.rs
@@ -1,0 +1,579 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use ahash::{HashMap, HashMapExt};
+use itertools::Itertools;
+use metrics::{counter, gauge};
+use rand::seq::{IteratorRandom, SliceRandom};
+use tokio::time::Instant;
+use tracing::{debug, error, warn};
+
+use restate_core::cluster_state::ClusterStateUpdater;
+use restate_core::network::{ConnectThrottle, NetworkSender};
+use restate_types::config::GossipOptions;
+use restate_types::net::node::{Gossip, GossipFlags};
+use restate_types::nodes_config::NodesConfiguration;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+
+use crate::metric_definitions::{
+    GOSSIP_INSTANCE, GOSSIP_LONELY, GOSSIP_NODES, GOSSIP_RECEIVED, STATE_ALIVE, STATE_DEAD,
+    STATE_FAILING_OVER, STATE_SUSPECT,
+};
+
+use super::node_state::{Node, NodeState};
+
+const GOSSIP_ATTEMPT_LIMIT: usize = 20;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("This node has been preempted, a higher generation has been observed in nodes configuration. current={} preempted_by={}", .my_node_id, .preempted_by)]
+    Preempted {
+        my_node_id: GenerationalNodeId,
+        preempted_by: GenerationalNodeId,
+    },
+    #[error("This node has been removed from nodes configuration")]
+    NodeRemovedFromConfig,
+}
+
+/// General Design Notes
+///
+/// Gossip can be faster to propagate than nodes configuration metadata between nodes, a new node
+/// starting up will likely broadcast its bring-up message before their peers have acquired the
+/// newly updated nodes configuration that this node is part of. Therefore, we allow our own state
+/// to be updated with nodes that we don't know about yet, but following a certain set of merge
+/// rules:
+/// 1. If the node's plain id is already recognized by the current configuration, we can only
+///    accept the gossip message if the generation is the same or higher.
+/// 2. If the gossip message is coming from a node that's been tombstoned in the current
+///    configuration, we ignore the gossip message.
+/// 3. For those unknown nodes, we record the the nodes configuration version that arrived with their message
+///    and we'll use that to determine if we should keep this node or not when we observe nodes
+///    configuration updates. The scenario we want to avoid is that we have a node that we learned
+///    about its liveness through gossip, and then we receive a nodes configuration update that
+///    doesn't contain this node yet (perhaps the node exists in a couple of versions away) and we
+///    decide that this node is unknown and we remove it from our state table. We want to keep this
+///    node in our table as long as we didn't observe a configuration update that's higher than the
+///    one we learned about from this node's original gossip message.
+/// 4. In outgoing gossip messages, we'll only include nodes that _exist_ in our current nodes
+///    configuration version.
+#[derive(derive_more::Debug)]
+pub struct FdState {
+    pub(super) my_instance_ts: MillisSinceEpoch,
+    in_failover: bool,
+    last_processed_nc_version: Version,
+    pub(super) my_node_id: GenerationalNodeId,
+    #[debug("{:?}", last_gossip_received_at.elapsed())]
+    last_gossip_received_at: Instant,
+    // show the elapsed in debug
+    #[debug("{:?}", last_gossip_tick.elapsed())]
+    last_gossip_tick: Instant,
+    num_gossip_received: usize,
+    node_states: HashMap<PlainNodeId, Node>,
+    #[debug(skip)]
+    cs_updater: ClusterStateUpdater,
+}
+
+impl FdState {
+    pub fn new(
+        my_node_id: GenerationalNodeId,
+        nodes_config: &NodesConfiguration,
+        cs_updater: ClusterStateUpdater,
+    ) -> Self {
+        let now = Instant::now();
+        let mut this = Self {
+            my_instance_ts: MillisSinceEpoch::now(),
+            in_failover: false,
+            last_processed_nc_version: Version::INVALID,
+            my_node_id,
+            last_gossip_received_at: now,
+            last_gossip_tick: now,
+            num_gossip_received: 0,
+            node_states: HashMap::with_capacity(nodes_config.len()),
+            cs_updater,
+        };
+        // make sure that our state is pre-seeded with our exact generation
+        let my_instance_ts = this.my_instance_ts;
+        gauge!(GOSSIP_INSTANCE).set(my_instance_ts.as_u64() as f64);
+        let my_node = this.get_node_or_insert(my_node_id);
+        my_node.maybe_reset(my_node_id, nodes_config.version(), my_instance_ts);
+
+        // we assume that this nodes configuration has this node with the exact generation
+        this.refresh_nodes_config(nodes_config)
+            .expect("initializing with nodes config that doesn't contain this node");
+
+        this
+    }
+
+    pub fn set_failover(&mut self) {
+        self.in_failover = true;
+    }
+
+    /// Excluding myself
+    pub fn peers(&mut self) -> impl Iterator<Item = (PlainNodeId, &mut Node)> {
+        let my_node = self.my_node_id.as_plain();
+        self.node_states
+            .iter_mut()
+            .filter_map(move |(node_id, node)| (my_node != *node_id).then_some((*node_id, node)))
+    }
+
+    pub fn refresh_nodes_config(&mut self, nodes_config: &NodesConfiguration) -> Result<(), Error> {
+        let my_node_id = self.my_node_id;
+        let nc_version = nodes_config.version();
+        if nc_version <= self.last_processed_nc_version {
+            // save energy, we have already processed this update in a previous run
+            return Ok(());
+        }
+
+        // Our goal is to synchronize the nodes configuration with the node states
+        for (_, config) in nodes_config.iter() {
+            // we want to know if this is potentially new node/generation or not
+            let node = self.get_node_or_insert(config.current_generation);
+
+            node.maybe_reset(
+                config.current_generation,
+                nc_version,
+                MillisSinceEpoch::UNIX_EPOCH,
+            );
+
+            // Are we preempted by a higher generation?
+            if my_node_id.is_same_but_different(&node.gen_node_id) {
+                return Err(Error::Preempted {
+                    my_node_id,
+                    preempted_by: node.gen_node_id,
+                });
+            }
+        }
+
+        let mut removed_nodes = Vec::new();
+        // remove nodes that are not in the new config
+        self.node_states.retain(|node_id, state| {
+            let keep = nodes_config.contains(node_id) || state.nc_version_witnessed() > nc_version;
+            if !keep {
+                removed_nodes.push(*node_id);
+            }
+
+            keep
+        });
+
+        // we have been removed from the config. We must shutdown.
+        if !self.node_states.contains_key(&self.my_node_id.as_plain()) {
+            return Err(Error::NodeRemovedFromConfig);
+        }
+
+        // update cluster state
+        let mut cs_guard = self.cs_updater.write();
+        for node in self.node_states.values() {
+            cs_guard.upsert_node_state(node.gen_node_id, node.state.into());
+        }
+        for node_id in removed_nodes {
+            cs_guard.remove_node(node_id);
+        }
+
+        Ok(())
+    }
+
+    pub fn is_stable(&self, opts: &GossipOptions) -> bool {
+        // special case for standalone mode
+        if self.node_states.len() == 1 {
+            return true;
+        }
+        self.num_gossip_received >= (opts.gossip_fd_stability_threshold.get() as usize)
+    }
+
+    /// returns true if there has been at least a gossip interval since the last one.
+    pub fn gossip_tick(&mut self, opts: &GossipOptions) -> bool {
+        let now = Instant::now();
+        assert!(!opts.gossip_tick_interval.is_zero());
+        // calculate how many intervals we have missed to compensate for long stalls
+        let full_intervals = self
+            .last_gossip_tick
+            .elapsed()
+            .div_duration_f32(*opts.gossip_tick_interval)
+            .floor() as u32;
+        if full_intervals > 0 {
+            for node in self.node_states.values_mut() {
+                if node.gen_node_id.as_plain() == self.my_node_id.as_plain() {
+                    // keeping ourselves alive
+                    node.gossip_age = 0;
+                } else {
+                    node.gossip_age = node.gossip_age.saturating_add(full_intervals);
+                }
+            }
+            self.last_gossip_tick = now;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_lonely(&self, opts: &GossipOptions) -> bool {
+        let intervals_since_last_received_gossip = self
+            .last_gossip_received_at
+            .elapsed()
+            .div_duration_f32(*opts.gossip_tick_interval)
+            .floor() as u32;
+        intervals_since_last_received_gossip > opts.gossip_loneliness_threshold.get()
+    }
+
+    pub fn detect_peer_failures(&mut self, opts: &GossipOptions) {
+        let is_standalone = self.node_states.len() == 1;
+
+        let changed: Vec<_> = self
+            .node_states
+            .values_mut()
+            .filter_map(|node| {
+                let maybe_updated_state =
+                    if node.gen_node_id.as_plain() == self.my_node_id.as_plain() {
+                        node.maybe_update_state(opts, is_standalone)
+                    } else {
+                        node.maybe_update_state(opts, false)
+                    };
+
+                match maybe_updated_state {
+                    Some(state) if state.is_potentially_alive() => {
+                        // reset connection throttle to this node to allow fresh connection attempts to go
+                        // through.
+                        ConnectThrottle::reset(&restate_core::network::Destination::Node(
+                            node.gen_node_id,
+                        ));
+                        Some(node)
+                    }
+                    Some(_) => Some(node),
+                    None => None,
+                }
+            })
+            .collect();
+
+        // some nodes states have changed
+        if !changed.is_empty() {
+            let mut guard = self.cs_updater.read();
+            for node in changed {
+                // update the cluster state with the new state
+                guard.set_node_state(node.gen_node_id, node.state.into());
+            }
+        }
+    }
+
+    pub fn update_from_gossip_message(
+        &mut self,
+        opts: &GossipOptions,
+        sender_id: GenerationalNodeId,
+        sender_nc_version: Version,
+        msg: &Gossip,
+    ) {
+        let is_sender_lonely = msg.flags.intersects(GossipFlags::FeelingLonely);
+        let is_sender_in_failover = msg.flags.intersects(GossipFlags::FailingOver);
+
+        // Depending on which flags are set, this could carry info about other nodes
+        // or a special message from the sender itself.
+        if msg.flags.intersects(GossipFlags::Special) {
+            let sender_node = self.get_node_or_insert(sender_id);
+            let new_state = if msg.flags.intersects(GossipFlags::BringUp) {
+                // Note that we do not touch the age in this case, we are not ready to consider this as a
+                // suspect node.
+                let old_state = sender_node.state;
+                sender_node.maybe_reset(sender_id, sender_nc_version, msg.instance_ts);
+                let new_state = sender_node.state;
+                (old_state != new_state).then_some(new_state)
+            } else if msg.flags.intersects(GossipFlags::ReadyToServe) {
+                // mark the sender alive
+                sender_node.maybe_reset(sender_id, sender_nc_version, msg.instance_ts);
+                sender_node.gossip_age = 0;
+                sender_node.maybe_update_state(opts, false)
+            } else if is_sender_in_failover {
+                // sender is failing over
+                sender_node.maybe_reset(sender_id, sender_nc_version, msg.instance_ts);
+                // We don't update gossip_age of lonely sender as by doing so, we'll falsely propagate
+                // that they are alive to others. We know that the node is alive but if it's
+                // unreachable by the rest of the cluster, doing so will only cause the cluster to insist
+                // that it's alive, preventing failover from this node.
+                //
+                // That said, we still learn about its view of the world since it's safe to merge
+                // our state with its view.
+                sender_node.gossip_age = if !is_sender_lonely {
+                    0
+                } else {
+                    sender_node.gossip_age
+                };
+                sender_node.in_failover = true;
+                sender_node.maybe_update_state(opts, false)
+            } else {
+                // for more flags in the future
+                None
+            };
+            // Update downstream ClusterState
+            if let Some(new_state) = new_state {
+                self.cs_updater
+                    .upsert_node_state(sender_id, new_state.into());
+            }
+            return;
+        }
+
+        // We only count non-broadcast gossip messages since broadcasts don't tell us much about
+        // the rest of the cluster. Instead, our budget for stability is to be only consumed by
+        // regular gossip messages.
+        self.num_gossip_received += 1;
+        counter!(GOSSIP_RECEIVED).increment(1);
+        self.last_gossip_received_at = Instant::now();
+
+        for incoming_node in msg.nodes.iter() {
+            if incoming_node.node_id.as_plain() == self.my_node_id.as_plain() {
+                // this is us, we don't need to update our state
+                continue;
+            }
+            // is the node failing over? if so, we need to determine if it's failing over in a
+            // higher instance or not.
+            let node = self.get_node_or_insert(incoming_node.node_id);
+            if incoming_node.instance_ts < node.instance_ts {
+                // this is an old instance, we ignore it
+                continue;
+            }
+            if node.gen_node_id.is_newer_than(incoming_node.node_id) {
+                // ignore, we know a newer node.
+                continue;
+            }
+
+            // todo: potentially check if instance_ts is too far in the future
+            if node.maybe_reset(
+                incoming_node.node_id,
+                sender_nc_version,
+                incoming_node.instance_ts,
+            ) {
+                // yes, we have reset
+                if node.gen_node_id == sender_id {
+                    node.in_failover = is_sender_in_failover;
+                    if !is_sender_lonely {
+                        // if lonely, we leave age as the default
+                        node.gossip_age = 0;
+                    }
+                } else {
+                    // just copy over the state from incoming message
+                    node.gossip_age = incoming_node.gossip_age;
+                    node.in_failover = incoming_node.in_failover;
+                }
+            } else if node.gen_node_id == sender_id {
+                node.in_failover = is_sender_in_failover;
+                if !is_sender_lonely {
+                    // if lonely, we leave age as the default
+                    node.gossip_age = 0;
+                }
+            } else {
+                // a gossip about a node we know about. Let's merge
+                node.gossip_age = node.gossip_age.min(incoming_node.gossip_age);
+                node.in_failover |= incoming_node.in_failover;
+            }
+        }
+
+        let left_until_stable = (opts.gossip_fd_stability_threshold.get() as usize)
+            .checked_sub(self.num_gossip_received);
+        if let Some(left_until_stable) = left_until_stable {
+            debug!(peer = %sender_id, "{} Gossips received, {} left until stable.", self.num_gossip_received, left_until_stable);
+        }
+    }
+
+    pub fn report_stats(&self, opts: &GossipOptions) {
+        let mut num_alive = 0;
+        let mut num_suspect = 0;
+        let mut num_dead = 0;
+        let mut num_failing_over = 0;
+        for node in self.node_states.values() {
+            match node.state {
+                NodeState::Alive => num_alive += 1,
+                NodeState::Suspect { .. } => num_suspect += 1,
+                NodeState::Dead => num_dead += 1,
+                NodeState::FailingOver => num_failing_over += 1,
+            }
+        }
+
+        gauge!(GOSSIP_LONELY).set(self.is_lonely(opts) as u8);
+        gauge!(GOSSIP_NODES, "state" => STATE_ALIVE).set(num_alive);
+        gauge!(GOSSIP_NODES, "state" => STATE_DEAD).set(num_dead);
+        gauge!(GOSSIP_NODES, "state" => STATE_SUSPECT).set(num_suspect);
+        gauge!(GOSSIP_NODES, "state" => STATE_FAILING_OVER).set(num_failing_over);
+    }
+
+    // Used for debugging purposes only
+    #[allow(dead_code)]
+    pub fn dump_as_string(&self, opts: &GossipOptions) -> String {
+        // display state in a nice table format
+        let mut result = String::new();
+        // where is the state?
+        result.push_str(&format!(
+            "Failure Detector (lonely?={})\n",
+            self.is_lonely(opts)
+        ));
+        // sorted by key
+        for (_, node) in self
+            .node_states
+            .iter()
+            .sorted_by_cached_key(|(node_id, _)| **node_id)
+        {
+            result.push_str(&format!(
+                "{}(gossip-age={})\t\t{}\t\t{}\t\n",
+                node.gen_node_id,
+                node.gossip_age,
+                node.state,
+                node.instance_ts.as_u64(),
+            ));
+        }
+        result
+    }
+
+    pub fn make_gossip_message(
+        &self,
+        opts: &GossipOptions,
+        include_extras: bool,
+        nodes_config: &NodesConfiguration,
+    ) -> Gossip {
+        let mut flags = GossipFlags::empty();
+        if include_extras {
+            // todo!()
+            flags |= GossipFlags::Enriched;
+        }
+
+        if self.is_lonely(opts) {
+            flags |= GossipFlags::FeelingLonely;
+        }
+
+        if self.in_failover {
+            // note that we don't use Special here. We just send this flag with every message while
+            // we are in failover.
+            flags |= GossipFlags::FailingOver;
+        }
+
+        // Fill up the nodes but only put nodes that we have witnessed in our nodes configuration
+        let nodes = nodes_config
+            .iter()
+            .map(|(plain_id, _node)| {
+                // must exist.
+                let state = self
+                    .node_states
+                    .get(&plain_id)
+                    .expect("nodes configuration must have refreshed our state");
+
+                // The value is better be aligned with the flag.
+                let in_failover = if plain_id == self.my_node_id.as_plain() {
+                    self.in_failover
+                } else {
+                    state.in_failover
+                };
+                restate_types::net::node::Node {
+                    instance_ts: state.instance_ts,
+                    node_id: state.gen_node_id,
+                    gossip_age: state.gossip_age,
+                    in_failover,
+                }
+            })
+            .collect();
+        Gossip {
+            instance_ts: self.my_instance_ts,
+            sent_at: MillisSinceEpoch::now(),
+            flags,
+            nodes,
+            extras: Vec::new(),
+        }
+    }
+
+    pub fn update_my_node_state(&mut self, opts: &GossipOptions) {
+        let is_standalone = self.node_states.len() == 1;
+        if let Some(new_state) = self.my_node_mut().maybe_update_state(opts, is_standalone) {
+            self.cs_updater
+                .upsert_node_state(self.my_node_id, new_state.into());
+        }
+    }
+
+    pub fn can_admit_message(
+        &mut self,
+        opts: &GossipOptions,
+        peer: GenerationalNodeId,
+        peer_nc_version: Version,
+        msg: &Gossip,
+    ) -> bool {
+        let now = MillisSinceEpoch::now();
+        let max_allowed = opts.gossip_time_skew_threshold.as_millis() + (now.as_u64() as u128);
+        // message sent to me from too far the future
+        if (msg.sent_at.as_u64() as u128) > max_allowed {
+            warn!(
+                %peer,
+                "Gossip received is too far in the future (now: {}, threshold: {}, sent_at: {})",
+                now, opts.gossip_time_skew_threshold, msg.sent_at,
+            );
+            return false;
+        }
+
+        if msg.instance_ts > msg.sent_at {
+            error!(
+                %peer,
+                "Gossip received message with sent_at higher than instance_ts (sent_at: {}, instance_ts: {})",
+                msg.sent_at, msg.instance_ts,
+            );
+            return false;
+        }
+
+        // Message came from an old generation or an old instance_ts
+        let node = self.get_node_or_insert(peer);
+        node.maybe_reset(peer, peer_nc_version, msg.instance_ts);
+
+        if node.instance_ts > msg.instance_ts {
+            debug!(
+                %peer,
+                "Gossip received is too old (now: {}, threshold: {}, instance_ts: {}, observed_instance_ts: {})",
+                now, opts.gossip_time_skew_threshold, msg.instance_ts, node.instance_ts
+            );
+            return false;
+        }
+
+        true
+    }
+
+    /// Selects a target node for gossiping. This will return None if no nodes are available to
+    /// gossip onto. This is expected if we are the only node in the cluster or if all other peers
+    /// have been observed as permanently dead (gone).
+    pub fn select_targets_for_gossip(
+        &mut self,
+        nodes_config: &NodesConfiguration,
+        networking: &impl NetworkSender,
+    ) -> Vec<&mut Node> {
+        // Which nodes are good candidates for gossiping?
+        //
+        // The selection pool exclude ourself and nodes that are known to be (gone)
+        // and nodes that are unknown in our current nodes configuration.
+        let mut rng = rand::rng();
+        let mut chosen = self
+            .node_states
+            .iter_mut()
+            .filter_map(|(_, node)| {
+                let is_known = nodes_config.contains(&node.gen_node_id.as_plain());
+                let has_capacity = node.connection(networking).has_capacity();
+                let is_me = node.gen_node_id.as_plain() == self.my_node_id.as_plain();
+                (is_known && has_capacity && !is_me).then_some(node)
+            })
+            .choose_multiple(&mut rng, GOSSIP_ATTEMPT_LIMIT);
+        chosen.shuffle(&mut rng);
+        chosen
+    }
+
+    /// Returns a mutable reference to the node state, creating it if it doesn't exist.
+    pub fn get_node_or_insert(&mut self, node_id: GenerationalNodeId) -> &mut Node {
+        self.node_states
+            .entry(node_id.as_plain())
+            .or_insert_with(|| Node::new(node_id))
+    }
+
+    pub fn node_mut(&mut self, node_id: &PlainNodeId) -> Option<&mut Node> {
+        self.node_states.get_mut(node_id)
+    }
+
+    fn my_node_mut(&mut self) -> &mut Node {
+        self.node_mut(&self.my_node_id.as_plain())
+            .expect("my node must be in FD")
+    }
+}

--- a/crates/node/src/failure_detector/node_state.rs
+++ b/crates/node/src/failure_detector/node_state.rs
@@ -1,0 +1,285 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Display;
+
+use tokio::time::Instant;
+use tracing::debug;
+
+use restate_core::network::{LazyConnection, NetworkSender};
+use restate_core::network::{SendToken, Swimlane, TrySendError};
+use restate_types::config::GossipOptions;
+use restate_types::net::node::Gossip;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, Version};
+
+/// Node state transitions
+///
+/// We start by assuming that all nodes are [`NodeState::Dead`]. As we receive gossip messages, we start to
+/// realise which nodes are alive and which are not. We have the option to speed up the initial
+/// state view by fetching a full ClusterState from a random peer.
+///
+/// We don't run failure detection until we consider ourselves to be stable. Our view is considered
+/// stable after we receive N number of gossip messages.
+/// Possible states each node can be in. All nodes initially start as `Dead`, and
+/// are moved into `Alive` as long as they have been [`NodeState::Suspect`] for `gossip_suspect_interval'
+/// duration.
+///
+/// State transitions are as follows:
+/// - `Dead` -> `Suspect`     When we observe that a dead node is potentially alive
+/// - `Suspect` -> `Alive`    If it didn't fall back down to Dead in the last `gossip_suspect_interval` duration
+/// - `Suspect -> `Dead`      If the node's gossip age grew above the failure threshold again
+/// - `Alive -> `Dead`        If the `Alive` node's gossip age grew above the failure threshold
+/// - `Alive -> `FailingOver` Node is performing a graceful shutdown, it's alive during shutdown.
+///
+/// The same transitions apply to our own node. We start dead and transition through `Suspect`
+/// all the way to `Alive`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NodeState {
+    /// Node is dead
+    #[default]
+    Dead,
+    /// Node has been known to be alive for some time now.
+    Alive,
+    /// Node is likely up (it's gossiping), but we'll give it some more time
+    /// before promoting it to `Alive`.
+    Suspect { suspected_at: Instant },
+    /// Node is alive but is performing a graceful shutdown. The exact moment where the node will
+    /// terminate is unknown, eventually it'll transition to Dead. The node might get reported Dead
+    /// before it completely terminates. We will move it to dead if it's been in this state for
+    /// longer than the failure detection threshold anyway.
+    FailingOver,
+}
+
+impl NodeState {
+    pub fn is_potentially_alive(&self) -> bool {
+        matches!(self, NodeState::Alive | NodeState::Suspect { .. })
+    }
+}
+
+impl Display for NodeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeState::Dead => write!(f, "Dead"),
+            NodeState::Alive => write!(f, "Alive"),
+            NodeState::Suspect { suspected_at } => {
+                write!(f, "Suspect(since {:?} ago)", suspected_at.elapsed())
+            }
+            NodeState::FailingOver => write!(f, "FailingOver"),
+        }
+    }
+}
+
+impl From<NodeState> for restate_core::cluster_state::NodeState {
+    fn from(state: NodeState) -> Self {
+        match state {
+            NodeState::Dead => restate_core::cluster_state::NodeState::Dead,
+            NodeState::Alive => restate_core::cluster_state::NodeState::Alive,
+            NodeState::Suspect { .. } => restate_core::cluster_state::NodeState::Dead,
+            NodeState::FailingOver => restate_core::cluster_state::NodeState::FailingOver,
+        }
+    }
+}
+
+#[derive(derive_more::Debug)]
+pub struct Node {
+    pub(super) gen_node_id: GenerationalNodeId,
+    pub(super) instance_ts: MillisSinceEpoch,
+    pub(super) state: NodeState,
+    pub(super) gossip_age: u32,
+    pub(super) in_failover: bool,
+    /// The version at which we observed the presence of this node. This could be directly acquired
+    /// from a nodes configuration object or from the header of a gossip message.
+    nc_version_witness: Version,
+    // pub(super) extras: Option<Box<dyn Extras>>,
+    // if we have a connection we can use to this node's generation
+    // The connection swims on gossip's swimlane.
+    #[debug("is_closed?={}, is_none?={}", connection.as_ref().is_some_and(|c| c.is_closed()), connection.is_none())]
+    connection: Option<LazyConnection>,
+}
+
+impl Node {
+    pub fn new(gen_node_id: GenerationalNodeId) -> Self {
+        Self {
+            gen_node_id,
+            instance_ts: MillisSinceEpoch::UNIX_EPOCH,
+            state: NodeState::Dead,
+            gossip_age: u32::MAX,
+            in_failover: false,
+            nc_version_witness: Version::INVALID,
+            connection: None,
+            // extras: None,
+        }
+    }
+    /// Resets the node state if the generation is higher than the current one.
+    ///
+    /// It returns `true` if the state was reset, and `false` otherwise.
+    pub fn maybe_reset(
+        &mut self,
+        gen_node_id: GenerationalNodeId,
+        nc_version: Version,
+        instance_ts: MillisSinceEpoch,
+    ) -> bool {
+        assert_eq!(self.gen_node_id.as_plain(), gen_node_id.as_plain());
+        if gen_node_id.is_newer_than(self.gen_node_id) {
+            self.gen_node_id = gen_node_id;
+            self.instance_ts = instance_ts;
+            self.state = NodeState::Dead;
+            self.gossip_age = u32::MAX;
+            self.in_failover = false;
+            self.nc_version_witness = nc_version;
+            self.connection = None;
+            true
+        } else if instance_ts > self.instance_ts {
+            // note that instance_ts can be 0 if the node is not alive yet, we accept that we don't
+            // necessarily need to bump the generation when we see a higher instance_ts coming from a
+            // gossip message.
+            self.instance_ts = instance_ts;
+            self.gossip_age = u32::MAX;
+            self.in_failover = false;
+            // Should we reset the state here to dead?
+            // No, because we might have acquired a previous state from an external
+            // source (i.e seeding our initial state from a peer) and in those
+            // requests we don't see `instance_ts` of peers.
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the updated state if it was updated. None otherwise.
+    ///
+    /// `force_alive` is used exclusively to force this node to be alive without transitioning into
+    /// suspect state in standalone setups.
+    pub fn maybe_update_state(
+        &mut self,
+        opts: &GossipOptions,
+        force_alive: bool,
+    ) -> Option<NodeState> {
+        // A node is considered dead if any of the following is true:
+        // 1. It's not been gossiping for `gossip_failure_threshold` intervals.
+        // 2. It's reporting that it's been lonely (not processing gossips) for too long. However,
+        //    it's not immediately marked dead, we just don't deduct from its gossip-age when we
+        //    receive messages from it.
+        // 3. We have lost gossip connection terminally
+        let target_state =
+            if (self.gossip_age > opts.gossip_failure_threshold.get()) || self.is_gone() {
+                NodeState::Dead
+            } else if self.in_failover {
+                NodeState::FailingOver
+            } else {
+                NodeState::Alive
+            };
+
+        let now = Instant::now();
+        let current_state = self.state;
+
+        let next_state = match (current_state, target_state) {
+            (_, NodeState::Suspect { .. }) => unreachable!(),
+
+            (NodeState::Alive, NodeState::Dead) => NodeState::Dead,
+            (NodeState::Dead, NodeState::Alive | NodeState::FailingOver) => {
+                // we are coming back to life
+                if force_alive {
+                    NodeState::Alive
+                } else if opts.gossip_suspect_interval.is_zero() {
+                    target_state
+                } else {
+                    NodeState::Suspect { suspected_at: now }
+                }
+            }
+            (
+                current @ NodeState::Suspect { suspected_at },
+                NodeState::Alive | NodeState::FailingOver,
+            ) => {
+                if force_alive {
+                    NodeState::Alive
+                } else if suspected_at.elapsed() >= *opts.gossip_suspect_interval {
+                    target_state
+                } else {
+                    current
+                }
+            }
+            (NodeState::FailingOver, NodeState::Alive) => {
+                // In general it shouldn't happen, but it can happen if we acquired the current
+                // state from a source other than failure detector (instance_ts was unknown).
+                // In that case, we'll respect FD's view.
+                // leaving this warn as a reminder if this case was hit.
+                tracing::warn!(
+                    "{} transitioned from {} to {}, perhaps our previous state was not acquired via FD?",
+                    self.gen_node_id,
+                    current_state,
+                    NodeState::Alive,
+                );
+                NodeState::Alive
+            }
+            (NodeState::Suspect { .. }, NodeState::Dead) => NodeState::Dead,
+            (NodeState::FailingOver, NodeState::Dead) => NodeState::Dead,
+            (NodeState::Alive, NodeState::Alive) => NodeState::Alive,
+            (NodeState::Dead, NodeState::Dead) => NodeState::Dead,
+            (_, NodeState::FailingOver) => NodeState::FailingOver,
+        };
+
+        // A state transition is about to take place
+        if current_state != next_state {
+            if matches!(next_state, NodeState::Dead | NodeState::Alive) {
+                tracing::info!(
+                    "{} transitioned from {} to {} (gossip-age={})",
+                    self.gen_node_id,
+                    current_state,
+                    next_state,
+                    self.gossip_age,
+                );
+            } else {
+                tracing::debug!(
+                    "{} transitioned from {} to {} (gossip-age={})",
+                    self.gen_node_id,
+                    current_state,
+                    next_state,
+                    self.gossip_age,
+                );
+            }
+
+            self.state = next_state;
+            return Some(next_state);
+        }
+        None
+    }
+
+    pub fn nc_version_witnessed(&self) -> Version {
+        self.nc_version_witness
+    }
+
+    /// Returns a connection reference and it'll spawn one if this is the first encounter
+    pub fn connection(&mut self, networking: &impl NetworkSender) -> &LazyConnection {
+        self.connection.get_or_insert_with(|| {
+            networking.lazy_connect(
+                self.gen_node_id,
+                Swimlane::Gossip,
+                // this buffer is intentionally small to provide fast feedback to failure detector
+                // if we cannot connect.
+                1,
+                true,
+            )
+        })
+    }
+
+    pub fn is_gone(&self) -> bool {
+        self.connection.as_ref().is_some_and(|c| c.is_closed())
+    }
+
+    pub fn send_gossip(
+        &mut self,
+        networking: &impl NetworkSender,
+        msg: Gossip,
+    ) -> Result<SendToken, TrySendError<Gossip>> {
+        self.connection(networking).try_send_unary(msg, None)
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -11,6 +11,7 @@
 mod cluster_marker;
 mod failure_detector;
 mod init;
+mod metric_definitions;
 mod network_server;
 mod roles;
 
@@ -25,8 +26,7 @@ use codederror::CodedError;
 use restate_bifrost::BifrostService;
 use restate_core::metadata_store::{ReadWriteError, WriteError, retry_on_retryable_error};
 use restate_core::network::{
-    GrpcConnector, MessageRouterBuilder, NetworkSender as _, NetworkServerBuilder, Networking,
-    Swimlane,
+    GrpcConnector, MessageRouterBuilder, NetworkServerBuilder, Networking,
 };
 use restate_core::partitions::{PartitionRoutingRefresher, spawn_partition_routing_refresher};
 use restate_core::{Metadata, MetadataKind, MetadataWriter, TaskKind};
@@ -127,7 +127,7 @@ pub struct Node {
     partition_routing_refresher: PartitionRoutingRefresher,
     bifrost: BifrostService,
     metadata_server_role: Option<BoxedMetadataServer>,
-    failure_detector: FailureDetector,
+    failure_detector: FailureDetector<Networking<GrpcConnector>>,
     admin_role: Option<AdminRole<GrpcConnector>>,
     worker_role: Option<WorkerRole>,
     ingress_role: Option<IngressRole<GrpcConnector>>,
@@ -142,6 +142,7 @@ impl Node {
         updateable_config: Live<Configuration>,
         prometheus: Prometheus,
     ) -> Result<Self, BuildError> {
+        metric_definitions::describe_metrics();
         let mut server_builder = NetworkServerBuilder::default();
         let config = updateable_config.pinned();
 
@@ -323,6 +324,8 @@ impl Node {
         };
 
         let failure_detector = FailureDetector::new(
+            &updateable_config.pinned().common.gossip,
+            networking.clone(),
             &mut router_builder,
             worker_role
                 .as_ref()
@@ -451,7 +454,8 @@ impl Node {
             .context("Giving up trying to initialize the node. Make sure that it can reach the metadata store and don't forget to provision the cluster on a fresh start")?
             .context("Failed initializing the node")?;
 
-        self.failure_detector.start()?;
+        self.failure_detector
+            .start(self.updateable_config.map(|c| &c.common.gossip))?;
 
         // wait for initial metadata sync.
         //
@@ -497,34 +501,6 @@ impl Node {
 
         // Start partition routing information refresher
         spawn_partition_routing_refresher(self.partition_routing_refresher)?;
-
-        //  todo this is a temporary solution to announce the updated NodesConfiguration to the
-        //  configured admin nodes. It should be removed once we have a gossip-based node status
-        //  protocol. Notifying the admin nodes is done on a best effort basis in case one admin
-        //  node is currently not available. This is ok, because the admin nodes will periodically
-        //  sync the NodesConfiguration from the metadata store themselves.
-        for admin_node in nodes_config.get_admin_nodes() {
-            // we don't have to announce us to ourselves
-            if admin_node.current_generation != my_node_id {
-                let admin_node_id = admin_node.current_generation;
-                let networking = self.networking.clone();
-
-                TaskCenter::spawn_unmanaged(
-                    TaskKind::Disposable,
-                    "announce-node-at-admin-node",
-                    async move {
-                        if let Err(err) = networking
-                            .get_connection(admin_node_id, Swimlane::Gossip)
-                            .await
-                        {
-                            debug!(
-                                "Failed connecting to admin node '{admin_node_id}' and announcing myself. This can indicate network problems: {err}"
-                            );
-                        }
-                    },
-                )?;
-            }
-        }
 
         // Ensures bifrost has initial metadata synced up before starting the worker.
         // Need to run start in new tc scope to have access to metadata()

--- a/crates/node/src/metric_definitions.rs
+++ b/crates/node/src/metric_definitions.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics::{Unit, describe_counter, describe_gauge};
+
+pub const STATE_ALIVE: &str = "alive";
+pub const STATE_SUSPECT: &str = "suspect";
+pub const STATE_DEAD: &str = "dead";
+pub const STATE_FAILING_OVER: &str = "failing_over";
+// Failure Detector Metrics
+pub const GOSSIP_RECEIVED: &str = "restate.failure_detector.gossip_received.total";
+pub const GOSSIP_SENT: &str = "restate.failure_detector.gossip_sent.total";
+
+pub const GOSSIP_INSTANCE: &str = "restate.failure_detector.instance";
+pub const GOSSIP_LONELY: &str = "restate.failure_detector.lonely";
+/// dimensioned by "state" (STATE_*)
+pub const GOSSIP_NODES: &str = "restate.failure_detector.nodes.total";
+
+pub fn describe_metrics() {
+    describe_counter!(
+        GOSSIP_RECEIVED,
+        Unit::Count,
+        "Number of gossip messages received"
+    );
+
+    describe_counter!(GOSSIP_SENT, Unit::Count, "Number of gossip messages sent");
+    describe_gauge!(GOSSIP_INSTANCE, "Gossip Instance TS/ID for this node");
+    describe_gauge!(
+        GOSSIP_LONELY,
+        "Node didn't receive gossip messages for too long"
+    );
+    // dimensioned by "state" (STATE_*)
+    describe_gauge!(
+        GOSSIP_NODES,
+        "Number of nodes per node state, dimensioned by state"
+    );
+}

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -66,7 +66,6 @@ pub struct NodeStateResponse {
     pub uptime: Duration,
 }
 
-// Gossip protocol types
 #[derive(Debug, Clone, BilrostNewType, NetSerde)]
 pub struct GossipFlags(u32);
 bitflags! {
@@ -90,6 +89,8 @@ bitflags! {
         /// to send gossips, this could happen in asymmetric network failures. In this case, we
         /// don't consider this node (the sender) as alive and we don't count the gossip message
         /// as a valid liveness signal, but we still use peer information within the message as usual.
+        ///
+        /// This is *not* a `Special` message
         const FeelingLonely = 1 << 4;
         /// This gossip message contains extra information about the nodes in the cluster.
         /// The field _extras_ can be respected.
@@ -97,10 +98,12 @@ bitflags! {
     }
 }
 
-/// The sender of the message is the
+/// A gossip message sent between nodes to drive the failure detector
+///
+/// Note: The sender of the message is inferred from the network message envelope
 #[derive(Debug, Clone, bilrost::Message, NetSerde)]
 pub struct Gossip {
-    /// the sender's startup time in milliseconds since epoch. This value must be unique and
+    /// The sender's startup time in milliseconds since epoch. This value must be unique and
     /// incrementing for each restart of the same node.
     #[bilrost(1)]
     pub instance_ts: MillisSinceEpoch,
@@ -115,7 +118,7 @@ pub struct Gossip {
     #[bilrost(4)]
     pub nodes: Vec<Node>,
     /// Extra optional information about the nodes in the cluster
-    /// Ignored if `Enriched` flag is not set on the message
+    /// Ignored if `Enriched` flag is not set on the message.
     #[bilrost(5)]
     pub extras: Vec<Extras>,
 }


### PR DESCRIPTION

A new failure detector system based on a custom gossip protocol design. The failure detector service uses an exclusive connection in `Gossip` swimlane to exchange a new `Gossip` unary message between nodes.


```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3230).
* #3241
* __->__ #3230