### PR TITLE
[Gossip] Nodes delay their own suspect->alive transition slightly

### DIFF
--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -176,10 +176,6 @@ where
 
         let log_trim_check_interval = create_log_trim_check_interval(&configuration.admin);
 
-        let mut find_logs_tail_interval =
-            time::interval(configuration.admin.log_tail_update_interval.into());
-        find_logs_tail_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
         let (epoch_metadata_tx, epoch_metadata_rx) = tokio::sync::mpsc::channel(1);
 
         TaskCenter::spawn_unmanaged(TaskKind::Background, "epoch-metadata-fetch", {

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -81,14 +81,6 @@ pub struct AdminOptions {
     /// This configuration option is deprecated and ignored in Restate >= 1.2.
     pub log_trim_threshold: Option<u64>,
 
-    /// # Log Tail Update interval
-    ///
-    /// Controls the interval at which cluster controller tries to refind the tails of logs. This
-    /// is a safety-net check in case of a concurrent cluster controller crash.
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-    pub log_tail_update_interval: humantime::Duration,
-
     /// # Default partition replication factor
     ///
     /// The default replication factor for partition processors, this impacts how many replicas
@@ -185,7 +177,6 @@ impl Default for AdminOptions {
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
             disable_web_ui: false,
-            log_tail_update_interval: Duration::from_secs(5 * 60).into(),
             experimental_feature_force_journal_retention: None,
         }
     }
@@ -230,7 +221,6 @@ impl From<AdminOptionsShadow> for AdminOptions {
             heartbeat_interval: value.heartbeat_interval,
             log_trim_check_interval,
             log_trim_threshold: value.log_trim_threshold,
-            log_tail_update_interval: value.log_tail_update_interval,
             default_partition_replication: partition_replication,
             disable_web_ui: value.disable_web_ui,
             #[cfg(any(test, feature = "test-util"))]
@@ -268,9 +258,6 @@ struct AdminOptionsShadow {
     log_trim_interval: Option<humantime::Duration>,
 
     log_trim_threshold: Option<u64>,
-
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    log_tail_update_interval: humantime::Duration,
 
     #[serde_as(
         as = "Option<serde_with::PickFirst<(_, PartitionReplicationFromReplicationProperty)>>"

--- a/crates/types/src/config/gossip.rs
+++ b/crates/types/src/config/gossip.rs
@@ -101,7 +101,7 @@ impl Default for GossipOptions {
         Self {
             gossip_failure_threshold: NonZeroU32::new(10).expect("be non zero"),
             gossip_fd_stability_threshold: NonZeroU32::new(3).expect("be non zero"),
-            gossip_tick_interval: Duration::from_millis(150).into(),
+            gossip_tick_interval: Duration::from_millis(100).into(),
             gossip_num_peers: NonZeroU32::new(2).expect("be non zero"),
             gossip_suspect_interval: Duration::from_secs(5).into(),
             gossip_loneliness_threshold: NonZeroU32::new(30).expect("be non zero"),


### PR DESCRIPTION

This delay (600ms) addresses the synchronized startup scenario where all nodes will transition into alive and compete on admin leadership for a brief period. It does not eliminate the problem completely of course but it has experimentally proven to improve the situation significantly.

This also updates the default gossip duration to be 100ms. Future adjustments are subject to lab-bench testing.
