### PR TITLE
flexbuffers backward compatibility for replicated_loglet messages

### DIFF
--- a/crates/types/src/net/codec.rs
+++ b/crates/types/src/net/codec.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::any::type_name;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -104,7 +105,12 @@ pub fn decode_as_flexbuffers<T: DeserializeOwned>(
         "unknown protocol version should never be set"
     );
 
-    flexbuffers::from_slice(buf.chunk()).context("failed decoding V1 (flexbuffers) network message")
+    flexbuffers::from_slice(buf.chunk()).with_context(|| {
+        format!(
+            "failed decoding V1 (flexbuffers) network message {}",
+            type_name::<T>()
+        )
+    })
 }
 
 pub fn encode_as_bilrost<T: bilrost::Message>(value: &T) -> Bytes {

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -49,7 +49,7 @@ bilrost_wire_codec_with_v1_fallback!(GetSequencerState);
 bilrost_wire_codec_with_v1_fallback!(SequencerState);
 
 /// Non-success status of sequencer response.
-#[derive(Debug, Clone, Serialize, Deserialize, derive_more::IsVariant, BilrostAs, Default)]
+#[derive(Debug, Clone, derive_more::IsVariant, BilrostAs, Default)]
 #[bilrost_as(dto::SequencerStatus)]
 pub enum SequencerStatus {
     /// Sealed is returned when the sequencer cannot accept more
@@ -88,6 +88,11 @@ pub struct CommonRequestHeader {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, bilrost::Message)]
+// todo: drop serde(from, into) in version 1.5
+#[serde(
+    from = "dto::CommonResponseHeaderV1",
+    into = "dto::CommonResponseHeaderV1"
+)]
 pub struct CommonResponseHeader {
     #[bilrost(1)]
     pub known_global_tail: Option<LogletOffset>,
@@ -252,6 +257,106 @@ mod dto {
                     super::SequencerStatus::Error { retryable, message }
                 }
                 SequencerStatus::Unknown => super::SequencerStatus::Unknown,
+            }
+        }
+    }
+
+    // This is for backward compatibility with serde/flexbuffers
+    // only needed during update from v1.3.2 to v1.4.
+    // TODO: remove this in version 1.5
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+    pub enum SequencerStatusV1 {
+        #[default]
+        Ok,
+        /// Sealed is returned when the sequencer cannot accept more
+        /// [`Append`] requests because it's sealed
+        Sealed,
+        /// Local sequencer is not available anymore, reconfiguration is needed
+        Gone,
+        /// LogletID does not match Segment
+        LogletIdMismatch,
+        /// Invalid LogId
+        UnknownLogId,
+        /// Invalid segment index
+        UnknownSegmentIndex,
+        /// Operation has been rejected, node is not a sequencer
+        NotSequencer,
+        /// Sequencer is shutting down
+        Shutdown,
+        /// Generic error message.
+        Error { retryable: bool, message: String },
+    }
+
+    impl From<super::SequencerStatus> for SequencerStatusV1 {
+        fn from(status: super::SequencerStatus) -> Self {
+            match status {
+                super::SequencerStatus::Sealed => SequencerStatusV1::Sealed,
+                super::SequencerStatus::Gone => SequencerStatusV1::Gone,
+                super::SequencerStatus::LogletIdMismatch => SequencerStatusV1::LogletIdMismatch,
+                super::SequencerStatus::UnknownLogId => SequencerStatusV1::UnknownLogId,
+                super::SequencerStatus::UnknownSegmentIndex => {
+                    SequencerStatusV1::UnknownSegmentIndex
+                }
+                super::SequencerStatus::NotSequencer => SequencerStatusV1::NotSequencer,
+                super::SequencerStatus::Shutdown => SequencerStatusV1::Shutdown,
+                super::SequencerStatus::Error { retryable, message } => {
+                    SequencerStatusV1::Error { retryable, message }
+                }
+                super::SequencerStatus::Unknown => SequencerStatusV1::Error {
+                    retryable: false,
+                    message: "Unknown error".to_string(),
+                },
+            }
+        }
+    }
+
+    impl From<SequencerStatusV1> for super::SequencerStatus {
+        fn from(value: SequencerStatusV1) -> Self {
+            match value {
+                SequencerStatusV1::Ok => unreachable!(),
+                SequencerStatusV1::Sealed => Self::Sealed,
+                SequencerStatusV1::Gone => Self::Gone,
+                SequencerStatusV1::LogletIdMismatch => Self::LogletIdMismatch,
+                SequencerStatusV1::UnknownLogId => Self::UnknownLogId,
+                SequencerStatusV1::UnknownSegmentIndex => Self::UnknownSegmentIndex,
+                SequencerStatusV1::NotSequencer => Self::NotSequencer,
+                SequencerStatusV1::Shutdown => Self::Shutdown,
+                SequencerStatusV1::Error { retryable, message } => {
+                    Self::Error { retryable, message }
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct CommonResponseHeaderV1 {
+        pub known_global_tail: Option<LogletOffset>,
+        pub sealed: Option<bool>,
+        pub status: SequencerStatusV1,
+    }
+
+    impl From<super::CommonResponseHeader> for CommonResponseHeaderV1 {
+        fn from(header: super::CommonResponseHeader) -> Self {
+            Self {
+                known_global_tail: header.known_global_tail,
+                sealed: header.sealed,
+                status: header
+                    .status
+                    .map(|s| s.into())
+                    .unwrap_or(SequencerStatusV1::Ok),
+            }
+        }
+    }
+
+    impl From<CommonResponseHeaderV1> for super::CommonResponseHeader {
+        fn from(header: CommonResponseHeaderV1) -> Self {
+            Self {
+                known_global_tail: header.known_global_tail,
+                sealed: header.sealed,
+                status: match header.status {
+                    SequencerStatusV1::Ok => None,
+                    status => Some(status.into()),
+                },
             }
         }
     }


### PR DESCRIPTION
flexbuffers backward compatibility for replicated_loglet messages

Building this on top of https://github.com/restatedev/restate/pull/3365 to restore
backward compatibility
