### PR TITLE
[Bifrost] Introduce read batch limit in configuration

### DIFF
--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -287,6 +287,15 @@ pub struct ReplicatedLogletOptions {
     /// that are not co-located with the loglet sequencer (i.e. partition processor followers).
     pub readahead_records: NonZeroU16,
 
+    /// # Limits memory per remote batch read
+    ///
+    /// When reading from a log-server, the server stops reading if the next record will tip over the
+    /// total number of bytes allowed in this configuration option.
+    ///
+    /// Note the limit is not strict and the server will always allow at least a single record to be
+    /// read even if that record exceeds the stated budget.
+    pub read_batch_size: NonZeroByteCount,
+
     /// Trigger to prefetch more records
     ///
     /// When read-ahead is used (readahead-records), this value (percentage in float) will determine when
@@ -339,6 +348,9 @@ impl Default for ReplicatedLogletOptions {
                 Some(Duration::from_millis(5000)),
             ),
             sequencer_inactivity_timeout: Duration::from_secs(15).into(),
+            read_batch_size: NonZeroByteCount::new(
+                NonZeroUsize::new(32 * 1024).expect("Non zero number"),
+            ),
             log_server_rpc_timeout: Duration::from_millis(2000).into(),
             log_server_retry_policy: RetryPolicy::exponential(
                 Duration::from_millis(250),
@@ -346,7 +358,7 @@ impl Default for ReplicatedLogletOptions {
                 Some(3),
                 Some(Duration::from_millis(2000)),
             ),
-            readahead_records: NonZeroU16::new(100).unwrap(),
+            readahead_records: NonZeroU16::new(20).unwrap(),
             readahead_trigger_ratio: 0.5,
             default_nodeset_size: NodeSetSize::default(),
         }


### PR DESCRIPTION

The new configuration option `bifrost.replicated-loglet.read-batch-size` will set (in bytes) the budget for every read batch request bifrost client will make to a log-server. The log-server will send at-least a single record even if it exceeds this budget.
The option is set by default to 32KiB.

Additionally:
- Default value of `bifrost.replicated-loglet.readahead-records` is reduced from 100 to 20 to reduce the potential memory ballooning during backfilling. As consequence, backfills will be slower.

Note: this doesn't address all potential memory ballooning issues, there is still a risk of ballooning during massive backfills depending on how many readers and how many loglets are being backfilled at the same time. The risk of ballooning is increased on the log-server side due to the concurrent number of read requests.

```
// intentionally empty
```
