### PR TITLE
SequencerStatus refactor

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -137,7 +137,7 @@ impl<T: TransportConnect> FindTailTask<T> {
                 )
                 .await
             {
-                if seq_state.header.error.is_none() {
+                if seq_state.header.status.is_none() {
                     let global_tail = seq_state
                         .header
                         .known_global_tail


### PR DESCRIPTION
This is a small refactor to the SequencerStatus type as a leading example to try to explore better patterns for data definitions in the application, and for encodable types in bilrost specifically.

Something to note in particular here about the data types within the application itself: SequencerStatus currently has an Ok variant, which means no error, total success -- but the functions create_loglet and get_loglet return the type Result<Arc<ReplicatedLoglet<T>>, SequencerStatus>. The value Err(SequencerStatus::Ok) is nonsensical but representable in this type.

Regarding bilrost's encoding semantics specifically:

- the goals of restate when parsing the error values are clear: we should always know when we parse a non-success status, even if we're not sure what it was
- bilrost has some partially conflicting goals: encodable fields always need to have an "empty" state, and any encoding behavior that's supported by bilrost itself needs to function in such a way that each value of the type can cleanly round-trip from the encoded data.
- a "oneof" enumeration's "empty" variant is the value we will end up with if we parse unknown data, but we can also round-trip it from empty data: it has a "canonical" value. if we were to be able to specify a different variant that would be used instead when the variant is unknown (perhaps via some special attribute), we'd have no way to encode that value.

Fortunately, there is a pretty clean ternary that already exists: None, Some(empty), Some(non-empty). I've done the refactor here; this cleans up some of the type snafus around SequencerStatus having that lingering Ok variant in the Result::Err variant, and the dto type now translates to and from via direct 1:1 translation so when bilrost has the capability to encode directly there would be no need to have any special conversion at all.

Are there any backwards-compatibility concerns with this? If we're looking at the whole "cluster incompatibility" thing, i think the only problem that arises is that upgraded versions will see old SequencerStatus::Ok messages as Unknown errors until all are upgraded. if that's a show-stopper it could even be possible to re-add transient handling for a non-fatal "Ok" variant inside the error and remove it later, but it looks like all this is very recently committed and idk how widely it could have been deployed :)