### PR TITLE
Update PartitionRouting to rely in PartitionReplicaSetStates and ClusterState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7730,6 +7730,7 @@ dependencies = [
  "enumset",
  "figment",
  "flexbuffers",
+ "futures",
  "googletest",
  "hostname",
  "http 1.2.0",

--- a/crates/admin/src/cluster_controller/observed_cluster_state.rs
+++ b/crates/admin/src/cluster_controller/observed_cluster_state.rs
@@ -57,7 +57,7 @@ impl ObservedClusterState {
         }
     }
 
-    pub fn update_liveness(&mut self, cs: &restate_core::cluster_state::ClusterState) {
+    pub fn update_liveness(&mut self, cs: &restate_types::cluster_state::ClusterState) {
         let mut unknown_nodes: HashSet<_> = self.nodes_to_partitions.keys().cloned().collect();
 
         for (node_id, state) in cs.all() {
@@ -392,14 +392,14 @@ pub mod tests {
             .collect(),
         };
 
-        let cs = restate_core::cluster_state::ClusterState::default();
+        let cs = restate_types::cluster_state::ClusterState::default();
         let mut updater = cs.clone().updater();
         updater
             .write()
-            .upsert_node_state(node_1, restate_core::cluster_state::NodeState::Alive);
+            .upsert_node_state(node_1, restate_types::cluster_state::NodeState::Alive);
         updater
             .write()
-            .upsert_node_state(node_2, restate_core::cluster_state::NodeState::Alive);
+            .upsert_node_state(node_2, restate_types::cluster_state::NodeState::Alive);
 
         observed_cluster_state.update_liveness(&cs);
         observed_cluster_state.update_partitions(&cluster_state);

--- a/crates/admin/src/cluster_controller/service/state.rs
+++ b/crates/admin/src/cluster_controller/service/state.rs
@@ -54,7 +54,7 @@ where
         &mut self,
         service: &Service<T>,
         nodes_config: &NodesConfiguration,
-        cs: &restate_core::cluster_state::ClusterState,
+        cs: &restate_types::cluster_state::ClusterState,
     ) {
         let maybe_leader = {
             let admin_nodes: Vec<_> = nodes_config

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -13,6 +13,7 @@ mod background_appender;
 mod bifrost;
 mod bifrost_admin;
 mod error;
+mod log_chain_extender;
 pub mod loglet;
 mod loglet_wrapper;
 pub mod providers;

--- a/crates/bifrost/src/log_chain_extender.rs
+++ b/crates/bifrost/src/log_chain_extender.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use tokio::sync::oneshot;
+use tracing::trace;
+
+use restate_core::{ShutdownError, cancellation_token};
+use restate_metadata_store::ReadModifyWriteError;
+use restate_types::logs::builder::LogsBuilder;
+use restate_types::logs::metadata::{LogletParams, Logs, ProviderKind, SegmentIndex};
+use restate_types::logs::{LogId, Lsn};
+
+use crate::Error;
+use crate::bifrost::{BifrostInner, ExtendLogChainReceiver};
+use crate::error::AdminError;
+
+const MAX_BATCH_SIZE_LOG_CHAIN_EXTENSIONS: usize = 128;
+
+pub(super) struct ExtendLogChain {
+    pub log_id: LogId,
+    pub last_segment_index: SegmentIndex,
+    pub base_lsn: Lsn,
+    pub provider: ProviderKind,
+    pub params: LogletParams,
+    pub response_tx: Option<oneshot::Sender<Result<(), Error>>>,
+}
+
+impl ExtendLogChain {
+    fn fail(&mut self, err: Error) {
+        if let Some(response_tx) = self.response_tx.take() {
+            // ignore if the receiver disappeared
+            let _ = response_tx.send(Err(err));
+        }
+    }
+
+    fn complete(&mut self) {
+        if let Some(response_tx) = self.response_tx.take() {
+            // ignore if the receiver disappeared
+            let _ = response_tx.send(Ok(()));
+        }
+    }
+}
+
+/// Component which coalesces multiple log-chain updates into a single [`Logs`] update. It works
+/// by draining all available [`ExtendLogChain`] commands and applying them to the current logs
+/// configuration using a read-modify-write metadata operation. A log chain can only be extended if
+/// the last segment index equals the value specified by the [`ExtendLogChain`] command.
+pub struct LogChainExtender {
+    inner: Arc<BifrostInner>,
+    extend_log_chain_rx: ExtendLogChainReceiver,
+}
+
+impl LogChainExtender {
+    pub fn new(inner: Arc<BifrostInner>, extend_log_chain_rx: ExtendLogChainReceiver) -> Self {
+        Self {
+            inner,
+            extend_log_chain_rx,
+        }
+    }
+
+    pub async fn run(self) -> anyhow::Result<()> {
+        trace!("Bifrost log chain extender started");
+
+        cancellation_token()
+            .run_until_cancelled(self.run_inner())
+            .await
+            .ok_or(ShutdownError)?;
+
+        Ok(())
+    }
+
+    pub async fn run_inner(mut self) {
+        let mut buffer = Vec::new();
+
+        // await the first extend log chain command
+        loop {
+            let received = self
+                .extend_log_chain_rx
+                .recv_many(&mut buffer, MAX_BATCH_SIZE_LOG_CHAIN_EXTENSIONS)
+                .await;
+
+            if received == 0 {
+                break;
+            }
+
+            // batch-apply all collected extend log chain commands
+            match self
+                .inner
+                .metadata_writer
+                .global_metadata()
+                .read_modify_write(|logs: Option<Arc<Logs>>| {
+                    let mut builder = logs
+                        .ok_or(Error::LogsMetadataNotProvisioned)?
+                        .as_ref()
+                        .clone()
+                        .into_builder();
+
+                    for extend_log_chain in &mut buffer {
+                        if let Err(err) = Self::extend_log_chain(
+                            &mut builder,
+                            extend_log_chain.log_id,
+                            extend_log_chain.last_segment_index,
+                            extend_log_chain.base_lsn,
+                            extend_log_chain.provider,
+                            extend_log_chain.params.clone(),
+                        ) {
+                            extend_log_chain.fail(err);
+                        }
+                    }
+                    Ok(builder.build())
+                })
+                .await
+                .map_err(|err: ReadModifyWriteError<Error>| err.transpose())
+            {
+                Ok(_) => {
+                    for mut extend_log_chain in buffer.drain(..) {
+                        extend_log_chain.complete();
+                    }
+                }
+                Err(err) => {
+                    for mut extend_log_chain in buffer.drain(..) {
+                        extend_log_chain.fail(err.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    fn extend_log_chain(
+        builder: &mut LogsBuilder,
+        log_id: LogId,
+        last_segment_index: SegmentIndex,
+        base_lsn: Lsn,
+        provider_kind: ProviderKind,
+        params: LogletParams,
+    ) -> Result<(), Error> {
+        let mut chain_builder = builder.chain(log_id).ok_or(Error::UnknownLogId(log_id))?;
+
+        if chain_builder.tail().index() != last_segment_index {
+            // tail is not what we expected.
+            Err(AdminError::SegmentMismatch {
+                expected: last_segment_index,
+                found: chain_builder.tail().index(),
+            })?;
+        }
+
+        let _ = chain_builder
+            .append_segment(base_lsn, provider_kind, params.clone())
+            .map_err(AdminError::from)?;
+
+        Ok(())
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,7 +16,6 @@
     clippy::mutex_atomic
 )]
 
-pub mod cluster_state;
 mod error;
 mod identification;
 mod metadata;

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -40,7 +40,7 @@ use crate::{ShutdownError, TaskCenter, TaskId, TaskKind};
 
 use self::metadata_client_wrapper::MetadataClientWrapper;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum SyncError {
     #[error("failed syncing with metadata store: {0}")]
     MetadataStore(#[from] Arc<ReadError>),

--- a/crates/core/src/metadata/metadata_client_wrapper.rs
+++ b/crates/core/src/metadata/metadata_client_wrapper.rs
@@ -48,7 +48,7 @@ impl<'a> MetadataClientWrapper<'a> {
             .put(
                 ByteString::from_static(T::KEY),
                 value.as_ref(),
-                precondition.clone(),
+                precondition,
             )
             .await
         {
@@ -121,7 +121,7 @@ impl<'a> MetadataClientWrapper<'a> {
                 Ok(new_value) => match self
                     .writer
                     .metadata_store_client
-                    .put(key.clone(), &new_value, precondition.clone())
+                    .put(key.clone(), &new_value, precondition)
                     .await
                 {
                     Ok(()) => {

--- a/crates/core/src/partitions.rs
+++ b/crates/core/src/partitions.rs
@@ -8,168 +8,69 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::{Debug, Formatter};
-use std::pin::pin;
-use std::sync::Arc;
-
-use ahash::{HashMap, HashMapExt};
-use arc_swap::ArcSwap;
-
-use restate_types::NodeId;
+use crate::TaskCenter;
 use restate_types::identifiers::PartitionId;
-use restate_types::net::metadata::MetadataKind;
-use restate_types::partition_table::PartitionTable;
-use tracing::debug;
+use restate_types::partitions::state::PartitionReplicaSetStates;
+use restate_types::{GenerationalNodeId, NodeId};
 
-use crate::{Metadata, ShutdownError, TaskCenter, TaskId, TaskKind, cancellation_watcher};
-
-/// Discover cluster nodes for a given partition. Compared to the partition table, this view is more
-/// dynamic as it changes based on cluster nodes' operational status. Can be cheaply cloned.
+/// Discover cluster nodes for a given partition based on the [`PartitionReplicaSetStates`] and the
+/// [`ClusterState`].
 #[derive(Clone)]
 pub struct PartitionRouting {
-    /// A mapping of partition IDs to node IDs that are believed to be authoritative for that serving requests.
-    partition_to_node_mappings: Arc<ArcSwap<PartitionToNodesRoutingTable>>,
+    partition_replica_set_states: PartitionReplicaSetStates,
 }
 
 impl PartitionRouting {
+    pub fn new(partition_replica_set_states: PartitionReplicaSetStates) -> Self {
+        Self {
+            partition_replica_set_states,
+        }
+    }
+
     /// Look up a suitable node to process requests for a given partition. Answers are authoritative
     /// though subject to propagation delays through the cluster in distributed deployments.
     /// Generally, as a consumer of routing information, your options are limited to backing off and
     /// retrying the request, or returning an error upstream when information is not available.
     ///
-    /// A `None` response indicates that either we have no knowledge about this partition, or that
-    /// the routing table has not yet been refreshed for the cluster.
+    /// A `None` response indicates that we have no knowledge about this partition.
     pub fn get_node_by_partition(&self, partition_id: PartitionId) -> Option<NodeId> {
-        self.partition_to_node_mappings
-            .load()
-            .inner
-            .get(&partition_id)
-            .cloned()
-    }
-}
+        let membership = self
+            .partition_replica_set_states
+            .membership_state(partition_id);
 
-impl Debug for PartitionRouting {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str("PartitionNodeResolver(")?;
-        self.partition_to_node_mappings.load().fmt(f)?;
-        f.write_str(")")
-    }
-}
-
-#[derive(Debug)]
-struct PartitionToNodesRoutingTable {
-    /// A mapping of partition IDs to node IDs that are believed to be authoritative for that
-    /// serving requests for that partition.
-    inner: HashMap<PartitionId, NodeId>,
-}
-impl PartitionToNodesRoutingTable {
-    fn new(partition_table: &PartitionTable) -> Self {
-        let mut inner = HashMap::<PartitionId, NodeId>::with_capacity(
-            partition_table.num_partitions() as usize,
-        );
-        for (partition_id, partition) in partition_table.iter() {
-            if let Some(leader) = partition.placement.leader() {
-                inner.insert(*partition_id, leader.into());
-            }
+        // if we know about a leader, then return it
+        if membership.current_leader().current_leader != GenerationalNodeId::INVALID {
+            return Some(NodeId::from(membership.current_leader().current_leader));
         }
 
-        Self { inner }
+        // otherwise, overlay the current configuration with the cluster state and take the first
+        // node alive
+        TaskCenter::with_current(|handle| membership.first_alive_node(handle.cluster_state()))
     }
-}
-
-/// Task to refresh the routing information, periodically or on-demand. A single
-/// instance of this component per node ensures that we don't get a stampeding
-/// herd of queries to the source of truth.
-//
-// Implementation note: the sole authority for node-level routing is currently the metadata store,
-// and in particular, the cluster scheduling plan. This will change in the future so avoid leaking
-// implementation details or assumptions about the source of truth.
-pub struct PartitionRoutingRefresher {
-    inner: Arc<ArcSwap<PartitionToNodesRoutingTable>>,
-}
-
-impl Default for PartitionRoutingRefresher {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartitionRoutingRefresher {
-    fn new() -> Self {
-        Self {
-            inner: Arc::new(ArcSwap::new(Arc::new(PartitionToNodesRoutingTable {
-                inner: HashMap::default(),
-            }))),
-        }
-    }
-
-    /// Get a handle to the partition-to-node routing table.
-    pub fn partition_routing(&self) -> PartitionRouting {
-        PartitionRouting {
-            partition_to_node_mappings: self.inner.clone(),
-        }
-    }
-
-    async fn run(self) -> anyhow::Result<()> {
-        debug!("Routing information refresher started");
-
-        let mut cancel = pin!(cancellation_watcher());
-        let (mut partition_table_watch, mut live_partition_table) =
-            Metadata::with_current(|metadata| {
-                (
-                    metadata.watch(MetadataKind::PartitionTable),
-                    metadata.updateable_partition_table(),
-                )
-            });
-        loop {
-            tokio::select! {
-                _ = &mut cancel => {
-                    break;
-                }
-                _ = partition_table_watch.changed() => {
-                    let partition_table = live_partition_table.live_load();
-                    debug!("Refreshing routing information based on partition table {}...", partition_table.version());
-                    let routing = PartitionToNodesRoutingTable::new(partition_table);
-                    self.inner.store(Arc::new(routing));
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-pub fn spawn_partition_routing_refresher(
-    partition_routing_refresher: PartitionRoutingRefresher,
-) -> Result<TaskId, ShutdownError> {
-    TaskCenter::spawn(
-        TaskKind::MetadataBackgroundSync,
-        "partition-routing-refresher",
-        partition_routing_refresher.run(),
-    )
 }
 
 #[cfg(any(test, feature = "test-util"))]
 pub mod mocks {
-    use std::collections::HashMap;
-    use std::sync::Arc;
-
-    use arc_swap::ArcSwap;
-
     use crate::partitions::PartitionRouting;
-    use restate_types::identifiers::PartitionId;
-    use restate_types::{GenerationalNodeId, NodeId};
+    use restate_types::GenerationalNodeId;
+    use restate_types::identifiers::{LeaderEpoch, PartitionId};
+    use restate_types::partitions::state::{LeadershipState, PartitionReplicaSetStates};
 
     pub fn fixed_single_node(
         node_id: GenerationalNodeId,
         partition_id: PartitionId,
     ) -> PartitionRouting {
-        let mut mappings = HashMap::default();
-        mappings.insert(partition_id, NodeId::Generational(node_id));
+        let partition_replica_set_states = PartitionReplicaSetStates::default();
+        partition_replica_set_states.note_observed_leader(
+            partition_id,
+            LeadershipState {
+                current_leader: node_id,
+                current_leader_epoch: LeaderEpoch::INITIAL,
+            },
+        );
 
         PartitionRouting {
-            partition_to_node_mappings: Arc::new(ArcSwap::new(Arc::new(
-                super::PartitionToNodesRoutingTable { inner: mappings },
-            ))),
+            partition_replica_set_states,
         }
     }
 }

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -40,14 +40,13 @@ use tokio::task_local;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::metric_definitions::{self, STATUS_COMPLETED, STATUS_FAILED, TC_FINISHED, TC_SPAWN};
+use crate::{Metadata, ShutdownError, ShutdownSourceErr};
 use restate_types::SharedString;
+use restate_types::cluster_state::ClusterState;
 use restate_types::health::{Health, NodeStatus};
 use restate_types::identifiers::PartitionId;
 use restate_types::{GenerationalNodeId, NodeId};
-
-use crate::cluster_state::ClusterState;
-use crate::metric_definitions::{self, STATUS_COMPLETED, STATUS_FAILED, TC_FINISHED, TC_SPAWN};
-use crate::{Metadata, ShutdownError, ShutdownSourceErr};
 
 const EXIT_CODE_FAILURE: i32 = 1;
 

--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -17,10 +17,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use restate_types::SharedString;
+use restate_types::cluster_state::{ClusterState, ClusterStateUpdater};
 use restate_types::health::{Health, NodeStatus};
 use restate_types::identifiers::PartitionId;
 
-use crate::cluster_state::{ClusterState, ClusterStateUpdater};
 use crate::{Metadata, ShutdownError};
 
 use super::{

--- a/crates/metadata-providers/src/replicated.rs
+++ b/crates/metadata-providers/src/replicated.rs
@@ -289,7 +289,7 @@ impl MetadataStore for GrpcMetadataServerClient {
                 .put(PutRequest {
                     key: key.clone().into(),
                     value: Some(value.clone().into()),
-                    precondition: Some(precondition.clone().into()),
+                    precondition: Some(precondition.into()),
                 })
                 .await
             {
@@ -325,7 +325,7 @@ impl MetadataStore for GrpcMetadataServerClient {
             return match client
                 .delete(DeleteRequest {
                     key: key.clone().into(),
-                    precondition: Some(precondition.clone().into()),
+                    precondition: Some(precondition.into()),
                 })
                 .await
             {

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -410,6 +410,20 @@ struct WriteRequest {
 }
 
 impl WriteRequest {
+    fn key(&self) -> &ByteString {
+        match &self.kind {
+            RequestKind::Put { key, .. } => key,
+            RequestKind::Delete { key, .. } => key,
+        }
+    }
+
+    fn precondition(&self) -> Precondition {
+        match &self.kind {
+            RequestKind::Put { precondition, .. } => *precondition,
+            RequestKind::Delete { precondition, .. } => *precondition,
+        }
+    }
+
     fn encode_to_vec(self) -> Result<Vec<u8>, StorageEncodeError> {
         let request = protobuf::WriteRequest::from(self);
         Ok(request.encode_to_vec())

--- a/crates/metadata-server/src/local/tests.rs
+++ b/crates/metadata-server/src/local/tests.rs
@@ -106,6 +106,7 @@ async fn basic_metadata_store_operations() -> anyhow::Result<()> {
     client
         .put(key.clone(), &other_value, Precondition::None)
         .await?;
+
     client.delete(key.clone(), Precondition::None).await?;
     assert!(client.get::<Value>(key.clone()).await?.is_none());
 

--- a/crates/metadata-server/src/raft/kv_memory_storage.rs
+++ b/crates/metadata-server/src/raft/kv_memory_storage.rs
@@ -111,7 +111,7 @@ impl KvMemoryStorage {
                     let _ = result_tx.send(Ok(result));
                 }
                 ReadOnlyRequestKind::GetVersion { key, result_tx } => {
-                    let result = self.get_version(key);
+                    let result = self.get_version(&key);
                     // err if caller has gone
                     let _ = result_tx.send(Ok(result));
                 }
@@ -121,12 +121,16 @@ impl KvMemoryStorage {
         }
     }
 
+    pub fn contains(&self, key: &str) -> bool {
+        self.kv_entries.contains_key(key)
+    }
+
     pub fn get(&self, key: ByteString) -> Option<VersionedValue> {
         self.kv_entries.get(&key).cloned()
     }
 
-    pub fn get_version(&self, key: ByteString) -> Option<Version> {
-        self.kv_entries.get(&key).map(|entry| entry.version)
+    pub fn get_version(&self, key: &ByteString) -> Option<Version> {
+        self.kv_entries.get(key).map(|entry| entry.version)
     }
 
     pub fn put(

--- a/crates/metadata-store/src/metadata_store.rs
+++ b/crates/metadata-store/src/metadata_store.rs
@@ -371,6 +371,13 @@ impl MetadataStoreClient {
 
     /// Deletes the key-value pair for the given key following the provided precondition. If the
     /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
+    ///
+    /// # Important
+    /// Parts of the system expect that the version of versioned values increases monotonically
+    /// (e.g. the metadata manager when exchanging metadata information, the raft server when
+    /// rejecting write requests early). Therefore, you should only delete key-value pairs if you
+    /// are certain that these values won't be used in the future ever again!
+    #[cfg(any(test, feature = "test-util"))]
     pub async fn delete(
         &self,
         key: ByteString,

--- a/crates/node/src/failure_detector/fd_state.rs
+++ b/crates/node/src/failure_detector/fd_state.rs
@@ -15,8 +15,8 @@ use rand::seq::{IteratorRandom, SliceRandom};
 use tokio::time::Instant;
 use tracing::{debug, error, warn};
 
-use restate_core::cluster_state::ClusterStateUpdater;
 use restate_core::network::{ConnectThrottle, NetworkSender};
+use restate_types::cluster_state::ClusterStateUpdater;
 use restate_types::config::GossipOptions;
 use restate_types::identifiers::PartitionId;
 use restate_types::net::node::{ClusterStateReply, Gossip, GossipFlags};

--- a/crates/node/src/failure_detector/node_state.rs
+++ b/crates/node/src/failure_detector/node_state.rs
@@ -82,13 +82,13 @@ impl Display for NodeState {
     }
 }
 
-impl From<NodeState> for restate_core::cluster_state::NodeState {
+impl From<NodeState> for restate_types::cluster_state::NodeState {
     fn from(state: NodeState) -> Self {
         match state {
-            NodeState::Dead => restate_core::cluster_state::NodeState::Dead,
-            NodeState::Alive => restate_core::cluster_state::NodeState::Alive,
-            NodeState::Suspect { .. } => restate_core::cluster_state::NodeState::Dead,
-            NodeState::FailingOver => restate_core::cluster_state::NodeState::FailingOver,
+            NodeState::Dead => restate_types::cluster_state::NodeState::Dead,
+            NodeState::Alive => restate_types::cluster_state::NodeState::Alive,
+            NodeState::Suspect { .. } => restate_types::cluster_state::NodeState::Dead,
+            NodeState::FailingOver => restate_types::cluster_state::NodeState::FailingOver,
         }
     }
 }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -215,7 +215,7 @@ where
 }
 
 pub struct ClusterTables {
-    cluster_state: restate_core::cluster_state::ClusterState,
+    cluster_state: restate_types::cluster_state::ClusterState,
     replica_set_states: PartitionReplicaSetStates,
     cluster_state_watch: watch::Receiver<Arc<ClusterState>>,
 }

--- a/crates/storage-query-datafusion/src/node/row.rs
+++ b/crates/storage-query-datafusion/src/node/row.rs
@@ -10,14 +10,13 @@
 
 use enumset::EnumSet;
 
-use restate_core::cluster_state::NodeState;
+use super::schema::NodeBuilder;
+use crate::table_util::format_using;
+use restate_types::cluster_state::NodeState;
 use restate_types::{
     PlainNodeId, Version,
     nodes_config::{NodeConfig, Role},
 };
-
-use super::schema::NodeBuilder;
-use crate::table_util::format_using;
 
 pub(crate) fn append_node_row(
     builder: &mut NodeBuilder,

--- a/crates/storage-query-datafusion/src/node/table.rs
+++ b/crates/storage-query-datafusion/src/node/table.rs
@@ -18,7 +18,7 @@ use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 use tokio::sync::mpsc::Sender;
 
 use restate_core::Metadata;
-use restate_core::cluster_state::ClusterState;
+use restate_types::cluster_state::ClusterState;
 use restate_types::nodes_config::NodesConfiguration;
 
 use crate::context::QueryContext;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -96,6 +96,7 @@ restate-types = {path = ".", default-features = false, features = ["test-util"]}
 restate-test-util = { workspace = true }
 
 criterion = { workspace = true, features = ["async_tokio"] }
+futures = { workspace = true }
 tempfile = { workspace = true }
 googletest = { workspace = true }
 rand = { workspace = true }

--- a/crates/types/src/cluster_state.rs
+++ b/crates/types/src/cluster_state.rs
@@ -17,8 +17,8 @@ use tokio::sync::Notify;
 use tokio::sync::futures::Notified;
 use tokio::sync::watch;
 
-pub use restate_types::net::node::NodeState;
-use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
+pub use crate::net::node::NodeState;
+use crate::{GenerationalNodeId, NodeId, PlainNodeId};
 
 type Generation = u32;
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -18,6 +18,8 @@ mod version;
 
 pub mod art;
 pub mod cluster;
+
+pub mod cluster_state;
 pub mod health;
 
 pub mod config;

--- a/crates/types/src/metadata.rs
+++ b/crates/types/src/metadata.rs
@@ -43,7 +43,7 @@ impl VersionedValue {
 flexbuffers_storage_encode_decode!(VersionedValue);
 
 /// Preconditions for the write operations of the [`MetadataStore`].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, derive_more::Display)]
 pub enum Precondition {
     /// No precondition
     None,

--- a/crates/types/src/replication/nodeset.rs
+++ b/crates/types/src/replication/nodeset.rs
@@ -64,10 +64,6 @@ impl NodeSet {
         self.0.len()
     }
 
-    pub(crate) fn insert_at_first(&mut self, node_id: PlainNodeId) {
-        self.0.insert_before(0, node_id);
-    }
-
     /// First element in the set
     pub fn first(&self) -> Option<PlainNodeId> {
         self.0.first().copied()


### PR DESCRIPTION
This commit updates the PartitionRouting to use the PartitionReplicaSetStates and ClusterState
to find the current leader. Additionally, it stops the Scheduler from updating the PartitionTable's
PartitionPlacement on every leader change.

The PartitionPlacement in the PartitionTable is replaced by the PartitionReplicaSetStates
and the ClusterState. Therefore, we can remove the PartitionPlacement which was an optional
field in the PartitionTable anyway.

This PR is based on #3352, #3348  and #3351.