### PR TITLE
EntryLite data model to avoid sending entry payloads around when rendering the invocation timeline

### DIFF
--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -58,9 +58,12 @@ define_table!(sys_journal (
     /// The journal version.
     version: DataType::UInt32,
 
-    /// The entry serialized as a JSON string (only relevant for journal version 2)
+    /// The entry serialized as a JSON string. Filled only if journal version is 2.
     entry_json: DataType::LargeUtf8,
 
-    /// When the entry was appended to the journal
+    /// The EntryLite projection serialized as a JSON string. Filled only if journal version is 2.
+    entry_lite_json: DataType::LargeUtf8,
+
+    /// When the entry was appended to the journal. Filled only if journal version is 2.
     appended_at: TimestampMillisecond,
 ));

--- a/crates/types/src/journal_v2/encoding.rs
+++ b/crates/types/src/journal_v2/encoding.rs
@@ -10,6 +10,7 @@
 
 use crate::errors::GenericError;
 use crate::journal_v2::Entry;
+use crate::journal_v2::lite::EntryLite;
 use crate::journal_v2::raw::RawEntry;
 
 #[derive(Debug, thiserror::Error)]
@@ -21,6 +22,8 @@ pub struct DecodingError(#[from] GenericError);
 /// This is typically depending on the concrete service protocol implementation/format/version.
 pub trait Decoder {
     fn decode_entry(entry: &RawEntry) -> Result<Entry, DecodingError>;
+
+    fn decode_entry_lite(entry: &RawEntry) -> Result<EntryLite, DecodingError>;
 }
 
 /// The encoder is the abstraction encapsulating how to represent entries as serialized data.

--- a/crates/types/src/journal_v2/lite.rs
+++ b/crates/types/src/journal_v2/lite.rs
@@ -1,0 +1,274 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::identifiers::InvocationId;
+use crate::invocation::InvocationTarget;
+use crate::journal_v2::{
+    AttachInvocationTarget, CommandType, CompleteAwakeableId, CompletionId, EntryMetadata,
+    EntryType, Event, NotificationId, NotificationMetadata, NotificationType, SignalId,
+};
+use crate::time::MillisSinceEpoch;
+use bytestring::ByteString;
+use enum_dispatch::enum_dispatch;
+use serde::{Deserialize, Serialize};
+
+/// Lite data model, exposing fewer info about the entries.
+/// This is exposed in SQL to avoid sending around full entry payloads, when only some fields of the entry are needed.
+#[enum_dispatch(EntryMetadata)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum EntryLite {
+    Command(CommandLite),
+    Notification(NotificationLite),
+    Event(Event),
+}
+
+// ---- Commands
+
+#[enum_dispatch(EntryMetadata)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum CommandLite {
+    Input(InputCommandLite),
+    Output(OutputCommandLite),
+    GetLazyState(GetLazyStateCommandLite),
+    SetState(SetStateCommandLite),
+    ClearState(ClearStateCommandLite),
+    ClearAllState(ClearAllStateCommandLite),
+    GetLazyStateKeys(GetLazyStateKeysCommandLite),
+    GetEagerState(GetEagerStateCommandLite),
+    GetEagerStateKeys(GetEagerStateKeysCommandLite),
+    GetPromise(GetPromiseCommandLite),
+    PeekPromise(PeekPromiseCommandLite),
+    CompletePromise(CompletePromiseCommandLite),
+    Sleep(SleepCommandLite),
+    Call(CallCommandLite),
+    OneWayCall(OneWayCallCommandLite),
+    SendSignal(SendSignalCommandLite),
+    Run(RunCommandLite),
+    AttachInvocation(AttachInvocationCommandLite),
+    GetInvocationOutput(GetInvocationOutputCommandLite),
+    CompleteAwakeable(CompleteAwakeableCommandLite),
+}
+
+// Little macro to reduce boilerplate for TryFromEntry and EntryMetadata.
+macro_rules! impl_command_accessors {
+    ($ty:ident -> []) => {
+        // End of macro
+    };
+    ($ty:ident -> [@from_entry $($tail:tt)*]) => {
+        impl From<paste::paste! { [< $ty CommandLite >] }> for EntryLite {
+            fn from(v: paste::paste! { [< $ty CommandLite >] }) -> Self {
+                Self::Command(v.into())
+            }
+        }
+        impl_command_accessors!($ty -> [$($tail)*]);
+    };
+    ($ty:ident -> [@metadata $($tail:tt)*]) => {
+        impl EntryMetadata for paste::paste! { [< $ty CommandLite >] } {
+            fn ty(&self) -> EntryType {
+                EntryType::Command(CommandType::$ty)
+            }
+        }
+        impl_command_accessors!($ty -> [$($tail)*]);
+    };
+
+    // Entrypoint of the macro
+    ($ty:ident: [$($tokens:tt)*]) => {
+        impl_command_accessors!($ty -> [$($tokens)*]);
+    };
+    ($ty:ident) => {
+        impl_command_accessors!($ty -> [@metadata @from_entry]);
+    };
+}
+
+// --- Actual implementation of individual commands
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InputCommandLite {}
+impl_command_accessors!(Input);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OutputCommandLite {
+    pub result: OutputResultLite,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum OutputResultLite {
+    Success,
+    Failure,
+}
+impl_command_accessors!(Output);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GetLazyStateCommandLite {
+    pub key: ByteString,
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(GetLazyState);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SetStateCommandLite {
+    pub key: ByteString,
+}
+impl_command_accessors!(SetState);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ClearStateCommandLite {
+    pub key: ByteString,
+}
+impl_command_accessors!(ClearState);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ClearAllStateCommandLite {}
+impl_command_accessors!(ClearAllState);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GetLazyStateKeysCommandLite {
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(GetLazyStateKeys);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GetEagerStateCommandLite {
+    pub key: ByteString,
+}
+impl_command_accessors!(GetEagerState);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GetEagerStateKeysCommandLite {}
+impl_command_accessors!(GetEagerStateKeys);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GetPromiseCommandLite {
+    pub key: ByteString,
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(GetPromise);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PeekPromiseCommandLite {
+    pub key: ByteString,
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(PeekPromise);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CompletePromiseCommandLite {
+    pub key: ByteString,
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(CompletePromise);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SleepCommandLite {
+    pub wake_up_time: MillisSinceEpoch,
+    pub completion_id: CompletionId,
+    #[serde(default, skip_serializing_if = "str::is_empty")]
+    pub name: ByteString,
+}
+impl_command_accessors!(Sleep);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CallCommandLite {
+    pub invocation_id: InvocationId,
+    pub invocation_target: InvocationTarget,
+    pub invocation_id_completion_id: CompletionId,
+    pub result_completion_id: CompletionId,
+    #[serde(default, skip_serializing_if = "str::is_empty")]
+    pub name: ByteString,
+}
+impl_command_accessors!(Call);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OneWayCallCommandLite {
+    pub invocation_id: InvocationId,
+    pub invocation_target: InvocationTarget,
+    pub invoke_time: MillisSinceEpoch,
+    pub invocation_id_completion_id: CompletionId,
+    #[serde(default, skip_serializing_if = "str::is_empty")]
+    pub name: ByteString,
+}
+impl_command_accessors!(OneWayCall);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SendSignalCommandLite {
+    pub target_invocation_id: InvocationId,
+    pub signal_id: SignalId,
+    pub result: SignalResultLite,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum SignalResultLite {
+    Void,
+    Success,
+    Failure,
+}
+impl_command_accessors!(SendSignal);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RunCommandLite {
+    pub completion_id: CompletionId,
+    #[serde(default, skip_serializing_if = "str::is_empty")]
+    pub name: ByteString,
+}
+impl_command_accessors!(Run);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AttachInvocationCommandLite {
+    pub target: AttachInvocationTarget,
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(AttachInvocation);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GetInvocationOutputCommandLite {
+    pub target: AttachInvocationTarget,
+    pub completion_id: CompletionId,
+}
+impl_command_accessors!(GetInvocationOutput);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CompleteAwakeableCommandLite {
+    pub id: CompleteAwakeableId,
+    pub result: CompleteAwakeableResultLite,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompleteAwakeableResultLite {
+    Success,
+    Failure,
+}
+impl_command_accessors!(CompleteAwakeable);
+
+// --- Notification lite
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NotificationLite {
+    pub ty: NotificationType,
+    pub id: NotificationId,
+    pub result: NotificationResultLite,
+}
+
+impl EntryMetadata for NotificationLite {
+    fn ty(&self) -> EntryType {
+        EntryType::Notification(self.ty)
+    }
+}
+
+impl NotificationMetadata for NotificationLite {
+    fn id(&self) -> NotificationId {
+        self.id.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum NotificationResultLite {
+    Void,
+    Success,
+    Failure,
+    StateKeys,
+    InvocationId,
+}

--- a/crates/types/src/journal_v2/mod.rs
+++ b/crates/types/src/journal_v2/mod.rs
@@ -8,9 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// TODO remove this!
-#![allow(dead_code)]
-
 //! This module contains the data model of the Journal.
 //!
 //! Within the runtime, Journal entries are represented in different ways in different stages/components:
@@ -34,6 +31,7 @@ use std::fmt;
 pub mod command;
 pub mod encoding;
 mod event;
+pub mod lite;
 pub mod notification;
 pub mod raw;
 mod types;
@@ -77,6 +75,7 @@ impl fmt::Display for EntryType {
     }
 }
 
+use crate::journal_v2::lite::*;
 use crate::journal_v2::raw::*;
 
 #[enum_dispatch]

--- a/crates/types/src/journal_v2/notification.rs
+++ b/crates/types/src/journal_v2/notification.rs
@@ -48,9 +48,9 @@ impl From<SignalId> for NotificationId {
 impl fmt::Display for NotificationId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NotificationId::SignalIndex(idx) => write!(f, "{idx}"),
-            NotificationId::SignalName(name) => write!(f, "{name}"),
-            NotificationId::CompletionId(idx) => write!(f, "{idx}"),
+            NotificationId::SignalIndex(idx) => write!(f, "SignalIndex: {idx}"),
+            NotificationId::SignalName(name) => write!(f, "SignalName: {name}"),
+            NotificationId::CompletionId(idx) => write!(f, "CompletionId: {idx}"),
         }
     }
 }


### PR DESCRIPTION
Fix #3294