### PR TITLE
Removes SuspectNode from old ClusterState

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -165,7 +165,6 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
                                     last_heartbeat_at, ..
                                 }) => Some(*last_heartbeat_at),
                                 NodeState::Dead(DeadNode { last_seen_alive }) => *last_seen_alive,
-                                NodeState::Suspect(_) => None,
                             },
                         );
 

--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -60,10 +60,6 @@ impl ObservedClusterState {
     }
 
     /// Update observed cluster state with given [`ClusterState`]
-    ///
-    /// Nodes in [`NodeState::Suspect`] state are treated as [`NodeState::Alive`].
-    /// This means that their `last known` state will not be cleared
-    /// until they are marked as dead in [`ClusterState`].
     fn update_nodes(&mut self, cluster_state: &ClusterState) {
         for (node_id, node_state) in &cluster_state.nodes {
             match node_state {
@@ -71,11 +67,6 @@ impl ObservedClusterState {
                     self.dead_nodes.remove(node_id);
                     self.alive_nodes
                         .insert(*node_id, alive_node.generational_node_id);
-                }
-                NodeState::Suspect(maybe_node) => {
-                    self.dead_nodes.remove(node_id);
-                    self.alive_nodes
-                        .insert(*node_id, maybe_node.generational_node_id);
                 }
                 NodeState::Dead(_) => {
                     self.alive_nodes.remove(node_id);

--- a/crates/storage-query-datafusion/src/node_state/row.rs
+++ b/crates/storage-query-datafusion/src/node_state/row.rs
@@ -35,9 +35,5 @@ pub(crate) fn append_node_row(
                 row.last_seen_at(ts.as_u64() as i64);
             }
         }
-        NodeState::Suspect(suspect) => {
-            row.last_attempt_at(suspect.last_attempt.as_u64() as i64);
-            row.gen_node_id(format_using(output, &suspect.generational_node_id));
-        }
     }
 }

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -26,16 +26,11 @@ message ClusterState {
 }
 
 message NodeState {
+  reserved 3;
   oneof state {
     AliveNode alive = 1;
     DeadNode dead = 2;
-    SuspectNode suspect = 3;
   }
-}
-
-message SuspectNode {
-  restate.common.NodeId generational_node_id = 1;
-  google.protobuf.Timestamp last_attempt = 2;
 }
 
 message AliveNode {

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -25,7 +25,7 @@ use restate_types::logs::metadata::{Chain, Logs};
 use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
-    DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode, SuspectNode, node_state,
+    DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
 };
 use restate_types::storage::StorageCodec;
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
@@ -98,13 +98,9 @@ pub async fn list_partitions(
 
     let mut partitions: Vec<(u32, PartitionListEntry)> = vec![];
     let mut dead_nodes: BTreeMap<PlainNodeId, DeadNode> = BTreeMap::new();
-    let mut suspect_nodes: BTreeMap<PlainNodeId, SuspectNode> = BTreeMap::new();
     let mut max_epoch_per_partition: HashMap<u32, u64> = HashMap::new();
     for (node_id, node_state) in cluster_state.nodes {
         match node_state.state.expect("node state is set") {
-            node_state::State::Suspect(suspect_node) => {
-                suspect_nodes.insert(PlainNodeId::from(node_id), suspect_node);
-            }
             node_state::State::Dead(dead_node) => {
                 dead_nodes.insert(PlainNodeId::from(node_id), dead_node);
             }
@@ -321,20 +317,6 @@ pub async fn list_partitions(
             ]);
         }
         c_println!("{}", dead_nodes_table);
-    }
-
-    if !suspect_nodes.is_empty() {
-        c_println!();
-        c_println!("🕵 Suspect nodes");
-        let mut suspect_nodes_table = Table::new_styled();
-        suspect_nodes_table.set_styled_header(vec!["NODE", "LAST-ATTEMPTS"]);
-        for (node_id, suspect_node) in suspect_nodes {
-            suspect_nodes_table.add_row(vec![
-                Cell::new(node_id),
-                render_as_duration(suspect_node.last_attempt, Tense::Past),
-            ]);
-        }
-        c_println!("{}", suspect_nodes_table);
     }
 
     Ok(())

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -134,12 +134,6 @@ async fn compact_cluster_status(
             State::Dead(_dead) => {
                 row.with_id(node_id, Color::Red);
             }
-            State::Suspect(suspect) => {
-                row.with_id(
-                    suspect.generational_node_id.context("node id is missing")?,
-                    Color::Yellow,
-                );
-            }
         };
 
         table.add_row(row);


### PR DESCRIPTION

It's effectively unused and clashes (semantically) with the future of cluster controller and failure detector

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3241).
* #3243
* __->__ #3241