### PR TITLE
[Restate UI] Update to v0.0.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7836,8 +7836,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.75"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.75#ae2b74d5adc88a4e701b85a784d6330f2d1896c4"
+version = "0.0.76"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.76#159b33650e5c9fef9bfff3afc68f147365dd4162"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -31,7 +31,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-utoipa = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.75", tag = "v0.0.75" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.76", tag = "v0.0.76" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.76
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.76/ui-v0.0.76.zip