### PR TITLE
Ensure local df scanner is always used

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -765,6 +765,7 @@ impl SealAndExtendTask {
                     TaskCenter::with_current(|handle| {
                         self.membership_state
                             .first_alive_node(handle.cluster_state())
+                            .map(NodeId::from)
                     })
                 }
             });

--- a/crates/core/src/partitions.rs
+++ b/crates/core/src/partitions.rs
@@ -9,9 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use crate::TaskCenter;
+use restate_types::GenerationalNodeId;
 use restate_types::identifiers::PartitionId;
 use restate_types::partitions::state::PartitionReplicaSetStates;
-use restate_types::{GenerationalNodeId, NodeId};
 
 /// Discover cluster nodes for a given partition based on the [`PartitionReplicaSetStates`] and the
 /// [`ClusterState`].
@@ -33,14 +33,14 @@ impl PartitionRouting {
     /// retrying the request, or returning an error upstream when information is not available.
     ///
     /// A `None` response indicates that we have no knowledge about this partition.
-    pub fn get_node_by_partition(&self, partition_id: PartitionId) -> Option<NodeId> {
+    pub fn get_node_by_partition(&self, partition_id: PartitionId) -> Option<GenerationalNodeId> {
         let membership = self
             .partition_replica_set_states
             .membership_state(partition_id);
 
         // if we know about a leader, then return it
         if membership.current_leader().current_leader != GenerationalNodeId::INVALID {
-            return Some(NodeId::from(membership.current_leader().current_leader));
+            return Some(membership.current_leader().current_leader);
         }
 
         // otherwise, overlay the current configuration with the cluster state and take the first

--- a/crates/core/src/worker_api/partition_processor_rpc_client.rs
+++ b/crates/core/src/worker_api/partition_processor_rpc_client.rs
@@ -202,12 +202,13 @@ where
             .pinned()
             .find_partition_id(inner_request.partition_key())?;
 
-        let node_id = self
-            .partition_routing
-            .get_node_by_partition(partition_id)
-            .ok_or(PartitionProcessorInvocationClientError::UnknownNode(
-                partition_id,
-            ))?;
+        let node_id = NodeId::from(
+            self.partition_routing
+                .get_node_by_partition(partition_id)
+                .ok_or(PartitionProcessorInvocationClientError::UnknownNode(
+                    partition_id,
+                ))?,
+        );
 
         // find connection for this node
         let connection = self

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -102,10 +102,10 @@ impl PartitionLocator for MetadataAwarePartitionLocator {
             None => {
                 bail!("node lookup for partition {} failed", partition_id)
             }
-            Some(node_id) if node_id.as_generational().is_some_and(|id| id == my_node_id) => {
-                Ok(PartitionLocation::Local)
-            }
-            Some(node_id) => Ok(PartitionLocation::Remote { node_id }),
+            Some(node_id) if node_id == my_node_id => Ok(PartitionLocation::Local),
+            Some(node_id) => Ok(PartitionLocation::Remote {
+                node_id: NodeId::from(node_id),
+            }),
         }
     }
 }


### PR DESCRIPTION
The current implementation will only use the local scanner if we found a generational node id as the leader of this partition, which we didn't always. We make sure that a generational node id is always obtained.