### PR TITLE
Log partition flush events

### DIFF
--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -257,6 +257,7 @@ impl PartitionStoreManager {
         // Require a lock to prevent closing/reopening stores while a snapshot is ongoing. Failure
         // to do so can lead to exporting a partially-initialized store.
         let guard = self.lookup.read().await;
+        info!("Obtained read-only lock for partition store lookup table");
         let mut partition_store = guard
             .get(&partition_id)
             .cloned()
@@ -267,6 +268,8 @@ impl PartitionStoreManager {
             .acquire()
             .await
             .expect("we never close the semaphore");
+        info!("Obtained snapshot concurrency limiter permit");
+
         partition_store
             .create_snapshot(snapshot_base_path, min_target_lsn, snapshot_id)
             .await


### PR DESCRIPTION
This change adds additional logging to partition store flush events. When a snapshot is requested, you should expect to see something like:

```
2025-05-21T20:35:48.306301Z  INFO restate_admin::cluster_controller::service: Create snapshot command received partition_id=0
2025-05-21T20:35:48.307839Z  INFO run: restate_partition_store::partition_store_manager: Obtained read-only lock for partition store lookup table snapshot_id=snap_13Zc8En49fx6jxqA6qfQBZn partition_id=0
2025-05-21T20:35:48.307876Z  INFO run: restate_partition_store::partition_store_manager: Obtained snapshot concurrency limiter permit snapshot_id=snap_13Zc8En49fx6jxqA6qfQBZn partition_id=0
2025-05-21T20:35:48.546764Z  INFO restate_partition_store::persisted_lsn_tracking: Partition store flush partition_id=0 applied_lsn=5 cf_name="data-0" file_path="/Users/pavel/restate/restate/restate-data/n1/db/000164.sst" smallest_seqno=131 largest_seqno=132 flush_reason=ManualFlush
2025-05-21T20:35:48.549753Z  INFO run: restate_worker::partition::snapshots::snapshot_task: Created partition snapshot archived_lsn=5 snapshot_id=snap_13Zc8En49fx6jxqA6qfQBZn snapshot_id=snap_13Zc8En49fx6jxqA6qfQBZn partition_id=0
2025-05-21T20:35:48.550013Z  INFO restate_admin::cluster_controller::service: Trim log command received log_id=0 trim_point_inclusive=Lsn(5)
```