### PR TITLE
Run SequencerAppender tasks in default runtime

### DIFF
--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -135,6 +135,13 @@ pub enum TaskKind {
     LogletProvider,
     #[strum(props(OnCancel = "abort"))]
     Watchdog,
+    /// Append records to the replicated loglet by storing them on a write-quorum of log servers. It
+    /// is important that these tasks complete if the sequencer does not fail because they update
+    /// the sequencer state (local and global tails of the loglet). If this does not happen (e.g.
+    /// because the task is running on the partition processor runtime which gets stopped), then
+    /// subsequent appends might be blocked until the sequencer learns about the current local tails
+    /// via the periodic tail check.
+    #[strum(props(runtime = "default"))]
     SequencerAppender,
     // -- Replicated loglet tasks
     /// Receives messages from remote sequencers on nodes with local sequencer. This is also used


### PR DESCRIPTION
We want to ensure that SequencerAppender tasks complete to update the sequencer state. Therefore, we run the tasks in the default runtime to avoid not completing them if they run as part of the partition processor runtime.

Before, it could happen that a SequencerAppender did not finish (because the corresponding partition processor runtime was shut down) and did not update the sequencer shared state once the store succeeded. This would prevent subsequent append operations to hang for as long as the periodic tail check needs to learn about the local tails of the log servers (~15s).

I have to admit that this bug almost broke me. I started running into with #3233 when all of a sudden the e2e tests became super unstable. The symptoms of this problem were that it looked as if the network layer was losing messages because appends were hanging for so long that we ran into test timeouts. Not a lot of output for a couple of days debugging but it should make things a tad bit more stable now.