### PR TITLE
Prefer worker nodes that are caught up when selecting leaders

### DIFF
--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -171,6 +171,12 @@ impl ObservedPartitionState {
             },
         );
     }
+
+    pub fn replay_status(&self, node_id: &PlainNodeId) -> Option<ReplayStatus> {
+        self.partition_processors
+            .get(node_id)
+            .map(|p| p.replay_status)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION

This commit improves the leader selection mechanism of the scheduler. The preference is now
the following:

1. Try to keep the observed leader
2. Prefer worker nodes that are caught up
   2.1 Choose the current target leader
   2.2 Choose the preferred leader
   2.3 Pick any of the nodes in the current partition configuration
3. Pick worker nodes that are alive
   3.1 Choose the current target leader
   3.2 Choose the preferred leader
   3.3 Pick any of the nodes in the current partition configuration
