### PR TITLE
[bilrost] migrate remote scanner types to bilrost

### DIFF
--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -245,10 +245,13 @@ struct FormatHyperError<'a>(&'a hyper_util::client::legacy::Error);
 
 impl fmt::Display for FormatHyperError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(source) = self.0.source() {
-            write!(f, "{}, {}", self.0, source)
-        } else {
-            write!(f, "{}", self.0)
+        write!(f, "{}", self.0)?;
+        let mut source = self.0.source();
+        while let Some(err) = source {
+            write!(f, " caused by: {}", err)?;
+            source = err.source();
         }
+
+        Ok(())
     }
 }

--- a/crates/types/src/net/remote_query_scanner.rs
+++ b/crates/types/src/net/remote_query_scanner.rs
@@ -11,10 +11,12 @@
 use std::fmt::{Display, Formatter};
 use std::ops::RangeInclusive;
 
+use restate_encoding::RestateEncoding;
+
 use super::ServiceTag;
 use crate::GenerationalNodeId;
 use crate::identifiers::{PartitionId, PartitionKey};
-use crate::net::{default_wire_codec, define_rpc, define_service};
+use crate::net::{bilrost_wire_codec_with_v1_fallback, define_rpc, define_service};
 
 pub struct RemoteDataFusionService;
 define_service! {
@@ -22,8 +24,10 @@ define_service! {
     @tag = ServiceTag::RemoteDataFusionService,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct ScannerId(pub GenerationalNodeId, pub u64);
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, bilrost::Message,
+)]
+pub struct ScannerId(#[bilrost(1)] pub GenerationalNodeId, #[bilrost(2)] pub u64);
 
 impl Display for ScannerId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -33,49 +37,93 @@ impl Display for ScannerId {
 
 // ----- open scanner -----
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct RemoteQueryScannerOpen {
+    #[bilrost(1)]
     pub partition_id: PartitionId,
+    #[bilrost(tag(2), encoding(RestateEncoding))]
     pub range: RangeInclusive<PartitionKey>,
+    #[bilrost(3)]
     pub table: String,
+    #[bilrost(tag(4), encoding(plainbytes))]
     pub projection_schema_bytes: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    bilrost::Message,
+    bilrost::Oneof,
+)]
 pub enum RemoteQueryScannerOpened {
-    Success { scanner_id: ScannerId },
     Failure,
+    #[bilrost(1)]
+    Success {
+        scanner_id: ScannerId,
+    },
 }
 
 // ----- next batch -----
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct RemoteQueryScannerNext {
+    #[bilrost(1)]
     pub scanner_id: ScannerId,
 }
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
+pub struct ScannerBatch {
+    #[bilrost(1)]
+    pub scanner_id: ScannerId,
+    #[bilrost(tag(2), encoding(plainbytes))]
+    pub record_batch: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
+pub struct ScannerFailure {
+    #[bilrost(1)]
+    pub scanner_id: ScannerId,
+    #[bilrost(2)]
+    pub message: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    bilrost::Message,
+    bilrost::Oneof,
+)]
 pub enum RemoteQueryScannerNextResult {
-    NextBatch {
-        scanner_id: ScannerId,
-        record_batch: Vec<u8>,
-    },
-    Failure {
-        scanner_id: ScannerId,
-        message: String,
-    },
+    Unknown,
+    #[bilrost(1)]
+    NextBatch(ScannerBatch),
+    #[bilrost(2)]
+    Failure(ScannerFailure),
+    #[bilrost(3)]
     NoMoreRecords(ScannerId),
+    #[bilrost(4)]
     NoSuchScanner(ScannerId),
 }
 
 // ----- close scanner -----
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct RemoteQueryScannerClose {
+    #[bilrost(1)]
     pub scanner_id: ScannerId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct RemoteQueryScannerClosed {
+    #[bilrost(1)]
     pub scanner_id: ScannerId,
 }
 
@@ -87,21 +135,82 @@ define_rpc! {
     @response = RemoteQueryScannerOpened,
     @service = RemoteDataFusionService,
 }
-default_wire_codec!(RemoteQueryScannerOpen);
-default_wire_codec!(RemoteQueryScannerOpened);
+
+bilrost_wire_codec_with_v1_fallback!(RemoteQueryScannerOpen);
+bilrost_wire_codec_with_v1_fallback!(RemoteQueryScannerOpened);
 
 define_rpc! {
     @request = RemoteQueryScannerNext,
     @response = RemoteQueryScannerNextResult,
     @service = RemoteDataFusionService,
 }
-default_wire_codec!(RemoteQueryScannerNext);
-default_wire_codec!(RemoteQueryScannerNextResult);
+bilrost_wire_codec_with_v1_fallback!(RemoteQueryScannerNext);
+bilrost_wire_codec_with_v1_fallback!(RemoteQueryScannerNextResult);
 
 define_rpc! {
     @request = RemoteQueryScannerClose,
     @response = RemoteQueryScannerClosed,
     @service = RemoteDataFusionService,
 }
-default_wire_codec!(RemoteQueryScannerClose);
-default_wire_codec!(RemoteQueryScannerClosed);
+bilrost_wire_codec_with_v1_fallback!(RemoteQueryScannerClose);
+bilrost_wire_codec_with_v1_fallback!(RemoteQueryScannerClosed);
+
+#[cfg(test)]
+mod test {
+
+    use serde::Deserialize;
+
+    use crate::{
+        GenerationalNodeId,
+        net::remote_query_scanner::{ScannerBatch, ScannerFailure, ScannerId},
+    };
+
+    // V1/flexbuffers scanner next result type.
+    #[derive(Deserialize)]
+    #[allow(dead_code)]
+    pub enum RemoteQueryScannerNextResult {
+        NextBatch {
+            scanner_id: ScannerId,
+            record_batch: Vec<u8>,
+        },
+        Failure {
+            scanner_id: ScannerId,
+            message: String,
+        },
+        NoMoreRecords(ScannerId),
+        NoSuchScanner(ScannerId),
+    }
+
+    #[test]
+    fn backward_compatibility() {
+        let scanner_id = ScannerId(GenerationalNodeId::new(10, 20), 100);
+        let batch = vec![1, 2, 3, 4];
+        let v2 = super::RemoteQueryScannerNextResult::NextBatch(ScannerBatch {
+            scanner_id,
+            record_batch: batch.clone(),
+        });
+
+        let bytes = flexbuffers::to_vec(&v2).expect("to serialize");
+
+        let v1: RemoteQueryScannerNextResult =
+            flexbuffers::from_slice(&bytes).expect("to deserialize");
+
+        assert!(
+            matches!(v1, RemoteQueryScannerNextResult::NextBatch { scanner_id: id, record_batch} if id == scanner_id && batch == record_batch )
+        );
+
+        let v2 = super::RemoteQueryScannerNextResult::Failure(ScannerFailure {
+            scanner_id,
+            message: "scanner failed successfully!".to_string(),
+        });
+
+        let bytes = flexbuffers::to_vec(&v2).expect("to serialize");
+
+        let v1: RemoteQueryScannerNextResult =
+            flexbuffers::from_slice(&bytes).expect("to deserialize");
+
+        assert!(
+            matches!(v1, RemoteQueryScannerNextResult::Failure { scanner_id: id, message} if id == scanner_id && message == "scanner failed successfully!" )
+        )
+    }
+}


### PR DESCRIPTION
[bilrost] migrate remote scanner types to bilrost

Summary:
Migrate all datafusion related scanner messages to use bilrost

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3396).
* __->__ #3396
* #3394