### PR TITLE
[WIP] Semantic version barrier support

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -26,10 +26,9 @@ use restate_core::network::protobuf::network::message::Body;
 use restate_core::network::protobuf::network::{Datagram, Message, datagram};
 use restate_invoker_api::{Effect, EffectKind};
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber, ProducerId};
-use restate_types::GenerationalNodeId;
 use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionProcessorRpcRequestId};
 use restate_types::invocation::{
-    InvocationTarget, RestateVersion, ServiceInvocation, ServiceInvocationSpanContext,
+    InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext,
 };
 use restate_types::journal_v2::CommandType;
 use restate_types::journal_v2::raw::{RawCommand, RawEntry, RawEntryHeader, RawEntryInner};
@@ -39,6 +38,7 @@ use restate_types::net::log_server::{LogServerRequestHeader, Store, StoreFlags};
 use restate_types::net::replicated_loglet::{Append, CommonRequestHeader};
 use restate_types::net::{RpcRequest, Service};
 use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, RestateVersion};
 use restate_wal_protocol::{Command, Destination, Envelope};
 
 #[cfg(not(target_env = "msvc"))]

--- a/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/partition-store/proto/dev/restate/storage/v1/domain.proto
@@ -61,6 +61,10 @@ message SequenceNumber {
   uint64 sequence_number = 1;
 }
 
+message RestateVersion {
+  string version = 1;
+}
+
 message JournalEntryIndex {
   uint32 entry_index = 1;
 }

--- a/crates/partition-store/src/protobuf_types.rs
+++ b/crates/partition-store/src/protobuf_types.rs
@@ -148,7 +148,7 @@ pub mod v1 {
             InboxEntry, InvocationId, InvocationResolutionResult, InvocationStatus,
             InvocationStatusV2, InvocationTarget, InvocationV2Lite, JournalCompletionTarget,
             JournalEntry, JournalEntryIndex, JournalMeta, KvPair, OutboxMessage, Promise,
-            ResponseResult, SequenceNumber, ServiceId, ServiceInvocation,
+            ResponseResult, RestateVersion, SequenceNumber, ServiceId, ServiceInvocation,
             ServiceInvocationResponseSink, Source, SpanContext, SpanRelation, StateMutation,
             SubmitNotificationSink, Timer, VirtualObjectStatus, enriched_entry_header, entry,
             entry_result, inbox_entry, invocation_resolution_result, invocation_status,
@@ -1240,8 +1240,7 @@ pub mod v1 {
                         journal_metadata,
                         pinned_deployment,
                         response_sinks,
-                        created_using_restate_version:
-                            restate_types::invocation::RestateVersion::unknown(),
+                        created_using_restate_version: restate_types::RestateVersion::unknown(),
                         timestamps:
                             restate_storage_api::invocation_status_table::StatusTimestamps::new(
                                 MillisSinceEpoch::new(value.creation_time),
@@ -1360,8 +1359,7 @@ pub mod v1 {
                 Ok((
                     restate_storage_api::invocation_status_table::InFlightInvocationMetadata {
                         invocation_target,
-                        created_using_restate_version:
-                            restate_types::invocation::RestateVersion::unknown(),
+                        created_using_restate_version: restate_types::RestateVersion::unknown(),
                         journal_metadata,
                         pinned_deployment,
                         response_sinks,
@@ -1489,7 +1487,7 @@ pub mod v1 {
                 Ok(restate_storage_api::invocation_status_table::InboxedInvocation {
                     inbox_sequence_number: value.inbox_sequence_number,
                     metadata: restate_storage_api::invocation_status_table::PreFlightInvocationMetadata {
-                        created_using_restate_version:   restate_types::invocation::RestateVersion::unknown(),
+                        created_using_restate_version:   restate_types::RestateVersion::unknown(),
                         response_sinks,
                         timestamps: restate_storage_api::invocation_status_table::StatusTimestamps::new(
                             MillisSinceEpoch::new(value.creation_time),
@@ -1579,8 +1577,7 @@ pub mod v1 {
                 Ok(
                     restate_storage_api::invocation_status_table::CompletedInvocation {
                         invocation_target,
-                        created_using_restate_version:
-                            restate_types::invocation::RestateVersion::unknown(),
+                        created_using_restate_version: restate_types::RestateVersion::unknown(),
                         source,
                         timestamps:
                             restate_storage_api::invocation_status_table::StatusTimestamps::new(
@@ -4115,6 +4112,20 @@ pub mod v1 {
             }
         }
 
+        impl From<RestateVersion> for restate_types::SemanticRestateVersion {
+            fn from(value: RestateVersion) -> Self {
+                Self::parse(&value.version).unwrap_or_default()
+            }
+        }
+
+        impl From<restate_types::SemanticRestateVersion> for RestateVersion {
+            fn from(value: restate_types::SemanticRestateVersion) -> Self {
+                RestateVersion {
+                    version: value.to_string(),
+                }
+            }
+        }
+
         impl From<crate::fsm_table::SequenceNumber> for SequenceNumber {
             fn from(value: crate::fsm_table::SequenceNumber) -> Self {
                 SequenceNumber {
@@ -4143,13 +4154,11 @@ pub mod v1 {
             }
         }
 
-        fn restate_version_from_pb(
-            restate_version: String,
-        ) -> restate_types::invocation::RestateVersion {
+        fn restate_version_from_pb(restate_version: String) -> restate_types::RestateVersion {
             if restate_version.is_empty() {
-                restate_types::invocation::RestateVersion::unknown()
+                restate_types::RestateVersion::unknown()
             } else {
-                restate_types::invocation::RestateVersion::new(restate_version)
+                restate_types::RestateVersion::new(restate_version)
             }
         }
     }

--- a/crates/partition-store/src/tests/barrier_test.rs
+++ b/crates/partition-store/src/tests/barrier_test.rs
@@ -1,0 +1,69 @@
+use googletest::prelude::*;
+
+use restate_rocksdb::RocksDbManager;
+use restate_storage_api::{
+    Transaction,
+    fsm_table::{FsmTable, ReadOnlyFsmTable},
+};
+use restate_types::{
+    SemanticRestateVersion,
+    config::{CommonOptions, RocksDbOptions, StorageOptions},
+    identifiers::{PartitionId, PartitionKey},
+    live::Constant,
+};
+
+use crate::{OpenMode, PartitionStoreManager};
+
+#[restate_core::test]
+async fn barrier_fsm() -> googletest::Result<()> {
+    let rocksdb = RocksDbManager::init(Constant::new(CommonOptions::default()));
+
+    let partition_store_manager =
+        PartitionStoreManager::create(Constant::new(StorageOptions::default()), &[]).await?;
+
+    let partition_id = PartitionId::MIN;
+    let mut partition_store = partition_store_manager
+        .open_partition_store(
+            partition_id,
+            PartitionKey::MIN..=PartitionKey::MAX,
+            OpenMode::CreateIfMissing,
+            &RocksDbOptions::default(),
+        )
+        .await?;
+
+    let mut txn = partition_store.transaction();
+    // we default to unknown if FSM doesn't have a min version, in that case, any "real" version
+    // should be greater.
+    let current_min = txn.get_min_restate_version().await?;
+    // sanity check
+    assert_that!(
+        SemanticRestateVersion::current(),
+        not(eq(&SemanticRestateVersion::unknown()))
+    );
+
+    // current_min should be equal to unknown
+    assert_that!(current_min, eq(SemanticRestateVersion::unknown()));
+    assert_that!(
+        SemanticRestateVersion::current().is_equal_or_newer_than(&current_min),
+        eq(true)
+    );
+
+    // lets update it to current.
+    txn.put_min_restate_version(SemanticRestateVersion::current())
+        .await?;
+
+    let current_min = txn.get_min_restate_version().await?;
+    assert_that!(&current_min, eq(SemanticRestateVersion::current()));
+
+    // commit.
+    txn.commit().await?;
+
+    // did it persist?
+    let mut txn = partition_store.transaction();
+    let current_min = txn.get_min_restate_version().await?;
+    // it's actually persisted
+    assert_that!(&current_min, eq(SemanticRestateVersion::current()));
+
+    rocksdb.shutdown().await;
+    Ok(())
+}

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -25,10 +25,10 @@ use restate_storage_api::invocation_status_table::{
     CompletionRangeEpochMap, InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
     InvokedInvocationStatusLite, JournalMetadata, ReadOnlyInvocationStatusTable, StatusTimestamps,
 };
+use restate_types::RestateVersion;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId, WithPartitionKey};
 use restate_types::invocation::{
-    InvocationTarget, RestateVersion, ServiceInvocationSpanContext, Source,
-    VirtualObjectHandlerType,
+    InvocationTarget, ServiceInvocationSpanContext, Source, VirtualObjectHandlerType,
 };
 use restate_types::time::MillisSinceEpoch;
 

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -28,6 +28,7 @@ use restate_types::invocation::{InvocationTarget, ServiceInvocation, Source};
 use restate_types::live::Constant;
 use restate_types::state_mut::ExternalStateMutation;
 
+mod barrier_test;
 mod durable_lsn_tracking_test;
 mod idempotency_table_test;
 mod inbox_table_test;

--- a/crates/service-client/src/metric_definitions.rs
+++ b/crates/service-client/src/metric_definitions.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics::{Unit, describe_counter, describe_gauge};
+
+pub const INGRESS_REQUESTS: &str = "restate.ingress.requests.total";
+
+pub fn describe_metrics() {
+    describe_counter!(
+        INGRESS_REQUESTS,
+        Unit::Count,
+        "Number of ingress requests in different states, see label state to classify"
+    );
+}

--- a/crates/storage-api/src/fsm_table/mod.rs
+++ b/crates/storage-api/src/fsm_table/mod.rs
@@ -8,10 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
+use std::future::Future;
+
+use restate_types::SemanticRestateVersion;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
-use std::future::Future;
+
+use crate::Result;
 
 pub trait ReadOnlyFsmTable {
     fn get_inbox_seq_number(&mut self) -> impl Future<Output = Result<MessageIndex>> + Send + '_;
@@ -19,6 +22,10 @@ pub trait ReadOnlyFsmTable {
     fn get_outbox_seq_number(&mut self) -> impl Future<Output = Result<MessageIndex>> + Send + '_;
 
     fn get_applied_lsn(&mut self) -> impl Future<Output = Result<Option<Lsn>>> + Send + '_;
+
+    fn get_min_restate_version(
+        &mut self,
+    ) -> impl Future<Output = Result<SemanticRestateVersion>> + Send + '_;
 }
 
 pub trait FsmTable: ReadOnlyFsmTable {
@@ -32,5 +39,10 @@ pub trait FsmTable: ReadOnlyFsmTable {
     fn put_outbox_seq_number(
         &mut self,
         seq_number: MessageIndex,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    fn put_min_restate_version(
+        &mut self,
+        version: &SemanticRestateVersion,
     ) -> impl Future<Output = Result<()>> + Send;
 }

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -13,11 +13,12 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use futures_util::Stream;
 use rangemap::RangeInclusiveMap;
+use restate_types::RestateVersion;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 use restate_types::invocation::{
-    Header, InvocationEpoch, InvocationInput, InvocationTarget, ResponseResult, RestateVersion,
-    ServiceInvocation, ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
+    Header, InvocationEpoch, InvocationInput, InvocationTarget, ResponseResult, ServiceInvocation,
+    ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
 };
 use restate_types::journal_v2::{CompletionId, EntryIndex, NotificationId};
 use restate_types::time::MillisSinceEpoch;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -68,6 +68,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 regress = { workspace = true }
 schemars = { workspace = true, optional = true }
+semver = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 serde_path_to_error = { version = "0.1" }
@@ -100,7 +101,6 @@ futures = { workspace = true }
 tempfile = { workspace = true }
 googletest = { workspace = true }
 rand = { workspace = true }
-semver = { workspace = true }
 test-log = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -12,7 +12,6 @@
 
 pub mod client;
 
-use crate::GenerationalNodeId;
 use crate::errors::InvocationError;
 use crate::identifiers::{
     EntryIndex, IdempotencyId, InvocationId, PartitionKey, PartitionProcessorRpcRequestId,
@@ -20,12 +19,12 @@ use crate::identifiers::{
 };
 use crate::journal_v2::{CompletionId, GetInvocationOutputResult, Signal};
 use crate::time::MillisSinceEpoch;
+use crate::{GenerationalNodeId, RestateVersion};
 
 use bytes::Bytes;
 use bytestring::ByteString;
 use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceState};
 use serde_with::{FromInto, serde_as};
-use std::borrow::Cow;
 use std::hash::Hash;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -397,33 +396,6 @@ impl InvocationRequest {
 impl WithInvocationId for InvocationRequest {
     fn invocation_id(&self) -> InvocationId {
         self.header.invocation_id()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(transparent)]
-pub struct RestateVersion(Cow<'static, str>);
-
-impl RestateVersion {
-    pub fn current() -> Self {
-        Self(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
-    }
-
-    pub fn unknown() -> Self {
-        // We still provide a semver valid version here
-        Self(Cow::Borrowed("0.0.0-unknown"))
-    }
-
-    pub fn new(s: String) -> Self {
-        Self(Cow::Owned(s))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    pub fn into_string(self) -> String {
-        self.0.into_owned()
     }
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -14,6 +14,7 @@ mod base62_util;
 mod id_util;
 mod macros;
 mod node_id;
+mod restate_version;
 mod version;
 
 pub mod art;
@@ -56,6 +57,7 @@ pub mod timer;
 
 pub use id_util::{IdDecoder, IdEncoder, IdResourceType, IdStrCursor};
 pub use node_id::*;
+pub use restate_version::*;
 pub use version::*;
 
 // Re-export metrics' SharedString (Space-efficient Cow + RefCounted variant)

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -1,0 +1,270 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::borrow::{Borrow, Cow};
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+use restate_encoding::BilrostNewType;
+use serde_with::serde_as;
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct RestateVersionError(#[from] semver::Error);
+
+/// Version of a restate binary
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, BilrostNewType)]
+#[serde(transparent)]
+pub struct RestateVersion(Cow<'static, str>);
+
+impl RestateVersion {
+    /// The current version of the currently running binary
+    pub fn current() -> Self {
+        Self(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
+    }
+
+    pub fn unknown() -> Self {
+        // We still provide a semver valid version here
+        Self(Cow::Borrowed("0.0.0-unknown"))
+    }
+
+    pub fn new(s: String) -> Self {
+        Self(Cow::Owned(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0.into_owned()
+    }
+}
+
+impl AsRef<str> for RestateVersion {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<str> for RestateVersion {
+    fn borrow(&self) -> &str {
+        self.0.borrow()
+    }
+}
+
+/// A parsed semantic version of a restate binary
+#[serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+pub struct SemanticRestateVersion(#[serde_as(as = "serde_with::DisplayFromStr")] semver::Version);
+
+restate_encoding::bilrost_as_display_from_str!(SemanticRestateVersion);
+
+impl Default for SemanticRestateVersion {
+    fn default() -> Self {
+        Self::unknown()
+    }
+}
+
+impl SemanticRestateVersion {
+    pub fn current() -> &'static Self {
+        static CURRENT_SEMVER: LazyLock<SemanticRestateVersion> = LazyLock::new(|| {
+            SemanticRestateVersion(semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap())
+        });
+        &CURRENT_SEMVER
+    }
+
+    pub fn unknown() -> Self {
+        Self(semver::Version::parse("0.0.0-unknown").unwrap())
+    }
+
+    pub fn new(major: u64, minor: u64, patch: u64) -> Self {
+        Self(semver::Version::new(major, minor, patch))
+    }
+
+    pub fn major(&self) -> u64 {
+        self.0.major
+    }
+
+    pub fn minor(&self) -> u64 {
+        self.0.minor
+    }
+
+    pub fn patch(&self) -> u64 {
+        self.0.patch
+    }
+
+    pub fn is_dev(&self) -> bool {
+        self.0.pre == semver::Prerelease::new("dev").unwrap()
+    }
+
+    pub fn parse(s: &str) -> Result<Self, RestateVersionError> {
+        Self::from_str(s)
+    }
+
+    /// Compare the major, minor, patch, and pre-release value of two versions,
+    /// disregarding build metadata. Versions that differ only in build metadata
+    /// are considered equal. This comparison is what the SemVer spec refers to
+    /// as "precedence".
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use crate::SemanticRestateVersion;
+    ///
+    /// let mut versions = [
+    ///     "1.20.0+c144a98".parse::<SemanticRestateVersion>().unwrap(),
+    ///     "1.20.0".parse().unwrap(),
+    ///     "1.0.0".parse().unwrap(),
+    ///     "1.0.0-alpha".parse().unwrap(),
+    ///     "1.20.0+bc17664".parse().unwrap(),
+    /// ];
+    ///
+    /// // This is a stable sort, so it preserves the relative order of equal
+    /// // elements. The three 1.20.0 versions differ only in build metadata so
+    /// // they are not reordered relative to one another.
+    /// versions.sort_by(SemanticRestateVersion::cmp_precedence);
+    /// assert_eq!(versions, [
+    ///     "1.0.0-alpha".parse().unwrap(),
+    ///     "1.0.0".parse().unwrap(),
+    ///     "1.20.0+c144a98".parse().unwrap(),
+    ///     "1.20.0".parse().unwrap(),
+    ///     "1.20.0+bc17664".parse().unwrap(),
+    /// ]);
+    ///
+    /// // Totally order the versions, including comparing the build metadata.
+    /// versions.sort();
+    /// assert_eq!(versions, [
+    ///     "1.0.0-alpha".parse().unwrap(),
+    ///     "1.0.0".parse().unwrap(),
+    ///     "1.20.0".parse().unwrap(),
+    ///     "1.20.0+bc17664".parse().unwrap(),
+    ///     "1.20.0+c144a98".parse().unwrap(),
+    /// ]);
+    /// ```
+    pub fn cmp_precedence(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp_precedence(&other.0)
+    }
+
+    /// True if this version is equal or newer than the other version
+    ///
+    /// note that a released version is considered newer than the equivalent dev version
+    pub fn is_equal_or_newer_than(&self, other: &Self) -> bool {
+        self.cmp_precedence(other) != std::cmp::Ordering::Less
+    }
+}
+
+impl std::fmt::Display for SemanticRestateVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for SemanticRestateVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for SemanticRestateVersion {
+    type Err = RestateVersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version = semver::Version::parse(s).map_err(RestateVersionError::from)?;
+        Ok(Self(version))
+    }
+}
+
+impl From<semver::Version> for SemanticRestateVersion {
+    fn from(value: semver::Version) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<&RestateVersion> for SemanticRestateVersion {
+    type Error = RestateVersionError;
+
+    fn try_from(value: &RestateVersion) -> Result<Self, Self::Error> {
+        let version = semver::Version::parse(value.borrow()).map_err(RestateVersionError::from)?;
+        Ok(Self(version))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use googletest::prelude::*;
+
+    #[test]
+    fn restate_semantic_version() {
+        let cargo_version = env!("CARGO_PKG_VERSION");
+        let plain_version = RestateVersion::current();
+        assert_that!(cargo_version, eq(plain_version.as_str()));
+        let parsed = SemanticRestateVersion::from_str(cargo_version).unwrap();
+        assert_that!(parsed.to_string(), eq(plain_version.as_str()));
+        let parsed = SemanticRestateVersion::try_from(&RestateVersion::current()).unwrap();
+        assert_that!(parsed.to_string(), eq(plain_version.as_str()));
+
+        let parsed = SemanticRestateVersion::from_str("1.66.0").unwrap();
+        assert_that!(parsed.major(), eq(1));
+        assert_that!(parsed.minor(), eq(66));
+        assert_that!(parsed.patch(), eq(0));
+        assert_that!(parsed.is_dev(), eq(false));
+
+        let parsed = SemanticRestateVersion::from_str("1.66.0-dev").unwrap();
+        assert_that!(parsed.major(), eq(1));
+        assert_that!(parsed.minor(), eq(66));
+        assert_that!(parsed.patch(), eq(0));
+        assert_that!(parsed.is_dev(), eq(true));
+    }
+
+    #[test]
+    fn restate_version_serde() {
+        let version = RestateVersion::new("1.66.2-dev".to_owned());
+        let serialized = serde_json::to_string(&version).unwrap();
+        assert_that!(serialized, eq(r#""1.66.2-dev""#));
+        let deserialized: RestateVersion = serde_json::from_str(&serialized).unwrap();
+        assert_that!(version, eq(deserialized));
+
+        // same for semantic version
+        let version = SemanticRestateVersion::from_str("1.66.2-dev").unwrap();
+        let serialized = serde_json::to_string(&version).unwrap();
+        println!("{}", serialized);
+        assert_that!(serialized, eq(r#""1.66.2-dev""#));
+        let deserialized: SemanticRestateVersion = serde_json::from_str(&serialized).unwrap();
+        assert_that!(version, eq(deserialized));
+    }
+
+    #[test]
+    fn restate_version_newer_than() {
+        // same same
+        let version = SemanticRestateVersion::parse("1.66.2-dev").unwrap();
+        assert_that!(version.is_equal_or_newer_than(&version), eq(true));
+
+        let newer = SemanticRestateVersion::parse("1.66.2").unwrap();
+        // both are equal
+        assert_that!(newer.is_equal_or_newer_than(&version), eq(true));
+        // 1.66.2 is newer than 1.66.2-dev
+        assert_that!(version.is_equal_or_newer_than(&newer), eq(false));
+        let even_newer = SemanticRestateVersion::parse("1.66.3").unwrap();
+        assert_that!(even_newer.is_equal_or_newer_than(&newer), eq(true));
+        assert_that!(newer.is_equal_or_newer_than(&even_newer), eq(false));
+
+        let newer_dev = SemanticRestateVersion::parse("1.66.3-dev").unwrap();
+        // 1.66.3-dev is newer than 1.66.2-dev
+        assert_that!(newer_dev.is_equal_or_newer_than(&version), eq(true));
+
+        let version = SemanticRestateVersion::parse("1.66.1").unwrap();
+        let newer = SemanticRestateVersion::parse("1.66.2").unwrap();
+        // newer is newer
+        assert_that!(version.is_equal_or_newer_than(&newer), eq(false));
+        assert_that!(newer.is_equal_or_newer_than(&version), eq(true));
+    }
+}

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -10,8 +10,9 @@
 
 use std::ops::RangeInclusive;
 
-use restate_types::GenerationalNodeId;
 use restate_types::identifiers::{LeaderEpoch, PartitionKey};
+use restate_types::logs::Keys;
+use restate_types::{GenerationalNodeId, SemanticRestateVersion};
 
 /// Announcing a new leader. This message can be written by any component to make the specified
 /// partition processor the leader.
@@ -25,6 +26,22 @@ pub struct AnnounceLeader {
     // Fallback if this is not set to use Envelope's header's destination partition-key as a
     // single key filter.
     pub partition_key_range: Option<RangeInclusive<PartitionKey>>,
+}
+
+/// A simple version barrier to fence off state machine changes that require a certain minimum
+/// version of restate server.
+///
+///
+/// Readers before 1.4.0 will crash when reading this command. For 1.4.0+, the barrier defines the
+/// minimum version of restate server that can progress after this command. It also updates the FSM
+/// in case command has been trimmed.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
+pub struct VersionBarrier {
+    /// The minimum version required (inclusive) to progress after this barrier.
+    pub version: SemanticRestateVersion,
+    /// A human-readable reason for why this barrier exists.
+    pub human_reason: Option<String>,
+    pub partition_key_range: Keys,
 }
 
 #[cfg(all(test, feature = "serde"))]

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -14,6 +14,8 @@ use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
 pub const PARTITION_LABEL: &str = "partition";
 
+pub const PARTITION_BLOCKED_FLARE: &str = "restate.partition.blocked_flare";
+
 pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command.seconds";
 pub const PARTITION_ACTUATOR_HANDLED: &str = "restate.partition.actuator_handled.total";
 pub const PARTITION_STORAGE_TX_CREATED: &str = "restate.partition.storage_tx_created.total";
@@ -45,6 +47,11 @@ pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
 pub const PARTITION_RECORD_READ_COUNT: &str = "restate.partition.record_read_count";
 
 pub(crate) fn describe_metrics() {
+    describe_gauge!(
+        PARTITION_BLOCKED_FLARE,
+        Unit::Count,
+        "A partition requires a higher restate-server version and is blocked from starting on this node"
+    );
     describe_histogram!(
         PARTITION_APPLY_COMMAND,
         Unit::Seconds,

--- a/crates/worker/src/partition/state_machine/lifecycle/mod.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/mod.rs
@@ -19,6 +19,7 @@ mod purge;
 mod purge_journal;
 mod resume;
 mod suspend;
+mod version_barrier;
 
 pub(super) use cancel::OnCancelCommand;
 pub(super) use migrate_journal_table::VerifyOrMigrateJournalTableToV2Command;
@@ -31,3 +32,4 @@ pub(super) use purge::OnPurgeCommand;
 pub(super) use purge_journal::OnPurgeJournalCommand;
 pub(super) use resume::ResumeInvocationCommand;
 pub(super) use suspend::OnSuspendCommand;
+pub(super) use version_barrier::OnVersionBarrierCommand;

--- a/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_storage_api::fsm_table::FsmTable;
+use restate_wal_protocol::control::VersionBarrier;
+
+use crate::debug_if_leader;
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
+
+pub struct OnVersionBarrierCommand {
+    pub barrier: VersionBarrier,
+}
+
+impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
+    for OnVersionBarrierCommand
+where
+    S: FsmTable,
+{
+    async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
+        if matches!(
+            self.barrier.version.cmp_precedence(ctx.min_restate_version),
+            std::cmp::Ordering::Greater,
+        ) {
+            ctx.storage
+                .put_min_restate_version(&self.barrier.version)
+                .await?;
+            *ctx.min_restate_version = self.barrier.version;
+            debug_if_leader!(
+                ctx.is_leader,
+                "Update a new minimum restate-server version barrier to {}",
+                ctx.min_restate_version
+            );
+        }
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -13,17 +13,24 @@ mod entries;
 mod lifecycle;
 mod utils;
 
-use crate::metric_definitions::PARTITION_APPLY_COMMAND;
-use crate::partition::state_machine::lifecycle::OnCancelCommand;
-use crate::partition::types::{InvokerEffect, InvokerEffectKind, OutboxMessageExt};
-use ::tracing::{Instrument, Span, debug, trace, warn};
 pub use actions::{Action, ActionCollector};
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+use std::ops::RangeInclusive;
+use std::str::FromStr;
+use std::time::Instant;
+
 use assert2::let_assert;
 use bytes::Bytes;
 use bytestring::ByteString;
 use enumset::EnumSet;
 use futures::{StreamExt, TryStreamExt};
 use metrics::{Histogram, histogram};
+use tracing::{Instrument, Span, debug, error, trace, warn};
+
 use restate_invoker_api::InvokeInputJournal;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
@@ -67,9 +74,9 @@ use restate_types::invocation::{
     AttachInvocationRequest, IngressInvocationResponseSink, InvocationEpoch,
     InvocationMutationResponseSink, InvocationQuery, InvocationResponse, InvocationTarget,
     InvocationTargetType, InvocationTermination, JournalCompletionTarget, NotifySignalRequest,
-    ResponseResult, RestateVersion, ServiceInvocation, ServiceInvocationResponseSink,
-    ServiceInvocationSpanContext, Source, SubmitNotificationSink, TerminationFlavor,
-    VirtualObjectHandlerType, WorkflowHandlerType,
+    ResponseResult, ServiceInvocation, ServiceInvocationResponseSink, ServiceInvocationSpanContext,
+    Source, SubmitNotificationSink, TerminationFlavor, VirtualObjectHandlerType,
+    WorkflowHandlerType,
 };
 use restate_types::invocation::{InvocationInput, SpanRelation};
 use restate_types::journal::Completion;
@@ -92,18 +99,15 @@ use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_types::state_mut::StateMutationVersion;
 use restate_types::time::MillisSinceEpoch;
+use restate_types::{RestateVersion, SemanticRestateVersion};
 use restate_wal_protocol::Command;
 use restate_wal_protocol::timer::TimerKeyDisplay;
 use restate_wal_protocol::timer::TimerKeyValue;
-use std::borrow::Cow;
-use std::collections::HashSet;
-use std::fmt;
-use std::fmt::{Debug, Formatter};
-use std::ops::RangeInclusive;
-use std::str::FromStr;
-use std::time::Instant;
-use tracing::error;
-use utils::SpanExt;
+
+use self::utils::SpanExt;
+use crate::metric_definitions::PARTITION_APPLY_COMMAND;
+use crate::partition::state_machine::lifecycle::OnCancelCommand;
+use crate::partition::types::{InvokerEffect, InvokerEffectKind, OutboxMessageExt};
 
 #[derive(Debug, Hash, enumset::EnumSetType, strum::Display)]
 pub enum ExperimentalFeature {}
@@ -113,6 +117,8 @@ pub struct StateMachine {
     inbox_seq_number: MessageIndex,
     /// First outbox message index.
     outbox_head_seq_number: Option<MessageIndex>,
+    /// The minimum version of restate server that we currently support
+    min_restate_version: SemanticRestateVersion,
     /// Sequence number of the next outbox message to be appended.
     outbox_seq_number: MessageIndex,
     partition_key_range: RangeInclusive<PartitionKey>,
@@ -128,12 +134,21 @@ impl Debug for StateMachine {
             .field("inbox_seq_number", &self.inbox_seq_number)
             .field("outbox_head_seq_number", &self.outbox_head_seq_number)
             .field("outbox_seq_number", &self.outbox_seq_number)
+            .field("min_restate_version", &self.min_restate_version)
             .finish()
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error(
+        "partition is blocked; requires and upgrade to restate-server version \
+        {required_min_version} or higher; reason='{barrier_reason}'"
+    )]
+    VersionBarrier {
+        required_min_version: SemanticRestateVersion,
+        barrier_reason: String,
+    },
     #[error("failed to deserialize entry: {0}")]
     Codec(#[from] RawEntryCodecError),
     #[error(transparent)]
@@ -198,6 +213,7 @@ impl StateMachine {
         outbox_seq_number: MessageIndex,
         outbox_head_seq_number: Option<MessageIndex>,
         partition_key_range: RangeInclusive<PartitionKey>,
+        min_restate_version: SemanticRestateVersion,
         experimental_features: EnumSet<ExperimentalFeature>,
     ) -> Self {
         let invoker_apply_latency =
@@ -208,6 +224,7 @@ impl StateMachine {
             outbox_head_seq_number,
             partition_key_range,
             invoker_apply_latency,
+            min_restate_version,
             experimental_features,
         }
     }
@@ -219,6 +236,7 @@ pub(crate) struct StateMachineApplyContext<'a, S> {
     inbox_seq_number: &'a mut MessageIndex,
     outbox_seq_number: &'a mut MessageIndex,
     outbox_head_seq_number: &'a mut Option<MessageIndex>,
+    min_restate_version: &'a mut SemanticRestateVersion,
     partition_key_range: RangeInclusive<PartitionKey>,
     invoker_apply_latency: &'a Histogram,
     #[allow(dead_code)]
@@ -249,6 +267,7 @@ impl StateMachine {
                 inbox_seq_number: &mut self.inbox_seq_number,
                 outbox_seq_number: &mut self.outbox_seq_number,
                 outbox_head_seq_number: &mut self.outbox_head_seq_number,
+                min_restate_version: &mut self.min_restate_version,
                 partition_key_range: self.partition_key_range.clone(),
                 invoker_apply_latency: &self.invoker_apply_latency,
                 experimental_features: &self.experimental_features,
@@ -409,6 +428,52 @@ impl<S> StateMachineApplyContext<'_, S> {
             + journal_table_v2::JournalTable,
     {
         match command {
+            Command::VersionBarrier(barrier) => {
+                // We have versions in play:
+                // - Our binary's version (this process)
+                // - `min_restate_version` coming from the FSM
+                // - `barrier.version` from bifrost.
+                //
+                // If we can process this command, we update the FSM.
+                //
+                // We can process this command if our own version is at or higher than the barrier
+                // version as indicated by the message. We'll apply the change to the FSM which
+                // will only be applied if the new barrier version is higher than what the FSM
+                // already has.
+                //
+                // If we can't, then what?
+                //
+                // In 1.4 we crash the PP but tell a good message. This is not the best solution
+                // but it'll make clear what's going on. The issue with this approach is that we
+                // will probably continue restarting PP on the same node leading to unavailability.
+                //
+                // [future] What's the ideal scenario?
+                // - Ideal scenario is that we inform the operator (flare).
+                // - We mark this node *generational* as a bad candidate (not to take leadership
+                // or run follower again).
+                // - Through gossip, this node broadcasts its partition block-list so it won't be
+                // considered for leadership until a new generation pops up.
+                // Noting that the blocklist for a generational node can only increase/grow until
+                // the daemon is restarted (higher generation).
+                //
+                // Impact?
+                // - Controller attempts to reconfigure or selects a different leader
+                // that's not blocking this partition if such replacement exists.
+                // - Peers will not pick this node as leader candidate when performing
+                // adhoc failovers.
+                if SemanticRestateVersion::current().is_equal_or_newer_than(&barrier.version) {
+                    // Feels amazing to be running a new version of restate!
+                    lifecycle::OnVersionBarrierCommand { barrier }
+                        .apply(self)
+                        .await?;
+                    Ok(())
+                } else {
+                    Err(Error::VersionBarrier {
+                        required_min_version: barrier.version,
+                        barrier_reason: barrier.human_reason.unwrap_or_default(),
+                    })
+                }
+            }
             Command::Invoke(service_invocation) => {
                 self.on_service_invocation(service_invocation).await
             }

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -95,6 +95,7 @@ impl TestEnv {
             0,    /* outbox_seq_number */
             None, /* outbox_head_seq_number */
             PartitionKey::MIN..=PartitionKey::MAX,
+            SemanticRestateVersion::unknown().clone(),
             experimental_features,
         ))
         .await
@@ -1057,6 +1058,7 @@ async fn truncate_outbox_with_gap() -> Result<(), Error> {
         outbox_tail_index,
         Some(outbox_head_index),
         PartitionKey::MIN..=PartitionKey::MAX,
+        SemanticRestateVersion::unknown().clone(),
         EnumSet::empty(),
     ))
     .await;


### PR DESCRIPTION

Version barriers is a protection mechanism for future versions of restate. The barrier allows the log to be used to guard against old/unsupported restate versions from processing messages at or after the barrier is observed.
