### PR TITLE
Fix `append_time` of the `InputCommand`

### DIFF
--- a/crates/types/src/journal_v2/raw/mod.rs
+++ b/crates/types/src/journal_v2/raw/mod.rs
@@ -92,6 +92,10 @@ impl RawEntry {
     pub fn header(&self) -> &RawEntryHeader {
         &self.header
     }
+
+    pub fn header_mut(&mut self) -> &mut RawEntryHeader {
+        &mut self.header
+    }
 }
 
 impl RawEntry {

--- a/crates/worker/src/partition/state_machine/lifecycle/migrate_journal_table.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/migrate_journal_table.rs
@@ -55,13 +55,18 @@ where
                     name: Default::default(),
                 }
                 .into();
+                let mut new_raw_entry = new_entry.encode::<ServiceProtocolV4Codec>();
+                // Journal V1 hasn't append_time, so we set here as timestamp the invocation creation time.
+                // SAFETY: this timestamp is used only for observability, it's fine if it's not agreed among followers.
+                new_raw_entry.header_mut().append_time =
+                    unsafe { self.metadata.timestamps.creation_time() };
 
                 // Now write the entry in the new table, and remove it from the old one
                 journal_table_v2::JournalTable::put_journal_entry(
                     ctx.storage,
                     self.invocation_id,
                     0,
-                    &new_entry.encode::<ServiceProtocolV4Codec>(),
+                    &new_raw_entry,
                     &[],
                 )
                 .await?;


### PR DESCRIPTION
Because of the journal migration from V1 to V2, `InputCommand` currently has an `append_time` that is always equal or after the first entry. 