### PR TITLE
bilrost 0.1013 is released 😌

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "bilrost"
-version = "0.1013.0-rc.4"
+version = "0.1013.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8e7a9f7362e2e380c13b6df94f81576c32c7b5d25e608f6279232e8f0aee76"
+checksum = "640b021fedf44f44640771b2c3e5ec53ff0122d89b3fd1448e6880da0ace787b"
 dependencies = [
  "bilrost-derive",
  "bytes",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "bilrost-derive"
-version = "0.1013.0-rc.4"
+version = "0.1013.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f1ceb0a2d313f690ef55bfd857d257bf9df859b2db08d2c1e690a10eaf449a"
+checksum = "e9910598cd6a5c5ee053af712bbb3385e96b4eb4adc043b24a69b6c37004ba22"
 dependencies = [
  "eyre",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ aws-smithy-async = {version = "1.2.5", default-features = false}
 aws-smithy-runtime-api = "1.7.4"
 aws-smithy-types = "1.3.0"
 base64 = "0.22"
-bilrost = { version = "0.1013.0-rc.4" }
+bilrost = { version = "0.1013" }
 bincode = { version = "2.0.1", default-features = false }
 bitflags = { version = "2.6.0" }
 bytes = { version = "1.7", features = ["serde"] }

--- a/crates/encoding/src/bilrost_encodings/display_from_str.rs
+++ b/crates/encoding/src/bilrost_encodings/display_from_str.rs
@@ -37,10 +37,6 @@ macro_rules! bilrost_as_display_from_str {
         {
             type Proxy = ::std::string::String;
 
-            fn new_proxy() -> ::std::string::String {
-                ::std::string::String::new()
-            }
-
             fn encode_proxy(&self) -> ::std::string::String {
                 self.to_string()
             }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -31,7 +31,7 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
-bilrost = { version = "0.1013.0-rc.4", features = ["bytestring"] }
+bilrost = { version = "0.1013", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 bytestring = { version = "1", default-features = false, features = ["serde"] }
@@ -150,7 +150,7 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "htt
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
-bilrost = { version = "0.1013.0-rc.4", features = ["bytestring"] }
+bilrost = { version = "0.1013", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 bytestring = { version = "1", default-features = false, features = ["serde"] }


### PR DESCRIPTION
the only functional change since rc.4 is the removal of `Proxiable::new_proxy` in lieu of using `ForOverwrite` in the destination encoding, which should pretty much always exist already.