### PR TITLE
[DataFusion] Move journal and idempotency tables to background iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7743,7 +7743,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "derive_more",
- "futures-util",
+ "futures",
  "num-traits",
  "rangemap",
  "restate-types",

--- a/crates/partition-store/src/idempotency_table/mod.rs
+++ b/crates/partition-store/src/idempotency_table/mod.rs
@@ -8,22 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::RangeInclusive;
+
+use bytes::Bytes;
+use bytestring::ByteString;
+use futures::Stream;
+
+use restate_rocksdb::Priority;
+use restate_storage_api::idempotency_table::{
+    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable, ScanIdempotencyTable,
+};
+use restate_storage_api::{Result, StorageError};
+use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
+
 use crate::keys::{KeyKind, TableKey, define_table_key};
-use crate::owned_iter::OwnedIterator;
 use crate::protobuf_types::PartitionStoreProtobufValue;
 use crate::scan::TableScan;
 use crate::{PartitionStore, TableKind};
 use crate::{PartitionStoreTransaction, StorageAccess};
-use bytes::Bytes;
-use bytestring::ByteString;
-use futures::Stream;
-use futures_util::stream;
-use restate_storage_api::idempotency_table::{
-    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
-};
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
-use std::ops::RangeInclusive;
 
 define_table_key!(
     TableKind::Idempotency,
@@ -64,36 +66,6 @@ fn get_idempotency_metadata<S: StorageAccess>(
     storage.get_value(create_key(idempotency_id))
 }
 
-fn all_idempotency_metadata<S: StorageAccess>(
-    storage: &S,
-    range: RangeInclusive<PartitionKey>,
-) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send + use<'_, S>> {
-    let iter = storage.iterator_from(TableScan::FullScanPartitionKeyRange::<IdempotencyKey>(
-        range,
-    ))?;
-    Ok(stream::iter(OwnedIterator::new(iter).map(
-        |(mut k, mut v)| {
-            let key = IdempotencyKey::deserialize_from(&mut k)?;
-            let idempotency_metadata = IdempotencyMetadata::decode(&mut v)?;
-
-            Ok((
-                IdempotencyId::new(
-                    key.service_name_ok_or()?.clone(),
-                    key.service_key
-                        .clone()
-                        .map(|b| {
-                            ByteString::try_from(b).map_err(|e| StorageError::Generic(e.into()))
-                        })
-                        .transpose()?,
-                    key.service_handler_ok_or()?.clone(),
-                    key.idempotency_key_ok_or()?.clone(),
-                ),
-                idempotency_metadata,
-            ))
-        },
-    )))
-}
-
 fn put_idempotency_metadata<S: StorageAccess>(
     storage: &mut S,
     idempotency_id: &IdempotencyId,
@@ -118,12 +90,38 @@ impl ReadOnlyIdempotencyTable for PartitionStore {
         self.assert_partition_key(idempotency_id)?;
         get_idempotency_metadata(self, idempotency_id)
     }
+}
 
-    fn all_idempotency_metadata(
+impl ScanIdempotencyTable for PartitionStore {
+    fn scan_idempotency_metadata(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send> {
-        all_idempotency_metadata(self, range)
+        self.run_iterator(
+            "df-idempotency",
+            Priority::Low,
+            TableScan::FullScanPartitionKeyRange::<IdempotencyKey>(range),
+            |(mut key, mut value)| {
+                let key = IdempotencyKey::deserialize_from(&mut key)?;
+                let idempotency_metadata = IdempotencyMetadata::decode(&mut value)?;
+
+                Ok((
+                    IdempotencyId::new(
+                        key.service_name_ok_or()?.clone(),
+                        key.service_key
+                            .clone()
+                            .map(|b| {
+                                ByteString::try_from(b).map_err(|e| StorageError::Generic(e.into()))
+                            })
+                            .transpose()?,
+                        key.service_handler_ok_or()?.clone(),
+                        key.idempotency_key_ok_or()?.clone(),
+                    ),
+                    idempotency_metadata,
+                ))
+            },
+        )
+        .map_err(|_| StorageError::OperationalError)
     }
 }
 
@@ -134,13 +132,6 @@ impl ReadOnlyIdempotencyTable for PartitionStoreTransaction<'_> {
     ) -> Result<Option<IdempotencyMetadata>> {
         self.assert_partition_key(idempotency_id)?;
         get_idempotency_metadata(self, idempotency_id)
-    }
-
-    fn all_idempotency_metadata(
-        &self,
-        range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send> {
-        all_idempotency_metadata(self, range)
     }
 }
 

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 derive_more = { workspace = true }
-futures-util = { workspace = true }
+futures = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }

--- a/crates/storage-api/src/deduplication_table/mod.rs
+++ b/crates/storage-api/src/deduplication_table/mod.rs
@@ -8,13 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
+use std::cmp::Ordering;
+
 use bytestring::ByteString;
-use futures_util::Stream;
+use futures::Stream;
+
 use restate_types::identifiers::{LeaderEpoch, PartitionId};
 use restate_types::message::MessageIndex;
-use std::cmp::Ordering;
-use std::future::Future;
+
+use crate::Result;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DedupInformation {

--- a/crates/storage-api/src/idempotency_table/mod.rs
+++ b/crates/storage-api/src/idempotency_table/mod.rs
@@ -8,12 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::Result;
-
-use futures_util::Stream;
-use restate_types::identifiers::{IdempotencyId, InvocationId, PartitionKey};
-use std::future::Future;
 use std::ops::RangeInclusive;
+
+use futures::Stream;
+
+use restate_types::identifiers::{IdempotencyId, InvocationId, PartitionKey};
+
+use super::Result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IdempotencyMetadata {
@@ -25,8 +26,10 @@ pub trait ReadOnlyIdempotencyTable {
         &mut self,
         idempotency_id: &IdempotencyId,
     ) -> impl Future<Output = Result<Option<IdempotencyMetadata>>> + Send;
+}
 
-    fn all_idempotency_metadata(
+pub trait ScanIdempotencyTable {
+    fn scan_idempotency_metadata(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send>;

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -10,7 +10,7 @@
 
 use crate::Result;
 use crate::promise_table::ReadOnlyPromiseTable;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey};
 use restate_types::message::MessageIndex;
 use restate_types::state_mut::ExternalStateMutation;

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -11,7 +11,7 @@
 use crate::Result;
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures_util::Stream;
+use futures::Stream;
 use rangemap::RangeInclusiveMap;
 use restate_types::RestateVersion;
 use restate_types::deployment::PinnedDeployment;

--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -8,13 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
-use futures_util::Stream;
+use std::ops::RangeInclusive;
+
+use futures::Stream;
+
 use restate_types::identifiers::{EntryIndex, InvocationId, JournalEntryId, PartitionKey};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::{CompletionResult, EntryType};
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use crate::Result;
 
 /// Different types of journal entries persisted by the runtime
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,8 +61,10 @@ pub trait ReadOnlyJournalTable {
         invocation_id: &InvocationId,
         journal_length: EntryIndex,
     ) -> Result<impl Stream<Item = Result<(EntryIndex, JournalEntry)>> + Send>;
+}
 
-    fn all_journals(
+pub trait ScanJournalTable {
+    fn scan_journals(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(JournalEntryId, JournalEntry)>> + Send>;

--- a/crates/storage-api/src/outbox_table/mod.rs
+++ b/crates/storage-api/src/outbox_table/mod.rs
@@ -14,7 +14,6 @@ use restate_types::invocation::{
     AttachInvocationRequest, InvocationResponse, InvocationTermination, NotifySignalRequest,
     ServiceInvocation,
 };
-use std::future::Future;
 use std::ops::RangeInclusive;
 
 /// Types of outbox messages.

--- a/crates/storage-api/src/promise_table/mod.rs
+++ b/crates/storage-api/src/promise_table/mod.rs
@@ -12,7 +12,7 @@ use super::Result;
 
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::errors::InvocationErrorCode;
 use restate_types::identifiers::{PartitionKey, ServiceId};
 use restate_types::invocation::JournalCompletionTarget;

--- a/crates/storage-api/src/service_status_table/mod.rs
+++ b/crates/storage-api/src/service_status_table/mod.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::Result;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId};
 use std::future::Future;
 use std::ops::RangeInclusive;

--- a/crates/storage-api/src/state_table/mod.rs
+++ b/crates/storage-api/src/state_table/mod.rs
@@ -11,7 +11,7 @@
 use std::ops::RangeInclusive;
 
 use bytes::Bytes;
-use futures_util::Stream;
+use futures::Stream;
 
 use restate_types::identifiers::{PartitionKey, ServiceId};
 

--- a/crates/storage-api/src/timer_table/mod.rs
+++ b/crates/storage-api/src/timer_table/mod.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::Result;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
 use restate_types::invocation::{InvocationEpoch, ServiceInvocation};
 use restate_types::time::MillisSinceEpoch;

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -16,7 +16,7 @@ use futures::Stream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::idempotency_table::{IdempotencyMetadata, ReadOnlyIdempotencyTable};
+use restate_storage_api::idempotency_table::{IdempotencyMetadata, ScanIdempotencyTable};
 use restate_types::identifiers::{IdempotencyId, PartitionKey};
 
 use super::row::append_idempotency_row;
@@ -65,7 +65,7 @@ impl ScanLocalPartition for IdempotencyScanner {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
     {
-        partition_store.all_idempotency_metadata(range)
+        partition_store.scan_idempotency_metadata(range)
     }
 
     fn append_row(


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3429).
* #3436
* #3433
* #3432
* #3431
* __->__ #3429