### PR TITLE
Metadata sync messages to use normal connection abstractions

### DIFF
--- a/crates/core/src/network/io/egress_sender.rs
+++ b/crates/core/src/network/io/egress_sender.rs
@@ -123,10 +123,6 @@ impl UnboundedEgressSender {
         self.inner.send(message).map_err(|_| ConnectionClosed)
     }
 
-    pub fn is_closed(&self) -> bool {
-        self.inner.is_closed()
-    }
-
     pub async fn closed(&self) {
         self.inner.closed().await
     }
@@ -135,22 +131,5 @@ impl UnboundedEgressSender {
     /// terminating but no new messages will be accepted.
     pub fn unbounded_drain(&self, reason: DrainReason) {
         let _ = self.inner.send(EgressMessage::Close(reason));
-    }
-
-    pub fn downgrade(&self) -> WeakUnboundedEgressSender {
-        WeakUnboundedEgressSender {
-            inner: self.inner.downgrade(),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct WeakUnboundedEgressSender {
-    inner: mpsc::WeakUnboundedSender<EgressMessage>,
-}
-
-impl WeakUnboundedEgressSender {
-    pub fn upgrade(&self) -> Option<UnboundedEgressSender> {
-        self.inner.upgrade().map(UnboundedEgressSender::new)
     }
 }

--- a/crates/core/src/network/io/mod.rs
+++ b/crates/core/src/network/io/mod.rs
@@ -16,7 +16,7 @@ mod rpc_tracker;
 use std::sync::Arc;
 
 pub use egress_sender::SendToken;
-pub(crate) use egress_sender::{Sent, WeakUnboundedEgressSender};
+pub(crate) use egress_sender::Sent;
 pub(super) use egress_stream::EgressMessage;
 pub(super) use egress_stream::EgressStream;
 

--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -30,7 +30,7 @@ mod tracking;
 pub mod transport_connector;
 mod types;
 
-pub use connection::{ConnectThrottle, Connection, UnboundedConnectionRef};
+pub use connection::{ConnectThrottle, Connection};
 pub use connection_manager::ConnectionManager;
 pub use error::*;
 pub use grpc::GrpcConnector;


### PR DESCRIPTION

Since the metadata syncing is now properly non-blocking, it's best to use normal connection abstraction for this. This closes the last gap in graceful connection drains as previously it was possible for a connection to hang at drain time when if it waited for the metadata update rpc response for too long.

```
// intentionally left empty
```
