### PR TITLE
Set RESTATE_NODE_NAME in helm charts

### DIFF
--- a/charts/restate-helm/templates/statefulset.yaml
+++ b/charts/restate-helm/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - containerPort: 5122
               name: node
           env:
-            - name: POD_NAME
+            - name: RESTATE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: "metadata.name"
@@ -70,7 +70,7 @@ spec:
             - name: RESTATE_ADVERTISED_ADDRESS
               # Use the stable network identifier (dns resolvable) provided by the stateful set. The second part is the
               # serviceName of the stateful set.
-              value: http://$(POD_NAME).{{ include "restate.fullname" . }}-cluster:5122
+              value: http://$(RESTATE_NODE_NAME).{{ include "restate.fullname" . }}-cluster:5122
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
If `restate-data` contains another directory, then Restate won't start if the node name is not specified. This commit solves this problem.