### PR TITLE
Don't try and load region from AWS sdk if its been provided

### DIFF
--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -86,13 +86,15 @@ pub async fn create_object_store_client(
                         .with_region(region.to_string())
                         .with_credentials(Arc::new(AwsSdkCredentialsProvider::new(&sdk_config)?))
                 } else {
-                    let default_region = DefaultRegionChain::builder().build().region().await;
-                    let region = options
-                        .aws_region
-                        .clone()
-                        .map(Region::new)
-                        .or(default_region)
-                        .context("Unable to determine AWS region")?;
+                    let region = if let Some(region) = options.aws_region.as_ref() {
+                        Region::new(region.clone())
+                    } else {
+                        DefaultRegionChain::builder()
+                            .build()
+                            .region()
+                            .await
+                            .context("Unable to determine AWS region")?
+                    };
 
                     AmazonS3Builder::new().with_region(region.to_string())
                 }


### PR DESCRIPTION
This was leading to red herring loglines like:
```
{"timestamp":"2025-06-17T08:09:17.464985Z","level":"WARN","fields":{"message":"failed to load region from IMDS","err":"failed to load IMDS session token: dispatch failure: timeout: client error (Connect): HTTP connect timeout occurred after 1s: timed out (FailedToLoadToken(FailedToLoadToken { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Timeout, source: hyper_util::client::legacy::Error(Connect, HttpTimeoutError { kind: \"HTTP connect\", duration: 1s }), connection: Unknown } }) }))"},"target":"aws_config::imds::region"}
```
even when aws_region is provided