### PR TITLE
Set default concurrent invocation limit to 1000

### DIFF
--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -225,7 +225,7 @@ impl Default for InvokerOptions {
             message_size_warning: NonZeroUsize::new(10 * 1024 * 1024).unwrap(), // 10MiB
             message_size_limit: None,
             tmp_dir: None,
-            concurrent_invocations_limit: None,
+            concurrent_invocations_limit: Some(NonZeroUsize::new(1000).expect("is non zero")),
             disable_eager_state: false,
             experimental_features_propose_events: false,
         }


### PR DESCRIPTION
Set default concurrent invocation limit to 1000

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3422).
* #3424
* __->__ #3422