### PR TITLE
Harden three_logserver_append_after_seal_concurrent

### DIFF
--- a/server/tests/replicated_loglet.rs
+++ b/server/tests/replicated_loglet.rs
@@ -188,7 +188,7 @@ mod tests {
         .await
     }
 
-    #[restate_core::test(flavor = "multi_thread", worker_threads = 4)]
+    #[test(restate_core::test(flavor = "multi_thread", worker_threads = 4))]
     async fn three_logserver_append_after_seal_concurrent() -> googletest::Result<()> {
         run_in_test_env(
             Configuration::default(),


### PR DESCRIPTION
This commit ensures that the test runner sees the manually written Logs configuration by awaiting its version. Otherwise, there was a risk that an empty Logs configuration with Version::MIN was received by a peer, which cause the test to fail with an unknown log '0' error.

This fixes #3265