### PR TITLE
Replace snapshot implicit log ids with partition table lookup

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -197,7 +197,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             .map_err(|_| Status::aborted("Node is shutting down"))?
         {
             Err(err) => {
-                info!("Failed creating partition snapshot: {err}");
+                info!("Failed to create partition snapshot: {err}");
                 Err(Status::internal(err.to_string()))
             }
             Ok(Snapshot {

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -14,6 +14,7 @@ use std::ops::RangeInclusive;
 use std::pin::pin;
 
 use futures::Stream;
+use restate_core::TestCoreEnv;
 use tokio_stream::StreamExt;
 
 use crate::{OpenMode, PartitionStore, PartitionStoreManager};
@@ -69,16 +70,16 @@ async fn storage_test_environment_with_manager() -> (PartitionStoreManager, Part
 
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_read_write() {
+    let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
     let (manager, store) = storage_test_environment_with_manager().await;
 
-    //
-    // run the tests
-    //
     inbox_table_test::run_tests(store.clone()).await;
     outbox_table_test::run_tests(store.clone()).await;
     state_table_test::run_tests(store.clone()).await;
     virtual_object_status_table_test::run_tests(store.clone()).await;
     timer_table_test::run_tests(store.clone()).await;
+
     snapshots_test::run_tests(manager.clone(), store.clone()).await;
 }
 

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -45,7 +45,7 @@ pub(crate) async fn run_tests(manager: PartitionStoreManager, mut partition_stor
         created_at: humantime::Timestamp::from(SystemTime::from(MillisSinceEpoch::new(0))),
         snapshot_id: SnapshotId::from_parts(0, 0),
         key_range: key_range.clone(),
-        log_id: Some(LogId::from(partition_id)),
+        log_id: LogId::from(partition_id),
         min_applied_lsn: snapshot.min_applied_lsn,
         db_comparator_name: snapshot.db_comparator_name.clone(),
         files: snapshot.files.clone(),

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -60,18 +60,18 @@ impl LogId {
     pub const fn new(value: u32) -> Self {
         Self(value)
     }
-}
 
-impl From<PartitionId> for LogId {
-    fn from(value: PartitionId) -> Self {
+    /// Use to create an authoritative partition-to-log association. Typically the log id value
+    /// should be read from the partition table.
+    pub fn default_for_partition(value: PartitionId) -> Self {
         LogId(u32::from(*value))
     }
 }
 
-impl From<LogId> for PartitionId {
-    fn from(value: LogId) -> Self {
-        // lower 16 bits represent the partition id
-        PartitionId::from(value.0 as u16)
+#[cfg(any(test, feature = "test-util"))]
+impl From<PartitionId> for LogId {
+    fn from(value: PartitionId) -> Self {
+        LogId(u32::from(*value))
     }
 }
 

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -266,7 +266,7 @@ impl Partition {
 
     pub fn log_id(&self) -> LogId {
         self.log_id
-            .unwrap_or_else(|| LogId::from(self.partition_id))
+            .unwrap_or_else(|| LogId::default_for_partition(self.partition_id))
     }
 
     pub fn db_name(&self) -> DbName {

--- a/crates/worker/src/partition/snapshots/repository.rs
+++ b/crates/worker/src/partition/snapshots/repository.rs
@@ -484,7 +484,7 @@ impl SnapshotRepository {
         );
         Ok(Some(LocalPartitionSnapshot {
             base_dir: snapshot_dir.into_path(),
-            log_id: snapshot_metadata.get_log_id(),
+            log_id: snapshot_metadata.log_id,
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
@@ -919,7 +919,7 @@ mod tests {
             created_at: humantime::Timestamp::from(SystemTime::now()),
             snapshot_id: SnapshotId::new(),
             key_range: PartitionKey::MIN..=PartitionKey::MAX,
-            log_id: Some(LogId::from(PartitionId::MIN)),
+            log_id: LogId::MIN,
             min_applied_lsn: Lsn::new(1),
             db_comparator_name: "leveldb.BytewiseComparator".to_string(),
             // this is totally bogus, but it doesn't matter since we won't be importing it into RocksDB

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -90,7 +90,7 @@ impl SnapshotPartitionTask {
             created_at: humantime::Timestamp::from(created_at),
             snapshot_id: self.snapshot_id,
             key_range: snapshot.key_range.clone(),
-            log_id: Some(snapshot.log_id),
+            log_id: snapshot.log_id,
             min_applied_lsn: snapshot.min_applied_lsn,
             db_comparator_name: snapshot.db_comparator_name.clone(),
             files: snapshot.files.clone(),


### PR DESCRIPTION
Per title, replace `LogId::from(PartitionId)` with partition table log id lookups in the snapshot creation path.