### PR TITLE
fix: restore PartitionProcessorRpcError::Busy variant

### DIFF
--- a/crates/core/src/worker_api/partition_processor_rpc_client.rs
+++ b/crates/core/src/worker_api/partition_processor_rpc_client.rs
@@ -153,6 +153,7 @@ impl From<PartitionProcessorRpcError> for RpcErrorKind {
         match value {
             PartitionProcessorRpcError::NotLeader(_) => RpcErrorKind::NotLeader,
             PartitionProcessorRpcError::LostLeadership(_) => RpcErrorKind::LostLeadership,
+            PartitionProcessorRpcError::Busy => RpcErrorKind::Busy,
             PartitionProcessorRpcError::Internal(msg) => RpcErrorKind::Internal(msg),
             PartitionProcessorRpcError::Starting => RpcErrorKind::Starting,
             PartitionProcessorRpcError::Stopping => RpcErrorKind::Stopping,

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -105,6 +105,10 @@ pub enum PartitionProcessorRpcError {
     NotLeader(PartitionId),
     #[error("not leader anymore for partition '{0}'")]
     LostLeadership(PartitionId),
+    // todo: remove in 1.5
+    #[error("rejecting rpc because too busy")]
+    // #[deprecated(since = "1.4.0", note = "retained for backwards compatibility with <= 1.3.2 nodes, remove in 1.5")]
+    Busy,
     #[error("internal error: {0}")]
     Internal(String),
     #[error("partition processor starting")]
@@ -119,6 +123,7 @@ impl PartitionProcessorRpcError {
             PartitionProcessorRpcError::NotLeader(_) => true,
             PartitionProcessorRpcError::LostLeadership(_) => true,
             PartitionProcessorRpcError::Stopping => true,
+            PartitionProcessorRpcError::Busy => false,
             PartitionProcessorRpcError::Internal(_) => false,
             PartitionProcessorRpcError::Starting => false,
         }


### PR DESCRIPTION
The variant was previously removed in 9fd454d1235e7d271569a0e6ae1a2fa39c792180. When running a mixed cluster with <= 1.3.2 nodes, a `Busy` response from a peer can cause a newer node to panic without this variant.

I was able to get this a few times on ECS, but can't repro it locally from a `main` ingress node talking to a `1.3.2` worker. I am a bit puzzled about how this happened in the first place because the newer node sees older workers as "dead" due to their lack of gossip support, so it won't even try talk to them. What am I missing?

```
{
    "timestamp": "2025-06-13T12:47:03.107615Z",
    "level": "DEBUG",
    "fields": {
        "message": "Processing ingress request"
    },
    "target": "restate_ingress_http::handler::service_handler",
    "span": {
        "restate.invocation.id": "inv_1eJVWUns0UdY5Mo4RN0TQF6jjjXZz8vG5X",
        "restate.invocation.target": "Greeter/greet",
        "name": "ingress"
    },
    "spans": [
        {
            "restate.invocation.id": "inv_1eJVWUns0UdY5Mo4RN0TQF6jjjXZz8vG5X",
            "restate.invocation.target": "Greeter/greet",
            "name": "ingress"
        }
    ]
}

rs:ingress-2' panicked at /restate/crates/types/src/net/codec.rs:45:49:
decode WireDecode message failed: failed decoding V1 (flexbuffers) network message
Caused by:
    Serde Error: unknown variant `Busy`, expected one of `NotLeader`, `LostLeadership`, `Internal`, `Starting`, `Stopping`
Stack backtrace:
   0: std::backtrace::Backtrace::create
   1: <E as anyhow::context::ext::StdError>::ext_context
   2: restate_core::worker_api::partition_processor_rpc_client::PartitionProcessorInvocationClient<C>::resolve_partition_id_and_send::{{closure}}
   3: restate_ingress_http::handler::service_handler::<impl restate_ingress_http::handler::Handler<Schemas,Dispatcher>>::handle_service_request::{{closure}}::{{closure}}
   4: <restate_ingress_http::handler::Handler<Schemas,Dispatcher> as tower_service::Service<http::request::Request<Body>>>::call::{{closure}}
   5: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
   6: <hyper_util::service::glue::TowerToHyperServiceFuture<S,R> as core::future::future::Future>::poll
   7: <hyper_util::server::conn::auto::Connection<I,S,E> as core::future::future::Future>::poll
   8: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
   9: tokio::runtime::task::raw::poll
  10: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  11: tokio::runtime::scheduler::multi_thread::worker::run
  12: tokio::runtime::task::raw::poll
  13: std::sys::backtrace::__rust_begin_short_backtrace
  14: core::ops::function::FnOnce::call_once{{vtable.shim}}
  15: std::sys::pal::unix::thread::Thread::new::thread_start
```