### PR TITLE
[tracing] improve http client errors

### DIFF
--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -245,10 +245,13 @@ struct FormatHyperError<'a>(&'a hyper_util::client::legacy::Error);
 
 impl fmt::Display for FormatHyperError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(source) = self.0.source() {
-            write!(f, "{}, {}", self.0, source)
-        } else {
-            write!(f, "{}", self.0)
+        write!(f, "{}", self.0)?;
+        let mut source = self.0.source();
+        while let Some(err) = source {
+            write!(f, " caused by: {}", err)?;
+            source = err.source();
         }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
[tracing] improve http client errors

Summary:
This make sure that the entire chain of causes is printed

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3394).
* #3396
* __->__ #3394