### PR TITLE
[Worker] minor metrics changes

### DIFF
--- a/crates/admin/src/cluster_controller/scheduler.rs
+++ b/crates/admin/src/cluster_controller/scheduler.rs
@@ -213,8 +213,13 @@ impl<T: TransportConnect> Scheduler<T> {
             .next
             .as_ref()
             .map(ReplicaSetState::from_partition_configuration);
+        // NOTE: We don't update the leadership state here because we cannot be confident that
+        // the leadership epoch has been acquired or not. The leadership state will only be
+        // updated when either the actual leader or any of the followers has observed the
+        // leader epoch as being the winner of the elections.
         replica_set_states.note_observed_membership(
             partition_id,
+            Default::default(),
             &current_membership,
             &next_membership,
         );

--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -248,7 +248,7 @@ impl Watchdog {
     /// the chances of stomping.
     fn improve_logs(&mut self, logs: &Logs) {
         let allowed_to_action = self.my_preferred_logs.len().div_ceil(3);
-        let mut actioned = 0;
+        let mut actioned: Vec<LogId> = Vec::default();
         for (log_id, preferred) in self.my_preferred_logs.iter_mut() {
             debug_assert!(preferred.ref_cnt > 0);
             if preferred.last_checked.elapsed() < with_jitter(IMPROVEMENT_ACTION_AFTER, 0.5) {
@@ -317,8 +317,8 @@ impl Watchdog {
 
             preferred.last_checked = Instant::now();
             if let Improvement::Possible { reason } = may_improve {
-                actioned += 1;
-                info!(
+                actioned.push(*log_id);
+                debug!(
                     log_id = %log_id,
                     %segment_index,
                     "[Auto Improvement] Bifrost will reconfigure the log because {reason}"
@@ -335,15 +335,22 @@ impl Watchdog {
                     })
                 else {
                     // we are shutting down, there is no point in continuing
-                    return;
+                    break;
                 };
 
                 preferred.in_flight = Some((segment_index, task));
             }
             // only action on 1/3 of the logs in every round
-            if actioned >= allowed_to_action {
-                return;
+            if actioned.len() >= allowed_to_action {
+                break;
             }
+        }
+
+        if !actioned.is_empty() {
+            info!(
+                "[Auto Improvement] Bifrost will reconfigure logs to improve placement. logs={:?}",
+                actioned
+            );
         }
     }
 

--- a/crates/node/src/failure_detector.rs
+++ b/crates/node/src/failure_detector.rs
@@ -378,6 +378,7 @@ impl<T: NetworkSender> FailureDetector<T> {
                 .partitions()
                 .map(|(id, membership)| PartitionReplicaSet {
                     id,
+                    current_leader: membership.current_leader(),
                     observed_current_membership: membership.observed_current_membership,
                     observed_next_membership: membership.observed_next_membership,
                 })

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -22,7 +22,7 @@ use crate::net::{
     bilrost_wire_codec, bilrost_wire_codec_with_v1_fallback, define_rpc, define_service,
     define_unary_message,
 };
-use crate::partitions::state::ReplicaSetState;
+use crate::partitions::state::{LeadershipState, ReplicaSetState};
 use crate::time::MillisSinceEpoch;
 use crate::{cluster::cluster_state::PartitionProcessorStatus, identifiers::PartitionId};
 
@@ -149,6 +149,7 @@ pub struct Node {
 #[derive(Debug, Clone, bilrost::Message, NetSerde)]
 pub struct PartitionReplicaSet {
     pub id: PartitionId,
+    pub current_leader: LeadershipState,
     pub observed_current_membership: ReplicaSetState,
     pub observed_next_membership: Option<ReplicaSetState>,
 }

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -107,6 +107,7 @@ impl FromStr for GenerationalNodeId {
 }
 
 impl GenerationalNodeId {
+    pub const INVALID: GenerationalNodeId = PlainNodeId::INVALID.with_generation(0);
     pub const INITIAL_NODE_ID: GenerationalNodeId = PlainNodeId::MIN.with_generation(1);
 
     pub fn decode<B: Buf>(mut data: B) -> Self {
@@ -298,6 +299,7 @@ impl From<GenerationalNodeId> for PlainNodeId {
 
 impl PlainNodeId {
     // Start with 1 as plain node id to leave 0 as a special value in the future
+    pub const INVALID: PlainNodeId = PlainNodeId::new(0);
     pub const MIN: PlainNodeId = PlainNodeId::new(1);
 
     pub const fn new(id: u32) -> PlainNodeId {

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -11,15 +11,15 @@
 use std::sync::Arc;
 
 use dashmap::Entry;
-use tokio::sync::Notify;
 use tokio::sync::futures::Notified;
+use tokio::sync::{Notify, watch};
 
 use restate_encoding::NetSerde;
 
-use crate::identifiers::PartitionId;
+use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::{Lsn, SequenceNumber};
 use crate::partitions::PartitionConfiguration;
-use crate::{Merge, PlainNodeId, Version};
+use crate::{GenerationalNodeId, Merge, PlainNodeId, Version};
 
 type DashMap<K, V> = dashmap::DashMap<K, V, ahash::RandomState>;
 
@@ -36,19 +36,57 @@ struct Inner {
 }
 
 impl PartitionReplicaSetStates {
-    /// Update the membership state for a partition
-    pub fn note_observed_membership(
+    /// Update the leadership state for a partition
+    ///
+    /// The leadership state should only be updated after we are confident that
+    /// the new leader has committed the leader epoch to the log. It's also acceptable
+    /// to delay updating it until the actual leader or any of the followers have
+    /// observed the leader epoch as being the winner of the elections.
+    pub fn note_observed_leader(
         &self,
         partition_id: PartitionId,
-        current_membership: &ReplicaSetState,
-        next_membership: &Option<ReplicaSetState>,
+        incoming_leader: LeadershipState,
     ) {
         let modified = match self.inner.partitions.entry(partition_id) {
             Entry::Occupied(mut occupied_entry) => occupied_entry
                 .get_mut()
-                .merge(current_membership, next_membership),
+                .current_leader
+                .send_if_modified(|l| l.merge(incoming_leader)),
             Entry::Vacant(entry) => {
                 entry.insert(MembershipState {
+                    current_leader: watch::Sender::new(incoming_leader),
+                    observed_current_membership: Default::default(),
+                    observed_next_membership: Default::default(),
+                });
+                true
+            }
+        };
+
+        if modified {
+            self.inner.global_notify.notify_waiters();
+        }
+    }
+
+    /// Update the membership state for a partition
+    ///
+    /// If you don't have a new leadership state, use Default::default() instead for the parameter
+    /// `leadershipstate`.
+    pub fn note_observed_membership(
+        &self,
+        partition_id: PartitionId,
+        current_leader: LeadershipState,
+        current_membership: &ReplicaSetState,
+        next_membership: &Option<ReplicaSetState>,
+    ) {
+        let modified = match self.inner.partitions.entry(partition_id) {
+            Entry::Occupied(mut occupied_entry) => {
+                occupied_entry
+                    .get_mut()
+                    .merge(current_leader, current_membership, next_membership)
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(MembershipState {
+                    current_leader: watch::Sender::new(current_leader),
                     observed_current_membership: current_membership.clone(),
                     observed_next_membership: next_membership.clone(),
                 });
@@ -61,11 +99,29 @@ impl PartitionReplicaSetStates {
         }
     }
 
-    pub fn get_membership_state(&self, partition_id: PartitionId) -> Option<MembershipState> {
-        self.inner
-            .partitions
-            .get(&partition_id)
-            .map(|k| k.value().clone())
+    pub fn watch_leadership_state(
+        &self,
+        partition_id: PartitionId,
+    ) -> watch::Receiver<LeadershipState> {
+        match self.inner.partitions.entry(partition_id) {
+            Entry::Occupied(occupied_entry) => occupied_entry.get().watch_current_leader(),
+            Entry::Vacant(entry) => {
+                let value = entry.insert(MembershipState::default());
+                self.inner.global_notify.notify_waiters();
+                value.value().watch_current_leader()
+            }
+        }
+    }
+
+    pub fn membership_state(&self, partition_id: PartitionId) -> MembershipState {
+        match self.inner.partitions.entry(partition_id) {
+            Entry::Occupied(occupied_entry) => occupied_entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let value = entry.insert(MembershipState::default());
+                self.inner.global_notify.notify_waiters();
+                value.value().clone()
+            }
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PartitionId, MembershipState)> {
@@ -84,15 +140,63 @@ impl PartitionReplicaSetStates {
     }
 }
 
+#[derive(Debug, Clone, Copy, bilrost::Message, NetSerde)]
+pub struct LeadershipState {
+    pub current_leader_epoch: LeaderEpoch,
+    pub current_leader: GenerationalNodeId,
+}
+
+impl Default for LeadershipState {
+    fn default() -> Self {
+        Self {
+            current_leader_epoch: LeaderEpoch::INVALID,
+            current_leader: GenerationalNodeId::INVALID,
+        }
+    }
+}
+
+impl Merge for LeadershipState {
+    fn merge(&mut self, other: Self) -> bool {
+        match self.current_leader_epoch.cmp(&other.current_leader_epoch) {
+            std::cmp::Ordering::Greater => false,
+            std::cmp::Ordering::Less => {
+                self.current_leader_epoch = other.current_leader_epoch;
+                self.current_leader = other.current_leader;
+                true
+            }
+            std::cmp::Ordering::Equal
+                if !self.current_leader.is_valid() && other.current_leader.is_valid() =>
+            {
+                // update our current leader if the incoming knows about it and we don't.
+                self.current_leader = other.current_leader;
+                true
+            }
+            std::cmp::Ordering::Equal => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MembershipState {
+    current_leader: watch::Sender<LeadershipState>,
     pub observed_current_membership: ReplicaSetState,
     pub observed_next_membership: Option<ReplicaSetState>,
+}
+
+impl Default for MembershipState {
+    fn default() -> Self {
+        Self {
+            current_leader: watch::Sender::new(LeadershipState::default()),
+            observed_current_membership: ReplicaSetState::default(),
+            observed_next_membership: None,
+        }
+    }
 }
 
 impl MembershipState {
     fn merge(
         &mut self,
+        incoming_leadership_state: LeadershipState,
         incoming_current_membership: &ReplicaSetState,
         incoming_next_membership: &Option<ReplicaSetState>,
     ) -> bool {
@@ -124,6 +228,10 @@ impl MembershipState {
             }
             std::cmp::Ordering::Less => { /* ignore it */ }
         }
+
+        modified |= self
+            .current_leader
+            .send_if_modified(|l| l.merge(incoming_leadership_state));
 
         // dealing with next membership configuration
         let Some(incoming_next_membership) = incoming_next_membership else {
@@ -169,6 +277,14 @@ impl MembershipState {
                 .as_ref()
                 .map(|m| m.members.iter().any(|m| m.node_id == node_id))
                 .unwrap_or(false)
+    }
+
+    pub fn current_leader(&self) -> LeadershipState {
+        *self.current_leader.borrow()
+    }
+
+    pub fn watch_current_leader(&self) -> watch::Receiver<LeadershipState> {
+        self.current_leader.subscribe()
     }
 }
 

--- a/crates/types/src/replication/nodeset.rs
+++ b/crates/types/src/replication/nodeset.rs
@@ -181,6 +181,11 @@ impl NodeSet {
         self.0.is_superset(&other.0)
     }
 
+    /// Returns true if it's the same nodeset but potentially shuffled
+    pub fn is_equivalent(&self, other: &NodeSet) -> bool {
+        self.0.is_superset(&other.0) && self.0.len() == other.0.len()
+    }
+
     pub fn as_slice(&self) -> &indexmap::set::Slice<PlainNodeId> {
         self.0.as_slice()
     }

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -20,6 +20,7 @@ pub const PARTITION_STORAGE_TX_CREATED: &str = "restate.partition.storage_tx_cre
 pub const PARTITION_STORAGE_TX_COMMITTED: &str = "restate.partition.storage_tx_committed.total";
 pub const PARTITION_HANDLE_LEADER_ACTIONS: &str = "restate.partition.handle_leader_action.total";
 
+pub const NUM_PARTITIONS: &str = "restate.num_partitions";
 pub const NUM_ACTIVE_PARTITIONS: &str = "restate.num_active_partitions";
 pub const PARTITION_TIME_SINCE_LAST_STATUS_UPDATE: &str =
     "restate.partition.time_since_last_status_update";
@@ -37,10 +38,6 @@ pub const PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION: &str =
     "restate.partition.handle_action_batch_duration.seconds";
 pub const PARTITION_HANDLE_INVOKER_EFFECT_COMMAND: &str =
     "restate.partition.handle_invoker_effect.seconds";
-pub const PARTITION_RPC_QUEUE_UTILIZATION_PERCENT: &str =
-    "restate.partition.rpc_queue.utilization.percent";
-pub const PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS: &str =
-    "restate.partition.rpc_queue.outstanding_requests";
 pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
     "restate.partition.record_committed_to_read_latency.seconds";
 
@@ -101,6 +98,12 @@ pub(crate) fn describe_metrics() {
     );
 
     describe_gauge!(
+        NUM_PARTITIONS,
+        Unit::Count,
+        "Total number of partitions in the partition table"
+    );
+
+    describe_gauge!(
         NUM_ACTIVE_PARTITIONS,
         Unit::Count,
         "Number of partitions started by partition processor manager on this node"
@@ -146,18 +149,6 @@ pub(crate) fn describe_metrics() {
         PARTITION_TIME_SINCE_LAST_RECORD,
         Unit::Seconds,
         "Number of seconds since the last record was applied"
-    );
-
-    describe_gauge!(
-        PARTITION_RPC_QUEUE_UTILIZATION_PERCENT,
-        Unit::Percent,
-        "Partition processor requests queue utilization, 0 to 100%"
-    );
-
-    describe_gauge!(
-        PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS,
-        Unit::Count,
-        "Number of outstanding requests in the partition processor request queue"
     );
 
     describe_counter!(

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -18,6 +18,7 @@ use std::ops::RangeInclusive;
 use std::time::Duration;
 
 use futures::{StreamExt, TryStreamExt};
+use restate_types::cluster::cluster_state::RunMode;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, instrument, warn};
@@ -35,6 +36,7 @@ use restate_storage_api::invocation_status_table::{
 use restate_storage_api::outbox_table::{OutboxMessage, OutboxTable};
 use restate_storage_api::timer_table::{TimerKey, TimerTable};
 use restate_timer::TokioClock;
+use restate_types::GenerationalNodeId;
 use restate_types::errors::GenericError;
 use restate_types::identifiers::{InvocationId, PartitionKey, PartitionProcessorRpcRequestId};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
@@ -191,6 +193,13 @@ where
         matches!(self.state, State::Leader(_))
     }
 
+    pub fn effective_mode(&self) -> RunMode {
+        match self.state {
+            State::Follower | State::Candidate { .. } => RunMode::Follower,
+            State::Leader(_) => RunMode::Leader,
+        }
+    }
+
     fn is_new_leader_epoch(&self, leader_epoch: LeaderEpoch) -> bool {
         if let Some(max_leader_epoch) = self.state.leader_epoch().or(self.last_seen_leader_epoch) {
             max_leader_epoch < leader_epoch
@@ -254,6 +263,40 @@ where
     pub async fn step_down(&mut self) {
         debug!("Stepping down. Being a role model for Joe.");
         self.become_follower().await
+    }
+
+    pub async fn maybe_step_down(
+        &mut self,
+        new_leader_epoch: LeaderEpoch,
+        new_leader_node: GenerationalNodeId,
+    ) {
+        match &self.state {
+            State::Follower => {}
+            State::Candidate { leader_epoch, .. } => match leader_epoch.cmp(&new_leader_epoch) {
+                Ordering::Less => {
+                    debug!(
+                        "Lost leadership campaign. Conceding to {} at epoch {}",
+                        new_leader_node, new_leader_epoch
+                    );
+                    self.become_follower().await;
+                }
+                Ordering::Equal => { /* nothing do to */ }
+                Ordering::Greater => { /* we are in the future */ }
+            },
+            State::Leader(leader_state) => match leader_state.leader_epoch.cmp(&new_leader_epoch) {
+                Ordering::Less => {
+                    debug!(
+                        my_leadership_epoch = %leader_state.leader_epoch,
+                        %new_leader_epoch,
+                        "Every reign must end. Stepping down and becoming an conceding to {} at epoch {}",
+                        new_leader_node, new_leader_epoch
+                    );
+                    self.become_follower().await;
+                }
+                Ordering::Equal => {}
+                Ordering::Greater => {}
+            },
+        }
     }
 
     #[instrument(level = "debug", skip_all, fields(leader_epoch = %announce_leader.leader_epoch))]

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -87,7 +87,7 @@ use restate_types::partition_table::PartitionTable;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_types::retries::with_jitter;
-use restate_types::{GenerationalNodeId, SharedString, Version};
+use restate_types::{GenerationalNodeId, SharedString};
 
 pub struct PartitionProcessorManager {
     health_status: HealthStatus<WorkerStatus>,
@@ -762,9 +762,9 @@ impl PartitionProcessorManager {
         if control_processor.current_version
             < self
                 .replica_set_states
-                .get_membership_state(partition_id)
-                .map(|m| m.observed_current_membership.version)
-                .unwrap_or(Version::MIN)
+                .membership_state(partition_id)
+                .observed_current_membership
+                .version
         {
             debug!("Ignoring control processor command because it is outdated");
             return;
@@ -1177,8 +1177,8 @@ impl PartitionProcessorManager {
 
         if self
             .replica_set_states
-            .get_membership_state(partition_id)
-            .is_some_and(|m| m.contains(Metadata::with_current(|m| m.my_node_id().as_plain())))
+            .membership_state(partition_id)
+            .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
         {
             self.start_partition_processor(partition_id, delay);
             true
@@ -1217,6 +1217,7 @@ impl PartitionProcessorManager {
             partition_key_range,
             self.updateable_config.clone(),
             self.bifrost.clone(),
+            self.replica_set_states.clone(),
             self.partition_store_manager.clone(),
             self.snapshot_repository.clone(),
             self.fast_forward_on_startup.remove(&partition_id),
@@ -1478,6 +1479,7 @@ mod tests {
             };
             replica_set_states.note_observed_membership(
                 PartitionId::MIN,
+                Default::default(),
                 current_replica_set,
                 &None,
             );

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -28,6 +28,7 @@ use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::live::Live;
 use restate_types::live::LiveLoadExt;
 use restate_types::logs::Lsn;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::schema::Schema;
 
 use crate::PartitionProcessorBuilder;
@@ -43,6 +44,7 @@ pub struct SpawnPartitionProcessorTask {
     key_range: RangeInclusive<PartitionKey>,
     configuration: Live<Configuration>,
     bifrost: Bifrost,
+    replica_set_states: PartitionReplicaSetStates,
     partition_store_manager: PartitionStoreManager,
     snapshot_repository: Option<SnapshotRepository>,
     fast_forward_lsn: Option<Lsn>,
@@ -56,6 +58,7 @@ impl SpawnPartitionProcessorTask {
         key_range: RangeInclusive<PartitionKey>,
         configuration: Live<Configuration>,
         bifrost: Bifrost,
+        replica_set_states: PartitionReplicaSetStates,
         partition_store_manager: PartitionStoreManager,
         snapshot_repository: Option<SnapshotRepository>,
         fast_forward_lsn: Option<Lsn>,
@@ -66,6 +69,7 @@ impl SpawnPartitionProcessorTask {
             key_range,
             configuration,
             bifrost,
+            replica_set_states,
             partition_store_manager,
             snapshot_repository,
             fast_forward_lsn,
@@ -93,6 +97,7 @@ impl SpawnPartitionProcessorTask {
             key_range,
             configuration,
             bifrost,
+            replica_set_states,
             partition_store_manager,
             snapshot_repository,
             fast_forward_lsn,
@@ -167,7 +172,7 @@ impl SpawnPartitionProcessorTask {
                     .map_err(|e| ProcessorError::from(anyhow::anyhow!(e)))?;
 
                     pp_builder
-                        .build(bifrost, partition_store)
+                        .build(bifrost, partition_store, replica_set_states)
                         .await
                         .map_err(ProcessorError::from)?
                         .run()


### PR DESCRIPTION

- RPC utilization as a gauge is useless. A gauge is the wrong type to track fast-moving value like this.
- Added a gauge to report the total number of partitions in partition table.
- Minor: using `with_jitter` instead of custom jitter for PP status reporter
