### PR TITLE
Integrate restate_core::cluster_state::ClusterState into the ClusterController

### DIFF
--- a/crates/admin/src/cluster_controller/logs_controller.rs
+++ b/crates/admin/src/cluster_controller/logs_controller.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use futures::future;
-use futures::never::Never;
 use rand::prelude::IteratorRandom;
 use rand::rng;
 use std::collections::HashMap;
@@ -26,7 +25,6 @@ use restate_bifrost::{Bifrost, Error as BifrostError};
 use restate_core::{Metadata, MetadataKind, MetadataWriter, ShutdownError, TaskCenterFutureExt};
 use restate_futures_util::overdue::OverdueLoggingExt;
 use restate_metadata_store::WriteError;
-use restate_types::errors::GenericError;
 use restate_types::identifiers::PartitionId;
 use restate_types::live::Pinned;
 use restate_types::logs::builder::LogsBuilder;
@@ -55,10 +53,6 @@ const FALLBACK_MAX_RETRY_DELAY: Duration = Duration::from_secs(5);
 pub enum LogsControllerError {
     #[error("failed creating logs: {0}")]
     LogsBuilder(#[from] logs::builder::BuilderError),
-    #[error("failed creating loglet params from loglet configuration: {0}")]
-    ConfigurationToLogletParams(GenericError),
-    #[error("failed creating loglet configuration from loglet params: {0}")]
-    LogletParamsToConfiguration(GenericError),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
 }
@@ -220,12 +214,12 @@ impl LogState {
         observed_cluster_state: &ObservedClusterState,
         log_builder: &mut LogsBuilder,
         node_set_selector_hints: impl NodeSetSelectorHints,
-    ) -> Result<()> {
+    ) {
         match self {
             LogState::Provisioning { log_id } => {
                 if log_builder.chain(*log_id).is_some() {
                     // already configured
-                    return Ok(());
+                    return;
                 }
 
                 if let Some(loglet_configuration) = try_provisioning(
@@ -236,7 +230,7 @@ impl LogState {
                 ) {
                     let chain = Chain::new(
                         loglet_configuration.as_provider(),
-                        loglet_configuration.to_loglet_params()?,
+                        loglet_configuration.to_loglet_params(),
                     );
                     log_builder
                         .add_log(*log_id, chain)
@@ -251,12 +245,8 @@ impl LogState {
                 }
             }
             // nothing to do :-)
-            LogState::Sealing { .. } | LogState::Sealed { .. } | LogState::Available { .. } => {
-                return Ok(());
-            }
+            LogState::Sealing { .. } | LogState::Sealed { .. } | LogState::Available { .. } => {}
         };
-
-        Ok(())
     }
 
     fn try_reconfiguring<F, G>(
@@ -292,7 +282,7 @@ impl LogState {
                     let segment_index = append_segment(
                         *seal_lsn,
                         loglet_configuration.as_provider(),
-                        loglet_configuration.to_loglet_params()?,
+                        loglet_configuration.to_loglet_params(),
                     )?;
 
                     *self = LogState::Available {
@@ -357,7 +347,7 @@ fn logserver_writeable_node_filter(
         matches!(
             config.log_server_config.storage_state,
             StorageState::ReadWrite
-        ) && observed_cluster_state.is_node_alive(node_id)
+        ) && observed_cluster_state.alive_generation(node_id).is_some()
     }
 }
 /// Build a new segment configuration for a replicated loglet based on the observed cluster state
@@ -378,20 +368,20 @@ pub fn build_new_replicated_loglet_configuration(
 
     let replication = replicated_loglet_config.replication_property.clone();
 
-    let &sequencer = preferred_sequencer
-        .and_then(|node_id| {
-            // map to a known alive node
-            observed_cluster_state.alive_nodes.get(&node_id.id())
-        })
+    let sequencer = preferred_sequencer
+        .and_then(|node_id| observed_cluster_state.alive_generation(node_id))
         .or_else(|| {
             // we can place the sequencer on any alive node
-            observed_cluster_state.alive_nodes.values().choose(&mut rng)
+            observed_cluster_state
+                .alive_nodes()
+                .choose(&mut rng)
+                .cloned()
         })?;
 
     let opts = NodeSetSelectorOptions::new(u32::from(log_id) as u64)
         .with_target_size(replicated_loglet_config.target_nodeset_size)
         .with_preferred_nodes_opt(preferred_nodes)
-        .with_top_priority_node(sequencer);
+        .with_top_priority_node(sequencer.id());
 
     let selection = NodeSetSelector::select(
         nodes_config,
@@ -439,6 +429,30 @@ enum LogletConfiguration {
 }
 
 impl LogletConfiguration {
+    /// Creates a [`LogletConfiguration`] from a [`LogletConfig`]. This method panics if the loglet
+    /// params could not be parsed.
+    fn from_loglet_config(loglet_config: &LogletConfig) -> Self {
+        match loglet_config.kind {
+            ProviderKind::Local => LogletConfiguration::Local(
+                loglet_config
+                    .params
+                    .parse()
+                    .expect("Invalid local loglet params"),
+            ),
+            ProviderKind::InMemory => LogletConfiguration::Memory(
+                loglet_config
+                    .params
+                    .parse()
+                    .expect("Invalid in-memory loglet params"),
+            ),
+            ProviderKind::Replicated => {
+                ReplicatedLogletParams::deserialize_from(loglet_config.params.as_bytes())
+                    .map(LogletConfiguration::Replicated)
+                    .expect("Invalid replicated loglet params")
+            }
+        }
+    }
+
     fn as_provider(&self) -> ProviderKind {
         match self {
             LogletConfiguration::Replicated(_) => ProviderKind::Replicated,
@@ -458,9 +472,10 @@ impl LogletConfiguration {
             (Self::Memory(_), ProviderConfiguration::InMemory) => false,
             (Self::Local(_), ProviderConfiguration::Local) => false,
             (Self::Replicated(params), ProviderConfiguration::Replicated(config)) => {
-                let sequencer_change_required = !observed_cluster_state
-                    .is_node_alive(params.sequencer)
-                    && !observed_cluster_state.alive_nodes.is_empty();
+                let sequencer_change_required = observed_cluster_state
+                    .alive_generation(params.sequencer)
+                    .is_none()
+                    && !observed_cluster_state.alive_nodes_empty();
 
                 if sequencer_change_required {
                     debug!(
@@ -542,16 +557,16 @@ impl LogletConfiguration {
         }
     }
 
-    fn to_loglet_params(&self) -> Result<LogletParams> {
-        Ok(match self {
+    fn to_loglet_params(&self) -> LogletParams {
+        match self {
             LogletConfiguration::Replicated(configuration) => LogletParams::from(
                 configuration
                     .serialize()
-                    .map_err(|err| LogsControllerError::ConfigurationToLogletParams(err.into()))?,
+                    .expect("Failed to serialize replicated loglet params"),
             ),
             LogletConfiguration::Local(id) => LogletParams::from(id.to_string()),
             LogletConfiguration::Memory(id) => LogletParams::from(id.to_string()),
-        })
+        }
     }
 
     fn try_reconfiguring(
@@ -604,22 +619,6 @@ impl LogletConfiguration {
             LogletConfiguration::Replicated(configuration) => Some(configuration.sequencer),
             LogletConfiguration::Local(_) => None,
             LogletConfiguration::Memory(_) => None,
-        }
-    }
-}
-
-impl TryFrom<&LogletConfig> for LogletConfiguration {
-    type Error = GenericError;
-
-    fn try_from(value: &LogletConfig) -> Result<Self, Self::Error> {
-        match value.kind {
-            ProviderKind::Local => Ok(LogletConfiguration::Local(value.params.parse()?)),
-            ProviderKind::InMemory => Ok(LogletConfiguration::Memory(value.params.parse()?)),
-            ProviderKind::Replicated => {
-                ReplicatedLogletParams::deserialize_from(value.params.as_bytes())
-                    .map(LogletConfiguration::Replicated)
-                    .map_err(Into::into)
-            }
         }
     }
 }
@@ -699,19 +698,16 @@ struct LogsControllerInner {
 }
 
 impl LogsControllerInner {
-    fn new(
-        current_logs: Arc<Logs>,
-        retry_policy: RetryPolicy,
-    ) -> Result<Self, LogsControllerError> {
+    fn new(current_logs: Arc<Logs>, retry_policy: RetryPolicy) -> Self {
         let mut logs_state = HashMap::with_capacity(current_logs.num_logs());
-        Self::update_logs_state(&mut logs_state, current_logs.as_ref())?;
+        Self::update_logs_state(&mut logs_state, current_logs.as_ref());
 
-        Ok(Self {
+        Self {
             current_logs,
             logs_state,
             logs_write_in_progress: None,
             retry_policy,
-        })
+        }
     }
 
     fn on_observed_cluster_state_update(
@@ -733,7 +729,7 @@ impl LogsControllerInner {
             observed_cluster_state,
             &mut builder,
             &node_set_selector_hints,
-        )?;
+        );
         self.reconfigure_logs(
             observed_cluster_state,
             &mut builder,
@@ -792,17 +788,15 @@ impl LogsControllerInner {
         observed_cluster_state: &ObservedClusterState,
         logs_builder: &mut LogsBuilder,
         node_set_selector_hints: impl NodeSetSelectorHints,
-    ) -> Result<()> {
+    ) {
         for log_state in self.logs_state.values_mut() {
             log_state.try_provisioning(
                 self.current_logs.configuration(),
                 observed_cluster_state,
                 logs_builder,
                 &node_set_selector_hints,
-            )?;
+            );
         }
-
-        Ok(())
     }
 
     fn reconfigure_logs(
@@ -835,7 +829,7 @@ impl LogsControllerInner {
         event: Event,
         effects: &mut Vec<Effect>,
         metadata_writer: &mut MetadataWriter,
-    ) -> Result<()> {
+    ) {
         match event {
             Event::WriteLogsSucceeded(version) => {
                 self.on_logs_written(version);
@@ -857,7 +851,7 @@ impl LogsControllerInner {
                 }
             }
             Event::NewLogs => {
-                self.on_logs_update(Metadata::with_current(|m| m.logs_ref()), effects)?;
+                self.on_logs_update(Metadata::with_current(|m| m.logs_ref()), effects);
             }
             Event::SealSucceeded {
                 log_id,
@@ -885,8 +879,6 @@ impl LogsControllerInner {
                 self.on_logs_tail_updates(&updates);
             }
         }
-
-        Ok(())
     }
 
     fn on_logs_written(&mut self, version: Version) {
@@ -896,7 +888,7 @@ impl LogsControllerInner {
         }
     }
 
-    fn on_logs_update(&mut self, logs: Pinned<Logs>, effects: &mut Vec<Effect>) -> Result<()> {
+    fn on_logs_update(&mut self, logs: Pinned<Logs>, effects: &mut Vec<Effect>) {
         // rebuild the internal state if we receive a newer logs or one with a version we were
         // supposed to write (race condition)
         if logs.version() > self.current_logs.version()
@@ -909,19 +901,14 @@ impl LogsControllerInner {
             self.logs_state
                 .retain(|_, state| matches!(state, LogState::Provisioning { .. }));
 
-            Self::update_logs_state(&mut self.logs_state, self.current_logs.as_ref())?;
+            Self::update_logs_state(&mut self.logs_state, self.current_logs.as_ref());
 
             // check whether we have a pending seal operation for any of the logs
             effects.push(Effect::FindLogsTail);
         }
-
-        Ok(())
     }
 
-    fn update_logs_state(
-        logs_state: &mut HashMap<LogId, LogState>,
-        logs: &Logs,
-    ) -> Result<(), LogsControllerError> {
+    fn update_logs_state(logs_state: &mut HashMap<LogId, LogState>, logs: &Logs) {
         for (log_id, chain) in logs.iter() {
             let tail = chain.tail();
 
@@ -930,10 +917,7 @@ impl LogsControllerInner {
                 logs_state.insert(
                     *log_id,
                     LogState::Sealed {
-                        configuration: tail
-                            .config
-                            .try_into()
-                            .map_err(LogsControllerError::LogletParamsToConfiguration)?,
+                        configuration: LogletConfiguration::from_loglet_config(tail.config),
                         segment_index: tail.index(),
                         seal_lsn,
                     },
@@ -943,18 +927,12 @@ impl LogsControllerInner {
                 logs_state.insert(
                     *log_id,
                     LogState::Available {
-                        configuration: Some(
-                            tail.config
-                                .try_into()
-                                .map_err(LogsControllerError::LogletParamsToConfiguration)?,
-                        ),
+                        configuration: Some(LogletConfiguration::from_loglet_config(tail.config)),
                         segment_index: tail.index(),
                     },
                 );
             }
         }
-
-        Ok(())
     }
 
     fn on_logs_tail_updates(&mut self, updates: &LogsTailUpdates) {
@@ -1011,10 +989,7 @@ pub struct LogsController {
 }
 
 impl LogsController {
-    pub fn new(
-        bifrost: Bifrost,
-        metadata_writer: MetadataWriter,
-    ) -> Result<Self, LogsControllerError> {
+    pub fn new(bifrost: Bifrost, metadata_writer: MetadataWriter) -> Self {
         //todo(azmy): make configurable
         let retry_policy = RetryPolicy::exponential(
             Duration::from_millis(10),
@@ -1028,7 +1003,7 @@ impl LogsController {
             inner: LogsControllerInner::new(
                 Metadata::with_current(|m| m.logs_snapshot()),
                 retry_policy,
-            )?,
+            ),
             bifrost,
             metadata_writer,
             async_operations: JoinSet::default(),
@@ -1036,7 +1011,7 @@ impl LogsController {
         };
 
         this.find_logs_tail();
-        Ok(this)
+        this
     }
 
     pub fn find_logs_tail(&mut self) {
@@ -1132,12 +1107,10 @@ impl LogsController {
         self.inner.on_partition_table_update(partition_table);
     }
 
-    pub fn on_logs_update(&mut self, logs: Pinned<Logs>) -> Result<()> {
+    pub fn on_logs_update(&mut self, logs: Pinned<Logs>) {
         self.inner
-            .on_logs_update(logs, self.effects.as_mut().expect("to be present"))?;
+            .on_logs_update(logs, self.effects.as_mut().expect("to be present"));
         self.apply_effects();
-
-        Ok(())
     }
 
     fn apply_effects(&mut self) {
@@ -1264,7 +1237,7 @@ impl LogsController {
         ).expect("to spawn seal-log task");
     }
 
-    pub async fn run_async_operations(&mut self) -> Result<Never> {
+    pub async fn run_async_operations(&mut self) {
         loop {
             if self.async_operations.is_empty() {
                 futures::future::pending().await
@@ -1279,7 +1252,7 @@ impl LogsController {
                     event,
                     self.effects.as_mut().expect("to be present"),
                     &mut self.metadata_writer,
-                )?;
+                );
                 self.apply_effects();
             }
         }
@@ -1393,10 +1366,8 @@ pub mod tests {
             storage_state: StorageState,
         ) {
             let node_id = node_id.into();
-            self.observed_state.dead_nodes.remove(&node_id);
             self.observed_state
-                .alive_nodes
-                .insert(node_id, node_id.with_generation(1));
+                .add_alive_node(node_id.with_generation(1));
             self.nodes_config
                 .upsert_node(node(node_id, roles, storage_state));
         }
@@ -1404,10 +1375,9 @@ pub mod tests {
         pub fn kill_node(&mut self, node_id: impl Into<PlainNodeId>) {
             let node_id = node_id.into();
             assert!(
-                self.observed_state.alive_nodes.remove(&node_id).is_some(),
+                self.observed_state.remove_node(&node_id).is_some(),
                 "node not found"
             );
-            self.observed_state.dead_nodes.insert(node_id);
         }
 
         pub fn kill_nodes<const N: usize>(&mut self, ids: [impl Into<PlainNodeId>; N]) {
@@ -1417,11 +1387,9 @@ pub mod tests {
         }
 
         pub fn revive_node(&mut self, (node_id, generation): (u32, u32)) {
-            let id = node_id.into();
-            assert!(self.observed_state.dead_nodes.remove(&id), "node not found");
+            let node_id = PlainNodeId::new(node_id);
             self.observed_state
-                .alive_nodes
-                .insert(id, id.with_generation(generation));
+                .add_alive_node(node_id.with_generation(generation));
         }
 
         pub fn revive_nodes<const N: usize>(&mut self, ids: [(u32, u32); N]) {
@@ -1443,12 +1411,10 @@ pub mod tests {
             roles: impl Into<EnumSet<Role>>,
             storage_state: StorageState,
         ) -> Self {
-            let id = node_id.into();
+            let id = PlainNodeId::new(node_id);
             self.nodes_config
                 .upsert_node(node(node_id, roles.into(), storage_state));
-            self.observed_state
-                .alive_nodes
-                .insert(id, id.with_generation(1));
+            self.observed_state.add_alive_node(id.with_generation(1));
 
             self
         }
@@ -1461,9 +1427,9 @@ pub mod tests {
             storage_state: StorageState,
         ) -> Self {
             let id = node_id.into();
+            self.observed_state.remove_node(&id);
             self.nodes_config
                 .upsert_node(node(node_id, roles, storage_state));
-            self.observed_state.dead_nodes.insert(id);
 
             self
         }
@@ -1483,8 +1449,7 @@ pub mod tests {
         pub fn dead_nodes<const N: usize>(mut self, ids: [u32; N]) -> Self {
             for id in ids {
                 let id = id.into();
-                self.observed_state.alive_nodes.remove(&id);
-                self.observed_state.dead_nodes.insert(id);
+                self.observed_state.remove_node(&id);
             }
             self
         }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -19,7 +19,7 @@ use futures::never::Never;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time;
 use tokio::time::{Instant, Interval, MissedTickBehavior};
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, warn};
 
 use restate_bifrost::{Bifrost, SealedSegment};
 use restate_core::cancellation_token;
@@ -329,21 +329,31 @@ impl<T: TransportConnect> Service<T> {
 
         let mut state: ClusterControllerState<T> = ClusterControllerState::Follower;
 
+        let cs = TaskCenter::with_current(|tc| tc.cluster_state().clone());
+        let mut cs_changed = std::pin::pin!(cs.changed());
+
+        // initialize the state based on the initial cluster state
+        state.update(&self, &cs);
+
         loop {
             tokio::select! {
                 _ = self.heartbeat_interval.tick() => {
                     // Ignore error if system is shutting down
                     let _ = self.cluster_state_refresher.schedule_refresh();
                 },
-                Ok(cluster_state) = cluster_state_watcher.next_cluster_state() => {
-                    self.observed_cluster_state.update(&cluster_state);
-                    trace!(observed_cluster_state = ?self.observed_cluster_state, "Observed cluster state updated");
-                    // todo quarantine this cluster controller if errors re-occur too often so that
-                    //  another cluster controller can take over
-                    if let Err(err) = state.update(&self) {
-                        warn!(%err, "Failed to update cluster state. This can impair the overall cluster operations");
-                        continue;
+                () = &mut cs_changed => {
+                    // register waiting for the next update
+                    cs_changed.set(cs.changed());
+
+                    state.update(&self, &cs);
+
+                    self.observed_cluster_state.update_liveness(&cs);
+                    if let Err(err) = state.on_observed_cluster_state(&self.observed_cluster_state).await {
+                        warn!(%err, "Failed to handle observed cluster state. This can impair the overall cluster operations");
                     }
+                },
+                Ok(cluster_state) = cluster_state_watcher.next_cluster_state() => {
+                    self.observed_cluster_state.update_partitions(&cluster_state);
 
                     if let Err(err) = state.on_observed_cluster_state(&self.observed_cluster_state).await {
                         warn!(%err, "Failed to handle observed cluster state. This can impair the overall cluster operations");
@@ -359,18 +369,7 @@ impl<T: TransportConnect> Service<T> {
                     self.heartbeat_interval = Self::create_heartbeat_interval(&configuration.admin);
                     state.reconfigure(configuration);
                 }
-                result = state.run() => {
-                    let leader_event = match result {
-                        Ok(leader_event) => leader_event,
-                        Err(err) => {
-                            warn!(
-                                %err,
-                                "Failed to run cluster controller operations. This can impair the overall cluster operations"
-                            );
-                            continue;
-                        }
-                    };
-
+                leader_event = state.run() => {
                     if let Err(err) = state.on_leader_event(&self.observed_cluster_state, leader_event).await {
                         warn!(
                             %err,
@@ -1362,16 +1361,21 @@ mod tests {
 
         let cluster_state_watcher = svc.cluster_state_refresher.cluster_state_watcher();
 
+        let mut cs_updater = TaskCenter::with_current(|h| h.cluster_state_updater());
+        let mut write_guard = cs_updater.write();
+
         let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
         for i in 1..=num_nodes {
+            let node_id = GenerationalNodeId::new(i as u32, i as u32);
             nodes_config.upsert_node(
                 NodeConfig::builder()
                     .name(format!("node-{}", i))
-                    .current_generation(GenerationalNodeId::new(i as u32, i as u32))
+                    .current_generation(node_id)
                     .address(AdvertisedAddress::Uds(format!("{}.sock", i).into()))
                     .roles(Role::Admin | Role::Worker)
                     .build(),
             );
+            write_guard.upsert_node_state(node_id, restate_core::cluster_state::NodeState::Alive);
         }
         let builder = modify_builder(builder.set_nodes_config(nodes_config));
 

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -47,25 +47,26 @@ impl<T> ClusterControllerState<T>
 where
     T: TransportConnect,
 {
-    pub fn update(&mut self, service: &Service<T>) -> anyhow::Result<()> {
+    pub fn update(&mut self, service: &Service<T>, cs: &restate_core::cluster_state::ClusterState) {
         let maybe_leader = {
             let nodes_config = Metadata::with_current(|m| m.nodes_config_ref());
-            nodes_config
+            let admin_nodes: Vec<_> = nodes_config
                 .get_admin_nodes()
-                .filter(|node| {
-                    service
-                        .observed_cluster_state
-                        .is_node_alive(node.current_generation)
-                })
-                .map(|node| node.current_generation)
+                .map(|c| c.current_generation)
                 .sorted()
+                .collect();
+            let states = cs.map_from_ids(admin_nodes.iter().map(Into::into));
+
+            admin_nodes
+                .iter()
+                .zip(states)
+                .filter_map(|(node_id, state)| state.is_alive().then_some(*node_id))
                 .next()
         };
 
         // A Cluster Controller is a leader if the node holds the smallest PlainNodeID
-        // If no other node was found to take leadership, we assume leadership
         let is_leader = match maybe_leader {
-            None => true,
+            None => false,
             Some(leader) => leader == my_node_id(),
         };
 
@@ -76,7 +77,7 @@ where
             }
             (true, ClusterControllerState::Follower) => {
                 info!("Cluster controller switching to leader mode");
-                *self = ClusterControllerState::Leader(Leader::from_service(service)?);
+                *self = ClusterControllerState::Leader(Leader::from_service(service));
             }
             (false, ClusterControllerState::Leader(_)) => {
                 info!(
@@ -86,8 +87,6 @@ where
                 *self = ClusterControllerState::Follower;
             }
         };
-
-        Ok(())
     }
 
     pub async fn on_leader_event(
@@ -107,9 +106,9 @@ where
 
     /// Runs the cluster controller state related tasks. It returns [`LeaderEvent`] which need to
     /// be processed by calling [`Self::on_leader_event`].
-    pub async fn run(&mut self) -> anyhow::Result<LeaderEvent> {
+    pub async fn run(&mut self) -> LeaderEvent {
         match self {
-            Self::Follower => futures::future::pending::<anyhow::Result<_>>().await,
+            Self::Follower => futures::future::pending().await,
             Self::Leader(leader) => leader.run().await,
         }
     }
@@ -161,13 +160,13 @@ impl<T> Leader<T>
 where
     T: TransportConnect,
 {
-    fn from_service(service: &Service<T>) -> anyhow::Result<Leader<T>> {
+    fn from_service(service: &Service<T>) -> Leader<T> {
         let configuration = service.configuration.pinned();
 
         let scheduler = Scheduler::new(service.metadata_writer.clone(), service.networking.clone());
 
         let logs_controller =
-            LogsController::new(service.bifrost.clone(), service.metadata_writer.clone())?;
+            LogsController::new(service.bifrost.clone(), service.metadata_writer.clone());
 
         let log_trim_check_interval = create_log_trim_check_interval(&configuration.admin);
 
@@ -191,7 +190,7 @@ where
         leader.logs_watcher.mark_changed();
         leader.partition_table_watcher.mark_changed();
 
-        Ok(leader)
+        leader
     }
 
     async fn on_observed_cluster_state(
@@ -222,23 +221,23 @@ where
         self.log_trim_check_interval = create_log_trim_check_interval(&configuration.admin);
     }
 
-    async fn run(&mut self) -> anyhow::Result<LeaderEvent> {
+    async fn run(&mut self) -> LeaderEvent {
         loop {
             tokio::select! {
                 _ = self.find_logs_tail_interval.tick() => {
                     self.logs_controller.find_logs_tail();
                 }
                 Some(_) = OptionFuture::from(self.log_trim_check_interval.as_mut().map(|interval| interval.tick())) => {
-                    return Ok(LeaderEvent::TrimLogs);
+                    return LeaderEvent::TrimLogs;
                 }
                 result = self.logs_controller.run_async_operations() => {
-                    result?;
+                    result
                 }
                 Ok(_) = self.logs_watcher.changed() => {
-                    return Ok(LeaderEvent::LogsUpdate);
+                    return LeaderEvent::LogsUpdate;
                 }
                 Ok(_) = self.partition_table_watcher.changed() => {
-                    return Ok(LeaderEvent::PartitionTableUpdate);
+                    return LeaderEvent::PartitionTableUpdate;
                 }
             }
         }
@@ -270,7 +269,7 @@ where
         observed_cluster_state: &ObservedClusterState,
     ) -> anyhow::Result<()> {
         self.logs_controller
-            .on_logs_update(Metadata::with_current(|m| m.logs_ref()))?;
+            .on_logs_update(Metadata::with_current(|m| m.logs_ref()));
 
         self.scheduler
             .on_observed_cluster_state(

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -53,13 +53,6 @@ impl ClusterState {
         })
     }
 
-    pub fn dead_nodes(&self) -> impl Iterator<Item = &PlainNodeId> {
-        self.nodes.iter().flat_map(|(node_id, state)| match state {
-            NodeState::Alive(_) => None,
-            NodeState::Dead(_) => Some(node_id),
-        })
-    }
-
     #[cfg(feature = "test-util")]
     pub fn empty() -> Self {
         ClusterState {
@@ -81,6 +74,7 @@ fn instant_to_proto(t: Instant) -> prost_types::Duration {
 #[strum(serialize_all = "snake_case")]
 pub enum NodeState {
     Alive(AliveNode),
+    // #[deprecated(since ="1.3.3", note = "Use restate_core::cluster_state::ClusterState instead for detecting dead nodes")]
     Dead(DeadNode),
 }
 

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -64,6 +64,18 @@ impl From<crate::protobuf::common::GenerationalNodeId> for GenerationalNodeId {
     }
 }
 
+impl From<&GenerationalNodeId> for NodeId {
+    fn from(value: &GenerationalNodeId) -> Self {
+        NodeId::Generational(*value)
+    }
+}
+
+impl From<&PlainNodeId> for NodeId {
+    fn from(value: &PlainNodeId) -> Self {
+        NodeId::Plain(*value)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("invalid plain node id: {0}")]
 pub struct MalformedPlainNodeId(String);


### PR DESCRIPTION
This PR changes how the ClusterController learns about alive/dead nodes. Now
it uses the restate_core::cluster_state::ClusterState to update the ObservedClusterState
which is used by the LogsController and the Scheduler.

As part of this commit, we hide the implementation details of the ObservedClusterState
to allow for easier evolutions of it. Moreover, it simplifies the error handling of the
LogsController by panicking if the loglet params cannot be parsed because it is a
situation from which the Restate server cannot recover until the metadata gets fixed.

This PR is based on #3281, #3282, #3279, #3276 (in short only the last commit is relevant for this PR).