### PR TITLE
[Restate UI] Update to v0.0.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7895,8 +7895,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.67"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.67#69e8d52e3eb8d963d9c9d11ad468208a356a67dc"
+version = "0.0.68"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.68#7b9b091c75c333024af908d89ae122fcac6a3d98"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -32,7 +32,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true, features = ["schemars"] }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.67", tag = "v0.0.67" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.68", tag = "v0.0.68" }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.68
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.68/ui-v0.0.68.zip