### PR TITLE
[minor] Improve PartitionTable naming and style

### DIFF
--- a/crates/admin/src/cluster_controller/cluster_state_refresher.rs
+++ b/crates/admin/src/cluster_controller/cluster_state_refresher.rs
@@ -165,7 +165,6 @@ impl<T: TransportConnect> ClusterStateRefresher<T> {
                                     last_heartbeat_at, ..
                                 }) => Some(*last_heartbeat_at),
                                 NodeState::Dead(DeadNode { last_seen_alive }) => *last_seen_alive,
-                                NodeState::Suspect(_) => None,
                             },
                         );
 

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -324,7 +324,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         let response = GetClusterConfigurationResponse {
             cluster_configuration: Some(ClusterConfiguration {
                 num_partitions: u32::from(partition_table.num_partitions()),
-                partition_replication: partition_table.partition_replication().clone().into(),
+                partition_replication: partition_table.replication().clone().into(),
                 bifrost_provider: Some(logs.configuration().default_provider.clone().into()),
             }),
         };

--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -985,7 +985,7 @@ impl LogsControllerInner {
 
     fn on_partition_table_update(&mut self, partition_table: &PartitionTable) {
         // update the provisioning logs
-        for (partition_id, _) in partition_table.partitions() {
+        for (partition_id, _) in partition_table.iter() {
             self.logs_state
                 .entry((*partition_id).into())
                 .or_insert_with(|| {

--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -60,10 +60,6 @@ impl ObservedClusterState {
     }
 
     /// Update observed cluster state with given [`ClusterState`]
-    ///
-    /// Nodes in [`NodeState::Suspect`] state are treated as [`NodeState::Alive`].
-    /// This means that their `last known` state will not be cleared
-    /// until they are marked as dead in [`ClusterState`].
     fn update_nodes(&mut self, cluster_state: &ClusterState) {
         for (node_id, node_state) in &cluster_state.nodes {
             match node_state {
@@ -71,11 +67,6 @@ impl ObservedClusterState {
                     self.dead_nodes.remove(node_id);
                     self.alive_nodes
                         .insert(*node_id, alive_node.generational_node_id);
-                }
-                NodeState::Suspect(maybe_node) => {
-                    self.dead_nodes.remove(node_id);
-                    self.alive_nodes
-                        .insert(*node_id, maybe_node.generational_node_id);
                 }
                 NodeState::Dead(_) => {
                     self.alive_nodes.remove(node_id);

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -125,7 +125,7 @@ impl<T: TransportConnect> Scheduler<T> {
         let logs = Metadata::with_current(|m| m.logs_ref());
         let partition_table = Metadata::with_current(|m| m.partition_table_ref());
 
-        if logs.num_logs() != partition_table.num_partitions() as usize {
+        if logs.num_logs() != partition_table.len() {
             // either the partition table or the logs are not fully initialized
             // hence there is nothing we can do atm.
             // we need to wait until both partitions and logs are created
@@ -377,7 +377,7 @@ impl<T: TransportConnect> Scheduler<T> {
 
         let mut commands = BTreeMap::default();
 
-        for (partition_id, partition) in partition_table.partitions() {
+        for (partition_id, partition) in partition_table.iter() {
             self.generate_instructions_for_partition(
                 partition_id,
                 partition,
@@ -499,7 +499,7 @@ impl logs_controller::NodeSetSelectorHints for PartitionTableNodeSetSelectorHint
         let partition_id = PartitionId::from(*log_id);
 
         self.partition_table
-            .get_partition(&partition_id)
+            .get(&partition_id)
             .and_then(|partition| partition.placement.leader().map(NodeId::from))
     }
 }
@@ -759,7 +759,7 @@ mod tests {
                 .map(|node| node.generational_node_id.as_plain())
                 .collect();
 
-            for (_, partition) in target_partition_table.partitions_mut() {
+            for (_, partition) in target_partition_table.iter_mut() {
                 let target_state = TargetPartitionPlacementState::new(&mut partition.placement);
                 // assert that the replication strategy was respected
                 match &partition_replication {
@@ -812,7 +812,7 @@ mod tests {
         )
         .await?;
         let partition = partition_table
-            .get_partition(&PartitionId::from(0))
+            .get(&PartitionId::from(0))
             .expect("must be present");
 
         assert_eq!(
@@ -844,7 +844,7 @@ mod tests {
         )
         .await?;
         let partition = partition_table
-            .get_partition(&PartitionId::from(0))
+            .get(&PartitionId::from(0))
             .expect("must be present");
 
         assert_eq!(
@@ -894,12 +894,9 @@ mod tests {
         partition_table: &PartitionTable,
         observed_state: &ObservedClusterState,
     ) -> googletest::Result<()> {
-        assert_that!(
-            observed_state.partitions.len(),
-            eq(partition_table.num_partitions() as usize)
-        );
+        assert_that!(observed_state.partitions.len(), eq(partition_table.len()));
 
-        for (partition_id, partition) in partition_table.partitions() {
+        for (partition_id, partition) in partition_table.iter() {
             let Some(observed_state) = observed_state.partitions.get(partition_id) else {
                 panic!("partition {partition_id} not found in observed state");
             };

--- a/crates/core/src/partitions.rs
+++ b/crates/core/src/partitions.rs
@@ -67,7 +67,7 @@ impl PartitionToNodesRoutingTable {
         let mut inner = HashMap::<PartitionId, NodeId>::with_capacity(
             partition_table.num_partitions() as usize,
         );
-        for (partition_id, partition) in partition_table.partitions() {
+        for (partition_id, partition) in partition_table.iter() {
             if let Some(leader) = partition.placement.leader() {
                 inner.insert(*partition_id, leader.into());
             }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -422,7 +422,7 @@ impl SelectPartitions for SelectPartitionsFromMetadata {
     async fn get_live_partitions(&self) -> Result<Vec<(PartitionId, Partition)>, GenericError> {
         Ok(Metadata::with_current(|m| {
             m.partition_table_ref()
-                .partitions()
+                .iter()
                 .map(|(a, b)| (*a, b.clone()))
                 .collect()
         }))

--- a/crates/storage-query-datafusion/src/node_state/row.rs
+++ b/crates/storage-query-datafusion/src/node_state/row.rs
@@ -35,9 +35,5 @@ pub(crate) fn append_node_row(
                 row.last_seen_at(ts.as_u64() as i64);
             }
         }
-        NodeState::Suspect(suspect) => {
-            row.last_attempt_at(suspect.last_attempt.as_u64() as i64);
-            row.gen_node_id(format_using(output, &suspect.generational_node_id));
-        }
     }
 }

--- a/crates/storage-query-datafusion/src/partition/table.rs
+++ b/crates/storage-query-datafusion/src/partition/table.rs
@@ -67,7 +67,7 @@ async fn for_each_partition(
     let mut builder = PartitionBuilder::new(schema.clone());
 
     let mut output = String::new();
-    for (_, partition) in partition_table.partitions() {
+    for (_, partition) in partition_table.iter() {
         append_partition_rows(
             &mut builder,
             &mut output,

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -26,16 +26,11 @@ message ClusterState {
 }
 
 message NodeState {
+  reserved 3;
   oneof state {
     AliveNode alive = 1;
     DeadNode dead = 2;
-    SuspectNode suspect = 3;
   }
-}
-
-message SuspectNode {
-  restate.common.NodeId generational_node_id = 1;
-  google.protobuf.Timestamp last_attempt = 2;
 }
 
 message AliveNode {

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -56,6 +56,7 @@ use crate::time::MillisSinceEpoch;
 #[debug("e{}", _0)]
 pub struct LeaderEpoch(u64);
 impl LeaderEpoch {
+    pub const INVALID: Self = Self(0);
     pub const INITIAL: Self = Self(1);
 
     pub fn next(self) -> Self {

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -136,15 +136,15 @@ impl PartitionTable {
         self.version = version;
     }
 
-    pub fn partitions(&self) -> impl Iterator<Item = (&PartitionId, &Partition)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&PartitionId, &Partition)> {
         self.partitions.iter()
     }
 
-    pub fn partitions_mut(&mut self) -> impl Iterator<Item = (&PartitionId, &mut Partition)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&PartitionId, &mut Partition)> {
         self.partitions.iter_mut()
     }
 
-    pub fn partition_ids(&self) -> impl Iterator<Item = &PartitionId> {
+    pub fn iter_ids(&self) -> impl Iterator<Item = &PartitionId> {
         self.partitions.keys()
     }
 
@@ -152,15 +152,24 @@ impl PartitionTable {
         u16::try_from(self.partitions.len()).expect("number of partitions should fit into u16")
     }
 
-    pub fn get_partition(&self, partition_id: &PartitionId) -> Option<&Partition> {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Please use num_partitions() if you need instead `u16`
+    pub fn len(&self) -> usize {
+        self.partitions.len()
+    }
+
+    pub fn get(&self, partition_id: &PartitionId) -> Option<&Partition> {
         self.partitions.get(partition_id)
     }
 
-    pub fn contains_partition(&self, partition_id: &PartitionId) -> bool {
+    pub fn contains(&self, partition_id: &PartitionId) -> bool {
         self.partitions.contains_key(partition_id)
     }
 
-    pub fn partition_replication(&self) -> &PartitionReplication {
+    pub fn replication(&self) -> &PartitionReplication {
         &self.replication
     }
 
@@ -352,6 +361,14 @@ impl PartitionTableBuilder {
 
     pub fn num_partitions(&self) -> u16 {
         self.inner.num_partitions()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 
     pub fn set_partition_replication(&mut self, partition_replication: PartitionReplication) {
@@ -649,7 +666,7 @@ mod tests {
         let num_partitions = 10;
         let partition_table =
             PartitionTable::with_equally_sized_partitions(Version::MIN, num_partitions);
-        let partitioner = partition_table.partitions();
+        let partitioner = partition_table.iter();
 
         for (partition_id, partition) in partitioner {
             assert_eq!(

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -813,7 +813,7 @@ impl PartitionProcessorManager {
                         }
                     }
                 } else if let Some(partition_key_range) = partition_table
-                    .get_partition(&partition_id)
+                    .get(&partition_id)
                     .map(|partition| &partition.key_range)
                 {
                     debug!(%partition_id, "Starting new partition processor to run as {}", control_processor.command);

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -25,7 +25,7 @@ use restate_types::logs::metadata::{Chain, Logs};
 use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
-    DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode, SuspectNode, node_state,
+    DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
 };
 use restate_types::storage::StorageCodec;
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
@@ -98,13 +98,9 @@ pub async fn list_partitions(
 
     let mut partitions: Vec<(u32, PartitionListEntry)> = vec![];
     let mut dead_nodes: BTreeMap<PlainNodeId, DeadNode> = BTreeMap::new();
-    let mut suspect_nodes: BTreeMap<PlainNodeId, SuspectNode> = BTreeMap::new();
     let mut max_epoch_per_partition: HashMap<u32, u64> = HashMap::new();
     for (node_id, node_state) in cluster_state.nodes {
         match node_state.state.expect("node state is set") {
-            node_state::State::Suspect(suspect_node) => {
-                suspect_nodes.insert(PlainNodeId::from(node_id), suspect_node);
-            }
             node_state::State::Dead(dead_node) => {
                 dead_nodes.insert(PlainNodeId::from(node_id), dead_node);
             }
@@ -321,20 +317,6 @@ pub async fn list_partitions(
             ]);
         }
         c_println!("{}", dead_nodes_table);
-    }
-
-    if !suspect_nodes.is_empty() {
-        c_println!();
-        c_println!("🕵 Suspect nodes");
-        let mut suspect_nodes_table = Table::new_styled();
-        suspect_nodes_table.set_styled_header(vec!["NODE", "LAST-ATTEMPTS"]);
-        for (node_id, suspect_node) in suspect_nodes {
-            suspect_nodes_table.add_row(vec![
-                Cell::new(node_id),
-                render_as_duration(suspect_node.last_attempt, Tense::Past),
-            ]);
-        }
-        c_println!("{}", suspect_nodes_table);
     }
 
     Ok(())

--- a/tools/restatectl/src/commands/snapshot/create_snapshot.rs
+++ b/tools/restatectl/src/commands/snapshot/create_snapshot.rs
@@ -61,7 +61,7 @@ async fn create_snapshot(
 
         let partition_table: PartitionTable = StorageCodec::decode(&mut response.encoded)?;
 
-        partition_table.partition_ids().cloned().collect()
+        partition_table.iter_ids().cloned().collect()
     } else {
         opts.partition_id
             .iter()

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -134,12 +134,6 @@ async fn compact_cluster_status(
             State::Dead(_dead) => {
                 row.with_id(node_id, Color::Red);
             }
-            State::Suspect(suspect) => {
-                row.with_id(
-                    suspect.generational_node_id.context("node id is missing")?,
-                    Color::Yellow,
-                );
-            }
         };
 
         table.add_row(row);


### PR DESCRIPTION

Bringing PartitionTable up to standard
```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3243).
* __->__ #3243
* #3241