### PR TITLE
Update object_store crate to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3981,7 +3981,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5036,9 +5036,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ce831b09395f933addbc56d894d889e4b226eba304d4e7adbab591e26daf1e"
+checksum = "7781f96d79ed0f961a7021424ab01840efbda64ae7a505aaea195efc91eaaec4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5055,7 +5055,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.37.2",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reqwest",
  "ring",
  "serde",
@@ -5066,6 +5066,8 @@ dependencies = [
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -6778,7 +6780,7 @@ dependencies = [
  "hyper-util",
  "itertools 0.14.0",
  "metrics",
- "object_store 0.12.0",
+ "object_store 0.12.2",
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",
@@ -7133,7 +7135,7 @@ dependencies = [
  "derive_more",
  "etcd-client",
  "indexmap 2.7.1",
- "object_store 0.12.0",
+ "object_store 0.12.2",
  "parking_lot",
  "rand 0.9.0",
  "restate-core",
@@ -7313,7 +7315,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "futures",
- "object_store 0.12.0",
+ "object_store 0.12.2",
  "restate-types",
  "tracing",
  "url",
@@ -7905,7 +7907,7 @@ dependencies = [
  "humantime",
  "itertools 0.14.0",
  "metrics",
- "object_store 0.12.0",
+ "object_store 0.12.2",
  "opentelemetry",
  "parking_lot",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ metrics-exporter-prometheus = { version = "0.17", default-features = false, feat
 metrics-util = { version = "0.19.0" }
 moka = "0.12.5"
 num-traits = { version = "0.2.17" }
-object_store = { version = "0.12.0", features = ["aws"] }
+object_store = { version = "0.12.2", features = ["aws"] }
 opentelemetry = { version = "0.27" }
 opentelemetry-contrib = { version = "0.19" }
 opentelemetry-otlp = { version = "0.27" }


### PR DESCRIPTION
I don't see any particularly relevant fixes in the recent changes (0.12.0..0.12.2) but there are a few useful sounding changes.