### PR TITLE
[Bifrost] Fixes and improvements to check-seal/find-tail and read-stream

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -215,12 +215,17 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
                             return Ok(*self.known_global_tail.get());
                         }
                         match result {
-                            CheckSealOutcome::Sealing => {
+                            CheckSealOutcome::Unknown {
+                                is_partially_sealed: true,
+                            }
+                            | CheckSealOutcome::Open {
+                                is_partially_sealed: true,
+                            } => {
                                 // We are likely to be sealing...
                                 // let's fire a seal to ensure this seal is complete.
                                 self.seal().await?;
                             }
-                            CheckSealOutcome::FullySealed => {
+                            CheckSealOutcome::Sealed => {
                                 // already fully sealed, just make sure the sequencer is drained.
                                 handle.drain().await;
                                 // note that we can only do that if we are the sequencer because


### PR DESCRIPTION

- CheckSealTask now returns Open only when we are confident that the loglet is really writeable.
- Fix for ReadStream to detect sealed segments in the absence of FindTail's ability to determine the seal status. Without this, the read-stream can stall indefinitely waiting to determine if the loglet has been sealed or not. This can happen if we cannot reach f-majority of nodes to confidently determine the seal status but the segment was succesfully sealed and the chain has already been updated.
- Added a test to cover seal/open requirements in tight nodesets.
- More documentation and comments.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3307).
* #3326
* #3318
* #3325
* #3309
* __->__ #3307