### PR TITLE
Invocation preemption-hint

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -966,6 +966,15 @@ where
         if suspension_indexes.is_empty() {
             return TerminalLoopState::Failed(InvokerError::EmptySuspensionMessage);
         }
+
+        if suspension.preempt_hint.unwrap_or_default() {
+            self.invocation_task
+                .send_invoker_tx(InvocationTaskOutputInner::PreemptionHint(
+                    suspension_indexes,
+                ));
+            return TerminalLoopState::Continue(());
+        }
+
         TerminalLoopState::SuspendedV2(suspension_indexes)
     }
 

--- a/crates/service-protocol-v4/src/message_codec/encoding.rs
+++ b/crates/service-protocol-v4/src/message_codec/encoding.rs
@@ -248,6 +248,7 @@ mod tests {
         decoder.push(encoder.encode(expected_msg_2.clone()));
 
         let (actual_msg_header_0, actual_msg_0) = decoder.consume_next().unwrap().unwrap();
+
         assert_eq!(actual_msg_header_0.message_type(), MessageType::Start);
         assert_eq!(actual_msg_0, expected_msg_0);
 

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -86,6 +86,7 @@ message SuspensionMessage {
   repeated uint32 waiting_completions = 1;
   repeated uint32 waiting_signals = 2;
   repeated string waiting_named_signals = 3;
+  optional bool preempt_hint = 4;
 }
 
 // Type: 0x0000 + 2


### PR DESCRIPTION
Invocation preemption-hint

> work in progress

This PR is only to introduce how preemption-hint should work
with invocations. This still rely fully on the global invoker
`concurrency limit`

Summary:
A cooperative preemption hint sent by the running invocation to suggest
that it can be suspended if necessary. This allows the runtime to reclaim
processing time for other tasks, but acting on the hint is optional.

The hint includes a set of `NotificationId`s. If any of these notifications
are completed and the task has not been suspended, the hint is ignored
until the task sends a new preemption hint.

If the task is suspended, the runtime must resume it as soon as one of the
specified `NotificationId`s is completed.
