### PR TITLE
Update to latest rust-rocksdb 0.41.0 + Checkpoint flush fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8055,8 +8055,8 @@ dependencies = [
 
 [[package]]
 name = "rust-librocksdb-sys"
-version = "0.36.0+10.1.3"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=0091f8ae75fcb64fcc55f9607953524e46f0c304#0091f8ae75fcb64fcc55f9607953524e46f0c304"
+version = "0.37.0+10.2.1"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=309f749c033731c21a520f5b47773fe31deafd79#309f749c033731c21a520f5b47773fe31deafd79"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -8071,8 +8071,8 @@ dependencies = [
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.40.0-restate.1"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=0091f8ae75fcb64fcc55f9607953524e46f0c304#0091f8ae75fcb64fcc55f9607953524e46f0c304"
+version = "0.41.0"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=309f749c033731c21a520f5b47773fe31deafd79#309f749c033731c21a520f5b47773fe31deafd79"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ regex = { version = "1.11" }
 regress = { version = "0.10" }
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "stream", ] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.40.0-restate.1", package = "rust-rocksdb", features = ["multi-threaded-cf", "jemalloc"], git = "https://github.com/restatedev/rust-rocksdb", rev = "0091f8ae75fcb64fcc55f9607953524e46f0c304" }
+rocksdb = { version = "0.41.0", package = "rust-rocksdb", features = ["multi-threaded-cf", "jemalloc"], git = "https://github.com/restatedev/rust-rocksdb", rev = "309f749c033731c21a520f5b47773fe31deafd79" }
 rstest = "0.24.0"
 rustls = { version = "0.23.11", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }


### PR DESCRIPTION
This PR updates the `rust-rocksdb` dependency to https://github.com/restatedev/rust-rocksdb/commit/309f749c033731c21a520f5b47773fe31deafd79. This change includes:

- latest https://github.com/zaidoon1/rust-rocksdb/releases/tag/v0.41.0 release which includes RocksDB 10.2.1
- Restate changes (WBBI, Checkpoint export, User Properties, Event Listeners) (https://github.com/restatedev/rust-rocksdb/pull/10)
- The proposed upstream fix for Checkpoint flush race condition (https://github.com/restatedev/rust-rocksdb/pull/11)