### PR TITLE
[Bifrost] Auto-improvement of logs on preferred writer nodes

### DIFF
--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -10,11 +10,9 @@ publish = false
 [features]
 default = []
 local-loglet = ["dep:restate-rocksdb", "dep:rocksdb"]
-replicated-loglet = ["auto-extend"]
+replicated-loglet = []
 memory-loglet = []
 test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util", "restate-core/test-util"]
-# enables bifrost to auto seal and extend. This is a transitional feature that will be removed soon.
-auto-extend = []
 
 [dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 
 use restate_core::{Metadata, MetadataKind, TaskCenter};
 use restate_futures_util::overdue::OverdueLoggingExt;
@@ -93,16 +93,21 @@ impl Appender {
 
     pub(crate) async fn append_batch_erased(&mut self, batch: Arc<[Record]>) -> Result<Lsn> {
         self.bifrost_inner.fail_if_shutting_down()?;
-        let mut retry_iter = self
-            .config
-            .live_load()
-            .bifrost
-            .append_retry_policy()
-            .into_iter();
+        let retry_iter = self.config.live_load().bifrost.append_retry_policy();
+        debug_assert!(retry_iter.max_attempts().is_none());
+        let mut retry_iter = retry_iter.into_iter();
 
         let mut attempt = 0;
+        let mut reconfiguration_attempt = 0;
+        let mut first_failed_at: Option<Instant> = None;
         loop {
             attempt += 1;
+            let auto_recovery_threshold: Duration = self
+                .config
+                .live_load()
+                .bifrost
+                .auto_recovery_interval
+                .into();
             let loglet = match self.loglet_cache.as_mut() {
                 None => self
                     .loglet_cache
@@ -116,6 +121,7 @@ impl Appender {
                         log_id = %self.log_id,
                         attempt = attempt,
                         segment_index = %loglet.segment_index(),
+                        error_recovery_strategy = %self.error_recovery_strategy,
                         "Batch append failed but will be retried ({err}). Waiting for reconfiguration to complete"
                     );
                     let new_loglet = Self::on_sealed_loglet(
@@ -128,35 +134,149 @@ impl Appender {
                     debug!(
                         log_id = %self.log_id,
                         segment_index = %loglet.segment_index(),
+                        error_recovery_strategy = %self.error_recovery_strategy,
                         "Log reconfiguration has been completed, appender will resume now"
                     );
 
                     self.loglet_cache = Some(new_loglet);
                 }
                 Err(AppendError::Other(err)) if err.retryable() => {
-                    if let Some(retry_dur) = retry_iter.next() {
-                        info!(
-                            %err,
-                            log_id = %self.log_id,
-                            attempt = attempt,
-                            segment_index = %loglet.segment_index(),
-                            "Failed to append this batch. Since underlying error is retryable, will retry in {:?}",
-                            retry_dur
-                        );
-                        tokio::time::sleep(retry_dur).await;
-                    } else {
-                        warn!(
-                            %err,
-                            log_id = %self.log_id,
-                            attempt = attempt,
-                            segment_index = %loglet.segment_index(),
-                            "Failed to append this batch and exhausted all attempts to retry",
-                        );
-                        return Err(Error::LogletError(err));
+                    if first_failed_at.is_none() {
+                        first_failed_at = Some(Instant::now());
+                    }
+                    let failing_since = first_failed_at.as_ref().unwrap().elapsed();
+                    let recovery_strategy = self.error_recovery_strategy;
+
+                    match recovery_strategy {
+                        ErrorRecoveryStrategy::ExtendChainAllowed
+                            if failing_since >= auto_recovery_threshold =>
+                        {
+                            // auto-recover
+                            reconfiguration_attempt += 1;
+                            info!(
+                                %err,
+                                log_id = %self.log_id,
+                                reconfiguration_attempt,
+                                attempt,
+                                segment_index = %loglet.segment_index(),
+                                error_recovery_strategy = %self.error_recovery_strategy,
+                                "Failed to append this batch. Will attempt to reconfigure the log",
+                            );
+                            let new_loglet = Self::perform_reconfiguration(
+                                self.log_id,
+                                &self.bifrost_inner,
+                                loglet.segment_index(),
+                            )
+                            .await?;
+                            self.loglet_cache = Some(new_loglet);
+                            first_failed_at = None; // reset the timer
+                        }
+                        ErrorRecoveryStrategy::Wait | ErrorRecoveryStrategy::ExtendChainAllowed => {
+                            let retry_dur =
+                                retry_iter.next().expect("append retries must be unbounded");
+                            info!(
+                                %err,
+                                log_id = %self.log_id,
+                                attempt,
+                                segment_index = %loglet.segment_index(),
+                                error_recovery_strategy = %self.error_recovery_strategy,
+                                "Failed to append this batch. Since underlying error is retryable, will retry in {:?}",
+                                retry_dur
+                            );
+                            tokio::time::sleep(retry_dur).await;
+                        }
+                        ErrorRecoveryStrategy::ExtendChainPreferred => {
+                            // auto-recover
+                            reconfiguration_attempt += 1;
+                            info!(
+                                %err,
+                                log_id = %self.log_id,
+                                reconfiguration_attempt,
+                                attempt,
+                                segment_index = %loglet.segment_index(),
+                                error_recovery_strategy = %self.error_recovery_strategy,
+                                "Failed to append this batch. Will attempt to reconfigure the log",
+                            );
+                            let new_loglet = Self::perform_reconfiguration(
+                                self.log_id,
+                                &self.bifrost_inner,
+                                loglet.segment_index(),
+                            )
+                            .await?;
+                            self.loglet_cache = Some(new_loglet);
+                            first_failed_at = None; // reset the timer
+                        }
                     }
                 }
                 Err(AppendError::Other(err)) => return Err(Error::LogletError(err)),
                 Err(AppendError::Shutdown(err)) => return Err(Error::Shutdown(err)),
+            }
+        }
+    }
+
+    #[instrument(level = "error" err, skip(bifrost_inner))]
+    async fn perform_reconfiguration(
+        log_id: LogId,
+        bifrost_inner: &Arc<BifrostInner>,
+        current_segment: SegmentIndex,
+    ) -> Result<LogletWrapper> {
+        let mut retry_iter = Configuration::pinned()
+            .bifrost
+            .append_retry_policy()
+            .into_iter();
+
+        let metadata = Metadata::current();
+        let mut logs = metadata.updateable_logs_metadata();
+        // initial sleep duration.
+        let mut sleep_dur = retry_iter
+            .next()
+            .expect("append retries should be infinite");
+        loop {
+            bifrost_inner.fail_if_shutting_down()?;
+            let log_metadata = logs.live_load();
+            let auto_recovery_threshold: Duration = Configuration::pinned()
+                .bifrost
+                .auto_recovery_interval
+                .into();
+
+            let loglet = bifrost_inner
+                .writeable_loglet_from_metadata(log_metadata, log_id)
+                .await?;
+            // Do we think that the last tail loglet is different and unsealed?
+            if loglet.tail_lsn.is_none() && loglet.segment_index() > current_segment {
+                return Ok(loglet);
+            }
+
+            // taking the matter into our own hands
+            let admin = BifrostAdmin::new(bifrost_inner);
+            let log_metadata_version = log_metadata.version();
+            if let Err(err) = admin
+                .seal_and_auto_extend_chain(log_id, Some(current_segment))
+                .log_slow_after(
+                    auto_recovery_threshold / 2,
+                    tracing::Level::INFO,
+                    "Extending the chain with new configuration",
+                )
+                .with_overdue(auto_recovery_threshold, tracing::Level::WARN)
+                .await
+            {
+                // we couldn't reconfigure. Let the loop handle retries as normal
+                info!(
+                    %err,
+                    %log_metadata_version,
+                    "Could not reconfigure the log, perhaps another node beat us to it? We'll check",
+                );
+                tokio::time::sleep(sleep_dur).await;
+                // backoff. This is at the bottom to avoid unnecessary sleeps in the happy path
+                sleep_dur = retry_iter
+                    .next()
+                    .expect("append retries should be infinite");
+            } else {
+                info!(
+                    log_metadata_version = %metadata.logs_version(),
+                    "Reconfiguration complete",
+                );
+                continue;
             }
         }
     }
@@ -199,12 +319,14 @@ impl Appender {
                 if tone_escalated {
                     info!(
                         open_segment = %loglet.segment_index(),
+                        %error_recovery_strategy,
                         "New segment detected after {:?}",
                         total_dur
                     );
                 } else {
                     debug!(
                         open_segment = %loglet.segment_index(),
+                        %error_recovery_strategy,
                         "New segment detected after {:?}",
                         total_dur
                     );
@@ -212,11 +334,14 @@ impl Appender {
                 return Ok(loglet);
             }
 
-            // Okay, tail segment is still sealed
+            // Okay, tail segment is still sealed or requires reconfiguration
             let log_metadata_version = log_metadata.version();
-            if start.elapsed() > auto_recovery_threshold
-                && error_recovery_strategy >= ErrorRecoveryStrategy::ExtendChainAllowed
+            if (error_recovery_strategy == ErrorRecoveryStrategy::ExtendChainPreferred
+                || (start.elapsed() > auto_recovery_threshold
+                    && error_recovery_strategy == ErrorRecoveryStrategy::ExtendChainAllowed))
                 && !TaskCenter::is_shutdown_requested()
+                // only attempt to seal/acquire ownership if we are alive in FD.
+                && TaskCenter::is_my_node_alive()
             {
                 // taking the matter into our own hands
                 let admin = BifrostAdmin::new(bifrost_inner);
@@ -239,13 +364,15 @@ impl Appender {
                     info!(
                         %err,
                         %log_metadata_version,
-                        "Could not reconfigure the log, perhaps something else beat us to it? We'll check",
+                        %error_recovery_strategy,
+                        "Could not reconfigure the log, perhaps another node beat us to it? We'll check",
                     );
                 } else {
                     // note that we are reporting metadata version directly from `metadata` since
                     // it might have been updated while sealing the loglet
                     info!(
                         log_metadata_version = %metadata.logs_version(),
+                        %error_recovery_strategy,
                         "[Auto Recovery] Reconfiguration complete",
                     );
                     // reconfiguration successful. Metadata is updated at this point
@@ -257,12 +384,14 @@ impl Appender {
                 if tone_escalated {
                     info!(
                         %log_metadata_version,
+                        %error_recovery_strategy,
                         "In holding pattern, still waiting for log reconfiguration to complete. Elapsed={:?}",
                         start.elapsed(),
                     );
                 } else {
                     debug!(
                         %log_metadata_version,
+                        %error_recovery_strategy,
                         "In holding pattern, waiting for log reconfiguration to complete. Elapsed={:?}",
                         start.elapsed(),
                     );

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -37,7 +37,7 @@ use crate::{BifrostAdmin, Error, InputRecord, LogReadStream, Result};
 /// a sealed loglet while it's tailing a log.
 ///
 /// Please keep this enum ordered, i.e. anything > Allowed should still mean allowed.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, derive_more::Display)]
 pub enum ErrorRecoveryStrategy {
     /// Do not extend the chain, wait indefinitely instead until the error disappears.
     Wait = 1,
@@ -48,24 +48,9 @@ pub enum ErrorRecoveryStrategy {
     ExtendChainPreferred,
 }
 
-impl ErrorRecoveryStrategy {
-    /// Conditional on a temporary feature gate `auto-extend` until transition is complete
-    pub fn extend_preferred() -> Self {
-        if cfg!(feature = "auto-extend") {
-            Self::ExtendChainPreferred
-        } else {
-            Self::Wait
-        }
-    }
-}
-
 impl Default for ErrorRecoveryStrategy {
     fn default() -> Self {
-        if cfg!(feature = "auto-extend") {
-            Self::ExtendChainAllowed
-        } else {
-            Self::Wait
-        }
+        Self::ExtendChainAllowed
     }
 }
 

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -16,7 +16,7 @@ pub use restate_types::logs::TailOffsetWatch;
 
 // exports
 pub use error::*;
-pub use provider::{LogletProvider, LogletProviderFactory};
+pub use provider::{Improvement, LogletProvider, LogletProviderFactory};
 
 use std::borrow::Cow;
 use std::pin::Pin;

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -215,12 +215,17 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
                             return Ok(*self.known_global_tail.get());
                         }
                         match result {
-                            CheckSealOutcome::Sealing => {
+                            CheckSealOutcome::Unknown {
+                                is_partially_sealed: true,
+                            }
+                            | CheckSealOutcome::Open {
+                                is_partially_sealed: true,
+                            } => {
                                 // We are likely to be sealing...
                                 // let's fire a seal to ensure this seal is complete.
                                 self.seal().await?;
                             }
-                            CheckSealOutcome::FullySealed => {
+                            CheckSealOutcome::Sealed => {
                                 // already fully sealed, just make sure the sequencer is drained.
                                 handle.drain().await;
                                 // note that we can only do that if we are the sequencer because

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -284,10 +284,7 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
                     .expect("LogletParams serde is infallible");
                 Ok(LogletParams::from(new_params))
             }
-            Err(err) => {
-                warn!(?log_id, "Cannot select node-set for log: {err}");
-                Err(OperationError::retryable(err))
-            }
+            Err(err) => Err(OperationError::retryable(err)),
         }
     }
 

--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -8,30 +8,37 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ahash::{HashMap, HashMapExt};
 use enum_map::Enum;
 use futures::future::OptionFuture;
 use futures::stream::FuturesUnordered;
+use restate_types::retries::with_jitter;
 use tokio::task::JoinSet;
+use tokio::time::Instant;
 use tokio_stream::StreamExt;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use restate_core::{
-    ShutdownError, TaskCenter, TaskCenterFutureExt, TaskHandle, TaskKind, cancellation_watcher,
+    Metadata, ShutdownError, TaskCenter, TaskCenterFutureExt, TaskHandle, TaskKind,
+    cancellation_watcher,
 };
 use restate_metadata_store::{ReadModifyWriteError, ReadWriteError, retry_on_retryable_error};
 use restate_types::config::Configuration;
-use restate_types::logs::metadata::{Logs, ProviderKind};
+use restate_types::logs::metadata::{Logs, ProviderKind, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
 
+use crate::BifrostAdmin;
 use crate::bifrost::BifrostInner;
-use crate::loglet::LogletProvider;
+use crate::loglet::{Improvement, LogletProvider};
 
 pub type WatchdogSender = tokio::sync::mpsc::UnboundedSender<WatchdogCommand>;
 type WatchdogReceiver = tokio::sync::mpsc::UnboundedReceiver<WatchdogCommand>;
+
+const IMPROVEMENT_ROUND_INTERVAL: Duration = Duration::from_secs(1);
+const IMPROVEMENT_ACTION_AFTER: Duration = Duration::from_secs(5);
 
 /// The watchdog is a task manager for background jobs that needs to run on bifrost.
 /// tasks managed by the watchdogs are cooperative and should not be terminated abruptly.
@@ -44,7 +51,26 @@ pub struct Watchdog {
     inbound: WatchdogReceiver,
     live_providers: Vec<Arc<dyn LogletProvider>>,
     in_flight_trim: Option<restate_core::task_center::TaskHandle<()>>,
+    my_preferred_logs: HashMap<LogId, PreferredLog>,
     pending_trims: TrimRequests,
+}
+
+struct PreferredLog {
+    /// the number of appender tasks that have indicated that they are the preferred writer
+    ref_cnt: usize,
+    /// the last time we checked this log for improvement
+    last_checked: Instant,
+    in_flight: Option<(SegmentIndex, TaskHandle<()>)>,
+}
+
+impl Default for PreferredLog {
+    fn default() -> Self {
+        Self {
+            ref_cnt: 1,
+            last_checked: Instant::now(),
+            in_flight: None,
+        }
+    }
 }
 
 type TrimRequests = HashMap<LogId, Lsn>;
@@ -62,11 +88,30 @@ impl Watchdog {
             live_providers: Vec::with_capacity(ProviderKind::LENGTH),
             in_flight_trim: None,
             pending_trims: HashMap::with_capacity(128),
+            my_preferred_logs: HashMap::default(),
         }
     }
 
     fn handle_command(&mut self, cmd: WatchdogCommand) {
         match cmd {
+            WatchdogCommand::PreferenceAcquire(log_id) => {
+                self.my_preferred_logs
+                    .entry(log_id)
+                    .and_modify(|l| l.ref_cnt += 1)
+                    .or_default();
+            }
+            WatchdogCommand::PreferenceRelease(log_id) => {
+                match self.my_preferred_logs.entry(log_id) {
+                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+                        let current = entry.get_mut();
+                        current.ref_cnt = current.ref_cnt.saturating_sub(1);
+                        if current.ref_cnt == 0 {
+                            entry.remove();
+                        }
+                    }
+                    std::collections::hash_map::Entry::Vacant(_) => {}
+                }
+            }
             WatchdogCommand::WatchProvider(provider) => {
                 self.live_providers.push(provider.clone());
                 let _ = TaskCenter::spawn(
@@ -155,6 +200,10 @@ impl Watchdog {
         tokio::pin!(shutdown);
         trace!("Bifrost watchdog started");
 
+        let mut improvement_interval = tokio::time::interval(IMPROVEMENT_ROUND_INTERVAL);
+        let mut logs = Metadata::with_current(|m| m.updateable_logs_metadata());
+        let mut config = Configuration::live();
+
         loop {
             if self.in_flight_trim.is_none() && !self.pending_trims.is_empty() {
                 let trims = self.pending_trims.drain().collect();
@@ -168,20 +217,133 @@ impl Watchdog {
             }
 
             tokio::select! {
-            biased;
-            _ = &mut shutdown => {
-                self.shutdown().await;
-                break;
-            }
-            Some(cmd) = self.inbound.recv() => {
-                self.handle_command(cmd)
-            }
-            Some(_) = OptionFuture::from(self.in_flight_trim.as_mut()) => {
-                self.in_flight_trim = None;
-            }
+                biased;
+                _ = &mut shutdown => {
+                    self.shutdown().await;
+                    break;
+                }
+                Some(cmd) = self.inbound.recv() => {
+                    self.handle_command(cmd)
+                }
+                _tick = improvement_interval.tick() => {
+                    if !config.live_load().bifrost.disable_auto_improvement && TaskCenter::is_my_node_alive() {
+                        // check if we have logs to improve
+                        let logs = logs.live_load();
+                        self.improve_logs(logs);
+                    }
+                }
+                Some(_) = OptionFuture::from(self.in_flight_trim.as_mut()) => {
+                    self.in_flight_trim = None;
+                }
             }
         }
         Ok(())
+    }
+
+    /// Checks if we have logs with preferred writers running being local and reconfigures them for
+    /// better performance/placement if needed.
+    ///
+    /// This will only take action over 1/3 of the preferred logs at a time to reduce
+    /// the chances of stomping.
+    fn improve_logs(&mut self, logs: &Logs) {
+        let allowed_to_action = self.my_preferred_logs.len().div_ceil(3);
+        let mut actioned = 0;
+        for (log_id, preferred) in self.my_preferred_logs.iter_mut() {
+            debug_assert!(preferred.ref_cnt > 0);
+            if preferred.last_checked.elapsed() < with_jitter(IMPROVEMENT_ACTION_AFTER, 0.5) {
+                continue;
+            }
+            let Some(chain) = logs.chain(log_id) else {
+                // check again later
+                preferred.last_checked = Instant::now();
+                continue;
+            };
+
+            let provider_config = &logs.configuration().default_provider;
+            let tail_segment = chain.tail();
+            let segment_index = tail_segment.index();
+            let current_provider = tail_segment.config.kind;
+
+            // wW abort the task it has not finished and the tail segment has moved beyond what the
+            // task is about.
+            //
+            // if there is a task in-flight, we let it continue and we touch the checked instant
+            // since we don't need to do anything here.
+            if let Some((in_flight_segment_index, in_flight_task)) = &preferred.in_flight {
+                if *in_flight_segment_index < segment_index {
+                    // the task is outdated, we can cancel it
+                    in_flight_task.abort();
+                    preferred.in_flight = None;
+                } else if !in_flight_task.is_finished() {
+                    // check again later
+                    preferred.last_checked = Instant::now();
+                    continue;
+                } else if in_flight_task.is_finished() {
+                    preferred.in_flight = None;
+                    // reset the check time to slow down reaction time
+                    preferred.last_checked = Instant::now();
+                    continue;
+                }
+            }
+
+            let may_improve = if current_provider != provider_config.kind() {
+                Improvement::Possible {
+                    reason: format!(
+                        "provider change from {current_provider} to {}",
+                        provider_config.kind(),
+                    ),
+                }
+            } else {
+                let current_params = &tail_segment.config.params;
+                let Ok(provider) = self.inner.provider_for(provider_config.kind()) else {
+                    // check again later
+                    preferred.last_checked = Instant::now();
+                    continue;
+                };
+                match provider.may_improve_params(*log_id, current_params, provider_config) {
+                    Ok(improvement) => improvement,
+                    Err(err) => {
+                        debug!(
+                            log_id = %log_id,
+                            %segment_index,
+                            %err,
+                            "[Auto Improvement] Bifrost watchdog failed to check if the log can be improved",
+                        );
+                        Improvement::None
+                    }
+                }
+            };
+
+            preferred.last_checked = Instant::now();
+            if let Improvement::Possible { reason } = may_improve {
+                actioned += 1;
+                info!(
+                    log_id = %log_id,
+                    %segment_index,
+                    "[Auto Improvement] Bifrost will reconfigure the log because {reason}"
+                );
+                let Ok(task) =
+                    TaskCenter::spawn_unmanaged(TaskKind::Disposable, "seal-for-improvement", {
+                        let log_id = *log_id;
+                        let bifrost = Arc::clone(&self.inner);
+                        async move {
+                            let _ = BifrostAdmin::new(&bifrost)
+                                .seal_and_auto_extend_chain(log_id, Some(segment_index))
+                                .await;
+                        }
+                    })
+                else {
+                    // we are shutting down, there is no point in continuing
+                    return;
+                };
+
+                preferred.in_flight = Some((segment_index, task));
+            }
+            // only action on 1/3 of the logs in every round
+            if actioned >= allowed_to_action {
+                return;
+            }
+        }
     }
 
     fn store_trim_request(&mut self, log_id: LogId, requested_trim_point: Lsn) {
@@ -305,6 +467,10 @@ async fn trim_chains_if_needed(
 
 pub enum WatchdogCommand {
     WatchProvider(Arc<dyn LogletProvider>),
+    /// A log appender running on this node has indicated that it's the preferred writer
+    PreferenceAcquire(LogId),
+    /// Indicating that a preference token has been dropped
+    PreferenceRelease(LogId),
     LogTrimmed {
         log_id: LogId,
         /// NOTE: This is **not** the actual trim point, this could easily be Lsn::MAX (legal)

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -118,7 +118,7 @@ impl Default for BifrostOptions {
             ),
             append_retry_min_interval: Duration::from_millis(10).into(),
             append_retry_max_interval: Duration::from_secs(1).into(),
-            auto_recovery_interval: Duration::from_secs(10).into(),
+            auto_recovery_interval: Duration::from_secs(15).into(),
             seal_retry_interval: Duration::from_secs(2).into(),
             record_cache_memory_size: ByteCount::from(250u64 * 1024 * 1024), // 250 MiB
         }

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -86,6 +86,16 @@ pub struct BifrostOptions {
     /// Defaults: 250MB
     #[cfg_attr(feature = "schemars", schemars(with = "ByteCount"))]
     pub record_cache_memory_size: ByteCount,
+
+    /// # Disable Automatic Improvement
+    ///
+    /// When enabled, automatic improvement periodically checks with the loglet provider
+    /// if the loglet configuration can be improved by performing a reconfiguration.
+    ///
+    /// This allows the log to pick up replication property changes, apply better placement
+    /// of replicas, or for other reasons.
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+    pub disable_auto_improvement: bool,
 }
 
 impl BifrostOptions {
@@ -121,6 +131,7 @@ impl Default for BifrostOptions {
             auto_recovery_interval: Duration::from_secs(15).into(),
             seal_retry_interval: Duration::from_secs(2).into(),
             record_cache_memory_size: ByteCount::from(250u64 * 1024 * 1024), // 250 MiB
+            disable_auto_improvement: false,
         }
     }
 }

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -44,7 +44,7 @@ impl SelfProposer {
         let bifrost_appender = bifrost
             .create_background_appender(
                 LogId::from(partition_id),
-                ErrorRecoveryStrategy::extend_preferred(),
+                ErrorRecoveryStrategy::ExtendChainPreferred,
                 BIFROST_QUEUE_SIZE,
                 MAX_BIFROST_APPEND_BATCH,
             )?

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -18,6 +18,7 @@ use assert2::let_assert;
 use enumset::EnumSet;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt as _};
 use metrics::{SharedString, counter, gauge, histogram};
+use restate_types::retries::RetryPolicy;
 use tokio::sync::{mpsc, watch};
 use tokio::time::MissedTickBehavior;
 use tracing::{Span, debug, error, info, instrument, trace, warn};
@@ -25,7 +26,7 @@ use tracing::{Span, debug, error, info, instrument, trace, warn};
 use restate_bifrost::Bifrost;
 use restate_bifrost::loglet::FindTailOptions;
 use restate_core::network::{Oneshot, Reciprocal, ServiceMessage, Verdict};
-use restate_core::{ShutdownError, cancellation_watcher};
+use restate_core::{Metadata, ShutdownError, cancellation_watcher};
 use restate_partition_store::{PartitionStore, PartitionStoreTransaction};
 use restate_storage_api::deduplication_table::{
     DedupInformation, DedupSequenceNumber, DeduplicationTable, ProducerId,
@@ -54,7 +55,7 @@ use restate_types::invocation::{
     SubmitNotificationSink, WorkflowHandlerType,
 };
 use restate_types::logs::MatchKeyQuery;
-use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber};
+use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
 use restate_types::net::RpcRequest;
 use restate_types::net::partition_processor::{
     AppendInvocationReplyOn, GetInvocationOutputResponseMode, PartitionLeaderService,
@@ -311,14 +312,49 @@ where
         let last_applied_lsn = last_applied_lsn.unwrap_or(Lsn::INVALID);
 
         self.status.last_applied_log_lsn = Some(last_applied_lsn);
+        let log_id = Metadata::with_current(|m| {
+            m.partition_table_ref()
+                .get(&self.partition_id)
+                .map(|p| p.log_id())
+        });
 
+        let Some(log_id) = log_id else {
+            return Err(ProcessorError::Other(anyhow::anyhow!(
+                "Partition {} was not found in partition table!",
+                self.partition_id
+            )));
+        };
+
+        // If the underlying log is not provisioned, now is the time to provision it.
+        // We'll retry a few times before giving back control to PPM
+        //
+        // The primary reason for retries is the initial cluster provision case where nodes might
+        // still be starting up and we don't have enough nodes to form legal nodesets.
+        let mut retries = RetryPolicy::exponential(
+            Duration::from_secs(1),
+            1.5,
+            Some(3),
+            Some(Duration::from_secs(5)),
+        )
+        .into_iter();
+        while let Err(e) = self.bifrost.admin().ensure_log_exists(log_id).await {
+            // We cannot provision the log for this partition
+            if let Some(dur) = retries.next() {
+                debug!(
+                    "Cannot create a bifrost log for partition {}, will retry in {:?}; reason={}",
+                    self.partition_id, dur, e
+                );
+                tokio::time::sleep(dur).await;
+            } else {
+                return Err(e.into());
+            }
+        }
+
+        debug!("Finding tail for partition",);
         // propagate errors and let the PPM handle error retries
         let current_tail = self
             .bifrost
-            .find_tail(
-                LogId::from(self.partition_id),
-                FindTailOptions::ConsistentRead,
-            )
+            .find_tail(log_id, FindTailOptions::ConsistentRead)
             .await?;
 
         debug!(
@@ -374,12 +410,7 @@ where
 
         let mut record_stream = self
             .bifrost
-            .create_reader(
-                LogId::from(self.partition_id),
-                key_query.clone(),
-                last_applied_lsn.next(),
-                Lsn::MAX,
-            )?
+            .create_reader(log_id, key_query.clone(), last_applied_lsn.next(), Lsn::MAX)?
             .map(|entry| match entry {
                 Ok(entry) => {
                     trace!(?entry, "Read entry");

--- a/tools/bifrost-benchpress/src/append_latency.rs
+++ b/tools/bifrost-benchpress/src/append_latency.rs
@@ -42,7 +42,7 @@ pub async fn run(
     let mut append_latencies = Histogram::<u64>::new(3)?;
     let mut counter = 0;
     let mut appender =
-        bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::extend_preferred())?;
+        bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::ExtendChainPreferred)?;
     let start = Instant::now();
     loop {
         if counter >= args.num_records {

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -96,7 +96,7 @@ pub async fn run(_common_args: &Arguments, args: &WriteToReadOpts, bifrost: Bifr
                 let appender_handle = bifrost
                     .create_background_appender(
                         LOG_ID,
-                        ErrorRecoveryStrategy::extend_preferred(),
+                        ErrorRecoveryStrategy::ExtendChainPreferred,
                         args.write_buffer_size,
                         args.max_batch_size,
                     )?


### PR DESCRIPTION

Bifrost will not gradually auto-reconfigure logs based on its knowledge of preferred writers of this log running on a node. The preferred writer in this context is the partition processor leader.

The intent is implied from the supplied error recovery strategy that the appender gets on creation.

Configuration: A new _hidden_ configuration `bifrost.disable_auto_improvement` is set to `false` by default that can disable this feature.
