### PR TITLE
Adds support for partition_replica_set cluster table

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -239,6 +239,12 @@ impl RegisterTable for ClusterTables {
         let metadata = Metadata::current();
         crate::node::register_self(ctx, metadata.clone(), self.cluster_state.clone())?;
         crate::partition::register_self(ctx, metadata.clone(), self.replica_set_states.clone())?;
+        crate::partition_replica_set::register_self(
+            ctx,
+            metadata.clone(),
+            self.cluster_state.clone(),
+            self.replica_set_states.clone(),
+        )?;
         crate::log::register_self(ctx, metadata)?;
         crate::partition_state::register_self(ctx, self.cluster_state_watch.clone())?;
 

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -23,6 +23,7 @@ mod keyed_service_status;
 mod log;
 mod node;
 mod partition;
+mod partition_replica_set;
 mod partition_state;
 mod partition_store_scanner;
 mod physical_optimizer;

--- a/crates/storage-query-datafusion/src/partition_replica_set/mod.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub use table::register_self;

--- a/crates/storage-query-datafusion/src/partition_replica_set/row.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/row.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_types::cluster_state::ClusterState;
+use restate_types::logs::{Lsn, SequenceNumber};
+use restate_types::partitions::state::{MemberState, MembershipState};
+use restate_types::{Version, partition_table::Partition};
+
+use super::schema::PartitionReplicaSetBuilder;
+use crate::table_util::format_using;
+
+pub(crate) fn append_replica_set_row(
+    builder: &mut PartitionReplicaSetBuilder,
+    output: &mut String,
+    membership: MembershipState,
+    cluster_state: &ClusterState,
+    partition: &Partition,
+) {
+    let leadership = membership.current_leader();
+
+    let mut build_row = |members: Vec<MemberState>, version: Version, membership: &str| {
+        for member in members {
+            let mut row = builder.row();
+            row.membership(membership);
+            row.membership_version(version.into());
+            row.partition_id(partition.partition_id.into());
+            if member.durable_lsn != Lsn::INVALID {
+                row.durable_lsn(member.durable_lsn.into());
+            }
+            row.plain_node_id(format_using(output, &member.node_id));
+
+            if let Some((gen_node_id, node_state)) =
+                cluster_state.get_node_state_and_generation(member.node_id)
+            {
+                if node_state.is_alive() {
+                    row.alive_gen_node_id(format_using(output, &gen_node_id));
+                }
+                if leadership.current_leader == gen_node_id {
+                    row.is_leader(true);
+                    row.leader_epoch(format_using(output, &leadership.current_leader_epoch));
+                }
+            }
+        }
+    };
+
+    build_row(
+        membership.observed_current_membership.members,
+        membership.observed_current_membership.version,
+        "current",
+    );
+    if let Some(next_membership) = membership.observed_next_membership {
+        build_row(next_membership.members, next_membership.version, "next");
+    }
+}

--- a/crates/storage-query-datafusion/src/partition_replica_set/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/schema.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
+
+define_table!(
+    /// Partition ReplicaSet table
+    partition_replica_set(
+        // Partition ID
+        partition_id: DataType::UInt32,
+
+        // The partition leader plain node id acquired from gossip
+        plain_node_id: DataType::Utf8,
+
+        // If the node is alive, this will have the generational node id
+        alive_gen_node_id: DataType::Utf8,
+
+        // Is this believed to be the current leader of the partition?
+        is_leader: DataType::Boolean,
+
+        // The observed membership version from gossip
+        // this can be either the current or next depending on the value of `membership`
+        membership_version: DataType::UInt32,
+
+        /// This can be either `current` or `next`.
+        membership: DataType::Utf8,
+
+        /// If this is the leader, what is the current leader epoch?
+        leader_epoch: DataType::Utf8,
+
+        /// Durable log LSN if reported via gossip
+        durable_lsn: DataType::UInt64,
+    )
+);

--- a/crates/storage-query-datafusion/src/partition_replica_set/table.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/table.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchReceiverStream;
+use tokio::sync::mpsc::Sender;
+
+use restate_core::Metadata;
+use restate_types::cluster_state::ClusterState;
+use restate_types::partition_table::PartitionTable;
+use restate_types::partitions::state::PartitionReplicaSetStates;
+
+use crate::context::QueryContext;
+use crate::table_providers::{GenericTableProvider, Scan};
+use crate::table_util::Builder;
+
+use super::row::append_replica_set_row;
+use super::schema::PartitionReplicaSetBuilder;
+
+pub fn register_self(
+    ctx: &QueryContext,
+    metadata: Metadata,
+    cluster_state: ClusterState,
+    replica_set_states: PartitionReplicaSetStates,
+) -> datafusion::common::Result<()> {
+    let replica_set_table = GenericTableProvider::new(
+        PartitionReplicaSetBuilder::schema(),
+        Arc::new(ReplicaSetScanner {
+            metadata,
+            replica_set_states,
+            cluster_state,
+        }),
+    );
+    ctx.register_non_partitioned_table("partition_replica_set", Arc::new(replica_set_table))
+}
+
+#[derive(Clone, derive_more::Debug)]
+#[debug("ReplicaSetScanner")]
+struct ReplicaSetScanner {
+    metadata: Metadata,
+    replica_set_states: PartitionReplicaSetStates,
+    cluster_state: ClusterState,
+}
+
+impl Scan for ReplicaSetScanner {
+    fn scan(
+        &self,
+        projection: SchemaRef,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> SendableRecordBatchStream {
+        let schema = projection.clone();
+        let partition_table = self.metadata.partition_table_snapshot();
+
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let tx = stream_builder.tx();
+
+        let cluster_state = self.cluster_state.clone();
+        let replica_set_states = self.replica_set_states.clone();
+        stream_builder.spawn(async move {
+            for_each_partition(
+                schema,
+                tx,
+                partition_table,
+                cluster_state,
+                replica_set_states,
+            )
+            .await;
+            Ok(())
+        });
+        stream_builder.build()
+    }
+}
+
+async fn for_each_partition(
+    schema: SchemaRef,
+    tx: Sender<datafusion::common::Result<RecordBatch>>,
+    partition_table: Arc<PartitionTable>,
+    cluster_state: ClusterState,
+    replica_set_states: PartitionReplicaSetStates,
+) {
+    let mut builder = PartitionReplicaSetBuilder::new(schema.clone());
+
+    let mut output = String::new();
+    for (_, partition) in partition_table.iter() {
+        let membership = replica_set_states.membership_state(partition.partition_id);
+        append_replica_set_row(
+            &mut builder,
+            &mut output,
+            membership,
+            &cluster_state,
+            partition,
+        );
+
+        if builder.full() {
+            let batch = builder.finish();
+            if tx.send(batch).await.is_err() {
+                // not sure what to do here?
+                // the other side has hung up on us.
+                // we probably don't want to panic, is it will cause the entire process to exit
+                return;
+            }
+            builder = PartitionReplicaSetBuilder::new(schema.clone());
+        }
+    }
+
+    if !builder.empty() {
+        let result = builder.finish();
+        let _ = tx.send(result).await;
+    }
+}

--- a/crates/types/src/cluster_state.rs
+++ b/crates/types/src/cluster_state.rs
@@ -212,6 +212,19 @@ impl ClusterState {
         }
     }
 
+    /// Returns the current state of the node along with its generation
+    pub fn get_node_state_and_generation(
+        &self,
+        node_id: PlainNodeId,
+    ) -> Option<(GenerationalNodeId, NodeState)> {
+        let current = self.inner.nodes.read().get(&node_id).map(|n| *n.borrow())?;
+        if current.generation == 0 {
+            return None;
+        }
+
+        Some((node_id.with_generation(current.generation), current.state))
+    }
+
     /// Consumes the input iterator and returns the node state for each node in the same order
     ///
     ///

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -176,6 +176,17 @@ where
                 esn.leader_epoch
             });
 
+        if let Some(last_leader_epoch) = last_seen_leader_epoch {
+            replica_set_states.note_observed_leader(
+                partition_id,
+                restate_types::partitions::state::LeadershipState {
+                    current_leader_epoch: last_leader_epoch,
+                    // we don't know the old leader node-id, another node might update it
+                    current_leader: GenerationalNodeId::INVALID,
+                },
+            );
+        }
+
         let leadership_state = LeadershipState::new(
             PartitionProcessorMetadata::new(partition_id, partition_key_range.clone()),
             num_timers_in_memory_limit,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -714,6 +714,17 @@ impl PartitionProcessorManager {
                 status.last_persisted_log_lsn = self.partition_store_manager.get_durable_lsn(*partition_id);
                 status.last_archived_log_lsn = self.archived_lsns.get(partition_id).cloned();
 
+                // todo: this will need to be moved to a place where PPM updates it regularly, or
+                // to be directly integrated into durable lsn tracking so we update it immediately
+                // after flush.
+                if let Some(durable_lsn) = status.last_persisted_log_lsn {
+                    self.replica_set_states.note_durable_lsn(
+                        *partition_id,
+                        my_node_id().as_plain(),
+                        durable_lsn,
+                    );
+                }
+
                 let current_tail_lsn = self.target_tail_lsns.get(partition_id).cloned();
 
                 let target_tail_lsn = if current_tail_lsn > status.target_tail_lsn {


### PR DESCRIPTION

This introduces a new cluster table `partition_replica_set` that can be used to view the max observed current and next configuration through gossip.

Additionally, this introduces basic support of integrating gossip's `durable_lsn` with PPM.

```
// intentionally empty
```
