### PR TITLE
Remove depreciated configuration options

### DIFF
--- a/crates/core/src/network/grpc/mod.rs
+++ b/crates/core/src/network/grpc/mod.rs
@@ -20,5 +20,4 @@ use tonic::codec::CompressionEncoding;
 pub const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
 /// Default send compression for grpc clients
-// todo: change this to zstd in v1.4
-pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;

--- a/crates/log-server-grpc/src/lib.rs
+++ b/crates/log-server-grpc/src/lib.rs
@@ -24,8 +24,7 @@ pub fn new_log_server_client(
 
     use tonic::codec::CompressionEncoding;
     /// Default send compression for grpc clients
-    // todo: change this to zstd in v1.4
-    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
     log_server_svc_client::LogServerSvcClient::new(channel)
         .max_decoding_message_size(MAX_MESSAGE_SIZE)

--- a/crates/metadata-server-grpc/src/grpc.rs
+++ b/crates/metadata-server-grpc/src/grpc.rs
@@ -17,9 +17,8 @@ pub fn new_metadata_server_client(
     channel: tonic::transport::Channel,
 ) -> metadata_server_svc_client::MetadataServerSvcClient<tonic::transport::Channel> {
     /// Default send compression for grpc clients
-    // todo: change this to zstd in v1.4
     use tonic::codec::CompressionEncoding;
-    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+    pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
     metadata_server_svc_client::MetadataServerSvcClient::new(channel)
         // note: the order of those calls defines the priority

--- a/crates/metadata-store/src/protobuf.rs
+++ b/crates/metadata-store/src/protobuf.rs
@@ -19,8 +19,7 @@ pub mod metadata_proxy_svc {
     #[cfg(feature = "grpc-client")]
     pub mod client {
         /// Default send compression for grpc clients
-        // todo: change this to zstd in v1.4
-        const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Gzip;
+        const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
         use bytestring::ByteString;
         use tonic::{Code, Status};

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -602,15 +602,7 @@ impl ClusterConfiguration {
     pub fn from_configuration(configuration: &Configuration) -> Self {
         ClusterConfiguration {
             num_partitions: configuration.common.default_num_partitions,
-            partition_replication: {
-                #[allow(deprecated)]
-                configuration
-                    .admin
-                    .default_partition_replication
-                    .clone()
-                    .unwrap_or_else(|| configuration.common.default_replication.clone())
-                    .into()
-            },
+            partition_replication: configuration.common.default_replication.clone().into(),
             bifrost_provider: ProviderConfiguration::from_configuration(configuration),
         }
     }

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -83,14 +83,7 @@ impl NodeCtlSvcHandler {
             .partition_replication
             .map(TryInto::try_into)
             .transpose()?
-            .unwrap_or_else(|| {
-                #[allow(deprecated)]
-                config
-                    .admin
-                    .default_partition_replication
-                    .clone()
-                    .unwrap_or_else(|| config.common.default_replication.clone())
-            });
+            .unwrap_or_else(|| config.common.default_replication.clone());
         let log_provider = request
             .log_provider
             .map(|log_provider| log_provider.parse())
@@ -105,15 +98,7 @@ impl NodeCtlSvcHandler {
             .log_replication
             .map(ReplicationProperty::try_from)
             .transpose()?
-            .unwrap_or_else(|| {
-                #[allow(deprecated)]
-                config
-                    .bifrost
-                    .replicated_loglet
-                    .default_log_replication
-                    .clone()
-                    .unwrap_or_else(|| config.common.default_replication.clone())
-            });
+            .unwrap_or_else(|| config.common.default_replication.clone());
 
         let provider_configuration =
             ProviderConfiguration::from((log_provider, log_replication, target_nodeset_size));

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -15,25 +15,19 @@ use std::time::Duration;
 
 use http::Uri;
 use serde::{Deserialize, Serialize};
-use serde_with::{DeserializeAs, serde_as};
+use serde_with::serde_as;
 use tokio::sync::Semaphore;
 
-use crate::{
-    partition_table::PartitionReplication,
-    replication::{ReplicationProperty, ReplicationPropertyFromTo},
-};
+use crate::config::print_warning_deprecated_config_option;
 
-use super::{
-    QueryEngineOptions, print_warning_deprecated_config_option,
-    print_warning_deprecated_value_using_default,
-};
+use super::QueryEngineOptions;
 
 /// # Admin server options
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(rename = "AdminOptions", default))]
-#[serde(rename_all = "kebab-case", from = "AdminOptionsShadow")]
+#[serde(rename_all = "kebab-case")]
 #[builder(default)]
 pub struct AdminOptions {
     /// # Endpoint address
@@ -79,23 +73,6 @@ pub struct AdminOptions {
     ///
     /// This configuration option is deprecated and ignored in Restate >= 1.2.
     pub log_trim_threshold: Option<u64>,
-
-    /// # Default partition replication factor
-    ///
-    /// The default replication factor for partition processors, this impacts how many replicas
-    /// each partition will have across the worker nodes of the cluster.
-    ///
-    /// Note that this value only impacts the cluster initial provisioning and will not be respected after
-    /// the cluster has been provisioned.
-    ///
-    /// To update existing clusters use the `restatectl` utility.
-    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-    #[serde_as(as = "Option<serde_with::PickFirst<(_, ReplicationPropertyFromTo)>>")]
-    #[deprecated(
-        since = "1.3.0",
-        note = "common.default_replication should be used instead. Will be removed with 1.4.0"
-    )]
-    pub default_partition_replication: Option<ReplicationProperty>,
 
     /// Disable serving the Restate Web UI on the admin port. Default is `false`.
     pub disable_web_ui: bool,
@@ -157,6 +134,13 @@ impl AdminOptions {
             );
         }
     }
+    #[allow(deprecated)]
+    pub fn print_deprecation_warnings(&self) {
+        if self.query_engine.pgsql_bind_address.is_some() {
+            print_warning_deprecated_config_option("admin.query-enging.pgsql-bind-address", None);
+            eprintln!("Please make SQL queries using the CLI or with the :9070/query API.")
+        }
+    }
 }
 
 impl Default for AdminOptions {
@@ -172,119 +156,10 @@ impl Default for AdminOptions {
             // check whether we can trim logs every hour
             log_trim_check_interval: Duration::from_secs(60 * 60).into(),
             log_trim_threshold: None,
-            default_partition_replication: None,
             #[cfg(any(test, feature = "test-util"))]
             disable_cluster_controller: false,
             disable_web_ui: false,
             experimental_feature_force_journal_retention: None,
         }
-    }
-}
-
-impl From<AdminOptionsShadow> for AdminOptions {
-    fn from(value: AdminOptionsShadow) -> Self {
-        let log_trim_check_interval = value
-            .log_trim_interval
-            .inspect(|_| {
-                print_warning_deprecated_config_option(
-                    "admin.log-trim-interval",
-                    Some("admin.log-trim-check-interval"),
-                )
-            })
-            .unwrap_or(value.log_trim_check_interval);
-
-        let partition_replication = value.default_partition_replication.map(|value| {
-            print_warning_deprecated_config_option(
-                "admin.default-partition-replication",
-                Some("default-replication"),
-            );
-
-            match value {
-                PartitionReplication::Everywhere => {
-                    print_warning_deprecated_value_using_default(
-                        "admin.default-partition-replication",
-                        "everywhere",
-                    );
-                    ReplicationProperty::new_unchecked(1)
-                }
-                PartitionReplication::Limit(replication_property) => replication_property,
-            }
-        });
-
-        #[allow(deprecated)]
-        if value.query_engine.pgsql_bind_address.is_some() {
-            print_warning_deprecated_config_option("admin.query-enging.pgsql-bind-address", None);
-            eprintln!("Please make SQL queries using the CLI or with the :9070/query API.")
-        }
-
-        #[allow(deprecated)]
-        Self {
-            bind_address: value.bind_address,
-            advertised_admin_endpoint: None,
-            concurrent_api_requests_limit: value.concurrent_api_requests_limit,
-            query_engine: value.query_engine,
-            heartbeat_interval: value.heartbeat_interval,
-            log_trim_check_interval,
-            log_trim_threshold: value.log_trim_threshold,
-            default_partition_replication: partition_replication,
-            disable_web_ui: value.disable_web_ui,
-            #[cfg(any(test, feature = "test-util"))]
-            disable_cluster_controller: value.disable_cluster_controller,
-            experimental_feature_force_journal_retention: value
-                .experimental_feature_force_journal_retention,
-        }
-    }
-}
-
-/// Used to deserialize the [`AdminOptions`] in backwards compatible way.
-///
-/// | Current Name                    | Backwards Compatible            | Since   |
-/// |---------------------------------|---------------------------------|---------|
-/// | `log_trim_check_interval`       | alias `log_trim_interval`       | 1.2     |
-/// |                                 | `default_partition_replication` | 1.3     |
-///
-/// Once we no longer support the backwards compatible aliases, we can remove this struct.
-#[serde_as]
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct AdminOptionsShadow {
-    bind_address: SocketAddr,
-    concurrent_api_requests_limit: Option<NonZeroUsize>,
-    query_engine: QueryEngineOptions,
-
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    heartbeat_interval: humantime::Duration,
-
-    #[serde_as(as = "serde_with::DisplayFromStr")]
-    log_trim_check_interval: humantime::Duration,
-
-    // todo: drop in version 1.3
-    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-    log_trim_interval: Option<humantime::Duration>,
-
-    log_trim_threshold: Option<u64>,
-
-    #[serde_as(
-        as = "Option<serde_with::PickFirst<(_, PartitionReplicationFromReplicationProperty)>>"
-    )]
-    default_partition_replication: Option<PartitionReplication>,
-
-    disable_web_ui: bool,
-
-    #[cfg(any(test, feature = "test-util"))]
-    disable_cluster_controller: bool,
-
-    #[serde_as(as = "Option<restate_serde_util::DurationString>")]
-    pub experimental_feature_force_journal_retention: Option<Duration>,
-}
-
-struct PartitionReplicationFromReplicationProperty;
-
-impl<'de> DeserializeAs<'de, PartitionReplication> for PartitionReplicationFromReplicationProperty {
-    fn deserialize_as<D>(deserializer: D) -> Result<PartitionReplication, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        ReplicationPropertyFromTo::deserialize_as(deserializer).map(PartitionReplication::Limit)
     }
 }

--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -53,6 +53,7 @@ pub struct QueryEngineOptions {
         since = "1.4.0",
         note = "Pgsql query engine be disable with 1.4.0, and removed with 1.5.0"
     )]
+    #[serde(skip_serializing)]
     pub pgsql_bind_address: Option<SocketAddr>,
 }
 

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -272,13 +272,15 @@ pub struct StorageOptions {
     /// This configuration option is deprecated and ignored in Restate >= 1.3.3.
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
-    #[deprecated(since = "1.3.3", note = "no longer used, will be removed with 1.4.0")]
+    #[deprecated(since = "1.4.0", note = "no longer used, will be removed with >1.4.0")]
+    #[serde(skip_serializing)]
     persist_lsn_interval: Option<humantime::Duration>,
 
     /// # Persist LSN threshold (deprecated)
     ///
     /// This configuration option is deprecated and ignored in Restate >= 1.3.3.
-    #[deprecated(since = "1.3.3", note = "no longer used, will be removed with 1.4.0")]
+    #[deprecated(since = "1.4.0", note = "no longer used, will be removed with >1.4.0")]
+    #[serde(skip_serializing)]
     pub persist_lsn_threshold: Option<u64>,
 
     /// Whether to perform commits in background IO thread pools eagerly or not

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -152,13 +152,7 @@ impl ProviderConfiguration {
     pub fn from_configuration(configuration: &Configuration) -> Self {
         ProviderConfiguration::from((
             configuration.bifrost.default_provider,
-            #[allow(deprecated)]
-            configuration
-                .bifrost
-                .replicated_loglet
-                .default_log_replication
-                .clone()
-                .unwrap_or_else(|| configuration.common.default_replication.clone()),
+            configuration.common.default_replication.clone(),
             configuration.bifrost.replicated_loglet.default_nodeset_size,
         ))
     }


### PR DESCRIPTION
Remove depreciated configuration options

Summary:
Clean up config and remove any deprecated flags are due
