### PR TITLE
[FailureDetector] PartitionReplicaSetStates in FailureDetector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7714,6 +7714,7 @@ dependencies = [
  "clap",
  "codederror",
  "criterion",
+ "dashmap",
  "derive_builder",
  "derive_more",
  "downcast-rs",

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -36,6 +36,7 @@ use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::net::partition_processor_manager::Snapshot;
 use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::cluster::ClusterConfiguration;
 use restate_types::storage::{StorageCodec, StorageEncode};
 use restate_types::{PlainNodeId, Version, Versioned};
@@ -50,6 +51,7 @@ pub(crate) struct ClusterCtrlSvcHandler {
     bifrost: Bifrost,
     metadata_writer: MetadataWriter,
     query_context: QueryContext,
+    _replica_set_states: PartitionReplicaSetStates,
 }
 
 impl ClusterCtrlSvcHandler {
@@ -58,12 +60,14 @@ impl ClusterCtrlSvcHandler {
         bifrost: Bifrost,
         metadata_writer: MetadataWriter,
         query_context: QueryContext,
+        replica_set_states: PartitionReplicaSetStates,
     ) -> Self {
         Self {
             controller_handle,
             bifrost,
             metadata_writer,
             query_context,
+            _replica_set_states: replica_set_states,
         }
     }
 

--- a/crates/node/src/failure_detector/fd_state.rs
+++ b/crates/node/src/failure_detector/fd_state.rs
@@ -20,8 +20,9 @@ use restate_core::network::{ConnectThrottle, NetworkSender};
 use restate_types::config::GossipOptions;
 use restate_types::net::node::{Gossip, GossipFlags};
 use restate_types::nodes_config::NodesConfiguration;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::time::MillisSinceEpoch;
-use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+use restate_types::{GenerationalNodeId, PlainNodeId, Version, net};
 
 use crate::metric_definitions::{
     GOSSIP_INSTANCE, GOSSIP_LONELY, GOSSIP_NODES, GOSSIP_RECEIVED, STATE_ALIVE, STATE_DEAD,
@@ -78,6 +79,8 @@ pub struct FdState {
     num_gossip_received: usize,
     node_states: HashMap<PlainNodeId, Node>,
     #[debug(skip)]
+    replica_set_states: PartitionReplicaSetStates,
+    #[debug(skip)]
     cs_updater: ClusterStateUpdater,
 }
 
@@ -85,6 +88,7 @@ impl FdState {
     pub fn new(
         my_node_id: GenerationalNodeId,
         nodes_config: &NodesConfiguration,
+        replica_set_states: PartitionReplicaSetStates,
         cs_updater: ClusterStateUpdater,
     ) -> Self {
         let now = Instant::now();
@@ -97,6 +101,7 @@ impl FdState {
             last_gossip_tick: now,
             num_gossip_received: 0,
             node_states: HashMap::with_capacity(nodes_config.len()),
+            replica_set_states,
             cs_updater,
         };
         // make sure that our state is pre-seeded with our exact generation
@@ -207,6 +212,7 @@ impl FdState {
                     node.gossip_age = node.gossip_age.saturating_add(full_intervals);
                 }
             }
+
             self.last_gossip_tick = now;
             true
         } else {
@@ -267,7 +273,7 @@ impl FdState {
         opts: &GossipOptions,
         sender_id: GenerationalNodeId,
         sender_nc_version: Version,
-        msg: &Gossip,
+        msg: Gossip,
     ) {
         let is_sender_lonely = msg.flags.intersects(GossipFlags::FeelingLonely);
         let is_sender_in_failover = msg.flags.intersects(GossipFlags::FailingOver);
@@ -372,6 +378,16 @@ impl FdState {
             }
         }
 
+        if msg.flags.intersects(GossipFlags::Enriched) {
+            for partition in msg.partitions.into_iter() {
+                self.replica_set_states.note_observed_membership(
+                    partition.id,
+                    &partition.observed_current_membership,
+                    &partition.observed_next_membership,
+                );
+            }
+        }
+
         let left_until_stable = (opts.gossip_fd_stability_threshold.get() as usize)
             .checked_sub(self.num_gossip_received);
         if let Some(left_until_stable) = left_until_stable {
@@ -428,14 +444,15 @@ impl FdState {
     }
 
     pub fn make_gossip_message(
-        &self,
+        &mut self,
         opts: &GossipOptions,
         include_extras: bool,
         nodes_config: &NodesConfiguration,
     ) -> Gossip {
         let mut flags = GossipFlags::empty();
+
+        // do not include extras if we don't have a valid partition table
         if include_extras {
-            // todo!()
             flags |= GossipFlags::Enriched;
         }
 
@@ -473,13 +490,31 @@ impl FdState {
                 }
             })
             .collect();
+
+        let partitions = if include_extras {
+            self.make_partition_state_list()
+        } else {
+            Vec::new()
+        };
+
         Gossip {
             instance_ts: self.my_instance_ts,
             sent_at: MillisSinceEpoch::now(),
             flags,
             nodes,
-            extras: Vec::new(),
+            partitions,
         }
+    }
+
+    fn make_partition_state_list(&mut self) -> Vec<net::node::PartitionReplicaSet> {
+        self.replica_set_states
+            .iter()
+            .map(|(id, state)| net::node::PartitionReplicaSet {
+                id,
+                observed_current_membership: state.observed_current_membership,
+                observed_next_membership: state.observed_next_membership,
+            })
+            .collect()
     }
 
     pub fn update_my_node_state(&mut self, opts: &GossipOptions) {

--- a/crates/node/src/failure_detector/node_state.rs
+++ b/crates/node/src/failure_detector/node_state.rs
@@ -98,7 +98,6 @@ pub struct Node {
     /// The version at which we observed the presence of this node. This could be directly acquired
     /// from a nodes configuration object or from the header of a gossip message.
     nc_version_witness: Version,
-    // pub(super) extras: Option<Box<dyn Extras>>,
     // if we have a connection we can use to this node's generation
     // The connection swims on gossip's swimlane.
     #[debug("is_closed?={}, is_none?={}", connection.as_ref().is_some_and(|c| c.is_closed()), connection.is_none())]
@@ -115,7 +114,6 @@ impl Node {
             in_failover: false,
             nc_version_witness: Version::INVALID,
             connection: None,
-            // extras: None,
         }
     }
     /// Resets the node state if the generation is higher than the current one.

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -48,6 +48,7 @@ use restate_types::nodes_config::{
     LogServerConfig, MetadataServerConfig, NodeConfig, NodesConfiguration, Role,
 };
 use restate_types::partition_table::{PartitionReplication, PartitionTable, PartitionTableBuilder};
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::{
     AdminStatus, IngressStatus, LogServerStatus, NodeRpcStatus, WorkerStatus,
 };
@@ -201,6 +202,7 @@ impl Node {
         let networking = Networking::with_grpc_connector();
         metadata_manager.register_in_message_router(&mut router_builder);
         let partition_routing_refresher = PartitionRoutingRefresher::default();
+        let replica_set_states = PartitionReplicaSetStates::default();
 
         let record_cache = RecordCache::new(
             Configuration::pinned()
@@ -255,6 +257,7 @@ impl Node {
                     TaskCenter::with_current(|tc| tc.health().worker_status()),
                     metadata.clone(),
                     partition_routing_refresher.partition_routing(),
+                    replica_set_states.clone(),
                     updateable_config.clone(),
                     &mut router_builder,
                     networking.clone(),
@@ -309,6 +312,7 @@ impl Node {
                     bifrost.clone(),
                     updateable_config.clone(),
                     partition_routing_refresher.partition_routing(),
+                    replica_set_states.clone(),
                     networking.clone(),
                     metadata,
                     metadata_manager.writer(),
@@ -327,6 +331,7 @@ impl Node {
             &updateable_config.pinned().common.gossip,
             networking.clone(),
             &mut router_builder,
+            replica_set_states,
             worker_role
                 .as_ref()
                 .map(|role| role.partition_processor_manager_handle()),

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -32,6 +32,7 @@ use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
 use restate_types::live::LiveLoadExt;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::AdminStatus;
 use restate_types::retries::RetryPolicy;
 
@@ -64,6 +65,7 @@ impl<T: TransportConnect> AdminRole<T> {
         bifrost: Bifrost,
         updateable_config: Live<Configuration>,
         partition_routing: PartitionRouting,
+        replica_set_states: PartitionReplicaSetStates,
         networking: Networking<T>,
         metadata: Metadata,
         metadata_writer: MetadataWriter,
@@ -112,6 +114,7 @@ impl<T: TransportConnect> AdminRole<T> {
                 cluster_controller::Service::create(
                     updateable_config.clone(),
                     health_status,
+                    replica_set_states,
                     bifrost,
                     networking,
                     server_builder,

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -25,6 +25,7 @@ use restate_types::Version;
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_types::schema::subscriptions::SubscriptionResolver;
 use restate_worker::SubscriptionController;
@@ -74,6 +75,7 @@ impl WorkerRole {
         health_status: HealthStatus<WorkerStatus>,
         metadata: Metadata,
         partition_routing: PartitionRouting,
+        replica_set_states: PartitionReplicaSetStates,
         updateable_config: Live<Configuration>,
         router_builder: &mut MessageRouterBuilder,
         networking: Networking<T>,
@@ -85,6 +87,7 @@ impl WorkerRole {
             health_status,
             metadata.clone(),
             partition_routing,
+            replica_set_states,
             networking,
             bifrost,
             router_builder,

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -37,6 +37,7 @@ bincode = { workspace = true, default-features = false, features = ["std", "serd
 chrono = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"], optional = true }
 codederror = { workspace = true }
+dashmap = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
 downcast-rs = { workspace = true }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -39,6 +39,7 @@ pub mod metadata_store;
 pub mod net;
 pub mod nodes_config;
 pub mod partition_table;
+pub mod partitions;
 pub mod protobuf;
 pub mod replicated_loglet;
 pub mod replication;

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -22,6 +22,7 @@ use crate::net::{
     bilrost_wire_codec, bilrost_wire_codec_with_v1_fallback, define_rpc, define_service,
     define_unary_message,
 };
+use crate::partitions::state::ReplicaSetState;
 use crate::time::MillisSinceEpoch;
 use crate::{cluster::cluster_state::PartitionProcessorStatus, identifiers::PartitionId};
 
@@ -92,8 +93,8 @@ bitflags! {
         ///
         /// This is *not* a `Special` message
         const FeelingLonely = 1 << 4;
-        /// This gossip message contains extra information about the nodes in the cluster.
-        /// The field _extras_ can be respected.
+        /// This gossip message contains the merged partition state, otherwise, extra
+        /// fields like `partitions` should be ignored.
         const Enriched = 1 << 5;
     }
 }
@@ -120,7 +121,7 @@ pub struct Gossip {
     /// Extra optional information about the nodes in the cluster
     /// Ignored if `Enriched` flag is not set on the message.
     #[bilrost(5)]
-    pub extras: Vec<Extras>,
+    pub partitions: Vec<PartitionReplicaSet>,
 }
 
 #[derive(Debug, Clone, bilrost::Message, NetSerde)]
@@ -138,6 +139,8 @@ pub struct Node {
 }
 
 #[derive(Debug, Clone, bilrost::Message, NetSerde)]
-pub struct Extras {
-    // todo!()
+pub struct PartitionReplicaSet {
+    pub id: PartitionId,
+    pub observed_current_membership: ReplicaSetState,
+    pub observed_next_membership: Option<ReplicaSetState>,
 }

--- a/crates/types/src/partitions.rs
+++ b/crates/types/src/partitions.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod configuration;
+pub mod state;
+
+pub use configuration::*;
+// re-exports of partition-related types in preparation for moving them under this module
+pub use super::epoch::*;
+pub use super::partition_table::*;

--- a/crates/types/src/partitions/configuration.rs
+++ b/crates/types/src/partitions/configuration.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use ahash::HashMap;
+
+use crate::logs::{Lsn, SequenceNumber};
+use crate::replication::{NodeSet, ReplicationProperty};
+use crate::time::MillisSinceEpoch;
+use crate::{Version, Versioned};
+
+use super::state::{MemberState, ReplicaSetState};
+
+#[serde_with::serde_as]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PartitionConfiguration {
+    version: Version,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    replication: ReplicationProperty,
+    replica_set: NodeSet,
+    modified_at: MillisSinceEpoch,
+    context: HashMap<String, String>,
+}
+
+impl Default for PartitionConfiguration {
+    fn default() -> Self {
+        Self {
+            version: Version::INVALID,
+            replication: ReplicationProperty::new_unchecked(1),
+            replica_set: NodeSet::default(),
+            modified_at: MillisSinceEpoch::now(),
+            context: HashMap::default(),
+        }
+    }
+}
+
+impl PartitionConfiguration {
+    pub fn new(
+        replication: ReplicationProperty,
+        replica_set: NodeSet,
+        context: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            version: Version::MIN,
+            replication,
+            replica_set,
+            modified_at: MillisSinceEpoch::now(),
+            context,
+        }
+    }
+
+    pub fn to_replica_set_state(&self) -> ReplicaSetState {
+        ReplicaSetState {
+            version: self.version,
+            members: self
+                .replica_set
+                .iter()
+                .map(|node_id| MemberState {
+                    node_id: *node_id,
+                    durable_lsn: Lsn::INVALID,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn replica_set(&self) -> &NodeSet {
+        &self.replica_set
+    }
+
+    pub fn replication(&self) -> &ReplicationProperty {
+        &self.replication
+    }
+
+    pub fn context(&self) -> &HashMap<String, String> {
+        &self.context
+    }
+
+    pub fn modified_at(&self) -> MillisSinceEpoch {
+        self.modified_at
+    }
+
+    /// Determine if the current partition configuration is valid or not
+    pub fn is_valid(&self) -> bool {
+        self.version != Version::INVALID
+    }
+}
+
+impl Versioned for PartitionConfiguration {
+    fn version(&self) -> Version {
+        self.version
+    }
+}

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -1,0 +1,182 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use restate_encoding::NetSerde;
+
+use crate::identifiers::PartitionId;
+use crate::logs::Lsn;
+use crate::{Merge, PlainNodeId, Version};
+
+type DashMap<K, V> = dashmap::DashMap<K, V, ahash::RandomState>;
+
+/// A map of max observed replica-set configurations for partitions
+#[derive(Clone, Default)]
+pub struct PartitionReplicaSetStates {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    partitions: DashMap<PartitionId, MembershipState>,
+}
+
+impl PartitionReplicaSetStates {
+    /// Update the membership state for a partition
+    pub fn note_observed_membership(
+        &self,
+        partition_id: PartitionId,
+        current_membership: &ReplicaSetState,
+        next_membership: &Option<ReplicaSetState>,
+    ) {
+        // we insert the partition id if unknown
+        self.inner
+            .partitions
+            .entry(partition_id)
+            .and_modify(|existing| {
+                existing.merge(current_membership, next_membership);
+            })
+            .or_insert_with(|| MembershipState {
+                observed_current_membership: current_membership.clone(),
+                observed_next_membership: next_membership.clone(),
+            });
+    }
+
+    pub fn get_membership_state(&self, partition_id: PartitionId) -> Option<MembershipState> {
+        self.inner
+            .partitions
+            .get(&partition_id)
+            .map(|k| k.value().clone())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (PartitionId, MembershipState)> {
+        self.inner
+            .partitions
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().clone()))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MembershipState {
+    pub observed_current_membership: ReplicaSetState,
+    pub observed_next_membership: Option<ReplicaSetState>,
+}
+
+impl MembershipState {
+    fn merge(
+        &mut self,
+        incoming_current_membership: &ReplicaSetState,
+        incoming_next_membership: &Option<ReplicaSetState>,
+    ) -> bool {
+        let mut modified = false;
+        match incoming_current_membership
+            .version
+            .cmp(&self.observed_current_membership.version)
+        {
+            // we have a new current membership
+            std::cmp::Ordering::Greater => {
+                self.observed_current_membership = incoming_current_membership.clone();
+                modified = true;
+                if self
+                    .observed_next_membership
+                    .as_ref()
+                    .is_some_and(|my_next| {
+                        my_next.version <= self.observed_current_membership.version
+                    })
+                {
+                    // unset our next, our current has caught up
+                    self.observed_next_membership = None;
+                }
+            }
+            std::cmp::Ordering::Equal => {
+                // merge member's durable lsns
+                modified = self
+                    .observed_current_membership
+                    .merge(incoming_current_membership.clone());
+            }
+            std::cmp::Ordering::Less => { /* ignore it */ }
+        }
+
+        // dealing with next membership configuration
+        let Some(incoming_next_membership) = incoming_next_membership else {
+            return modified;
+        };
+
+        // incoming has next but it older/equal to our own current
+        if incoming_next_membership.version <= self.observed_current_membership.version {
+            // ignore it, their next is lower that our current's
+            return modified;
+        }
+
+        let Some(my_next_membership) = &mut self.observed_next_membership else {
+            self.observed_next_membership = Some(incoming_next_membership.clone());
+            return true;
+        };
+
+        match incoming_next_membership
+            .version
+            .cmp(&my_next_membership.version)
+        {
+            std::cmp::Ordering::Greater => {
+                *my_next_membership = incoming_next_membership.clone();
+                modified = true;
+            }
+            std::cmp::Ordering::Equal => {
+                modified = my_next_membership.merge(incoming_next_membership.clone());
+            }
+            std::cmp::Ordering::Less => { /* ignore it */ }
+        }
+
+        modified
+    }
+}
+
+#[derive(Debug, Clone, bilrost::Message, NetSerde)]
+pub struct ReplicaSetState {
+    pub version: Version,
+    // ordered, akin to NodeSet
+    pub members: Vec<MemberState>,
+}
+
+impl Default for ReplicaSetState {
+    fn default() -> Self {
+        Self {
+            version: Version::INVALID,
+            members: Vec::new(),
+        }
+    }
+}
+
+impl Merge for ReplicaSetState {
+    fn merge(&mut self, other: Self) -> bool {
+        debug_assert_eq!(
+            self.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+            other.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+        );
+
+        let mut modified = false;
+        for (member, incoming_member) in self.members.iter_mut().zip(other.members) {
+            if incoming_member.durable_lsn > member.durable_lsn {
+                member.durable_lsn = incoming_member.durable_lsn;
+                modified = true;
+            }
+        }
+
+        modified
+    }
+}
+
+#[derive(Debug, Clone, bilrost::Message, NetSerde)]
+pub struct MemberState {
+    pub node_id: PlainNodeId,
+    pub durable_lsn: Lsn,
+}

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use restate_encoding::NetSerde;
+
 /// A type used for versioned metadata.
 #[derive(
     Clone,
@@ -24,6 +26,7 @@
     serde::Serialize,
     serde::Deserialize,
     restate_encoding::BilrostNewType,
+    NetSerde,
 )]
 #[display("v{}", _0)]
 #[debug("v{}", _0)]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -45,6 +45,7 @@ use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
 use restate_types::live::LiveLoadExt;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
@@ -114,6 +115,7 @@ impl Worker {
         health_status: HealthStatus<WorkerStatus>,
         metadata: Metadata,
         partition_routing: PartitionRouting,
+        replica_set_states: PartitionReplicaSetStates,
         networking: Networking<T>,
         bifrost: Bifrost,
         router_builder: &mut MessageRouterBuilder,
@@ -152,6 +154,7 @@ impl Worker {
             live_config_clone,
             metadata_store_client,
             partition_store_manager.clone(),
+            replica_set_states,
             router_builder,
             bifrost,
             SnapshotRepository::create_if_configured(

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -66,6 +66,7 @@ use restate_types::net::partition_processor_manager::{
 };
 use restate_types::net::{RpcRequest as _, UnaryMessage};
 use restate_types::partition_table::PartitionTable;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_types::retries::with_jitter;
 use restate_types::{GenerationalNodeId, SharedString, Version};
@@ -99,6 +100,7 @@ pub struct PartitionProcessorManager {
     rx: mpsc::Receiver<ProcessorsManagerCommand>,
     tx: mpsc::Sender<ProcessorsManagerCommand>,
 
+    _replica_set_states: PartitionReplicaSetStates,
     target_tail_lsns: HashMap<PartitionId, Lsn>,
     archived_lsns: HashMap<PartitionId, Lsn>,
     invokers_status_reader: MultiplexedInvokerStatusReader,
@@ -180,6 +182,7 @@ impl PartitionProcessorManager {
         updateable_config: Live<Configuration>,
         metadata_store_client: MetadataStoreClient,
         partition_store_manager: PartitionStoreManager,
+        replica_set_states: PartitionReplicaSetStates,
         router_builder: &mut MessageRouterBuilder,
         bifrost: Bifrost,
         snapshot_repository: Option<SnapshotRepository>,
@@ -200,6 +203,7 @@ impl PartitionProcessorManager {
             bifrost,
             rx,
             tx,
+            _replica_set_states: replica_set_states,
             archived_lsns: HashMap::default(),
             target_tail_lsns: HashMap::default(),
             invokers_status_reader: MultiplexedInvokerStatusReader::default(),
@@ -1250,6 +1254,7 @@ mod tests {
     use restate_types::nodes_config::{
         LogServerConfig, MetadataServerConfig, NodeConfig, NodesConfiguration, Role,
     };
+    use restate_types::partitions::state::PartitionReplicaSetStates;
     use restate_types::{GenerationalNodeId, Version};
     use std::time::Duration;
     use test_log::test;
@@ -1282,6 +1287,8 @@ mod tests {
             .with_factory(memory_loglet::Factory::default());
         let bifrost = bifrost_svc.handle();
 
+        let replica_set_states = PartitionReplicaSetStates::default();
+
         let partition_store_manager = PartitionStoreManager::create(
             Constant::new(StorageOptions::default()),
             &[(PartitionId::MIN, 0..=PartitionKey::MAX)],
@@ -1293,6 +1300,7 @@ mod tests {
             Live::from_value(Configuration::default()),
             env_builder.metadata_store_client.clone(),
             partition_store_manager,
+            replica_set_states,
             &mut env_builder.router_builder,
             bifrost,
             None,


### PR DESCRIPTION

Introducing gossip-driven dissemination of partition replica-set states through selective gossip messaging. This also introduces base data structures for `PartitionConfiguration` that will be eventually stored into `EpochMetadata`.
