### PR TITLE
[FailureDetector] Seed FD with cluster-state from peer on startup

### DIFF
--- a/crates/core/src/cluster_state.rs
+++ b/crates/core/src/cluster_state.rs
@@ -17,24 +17,10 @@ use tokio::sync::Notify;
 use tokio::sync::futures::Notified;
 use tokio::sync::watch;
 
+pub use restate_types::net::node::NodeState;
 use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
 
 type Generation = u32;
-
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
-#[repr(u8)]
-pub enum NodeState {
-    #[default]
-    Dead = 0,
-    Alive,
-    FailingOver,
-}
-
-impl NodeState {
-    pub fn is_alive(self) -> bool {
-        matches!(self, Self::Alive | Self::FailingOver)
-    }
-}
 
 #[derive(Debug, Clone, Copy, Default)]
 struct State {

--- a/crates/node/src/failure_detector/fd_state.rs
+++ b/crates/node/src/failure_detector/fd_state.rs
@@ -18,9 +18,10 @@ use tracing::{debug, error, warn};
 use restate_core::cluster_state::ClusterStateUpdater;
 use restate_core::network::{ConnectThrottle, NetworkSender};
 use restate_types::config::GossipOptions;
-use restate_types::net::node::{Gossip, GossipFlags};
+use restate_types::identifiers::PartitionId;
+use restate_types::net::node::{ClusterStateReply, Gossip, GossipFlags};
 use restate_types::nodes_config::NodesConfiguration;
-use restate_types::partitions::state::PartitionReplicaSetStates;
+use restate_types::partitions::state::{MembershipState, PartitionReplicaSetStates};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::{GenerationalNodeId, PlainNodeId, Version, net};
 
@@ -53,9 +54,9 @@ pub enum Error {
 /// rules:
 /// 1. If the node's plain id is already recognized by the current configuration, we can only
 ///    accept the gossip message if the generation is the same or higher.
-/// 2. If the gossip message is coming from a node that's been tombstoned in the current
+/// 2. If the gossip message is coming from a node that's been tombstone-ed in the current
 ///    configuration, we ignore the gossip message.
-/// 3. For those unknown nodes, we record the the nodes configuration version that arrived with their message
+/// 3. For those unknown nodes, we record the nodes configuration version that arrived with their message
 ///    and we'll use that to determine if we should keep this node or not when we observe nodes
 ///    configuration updates. The scenario we want to avoid is that we have a node that we learned
 ///    about its liveness through gossip, and then we receive a nodes configuration update that
@@ -127,6 +128,16 @@ impl FdState {
         self.node_states
             .iter_mut()
             .filter_map(move |(node_id, node)| (my_node != *node_id).then_some((*node_id, node)))
+    }
+
+    pub fn all_node_states(&self) -> impl Iterator<Item = (GenerationalNodeId, NodeState)> {
+        self.node_states
+            .values()
+            .map(|node| (node.gen_node_id, node.state))
+    }
+
+    pub fn partitions(&self) -> impl Iterator<Item = (PartitionId, MembershipState)> {
+        self.replica_set_states.iter()
     }
 
     pub fn refresh_nodes_config(&mut self, nodes_config: &NodesConfiguration) -> Result<(), Error> {
@@ -266,6 +277,37 @@ impl FdState {
                 guard.set_node_state(node.gen_node_id, node.state.into());
             }
         }
+    }
+
+    pub fn update_from_cluster_state_message(
+        &mut self,
+        opts: &GossipOptions,
+        cs_reply: ClusterStateReply,
+    ) {
+        for incoming_node in cs_reply.nodes {
+            if incoming_node.node_id == self.my_node_id {
+                // We already know our own state, no need to update it.
+                continue;
+            }
+
+            if incoming_node.state == net::node::NodeState::Alive {
+                let node = self.get_node_or_insert(incoming_node.node_id);
+                // reset the age of the node if it's alive
+                node.gossip_age = 0;
+                node.state = NodeState::Alive;
+                self.cs_updater
+                    .upsert_node_state(incoming_node.node_id, NodeState::Alive.into());
+            }
+        }
+
+        for partition in cs_reply.partitions {
+            self.replica_set_states.note_observed_membership(
+                partition.id,
+                &partition.observed_current_membership,
+                &partition.observed_next_membership,
+            );
+        }
+        debug!("{}", self.dump_as_string(opts));
     }
 
     pub fn update_from_gossip_message(
@@ -416,8 +458,7 @@ impl FdState {
         gauge!(GOSSIP_NODES, "state" => STATE_FAILING_OVER).set(num_failing_over);
     }
 
-    // Used for debugging purposes only
-    #[allow(dead_code)]
+    // Used for debugging purposes
     pub fn dump_as_string(&self, opts: &GossipOptions) -> String {
         // display state in a nice table format
         let mut result = String::new();
@@ -601,6 +642,14 @@ impl FdState {
         self.node_states
             .entry(node_id.as_plain())
             .or_insert_with(|| Node::new(node_id))
+    }
+
+    pub fn am_i_alive(&self) -> bool {
+        self.node_states
+            .get(&self.my_node_id.as_plain())
+            .expect("my node must be in FD")
+            .state
+            == NodeState::Alive
     }
 
     pub fn node_mut(&mut self, node_id: &PlainNodeId) -> Option<&mut Node> {


### PR DESCRIPTION

We broadcast GetClusterState on startup and drop the rest of requests once we get the first good response.

```
// intentionally empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3313).
* #3318
* #3309
* #3307
* __->__ #3313