### PR TITLE
[Restate UI] Update to v0.0.70

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7830,8 +7830,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.69"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.69#8a329eeb01b71e650860854a63897e113fbba913"
+version = "0.0.70"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.70#cdebab82eaec6a71fb6d2c5ef5174da9646e3e0b"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -31,7 +31,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.69", tag = "v0.0.69" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.70", tag = "v0.0.70" }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.70
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.70/ui-v0.0.70.zip