### PR TITLE
Support pushed-down limits in datafusion

### DIFF
--- a/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
@@ -75,6 +75,7 @@ pub fn remote_scan_as_datafusion_stream(
     range: RangeInclusive<PartitionKey>,
     table_name: String,
     projection_schema: SchemaRef,
+    limit: Option<usize>,
 ) -> SendableRecordBatchStream {
     let mut builder = RecordBatchReceiverStream::builder(projection_schema.clone(), 2);
 
@@ -89,6 +90,7 @@ pub fn remote_scan_as_datafusion_stream(
             range,
             table: table_name,
             projection_schema_bytes: encode_schema(&projection_schema),
+            limit: limit.map(|limit| u64::try_from(limit).expect("limit to fit in a u64")),
         };
 
         let RemoteQueryScannerOpened::Success { scanner_id } =

--- a/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
@@ -53,6 +53,9 @@ impl Scanner {
             request.partition_id,
             request.range.clone(),
             Arc::new(schema),
+            request
+                .limit
+                .map(|limit| usize::try_from(limit).expect("limit to fit in a usize")),
         )?;
         Ok(Self {
             stream,

--- a/crates/types/src/net/remote_query_scanner.rs
+++ b/crates/types/src/net/remote_query_scanner.rs
@@ -39,6 +39,8 @@ pub struct RemoteQueryScannerOpen {
     pub range: RangeInclusive<PartitionKey>,
     pub table: String,
     pub projection_schema_bytes: Vec<u8>,
+    #[serde(default)]
+    pub limit: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Most datafusion providers seem to use these limits. In my testing they don't get enforced by df itself (only top-level output limits are.)