### PR TITLE
Move some long-running ClusterContoller select arms to background tasks

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -490,8 +490,6 @@ impl<T: TransportConnect> Scheduler<T> {
     }
 }
 
-/// Placement hints for the [`logs_controller::LogsController`] based on the current
-/// [`SchedulingPlan`].
 pub struct PartitionTableNodeSetSelectorHints {
     partition_table: Arc<PartitionTable>,
 }

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -225,7 +225,7 @@ where
         loop {
             tokio::select! {
                 _ = self.find_logs_tail_interval.tick() => {
-                    self.logs_controller.find_logs_tail();
+                    self.logs_controller.find_log_tails();
                 }
                 Some(_) = OptionFuture::from(self.log_trim_check_interval.as_mut().map(|interval| interval.tick())) => {
                     return LeaderEvent::TrimLogs;


### PR DESCRIPTION
Move UpdateClusterConfiguration and TrimLog RPC handling to separate tasks. We eliminated the `SchedulingPlan` in the 1.2.0 release; I believe these are all the remaining paths that could significantly block the ClusterController select loop.

Fixes: https://github.com/restatedev/restate/issues/2601