### PR TITLE
Set the initial current partition configuration version to be equal to the EpochMetadata's version

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -393,9 +393,9 @@ impl<T: TransportConnect> Scheduler<T> {
                 partition_processor_epoch_key(partition_id),
                 |epoch_metadata: Option<EpochMetadata>| {
                     if let Some(epoch_metadata) = epoch_metadata {
-                        // check if current has been modified in the meantime
-                        if epoch_metadata.current().version() < current.version() {
-                            Ok(epoch_metadata.update_current_configuration(current.clone()))
+                        // check whether someone else stored an initial current partition configuration
+                        if epoch_metadata.current().version() == Version::INVALID {
+                            Ok(epoch_metadata.set_initial_current_configuration(current.clone()))
                         } else {
                             let (_, _, current, next) = epoch_metadata.into_inner();
                             Err(PartitionConfigurationUpdate { current, next })

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -407,9 +407,10 @@ impl<T: TransportConnect> Scheduler<T> {
             )
             .await
         {
-            Ok(_) => {
+            Ok(epoch_metadata) => {
+                let (_, _, current, next) = epoch_metadata.into_inner();
                 debug!("Initialized partition {} with {:?}", partition_id, current);
-                Ok(PartitionState::new(current, None))
+                Ok(PartitionState::new(current, next))
             }
             Err(ReadModifyWriteError::FailedOperation(concurrent_update)) => Ok(
                 PartitionState::new(concurrent_update.current, concurrent_update.next),

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -375,11 +375,13 @@ impl Default for ReplicaSetState {
 
 impl Merge for ReplicaSetState {
     fn merge(&mut self, other: Self) -> bool {
-        debug_assert_eq!(
-            self.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
-            other.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+        assert!(
+            itertools::equal(
+                self.members.iter().map(|m| m.node_id),
+                other.members.iter().map(|m| m.node_id)
+            ),
+            "The system currently relies on a consistent view of the replica set state (e.g. for routing decisions and starting partition processors)"
         );
-
         let mut modified = false;
         for (member, incoming_member) in self.members.iter_mut().zip(other.members) {
             if incoming_member.durable_lsn > member.durable_lsn {


### PR DESCRIPTION
By setting the initial current partition configuration version to be equal to the EpochMetadata's version we ensure that clobbering the EpochMetadata (e.g. during a rolling upgrade) won't cause a diverging view on the cluster's ReplicaSetState. W/o this fix, it was possible that the system was reusing versions for different partition configurations which would have caused the system to end up with a divergent view on which node is running which partition processors.