### PR TITLE
[datafusion] reduce default sizes

### DIFF
--- a/crates/storage-query-datafusion/src/partition_store_scanner.rs
+++ b/crates/storage-query-datafusion/src/partition_store_scanner.rs
@@ -66,7 +66,7 @@ where
         range: RangeInclusive<PartitionKey>,
         projection: SchemaRef,
     ) -> anyhow::Result<SendableRecordBatchStream> {
-        let mut stream_builder = RecordBatchReceiverStream::builder(projection.clone(), 2);
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection.clone(), 1);
         let tx = stream_builder.tx();
         let partition_store_manager = self.partition_store_manager.clone();
         let background_task = async move {
@@ -101,7 +101,6 @@ where
                 let result = builder.finish();
                 let _ = tx.send(result).await;
             }
-
             Ok(())
         };
         stream_builder.spawn(background_task);

--- a/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
@@ -76,7 +76,7 @@ pub fn remote_scan_as_datafusion_stream(
     table_name: String,
     projection_schema: SchemaRef,
 ) -> SendableRecordBatchStream {
-    let mut builder = RecordBatchReceiverStream::builder(projection_schema.clone(), 2);
+    let mut builder = RecordBatchReceiverStream::builder(projection_schema.clone(), 1);
 
     let tx = builder.tx();
 

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -553,7 +553,7 @@ macro_rules! define_table {
 
             #[inline]
             pub fn default_capacity() -> usize {
-                1024
+                64
             }
         }
 


### PR DESCRIPTION
This PR reduces the number of the in flight `RecordBatch`, and also their size (1024 -> 64).