### PR TITLE
Rename Persisted LSN to Durable LSN

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -886,7 +886,7 @@ mod tests {
     #[derive(Default)]
     struct HandlerState {
         applied_lsn: AtomicU64,
-        persisted_lsn: AtomicU64,
+        durable_lsn: AtomicU64,
         archived_lsn: AtomicU64,
     }
 
@@ -907,7 +907,7 @@ mod tests {
                     self.inner.applied_lsn.load(Ordering::Relaxed),
                 )),
                 last_persisted_log_lsn: Some(Lsn::from(
-                    self.inner.persisted_lsn.load(Ordering::Relaxed),
+                    self.inner.durable_lsn.load(Ordering::Relaxed),
                 )),
                 last_archived_log_lsn: match self.inner.archived_lsn.load(Ordering::Relaxed) {
                     0 => None,
@@ -1021,7 +1021,7 @@ mod tests {
     }
 
     #[test(restate_core::test(start_paused = true))]
-    async fn single_node_no_snapshots_auto_trim_log_by_persisted_lsn() -> anyhow::Result<()> {
+    async fn single_node_no_snapshots_auto_trim_log_by_durable_lsn() -> anyhow::Result<()> {
         const LOG_ID: LogId = LogId::new(0);
 
         let interval_duration = Duration::from_secs(10);
@@ -1070,11 +1070,11 @@ mod tests {
         tokio::time::sleep(interval_duration * 2).await;
         assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
-        handler_state.persisted_lsn.store(3, Ordering::Relaxed);
+        handler_state.durable_lsn.store(3, Ordering::Relaxed);
         tokio::time::sleep(interval_duration * 2).await;
         assert_eq!(bifrost.get_trim_point(LOG_ID).await?, Lsn::from(3));
 
-        handler_state.persisted_lsn.store(20, Ordering::Relaxed);
+        handler_state.durable_lsn.store(20, Ordering::Relaxed);
         tokio::time::sleep(interval_duration * 2).await;
         assert_eq!(Lsn::from(20), bifrost.get_trim_point(LOG_ID).await?);
 
@@ -1132,7 +1132,7 @@ mod tests {
                 .as_u64(),
             Ordering::Relaxed,
         );
-        handler_state.persisted_lsn.store(10, Ordering::Relaxed);
+        handler_state.durable_lsn.store(10, Ordering::Relaxed);
 
         tokio::time::sleep(interval_duration * 2).await;
         assert_eq!(cluster_state.current().nodes.len(), 1);
@@ -1148,7 +1148,7 @@ mod tests {
         // we default to trimming by archived_lsn only, just like in multi-node
         assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 
-        handler_state.persisted_lsn.store(20, Ordering::Relaxed);
+        handler_state.durable_lsn.store(20, Ordering::Relaxed);
         tokio::time::sleep(interval_duration * 2).await;
         assert_eq!(Lsn::INVALID, bifrost.get_trim_point(LOG_ID).await?);
 

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -352,13 +352,13 @@ fn create_log_trim_check_interval(options: &AdminOptions) -> Option<Interval> {
 }
 
 enum TrimMode {
-    /// Trim logs by the reported persisted LSN. This strategy is only appropriate for
-    /// single-node deployments.
-    PersistedLsn {
+    /// Trim logs based on partition processors' reported Durable LSN. This strategy is only
+    /// appropriate for single-node deployments.
+    DurableLsn {
         partition_status:
             BTreeMap<PartitionId, BTreeMap<GenerationalNodeId, PartitionProcessorStatus>>,
     },
-    /// Select safe trim points based on the maximum reported archived LSN per partition.
+    /// Trim logs based on the highest reported archived LSN per partition.
     ArchivedLsn {
         partition_status:
             BTreeMap<PartitionId, BTreeMap<GenerationalNodeId, PartitionProcessorStatus>>,
@@ -367,8 +367,8 @@ enum TrimMode {
 
 impl TrimMode {
     /// In clusters with more than one node, or on single nodes with a snapshot repository
-    /// configured, trimming is driven by archived LSN. The persisted LSN method is only
-    /// used on single-nodes with no snapshots configured.
+    /// configured, trimming is driven by archived LSN. The durable LSN method is only used on
+    /// single-nodes with no snapshots configured.
     fn from(snapshots_repository_configured: bool, cluster_state: &Arc<ClusterState>) -> TrimMode {
         let mut partition_status: BTreeMap<
             PartitionId,
@@ -399,7 +399,7 @@ impl TrimMode {
             }
             TrimMode::ArchivedLsn { partition_status }
         } else {
-            TrimMode::PersistedLsn { partition_status }
+            TrimMode::DurableLsn { partition_status }
         }
     }
 
@@ -447,16 +447,16 @@ impl TrimMode {
                     }
                 }
             }
-            TrimMode::PersistedLsn {
+            TrimMode::DurableLsn {
                 partition_status, ..
             } => {
                 // If no partitions are reporting archived LSN, we fall back to using the
-                // min(persisted LSN) across the board as the safe trim point. Note that at this
-                // point we know that there are no known dead nodes, so it's safe to take the min of
-                // persisted LSNs reported by all the partition processors as the safe trim point.
+                // min(durable_lsn) across the board as the safe trim point. Note that at this point
+                // we know that there are no known dead nodes, so it's safe to take the min of all
+                // durable LSNs reported by all the partition processors as the safe trim point.
                 for (partition_id, processor_status) in partition_status.iter() {
                     let log_id = LogId::from(*partition_id);
-                    let min_persisted_lsn = processor_status
+                    let min_durable_lsn = processor_status
                         .values()
                         .map(|s| s.last_persisted_log_lsn.unwrap_or(Lsn::INVALID))
                         .min()
@@ -464,9 +464,9 @@ impl TrimMode {
 
                     trace!(
                         ?partition_id,
-                        "Safe trim point for log {}: {:?}", log_id, min_persisted_lsn
+                        "Safe trim point for log {}: {:?}", log_id, min_durable_lsn
                     );
-                    safe_trim_points.insert(log_id, (min_persisted_lsn, *partition_id));
+                    safe_trim_points.insert(log_id, (min_durable_lsn, *partition_id));
                 }
             }
         }
@@ -501,9 +501,9 @@ mod tests {
             p1,
             ProcessorStatus {
                 mode: Leader,
-                applied: Some(Lsn::new(10)),
-                persisted: Some(Lsn::new(10)),
-                archived: None,
+                applied_lsn: Some(Lsn::new(10)),
+                durable_lsn: Some(Lsn::new(10)),
+                archived_lsn: None,
             }
             .into(),
         )]
@@ -515,9 +515,9 @@ mod tests {
             p2,
             ProcessorStatus {
                 mode: Follower,
-                applied: Some(Lsn::new(10)),
-                persisted: Some(Lsn::new(10)),
-                archived: None,
+                applied_lsn: Some(Lsn::new(10)),
+                durable_lsn: Some(Lsn::new(10)),
+                archived_lsn: None,
             }
             .into(),
         )]
@@ -561,9 +561,9 @@ mod tests {
                 p1,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(10)),
-                    persisted: Some(Lsn::new(10)),
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: Some(Lsn::new(10)),
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -571,9 +571,9 @@ mod tests {
                 p2,
                 ProcessorStatus {
                     mode: Follower,
-                    applied: Some(Lsn::new(10)),
-                    persisted: Some(Lsn::new(5)),
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: Some(Lsn::new(5)),
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -609,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn single_node_may_trim_by_persisted_lsn() {
+    fn single_node_may_trim_by_durable_lsn() {
         let p1 = PartitionId::from(0);
         let p2 = PartitionId::from(1);
         let p3 = PartitionId::from(2);
@@ -620,9 +620,9 @@ mod tests {
                 p1,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(10)),
-                    persisted: None,
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: None,
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -630,9 +630,9 @@ mod tests {
                 p2,
                 ProcessorStatus {
                     mode: Follower,
-                    applied: Some(Lsn::new(10)),
-                    persisted: Some(Lsn::new(5)),
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: Some(Lsn::new(5)),
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -640,9 +640,9 @@ mod tests {
                 p3,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(10)),
-                    persisted: Some(Lsn::new(10)),
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: Some(Lsn::new(10)),
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -661,7 +661,7 @@ mod tests {
         let trim_mode = TrimMode::from(false, &cluster_state);
         let trim_points = trim_mode.calculate_safe_trim_points();
 
-        assert!(matches!(trim_mode, TrimMode::PersistedLsn { .. }));
+        assert!(matches!(trim_mode, TrimMode::DurableLsn { .. }));
         assert_eq!(
             trim_points,
             BTreeMap::from([
@@ -669,7 +669,7 @@ mod tests {
                 (LogId::from(p2), (Lsn::new(5), p2)),
                 (LogId::from(p3), (Lsn::new(10), p3)),
             ]),
-            "Use min persisted LSN per partition as the safe point in single-node mode when not archiving"
+            "Use min durable LSN per partition as the safe point in single-node mode when not archiving"
         );
     }
 
@@ -685,9 +685,9 @@ mod tests {
                 p1,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(10)),
-                    persisted: Some(Lsn::new(10)), // should not make any difference
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: Some(Lsn::new(10)), // should not make any difference
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -695,9 +695,9 @@ mod tests {
                 p2,
                 ProcessorStatus {
                     mode: Follower,
-                    applied: Some(Lsn::new(18)),
-                    persisted: Some(Lsn::new(15)), // should not make any difference
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(18)),
+                    durable_lsn: Some(Lsn::new(15)), // should not make any difference
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -711,9 +711,9 @@ mod tests {
                 p2,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(20)),
-                    persisted: None,
-                    archived: Some(Lsn::new(10)),
+                    applied_lsn: Some(Lsn::new(20)),
+                    durable_lsn: None,
+                    archived_lsn: Some(Lsn::new(10)),
                 }
                 .into(),
             ),
@@ -721,9 +721,9 @@ mod tests {
                 p3,
                 ProcessorStatus {
                     mode: Follower,
-                    applied: Some(Lsn::new(10)),
-                    persisted: None,
-                    archived: Some(Lsn::new(5)),
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: None,
+                    archived_lsn: Some(Lsn::new(5)),
                 }
                 .into(),
             ),
@@ -767,9 +767,9 @@ mod tests {
             p1,
             ProcessorStatus {
                 mode: Leader,
-                applied: Some(Lsn::new(15)),
-                persisted: None,
-                archived: Some(Lsn::new(10)),
+                applied_lsn: Some(Lsn::new(15)),
+                durable_lsn: None,
+                archived_lsn: Some(Lsn::new(10)),
             }
             .into(),
         )]
@@ -781,9 +781,9 @@ mod tests {
             p1,
             ProcessorStatus {
                 mode: Leader,
-                applied: Some(Lsn::new(5)), // behind the archived LSN reported by n1
-                persisted: None,
-                archived: None,
+                applied_lsn: Some(Lsn::new(5)), // behind the archived LSN reported by n1
+                durable_lsn: None,
+                archived_lsn: None,
             }
             .into(),
         )]
@@ -826,9 +826,9 @@ mod tests {
                 p1,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(10)),
-                    persisted: Some(Lsn::new(10)), // should not make any difference
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: Some(Lsn::new(10)), // should not make any difference
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -836,9 +836,9 @@ mod tests {
                 p2,
                 ProcessorStatus {
                     mode: Follower,
-                    applied: Some(Lsn::new(18)),
-                    persisted: Some(Lsn::new(15)), // should not make any difference
-                    archived: None,
+                    applied_lsn: Some(Lsn::new(18)),
+                    durable_lsn: Some(Lsn::new(15)), // should not make any difference
+                    archived_lsn: None,
                 }
                 .into(),
             ),
@@ -852,9 +852,9 @@ mod tests {
                 p2,
                 ProcessorStatus {
                     mode: Leader,
-                    applied: Some(Lsn::new(20)),
-                    persisted: None,
-                    archived: Some(Lsn::new(10)),
+                    applied_lsn: Some(Lsn::new(20)),
+                    durable_lsn: None,
+                    archived_lsn: Some(Lsn::new(10)),
                 }
                 .into(),
             ),
@@ -862,9 +862,9 @@ mod tests {
                 p3,
                 ProcessorStatus {
                     mode: Follower,
-                    applied: Some(Lsn::new(10)),
-                    persisted: None,
-                    archived: Some(Lsn::new(5)),
+                    applied_lsn: Some(Lsn::new(10)),
+                    durable_lsn: None,
+                    archived_lsn: Some(Lsn::new(5)),
                 }
                 .into(),
             ),
@@ -902,19 +902,19 @@ mod tests {
 
     struct ProcessorStatus {
         mode: RunMode,
-        applied: Option<Lsn>,
-        persisted: Option<Lsn>,
-        archived: Option<Lsn>,
+        applied_lsn: Option<Lsn>,
+        durable_lsn: Option<Lsn>,
+        archived_lsn: Option<Lsn>,
     }
 
     impl From<ProcessorStatus> for PartitionProcessorStatus {
-        fn from(val: ProcessorStatus) -> Self {
+        fn from(status: ProcessorStatus) -> Self {
             PartitionProcessorStatus {
-                planned_mode: val.mode,
-                effective_mode: val.mode,
-                last_applied_log_lsn: val.applied,
-                last_persisted_log_lsn: val.persisted,
-                last_archived_log_lsn: val.archived,
+                planned_mode: status.mode,
+                effective_mode: status.mode,
+                last_applied_log_lsn: status.applied_lsn,
+                last_persisted_log_lsn: status.durable_lsn,
+                last_archived_log_lsn: status.archived_lsn,
                 ..PartitionProcessorStatus::default()
             }
         }

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 pub mod deduplication_table;
+mod durable_lsn_tracking;
 pub mod fsm_table;
 pub mod idempotency_table;
 pub mod inbox_table;
@@ -20,7 +21,6 @@ pub mod outbox_table;
 mod owned_iter;
 mod partition_store;
 mod partition_store_manager;
-mod persisted_lsn_tracking;
 pub mod promise_table;
 // todo(azmy): Follow up issue https://github.com/restatedev/restate/issues/3284
 pub mod protobuf_types;

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -42,9 +42,9 @@ use restate_types::logs::LogId;
 use restate_types::logs::Lsn;
 use restate_types::storage::StorageCodec;
 
+use crate::durable_lsn_tracking::AppliedLsnCollectorFactory;
 use crate::keys::KeyKind;
 use crate::keys::TableKey;
-use crate::persisted_lsn_tracking::AppliedLsnCollectorFactory;
 use crate::protobuf_types::{PartitionStoreProtobufValue, ProtobufStorageWrapper};
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;

--- a/crates/partition-store/src/tests/durable_lsn_tracking_test.rs
+++ b/crates/partition-store/src/tests/durable_lsn_tracking_test.rs
@@ -34,23 +34,20 @@ async fn track_latest_applied_lsn() -> googletest::Result<()> {
 
     assert_eq!(
         Some(Lsn::INVALID),
-        partition_store_manager.get_persisted_lsn(partition_id)
+        partition_store_manager.get_durable_lsn(partition_id)
     );
 
     partition_store.flush_memtables(true).await?;
     assert_eq!(
         Some(Lsn::new(100)),
-        partition_store_manager.get_persisted_lsn(partition_id)
+        partition_store_manager.get_durable_lsn(partition_id)
     );
 
     drop(partition_store);
     partition_store_manager
         .close_partition_store(partition_id)
         .await?;
-    assert_eq!(
-        None,
-        partition_store_manager.get_persisted_lsn(partition_id)
-    );
+    assert_eq!(None, partition_store_manager.get_durable_lsn(partition_id));
 
     let mut partition_store = partition_store_manager
         .open_partition_store(
@@ -62,8 +59,8 @@ async fn track_latest_applied_lsn() -> googletest::Result<()> {
         .await?;
     assert_eq!(
         Some(Lsn::new(100)),
-        partition_store_manager.get_persisted_lsn(partition_id),
-        "partition store manager should announce the persisted LSN on open"
+        partition_store_manager.get_durable_lsn(partition_id),
+        "partition store manager should announce the durable LSN on open"
     );
 
     partition_store.flush_memtables(true).await?;
@@ -77,15 +74,15 @@ async fn track_latest_applied_lsn() -> googletest::Result<()> {
 
         assert_eq!(
             Some(Lsn::new(100)),
-            partition_store_manager.get_persisted_lsn(partition_id),
-            "persisted LSN remains unchanged"
+            partition_store_manager.get_durable_lsn(partition_id),
+            "durable LSN remains unchanged"
         );
     }
 
     partition_store.flush_memtables(true).await?;
     assert_eq!(
         Some(Lsn::new(200)),
-        partition_store_manager.get_persisted_lsn(partition_id),
+        partition_store_manager.get_durable_lsn(partition_id),
     );
 
     rocksdb.shutdown().await;

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -27,6 +27,7 @@ use restate_types::invocation::{InvocationTarget, ServiceInvocation, Source};
 use restate_types::live::Constant;
 use restate_types::state_mut::ExternalStateMutation;
 
+mod durable_lsn_tracking_test;
 mod idempotency_table_test;
 mod inbox_table_test;
 mod invocation_status_table_test;
@@ -38,8 +39,6 @@ mod snapshots_test;
 mod state_table_test;
 mod timer_table_test;
 mod virtual_object_status_table_test;
-
-mod persisted_lsn_tracking_test;
 
 async fn storage_test_environment() -> PartitionStore {
     storage_test_environment_with_manager().await.1

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -53,7 +53,7 @@ define_table!(
         /// Replay status
         replay_status: DataType::Utf8,
 
-        /// Last persisted log LSN
+        /// Durable log LSN (previously, persisted log LSN)
         persisted_log_lsn: DataType::UInt64,
 
         /// Last archived log LSN

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -160,6 +160,8 @@ pub struct PartitionProcessorStatus {
     pub num_skipped_records: u64,
     #[bilrost(9)]
     pub replay_status: ReplayStatus,
+    /// Also known as Durable LSN. Old name kept for compatibility with V1 networking clients.
+    // todo: rename in 1.5 (or as soon as we no longer support interop with V1 cluster controllers)
     #[bilrost(10)]
     pub last_persisted_log_lsn: Option<Lsn>,
     #[bilrost(11)]

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -67,11 +67,10 @@ pub struct AdminOptions {
     /// can be disabled by setting it to "0s".
     ///
     /// Note that this is only the interval at which logs are checked, and does not guarantee that
-    /// trim will be performed. To safely trim the log, the log records must be known to be
-    /// persisted by the corresponding partition processor(s). For single server deployments, use
-    /// the `persist-lsn-*` settings in `worker.storage`. In distributed deployments, this is
-    /// accomplished by configuring an external snapshot destination - see `worker.snapshots` for
-    /// more.
+    /// trim will be performed. The conditions for safely trim the log vary depending on the
+    /// deployment. For single nodes, the log records must be durably persisted to disk. In
+    /// distributed deployments, automatic trimming requires an external snapshot destination - see
+    /// `worker.snapshots` for more.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     log_trim_check_interval: humantime::Duration,

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -221,6 +221,7 @@ impl Configuration {
     }
 
     pub fn apply_cascading_values(mut self) -> Self {
+        self.worker.storage.print_deprecation_warnings();
         self.worker.storage.apply_common(&self.common);
         self.bifrost.apply_common(&self.common);
         self.metadata_server.apply_common(&self.common);

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -24,9 +24,9 @@ pub const NUM_ACTIVE_PARTITIONS: &str = "restate.num_active_partitions";
 pub const PARTITION_TIME_SINCE_LAST_STATUS_UPDATE: &str =
     "restate.partition.time_since_last_status_update";
 pub const PARTITION_TIME_SINCE_LAST_RECORD: &str = "restate.partition.time_since_last_record";
-pub const PARTITION_LAST_APPLIED_LOG_LSN: &str = "restate.partition.last_applied_lsn";
-pub const PARTITION_LAST_APPLIED_LSN_LAG: &str = "restate.partition.applied_lsn_lag";
-pub const PARTITION_LAST_PERSISTED_LOG_LSN: &str = "restate.partition.last_persisted_lsn";
+pub const PARTITION_APPLIED_LSN: &str = "restate.partition.applied_lsn";
+pub const PARTITION_APPLIED_LSN_LAG: &str = "restate.partition.applied_lsn_lag";
+pub const PARTITION_DURABLE_LSN: &str = "restate.partition.durable_lsn";
 pub const PARTITION_IS_EFFECTIVE_LEADER: &str = "restate.partition.is_effective_leader";
 pub const PARTITION_IS_ACTIVE: &str = "restate.partition.is_active";
 
@@ -125,19 +125,19 @@ pub(crate) fn describe_metrics() {
     );
 
     describe_gauge!(
-        PARTITION_LAST_APPLIED_LOG_LSN,
+        PARTITION_APPLIED_LSN,
         Unit::Count,
         "Raw value of the last applied log LSN"
     );
 
     describe_gauge!(
-        PARTITION_LAST_APPLIED_LSN_LAG,
+        PARTITION_APPLIED_LSN_LAG,
         Unit::Count,
         "Number of records between last applied lsn and the log tail"
     );
 
     describe_gauge!(
-        PARTITION_LAST_PERSISTED_LOG_LSN,
+        PARTITION_DURABLE_LSN,
         Unit::Count,
         "Raw value of the LSN that can be trimmed"
     );

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -31,14 +31,14 @@ use tokio::task::JoinSet;
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, info_span, instrument, warn};
 
+use crate::metric_definitions::PARTITION_APPLIED_LSN;
+use crate::metric_definitions::PARTITION_DURABLE_LSN;
 use crate::metric_definitions::PARTITION_IS_ACTIVE;
 use crate::metric_definitions::PARTITION_IS_EFFECTIVE_LEADER;
 use crate::metric_definitions::PARTITION_LABEL;
-use crate::metric_definitions::PARTITION_LAST_APPLIED_LOG_LSN;
-use crate::metric_definitions::PARTITION_LAST_PERSISTED_LOG_LSN;
 use crate::metric_definitions::PARTITION_TIME_SINCE_LAST_RECORD;
 use crate::metric_definitions::PARTITION_TIME_SINCE_LAST_STATUS_UPDATE;
-use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_LAST_APPLIED_LSN_LAG};
+use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_APPLIED_LSN_LAG};
 use crate::partition::ProcessorError;
 use crate::partition::snapshots::{SnapshotPartitionTask, SnapshotRepository};
 use crate::partition_processor_manager::processor_state::{
@@ -672,15 +672,15 @@ impl PartitionProcessorManager {
                 });
 
                 if let Some(last_applied_log_lsn) = status.last_applied_log_lsn {
-                    gauge!(PARTITION_LAST_APPLIED_LOG_LSN,
+                    gauge!(PARTITION_APPLIED_LSN,
                         PARTITION_LABEL => partition_id.to_string())
                     .set(last_applied_log_lsn.as_u64() as f64);
                 }
 
-                if let Some(last_persisted_log_lsn) = status.last_persisted_log_lsn {
-                    gauge!(PARTITION_LAST_PERSISTED_LOG_LSN,
+                if let Some(durable_lsn) = status.last_persisted_log_lsn {
+                    gauge!(PARTITION_DURABLE_LSN,
                         PARTITION_LABEL => partition_id.to_string())
-                    .set(last_persisted_log_lsn.as_u64() as f64);
+                    .set(durable_lsn.as_u64() as f64);
                 }
 
                 if let Some(last_record_applied_at) = status.last_record_applied_at {
@@ -691,7 +691,7 @@ impl PartitionProcessorManager {
 
                 // it is a bit unfortunate that we share PartitionProcessorStatus between the
                 // PP and the PPManager :-(. Maybe at some point we want to split the struct for it.
-                status.last_persisted_log_lsn = self.partition_store_manager.get_persisted_lsn(*partition_id);
+                status.last_persisted_log_lsn = self.partition_store_manager.get_durable_lsn(*partition_id);
                 status.last_archived_log_lsn = self.archived_lsns.get(partition_id).cloned();
 
                 let current_tail_lsn = self.target_tail_lsns.get(partition_id).cloned();
@@ -706,7 +706,7 @@ impl PartitionProcessorManager {
                     None => {
                         // current tail lsn is unknown.
                         // This might indicate an issue, so we set the metric to infinity
-                        gauge!(PARTITION_LAST_APPLIED_LSN_LAG, PARTITION_LABEL => partition_id.to_string())
+                        gauge!(PARTITION_APPLIED_LSN_LAG, PARTITION_LABEL => partition_id.to_string())
                         .set(f64::INFINITY);
                     },
                     Some(target_tail_lsn) => {
@@ -714,7 +714,7 @@ impl PartitionProcessorManager {
 
                         // tail lsn always points to the next "free" lsn slot. Therefor the lag is calculate as `lsn-1`
                         // hence we do target_tail_lsn.prev() below
-                        gauge!(PARTITION_LAST_APPLIED_LSN_LAG, PARTITION_LABEL => partition_id.to_string())
+                        gauge!(PARTITION_APPLIED_LSN_LAG, PARTITION_LABEL => partition_id.to_string())
                         .set(target_tail_lsn.prev().as_u64().saturating_sub(status.last_applied_log_lsn.unwrap_or(Lsn::OLDEST).as_u64()) as f64);
                     }
                 }

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -138,7 +138,7 @@ pub async fn list_partitions(
         "EPOCH",
         "SEQUENCER",
         "APPLIED-LSN",
-        "PERSISTED-LSN",
+        "DURABLE-LSN",
         "SKIPPED-RECORDS",
         "ARCHIVED-LSN",
         "LSN-LAG",


### PR DESCRIPTION
This change renames "persisted LSN" to "durable LSN" to reflect partition data which has been durably committed to local disk by a node.

This is a breaking change for the following metrics but I feel this is justified; happy to undo if there are any concerns:

- `restate.partition.last_applied_lsn` -> `restate.partition.applied_lsn`
- `restate.partition.applied_lsn_lag` -> `restate.partition.applied_lsn_lag`
- `restate.partition.last_persisted_lsn` -> `restate.partition.durable_lsn`

Additionally:

- Updates `restatectl` column display to "Durable LSN"
- Keeps the `NodeStateResponse` RPC message (response to `GetNodeState`, used by Custer Controller) using the old naming as we still have a FlexBuffers-based `WireEncode` fallback implementation for these; this will be safe to rename when we drop V1 networking support
- other purely internal usages

Fixes: #3252