### PR TITLE
[Restate UI] Update to v0.0.77

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7879,8 +7879,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.76"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.76#159b33650e5c9fef9bfff3afc68f147365dd4162"
+version = "0.0.77"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.77#e547355578ceaeca599b985470f8b9d742ce1952"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.76", tag = "v0.0.76" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.77", tag = "v0.0.77" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.77
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.77/ui-v0.0.77.zip