### PR TITLE
[Restate UI] Update to v0.0.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7845,8 +7845,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.71"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.71#9d1e9789bcbbe11a0a231e62a213eed2bd421e71"
+version = "0.0.72"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.72#6385b71e9e12fb8e253fabb2a7ca6bdd7a8d69ee"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -31,7 +31,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.71", tag = "v0.0.71" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.72", tag = "v0.0.72" }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.72
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.72/ui-v0.0.72.zip