### PR TITLE
change SequencerStatus to a type that only bears non-success variants

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -22,7 +22,7 @@ use restate_types::logs::{LogletOffset, SequenceNumber, TailOffsetWatch};
 use restate_types::net::RpcRequest;
 use restate_types::net::replicated_loglet::{
     Append, Appended, CommonRequestHeader, CommonResponseHeader, GetSequencerState,
-    SequencerDataService, SequencerMetaService, SequencerState, SequencerStatus,
+    SequencerDataService, SequencerError, SequencerMetaService, SequencerState,
 };
 
 use super::error::ReplicatedLogletError;
@@ -37,7 +37,7 @@ macro_rules! return_error_status {
             header: CommonResponseHeader {
                 known_global_tail: Some($tail.latest_offset()),
                 sealed: Some($tail.is_sealed()),
-                status: $status,
+                error: Some($status),
             },
         };
 
@@ -50,7 +50,7 @@ macro_rules! return_error_status {
             header: CommonResponseHeader {
                 known_global_tail: None,
                 sealed: None,
-                status: $status,
+                error: Some($status),
             },
         };
 
@@ -101,7 +101,7 @@ impl<T: TransportConnect> SequencerDataRpcHandler<T> {
         };
 
         if !loglet.is_sequencer_local() {
-            return_error_status!(reciprocal, SequencerStatus::NotSequencer);
+            return_error_status!(reciprocal, SequencerError::NotSequencer);
         }
 
         let global_tail = loglet.known_global_tail();
@@ -109,7 +109,7 @@ impl<T: TransportConnect> SequencerDataRpcHandler<T> {
         let loglet_commit = match loglet.enqueue_batch(append.payloads.into()).await {
             Ok(loglet_commit) => loglet_commit,
             Err(err) => {
-                return_error_status!(reciprocal, SequencerStatus::from(err), global_tail);
+                return_error_status!(reciprocal, SequencerError::from(err), global_tail);
             }
         };
 
@@ -157,7 +157,7 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
                     header: CommonResponseHeader {
                         known_global_tail: None,
                         sealed: None,
-                        status: err,
+                        error: Some(err),
                     },
                 };
                 reciprocal.send(response);
@@ -170,7 +170,7 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
                 header: CommonResponseHeader {
                     known_global_tail: None,
                     sealed: None,
-                    status: SequencerStatus::NotSequencer,
+                    error: Some(SequencerError::NotSequencer),
                 },
             };
             reciprocal.send(response);
@@ -185,7 +185,7 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
                             header: CommonResponseHeader {
                                 known_global_tail: Some(tail.offset()),
                                 sealed: Some(tail.is_sealed()),
-                                status: SequencerStatus::Ok,
+                                error: None,
                             },
                         };
                         reciprocal.send(sequencer_state);
@@ -195,10 +195,10 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
                             header: CommonResponseHeader {
                                 known_global_tail: None,
                                 sealed: None,
-                                status: SequencerStatus::Error {
+                                error: Some(SequencerError::Error {
                                     retryable: true,
                                     message: err.to_string(),
-                                },
+                                }),
                             },
                         };
                         reciprocal.send(failure);
@@ -214,7 +214,7 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
                 header: CommonResponseHeader {
                     known_global_tail: Some(tail.offset()),
                     sealed: Some(tail.is_sealed()),
-                    status: SequencerStatus::Ok,
+                    error: None,
                 },
             };
             reciprocal.send(sequencer_state);
@@ -225,29 +225,29 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
 fn create_loglet<T: TransportConnect>(
     provider: &ReplicatedLogletProvider<T>,
     header: &CommonRequestHeader,
-) -> Result<Arc<ReplicatedLoglet<T>>, SequencerStatus> {
+) -> Result<Arc<ReplicatedLoglet<T>>, SequencerError> {
     // search the chain
     let logs = Metadata::with_current(|m| m.logs_ref());
     let chain = logs
         .chain(&header.log_id)
-        .ok_or(SequencerStatus::UnknownLogId)?;
+        .ok_or(SequencerError::UnknownLogId)?;
 
     let segment = chain
         .iter()
         .rev()
         .find(|segment| segment.index() == header.segment_index)
-        .ok_or(SequencerStatus::UnknownSegmentIndex)?;
+        .ok_or(SequencerError::UnknownSegmentIndex)?;
 
     provider
         .get_or_create_loglet(header.log_id, header.segment_index, &segment.config.params)
-        .map_err(SequencerStatus::from)
+        .map_err(SequencerError::from)
 }
 
 async fn get_loglet<T: TransportConnect>(
     provider: &ReplicatedLogletProvider<T>,
     request_logs_version: Version,
     header: &CommonRequestHeader,
-) -> Result<Arc<ReplicatedLoglet<T>>, SequencerStatus> {
+) -> Result<Arc<ReplicatedLoglet<T>>, SequencerError> {
     let metadata = Metadata::current();
     let mut current_logs_version = metadata.logs_version();
 
@@ -257,15 +257,15 @@ async fn get_loglet<T: TransportConnect>(
                 return Ok(loglet);
             }
 
-            return Err(SequencerStatus::LogletIdMismatch);
+            return Err(SequencerError::LogletIdMismatch);
         }
 
         match create_loglet(provider, header) {
             Ok(loglet) => return Ok(loglet),
-            Err(SequencerStatus::UnknownLogId | SequencerStatus::UnknownSegmentIndex) => {
+            Err(SequencerError::UnknownLogId | SequencerError::UnknownSegmentIndex) => {
                 // possible outdated metadata
             }
-            Err(status) => return Err(status),
+            Err(err) => return Err(err),
         }
 
         if request_logs_version > current_logs_version {
@@ -274,22 +274,22 @@ async fn get_loglet<T: TransportConnect>(
                 .wait_for_version(MetadataKind::Logs, request_logs_version)
                 .await
             {
-                Err(_) => return Err(SequencerStatus::Shutdown),
+                Err(_) => return Err(SequencerError::Shutdown),
                 Ok(version) => {
                     current_logs_version = version;
                 }
             }
         } else {
-            return Err(SequencerStatus::UnknownLogId);
+            return Err(SequencerError::UnknownLogId);
         }
     }
 }
 
-impl From<OperationError> for SequencerStatus {
+impl From<OperationError> for SequencerError {
     fn from(value: OperationError) -> Self {
         match value {
-            OperationError::Shutdown(_) => SequencerStatus::Shutdown,
-            OperationError::Other(err) => Self::Error {
+            OperationError::Shutdown(_) => SequencerError::Shutdown,
+            OperationError::Other(err) => SequencerError::Error {
                 retryable: err.retryable(),
                 message: err.to_string(),
             },
@@ -297,7 +297,7 @@ impl From<OperationError> for SequencerStatus {
     }
 }
 
-impl From<ReplicatedLogletError> for SequencerStatus {
+impl From<ReplicatedLogletError> for SequencerError {
     fn from(value: ReplicatedLogletError) -> Self {
         Self::Error {
             retryable: value.retryable(),
@@ -319,7 +319,7 @@ impl WaitForCommitTask {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),
                     sealed: Some(self.global_tail.is_sealed()),
-                    status: SequencerStatus::Ok,
+                    error: None,
                 },
                 last_offset: offset,
             },
@@ -327,7 +327,7 @@ impl WaitForCommitTask {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),
                     sealed: Some(self.global_tail.is_sealed()), // this must be true
-                    status: SequencerStatus::Sealed,
+                    error: Some(SequencerError::Sealed),
                 },
                 last_offset: LogletOffset::INVALID,
             },
@@ -335,7 +335,7 @@ impl WaitForCommitTask {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),
                     sealed: Some(self.global_tail.is_sealed()), // this must be true
-                    status: SequencerStatus::Gone,
+                    error: Some(SequencerError::Gone),
                 },
                 last_offset: LogletOffset::INVALID,
             },
@@ -343,7 +343,7 @@ impl WaitForCommitTask {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),
                     sealed: Some(self.global_tail.is_sealed()),
-                    status: SequencerStatus::Shutdown,
+                    error: Some(SequencerError::Shutdown),
                 },
                 last_offset: LogletOffset::INVALID,
             },
@@ -351,10 +351,10 @@ impl WaitForCommitTask {
                 header: CommonResponseHeader {
                     known_global_tail: Some(self.global_tail.latest_offset()),
                     sealed: Some(self.global_tail.is_sealed()),
-                    status: SequencerStatus::Error {
+                    error: Some(SequencerError::Error {
                         retryable: err.retryable(),
                         message: err.to_string(),
-                    },
+                    }),
                 },
                 last_offset: LogletOffset::INVALID,
             },

--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -138,7 +138,7 @@ impl<T: TransportConnect> FindTailTask<T> {
                 )
                 .await
             {
-                if seq_state.header.status.is_ok() {
+                if seq_state.header.error.is_none() {
                     let global_tail = seq_state
                         .header
                         .known_global_tail


### PR DESCRIPTION
change SequencerStatus to a type that only bears non-success variants

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3388).
* #3390
* #3365
* #3389
* __->__ #3388