### PR TITLE
[invoker] Validate when user incorrectly provides key

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -267,6 +267,10 @@ pub(crate) enum CommandPreconditionError {
     ServiceHandlerNotFound(String, String),
     #[error("the request key is not a valid UTF-8 string: {0}")]
     BadRequestKey(#[from] std::str::Utf8Error),
+    #[error(
+        "a key was provided, but the callee '{0}' is a Service. Only VirtualObjects or Workflows accept a key"
+    )]
+    UnexpectedKey(String),
     #[error("the idempotency key provided in the request is empty")]
     EmptyIdempotencyKey,
     #[error("unsupported entry type, only Workflow services support it")]

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -1015,6 +1015,12 @@ fn resolve_call_request(
             )
         })?;
 
+    if !request.key.is_empty() && !meta.target_ty.is_keyed() {
+        return Err(CommandPreconditionError::UnexpectedKey(
+            request.service_name.to_string(),
+        ));
+    }
+
     let invocation_target = match meta.target_ty {
         InvocationTargetType::Service => {
             InvocationTarget::service(request.service_name, request.handler_name)


### PR DESCRIPTION
In service to service communication, validate when the user provides a key calling a regular service. In that case, a retryable error is generated.

Fix #3246