### PR TITLE
[RocksDB] Introducing background iterators for data fusion

### DIFF
--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -35,5 +35,7 @@ mod tests;
 
 pub use partition_store::*;
 pub use partition_store_manager::*;
+// re-export
+pub use restate_rocksdb::Priority;
 
 use crate::scan::TableScan;

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -18,15 +18,17 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use codederror::CodedError;
 use enum_map::Enum;
-use rocksdb::table_properties::TablePropertiesExt;
 use rocksdb::{
     BoundColumnFamily, DBCompressionType, DBPinnableSlice, DBRawIteratorWithThreadMode,
     PrefixRange, ReadOptions, SliceTransform, SnapshotWithThreadMode,
 };
 use static_assertions::const_assert_eq;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::trace;
 
 use restate_core::{Metadata, ShutdownError};
+use restate_rocksdb::IterAction;
 use restate_rocksdb::{CfName, IoMode, Priority, RocksDb, RocksError};
 use restate_storage_api::fsm_table::ReadOnlyFsmTable;
 use restate_storage_api::{IsolationLevel, Storage, StorageError, Transaction};
@@ -35,6 +37,7 @@ use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId, WithPart
 use restate_types::logs::Lsn;
 use restate_types::partitions::Partition;
 use restate_types::storage::StorageCodec;
+use rocksdb::table_properties::TablePropertiesExt;
 
 use crate::durable_lsn_tracking::AppliedLsnCollectorFactory;
 use crate::keys::KeyKind;
@@ -106,7 +109,7 @@ const_assert_eq!(
     std::mem::size_of::<PaddedPartitionId>(),
 );
 
-pub(crate) type Result<T> = std::result::Result<T, StorageError>;
+pub(crate) type Result<T, E = StorageError> = std::result::Result<T, E>;
 
 pub enum TableScanIterationDecision<R> {
     Emit(Result<R>),
@@ -311,50 +314,23 @@ impl PartitionStore {
         find_cf_handle(&self.rocksdb, &self.data_cf_name, table_kind)
     }
 
-    fn prefix_iterator(
-        &self,
-        table: TableKind,
-        _key_kind: KeyKind,
-        prefix: Bytes,
-    ) -> Result<DBIterator> {
-        let table = self.table_handle(table)?;
+    fn new_prefix_iterator_opts(&self, _key_kind: KeyKind, prefix: Bytes) -> ReadOptions {
         let mut opts = ReadOptions::default();
         opts.set_prefix_same_as_start(true);
         opts.set_iterate_range(PrefixRange(prefix.clone()));
         opts.set_async_io(true);
         opts.set_total_order_seek(false);
-        let mut it = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(&table, opts);
-        it.seek(prefix);
-        Ok(it)
+        opts
     }
 
-    fn range_iterator(
-        &self,
-        table: TableKind,
-        _key: KeyKind,
-        scan_mode: ScanMode,
-        from: Bytes,
-        to: Bytes,
-    ) -> Result<DBIterator> {
-        let table = self.table_handle(table)?;
+    fn new_range_iterator_opts(&self, scan_mode: ScanMode, from: Bytes, to: Bytes) -> ReadOptions {
         let mut opts = ReadOptions::default();
         // todo: use auto_prefix_mode, at the moment, rocksdb doesn't expose this through the C
         // binding.
         opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
-        opts.set_iterate_range(from.clone()..to);
+        opts.set_iterate_range(from..to);
         opts.set_async_io(true);
-
-        let mut it = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(&table, opts);
-        it.seek(from);
-        Ok(it)
+        opts
     }
 
     #[track_caller]
@@ -366,13 +342,32 @@ impl PartitionStore {
         match scan {
             PhysicalScan::Prefix(table, key_kind, prefix) => {
                 assert!(table.has_key_kind(&prefix));
-                self.prefix_iterator(table, key_kind, prefix.freeze())
+                let prefix = prefix.freeze();
+                let opts = self.new_prefix_iterator_opts(key_kind, prefix.clone());
+                let table = self.table_handle(table)?;
+                let mut it = self
+                    .rocksdb
+                    .inner()
+                    .as_raw_db()
+                    .raw_iterator_cf_opt(&table, opts);
+                it.seek(prefix);
+                Ok(it)
             }
-            PhysicalScan::RangeExclusive(table, key_kind, scan_mode, start, end) => {
+            PhysicalScan::RangeExclusive(table, _key_kind, scan_mode, start, end) => {
                 assert!(table.has_key_kind(&start));
-                self.range_iterator(table, key_kind, scan_mode, start.freeze(), end.freeze())
+                let start = start.freeze();
+                let end = end.freeze();
+                let opts = self.new_range_iterator_opts(scan_mode, start.clone(), end);
+                let table = self.table_handle(table)?;
+                let mut it = self
+                    .rocksdb
+                    .inner()
+                    .as_raw_db()
+                    .raw_iterator_cf_opt(&table, opts);
+                it.seek(start);
+                Ok(it)
             }
-            PhysicalScan::RangeOpen(table, key_kind, start) => {
+            PhysicalScan::RangeOpen(table, _key_kind, start) => {
                 // We delayed the generate the synthetic iterator upper bound until this point
                 // because we might have different prefix length requirements based on the
                 // table+key_kind combination and we should keep this knowledge as low-level as
@@ -386,15 +381,107 @@ impl PartitionStore {
                 // So, we limit the iterator to the upper bound of this prefix
                 let kind_upper_bound = K::KEY_KIND.exclusive_upper_bound();
                 end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
-                self.range_iterator(
-                    table,
-                    key_kind,
-                    ScanMode::TotalOrder,
-                    start.freeze(),
-                    end.freeze(),
-                )
+                let start = start.freeze();
+                let end = end.freeze();
+                let opts = self.new_range_iterator_opts(ScanMode::TotalOrder, start.clone(), end);
+                let table = self.table_handle(table)?;
+                let mut it = self
+                    .rocksdb
+                    .inner()
+                    .as_raw_db()
+                    .raw_iterator_cf_opt(&table, opts);
+                it.seek(start);
+                Ok(it)
             }
         }
+    }
+
+    pub fn run_iterator<K: TableKey, O: Send + 'static>(
+        &self,
+        name: &'static str,
+        priority: Priority,
+        scan: TableScan<K>,
+        f: impl Fn((&[u8], &[u8])) -> Result<O> + Send + 'static,
+    ) -> Result<ReceiverStream<Result<O>>, ShutdownError> {
+        let (tx, rx) = mpsc::channel(1);
+        let scan: PhysicalScan = scan.into();
+        let on_iter = move |item: Result<(&[u8], &[u8]), RocksError>| -> IterAction {
+            let res = match item {
+                // apply the caller's function
+                Ok((key, value)) => match f((key, value)) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(e));
+                        return IterAction::Stop;
+                    }
+                },
+                Err(e) => {
+                    let _ = tx.blocking_send(Err(StorageError::Generic(e.into())));
+                    return IterAction::Stop;
+                }
+            };
+            if tx.blocking_send(Ok(res)).is_err() {
+                return IterAction::Stop;
+            }
+            // the channel is not closed yet, keep iterating
+            IterAction::Next
+        };
+        match scan {
+            PhysicalScan::Prefix(table, key_kind, prefix) => {
+                assert!(table.has_key_kind(&prefix));
+                let prefix = prefix.freeze();
+                let opts = self.new_prefix_iterator_opts(key_kind, prefix.clone());
+                self.rocksdb.run_background_iterator(
+                    self.data_cf_name.clone(),
+                    name,
+                    priority,
+                    IterAction::Seek(prefix),
+                    opts,
+                    on_iter,
+                )?;
+            }
+            PhysicalScan::RangeExclusive(table, _key_kind, scan_mode, start, end) => {
+                assert!(table.has_key_kind(&start));
+                let start = start.freeze();
+                let end = end.freeze();
+                let opts = self.new_range_iterator_opts(scan_mode, start.clone(), end);
+                self.rocksdb.run_background_iterator(
+                    self.data_cf_name.clone(),
+                    name,
+                    priority,
+                    IterAction::Seek(start),
+                    opts,
+                    on_iter,
+                )?;
+            }
+            PhysicalScan::RangeOpen(_table, _key_kind, start) => {
+                // We delayed the generate the synthetic iterator upper bound until this point
+                // because we might have different prefix length requirements based on the
+                // table+key_kind combination and we should keep this knowledge as low-level as
+                // possible.
+                //
+                // make the end has the same length as all prefixes to ensure rocksdb key
+                // comparator can leverage bloom filters when applicable
+                // (if auto_prefix_mode is enabled)
+                let mut end = BytesMut::zeroed(DB_PREFIX_LENGTH);
+                // We want to ensure that Range scans fall within the same key kind.
+                // So, we limit the iterator to the upper bound of this prefix
+                let kind_upper_bound = K::KEY_KIND.exclusive_upper_bound();
+                end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
+                let start = start.freeze();
+                let end = end.freeze();
+                let opts = self.new_range_iterator_opts(ScanMode::TotalOrder, start.clone(), end);
+                self.rocksdb.run_background_iterator(
+                    self.data_cf_name.clone(),
+                    name,
+                    priority,
+                    IterAction::Seek(start),
+                    opts,
+                    on_iter,
+                )?;
+            }
+        }
+        Ok(ReceiverStream::new(rx))
     }
 
     pub fn transaction(&mut self) -> PartitionStoreTransaction {

--- a/crates/rocksdb/src/background.rs
+++ b/crates/rocksdb/src/background.rs
@@ -31,6 +31,7 @@ pub enum StorageTaskKind {
     Compaction,
     Shutdown,
     OpenDb,
+    BackgroundIterator,
 }
 
 impl StorageTaskKind {

--- a/crates/rocksdb/src/iterator.rs
+++ b/crates/rocksdb/src/iterator.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+use rocksdb::{DB, DBRawIteratorWithThreadMode};
+
+use crate::RocksError;
+
+pub enum Disposition {
+    // No value to emit, continue driving the iterator
+    Continue,
+    // Returned when the iterator will block _if_ it's configured
+    // to be non blocking (via ReadOptions::set_read_tier)
+    WouldBlock,
+    /// Iterator has terminated. No more values will be emitted
+    /// This is a terminal state.
+    Stop,
+}
+
+#[derive(Default, Clone, Eq, PartialEq)]
+pub enum IterAction {
+    Seek(Bytes),
+    Prev,
+    Next,
+    #[default]
+    SeekToFirst,
+    SeekToLast,
+    // Stop the iterator
+    Stop,
+}
+
+enum State<'a> {
+    Active {
+        iterator: DBRawIteratorWithThreadMode<'a, DB>,
+        next_step: IterAction,
+    },
+    Terminated,
+}
+
+pub struct RocksIterator<'a, F> {
+    state: State<'a>,
+    f: F,
+}
+
+impl<'a, F> RocksIterator<'a, F>
+where
+    F: Fn(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
+{
+    pub fn new(iterator: DBRawIteratorWithThreadMode<'a, DB>, next_step: IterAction, f: F) -> Self {
+        Self {
+            f,
+            state: State::Active {
+                iterator,
+                next_step,
+            },
+        }
+    }
+
+    /// Drive the iterator one step at a time
+    pub fn step(&mut self) -> Disposition {
+        let (iterator, next_step) = match &mut self.state {
+            State::Active {
+                iterator,
+                next_step,
+                ..
+            } => {
+                match next_step {
+                    IterAction::Seek(items) => iterator.seek(items),
+                    IterAction::Prev => iterator.prev(),
+                    IterAction::Next => iterator.next(),
+                    IterAction::SeekToFirst => iterator.seek_to_first(),
+                    IterAction::SeekToLast => iterator.seek_to_last(),
+                    IterAction::Stop => {
+                        self.state = State::Terminated;
+                        return Disposition::Stop;
+                    }
+                }
+                (iterator, next_step)
+            }
+            State::Terminated => return Disposition::Stop,
+        };
+
+        let Some((key, value)) = iterator.item() else {
+            match iterator.status() {
+                Ok(()) => {
+                    self.state = State::Terminated;
+                    return Disposition::Stop;
+                }
+                Err(e) => {
+                    if e.kind() == rocksdb::ErrorKind::Incomplete {
+                        return Disposition::WouldBlock;
+                    }
+                    // todo: perhaps in the future we can allow the user to decide
+                    // to retry on IO errors. But for now, we ignore the returned
+                    // action and always terminate.
+                    let _ = (self.f)(Err(RocksError::from(e)));
+                    self.state = State::Terminated;
+                    return Disposition::Stop;
+                }
+            }
+        };
+
+        // call the user's function
+        *next_step = (self.f)(Ok((key, value)));
+        Disposition::Continue
+    }
+}

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -12,6 +12,7 @@ mod background;
 mod db_manager;
 mod db_spec;
 mod error;
+mod iterator;
 mod metric_definitions;
 mod perf;
 mod rock_access;
@@ -19,8 +20,6 @@ mod rock_access;
 use metrics::counter;
 use metrics::gauge;
 use metrics::histogram;
-use restate_core::ShutdownError;
-use restate_types::config::RocksDbOptions;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -36,10 +35,15 @@ use rocksdb::statistics::Histogram;
 use rocksdb::statistics::HistogramData;
 use rocksdb::statistics::Ticker;
 
+use restate_core::ShutdownError;
+use restate_types::config::RocksDbOptions;
+
 // re-exports
 pub use self::db_manager::RocksDbManager;
 pub use self::db_spec::*;
 pub use self::error::*;
+pub use self::iterator::IterAction;
+use self::iterator::RocksIterator;
 pub use self::perf::RocksDbPerfGuard;
 pub use self::rock_access::RocksAccess;
 
@@ -284,6 +288,62 @@ impl RocksDb {
                 Err(e.into())
             }
         }
+    }
+
+    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    pub fn run_background_iterator(
+        &self,
+        cf: CfName,
+        name: &'static str,
+        priority: Priority,
+        initial_action: IterAction,
+        mut read_options: rocksdb::ReadOptions,
+        on_item: impl Fn(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
+    ) -> Result<(), ShutdownError> {
+        // ensure that we allow blocking IO.
+        read_options.set_read_tier(rocksdb::ReadTier::All);
+
+        let db = self.db.clone();
+        let task = StorageTask::default()
+            .kind(StorageTaskKind::BackgroundIterator)
+            .priority(priority)
+            .op(move || {
+                // note: the perf guard's lifetime encapsulates all operations in the iterator and
+                // the total duration includes all the time spent blocking on the tx's capacity.
+                let _x = RocksDbPerfGuard::new(name);
+                let Some(cf) = db.cf_handle(cf.as_str()) else {
+                    on_item(Err(RocksError::UnknownColumnFamily(cf)));
+                    return;
+                };
+                let mut iter = RocksIterator::new(
+                    db.as_raw_db().raw_iterator_cf_opt(&cf, read_options),
+                    initial_action,
+                    on_item,
+                );
+                loop {
+                    match iter.step() {
+                        iterator::Disposition::WouldBlock => {
+                            // we should not be here if the iterator is configured correctly.
+                            // as we are already in the storage thread pool, we expect the
+                            // iterator to be blocking.
+                            //
+                            // Why do we panic? because this iterator will be stopped short of all
+                            // values it should return and we don't want to mislead readers that
+                            // they have consumed the iterator cleanly.
+                            panic!(
+                                "RocksDB iterator is reporting that it WouldBlock but it's \
+                                already on the storage thread pool. This is a bug!"
+                            );
+                        }
+                        iterator::Disposition::Continue => continue,
+                        iterator::Disposition::Stop => return,
+                    }
+                }
+            })
+            .build()
+            .unwrap();
+
+        self.manager.spawn(task)
     }
 
     #[tracing::instrument(skip_all, fields(db = %self.name))]

--- a/crates/storage-api/src/state_table/mod.rs
+++ b/crates/storage-api/src/state_table/mod.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
+use std::ops::RangeInclusive;
+
 use bytes::Bytes;
 use futures_util::Stream;
+
 use restate_types::identifiers::{PartitionKey, ServiceId};
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use crate::Result;
 
 pub trait ReadOnlyStateTable {
     fn get_user_state(
@@ -26,12 +28,10 @@ pub trait ReadOnlyStateTable {
         &mut self,
         service_id: &ServiceId,
     ) -> Result<impl Stream<Item = Result<(Bytes, Bytes)>> + Send>;
+}
 
-    fn get_all_user_states(
-        &self,
-    ) -> Result<impl Stream<Item = Result<(ServiceId, Bytes, Bytes)>> + Send>;
-
-    fn get_all_user_states_in_range(
+pub trait ScanStateTable {
+    fn scan_all_user_states(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(ServiceId, Bytes, Bytes)>> + Send>;

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -8,16 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
 use std::fmt::Debug;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use futures::Stream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::state_table::ReadOnlyStateTable;
+use restate_storage_api::state_table::ScanStateTable;
 use restate_types::identifiers::{PartitionKey, ServiceId};
 
 use crate::context::{QueryContext, SelectPartitions};
@@ -64,7 +64,7 @@ impl ScanLocalPartition for StateScanner {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
     {
-        partition_store.get_all_user_states_in_range(range)
+        partition_store.scan_all_user_states(range)
     }
 
     fn append_row(row_builder: &mut Self::Builder, _: &mut String, value: Self::Item) {


### PR DESCRIPTION

This change introduces a background iterator and a flexible mechanism to drive rocksdb iterators on the storage thread pool.
- Moves the state table to use the new iterator
- Added separate trait for partition-store data table scan operations because those will not be valid/usable on transactions, only partition store.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3428).
* #3432
* #3431
* #3429
* __->__ #3428