### PR TITLE
Use ReplicatedLoglet by default

### DIFF
--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -86,17 +86,9 @@ impl BifrostService {
     /// before continuing. For instance, a worker mark itself as `STARTING_UP` and not accept any
     /// requests until this is completed.
     ///
-    /// This requires to run within a task_center context.
+    /// This requires to run within a task_center context. Expects that logs metadata is synced.
     pub async fn start(self) -> anyhow::Result<()> {
-        // Make sure we have v1 metadata written to metadata store with the default
-        // configuration. If metadata is already initialized, this will make sure we have the
-        // latest version set in metadata manager.
-
-        // todo we seem to have a race condition between this call and the provision step which might
-        //  write a different logs configuration
-        self.bifrost.admin().init_metadata().await?;
-
-        // initialize all enabled providers.
+        // Initialize enabled providers.
         if self.factories.is_empty() {
             anyhow::bail!("No loglet providers enabled!");
         }

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -36,7 +36,7 @@ use super::{
 pub struct BifrostOptions {
     /// # The default kind of loglet to be used
     ///
-    /// Default: Local
+    /// Default: Replicated
     pub default_provider: ProviderKind,
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     /// Configuration of local loglet provider
@@ -117,7 +117,7 @@ impl BifrostOptions {
 impl Default for BifrostOptions {
     fn default() -> Self {
         Self {
-            default_provider: ProviderKind::Local,
+            default_provider: ProviderKind::Replicated,
             replicated_loglet: ReplicatedLogletOptions::default(),
             local: LocalLogletOptions::default(),
             read_retry_policy: RetryPolicy::exponential(


### PR DESCRIPTION
Automatically migrates logs metadata to replicated loglet in single-node configuration. This will cause Bifrost to extend the chain with new replicated loglet segments. The commit also removes an old logs initialization path which has sinced been replaced by the provisioning task.

Closes #3129

---

Testing notes

## 1.4.0-dev: fresh start

✅ Starts with replicated loglet as expected:

```
% restatectl logs ls
Logs v25
└ Logs Provider: replicated
 ├ Log replication: {node: 1}
 └ Nodeset size: 0
 L-ID  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     1         Replicated  0_0        {node: 1}    N1:2       [N1]
 1     1         Replicated  1_0        {node: 1}    N1:2       [N1]
 2     1         Replicated  2_0        {node: 1}    N1:2       [N1]
 3     1         Replicated  3_0        {node: 1}    N1:2       [N1]
 4     1         Replicated  4_0        {node: 1}    N1:2       [N1]
...
```

## 1.3.2 -> 1.4.0-dev: default loglet config automatic migration

`% npx @restatedev/restate-server@1.3.2 --node-name n1`

```
% restatectl logs ls
Logs v2
└ Logs Provider: local
 L-ID  FROM-LSN  KIND   LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     1         Local  N/A        N/A          N/A        N/A
 1     1         Local  N/A        N/A          N/A        N/A
 2     1         Local  N/A        N/A          N/A        N/A
 3     1         Local  N/A        N/A          N/A        N/A
 4     1         Local  N/A        N/A          N/A        N/A
 ...
```

Stop and re-start with 1.4.0-dev: `% restate-server --node-name n1`

```
2025-06-17T13:51:34.209045Z INFO restate_server
  Starting Restate Server 1.4.0-dev (debug) (9464d0e8 aarch64-apple-darwin 2025-06-17)
    node_name: "n1"
    config_source: [default]
    base_dir: /Users/pavel/restate/restate/restate-data/n1/

...

2025-06-17T13:51:34.502555Z INFO restate_node
  Migrating default loglet configuration to replicated
on rs:worker-0

...

2025-06-17T13:51:40.503517Z INFO restate_bifrost::watchdog
  [Auto Improvement] Bifrost will reconfigure logs to improve placement. logs=[14, 20, 2, 6, 0, 13, 23, 5]
on rs:worker-8
2025-06-17T13:51:41.503715Z INFO restate_bifrost::watchdog
  [Auto Improvement] Bifrost will reconfigure logs to improve placement. logs=[18, 10, 22, 15, 19, 12, 3, 21]
on rs:worker-12
2025-06-17T13:51:42.505307Z INFO restate_bifrost::watchdog
  [Auto Improvement] Bifrost will reconfigure logs to improve placement. logs=[11, 4, 7, 17, 9, 8, 1, 16]
on rs:worker-5
```

✅ Migrated as expected:

```
% restatectl logs ls
Logs v8
└ Logs Provider: replicated
 ├ Log replication: {node: 1}
 └ Nodeset size: 1
 L-ID  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     3         Replicated  0_1        {node: 1}    N1:3       [N1]
 1     3         Replicated  1_1        {node: 1}    N1:3       [N1]
 2     3         Replicated  2_1        {node: 1}    N1:3       [N1]
 3     3         Replicated  3_1        {node: 1}    N1:3       [N1]
 4     3         Replicated  4_1        {node: 1}    N1:3       [N1]
 ...
 ```
 
 ## 1.3.2 -> 1.4.0-dev: no migration if loglet type is explicitly configured
 
 `RESTATE_BIFROST__DEFAULT_PROVIDER="local" restate-server --node-name n1`
 
✅ No migration as expected:
 
 ```
 % restatectl logs ls
Logs v2
└ Logs Provider: local
 L-ID  FROM-LSN  KIND   LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     1         Local  N/A        N/A          N/A        N/A
 1     1         Local  N/A        N/A          N/A        N/A
 2     1         Local  N/A        N/A          N/A        N/A
 3     1         Local  N/A        N/A          N/A        N/A
 4     1         Local  N/A        N/A          N/A        N/A
 ...
 ```
 
 ## 1.3.2 -> 1.4.0-dev: no migration if `log-server` role is not enabled

 `restate-server --node-name n1 --roles=worker,admin,metadata-server`
 
✅ No migration as expected:
 
 ```
 % restatectl logs ls
Logs v2
└ Logs Provider: local
 L-ID  FROM-LSN  KIND   LOGLET-ID  REPLICATION  SEQUENCER  NODESET
 0     1         Local  N/A        N/A          N/A        N/A
 1     1         Local  N/A        N/A          N/A        N/A
 2     1         Local  N/A        N/A          N/A        N/A
 3     1         Local  N/A        N/A          N/A        N/A
 4     1         Local  N/A        N/A          N/A        N/A
 ...
 ```
 