### PR TITLE
WAL: Custom Encoding for `Envelope`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ checksum = "815ed941f4e34d221bda5ac688ff1f80f579ca0c1b062d381347be6d53786e02"
 dependencies = [
  "bilrost-derive",
  "bytes",
+ "bytestring",
  "thin-vec",
 ]
 
@@ -2967,11 +2968,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -4284,7 +4286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4302,6 +4304,15 @@ dependencies = [
  "bitflags 2.8.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4541,9 +4552,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -6565,6 +6576,7 @@ dependencies = [
  "restate-bifrost",
  "restate-core",
  "restate-futures-util",
+ "restate-invoker-api",
  "restate-log-server",
  "restate-metadata-store",
  "restate-rocksdb",
@@ -7803,6 +7815,7 @@ dependencies = [
  "anyhow",
  "assert2",
  "async-trait",
+ "bilrost",
  "bytes",
  "bytestring",
  "codederror",
@@ -7811,8 +7824,10 @@ dependencies = [
  "enum-map",
  "flexbuffers",
  "googletest",
+ "prost",
  "restate-core",
  "restate-invoker-api",
+ "restate-partition-store",
  "restate-storage-api",
  "restate-test-util",
  "restate-types",
@@ -7830,12 +7845,12 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.70"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.70#cdebab82eaec6a71fb6d2c5ef5174da9646e3e0b"
+version = "0.0.71"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.71#9d1e9789bcbbe11a0a231e62a213eed2bd421e71"
 dependencies = [
  "anyhow",
  "include_dir",
- "zip 2.5.0",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -10326,9 +10341,11 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "axum-core",
+ "bilrost",
  "bitflags 2.8.0",
  "byteorder",
  "bytes",
+ "bytestring",
  "bzip2-sys",
  "cc",
  "chrono",
@@ -10657,16 +10674,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "aes",
  "arbitrary",
  "bzip2 0.5.2",
  "constant_time_eq 0.3.1",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
  "flate2",
  "getrandom 0.3.1",
@@ -10682,6 +10698,12 @@ dependencies = [
  "zopfli",
  "zstd 0.13.2",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
 
 [[package]]
 name = "zopfli"

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -31,7 +31,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.70", tag = "v0.0.70" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.71", tag = "v0.0.71" }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -66,6 +66,7 @@ restate-storage-api = { workspace = true }
 restate-test-util = { workspace = true }
 restate-types = { workspace = true, features = ["test-util"] }
 restate-wal-protocol = { workspace = true, features = ["serde"] }
+restate-invoker-api = { workspace = true }
 
 bytestring = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -62,8 +62,7 @@ impl_net_serde!(
     String,
     bytes::Bytes,
     bytestring::ByteString,
-    std::time::Duration,
-    std::path::PathBuf
+    std::time::Duration
 );
 
 macro_rules! impl_net_serde_tuple {

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -22,7 +22,8 @@ mod partition_store;
 mod partition_store_manager;
 mod persisted_lsn_tracking;
 pub mod promise_table;
-mod protobuf_types;
+// todo(azmy): Follow up issue https://github.com/restatedev/restate/issues/3284
+pub mod protobuf_types;
 pub mod scan;
 pub mod service_status_table;
 pub mod snapshots;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -32,7 +32,7 @@ base64 = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
-bilrost = { workspace = true }
+bilrost = { workspace = true, features = ["bytestring"] }
 bincode = { workspace = true, default-features = false, features = ["std", "serde"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env"], optional = true }

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -16,6 +16,8 @@ use std::fmt::{Debug, Display, Formatter};
 use tonic;
 use tracing::Level;
 
+use restate_encoding::BilrostNewType;
+
 /// Error type which abstracts away the actual [`std::error::Error`] type. Use this type
 /// if you don't know the actual error type or if it is not important.
 pub type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -93,7 +95,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, BilrostNewType)]
 #[serde(transparent)]
 pub struct InvocationErrorCode(u16);
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -22,7 +22,7 @@ use std::mem::size_of;
 use std::str::FromStr;
 use ulid::Ulid;
 
-use restate_encoding::{BilrostNewType, NetSerde};
+use restate_encoding::{BilrostAs, BilrostDisplayFromStr, BilrostNewType, NetSerde};
 
 use crate::base62_util::base62_encode_fixed_width;
 use crate::base62_util::base62_max_length_for_type;
@@ -200,6 +200,7 @@ pub trait ResourceId {
     Clone,
     Copy,
     Debug,
+    Default,
     Ord,
     PartialOrd,
     serde_with::SerializeDisplay,
@@ -423,7 +424,10 @@ impl Display for ServiceId {
     Ord,
     serde_with::SerializeDisplay,
     serde_with::DeserializeFromStr,
+    Default,
+    BilrostAs,
 )]
+#[bilrost_as(BilrostDisplayFromStr)]
 pub struct InvocationId {
     /// Partition key of the called service
     partition_key: PartitionKey,

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -456,10 +456,15 @@ pub struct InvocationInput {
 }
 
 /// Target of a completion sent from another Partition Processor.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash, bilrost::Message,
+)]
 pub struct JournalCompletionTarget {
+    #[bilrost(1)]
     pub caller_id: InvocationId,
+    #[bilrost(2)]
     pub caller_completion_id: CompletionId,
+    #[bilrost(3)]
     pub caller_invocation_epoch: InvocationEpoch,
 }
 
@@ -537,13 +542,15 @@ impl From<&InvocationError> for ResponseResult {
 }
 
 // Represents a response to get invocation output
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 #[serde(
     from = "serde_hacks::GetInvocationOutputResponse",
     into = "serde_hacks::GetInvocationOutputResponse"
 )]
 pub struct GetInvocationOutputResponse {
+    #[bilrost(1)]
     pub target: JournalCompletionTarget,
+    #[bilrost(oneof(2, 3))]
     pub result: GetInvocationOutputResult,
 }
 
@@ -833,7 +840,7 @@ impl SpanRelation {
 }
 
 /// Message to terminate an invocation.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct InvocationTermination {
     pub invocation_id: InvocationId,
     pub flavor: TerminationFlavor,
@@ -856,17 +863,20 @@ impl InvocationTermination {
 }
 
 /// Flavor of the termination. Can be kill (hard stop) or graceful cancel.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Enumeration,
+)]
 pub enum TerminationFlavor {
     /// hard termination, no clean up
-    Kill,
+    Kill = 0,
     /// graceful termination allowing the invocation to clean up
-    Cancel,
+    Cancel = 1,
 }
 
 /// Message to purge an invocation.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct PurgeInvocationRequest {
+    #[bilrost(1)]
     pub invocation_id: InvocationId,
 }
 

--- a/crates/types/src/journal_v2/notification.rs
+++ b/crates/types/src/journal_v2/notification.rs
@@ -299,10 +299,12 @@ pub struct GetInvocationOutputCompletion {
     pub completion_id: CompletionId,
     pub result: GetInvocationOutputResult,
 }
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bilrost::Oneof)]
 pub enum GetInvocationOutputResult {
     Void,
+    #[bilrost(2)]
     Success(Bytes),
+    #[bilrost(3)]
     Failure(Failure),
 }
 impl_completion_accessors!(GetInvocationOutput);

--- a/crates/types/src/journal_v2/types.rs
+++ b/crates/types/src/journal_v2/types.rs
@@ -13,9 +13,11 @@
 use crate::errors::{InvocationError, InvocationErrorCode};
 use bytestring::ByteString;
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct Failure {
+    #[bilrost(1)]
     pub code: InvocationErrorCode,
+    #[bilrost(2)]
     pub message: ByteString,
 }
 

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -40,7 +40,9 @@ pub enum StorageDecodeError {
     UnsupportedCodecKind(StorageCodecKind),
 }
 
-#[derive(Debug, Copy, Clone, strum::FromRepr, derive_more::Display)]
+#[derive(
+    Debug, Copy, Clone, strum::FromRepr, derive_more::Display, PartialEq, Eq, bilrost::Enumeration,
+)]
 #[repr(u8)]
 pub enum StorageCodecKind {
     /// plain old protobuf
@@ -53,6 +55,18 @@ pub enum StorageCodecKind {
     BincodeSerde = 4,
     /// Json (no length prefix)
     Json = 5,
+    /// Bilrost (no length-prefixed)
+    Bilrost = 6,
+    /// A custom encoding that does not rely on any of the standard encoding formats
+    /// supported by the [`encode`] and [`decode`] modules.
+    ///
+    /// When using this variant, the encoding and decoding logic is entirely defined
+    /// by the implementation of the [`StorageEncode`] and [`StorageDecode`] traits.
+    ///
+    /// While you may still use utility functions from the [`encode`] and [`decode`] modules,
+    /// it is up to your implementation to decide how (or if) to use them, and how the final
+    /// byte representation is constructed.
+    Custom = 7,
 }
 
 impl From<StorageCodecKind> for u8 {

--- a/crates/types/src/storage/decode.rs
+++ b/crates/types/src/storage/decode.rs
@@ -92,3 +92,7 @@ fn decode_serde_from_json<T: DeserializeOwned, B: Buf>(
     })?;
     Ok(result)
 }
+
+pub fn decode_bilrost<T: bilrost::OwnedMessage, B: Buf>(buf: B) -> Result<T, StorageDecodeError> {
+    T::decode(buf).map_err(|err| StorageDecodeError::DecodeValue(err.into()))
+}

--- a/crates/types/src/storage/encode.rs
+++ b/crates/types/src/storage/encode.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 use std::mem;
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::Serialize;
 
 use super::{StorageCodecKind, StorageEncodeError};
@@ -77,4 +77,9 @@ fn encode_serde_as_json<T: Serialize>(
     serde_json::to_writer(buf.writer(), value)?;
 
     Ok(())
+}
+
+/// Utility method to encode a [`bilrost::Message`] type
+pub fn encode_bilrost<T: bilrost::Message>(value: &T) -> Bytes {
+    value.encode_contiguous().into_vec().into()
 }

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -15,6 +15,9 @@ serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 restate-core = { workspace = true }
 restate-invoker-api = { workspace = true }
+# todo(azmy): Follow up https://github.com/restatedev/restate/pull/3261
+# remove dependency on restate-partition-store
+restate-partition-store = { workspace = true }
 restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 
@@ -22,6 +25,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+bilrost = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
 derive_more = { workspace = true }
@@ -32,6 +36,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
+prost = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -8,20 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use bytes::BufMut;
+use tracing::error;
+
 use restate_storage_api::deduplication_table::DedupInformation;
+use restate_types::GenerationalNodeId;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey};
 use restate_types::invocation::{
     AttachInvocationRequest, GetInvocationOutputResponse, InvocationResponse,
     InvocationTermination, NotifySignalRequest, PurgeInvocationRequest, ServiceInvocation,
 };
+use restate_types::logs::{HasRecordKeys, Keys, MatchKeyQuery};
 use restate_types::message::MessageIndex;
 use restate_types::state_mut::ExternalStateMutation;
+use restate_types::storage::decode::decode_serde;
+use restate_types::storage::encode::encode_serde;
+use restate_types::storage::{
+    StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError,
+};
 use restate_types::{PlainNodeId, Version, logs};
 
 use crate::control::AnnounceLeader;
 use crate::timer::TimerKeyValue;
-use restate_types::GenerationalNodeId;
-use restate_types::logs::{HasRecordKeys, Keys, MatchKeyQuery};
 
 pub mod control;
 pub mod timer;
@@ -57,7 +65,47 @@ impl Envelope {
 }
 
 #[cfg(feature = "serde")]
-restate_types::flexbuffers_storage_encode_decode!(Envelope);
+impl StorageEncode for Envelope {
+    fn default_codec(&self) -> StorageCodecKind {
+        // TODO(azmy): Change to `Custom` in v1.4
+        StorageCodecKind::FlexbuffersSerde
+    }
+
+    fn encode(&self, buf: &mut ::bytes::BytesMut) -> Result<(), StorageEncodeError> {
+        match self.default_codec() {
+            StorageCodecKind::FlexbuffersSerde => encode_serde(self, buf, self.default_codec()),
+            StorageCodecKind::Custom => {
+                buf.put_slice(&envelope::encode(self)?);
+                Ok(())
+            }
+            _ => unreachable!("developer error"),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl StorageDecode for Envelope {
+    fn decode<B: ::bytes::Buf>(
+        buf: &mut B,
+        kind: StorageCodecKind,
+    ) -> Result<Self, StorageDecodeError>
+    where
+        Self: Sized,
+    {
+        match kind {
+            StorageCodecKind::Json
+            | StorageCodecKind::BincodeSerde
+            | StorageCodecKind::FlexbuffersSerde => decode_serde(buf, kind).map_err(|err| {
+                error!(%err, "{} decode failure (decoding Envelope)", kind);
+                err
+            }),
+            StorageCodecKind::LengthPrefixedRawBytes
+            | StorageCodecKind::Protobuf
+            | StorageCodecKind::Bilrost => Err(StorageDecodeError::UnsupportedCodecKind(kind)),
+            StorageCodecKind::Custom => envelope::decode(buf),
+        }
+    }
+}
 
 /// Header is set on every message
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -223,5 +271,308 @@ impl HasRecordKeys for Envelope {
 impl MatchKeyQuery for Envelope {
     fn matches_key_query(&self, query: &logs::KeyFilter) -> bool {
         self.record_keys().matches_key_query(query)
+    }
+}
+
+mod envelope {
+    use bilrost::{Message, OwnedMessage};
+    use bytes::{Buf, Bytes, BytesMut};
+    use serde::{Serialize, de::DeserializeOwned};
+
+    use restate_partition_store::protobuf_types::v1 as protobuf;
+    use restate_types::storage::{self, StorageCodecKind, StorageDecodeError, StorageEncodeError};
+
+    use crate::Command;
+
+    #[derive(Debug, thiserror::Error)]
+    enum DecodeError {
+        #[error("missing field codec")]
+        MissingFieldCodec,
+        #[error("unknown command kind")]
+        UnknownCommandKind,
+        #[error("unexpected codec kind {0}")]
+        UnexpectedCodec(StorageCodecKind),
+    }
+
+    impl From<DecodeError> for StorageDecodeError {
+        fn from(value: DecodeError) -> Self {
+            Self::DecodeValue(value.into())
+        }
+    }
+
+    #[derive(PartialEq, Eq, bilrost::Enumeration)]
+    enum CommandKind {
+        Unknown = 0,
+        AnnounceLeader = 1,                     // flexbuffers
+        PatchState = 2,                         // protobuf
+        TerminateInvocation = 3,                // bilrost
+        PurgeInvocation = 4,                    // bilrost
+        Invoke = 5,                             // protobuf
+        TruncateOutbox = 6,                     // flexbuffers
+        ProxyThrough = 7,                       // protobuf
+        AttachInvocation = 8,                   // protobuf
+        InvokerEffect = 9,                      // flexbuffers
+        Timer = 10,                             // flexbuffers
+        ScheduleTimer = 11,                     // flexbuffers
+        InvocationResponse = 12,                // protobuf
+        NotifyGetInvocationOutputResponse = 13, // bilrost
+        NotifySignal = 14,                      // protobuf
+    }
+
+    #[derive(bilrost::Message)]
+    struct Field {
+        #[bilrost(1)]
+        codec: Option<StorageCodecKind>,
+        #[bilrost(2)]
+        bytes: Bytes,
+    }
+
+    impl Field {
+        fn encode_serde<T: Serialize>(
+            codec: StorageCodecKind,
+            value: &T,
+        ) -> Result<Self, StorageEncodeError> {
+            let mut buf = BytesMut::new();
+            storage::encode::encode_serde(value, &mut buf, codec)?;
+
+            Ok(Self {
+                codec: Some(codec),
+                bytes: buf.freeze(),
+            })
+        }
+
+        fn encode_bilrost<T: bilrost::Message>(value: &T) -> Result<Self, StorageEncodeError> {
+            Ok(Self {
+                codec: Some(StorageCodecKind::Bilrost),
+                bytes: storage::encode::encode_bilrost(value),
+            })
+        }
+
+        fn encode_protobuf<T: prost::Message>(value: &T) -> Result<Self, StorageEncodeError> {
+            let mut buf = BytesMut::new();
+            value
+                .encode(&mut buf)
+                .map_err(|err| StorageEncodeError::EncodeValue(err.into()))?;
+
+            Ok(Self {
+                codec: Some(StorageCodecKind::Protobuf),
+                bytes: buf.freeze(),
+            })
+        }
+
+        fn decode_serde<T: DeserializeOwned>(mut self) -> Result<T, StorageDecodeError> {
+            let codec = self.codec()?;
+            if !matches!(
+                codec,
+                StorageCodecKind::Json
+                    | StorageCodecKind::FlexbuffersSerde
+                    | StorageCodecKind::BincodeSerde
+            ) {
+                return Err(StorageDecodeError::UnsupportedCodecKind(codec));
+            }
+
+            storage::decode::decode_serde(
+                &mut self.bytes,
+                self.codec.ok_or(DecodeError::MissingFieldCodec)?,
+            )
+        }
+
+        fn decode_bilrost<T: bilrost::OwnedMessage>(mut self) -> Result<T, StorageDecodeError> {
+            let codec = self.codec()?;
+            if codec != StorageCodecKind::Bilrost {
+                return Err(StorageDecodeError::UnsupportedCodecKind(codec));
+            }
+
+            storage::decode::decode_bilrost(&mut self.bytes)
+        }
+
+        fn decode_protobuf<T: prost::Message + Default>(self) -> Result<T, StorageDecodeError> {
+            let codec = self.codec()?;
+            if codec != StorageCodecKind::Protobuf {
+                return Err(StorageDecodeError::UnsupportedCodecKind(codec));
+            }
+
+            T::decode(self.bytes).map_err(|err| StorageDecodeError::DecodeValue(err.into()))
+        }
+
+        fn codec(&self) -> Result<StorageCodecKind, DecodeError> {
+            self.codec.ok_or(DecodeError::MissingFieldCodec)
+        }
+    }
+
+    #[derive(bilrost::Message)]
+    struct Envelope {
+        #[bilrost(1)]
+        header: Field,
+        #[bilrost(2)]
+        command_kind: CommandKind,
+        #[bilrost(3)]
+        command: Field,
+    }
+
+    macro_rules! codec_or_error {
+        ($field:expr, $expected:path) => {{
+            let codec = $field.codec()?;
+            if !matches!(codec, $expected) {
+                return Err(DecodeError::UnexpectedCodec(codec).into());
+            }
+        }};
+    }
+
+    pub fn encode(envelope: &super::Envelope) -> Result<Bytes, StorageEncodeError> {
+        // todo(azmy): avoid clone? this will require change to `From` implementation
+        let (command_kind, command) = match &envelope.command {
+            Command::AnnounceLeader(value) => (
+                CommandKind::AnnounceLeader,
+                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
+            ),
+            Command::PatchState(value) => {
+                let value = protobuf::StateMutation::from(value.clone());
+                (CommandKind::PatchState, Field::encode_protobuf(&value))
+            }
+            Command::TerminateInvocation(value) => (
+                CommandKind::TerminateInvocation,
+                Field::encode_bilrost(value),
+            ),
+            Command::PurgeInvocation(value) => {
+                (CommandKind::PurgeInvocation, Field::encode_bilrost(value))
+            }
+            Command::Invoke(value) => {
+                let value = protobuf::ServiceInvocation::from(value.clone());
+                (CommandKind::Invoke, Field::encode_protobuf(&value))
+            }
+            Command::TruncateOutbox(value) => (
+                CommandKind::TruncateOutbox,
+                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
+            ),
+            Command::ProxyThrough(value) => {
+                let value = protobuf::ServiceInvocation::from(value.clone());
+                (CommandKind::ProxyThrough, Field::encode_protobuf(&value))
+            }
+            Command::AttachInvocation(value) => {
+                let value = protobuf::outbox_message::AttachInvocationRequest::from(value.clone());
+                (
+                    CommandKind::AttachInvocation,
+                    Field::encode_protobuf(&value),
+                )
+            }
+            Command::InvokerEffect(value) => (
+                CommandKind::InvokerEffect,
+                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
+            ),
+            Command::Timer(value) => (
+                CommandKind::Timer,
+                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
+            ),
+            Command::ScheduleTimer(value) => (
+                CommandKind::ScheduleTimer,
+                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
+            ),
+            Command::InvocationResponse(value) => {
+                let value =
+                    protobuf::outbox_message::OutboxServiceInvocationResponse::from(value.clone());
+                (
+                    CommandKind::InvocationResponse,
+                    Field::encode_protobuf(&value),
+                )
+            }
+            Command::NotifyGetInvocationOutputResponse(value) => (
+                CommandKind::NotifyGetInvocationOutputResponse,
+                Field::encode_bilrost(value),
+            ),
+            Command::NotifySignal(value) => {
+                let value = protobuf::outbox_message::NotifySignal::from(value.clone());
+                (CommandKind::NotifySignal, Field::encode_protobuf(&value))
+            }
+        };
+
+        let dto = Envelope {
+            header: Field::encode_serde(StorageCodecKind::FlexbuffersSerde, &envelope.header)?,
+            command_kind,
+            command: command?,
+        };
+
+        Ok(dto.encode_contiguous().into_vec().into())
+    }
+
+    pub fn decode<B: Buf>(buf: B) -> Result<super::Envelope, StorageDecodeError> {
+        let envelope =
+            Envelope::decode(buf).map_err(|err| StorageDecodeError::DecodeValue(err.into()))?;
+
+        // header is encoded with serde
+        codec_or_error!(envelope.header, StorageCodecKind::FlexbuffersSerde);
+        let header = envelope.header.decode_serde::<super::Header>()?;
+
+        let command = match envelope.command_kind {
+            CommandKind::Unknown => return Err(DecodeError::UnknownCommandKind.into()),
+            CommandKind::AnnounceLeader => {
+                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
+                Command::AnnounceLeader(envelope.command.decode_serde()?)
+            }
+            CommandKind::PatchState => {
+                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
+                let value: protobuf::StateMutation = envelope.command.decode_protobuf()?;
+                Command::PatchState(value.try_into()?)
+            }
+            CommandKind::TerminateInvocation => {
+                codec_or_error!(envelope.command, StorageCodecKind::Bilrost);
+                Command::TerminateInvocation(envelope.command.decode_bilrost()?)
+            }
+            CommandKind::PurgeInvocation => {
+                codec_or_error!(envelope.command, StorageCodecKind::Bilrost);
+                Command::PurgeInvocation(envelope.command.decode_bilrost()?)
+            }
+            CommandKind::Invoke => {
+                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
+                let value: protobuf::ServiceInvocation = envelope.command.decode_protobuf()?;
+                Command::Invoke(value.try_into()?)
+            }
+            CommandKind::TruncateOutbox => {
+                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
+                Command::TruncateOutbox(envelope.command.decode_serde()?)
+            }
+            CommandKind::ProxyThrough => {
+                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
+                let value: protobuf::ServiceInvocation = envelope.command.decode_protobuf()?;
+                Command::ProxyThrough(value.try_into()?)
+            }
+            CommandKind::AttachInvocation => {
+                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
+                let value: protobuf::outbox_message::AttachInvocationRequest =
+                    envelope.command.decode_protobuf()?;
+                Command::AttachInvocation(value.try_into()?)
+            }
+            CommandKind::InvokerEffect => {
+                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
+                Command::InvokerEffect(envelope.command.decode_serde()?)
+            }
+            CommandKind::Timer => {
+                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
+                Command::Timer(envelope.command.decode_serde()?)
+            }
+            CommandKind::ScheduleTimer => {
+                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
+                Command::ScheduleTimer(envelope.command.decode_serde()?)
+            }
+            CommandKind::InvocationResponse => {
+                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
+                let value: protobuf::outbox_message::OutboxServiceInvocationResponse =
+                    envelope.command.decode_protobuf()?;
+                Command::InvocationResponse(value.try_into()?)
+            }
+            CommandKind::NotifyGetInvocationOutputResponse => {
+                codec_or_error!(envelope.command, StorageCodecKind::Bilrost);
+                Command::NotifyGetInvocationOutputResponse(envelope.command.decode_bilrost()?)
+            }
+            CommandKind::NotifySignal => {
+                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
+                let value: protobuf::outbox_message::NotifySignal =
+                    envelope.command.decode_protobuf()?;
+
+                Command::NotifySignal(value.try_into()?)
+            }
+        };
+
+        Ok(super::Envelope { header, command })
     }
 }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -31,8 +31,10 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
+bilrost = { version = "0.1012", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
+bytestring = { version = "1", default-features = false, features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", default-features = false, features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
@@ -44,7 +46,7 @@ digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }
 enumset = { version = "1", default-features = false, features = ["serde"] }
-flate2 = { version = "1" }
+flate2 = { version = "1", features = ["zlib-rs"] }
 futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
@@ -148,8 +150,10 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
+bilrost = { version = "0.1012", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
+bytestring = { version = "1", default-features = false, features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -163,7 +167,7 @@ either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }
 enumset = { version = "1", default-features = false, features = ["serde"] }
 enumset_derive = { version = "0.10", default-features = false, features = ["serde"] }
-flate2 = { version = "1" }
+flate2 = { version = "1", features = ["zlib-rs"] }
 futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }


### PR DESCRIPTION
WAL: Custom Encoding for `Envelope`

This PR enables `Envelope` to apply custom encoding strategies for individual Command variants, selecting the most efficient encoding available for each case.

The design is forward-compatible, allowing future changes to the encoding of specific variants without breaking backward compatibility.

## Benches
Benchmarks shows a big improvement for variants that uses protobuf (e.g invoke-cmd in this example).
While also unfortunately shows a small regression in performance for variants that still uses flexbuffers internally.

Those variants will eventually switch to bilrost overtime, so I think even if we have a slight decrease in performance right now
this changeset will allow us to improve this later on.

*NOTE:* To run the benchmarks locally make sure to modify the envelope `StorageEncode` implementation
to actually use `Custom` encoding

## Before
<details>

<summary>Benchmarks results before switching to custom encoding</summary>

```
     Running benches/replicated_loglet_serde.rs (target/release/deps/replicated_loglet_serde-5dda2eb5d1331e02)
Gnuplot not found, using plotters backend
replicated-loglet-serde.invoke-cmd/serialize-append
                        time:   [58.196 µs 58.248 µs 58.305 µs]
                        change: [+64.298% +64.636% +64.929%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 50 measurements (12.00%)
  1 (2.00%) low severe
  1 (2.00%) low mild
  4 (8.00%) high mild
replicated-loglet-serde.invoke-cmd/deserialize-append
                        time:   [1.9243 µs 1.9267 µs 1.9295 µs]
                        change: [-4.3010% -4.1884% -4.0626%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  2 (4.00%) high mild
  2 (4.00%) high severe
replicated-loglet-serde.invoke-cmd/serialize-store
                        time:   [58.438 µs 58.475 µs 58.517 µs]
                        change: [+62.380% +62.647% +62.876%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) low mild
  1 (2.00%) high mild

replicated-loglet-serde.invoker-effect/serialize-append
                        time:   [36.209 µs 36.256 µs 36.319 µs]
                        change: [-8.3523% -8.1153% -7.9057%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe
replicated-loglet-serde.invoker-effect/deserialize-append
                        time:   [1.9168 µs 1.9208 µs 1.9262 µs]
                        change: [+1.3047% +1.6301% +1.8847%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
replicated-loglet-serde.invoker-effect/serialize-store
                        time:   [36.556 µs 36.603 µs 36.663 µs]
                        change: [-8.4178% -8.2808% -8.1429%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) high mild
  3 (6.00%) high severe
```

</details>

### After
<details>

<summary>Benchmarks results after switching to custom encoding</summary>

```
     Running benches/replicated_loglet_serde.rs (target/release/deps/replicated_loglet_serde-fdc6dca006aa05a2)
Gnuplot not found, using plotters backend
replicated-loglet-serde.invoke-cmd/serialize-append
                        time:   [35.439 µs 35.468 µs 35.500 µs]
                        change: [-39.114% -39.039% -38.965%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
replicated-loglet-serde.invoke-cmd/deserialize-append
                        time:   [1.8101 µs 1.8129 µs 1.8161 µs]
                        change: [-6.0752% -5.9156% -5.7532%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 50 measurements (16.00%)
  1 (2.00%) low mild
  3 (6.00%) high mild
  4 (8.00%) high severe
replicated-loglet-serde.invoke-cmd/serialize-store
                        time:   [35.910 µs 35.944 µs 35.980 µs]
                        change: [-38.591% -38.463% -38.312%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe

replicated-loglet-serde.invoker-effect/serialize-append
                        time:   [39.387 µs 39.453 µs 39.520 µs]
                        change: [+8.3225% +8.5442% +8.7673%] (p = 0.00 < 0.05)
                        Performance has regressed.
replicated-loglet-serde.invoker-effect/deserialize-append
                        time:   [1.8490 µs 1.8517 µs 1.8547 µs]
                        change: [-3.8572% -3.6454% -3.4561%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high mild
replicated-loglet-serde.invoker-effect/serialize-store
                        time:   [39.832 µs 39.868 µs 39.905 µs]
                        change: [+8.6906% +8.8668% +9.0299%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) low mild
  3 (6.00%) high severe
```
</details>
