### PR TITLE
[helm] Add namespace to metadata of remaining resources

### DIFF
--- a/charts/restate-helm/templates/serviceaccount.yaml
+++ b/charts/restate-helm/templates/serviceaccount.yaml
@@ -10,6 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: true
 {{- end }}


### PR DESCRIPTION
ServiceAccount metadata has `namespace` and other resources don't have it, just for consistency, maybe it should be in all of them or in none of them.