### PR TITLE
Implement a custom encoder for 3rd party types

### DIFF
--- a/crates/encoding/src/bilrost_encodings/mod.rs
+++ b/crates/encoding/src/bilrost_encodings/mod.rs
@@ -11,6 +11,23 @@
 //! Defines messages between replicated loglet instances
 
 mod arc_encodings;
+mod nonzero;
+mod range;
+
 pub mod display_from_str;
 
 pub use arc_encodings::{Arced, ArcedSlice};
+
+/// The encoding used for all 3rd party types in the `bilrost_encoding` crate.
+///
+/// example:
+/// ```ignore
+/// #[derive(bilrost::Message)]
+/// struct MyMessage {
+///     #[bilrost(tag(1), encoding(RestateEncoding))]
+///     range: RangeInclusive<u64>,
+/// }
+pub struct RestateEncoding;
+
+bilrost::encoding_implemented_via_value_encoding!(RestateEncoding);
+bilrost::implement_core_empty_state_rules!(RestateEncoding);

--- a/crates/encoding/src/bilrost_encodings/nonzero.rs
+++ b/crates/encoding/src/bilrost_encodings/nonzero.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::num::NonZero;
+
+use bilrost::{
+    DecodeErrorKind,
+    encoding::{ForOverwrite, Proxiable},
+};
+
+use crate::bilrost_encodings::RestateEncoding;
+
+struct NonZeroTag;
+
+macro_rules! impl_nonzero_encoding {
+
+    ($ty:ty) => {
+        impl Proxiable<NonZeroTag> for NonZero<$ty> {
+            type Proxy = $ty;
+            fn encode_proxy(&self) -> Self::Proxy {
+                self.get()
+            }
+
+            fn decode_proxy(&mut self, proxy: Self::Proxy) -> Result<(), DecodeErrorKind> {
+                let v = NonZero::new(proxy).ok_or(DecodeErrorKind::InvalidValue)?;
+                *self = v;
+                Ok(())
+            }
+        }
+
+        impl ForOverwrite<RestateEncoding, NonZero<$ty>> for () {
+            fn for_overwrite() -> NonZero<$ty> {
+                // This function is called by the decoder to get a "zero" value of this type (NonZero<T> in this case)
+                // that then immediately gets overridden by the `decoder_proxy`
+                // But we can't get a `NonZero<T>` with a value of 0, so we use 1 instead.
+                // so we can use any value here. The compiler will optimize it out.
+                //
+                // For more details see https://github.com/restatedev/restate/pull/3359#discussion_r2132719080
+                NonZero::new(1).unwrap()
+            }
+        }
+
+
+        bilrost::delegate_proxied_encoding!(
+            use encoding (bilrost::encoding::General)
+            to encode proxied type (NonZero<$ty>) using proxy tag (NonZeroTag)
+            with encoding (RestateEncoding)
+        );
+    };
+    ($($ty:ty),+) => {
+        $(impl_nonzero_encoding!($ty);)+
+    };
+}
+
+impl_nonzero_encoding!(u64, u32, u16, usize);
+
+#[cfg(test)]
+mod test {
+
+    use std::num::NonZeroU64;
+
+    use bytes::Bytes;
+
+    use super::*;
+
+    #[derive(bilrost::Message)]
+    struct NonZeroMessage {
+        #[bilrost(tag(1), encoding(RestateEncoding))]
+        inner: Option<NonZero<u64>>,
+    }
+
+    #[test]
+    fn test_range_encoding() {
+        let message = NonZeroMessage {
+            inner: Some(NonZeroU64::new(10).unwrap()),
+        };
+        let encoded = <NonZeroMessage as bilrost::Message>::encode_to_vec(&message);
+
+        let decoded =
+            <NonZeroMessage as bilrost::OwnedMessage>::decode(Bytes::from(encoded)).unwrap();
+        assert_eq!(message.inner, decoded.inner);
+    }
+}

--- a/crates/encoding/src/bilrost_encodings/range.rs
+++ b/crates/encoding/src/bilrost_encodings/range.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::ops::RangeInclusive;
+
+use bilrost::{
+    DecodeErrorKind,
+    encoding::{EmptyState, ForOverwrite, Proxiable},
+};
+
+use crate::bilrost_encodings::RestateEncoding;
+
+struct RangeTag;
+
+impl<T> Proxiable<RangeTag> for RangeInclusive<T>
+where
+    T: Default + Copy,
+{
+    type Proxy = (T, T);
+
+    fn encode_proxy(&self) -> Self::Proxy {
+        (*self.start(), *self.end())
+    }
+
+    fn decode_proxy(&mut self, proxy: Self::Proxy) -> Result<(), DecodeErrorKind> {
+        *self = proxy.0..=proxy.1;
+        Ok(())
+    }
+}
+
+impl<T> ForOverwrite<RestateEncoding, RangeInclusive<T>> for ()
+where
+    T: Default,
+{
+    fn for_overwrite() -> RangeInclusive<T> {
+        T::default()..=T::default()
+    }
+}
+
+impl<T> EmptyState<RestateEncoding, RangeInclusive<T>> for ()
+where
+    T: Default + Copy + PartialEq<T>,
+{
+    fn empty() -> RangeInclusive<T> {
+        T::default()..=T::default()
+    }
+
+    fn is_empty(val: &RangeInclusive<T>) -> bool {
+        let empty = T::default();
+        *val.start() == empty && *val.end() == empty
+    }
+
+    fn clear(val: &mut RangeInclusive<T>) {
+        *val = Self::empty();
+    }
+}
+
+bilrost::delegate_proxied_encoding!(
+    use encoding (::bilrost::encoding::General)
+    to encode proxied type (RangeInclusive<u64>)
+    using proxy tag (RangeTag)
+    with encoding (RestateEncoding)
+);

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -19,7 +19,7 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 pub use bilrost_as::BilrostAsAdaptor;
-pub use bilrost_encodings::{Arced, ArcedSlice};
+pub use bilrost_encodings::{Arced, ArcedSlice, RestateEncoding};
 pub use common::U128;
 pub use restate_encoding_derive::{BilrostAs, BilrostNewType, NetSerde};
 /// A marker trait for types that can be serialized and sent over the network.


### PR DESCRIPTION
Implement a custom encoder for 3rd party types

Summary:
This is uses the latest release of bilrost to support
implemented a proxied custom encoding for some common types

The list of supported types here will probably grow in the future
but these meant to cover a good example and starting point to
implement more.
