### PR TITLE
[CLI] Add a `state patch` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6642,6 +6642,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "itertools 0.14.0",
+ "json-patch",
  "jsonwebtoken",
  "octocrab",
  "open",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -59,6 +59,7 @@ humantime = { workspace = true }
 indicatif = "0.17.7"
 indoc = { version = "2.0.4" }
 itertools = { workspace = true }
+json-patch = "2.0.0"
 jsonwebtoken = { version = "9.1.0" }
 octocrab = { version = "0.44.0", features = ["stream"] }
 open = "5.1.2"

--- a/cli/src/commands/state/mod.rs
+++ b/cli/src/commands/state/mod.rs
@@ -11,6 +11,7 @@
 mod clear;
 mod edit;
 mod get;
+mod patch;
 mod util;
 
 use cling::prelude::*;
@@ -21,6 +22,8 @@ pub enum ServiceState {
     Get(get::Get),
     /// Edit the persisted state stored for a service key
     Edit(edit::Edit),
+    /// Patch persisted key-value state for a service key
+    Patch(patch::Patch),
     /// Clear of the state of a given service
     Clear(clear::Clear),
 }

--- a/cli/src/commands/state/patch.rs
+++ b/cli/src/commands/state/patch.rs
@@ -11,67 +11,56 @@
 use anyhow::{Context, Result};
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
-use tempfile::tempdir;
 
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_cli_util::{c_println, c_title};
 
 use crate::cli_env::CliEnv;
 use crate::commands::state::util::{
-    as_json, compute_version, from_json, get_current_state, pretty_print_json, read_json_file,
-    update_state, write_json_file,
+    as_json, compute_version, from_json, get_current_state, pretty_print_json, update_state,
 };
 
 #[derive(Run, Parser, Collect, Clone)]
-#[cling(run = "run_edit")]
-pub struct Edit {
-    /// Don't try to convert the values to a UTF-8 string
-    #[clap(long, alias = "bin")]
-    binary: bool,
-
+#[cling(run = "patch")]
+pub struct Patch {
     /// Force means, ignore the current version
     #[clap(long, short)]
     force: bool,
 
-    /// service name
+    /// Service name
     service: String,
 
-    /// service key
+    /// Service key
     key: String,
+
+    /// JSON patch
+    #[arg(short, long)]
+    patch: String,
 }
 
-pub async fn run_edit(State(env): State<CliEnv>, opts: &Edit) -> Result<()> {
-    edit(&env, opts).await
-}
+pub async fn patch(State(env): State<CliEnv>, opts: &Patch) -> Result<()> {
+    let patch = serde_json::from_str::<json_patch::Patch>(&opts.patch)
+        .map_err(|e| anyhow::anyhow!("Parsing JSON patch: {}", e))?;
 
-async fn edit(env: &CliEnv, opts: &Edit) -> Result<()> {
-    let current_state = get_current_state(env, &opts.service, &opts.key, false).await?;
+    let current_state = get_current_state(&env, &opts.service, &opts.key, false).await?;
     let current_version = compute_version(&current_state);
 
-    let tempdir = tempdir().context("unable to create a temporary directory")?;
-    let edit_file = tempdir.path().join(".restate_edit");
-    let current_state_json = as_json(current_state, opts.binary)?;
-    write_json_file(&edit_file, current_state_json)?;
-    env.open_default_editor(&edit_file)?;
-    let modified_state_json = read_json_file(&edit_file)?;
+    let mut state = as_json(current_state, false)?;
 
-    //
-    // confirm change
-    //
+    json_patch::patch(&mut state, &patch).context("Patch failed")?;
 
     let mut table = Table::new_styled();
     table.set_styled_header(vec!["", ""]);
     table.add_row(vec![Cell::new("Service"), Cell::new(&opts.service)]);
     table.add_row(vec![Cell::new("Key"), Cell::new(&opts.key)]);
     table.add_row(vec![Cell::new("Force?"), Cell::new(opts.force)]);
-    table.add_row(vec![Cell::new("Binary?"), Cell::new(opts.binary)]);
 
-    c_title!("ℹ️ ", "State Update");
+    c_title!("ℹ️ ", "Patch State");
     c_println!("{table}");
     c_println!();
 
     c_title!("ℹ️ ", "New State");
-    c_println!("{}", pretty_print_json(&modified_state_json)?);
+    c_println!("{}", pretty_print_json(&state)?);
     c_println!();
 
     c_println!("About to submit the new state mutation to the system for processing.");
@@ -83,23 +72,13 @@ async fn edit(env: &CliEnv, opts: &Edit) -> Result<()> {
 
     c_println!();
 
-    //
-    // back to binary
-    //
-    let modified_state = from_json(modified_state_json, opts.binary)?;
-    //
-    // attach the current version
-    //
+    let modified_state = from_json(state, false)?;
     let version = if opts.force {
         None
     } else {
         Some(current_version)
     };
-    update_state(env, version, &opts.service, &opts.key, modified_state).await?;
-
-    //
-    // done
-    //
+    update_state(&env, version, &opts.service, &opts.key, modified_state).await?;
 
     c_println!();
     c_println!("Successfully submitted state update.");


### PR DESCRIPTION
I built this for some ops work I needed elsewhere - I think it's pretty useful for scripting small changes!


Example usage:

```
~ % cargo run --bin restate state patch Accounts acc_100 \
    --patch '[ { "op": "replace", "path": "/state/environments", "value": [] } ]'
```

This tool is analogous to the existing `restatectl metadata patch` subcommand, but for service state.