### PR TITLE
Set default grpc compression to Zstd

### DIFF
--- a/crates/core/src/network/grpc/mod.rs
+++ b/crates/core/src/network/grpc/mod.rs
@@ -20,5 +20,4 @@ use tonic::codec::CompressionEncoding;
 pub const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
 /// Default send compression for grpc clients
-// todo: change this to zstd in v1.4
-pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;

--- a/crates/log-server-grpc/src/lib.rs
+++ b/crates/log-server-grpc/src/lib.rs
@@ -24,8 +24,7 @@ pub fn new_log_server_client(
 
     use tonic::codec::CompressionEncoding;
     /// Default send compression for grpc clients
-    // todo: change this to zstd in v1.4
-    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
     log_server_svc_client::LogServerSvcClient::new(channel)
         .max_decoding_message_size(MAX_MESSAGE_SIZE)

--- a/crates/metadata-server-grpc/src/grpc.rs
+++ b/crates/metadata-server-grpc/src/grpc.rs
@@ -17,9 +17,8 @@ pub fn new_metadata_server_client(
     channel: tonic::transport::Channel,
 ) -> metadata_server_svc_client::MetadataServerSvcClient<tonic::transport::Channel> {
     /// Default send compression for grpc clients
-    // todo: change this to zstd in v1.4
     use tonic::codec::CompressionEncoding;
-    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
     metadata_server_svc_client::MetadataServerSvcClient::new(channel)
         // note: the order of those calls defines the priority

--- a/crates/metadata-store/src/protobuf.rs
+++ b/crates/metadata-store/src/protobuf.rs
@@ -19,8 +19,7 @@ pub mod metadata_proxy_svc {
     #[cfg(feature = "grpc-client")]
     pub mod client {
         /// Default send compression for grpc clients
-        // todo: change this to zstd in v1.4
-        const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+        const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
         use bytestring::ByteString;
         use tonic::{Code, Status};


### PR DESCRIPTION
Set default grpc compression to Zstd

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3414).
* #3416
* __->__ #3414