### PR TITLE
[restatectl] Support --replication

### DIFF
--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -20,6 +20,7 @@ pub const PARTITION_STORAGE_TX_CREATED: &str = "restate.partition.storage_tx_cre
 pub const PARTITION_STORAGE_TX_COMMITTED: &str = "restate.partition.storage_tx_committed.total";
 pub const PARTITION_HANDLE_LEADER_ACTIONS: &str = "restate.partition.handle_leader_action.total";
 
+pub const NUM_PARTITIONS: &str = "restate.num_partitions";
 pub const NUM_ACTIVE_PARTITIONS: &str = "restate.num_active_partitions";
 pub const PARTITION_TIME_SINCE_LAST_STATUS_UPDATE: &str =
     "restate.partition.time_since_last_status_update";
@@ -37,10 +38,6 @@ pub const PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION: &str =
     "restate.partition.handle_action_batch_duration.seconds";
 pub const PARTITION_HANDLE_INVOKER_EFFECT_COMMAND: &str =
     "restate.partition.handle_invoker_effect.seconds";
-pub const PARTITION_RPC_QUEUE_UTILIZATION_PERCENT: &str =
-    "restate.partition.rpc_queue.utilization.percent";
-pub const PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS: &str =
-    "restate.partition.rpc_queue.outstanding_requests";
 pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
     "restate.partition.record_committed_to_read_latency.seconds";
 
@@ -101,6 +98,12 @@ pub(crate) fn describe_metrics() {
     );
 
     describe_gauge!(
+        NUM_PARTITIONS,
+        Unit::Count,
+        "Total number of partitions in the partition table"
+    );
+
+    describe_gauge!(
         NUM_ACTIVE_PARTITIONS,
         Unit::Count,
         "Number of partitions started by partition processor manager on this node"
@@ -146,18 +149,6 @@ pub(crate) fn describe_metrics() {
         PARTITION_TIME_SINCE_LAST_RECORD,
         Unit::Seconds,
         "Number of seconds since the last record was applied"
-    );
-
-    describe_gauge!(
-        PARTITION_RPC_QUEUE_UTILIZATION_PERCENT,
-        Unit::Percent,
-        "Partition processor requests queue utilization, 0 to 100%"
-    );
-
-    describe_gauge!(
-        PARTITION_RPC_QUEUE_OUTSTANDING_REQUESTS,
-        Unit::Count,
-        "Number of outstanding requests in the partition processor request queue"
     );
 
     describe_counter!(

--- a/tools/restatectl/src/commands/config/set.rs
+++ b/tools/restatectl/src/commands/config/set.rs
@@ -11,6 +11,7 @@
 use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
+
 use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_cli_util::{c_println, c_warn};
@@ -27,19 +28,24 @@ use crate::connection::ConnectionInfo;
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "config_set")]
 pub struct ConfigSetOpts {
-    /// Partition replication strategy. If not set places
-    /// partitions replicas on all nodes.
-    /// Accepts `replication property` as a value.
-    #[clap(long)]
-    partition_replication: Option<ReplicationProperty>,
-
-    /// Bifrost provider kind.
-    #[clap(long)]
-    log_provider: Option<ProviderKind>,
+    /// Replication property of logs and partitions.
+    ///
+    /// (mutually exclusive with `log-replication` and/or `partition-replication`)
+    #[clap(short, long, group = "sep1", group = "sep2")]
+    replication: Option<ReplicationProperty>,
 
     /// Replication property of bifrost logs if using replicated as log provider
-    #[clap(long)]
+    #[clap(long, group = "sep1")]
     log_replication: Option<ReplicationProperty>,
+
+    /// Partition replication. If unset, uses
+    /// the default `admin.default-partition-replication`
+    #[clap(long, group = "sep2")]
+    partition_replication: Option<ReplicationProperty>,
+
+    /// Default log provider kind
+    #[clap(long)]
+    log_provider: Option<ProviderKind>,
 
     /// The nodeset size used for replicated log, this is an advanced feature.
     /// It's recommended to leave it unset (defaults to 0)
@@ -50,7 +56,7 @@ pub struct ConfigSetOpts {
     ///
     /// It is only possible to change the number of partitions if the current cluster value is 0.
     /// Otherwise, the set operation will fail.
-    #[clap(long)]
+    #[clap(short, long)]
     num_partitions: Option<u16>,
 }
 
@@ -69,8 +75,18 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
 
     let current_config_string = cluster_config_string(&current)?;
 
-    if let Some(replication_property) = &set_opts.partition_replication {
-        current.partition_replication = Some(replication_property.clone().into());
+    let partition_replication = set_opts
+        .partition_replication
+        .clone()
+        .or(set_opts.replication.clone());
+
+    let log_replication = set_opts
+        .log_replication
+        .clone()
+        .or(set_opts.replication.clone());
+
+    if let Some(replication_property) = partition_replication {
+        current.partition_replication = Some(replication_property.into());
     }
 
     set_opts.log_provider.inspect(|provider| {
@@ -97,7 +113,7 @@ async fn config_set(connection: &ConnectionInfo, set_opts: &ConfigSetOpts) -> an
         bifrost_provider.provider = provider.to_string();
     }
 
-    if let Some(log_replication) = set_opts.log_replication.clone() {
+    if let Some(log_replication) = log_replication {
         bifrost_provider.replication_property = Some(log_replication.into());
     }
 

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -1,5 +1,4 @@
-// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
-// All rights reserved.
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH. All rights reserved.
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
@@ -28,21 +27,27 @@ use crate::util::grpc_channel;
 #[cling(run = "provision_cluster")]
 pub struct ProvisionOpts {
     /// Number of partitions
-    #[clap(long)]
+    #[clap(short, long)]
     num_partitions: Option<u16>,
+
+    /// Replication property of logs and partitions.
+    ///
+    /// (mutually exclusive with `log-replication` and/or `partition-replication`)
+    #[clap(short, long, group = "sep1", group = "sep2")]
+    replication: Option<ReplicationProperty>,
+
+    /// Replication property of bifrost logs if using replicated as log provider
+    #[clap(long, group = "sep1")]
+    log_replication: Option<ReplicationProperty>,
 
     /// Partition replication. If unset, uses
     /// the default `admin.default-partition-replication`
-    #[clap(long)]
+    #[clap(long, group = "sep2")]
     partition_replication: Option<ReplicationProperty>,
 
     /// Default log provider kind
     #[clap(long)]
     log_provider: Option<ProviderKind>,
-
-    /// Replication property of bifrost logs if using replicated as log provider
-    #[clap(long)]
-    log_replication: Option<ReplicationProperty>,
 
     /// The nodeset size used for replicated log, this is an advanced feature.
     /// It's recommended to leave it unset (defaults to 0)
@@ -72,14 +77,26 @@ async fn provision_cluster(
 
     let mut client = new_node_ctl_client(channel);
 
+    let partition_replication = provision_opts
+        .partition_replication
+        .clone()
+        .or(provision_opts.replication.clone())
+        .map(Into::into);
+
+    let log_replication = provision_opts
+        .log_replication
+        .clone()
+        .or(provision_opts.replication.clone())
+        .map(Into::into);
+
     let request = ProvisionClusterRequest {
         dry_run: true,
         num_partitions: provision_opts.num_partitions.map(u32::from),
-        partition_replication: provision_opts.partition_replication.clone().map(Into::into),
+        partition_replication,
         log_provider: provision_opts
             .log_provider
             .map(|provider| provider.to_string()),
-        log_replication: provision_opts.log_replication.clone().map(Into::into),
+        log_replication,
         target_nodeset_size: provision_opts.log_default_nodeset_size.map(Into::into),
     };
 


### PR DESCRIPTION

This adds `--replication` argument to `restatectl config set` and `restatectl provision` commands. This parameter is mutually exlusive with the use of `--log-replication` and `--partition-replication`.

```
// intentionlly empty
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3346).
* __->__ #3346
* #3345