### PR TITLE
[CI] pin install-action nextest to 0.9.98

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
         uses: ./.github/actions/install-protoc
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
 
       - name: Setup just
         uses: extractions/setup-just@v2

--- a/.github/workflows/hack-clippy.yml
+++ b/.github/workflows/hack-clippy.yml
@@ -48,7 +48,9 @@ jobs:
         uses: ./.github/actions/install-protoc
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
 
       - name: Setup just
         uses: extractions/setup-just@v2


### PR DESCRIPTION

See https://github.com/taiki-e/install-action/issues/1005
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3413).
* #3412
* __->__ #3413