### PR TITLE
More graceful polls of epoch metadata

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -217,8 +217,13 @@ impl<T: TransportConnect> Scheduler<T> {
             .next
             .as_ref()
             .map(ReplicaSetState::from_partition_configuration);
+        // NOTE: We don't update the leadership state here because we cannot be confident that
+        // the leadership epoch has been acquired or not. The leadership state will only be
+        // updated when either the actual leader or any of the followers has observed the
+        // leader epoch as being the winner of the elections.
         replica_set_states.note_observed_membership(
             partition_id,
+            Default::default(),
             &current_membership,
             &next_membership,
         );

--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -32,7 +32,7 @@ use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::partition_processor_manager::{
     ControlProcessor, ControlProcessors, ProcessorCommand,
 };
-use restate_types::nodes_config::NodesConfiguration;
+use restate_types::nodes_config::{NodeConfig, NodesConfiguration};
 use restate_types::partition_table::{PartitionPlacement, PartitionReplication, PartitionTable};
 use restate_types::partitions::state::{PartitionReplicaSetStates, ReplicaSetState};
 use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter};
@@ -58,24 +58,6 @@ pub enum Error {
     Metadata(#[from] SyncError),
     #[error("system is shutting down")]
     Shutdown(#[from] ShutdownError),
-}
-
-/// Placement hints for the [`Scheduler`]. The hints can specify which nodes should be chosen for
-/// the partition processor placement and on which node the leader should run.
-pub trait PartitionProcessorPlacementHints {
-    fn preferred_nodes(&self, partition_id: &PartitionId) -> impl Iterator<Item = &PlainNodeId>;
-
-    fn preferred_leader(&self, partition_id: &PartitionId) -> Option<PlainNodeId>;
-}
-
-impl<T: PartitionProcessorPlacementHints> PartitionProcessorPlacementHints for &T {
-    fn preferred_nodes(&self, partition_id: &PartitionId) -> impl Iterator<Item = &PlainNodeId> {
-        (*self).preferred_nodes(partition_id)
-    }
-
-    fn preferred_leader(&self, partition_id: &PartitionId) -> Option<PlainNodeId> {
-        (*self).preferred_leader(partition_id)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -275,44 +257,33 @@ impl<T: TransportConnect> Scheduler<T> {
 
         // todo a bulk get of all EpochMetadata if self.partitions.is_empty()
 
-        for partition_id in partition_table.iter_ids() {
-            let entry = self.partitions.entry(*partition_id);
+        for partition_id in partition_table.iter_ids().copied() {
+            let entry = self.partitions.entry(partition_id);
 
             // make sure that we have a valid partition processor configuration
             let mut occupied_entry = match entry {
                 Entry::Occupied(mut entry) if entry.get().current.is_valid() => {
-                    if Self::requires_reconfiguration(entry.get(), nodes_config) {
+                    let partition_replication = Self::partition_replication_to_replication_property(
+                        nodes_config,
+                        &partition_table,
+                    );
+                    if Self::requires_reconfiguration(
+                        partition_id,
+                        entry.get(),
+                        &partition_replication,
+                        nodes_config,
+                    ) {
                         trace!("Partition {} requires reconfiguration", partition_id);
 
-                        let partition_replication =
-                            Self::partition_replication_to_replication_property(
-                                nodes_config,
-                                &partition_table,
-                            );
-
-                        // select all valid worker candidates as the preferred nodes for the next
-                        // configuration
-                        let preferred_nodes = entry
-                            .get()
-                            .replicas()
-                            .filter(|replica| {
-                                // only keep alive nodes in the preferred nodes set to allow moving
-                                // slowly to a more evenly spread replica set if nodes are currently
-                                // dead.
-                                observed_cluster_state.alive_generation(**replica).is_some()
-                            })
-                            .copied()
-                            .collect();
-
                         if let Some(next) = Self::choose_partition_configuration(
-                            *partition_id,
+                            partition_id,
                             nodes_config,
                             partition_replication,
-                            preferred_nodes,
+                            NodeSet::new(),
                         ) {
                             *entry.get_mut() = Self::reconfigure_partition_configuration(
                                 self.metadata_writer.raw_metadata_store_client(),
-                                *partition_id,
+                                partition_id,
                                 entry
                                     .get()
                                     .next
@@ -323,7 +294,7 @@ impl<T: TransportConnect> Scheduler<T> {
                             )
                             .await?;
                             Self::note_observed_membership_update(
-                                *partition_id,
+                                partition_id,
                                 entry.get(),
                                 &self.replica_set_states,
                             );
@@ -340,7 +311,7 @@ impl<T: TransportConnect> Scheduler<T> {
 
                     // no or no valid current configuration, pick a valid configuration
                     if let Some(current) = Self::choose_partition_configuration(
-                        *partition_id,
+                        partition_id,
                         nodes_config,
                         partition_replication.clone(),
                         NodeSet::default(),
@@ -348,13 +319,13 @@ impl<T: TransportConnect> Scheduler<T> {
                         let occupied_entry = entry.insert_entry(
                             Self::store_initial_partition_configuration(
                                 self.metadata_writer.raw_metadata_store_client(),
-                                *partition_id,
+                                partition_id,
                                 current,
                             )
                             .await?,
                         );
                         Self::note_observed_membership_update(
-                            *partition_id,
+                            partition_id,
                             occupied_entry.get(),
                             &self.replica_set_states,
                         );
@@ -371,11 +342,11 @@ impl<T: TransportConnect> Scheduler<T> {
             // next configuration has become active
             if let Some(next) = &occupied_entry.get().next {
                 if next.replica_set().iter().any(|node_id| {
-                    observed_cluster_state.is_partition_processor_active(partition_id, node_id)
+                    observed_cluster_state.is_partition_processor_active(&partition_id, node_id)
                 }) {
                     let partition_configuration_update = Self::complete_reconfiguration(
                         self.metadata_writer.raw_metadata_store_client(),
-                        *partition_id,
+                        partition_id,
                         occupied_entry.get().current.version(),
                         next.version(),
                     )
@@ -385,7 +356,7 @@ impl<T: TransportConnect> Scheduler<T> {
                         partition_configuration_update.next,
                     ) {
                         Self::note_observed_membership_update(
-                            *partition_id,
+                            partition_id,
                             occupied_entry.get(),
                             &self.replica_set_states,
                         );
@@ -394,7 +365,7 @@ impl<T: TransportConnect> Scheduler<T> {
             }
 
             // select the leader based on the observed cluster state
-            self.select_leader(partition_id, observed_cluster_state);
+            self.select_leader(&partition_id, observed_cluster_state);
         }
 
         // update the PartitionTable placement which is still needed for routing messages from the
@@ -517,7 +488,7 @@ impl<T: TransportConnect> Scheduler<T> {
             .await
         {
             Ok(epoch_metadata) => {
-                debug!("Reconfigured partition {} to {:?}", partition_id, next);
+                debug!(%partition_id, "Reconfigured partition to {next:?}");
                 let (_, _, current, next) = epoch_metadata.into_inner();
                 Ok(PartitionState::new(current, next))
             }
@@ -562,7 +533,11 @@ impl<T: TransportConnect> Scheduler<T> {
             }
         }).await {
             Ok(epoch_metadata) => {
-                info!("Successfully transitioned from partition processor configuration {} to {}", current_version, next_version);
+                info!(
+                    %partition_id,
+                    replica_set = %epoch_metadata.current().replica_set(),
+                    "Transitioned from partition configuration {current_version} to {next_version}"
+                );
                 let (_, _, current, next) = epoch_metadata.into_inner();
                 Ok(PartitionConfigurationUpdate {
                     current,
@@ -581,37 +556,51 @@ impl<T: TransportConnect> Scheduler<T> {
     /// Checks whether the given partition requires reconfiguration. A partition requires
     /// reconfiguration in the following cases:
     ///
-    /// * next contains a replica that is no longer a valid worker candidate.
-    /// * current contains a replica that is no longer a valid worker candidate, and there is no
-    ///   ongoing reconfiguration happening already
+    /// * replication has changed
+    /// * possible improvement/rebalance in replica-set, this includes if a node has been dead for
+    /// some time.
+    /// Note: if we take whether a node is dead or not into account, we can do great job but we
+    /// need to rest our dead timers/instants when we switch from follower to leader. This is to
+    /// avoid knee-jerk reaction if we are new leaders with outdated view of the world.
     ///
     /// In this case, the method returns true, otherwise false.
     fn requires_reconfiguration(
+        partition_id: PartitionId,
         partition_state: &PartitionState,
+        default_replication: &ReplicationProperty,
         nodes_config: &NodesConfiguration,
     ) -> bool {
-        let current_requires_reconfiguration =
-            partition_state.current.replica_set().iter().any(|replica| {
-                !nodes_config
-                    .find_node_by_id(*replica)
-                    .map(|node_config| worker_candidate_filter(*replica, node_config))
-                    .unwrap_or_default()
-            });
-
         let next_requires_reconfiguration = partition_state.next.as_ref().map(|next| {
-            next.replica_set().iter().any(|replica| {
-                !nodes_config
-                    .find_node_by_id(*replica)
-                    .map(|node_config| worker_candidate_filter(*replica, node_config))
-                    .unwrap_or_default()
-            })
+            next.replication() != default_replication ||
+                // check if a different replica-set is eminent
+                Self::choose_partition_configuration(
+                    partition_id,
+                    nodes_config,
+                    default_replication.clone(),
+                    NodeSet::default(),
+                )
+                .map(|new_config|
+                    !new_config.replica_set().is_equivalent(next.replica_set()))
+                .unwrap_or(false)
         });
 
-        let ongoing_reconfiguration = next_requires_reconfiguration.is_some();
-        let next_requires_reconfiguration = next_requires_reconfiguration.unwrap_or(false);
+        if next_requires_reconfiguration.is_some_and(|c| c) {
+            return true;
+        }
 
-        (current_requires_reconfiguration && !ongoing_reconfiguration)
-            || next_requires_reconfiguration
+        partition_state.current.replication() != default_replication
+            || Self::choose_partition_configuration(
+                partition_id,
+                nodes_config,
+                default_replication.clone(),
+                NodeSet::default(),
+            )
+            .map(|new_config| {
+                !new_config
+                    .replica_set()
+                    .is_equivalent(partition_state.current.replica_set())
+            })
+            .unwrap_or(false)
     }
 
     fn choose_partition_configuration(
@@ -622,36 +611,31 @@ impl<T: TransportConnect> Scheduler<T> {
     ) -> Option<PartitionConfiguration> {
         let options =
             SelectorOptions::new(u64::from(partition_id)).with_preferred_nodes(preferred_nodes);
+        let cluster_state = TaskCenter::with_current(|tc| tc.cluster_state().clone());
+        let filter = |node_id: PlainNodeId, node_config: &NodeConfig| {
+            cluster_state.is_alive(node_id.into()) && worker_candidate_filter(node_id, node_config)
+        };
 
-        BalancedSpreadSelector::select(
-            nodes_config,
-            &partition_replication,
-            worker_candidate_filter,
-            &options,
-        )
-        .map(|replica_set| {
-            PartitionConfiguration::new(partition_replication, replica_set, HashMap::default())
-        })
-        .inspect_err(|err| {
-            debug!(
-                "Failed to select replica set for partition {partition_id}: {}",
-                err
-            )
-        })
-        .ok()
+        BalancedSpreadSelector::select(nodes_config, &partition_replication, filter, &options)
+            .map(|replica_set| {
+                PartitionConfiguration::new(partition_replication, replica_set, HashMap::default())
+            })
+            .inspect_err(|err| {
+                debug!(
+                    "Failed to select replica set for partition {partition_id}: {}",
+                    err
+                )
+            })
+            .ok()
     }
 
     /// Selects a leader based on the current target leader, observed cluster state and preferred leader.
     ///
-    /// 1. Try to keep the observed leader
-    /// 2. Prefer worker nodes that are caught up
+    /// 1. Prefer worker nodes that are caught up
     ///    2.1 Choose the current target leader
     ///    2.2 Choose the preferred leader
     ///    2.3 Pick any of the nodes in the current partition configuration
-    /// 3. Pick worker nodes that are alive
-    ///    3.1 Choose the current target leader
-    ///    3.2 Choose the preferred leader
-    ///    3.3 Pick any of the nodes in the current partition configuration
+    /// 2. Pick worker nodes that are alive
     fn select_leader(
         &mut self,
         partition_id: &PartitionId,
@@ -660,28 +644,6 @@ impl<T: TransportConnect> Scheduler<T> {
         let Some(partition) = self.partitions.get_mut(partition_id) else {
             return;
         };
-
-        // 1. keep current observed leader
-        if let Some(leader) = observed_cluster_state
-            .partition_state(partition_id)
-            .and_then(|partition_state| {
-                partition_state
-                    .partition_processors
-                    .iter()
-                    .find(|(node_id, state)| {
-                        state.run_mode == RunMode::Leader
-                            && partition.contains_replica_current(**node_id)
-                    })
-                    .map(|(node_id, _)| *node_id)
-            })
-        {
-            assert!(
-                observed_cluster_state.alive_generation(leader).is_some(),
-                "only alive nodes should run the leader"
-            );
-            partition.target_leader = Some(leader);
-            return;
-        }
 
         if let Some(observed_partition_state) = observed_cluster_state.partition_state(partition_id)
         {
@@ -711,17 +673,7 @@ impl<T: TransportConnect> Scheduler<T> {
         observed_cluster_state: &ObservedClusterState,
         additional_criterion: impl Fn(PlainNodeId) -> bool,
     ) -> Option<PlainNodeId> {
-        // 1. keep the current target leader if it is still alive because we might have instructed
-        // it already
-        if partition.target_leader.is_some_and(|leader| {
-            observed_cluster_state.alive_generation(leader).is_some()
-                && partition.contains_replica_current(leader)
-                && additional_criterion(leader)
-        }) {
-            return partition.target_leader;
-        }
-
-        // 2. select any of the alive nodes in current
+        // select any of the alive nodes in current
         if let Some(alive_replica) =
             partition
                 .current

--- a/crates/node/src/failure_detector.rs
+++ b/crates/node/src/failure_detector.rs
@@ -378,6 +378,7 @@ impl<T: NetworkSender> FailureDetector<T> {
                 .partitions()
                 .map(|(id, membership)| PartitionReplicaSet {
                     id,
+                    current_leader: membership.current_leader(),
                     observed_current_membership: membership.observed_current_membership,
                     observed_next_membership: membership.observed_next_membership,
                 })

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -22,7 +22,7 @@ use crate::net::{
     bilrost_wire_codec, bilrost_wire_codec_with_v1_fallback, define_rpc, define_service,
     define_unary_message,
 };
-use crate::partitions::state::ReplicaSetState;
+use crate::partitions::state::{LeadershipState, ReplicaSetState};
 use crate::time::MillisSinceEpoch;
 use crate::{cluster::cluster_state::PartitionProcessorStatus, identifiers::PartitionId};
 
@@ -149,6 +149,7 @@ pub struct Node {
 #[derive(Debug, Clone, bilrost::Message, NetSerde)]
 pub struct PartitionReplicaSet {
     pub id: PartitionId,
+    pub current_leader: LeadershipState,
     pub observed_current_membership: ReplicaSetState,
     pub observed_next_membership: Option<ReplicaSetState>,
 }

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -107,6 +107,7 @@ impl FromStr for GenerationalNodeId {
 }
 
 impl GenerationalNodeId {
+    pub const INVALID: GenerationalNodeId = PlainNodeId::INVALID.with_generation(0);
     pub const INITIAL_NODE_ID: GenerationalNodeId = PlainNodeId::MIN.with_generation(1);
 
     pub fn decode<B: Buf>(mut data: B) -> Self {
@@ -298,6 +299,7 @@ impl From<GenerationalNodeId> for PlainNodeId {
 
 impl PlainNodeId {
     // Start with 1 as plain node id to leave 0 as a special value in the future
+    pub const INVALID: PlainNodeId = PlainNodeId::new(0);
     pub const MIN: PlainNodeId = PlainNodeId::new(1);
 
     pub const fn new(id: u32) -> PlainNodeId {

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -11,15 +11,15 @@
 use std::sync::Arc;
 
 use dashmap::Entry;
-use tokio::sync::Notify;
 use tokio::sync::futures::Notified;
+use tokio::sync::{Notify, watch};
 
 use restate_encoding::NetSerde;
 
-use crate::identifiers::PartitionId;
+use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::{Lsn, SequenceNumber};
 use crate::partitions::PartitionConfiguration;
-use crate::{Merge, PlainNodeId, Version};
+use crate::{GenerationalNodeId, Merge, PlainNodeId, Version};
 
 type DashMap<K, V> = dashmap::DashMap<K, V, ahash::RandomState>;
 
@@ -36,19 +36,57 @@ struct Inner {
 }
 
 impl PartitionReplicaSetStates {
-    /// Update the membership state for a partition
-    pub fn note_observed_membership(
+    /// Update the leadership state for a partition
+    ///
+    /// The leadership state should only be updated after we are confident that
+    /// the new leader has committed the leader epoch to the log. It's also acceptable
+    /// to delay updating it until the actual leader or any of the followers have
+    /// observed the leader epoch as being the winner of the elections.
+    pub fn note_observed_leader(
         &self,
         partition_id: PartitionId,
-        current_membership: &ReplicaSetState,
-        next_membership: &Option<ReplicaSetState>,
+        incoming_leader: LeadershipState,
     ) {
         let modified = match self.inner.partitions.entry(partition_id) {
             Entry::Occupied(mut occupied_entry) => occupied_entry
                 .get_mut()
-                .merge(current_membership, next_membership),
+                .current_leader
+                .send_if_modified(|l| l.merge(incoming_leader)),
             Entry::Vacant(entry) => {
                 entry.insert(MembershipState {
+                    current_leader: watch::Sender::new(incoming_leader),
+                    observed_current_membership: Default::default(),
+                    observed_next_membership: Default::default(),
+                });
+                true
+            }
+        };
+
+        if modified {
+            self.inner.global_notify.notify_waiters();
+        }
+    }
+
+    /// Update the membership state for a partition
+    ///
+    /// If you don't have a new leadership state, use Default::default() instead for the parameter
+    /// `leadershipstate`.
+    pub fn note_observed_membership(
+        &self,
+        partition_id: PartitionId,
+        current_leader: LeadershipState,
+        current_membership: &ReplicaSetState,
+        next_membership: &Option<ReplicaSetState>,
+    ) {
+        let modified = match self.inner.partitions.entry(partition_id) {
+            Entry::Occupied(mut occupied_entry) => {
+                occupied_entry
+                    .get_mut()
+                    .merge(current_leader, current_membership, next_membership)
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(MembershipState {
+                    current_leader: watch::Sender::new(current_leader),
                     observed_current_membership: current_membership.clone(),
                     observed_next_membership: next_membership.clone(),
                 });
@@ -61,11 +99,29 @@ impl PartitionReplicaSetStates {
         }
     }
 
-    pub fn get_membership_state(&self, partition_id: PartitionId) -> Option<MembershipState> {
-        self.inner
-            .partitions
-            .get(&partition_id)
-            .map(|k| k.value().clone())
+    pub fn watch_leadership_state(
+        &self,
+        partition_id: PartitionId,
+    ) -> watch::Receiver<LeadershipState> {
+        match self.inner.partitions.entry(partition_id) {
+            Entry::Occupied(occupied_entry) => occupied_entry.get().watch_current_leader(),
+            Entry::Vacant(entry) => {
+                let value = entry.insert(MembershipState::default());
+                self.inner.global_notify.notify_waiters();
+                value.value().watch_current_leader()
+            }
+        }
+    }
+
+    pub fn membership_state(&self, partition_id: PartitionId) -> MembershipState {
+        match self.inner.partitions.entry(partition_id) {
+            Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let value = entry.insert(MembershipState::default());
+                self.inner.global_notify.notify_waiters();
+                value.value().clone()
+            }
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PartitionId, MembershipState)> {
@@ -84,15 +140,63 @@ impl PartitionReplicaSetStates {
     }
 }
 
+#[derive(Debug, Clone, Copy, bilrost::Message, NetSerde)]
+pub struct LeadershipState {
+    pub current_leader_epoch: LeaderEpoch,
+    pub current_leader: GenerationalNodeId,
+}
+
+impl Default for LeadershipState {
+    fn default() -> Self {
+        Self {
+            current_leader_epoch: LeaderEpoch::INVALID,
+            current_leader: GenerationalNodeId::INVALID,
+        }
+    }
+}
+
+impl Merge for LeadershipState {
+    fn merge(&mut self, other: Self) -> bool {
+        match self.current_leader_epoch.cmp(&other.current_leader_epoch) {
+            std::cmp::Ordering::Greater => false,
+            std::cmp::Ordering::Less => {
+                self.current_leader_epoch = other.current_leader_epoch;
+                self.current_leader = other.current_leader;
+                true
+            }
+            std::cmp::Ordering::Equal
+                if !self.current_leader.is_valid() && other.current_leader.is_valid() =>
+            {
+                // update our current leader if the incoming knows about it and we don't.
+                self.current_leader = other.current_leader;
+                true
+            }
+            std::cmp::Ordering::Equal => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MembershipState {
+    current_leader: watch::Sender<LeadershipState>,
     pub observed_current_membership: ReplicaSetState,
     pub observed_next_membership: Option<ReplicaSetState>,
+}
+
+impl Default for MembershipState {
+    fn default() -> Self {
+        Self {
+            current_leader: watch::Sender::new(LeadershipState::default()),
+            observed_current_membership: ReplicaSetState::default(),
+            observed_next_membership: None,
+        }
+    }
 }
 
 impl MembershipState {
     fn merge(
         &mut self,
+        incoming_leadership_state: LeadershipState,
         incoming_current_membership: &ReplicaSetState,
         incoming_next_membership: &Option<ReplicaSetState>,
     ) -> bool {
@@ -124,6 +228,10 @@ impl MembershipState {
             }
             std::cmp::Ordering::Less => { /* ignore it */ }
         }
+
+        modified |= self
+            .current_leader
+            .send_if_modified(|l| l.merge(incoming_leadership_state));
 
         // dealing with next membership configuration
         let Some(incoming_next_membership) = incoming_next_membership else {
@@ -169,6 +277,14 @@ impl MembershipState {
                 .as_ref()
                 .map(|m| m.members.iter().any(|m| m.node_id == node_id))
                 .unwrap_or(false)
+    }
+
+    pub fn current_leader(&self) -> LeadershipState {
+        *self.current_leader.borrow()
+    }
+
+    pub fn watch_current_leader(&self) -> watch::Receiver<LeadershipState> {
+        self.current_leader.subscribe()
     }
 }
 

--- a/crates/types/src/replication/nodeset.rs
+++ b/crates/types/src/replication/nodeset.rs
@@ -181,6 +181,11 @@ impl NodeSet {
         self.0.is_superset(&other.0)
     }
 
+    /// Returns true if it's the same nodeset but potentially shuffled
+    pub fn is_equivalent(&self, other: &NodeSet) -> bool {
+        self.0.is_superset(&other.0) && self.0.len() == other.0.len()
+    }
+
     pub fn as_slice(&self) -> &indexmap::set::Slice<PlainNodeId> {
         self.0.as_slice()
     }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -18,7 +18,6 @@ use assert2::let_assert;
 use enumset::EnumSet;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt as _};
 use metrics::{SharedString, counter, gauge, histogram};
-use restate_types::retries::RetryPolicy;
 use tokio::sync::{mpsc, watch};
 use tokio::time::MissedTickBehavior;
 use tracing::{Span, debug, error, info, instrument, trace, warn};
@@ -47,7 +46,6 @@ use restate_types::config::WorkerOptions;
 use restate_types::identifiers::{
     LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
-use restate_types::invocation;
 use restate_types::invocation::client::{InvocationOutput, InvocationOutputResponse};
 use restate_types::invocation::{
     AttachInvocationRequest, InvocationQuery, InvocationTarget, InvocationTargetType,
@@ -62,8 +60,11 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcError, PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner,
     PartitionProcessorRpcResponse,
 };
+use restate_types::partitions::state::PartitionReplicaSetStates;
+use restate_types::retries::RetryPolicy;
 use restate_types::storage::StorageDecodeError;
 use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, invocation};
 use restate_wal_protocol::control::AnnounceLeader;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
 
@@ -143,6 +144,7 @@ where
         self,
         bifrost: Bifrost,
         mut partition_store: PartitionStore,
+        replica_set_states: PartitionReplicaSetStates,
     ) -> Result<PartitionProcessor<InvokerInputSender>, StorageError> {
         let PartitionProcessorBuilder {
             partition_id,
@@ -195,6 +197,7 @@ where
             network_leader_svc_rx: rpc_rx,
             status_watch_tx,
             status,
+            replica_set_states,
         })
     }
 
@@ -228,6 +231,7 @@ pub struct PartitionProcessor<InvokerSender> {
     network_leader_svc_rx: mpsc::Receiver<ServiceMessage<PartitionLeaderService>>,
     status_watch_tx: watch::Sender<PartitionProcessorStatus>,
     status: PartitionProcessorStatus,
+    replica_set_states: PartitionReplicaSetStates,
 
     max_command_batch_size: usize,
     partition_store: PartitionStore,
@@ -451,6 +455,11 @@ where
         let mut action_collector = ActionCollector::default();
         let mut command_buffer = Vec::with_capacity(self.max_command_batch_size);
 
+        let mut watch_leader_changes = self
+            .replica_set_states
+            .watch_leadership_state(self.partition_id);
+        watch_leader_changes.mark_changed();
+
         info!("Partition {} started", self.partition_id);
 
         loop {
@@ -462,6 +471,11 @@ where
             rpc_queue_len.set(rpc_rx_len as f64);
 
             tokio::select! {
+                Ok(()) = watch_leader_changes.changed() => {
+                    // cloning to avoid holding the underlying RwLock.
+                    let new_state = *watch_leader_changes.borrow_and_update();
+                    self.leadership_state.maybe_step_down(new_state.current_leader_epoch, new_state.current_leader).await;
+                }
                 Some(command) = self.control_rx.recv() => {
                     if let Err(err) = self.on_command(command).await {
                         warn!("Failed executing command: {err}");
@@ -529,6 +543,13 @@ where
                                 // older AnnounceLeader messages have the announce_leader.node_id set
                                 self.status.last_observed_leader_node = announce_leader.node_id;
                             }
+                            self.replica_set_states.note_observed_leader(
+                                self.partition_id,
+                                restate_types::partitions::state::LeadershipState {
+                                    current_leader_epoch: announce_leader.leader_epoch,
+                                    current_leader:
+                                    self.status.last_observed_leader_node.unwrap_or(GenerationalNodeId::INVALID),
+                                });
 
                             let is_leader = self.leadership_state.on_announce_leader(announce_leader, &mut partition_store).await?;
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -28,6 +28,7 @@ use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::live::Live;
 use restate_types::live::LiveLoadExt;
 use restate_types::logs::Lsn;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::schema::Schema;
 
 use crate::PartitionProcessorBuilder;
@@ -43,6 +44,7 @@ pub struct SpawnPartitionProcessorTask {
     key_range: RangeInclusive<PartitionKey>,
     configuration: Live<Configuration>,
     bifrost: Bifrost,
+    replica_set_states: PartitionReplicaSetStates,
     partition_store_manager: PartitionStoreManager,
     snapshot_repository: Option<SnapshotRepository>,
     fast_forward_lsn: Option<Lsn>,
@@ -56,6 +58,7 @@ impl SpawnPartitionProcessorTask {
         key_range: RangeInclusive<PartitionKey>,
         configuration: Live<Configuration>,
         bifrost: Bifrost,
+        replica_set_states: PartitionReplicaSetStates,
         partition_store_manager: PartitionStoreManager,
         snapshot_repository: Option<SnapshotRepository>,
         fast_forward_lsn: Option<Lsn>,
@@ -66,6 +69,7 @@ impl SpawnPartitionProcessorTask {
             key_range,
             configuration,
             bifrost,
+            replica_set_states,
             partition_store_manager,
             snapshot_repository,
             fast_forward_lsn,
@@ -93,6 +97,7 @@ impl SpawnPartitionProcessorTask {
             key_range,
             configuration,
             bifrost,
+            replica_set_states,
             partition_store_manager,
             snapshot_repository,
             fast_forward_lsn,
@@ -167,7 +172,7 @@ impl SpawnPartitionProcessorTask {
                     .map_err(|e| ProcessorError::from(anyhow::anyhow!(e)))?;
 
                     pp_builder
-                        .build(bifrost, partition_store)
+                        .build(bifrost, partition_store, replica_set_states)
                         .await
                         .map_err(ProcessorError::from)?
                         .run()


### PR DESCRIPTION

Key changes:
1. Refreshes of epoch metadata starts again after 30s of the last fetch is completed, yet we are still eager when switching to leader, yet we are still eager when switching to leader.
2. Stop fetching if admin lost leadership
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3342).
* __->__ #3342
* #3339
* #3330