### PR TITLE
Improve snapshot download error messages

### DIFF
--- a/crates/core/src/worker_api/partition_processor_manager.rs
+++ b/crates/core/src/worker_api/partition_processor_manager.rs
@@ -84,7 +84,7 @@ pub struct SnapshotCreated {
 }
 
 #[derive(Debug, derive_more::Display)]
-#[display("{kind} for partition id: {partition_id}")]
+#[display("{kind} for partition {partition_id}")]
 pub struct SnapshotError {
     pub partition_id: PartitionId,
     pub kind: SnapshotErrorKind,

--- a/crates/worker/src/partition/snapshots/snapshot_task.rs
+++ b/crates/worker/src/partition/snapshots/snapshot_task.rs
@@ -36,20 +36,21 @@ pub struct SnapshotPartitionTask {
 }
 
 impl SnapshotPartitionTask {
-    #[instrument(level = "info", skip_all, fields(snapshot_id = %self.snapshot_id, partition_id = %self.partition_id))]
+    #[instrument(
+        name = "create-snapshot",
+        level = "error",
+        skip_all,
+        fields(partition_id = %self.partition_id, snapshot_id = %self.snapshot_id)
+    )]
     pub async fn run(self) -> Result<PartitionSnapshotMetadata, SnapshotError> {
         debug!("Creating partition snapshot");
         self.create_snapshot_inner()
             .await
             .inspect(|metadata| {
-                info!(
-                    archived_lsn = %metadata.min_applied_lsn,
-                    snapshot_id = %metadata.snapshot_id,
-                    "Created partition snapshot"
-                );
+                info!(archived_lsn = %metadata.min_applied_lsn, "Created partition snapshot");
             })
             .inspect_err(|err| {
-                warn!("Failed to create partition snapshot: {}", err);
+                warn!("Create snapshot failed: {}", err);
             })
     }
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -317,9 +317,8 @@ async fn create_or_recreate_store(
         (maybe_snapshot, Some(fast_forward_lsn)) => {
             // Play it safe and keep the partition store intact; we can't do much else at this
             // point. We'll likely halt again as soon as the processor starts up.
-            let recovery_guide_msg =
-                "The partition's log is trimmed to a point from which this processor can not resume.
-                Visit https://docs.restate.dev/operate/clusters/#handling-missing-snapshots
+            let recovery_guide_msg = "The partition's log is trimmed to a point from which this processor can not resume. \
+                Visit https://docs.restate.dev/operate/clusters#handling-missing-snapshots \
                 to learn more about how to recover this processor.";
 
             if let Some(snapshot) = maybe_snapshot {


### PR DESCRIPTION
Include additional context - partition and snapshot ids - in errors that are returned from `SnapshotRepository::get_latest`.