### PR TITLE
Store Transient errors in journal events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,24 @@ jobs:
     with:
       restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
 
+  sdk-java-journal-retention-and-events:
+    name: Run SDK-Java integration tests with Journal retention and journal events
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+      actions: read
+    secrets: inherit
+    needs: docker
+    uses: restatedev/sdk-java/.github/workflows/integration.yaml@main
+    with:
+      restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
+      envVars: |
+        RESTATE_ADMIN__experimental_feature_force_journal_retention=365days
+        RESTATE_WORKER__INVOKER__experimental_features_propose_events=true
+      testArtifactOutput: sdk-java-journal-retention-and-events-integration-test-report
+
   sdk-python:
     name: Run SDK-Python integration tests
     permissions:

--- a/crates/invoker-api/src/invocation_reader.rs
+++ b/crates/invoker-api/src/invocation_reader.rs
@@ -77,6 +77,8 @@ pub trait InvocationReaderTransaction {
 
     /// Read the journal for the given invocation id.
     ///
+    /// The returned journal **MUST** not return events.
+    ///
     /// Returns `None` when either the invocation was not found, or the invocation is not in `Invoked` state.
     fn read_journal<'a>(
         &'a mut self,

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -224,8 +224,8 @@ impl InvocationStateMachine {
         self.selected_service_protocol = Some(service_protocol_version);
     }
 
-    pub(super) fn selected_service_protocol(&self) -> Option<&ServiceProtocolVersion> {
-        self.selected_service_protocol.as_ref()
+    pub(super) fn selected_service_protocol(&self) -> Option<ServiceProtocolVersion> {
+        self.selected_service_protocol
     }
 
     pub(super) fn pinned_deployment_to_notify(&mut self) -> Option<PinnedDeployment> {

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -12,6 +12,7 @@ use super::*;
 
 use restate_types::journal::Completion;
 use restate_types::retries;
+use restate_types::service_protocol::ServiceProtocolVersion;
 use std::fmt;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -22,6 +23,7 @@ use tokio::task::AbortHandle;
 pub(super) struct InvocationStateMachine {
     pub(super) invocation_target: InvocationTarget,
     pub(super) invocation_epoch: InvocationEpoch,
+    selected_service_protocol: Option<ServiceProtocolVersion>,
     invocation_state: InvocationState,
     retry_iter: retries::RetryIter<'static>,
     /// This retry count is passed in the StartMessage.
@@ -166,6 +168,7 @@ impl InvocationStateMachine {
         Self {
             invocation_target,
             invocation_epoch,
+            selected_service_protocol: None,
             invocation_state: InvocationState::New,
             retry_iter: retry_policy.into_iter(),
             start_message_retry_count_since_last_stored_command: 0,
@@ -214,6 +217,17 @@ impl InvocationStateMachine {
         }
     }
 
+    pub(super) fn notify_selected_service_protocol(
+        &mut self,
+        service_protocol_version: ServiceProtocolVersion,
+    ) {
+        self.selected_service_protocol = Some(service_protocol_version);
+    }
+
+    pub(super) fn selected_service_protocol(&self) -> Option<&ServiceProtocolVersion> {
+        self.selected_service_protocol.as_ref()
+    }
+
     pub(super) fn pinned_deployment_to_notify(&mut self) -> Option<PinnedDeployment> {
         debug_assert!(matches!(
             &self.invocation_state,
@@ -224,7 +238,13 @@ impl InvocationStateMachine {
             pinned_deployment, ..
         } = &mut self.invocation_state
         {
-            pinned_deployment.take()
+            if let Some(pinned_deployment) = pinned_deployment.take() {
+                // When notifying the pinned deployment, we also set the protocol version
+                self.selected_service_protocol = Some(pinned_deployment.service_protocol_version);
+                Some(pinned_deployment)
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1227,12 +1227,16 @@ where
                 if options.experimental_features_propose_events()
                     && ism
                         .selected_service_protocol()
-                        .is_some_and(|sp| *sp >= ServiceProtocolVersion::V4)
+                        .is_some_and(|sp| sp >= ServiceProtocolVersion::V4)
                 {
                     // Only if protocol version >= 4 was selected we can propose the transient error
                     let event = Event::TransientError(TransientErrorEvent {
                         error_code: invocation_error_report.err.code(),
                         error_message: invocation_error_report.err.message().to_owned(),
+                        // Note from the review:
+                        //  The stacktrace might be very long, but trimming it is not a piece of cake.
+                        //  That's because some languages (Python!) have the stacktrace in reverse,
+                        //  so it's hard here to decide whether to just drop the suffix or the prefix.
                         error_stacktrace: invocation_error_report
                             .err
                             .stacktrace()

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -42,6 +42,7 @@ use restate_types::schema::deployment::DeploymentResolver;
 use status_store::InvocationStatusStore;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
+use std::num::NonZeroU32;
 use std::ops::RangeInclusive;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -52,6 +53,7 @@ use tokio::task::{AbortHandle, JoinSet};
 use tracing::{debug, trace};
 use tracing::{error, instrument};
 
+use crate::error::SdkInvocationErrorV2;
 use crate::metric_definitions::{
     INVOKER_ENQUEUE, INVOKER_INVOCATION_TASKS, TASK_OP_COMPLETED, TASK_OP_FAILED, TASK_OP_STARTED,
     TASK_OP_SUSPENDED,
@@ -64,10 +66,15 @@ use restate_service_client::{AssumeRoleCacheMode, ServiceClient};
 use restate_types::deployment::PinnedDeployment;
 use restate_types::invocation::{InvocationEpoch, InvocationTarget};
 use restate_types::journal_v2;
-use restate_types::journal_v2::raw::{RawCommand, RawEntry, RawEntryHeader, RawNotification};
-use restate_types::journal_v2::{CommandIndex, EntryMetadata, NotificationId};
+use restate_types::journal_v2::raw::{
+    RawCommand, RawEntry, RawEntryHeader, RawEvent, RawNotification,
+};
+use restate_types::journal_v2::{
+    CommandIndex, EntryMetadata, Event, NotificationId, TransientErrorEvent,
+};
 use restate_types::schema::invocation_target::InvocationTargetResolver;
 use restate_types::schema::service::ServiceMetadataResolver;
+use restate_types::service_protocol::ServiceProtocolVersion;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Notification {
@@ -405,7 +412,7 @@ where
                         self.handle_pinned_deployment(
                             partition,
                             invocation_id,
-                              invocation_epoch,
+                            invocation_epoch,
                             deployment_metadata,
                             has_changed,
                         )
@@ -440,7 +447,7 @@ where
                         self.handle_invocation_task_closed(partition, invocation_id, invocation_epoch).await
                     },
                     InvocationTaskOutputInner::Failed(e) => {
-                        self.handle_invocation_task_failed(partition, invocation_id, invocation_epoch, e).await
+                        self.handle_invocation_task_failed(options, partition, invocation_id, invocation_epoch, e).await
                     },
                     InvocationTaskOutputInner::Suspended(indexes) => {
                         self.handle_invocation_task_suspended(partition, invocation_id, invocation_epoch, indexes).await
@@ -673,6 +680,12 @@ where
                 // we assume that we have stored it previously.
                 if has_changed {
                     ism.notify_pinned_deployment(pinned_deployment);
+                } else {
+                    // The service protocol is selected only if this was the stored version already,
+                    // or if we send the pinned deployment through (see handle_new_command)
+                    ism.notify_selected_service_protocol(
+                        pinned_deployment.service_protocol_version,
+                    );
                 }
             },
         );
@@ -1067,6 +1080,7 @@ where
     )]
     async fn handle_invocation_task_failed(
         &mut self,
+        options: &InvokerOptions,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
         invocation_epoch: InvocationEpoch,
@@ -1077,7 +1091,7 @@ where
             .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
         {
             debug_assert_eq!(invocation_epoch, ism.invocation_epoch);
-            self.handle_error_event(partition, invocation_id, error, ism)
+            self.handle_error_event(options, partition, invocation_id, error, ism)
                 .await;
         } else {
             // If no state machine, this might be a result for an aborted invocation.
@@ -1160,6 +1174,7 @@ where
 
     async fn handle_error_event(
         &mut self,
+        options: &InvokerOptions,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
         error: InvokerError,
@@ -1196,10 +1211,59 @@ where
                 trace!("Invocation state: {:?}.", ism.invocation_state_debug());
                 let next_retry_at = SystemTime::now() + next_retry_timer_duration;
 
+                let journal_v2_related_command_type =
+                    if let InvokerError::SdkV2(SdkInvocationErrorV2 {
+                        related_command: Some(ref related_entry),
+                        ..
+                    }) = error
+                    {
+                        related_entry
+                            .related_entry_type
+                            .and_then(|e| e.try_as_command_ref().copied())
+                    } else {
+                        None
+                    };
+                let invocation_error_report = error.into_invocation_error_report();
+                if options.experimental_features_propose_events()
+                    && ism
+                        .selected_service_protocol()
+                        .is_some_and(|sp| *sp >= ServiceProtocolVersion::V4)
+                {
+                    // Only if protocol version >= 4 was selected we can propose the transient error
+                    let event = Event::TransientError(TransientErrorEvent {
+                        error_code: invocation_error_report.err.code(),
+                        error_message: invocation_error_report.err.message().to_owned(),
+                        error_stacktrace: invocation_error_report
+                            .err
+                            .stacktrace()
+                            .map(|s| s.to_owned()),
+                        restate_doc_error_code: invocation_error_report
+                            .doc_error_code
+                            .map(|c| c.code().to_owned()),
+                        related_command_index: invocation_error_report.related_entry_index,
+                        related_command_name: invocation_error_report.related_entry_name.clone(),
+                        related_command_type: journal_v2_related_command_type,
+                        count: NonZeroU32::new(1).unwrap(),
+                    });
+                    let _ = self
+                        .invocation_state_machine_manager
+                        .resolve_partition_sender(partition)
+                        .expect("Partition should be registered")
+                        .send(Effect {
+                            invocation_id,
+                            invocation_epoch: ism.invocation_epoch,
+                            kind: EffectKind::JournalEntryV2 {
+                                entry: RawEntry::new(RawEntryHeader::new(), RawEvent::from(event)),
+                                command_index_to_ack: None,
+                            },
+                        })
+                        .await;
+                }
+
                 self.status_store.on_failure(
                     partition,
                     invocation_id,
-                    error.into_invocation_error_report(),
+                    invocation_error_report,
                     Some(next_retry_at),
                 );
                 let epoch = ism.invocation_epoch;
@@ -1816,6 +1880,7 @@ mod tests {
         // Handle error coming after the abort (this should be noop)
         service_inner
             .handle_invocation_task_failed(
+                &invoker_options,
                 MOCK_PARTITION,
                 invocation_id,
                 0,
@@ -1869,6 +1934,7 @@ mod tests {
         // Also handle error on epoch 0 should have no effect
         service_inner
             .handle_invocation_task_failed(
+                &InvokerOptions::default(),
                 MOCK_PARTITION,
                 invocation_id,
                 0,

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1249,14 +1249,14 @@ where
                         .invocation_state_machine_manager
                         .resolve_partition_sender(partition)
                         .expect("Partition should be registered")
-                        .send(Effect {
+                        .send(Box::new(Effect {
                             invocation_id,
                             invocation_epoch: ism.invocation_epoch,
                             kind: EffectKind::JournalEntryV2 {
                                 entry: RawEntry::new(RawEntryHeader::new(), RawEvent::from(event)),
                                 command_index_to_ack: None,
                             },
-                        })
+                        }))
                         .await;
                 }
 

--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -520,11 +520,6 @@ message JournalEntry {
 
 // -------- Entry V2 --------
 message Entry {
-  message EventEntry {
-    string ty = 1;
-    map<string, string> metadata = 2;
-  }
-
   message CallOrSendCommandMetadata {
     InvocationId invocation_id = 1;
     InvocationTarget invocation_target = 2;
@@ -571,8 +566,8 @@ message Entry {
   }
 
   EntryType ty = 3;
-  // For Event ty, this contains the EventEntry,
-  // otherwise the content depends on the RawEntry Encoder/Decoder.
+
+  // The content depends on the RawEntry Encoder/Decoder.
   bytes content = 4;
 
   // Additional metadata for all entries
@@ -587,6 +582,14 @@ message Entry {
     uint32 signal_idx = 8;
     string signal_name = 9;
   }
+
+  enum EventType {
+    UNKNOWN_EVENT = 0;
+    TRANSIENT_ERROR = 1;
+  }
+
+  // Additional metadata for EVENT
+  EventType event_type = 10;
 }
 
 message ResponseResult {

--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -590,6 +590,7 @@ message Entry {
 
   // Additional metadata for EVENT
   EventType event_type = 10;
+  optional bytes event_deduplication_hash = 11;
 }
 
 message ResponseResult {

--- a/crates/partition-store/src/protobuf_types.rs
+++ b/crates/partition-store/src/protobuf_types.rs
@@ -118,22 +118,6 @@ pub mod v1 {
     ));
 
     pub mod pb_conversion {
-        use crate::protobuf_types::v1::entry::EntryType;
-        use crate::protobuf_types::v1::entry::EventEntry;
-        use std::collections::{HashMap, HashSet};
-        use std::str::FromStr;
-        use std::sync::Arc;
-
-        use anyhow::anyhow;
-        use bytes::{Buf, Bytes};
-        use bytestring::ByteString;
-        use opentelemetry::trace::TraceState;
-        use prost::Message;
-        use restate_storage_api::invocation_status_table::{
-            CompletionRangeEpochMap, JournalMetadata,
-        };
-        use restate_types::deployment::PinnedDeployment;
-
         use crate::protobuf_types::ConversionError;
         use crate::protobuf_types::v1::dedup_sequence_number::Variant;
         use crate::protobuf_types::v1::enriched_entry_header::{
@@ -142,6 +126,7 @@ pub mod v1 {
             GetInvocationOutput, GetPromise, GetState, GetStateKeys, Input, Invoke, Output,
             PeekPromise, SetState, SideEffect, Sleep,
         };
+        use crate::protobuf_types::v1::entry::EntryType;
         use crate::protobuf_types::v1::invocation_status::{
             Completed, Free, Inboxed, Invoked, Suspended,
         };
@@ -171,7 +156,16 @@ pub mod v1 {
             response_result, source, span_relation, submit_notification_sink, timer,
             virtual_object_status,
         };
+        use anyhow::anyhow;
+        use bytes::{Buf, Bytes};
+        use bytestring::ByteString;
+        use opentelemetry::trace::TraceState;
+        use prost::Message;
         use restate_storage_api::StorageError;
+        use restate_storage_api::invocation_status_table::{
+            CompletionRangeEpochMap, JournalMetadata,
+        };
+        use restate_types::deployment::PinnedDeployment;
         use restate_types::errors::{IdDecodeError, InvocationError};
         use restate_types::identifiers::{
             PartitionProcessorRpcRequestId, WithInvocationId, WithPartitionKey,
@@ -189,6 +183,8 @@ pub mod v1 {
         };
         use restate_types::time::MillisSinceEpoch;
         use restate_types::{GenerationalNodeId, journal_v2};
+        use std::collections::{HashMap, HashSet};
+        use std::str::FromStr;
 
         impl TryFrom<VirtualObjectStatus>
             for restate_storage_api::service_status_table::VirtualObjectStatus
@@ -3369,21 +3365,12 @@ pub mod v1 {
                         .try_into()?
                     {
                         journal_v2::EntryType::Event => {
-                            let event_entry = EventEntry::decode(value.content)
-                                .map_err(|e| ConversionError::InvalidData(e.into()))?;
+                            let event_type = journal_v2::EventType::from(
+                                entry::EventType::try_from(value.event_type).unwrap_or_default(),
+                            );
                             journal_v2::raw::RawEntry::new(
                                 header,
-                                journal_v2::Event {
-                                    ty: event_entry
-                                        .ty
-                                        .parse::<journal_v2::EventType>()
-                                        .map_err(|e| ConversionError::InvalidData(e.into()))?,
-                                    metadata: event_entry
-                                        .metadata
-                                        .into_iter()
-                                        .map(|(k, v)| (k, v.into()))
-                                        .collect(),
-                                },
+                                journal_v2::raw::RawEvent::new(event_type, value.content),
                             )
                         }
                         journal_v2::EntryType::Notification(notification_ty) => {
@@ -3445,6 +3432,7 @@ pub mod v1 {
                 let ty = EntryType::from(raw_entry.ty());
                 let append_time = raw_entry.header().append_time.into();
 
+                let mut event_type = entry::EventType::UnknownEvent;
                 let mut call_or_send_command_metadata: Option<entry::CallOrSendCommandMetadata> =
                     None;
                 let mut notification_id: Option<entry::NotificationId> = None;
@@ -3477,16 +3465,11 @@ pub mod v1 {
 
                         notification.serialized_content()
                     }
-                    journal_v2::raw::RawEntryInner::Event(event) => EventEntry {
-                        ty: event.ty.to_string(),
-                        metadata: event
-                            .metadata
-                            .into_iter()
-                            .map(|(k, v)| (k, v.to_string()))
-                            .collect(),
+                    journal_v2::raw::RawEntryInner::Event(event) => {
+                        let (ty, value) = event.into_inner();
+                        event_type = ty.into();
+                        value
                     }
-                    .encode_to_vec()
-                    .into(),
                 };
 
                 Entry {
@@ -3494,7 +3477,26 @@ pub mod v1 {
                     content,
                     append_time,
                     call_or_send_command_metadata,
+                    event_type: event_type.into(),
                     notification_id,
+                }
+            }
+        }
+
+        impl From<journal_v2::EventType> for entry::EventType {
+            fn from(value: journal_v2::EventType) -> Self {
+                match value {
+                    journal_v2::EventType::TransientError => entry::EventType::TransientError,
+                    journal_v2::EventType::Unknown => entry::EventType::UnknownEvent,
+                }
+            }
+        }
+
+        impl From<entry::EventType> for journal_v2::EventType {
+            fn from(value: entry::EventType) -> Self {
+                match value {
+                    entry::EventType::TransientError => journal_v2::EventType::TransientError,
+                    entry::EventType::UnknownEvent => journal_v2::EventType::Unknown,
                 }
             }
         }

--- a/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroU32;
 use std::pin::pin;
 use std::time::Duration;
 
@@ -25,8 +26,8 @@ use restate_types::journal_v2;
 use restate_types::journal_v2::raw::RawCommandSpecificMetadata;
 use restate_types::journal_v2::{
     CallCommand, CallRequest, CommandType, CompletionId, CompletionType, Entry, EntryMetadata,
-    EntryType, EventType, NotificationId, NotificationType, OneWayCallCommand, SleepCommand,
-    SleepCompletion,
+    EntryType, Event, NotificationId, NotificationType, OneWayCallCommand, SleepCommand,
+    SleepCompletion, TransientErrorEvent,
 };
 
 const MOCK_INVOCATION_ID_1: InvocationId =
@@ -307,10 +308,16 @@ async fn test_event() {
 
     let mut txn = rocksdb.transaction();
 
-    let event = journal_v2::Event {
-        ty: EventType::Lifecycle,
-        metadata: [("abc".to_string(), ByteString::from_static("123"))].into(),
-    };
+    let event = journal_v2::Event::TransientError(TransientErrorEvent {
+        error_code: 500u16.into(),
+        error_message: "my_error".to_string(),
+        error_stacktrace: None,
+        restate_doc_error_code: None,
+        related_command_index: None,
+        related_command_name: Some("Input".to_string()),
+        related_command_type: None,
+        count: NonZeroU32::new(10).unwrap(),
+    });
 
     // Populate
     txn.put_journal_entry(
@@ -325,7 +332,10 @@ async fn test_event() {
     // Verify the event is correct
     let mut journal = txn.get_journal(MOCK_INVOCATION_ID_1, 1).unwrap();
     let entry = journal.next().await.unwrap().unwrap().1;
-    assert_eq!(entry.inner.try_as_event().unwrap(), event);
+    assert_eq!(
+        entry.decode::<ServiceProtocolV4Codec, Event>().unwrap(),
+        event
+    );
 
     assert!(journal.next().await.is_none());
     drop(journal);

--- a/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroU32;
 use std::pin::pin;
 use std::time::Duration;
 
@@ -316,7 +315,6 @@ async fn test_event() {
         related_command_index: None,
         related_command_name: Some("Input".to_string()),
         related_command_type: None,
-        count: NonZeroU32::new(10).unwrap(),
     });
 
     // Populate

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -71,7 +71,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 serde_path_to_error = { version = "0.1" }
-serde_with = { workspace = true }
+serde_with = { workspace = true, features = ["json"] }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
 smartstring = { workspace = true, features = ["serde"]}

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -117,6 +117,7 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
                 "./protobuf/restate/common.proto",
                 "./protobuf/restate/metadata.proto",
                 "./protobuf/restate/cluster.proto",
+                "./protobuf/restate/journal_events.proto",
                 "./protobuf/restate/log_server_common.proto",
             ],
             &["protobuf"],

--- a/crates/types/protobuf/restate/journal_events.proto
+++ b/crates/types/protobuf/restate/journal_events.proto
@@ -14,27 +14,26 @@ package restate.journal.events;
 
 message TransientErrorEvent {
   enum CommandType {
-    UNKNOWN = 0;
-    INPUT = 1;
-    OUTPUT = 2;
-    GET_LAZY_STATE = 3;
-    SET_STATE = 4;
-    CLEAR_STATE = 5;
-    CLEAR_ALL_STATE = 6;
-    GET_LAZY_STATE_KEYS = 7;
-    GET_EAGER_STATE = 8;
-    GET_EAGER_STATE_KEYS = 9;
-    GET_PROMISE = 10;
-    PEEK_PROMISE = 11;
-    COMPLETE_PROMISE = 12;
-    SLEEP = 13;
-    CALL = 14;
-    ONE_WAY_CALL = 15;
-    SEND_SIGNAL = 16;
-    RUN = 17;
-    ATTACH_INVOCATION = 18;
-    GET_INVOCATION_OUTPUT = 19;
-    COMPLETE_AWAKEABLE = 20;
+    INPUT = 0;
+    OUTPUT = 1;
+    GET_LAZY_STATE = 2;
+    SET_STATE = 3;
+    CLEAR_STATE = 4;
+    CLEAR_ALL_STATE = 5;
+    GET_LAZY_STATE_KEYS = 6;
+    GET_EAGER_STATE = 7;
+    GET_EAGER_STATE_KEYS = 8;
+    GET_PROMISE = 9;
+    PEEK_PROMISE = 10;
+    COMPLETE_PROMISE = 11;
+    SLEEP = 12;
+    CALL = 13;
+    ONE_WAY_CALL = 14;
+    SEND_SIGNAL = 15;
+    RUN = 16;
+    ATTACH_INVOCATION = 17;
+    GET_INVOCATION_OUTPUT = 18;
+    COMPLETE_AWAKEABLE = 19;
   }
 
   uint32 error_code = 1;

--- a/crates/types/protobuf/restate/journal_events.proto
+++ b/crates/types/protobuf/restate/journal_events.proto
@@ -44,5 +44,4 @@ message TransientErrorEvent {
   optional uint32 related_command_index = 5;
   optional string related_command_name = 6;
   optional CommandType related_command_type = 7;
-  uint32 count = 8;
 }

--- a/crates/types/protobuf/restate/journal_events.proto
+++ b/crates/types/protobuf/restate/journal_events.proto
@@ -13,12 +13,36 @@ syntax = "proto3";
 package restate.journal.events;
 
 message TransientErrorEvent {
+  enum CommandType {
+    UNKNOWN = 0;
+    INPUT = 1;
+    OUTPUT = 2;
+    GET_LAZY_STATE = 3;
+    SET_STATE = 4;
+    CLEAR_STATE = 5;
+    CLEAR_ALL_STATE = 6;
+    GET_LAZY_STATE_KEYS = 7;
+    GET_EAGER_STATE = 8;
+    GET_EAGER_STATE_KEYS = 9;
+    GET_PROMISE = 10;
+    PEEK_PROMISE = 11;
+    COMPLETE_PROMISE = 12;
+    SLEEP = 13;
+    CALL = 14;
+    ONE_WAY_CALL = 15;
+    SEND_SIGNAL = 16;
+    RUN = 17;
+    ATTACH_INVOCATION = 18;
+    GET_INVOCATION_OUTPUT = 19;
+    COMPLETE_AWAKEABLE = 20;
+  }
+
   uint32 error_code = 1;
   string error_message = 2;
   optional string error_stacktrace = 3;
   optional string restate_doc_error_code = 4;
   optional uint32 related_command_index = 5;
   optional string related_command_name = 6;
-  optional string related_command_type = 7;
+  optional CommandType related_command_type = 7;
   uint32 count = 8;
 }

--- a/crates/types/protobuf/restate/journal_events.proto
+++ b/crates/types/protobuf/restate/journal_events.proto
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package restate.journal.events;
+
+message TransientErrorEvent {
+  uint32 error_code = 1;
+  string error_message = 2;
+  optional string error_stacktrace = 3;
+  optional string restate_doc_error_code = 4;
+  optional uint32 related_command_index = 5;
+  optional string related_command_name = 6;
+  optional string related_command_type = 7;
+  uint32 count = 8;
+}

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -179,6 +179,10 @@ pub struct InvokerOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub disable_eager_state: bool,
+
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    experimental_features_propose_events: bool,
 }
 
 impl InvokerOptions {
@@ -198,6 +202,10 @@ impl InvokerOptions {
 
     pub fn message_size_limit(&self) -> Option<usize> {
         self.message_size_limit.map(Into::into)
+    }
+
+    pub fn experimental_features_propose_events(&self) -> bool {
+        self.experimental_features_propose_events
     }
 }
 
@@ -219,6 +227,7 @@ impl Default for InvokerOptions {
             tmp_dir: None,
             concurrent_invocations_limit: None,
             disable_eager_state: false,
+            experimental_features_propose_events: false,
         }
     }
 }

--- a/crates/types/src/journal_v2/command.rs
+++ b/crates/types/src/journal_v2/command.rs
@@ -38,7 +38,7 @@ pub trait CommandMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, strum::EnumDiscriminants, Serialize, Deserialize)]
 #[strum_discriminants(vis(pub))]
 #[strum_discriminants(name(CommandType))]
-#[strum_discriminants(derive(serde::Serialize, serde::Deserialize))]
+#[strum_discriminants(derive(serde::Serialize, serde::Deserialize, strum::EnumString))]
 pub enum Command {
     Input(InputCommand),
     Output(OutputCommand),

--- a/crates/types/src/journal_v2/command.rs
+++ b/crates/types/src/journal_v2/command.rs
@@ -38,7 +38,12 @@ pub trait CommandMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, strum::EnumDiscriminants, Serialize, Deserialize)]
 #[strum_discriminants(vis(pub))]
 #[strum_discriminants(name(CommandType))]
-#[strum_discriminants(derive(serde::Serialize, serde::Deserialize, strum::EnumString))]
+#[strum_discriminants(derive(
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr
+))]
 pub enum Command {
     Input(InputCommand),
     Output(OutputCommand),

--- a/crates/types/src/journal_v2/event.rs
+++ b/crates/types/src/journal_v2/event.rs
@@ -8,9 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroU32;
-
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use strum::EnumString;
 
 use crate::errors::InvocationErrorCode;
@@ -21,25 +21,6 @@ use crate::journal_v2::{CommandIndex, CommandType, Encoder, Entry, EntryMetadata
 pub enum EventType {
     TransientError,
     Unknown,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TransientErrorEvent {
-    pub error_code: InvocationErrorCode,
-    pub error_message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error_stacktrace: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub restate_doc_error_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub related_command_index: Option<CommandIndex>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub related_command_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub related_command_type: Option<CommandType>,
-
-    // Count of the same transient error
-    pub count: NonZeroU32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -71,5 +52,65 @@ impl TryFromEntry for Event {
                 actual: e.ty(),
             }),
         }
+    }
+}
+
+// --- The individual events
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransientErrorEvent {
+    pub error_code: InvocationErrorCode,
+    pub error_message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_stacktrace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restate_doc_error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_command_index: Option<CommandIndex>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_command_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_command_type: Option<CommandType>,
+}
+
+impl TransientErrorEvent {
+    pub fn deduplication_hash(&self) -> Bytes {
+        const HASH_SEPARATOR: u8 = 0x2c;
+
+        // WARNING: Changing this code will result in having duplicated events between restate versions.
+        let mut hasher = Sha256::new();
+        hasher.update(b"tee");
+        hasher.update([HASH_SEPARATOR]);
+        hasher.update(u16::from(self.error_code).to_le_bytes());
+        hasher.update([HASH_SEPARATOR]);
+        hasher.update(&self.error_message);
+        hasher.update([HASH_SEPARATOR]);
+        if let Some(error_code) = &self.restate_doc_error_code {
+            hasher.update(error_code);
+        } else {
+            hasher.update(b"-");
+        }
+        hasher.update([HASH_SEPARATOR]);
+        if let Some(command_index) = &self.related_command_index {
+            hasher.update(command_index.to_le_bytes());
+        } else {
+            hasher.update(b"-");
+        }
+        hasher.update([HASH_SEPARATOR]);
+        if let Some(command_name) = &self.related_command_name {
+            hasher.update(command_name);
+        } else {
+            hasher.update(b"-");
+        }
+        hasher.update([HASH_SEPARATOR]);
+        if let Some(command_type) = &self.related_command_type {
+            let str: &'static str = command_type.into();
+            hasher.update(str);
+        } else {
+            hasher.update(b"-");
+        }
+        let result = hasher.finalize();
+
+        result.to_vec().into()
     }
 }

--- a/crates/types/src/journal_v2/event.rs
+++ b/crates/types/src/journal_v2/event.rs
@@ -8,15 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::num::NonZeroU32;
 
-use bytestring::ByteString;
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
 
-use crate::journal_v2::raw::{TryFromEntry, TryFromEntryError};
-use crate::journal_v2::{Entry, EntryMetadata, EntryType};
-
+use crate::errors::InvocationErrorCode;
+use crate::journal_v2::raw::{RawEntry, TryFromEntry, TryFromEntryError};
+use crate::journal_v2::{CommandIndex, CommandType, Encoder, Entry, EntryMetadata, EntryType};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, strum::Display, Serialize, Deserialize)]
 pub enum EventType {
@@ -58,8 +57,8 @@ impl EntryMetadata for Event {
 }
 
 impl Event {
-    pub fn encode<E: Encoder>(&self) -> RawEntry {
-        E::encode_entry(&Entry::Event(self.clone()))
+    pub fn encode<E: Encoder>(self) -> RawEntry {
+        E::encode_entry(Entry::Event(self.clone()))
     }
 }
 

--- a/crates/types/src/journal_v2/mod.rs
+++ b/crates/types/src/journal_v2/mod.rs
@@ -53,7 +53,9 @@ pub type SignalName = ByteString;
 
 // -- Entry metadata
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, strum::EnumIs, derive_more::From)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, strum::EnumIs, strum::EnumTryAs, derive_more::From,
+)]
 pub enum EntryType {
     Command(CommandType),
     Notification(NotificationType),
@@ -86,7 +88,14 @@ pub trait EntryMetadata {
 
 /// Root enum representing a decoded entry.
 #[enum_dispatch(EntryMetadata)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    /* The deserialize trait is used only by CLI */ Deserialize,
+)]
 // todo: fix this and box the large variant (Command is 416 bytes)
 #[allow(clippy::large_enum_variant)]
 pub enum Entry {

--- a/crates/types/src/journal_v2/mod.rs
+++ b/crates/types/src/journal_v2/mod.rs
@@ -93,6 +93,7 @@ pub trait EntryMetadata {
     Clone,
     PartialEq,
     Eq,
+    /* The serialize trait is used in Datafusion to propagate entries to the UI and CLI */
     Serialize,
     /* The deserialize trait is used only by CLI */ Deserialize,
 )]

--- a/crates/types/src/journal_v2/raw/events.rs
+++ b/crates/types/src/journal_v2/raw/events.rs
@@ -68,7 +68,8 @@ mod pb {
                 restate_doc_error_code,
                 related_command_index,
                 related_command_name,
-                related_command_type: related_command_type.map(|ct| ct.to_string()),
+                related_command_type: related_command_type
+                    .map(|ct| transient_error_event::CommandType::from(ct).into()),
                 count: count.into(),
             }
         }
@@ -98,13 +99,79 @@ mod pb {
                 related_command_name,
                 related_command_type: related_command_type
                     .map(|ct| {
-                        ct.parse::<journal_v2::CommandType>()
-                            .map_err(|e| anyhow::anyhow!("unrecognized command type: {}", e))
+                        transient_error_event::CommandType::try_from(ct)
+                            .unwrap_or(transient_error_event::CommandType::Unknown)
+                            .try_into()
                     })
                     .transpose()?,
                 count: NonZeroU32::new(count)
                     .ok_or_else(|| anyhow::anyhow!("count out of bounds"))?,
             })
+        }
+    }
+
+    impl From<journal_v2::CommandType> for transient_error_event::CommandType {
+        fn from(value: journal_v2::CommandType) -> Self {
+            match value {
+                journal_v2::CommandType::Input => Self::Input,
+                journal_v2::CommandType::Output => Self::Output,
+                journal_v2::CommandType::GetLazyState => Self::GetLazyState,
+                journal_v2::CommandType::SetState => Self::SetState,
+                journal_v2::CommandType::ClearState => Self::ClearState,
+                journal_v2::CommandType::ClearAllState => Self::ClearAllState,
+                journal_v2::CommandType::GetLazyStateKeys => Self::GetLazyStateKeys,
+                journal_v2::CommandType::GetEagerState => Self::GetEagerState,
+                journal_v2::CommandType::GetEagerStateKeys => Self::GetEagerStateKeys,
+                journal_v2::CommandType::GetPromise => Self::GetPromise,
+                journal_v2::CommandType::PeekPromise => Self::PeekPromise,
+                journal_v2::CommandType::CompletePromise => Self::CompletePromise,
+                journal_v2::CommandType::Sleep => Self::Sleep,
+                journal_v2::CommandType::Call => Self::Call,
+                journal_v2::CommandType::OneWayCall => Self::OneWayCall,
+                journal_v2::CommandType::SendSignal => Self::SendSignal,
+                journal_v2::CommandType::Run => Self::Run,
+                journal_v2::CommandType::AttachInvocation => Self::AttachInvocation,
+                journal_v2::CommandType::GetInvocationOutput => Self::GetInvocationOutput,
+                journal_v2::CommandType::CompleteAwakeable => Self::CompleteAwakeable,
+            }
+        }
+    }
+
+    impl TryFrom<transient_error_event::CommandType> for journal_v2::CommandType {
+        type Error = anyhow::Error;
+
+        fn try_from(value: transient_error_event::CommandType) -> Result<Self, Self::Error> {
+            match value {
+                transient_error_event::CommandType::Unknown => {
+                    Err(anyhow::anyhow!("unknown command type"))
+                }
+                transient_error_event::CommandType::Input => Ok(Self::Input),
+                transient_error_event::CommandType::Output => Ok(Self::Output),
+                transient_error_event::CommandType::GetLazyState => Ok(Self::GetLazyState),
+                transient_error_event::CommandType::SetState => Ok(Self::SetState),
+                transient_error_event::CommandType::ClearState => Ok(Self::ClearState),
+                transient_error_event::CommandType::ClearAllState => Ok(Self::ClearAllState),
+                transient_error_event::CommandType::GetLazyStateKeys => Ok(Self::GetLazyStateKeys),
+                transient_error_event::CommandType::GetEagerState => Ok(Self::GetEagerState),
+                transient_error_event::CommandType::GetEagerStateKeys => {
+                    Ok(Self::GetEagerStateKeys)
+                }
+                transient_error_event::CommandType::GetPromise => Ok(Self::GetPromise),
+                transient_error_event::CommandType::PeekPromise => Ok(Self::PeekPromise),
+                transient_error_event::CommandType::CompletePromise => Ok(Self::CompletePromise),
+                transient_error_event::CommandType::Sleep => Ok(Self::Sleep),
+                transient_error_event::CommandType::Call => Ok(Self::Call),
+                transient_error_event::CommandType::OneWayCall => Ok(Self::OneWayCall),
+                transient_error_event::CommandType::SendSignal => Ok(Self::SendSignal),
+                transient_error_event::CommandType::Run => Ok(Self::Run),
+                transient_error_event::CommandType::AttachInvocation => Ok(Self::AttachInvocation),
+                transient_error_event::CommandType::GetInvocationOutput => {
+                    Ok(Self::GetInvocationOutput)
+                }
+                transient_error_event::CommandType::CompleteAwakeable => {
+                    Ok(Self::CompleteAwakeable)
+                }
+            }
         }
     }
 }

--- a/crates/types/src/journal_v2/raw/events.rs
+++ b/crates/types/src/journal_v2/raw/events.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::journal_v2::raw::RawEvent;
+use crate::journal_v2::{Event, EventType};
+use bytes::Bytes;
+use prost::Message;
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum EventDecodingError {
+    #[error("decoding error: {0:?}")]
+    Protobuf(#[from] prost::DecodeError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+pub(super) fn decode(ty: EventType, value: Bytes) -> Result<Event, EventDecodingError> {
+    match ty {
+        EventType::TransientError => Ok(Event::TransientError(
+            pb::TransientErrorEvent::decode(value)?.try_into()?,
+        )),
+        EventType::Unknown => Ok(Event::Unknown),
+    }
+}
+
+pub(super) fn encode(event: Event) -> RawEvent {
+    match event {
+        Event::TransientError(e) => RawEvent::new(
+            EventType::TransientError,
+            pb::TransientErrorEvent::from(e).encode_to_vec().into(),
+        ),
+        Event::Unknown => RawEvent::unknown(),
+    }
+}
+
+mod pb {
+    use crate::errors::InvocationErrorCode;
+    use crate::journal_v2;
+    use crate::journal_v2::event;
+    use std::num::NonZeroU32;
+
+    include!(concat!(env!("OUT_DIR"), "/restate.journal.events.rs"));
+
+    impl From<event::TransientErrorEvent> for TransientErrorEvent {
+        fn from(
+            event::TransientErrorEvent {
+                error_code,
+                error_message,
+                error_stacktrace,
+                restate_doc_error_code,
+                related_command_index,
+                related_command_name,
+                related_command_type,
+                count,
+            }: event::TransientErrorEvent,
+        ) -> Self {
+            TransientErrorEvent {
+                error_code: error_code.into(),
+                error_message,
+                error_stacktrace,
+                restate_doc_error_code,
+                related_command_index,
+                related_command_name,
+                related_command_type: related_command_type.map(|ct| ct.to_string()),
+                count: count.into(),
+            }
+        }
+    }
+
+    impl TryFrom<TransientErrorEvent> for event::TransientErrorEvent {
+        type Error = anyhow::Error;
+
+        fn try_from(
+            TransientErrorEvent {
+                error_code,
+                error_message,
+                error_stacktrace,
+                restate_doc_error_code,
+                related_command_index,
+                related_command_name,
+                related_command_type,
+                count,
+            }: TransientErrorEvent,
+        ) -> Result<Self, Self::Error> {
+            Ok(event::TransientErrorEvent {
+                error_code: InvocationErrorCode::new(error_code as u16),
+                error_message,
+                error_stacktrace,
+                restate_doc_error_code,
+                related_command_index,
+                related_command_name,
+                related_command_type: related_command_type
+                    .map(|ct| {
+                        ct.parse::<journal_v2::CommandType>()
+                            .map_err(|e| anyhow::anyhow!("unrecognized command type: {}", e))
+                    })
+                    .transpose()?,
+                count: NonZeroU32::new(count)
+                    .ok_or_else(|| anyhow::anyhow!("count out of bounds"))?,
+            })
+        }
+    }
+}

--- a/crates/types/src/journal_v2/raw/events.rs
+++ b/crates/types/src/journal_v2/raw/events.rs
@@ -44,6 +44,7 @@ mod pb {
     use crate::errors::InvocationErrorCode;
     use crate::journal_v2;
     use crate::journal_v2::event;
+    use anyhow::Context;
 
     include!(concat!(env!("OUT_DIR"), "/restate.journal.events.rs"));
 
@@ -96,8 +97,8 @@ mod pb {
                 related_command_type: related_command_type
                     .map(|ct| {
                         transient_error_event::CommandType::try_from(ct)
-                            .unwrap_or(transient_error_event::CommandType::Unknown)
-                            .try_into()
+                            .context("Unrecognized command type")
+                            .map(Into::into)
                     })
                     .transpose()?,
             })
@@ -131,40 +132,31 @@ mod pb {
         }
     }
 
-    impl TryFrom<transient_error_event::CommandType> for journal_v2::CommandType {
-        type Error = anyhow::Error;
-
-        fn try_from(value: transient_error_event::CommandType) -> Result<Self, Self::Error> {
+    impl From<transient_error_event::CommandType> for journal_v2::CommandType {
+        fn from(value: transient_error_event::CommandType) -> Self {
             match value {
-                transient_error_event::CommandType::Unknown => {
-                    Err(anyhow::anyhow!("unknown command type"))
-                }
-                transient_error_event::CommandType::Input => Ok(Self::Input),
-                transient_error_event::CommandType::Output => Ok(Self::Output),
-                transient_error_event::CommandType::GetLazyState => Ok(Self::GetLazyState),
-                transient_error_event::CommandType::SetState => Ok(Self::SetState),
-                transient_error_event::CommandType::ClearState => Ok(Self::ClearState),
-                transient_error_event::CommandType::ClearAllState => Ok(Self::ClearAllState),
-                transient_error_event::CommandType::GetLazyStateKeys => Ok(Self::GetLazyStateKeys),
-                transient_error_event::CommandType::GetEagerState => Ok(Self::GetEagerState),
-                transient_error_event::CommandType::GetEagerStateKeys => {
-                    Ok(Self::GetEagerStateKeys)
-                }
-                transient_error_event::CommandType::GetPromise => Ok(Self::GetPromise),
-                transient_error_event::CommandType::PeekPromise => Ok(Self::PeekPromise),
-                transient_error_event::CommandType::CompletePromise => Ok(Self::CompletePromise),
-                transient_error_event::CommandType::Sleep => Ok(Self::Sleep),
-                transient_error_event::CommandType::Call => Ok(Self::Call),
-                transient_error_event::CommandType::OneWayCall => Ok(Self::OneWayCall),
-                transient_error_event::CommandType::SendSignal => Ok(Self::SendSignal),
-                transient_error_event::CommandType::Run => Ok(Self::Run),
-                transient_error_event::CommandType::AttachInvocation => Ok(Self::AttachInvocation),
+                transient_error_event::CommandType::Input => Self::Input,
+                transient_error_event::CommandType::Output => Self::Output,
+                transient_error_event::CommandType::GetLazyState => Self::GetLazyState,
+                transient_error_event::CommandType::SetState => Self::SetState,
+                transient_error_event::CommandType::ClearState => Self::ClearState,
+                transient_error_event::CommandType::ClearAllState => Self::ClearAllState,
+                transient_error_event::CommandType::GetLazyStateKeys => Self::GetLazyStateKeys,
+                transient_error_event::CommandType::GetEagerState => Self::GetEagerState,
+                transient_error_event::CommandType::GetEagerStateKeys => Self::GetEagerStateKeys,
+                transient_error_event::CommandType::GetPromise => Self::GetPromise,
+                transient_error_event::CommandType::PeekPromise => Self::PeekPromise,
+                transient_error_event::CommandType::CompletePromise => Self::CompletePromise,
+                transient_error_event::CommandType::Sleep => Self::Sleep,
+                transient_error_event::CommandType::Call => Self::Call,
+                transient_error_event::CommandType::OneWayCall => Self::OneWayCall,
+                transient_error_event::CommandType::SendSignal => Self::SendSignal,
+                transient_error_event::CommandType::Run => Self::Run,
+                transient_error_event::CommandType::AttachInvocation => Self::AttachInvocation,
                 transient_error_event::CommandType::GetInvocationOutput => {
-                    Ok(Self::GetInvocationOutput)
+                    Self::GetInvocationOutput
                 }
-                transient_error_event::CommandType::CompleteAwakeable => {
-                    Ok(Self::CompleteAwakeable)
-                }
+                transient_error_event::CommandType::CompleteAwakeable => Self::CompleteAwakeable,
             }
         }
     }

--- a/crates/types/src/journal_v2/raw/events.rs
+++ b/crates/types/src/journal_v2/raw/events.rs
@@ -44,7 +44,6 @@ mod pb {
     use crate::errors::InvocationErrorCode;
     use crate::journal_v2;
     use crate::journal_v2::event;
-    use std::num::NonZeroU32;
 
     include!(concat!(env!("OUT_DIR"), "/restate.journal.events.rs"));
 
@@ -58,7 +57,6 @@ mod pb {
                 related_command_index,
                 related_command_name,
                 related_command_type,
-                count,
             }: event::TransientErrorEvent,
         ) -> Self {
             TransientErrorEvent {
@@ -70,7 +68,6 @@ mod pb {
                 related_command_name,
                 related_command_type: related_command_type
                     .map(|ct| transient_error_event::CommandType::from(ct).into()),
-                count: count.into(),
             }
         }
     }
@@ -87,7 +84,6 @@ mod pb {
                 related_command_index,
                 related_command_name,
                 related_command_type,
-                count,
             }: TransientErrorEvent,
         ) -> Result<Self, Self::Error> {
             Ok(event::TransientErrorEvent {
@@ -104,8 +100,6 @@ mod pb {
                             .try_into()
                     })
                     .transpose()?,
-                count: NonZeroU32::new(count)
-                    .ok_or_else(|| anyhow::anyhow!("count out of bounds"))?,
             })
         }
     }

--- a/crates/types/src/journal_v2/raw/mod.rs
+++ b/crates/types/src/journal_v2/raw/mod.rs
@@ -10,14 +10,17 @@
 
 use std::time::Duration;
 
+use anyhow::Context;
 use bytes::Bytes;
 use enum_dispatch::enum_dispatch;
 
+use crate::errors::GenericError;
 use crate::identifiers::InvocationId;
 use crate::invocation::{InvocationTarget, ServiceInvocationSpanContext};
 use crate::journal_v2::encoding::DecodingError;
 use crate::journal_v2::{
-    CommandType, Decoder, Entry, EntryMetadata, EntryType, Event, NotificationId, NotificationType,
+    CommandType, Decoder, Entry, EntryMetadata, EntryType, Event, EventType, NotificationId,
+    NotificationType,
 };
 use crate::time::MillisSinceEpoch;
 

--- a/crates/worker/src/partition/state_machine/entries/event.rs
+++ b/crates/worker/src/partition/state_machine/entries/event.rs
@@ -8,24 +8,189 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![allow(dead_code)]
-
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
+use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_storage_api::invocation_status_table::InvocationStatus;
+use restate_storage_api::journal_table_v2::JournalTable;
 use restate_types::identifiers::InvocationId;
-use restate_types::journal_v2::Event;
+use restate_types::journal_v2::raw::RawEntry;
+use restate_types::journal_v2::{EntryMetadata, EntryType, Event};
 
 pub(super) struct ApplyEventCommand<'e> {
     pub(super) invocation_id: InvocationId,
     pub(super) invocation_status: &'e mut InvocationStatus,
-    pub(super) entry: &'e Event,
+    pub(super) entry: &'e mut Option<RawEntry>,
 }
 
-impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
-    for ApplyEventCommand<'e>
+impl<'e, 'ctx: 'e, 's: 'ctx, S: JournalTable>
+    CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>> for ApplyEventCommand<'e>
 {
-    async fn apply(self, _ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
-        // TODO is there anything to do here?!
+    async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
+        // --- Event deduplication logic
+        // Some Events are merged together when duplicated, to avoid storing too many duplicate events.
+        // This logic is completely optional and can fail silently.
+        let Some(journal_metadata) = self.invocation_status.get_journal_metadata() else {
+            return Ok(());
+        };
+        let last_entry_index = journal_metadata.length - 1;
+        let Some(last_entry) = ctx
+            .storage
+            .get_journal_entry(self.invocation_id, last_entry_index)
+            .await?
+        else {
+            return Ok(());
+        };
+        if last_entry.ty() != EntryType::Event {
+            return Ok(());
+        }
+
+        let new_entry = self.entry.as_ref().unwrap();
+
+        // If entry types don't match, there's nothing to deduplicate
+        if last_entry.inner.try_as_event_ref().map(|e| e.event_type())
+            != new_entry.inner.try_as_event_ref().map(|e| e.event_type())
+        {
+            return Ok(());
+        }
+
+        let new_event = new_entry.decode::<ServiceProtocolV4Codec, Event>()?;
+        let last_stored_event = last_entry.decode::<ServiceProtocolV4Codec, Event>()?;
+
+        match (last_stored_event, new_event) {
+            (
+                Event::TransientError(mut stored_transient_error_event),
+                Event::TransientError(new_transient_error_event),
+            ) if stored_transient_error_event.error_code
+                == new_transient_error_event.error_code
+                && stored_transient_error_event.error_message
+                    == new_transient_error_event.error_message
+                && stored_transient_error_event.restate_doc_error_code
+                    == new_transient_error_event.restate_doc_error_code
+                && stored_transient_error_event.related_command_type
+                    == new_transient_error_event.related_command_type
+                && stored_transient_error_event.related_command_name
+                    == new_transient_error_event.related_command_name
+                && stored_transient_error_event.related_command_index
+                    == new_transient_error_event.related_command_index =>
+            {
+                // Override count and error_stacktrace
+                stored_transient_error_event.count =
+                    stored_transient_error_event.count.saturating_add(1);
+                stored_transient_error_event.error_stacktrace =
+                    new_transient_error_event.error_stacktrace;
+
+                ctx.storage
+                    .put_journal_entry(
+                        self.invocation_id,
+                        last_entry_index,
+                        &Event::TransientError(stored_transient_error_event)
+                            .encode::<ServiceProtocolV4Codec>(),
+                        &[],
+                    )
+                    .await?;
+
+                *self.entry = None;
+            }
+            _ => {}
+        };
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU32;
+
+    use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
+    use googletest::prelude::*;
+    use restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable;
+    use restate_types::journal_v2::TransientErrorEvent;
+
+    #[restate_core::test]
+    async fn store_event_then_get_deduplicated() {
+        let mut test_env = TestEnv::create().await;
+        let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
+        fixtures::mock_pinned_deployment_v5(&mut test_env, invocation_id).await;
+
+        let mut transient_error_event = TransientErrorEvent {
+            error_code: 501u16.into(),
+            error_message: "my bad".to_string(),
+            error_stacktrace: Some("something something".to_string()),
+            restate_doc_error_code: Some("RT0001".to_string()),
+            related_command_index: None,
+            related_command_name: Some("my command".to_string()),
+            related_command_type: None,
+            count: NonZeroU32::new(1).unwrap(),
+        };
+
+        let _ = test_env
+            .apply(fixtures::invoker_entry_effect(
+                invocation_id,
+                Event::TransientError(transient_error_event.clone()),
+            ))
+            .await;
+
+        assert_eq!(
+            test_env.read_journal_entry::<Event>(invocation_id, 1).await,
+            Event::TransientError(transient_error_event.clone())
+        );
+
+        // --- Applying the same event the second time will result in bumping the count
+
+        let _ = test_env
+            .apply(fixtures::invoker_entry_effect(
+                invocation_id,
+                Event::TransientError(transient_error_event.clone()),
+            ))
+            .await;
+
+        transient_error_event.count = transient_error_event.count.saturating_add(1);
+
+        assert_that!(
+            test_env.storage.get_invocation_status(&invocation_id).await,
+            ok(matchers::storage::has_journal_length(2))
+        );
+        assert_eq!(
+            test_env.read_journal_entry::<Event>(invocation_id, 1).await,
+            Event::TransientError(transient_error_event.clone())
+        );
+
+        // --- Applying a new event will result in a new entry
+
+        let another_transient_error_event = TransientErrorEvent {
+            error_code: 502u16.into(),
+            error_message: "my bad 2".to_string(),
+            error_stacktrace: Some("something something".to_string()),
+            restate_doc_error_code: Some("RT0001".to_string()),
+            related_command_index: None,
+            related_command_name: Some("my command 2".to_string()),
+            related_command_type: None,
+            count: NonZeroU32::new(1).unwrap(),
+        };
+
+        let _ = test_env
+            .apply(fixtures::invoker_entry_effect(
+                invocation_id,
+                Event::TransientError(another_transient_error_event.clone()),
+            ))
+            .await;
+
+        assert_that!(
+            test_env.storage.get_invocation_status(&invocation_id).await,
+            ok(matchers::storage::has_journal_length(3))
+        );
+        // Previous event didn't change
+        assert_eq!(
+            test_env.read_journal_entry::<Event>(invocation_id, 1).await,
+            Event::TransientError(transient_error_event)
+        );
+        assert_eq!(
+            test_env.read_journal_entry::<Event>(invocation_id, 2).await,
+            Event::TransientError(another_transient_error_event.clone())
+        );
+
+        test_env.shutdown().await;
     }
 }

--- a/crates/worker/src/partition/state_machine/entries/event.rs
+++ b/crates/worker/src/partition/state_machine/entries/event.rs
@@ -60,19 +60,10 @@ impl<'e, 'ctx: 'e, 's: 'ctx, S: ReadOnlyJournalTable>
             && last_event.deduplication_hash() == new_event.deduplication_hash()
         {
             trace!(
-                "Deduplicating event {} because the last entry in the journal is an event, and has deduplication hashes that match",
+                "Deduplicating event {} because the last entry in the journal is an event, and its deduplication hash matches with the current event",
                 last_event.event_type()
             );
             *self.entry = None;
-        } else {
-            trace!(
-                "{} != {}\n
-                {:?} != {:?}",
-                last_event.event_type(),
-                new_event.event_type(),
-                last_event.deduplication_hash(),
-                new_event.deduplication_hash()
-            );
         }
 
         Ok(())

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -103,7 +103,7 @@ schemars = { version = "0.8", features = ["bytes", "enumset", "preserve_order"] 
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1", features = ["alloc", "raw_value", "unbounded_depth"] }
-serde_with = { version = "3", features = ["hex"] }
+serde_with = { version = "3", features = ["hex", "json"] }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde"] }
 snafu = { version = "0.8" }
 stable_deref_trait = { version = "1" }
@@ -224,7 +224,7 @@ schemars = { version = "0.8", features = ["bytes", "enumset", "preserve_order"] 
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1", features = ["alloc", "raw_value", "unbounded_depth"] }
-serde_with = { version = "3", features = ["hex"] }
+serde_with = { version = "3", features = ["hex", "json"] }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde"] }
 snafu = { version = "0.8" }
 stable_deref_trait = { version = "1" }


### PR DESCRIPTION
See individual commits. The final result:

[data(1).json](https://github.com/user-attachments/files/20439341/data.1.json)

To enable it: `RESTATE_WORKER__INVOKER__experimental_features_propose_events=true`
