### PR TITLE
Fix: restate invocations cancel should not consider completed invocat…

### DIFF
--- a/cli/src/commands/invocations/purge.rs
+++ b/cli/src/commands/invocations/purge.rs
@@ -61,7 +61,8 @@ pub async fn run_purge(State(env): State<CliEnv>, opts: &Purge) -> Result<()> {
     let invocations = find_active_invocations_simple(&sql_client, &filter).await?;
     if invocations.is_empty() {
         bail!(
-            "No invocations found for query {}! Note that the purge command works only on completed invocations. If you need to cancel/kill an invocation, consider using the cancel command.",
+            "No invocations found for query {}! Note that the purge command only works on completed invocations. \
+            If you need to cancel/kill an invocation, consider using the cancel command instead.",
             opts.query
         );
     };


### PR DESCRIPTION
Spotted this wile doing some testing - `restate invocations cancel <Service>` will list successfully completed invocations.

Before:

```
% restate inv cancel --kill Counter
 ID                                      TARGET                    STATUS
 inv_1i4G3fO0IBfG3WluVzLBlFHs8gccA2J7vH  Counter/le0vczvro5f4/get  completed
 inv_1giDSEyTIcx21YSrqyDWkrMmJ52X4mVvI5  Counter/l35vtdbb06zu/get  completed
 inv_1coNm82dx7P20UqztDdpdt3NxRHk5bs70R  Counter/9vvv2aqr7r1h/get  completed
 inv_1hiGx2BbkFJ64fPxl7QeQYKLuQTCW0yi4h  Counter/frzm5yznx2m4/get  completed
 inv_17vDkJ60gCyI4x3sEETvJTIGlekvExmr61  Counter/ajcf4nn16l3e/get  completed
 inv_1dWVpOhrLi6I1klTYSvwL41AhMSMeGo4fL  Counter/sam4b2oqrgpy/get  completed
 inv_16H4t2rNW3NS31eQH7hcCA1FlwXXvZtIkN  Counter/iteztqlvjjg8/get  completed
 inv_1iqKCRi0PKog7Ca7NtC9EFDGrqKYw1Nt8l  Counter/4pui38h9bm2e/get  completed
 inv_151BGQ4ulSyQ6FMk9rpJYEdweKvAFIkvkJ  Counter/pr4zv6r02zh2/get  completed
...
? Are you sure you want to kill these invocations? (y/n) › no
```

After:

```
% cargo run --bin restate inv cancel Counter
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/restate inv cancel Counter`
Error: No invocations found for query Counter! Note that the cancel command only works on non-completed invocations. If you want to remove a completed invocation, consider using the purge command instead.
```

If you specify a completed invocation id explicitly, you'll get an error:

```
% cargo run --bin restate inv cancel inv_1eH1IouKzDGL4lQUSrUVPUm4MsQEJ5mijv
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.32s
     Running `target/debug/restate inv cancel inv_1eH1IouKzDGL4lQUSrUVPUm4MsQEJ5mijv`
 ID                                      TARGET                    STATUS
 inv_1eH1IouKzDGL4lQUSrUVPUm4MsQEJ5mijv  Counter/pmk9a2fxj1zw/get  completed

❌ The invocations matching your query are completed; cancel/kill has no effect on them. If you want to remove a completed invocation, consider using the purge command instead.
```

Fixes: https://github.com/restatedev/restate/issues/3333