### PR TITLE
[Restate UI] Update to v0.0.74

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7824,8 +7824,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.73"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.73#5ace91516e95eafebde4835a547a82bcc825a0d3"
+version = "0.0.74"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.74#1798206ca764722b7d508e46ddc39b022629bb5e"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -31,7 +31,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.73", tag = "v0.0.73" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.74", tag = "v0.0.74" }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.74
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.74/ui-v0.0.74.zip