### PR TITLE
Report the correct planned mode based on the last observed leader epoch 

### DIFF
--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -548,20 +548,13 @@ impl PartitionProcessorManager {
                 if let Some(processor_state) = self.processor_states.get_mut(&partition_id) {
                     match result {
                         Ok(leader_epoch) => {
-                            if let Err(err) = processor_state
-                                .on_leader_epoch_obtained(leader_epoch, leader_epoch_token)
-                            {
-                                info!(%partition_id, %err, "Partition processor failed to process new leader epoch. Stopping it now");
-                                processor_state.stop();
-                            }
+                            processor_state
+                                .on_leader_epoch_obtained(leader_epoch, leader_epoch_token);
                         }
                         Err(err) => {
                             if processor_state.is_valid_leader_epoch_token(leader_epoch_token) {
                                 info!(%partition_id, %err, "Failed obtaining new leader epoch. Continue running as follower");
-                                if let Err(err) = processor_state.run_as_follower() {
-                                    info!(%partition_id, %err, "Partition processor failed to run as follower. Stopping it now");
-                                    processor_state.stop();
-                                }
+                                processor_state.run_as_follower();
                             } else {
                                 debug!("Received outdated new leader epoch. Ignoring it.");
                             }

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -32,9 +32,9 @@ use restate_types::schema::Schema;
 
 use crate::PartitionProcessorBuilder;
 use crate::invoker_integration::EntryEnricher;
-use crate::partition::ProcessorError;
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
 use crate::partition::snapshots::SnapshotRepository;
+use crate::partition::{ProcessorError, TargetLeaderState};
 use crate::partition_processor_manager::processor_state::StartedProcessor;
 
 pub struct SpawnPartitionProcessorTask {
@@ -113,7 +113,7 @@ impl SpawnPartitionProcessorTask {
 
         let status_reader = invoker.status_reader();
 
-        let (control_tx, control_rx) = mpsc::channel(2);
+        let (control_tx, control_rx) = watch::channel(TargetLeaderState::Follower);
         let (net_tx, net_rx) = mpsc::channel(128);
         let status = PartitionProcessorStatus::new();
         let (watch_tx, watch_rx) = watch::channel(status.clone());


### PR DESCRIPTION
[Report the correct planned mode based on the last observed leader epoch](https://github.com/restatedev/restate/commit/27bd83383fdfd7ddd7252afb44d37a96e2914718) 

In order to report the correct planned mode, we need to take the last observed
leader epoch into consideration. If it is higher than the obtained leader epoch,
then a pp can no longer become the leader.

[Replace bounded partition processor control message channel with watch](https://github.com/restatedev/restate/commit/3151167b3392feabf213082bb38f09def42c9091) 

We currently cannot tolerate dropping PartitionProcessorControlMessages because
the upper layers assume that the message will be seen and acted upon by the
PartitionProcessor. To solve this problem, this commit replaces the bounded
channel with a watch since the partition processor should only be interested in
the last target leader state that the PPM instructed it to become.