### PR TITLE
[DataFusion] Move invocation_status table to use background iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7743,7 +7743,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "derive_more",
- "futures-util",
+ "futures",
  "num-traits",
  "rangemap",
  "restate-types",

--- a/crates/partition-store/src/idempotency_table/mod.rs
+++ b/crates/partition-store/src/idempotency_table/mod.rs
@@ -8,22 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::RangeInclusive;
+
+use bytes::Bytes;
+use bytestring::ByteString;
+use futures::Stream;
+
+use restate_rocksdb::Priority;
+use restate_storage_api::idempotency_table::{
+    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable, ScanIdempotencyTable,
+};
+use restate_storage_api::{Result, StorageError};
+use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
+
 use crate::keys::{KeyKind, TableKey, define_table_key};
-use crate::owned_iter::OwnedIterator;
 use crate::protobuf_types::PartitionStoreProtobufValue;
 use crate::scan::TableScan;
 use crate::{PartitionStore, TableKind};
 use crate::{PartitionStoreTransaction, StorageAccess};
-use bytes::Bytes;
-use bytestring::ByteString;
-use futures::Stream;
-use futures_util::stream;
-use restate_storage_api::idempotency_table::{
-    IdempotencyMetadata, IdempotencyTable, ReadOnlyIdempotencyTable,
-};
-use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
-use std::ops::RangeInclusive;
 
 define_table_key!(
     TableKind::Idempotency,
@@ -64,36 +66,6 @@ fn get_idempotency_metadata<S: StorageAccess>(
     storage.get_value(create_key(idempotency_id))
 }
 
-fn all_idempotency_metadata<S: StorageAccess>(
-    storage: &S,
-    range: RangeInclusive<PartitionKey>,
-) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send + use<'_, S>> {
-    let iter = storage.iterator_from(TableScan::FullScanPartitionKeyRange::<IdempotencyKey>(
-        range,
-    ))?;
-    Ok(stream::iter(OwnedIterator::new(iter).map(
-        |(mut k, mut v)| {
-            let key = IdempotencyKey::deserialize_from(&mut k)?;
-            let idempotency_metadata = IdempotencyMetadata::decode(&mut v)?;
-
-            Ok((
-                IdempotencyId::new(
-                    key.service_name_ok_or()?.clone(),
-                    key.service_key
-                        .clone()
-                        .map(|b| {
-                            ByteString::try_from(b).map_err(|e| StorageError::Generic(e.into()))
-                        })
-                        .transpose()?,
-                    key.service_handler_ok_or()?.clone(),
-                    key.idempotency_key_ok_or()?.clone(),
-                ),
-                idempotency_metadata,
-            ))
-        },
-    )))
-}
-
 fn put_idempotency_metadata<S: StorageAccess>(
     storage: &mut S,
     idempotency_id: &IdempotencyId,
@@ -118,12 +90,38 @@ impl ReadOnlyIdempotencyTable for PartitionStore {
         self.assert_partition_key(idempotency_id)?;
         get_idempotency_metadata(self, idempotency_id)
     }
+}
 
-    fn all_idempotency_metadata(
+impl ScanIdempotencyTable for PartitionStore {
+    fn scan_idempotency_metadata(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send> {
-        all_idempotency_metadata(self, range)
+        self.run_iterator(
+            "df-idempotency",
+            Priority::Low,
+            TableScan::FullScanPartitionKeyRange::<IdempotencyKey>(range),
+            |(mut key, mut value)| {
+                let key = IdempotencyKey::deserialize_from(&mut key)?;
+                let idempotency_metadata = IdempotencyMetadata::decode(&mut value)?;
+
+                Ok((
+                    IdempotencyId::new(
+                        key.service_name_ok_or()?.clone(),
+                        key.service_key
+                            .clone()
+                            .map(|b| {
+                                ByteString::try_from(b).map_err(|e| StorageError::Generic(e.into()))
+                            })
+                            .transpose()?,
+                        key.service_handler_ok_or()?.clone(),
+                        key.idempotency_key_ok_or()?.clone(),
+                    ),
+                    idempotency_metadata,
+                ))
+            },
+        )
+        .map_err(|_| StorageError::OperationalError)
     }
 }
 
@@ -134,13 +132,6 @@ impl ReadOnlyIdempotencyTable for PartitionStoreTransaction<'_> {
     ) -> Result<Option<IdempotencyMetadata>> {
         self.assert_partition_key(idempotency_id)?;
         get_idempotency_metadata(self, idempotency_id)
-    }
-
-    fn all_idempotency_metadata(
-        &self,
-        range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send> {
-        all_idempotency_metadata(self, range)
     }
 }
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -775,10 +775,6 @@ impl PartitionStoreTransaction<'_> {
         self.partition_id
     }
 
-    pub(crate) fn partition_key_range(&self) -> &RangeInclusive<PartitionKey> {
-        self.partition_key_range
-    }
-
     #[inline]
     pub(crate) fn assert_partition_key(&self, partition_key: &impl WithPartitionKey) -> Result<()> {
         assert_partition_key_or_err(self.partition_key_range, partition_key)

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -8,24 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::RangeInclusive;
+
+use bytes::Bytes;
+use bytestring::ByteString;
+use futures::Stream;
+
+use restate_rocksdb::{Priority, RocksDbPerfGuard};
+use restate_storage_api::promise_table::{
+    OwnedPromiseRow, Promise, PromiseTable, ReadOnlyPromiseTable, ScanPromiseTable,
+};
+use restate_storage_api::{Result, StorageError};
+use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
+
 use crate::keys::{KeyKind, TableKey, define_table_key};
-use crate::owned_iter::OwnedIterator;
 use crate::protobuf_types::PartitionStoreProtobufValue;
 use crate::scan::TableScan;
 use crate::{PartitionStore, TableKind, TableScanIterationDecision};
 use crate::{PartitionStoreTransaction, StorageAccess};
-use anyhow::anyhow;
-use bytes::Bytes;
-use bytestring::ByteString;
-use futures::Stream;
-use futures_util::stream;
-use restate_rocksdb::RocksDbPerfGuard;
-use restate_storage_api::Result;
-use restate_storage_api::promise_table::{
-    OwnedPromiseRow, Promise, PromiseTable, ReadOnlyPromiseTable,
-};
-use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
-use std::ops::RangeInclusive;
 
 define_table_key!(
     TableKind::Promise,
@@ -57,32 +57,6 @@ fn get_promise<S: StorageAccess>(
 ) -> Result<Option<Promise>> {
     let _x = RocksDbPerfGuard::new("get-promise");
     storage.get_value(create_key(service_id, key))
-}
-
-fn all_promise<S: StorageAccess>(
-    storage: &S,
-    range: RangeInclusive<PartitionKey>,
-) -> Result<impl Stream<Item = Result<OwnedPromiseRow>> + Send + use<'_, S>> {
-    let iter = storage.iterator_from(TableScan::FullScanPartitionKeyRange::<PromiseKey>(range))?;
-    Ok(stream::iter(OwnedIterator::new(iter).map(
-        |(mut k, mut v)| {
-            let key = PromiseKey::deserialize_from(&mut k)?;
-            let metadata = Promise::decode(&mut v)?;
-
-            let (partition_key, service_name, service_key, promise_key) = key.into_inner_ok_or()?;
-
-            Ok(OwnedPromiseRow {
-                service_id: ServiceId::with_partition_key(
-                    partition_key,
-                    service_name,
-                    ByteString::try_from(service_key)
-                        .map_err(|e| anyhow!("Cannot convert to string {e}"))?,
-                ),
-                key: promise_key,
-                metadata,
-            })
-        },
-    )))
 }
 
 fn put_promise<S: StorageAccess>(
@@ -121,12 +95,37 @@ impl ReadOnlyPromiseTable for PartitionStore {
         self.assert_partition_key(service_id)?;
         get_promise(self, service_id, key)
     }
+}
 
-    fn all_promises(
+impl ScanPromiseTable for PartitionStore {
+    fn scan_promises(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<OwnedPromiseRow>> + Send> {
-        all_promise(self, range)
+        self.run_iterator(
+            "df-promise",
+            Priority::Low,
+            TableScan::FullScanPartitionKeyRange::<PromiseKey>(range),
+            |(mut k, mut v)| {
+                let key = PromiseKey::deserialize_from(&mut k)?;
+                let metadata = Promise::decode(&mut v)?;
+
+                let (partition_key, service_name, service_key, promise_key) =
+                    key.into_inner_ok_or()?;
+
+                Ok(OwnedPromiseRow {
+                    service_id: ServiceId::with_partition_key(
+                        partition_key,
+                        service_name,
+                        ByteString::try_from(service_key)
+                            .map_err(|e| anyhow::anyhow!("Cannot convert to string {e}"))?,
+                    ),
+                    key: promise_key,
+                    metadata,
+                })
+            },
+        )
+        .map_err(|_| StorageError::OperationalError)
     }
 }
 
@@ -138,13 +137,6 @@ impl ReadOnlyPromiseTable for PartitionStoreTransaction<'_> {
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
         get_promise(self, service_id, key)
-    }
-
-    fn all_promises(
-        &self,
-        range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<OwnedPromiseRow>> + Send> {
-        all_promise(self, range)
     }
 }
 

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -17,13 +17,11 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use bytestring::ByteString;
-use futures_util::TryStreamExt;
-use googletest::prelude::*;
 
 use restate_storage_api::Transaction;
 use restate_storage_api::invocation_status_table::{
     CompletionRangeEpochMap, InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
-    InvokedInvocationStatusLite, JournalMetadata, ReadOnlyInvocationStatusTable, StatusTimestamps,
+    JournalMetadata, ReadOnlyInvocationStatusTable, StatusTimestamps,
 };
 use restate_types::RestateVersion;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId, WithPartitionKey};
@@ -171,30 +169,6 @@ async fn verify_point_lookups<T: InvocationStatusTable>(txn: &mut T) {
     );
 }
 
-async fn verify_all_svc_with_status_invoked<T: InvocationStatusTable>(txn: &mut T) {
-    let actual = txn
-        .all_invoked_invocations()
-        .unwrap()
-        .try_collect::<Vec<_>>()
-        .await
-        .unwrap();
-    assert_that!(
-        actual,
-        unordered_elements_are![
-            eq(InvokedInvocationStatusLite {
-                invocation_id: *INVOCATION_ID_1,
-                invocation_target: INVOCATION_TARGET_1.clone(),
-                current_invocation_epoch: 1,
-            }),
-            eq(InvokedInvocationStatusLite {
-                invocation_id: *INVOCATION_ID_2,
-                invocation_target: INVOCATION_TARGET_2.clone(),
-                current_invocation_epoch: 1,
-            })
-        ]
-    );
-}
-
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_invocation_status() {
     let mut rocksdb = storage_test_environment().await;
@@ -202,7 +176,18 @@ async fn test_invocation_status() {
     populate_data(&mut txn).await;
 
     verify_point_lookups(&mut txn).await;
-    verify_all_svc_with_status_invoked(&mut txn).await;
+    assert_eq!(
+        txn.get_invocation_status(&INVOCATION_ID_1)
+            .await
+            .expect("should not fail"),
+        invoked_status(INVOCATION_TARGET_1.clone())
+    );
+    assert_eq!(
+        txn.get_invocation_status(&INVOCATION_ID_2)
+            .await
+            .expect("should not fail"),
+        invoked_status(INVOCATION_TARGET_2.clone())
+    );
 }
 
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 derive_more = { workspace = true }
-futures-util = { workspace = true }
+futures = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }

--- a/crates/storage-api/src/deduplication_table/mod.rs
+++ b/crates/storage-api/src/deduplication_table/mod.rs
@@ -8,13 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
+use std::cmp::Ordering;
+
 use bytestring::ByteString;
-use futures_util::Stream;
+use futures::Stream;
+
 use restate_types::identifiers::{LeaderEpoch, PartitionId};
 use restate_types::message::MessageIndex;
-use std::cmp::Ordering;
-use std::future::Future;
+
+use crate::Result;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DedupInformation {

--- a/crates/storage-api/src/idempotency_table/mod.rs
+++ b/crates/storage-api/src/idempotency_table/mod.rs
@@ -8,12 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::Result;
-
-use futures_util::Stream;
-use restate_types::identifiers::{IdempotencyId, InvocationId, PartitionKey};
-use std::future::Future;
 use std::ops::RangeInclusive;
+
+use futures::Stream;
+
+use restate_types::identifiers::{IdempotencyId, InvocationId, PartitionKey};
+
+use super::Result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IdempotencyMetadata {
@@ -25,8 +26,10 @@ pub trait ReadOnlyIdempotencyTable {
         &mut self,
         idempotency_id: &IdempotencyId,
     ) -> impl Future<Output = Result<Option<IdempotencyMetadata>>> + Send;
+}
 
-    fn all_idempotency_metadata(
+pub trait ScanIdempotencyTable {
+    fn scan_idempotency_metadata(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(IdempotencyId, IdempotencyMetadata)>> + Send>;

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -8,14 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
-use crate::promise_table::ReadOnlyPromiseTable;
+use std::ops::RangeInclusive;
+
 use futures::Stream;
+
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey};
 use restate_types::message::MessageIndex;
 use restate_types::state_mut::ExternalStateMutation;
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use crate::Result;
+use crate::promise_table::ReadOnlyPromiseTable;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum InboxEntry {
@@ -88,8 +90,10 @@ pub trait ReadOnlyInboxTable {
         &mut self,
         service_id: &ServiceId,
     ) -> Result<impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send>;
+}
 
-    fn all_inboxes(
+pub trait ScanInboxTable {
+    fn scan_inboxes(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send>;

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -10,7 +10,7 @@
 
 use crate::Result;
 use crate::promise_table::ReadOnlyPromiseTable;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey};
 use restate_types::message::MessageIndex;
 use restate_types::state_mut::ExternalStateMutation;

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -11,7 +11,7 @@
 use crate::Result;
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures_util::Stream;
+use futures::Stream;
 use rangemap::RangeInclusiveMap;
 use restate_types::RestateVersion;
 use restate_types::deployment::PinnedDeployment;

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -758,15 +758,17 @@ pub trait ReadOnlyInvocationStatusTable {
         &mut self,
         invocation_id: &InvocationId,
     ) -> impl Future<Output = Result<InvocationStatus>> + Send;
+}
 
-    fn all_invoked_invocations(
-        &mut self,
-    ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send>;
-
-    fn all_invocation_statuses(
+pub trait ScanInvocationStatusTable {
+    fn scan_invocation_statuses(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(InvocationId, InvocationStatus)>> + Send>;
+
+    fn scan_invoked_invocations(
+        &self,
+    ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send>;
 }
 
 pub trait InvocationStatusTable: ReadOnlyInvocationStatusTable {

--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -8,13 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::Result;
-use futures_util::Stream;
+use std::ops::RangeInclusive;
+
+use futures::Stream;
+
 use restate_types::identifiers::{EntryIndex, InvocationId, JournalEntryId, PartitionKey};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::{CompletionResult, EntryType};
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use crate::Result;
 
 /// Different types of journal entries persisted by the runtime
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,8 +61,10 @@ pub trait ReadOnlyJournalTable {
         invocation_id: &InvocationId,
         journal_length: EntryIndex,
     ) -> Result<impl Stream<Item = Result<(EntryIndex, JournalEntry)>> + Send>;
+}
 
-    fn all_journals(
+pub trait ScanJournalTable {
+    fn scan_journals(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(JournalEntryId, JournalEntry)>> + Send>;

--- a/crates/storage-api/src/outbox_table/mod.rs
+++ b/crates/storage-api/src/outbox_table/mod.rs
@@ -14,7 +14,6 @@ use restate_types::invocation::{
     AttachInvocationRequest, InvocationResponse, InvocationTermination, NotifySignalRequest,
     ServiceInvocation,
 };
-use std::future::Future;
 use std::ops::RangeInclusive;
 
 /// Types of outbox messages.

--- a/crates/storage-api/src/promise_table/mod.rs
+++ b/crates/storage-api/src/promise_table/mod.rs
@@ -12,7 +12,7 @@ use super::Result;
 
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::errors::InvocationErrorCode;
 use restate_types::identifiers::{PartitionKey, ServiceId};
 use restate_types::invocation::JournalCompletionTarget;

--- a/crates/storage-api/src/promise_table/mod.rs
+++ b/crates/storage-api/src/promise_table/mod.rs
@@ -8,11 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::Result;
+use std::future::Future;
+use std::ops::RangeInclusive;
 
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
+
 use restate_types::errors::InvocationErrorCode;
 use restate_types::identifiers::{PartitionKey, ServiceId};
 use restate_types::invocation::JournalCompletionTarget;
@@ -20,8 +22,8 @@ use restate_types::journal::{CompletionResult, EntryResult};
 use restate_types::journal_v2::{
     CompletePromiseValue, Failure, GetPromiseResult, PeekPromiseResult,
 };
-use std::future::Future;
-use std::ops::RangeInclusive;
+
+use super::Result;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PromiseResult {
@@ -111,8 +113,10 @@ pub trait ReadOnlyPromiseTable {
         service_id: &ServiceId,
         key: &ByteString,
     ) -> impl Future<Output = Result<Option<Promise>>> + Send;
+}
 
-    fn all_promises(
+pub trait ScanPromiseTable {
+    fn scan_promises(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<OwnedPromiseRow>> + Send>;

--- a/crates/storage-api/src/service_status_table/mod.rs
+++ b/crates/storage-api/src/service_status_table/mod.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::Result;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId};
 use std::future::Future;
 use std::ops::RangeInclusive;

--- a/crates/storage-api/src/state_table/mod.rs
+++ b/crates/storage-api/src/state_table/mod.rs
@@ -11,7 +11,7 @@
 use std::ops::RangeInclusive;
 
 use bytes::Bytes;
-use futures_util::Stream;
+use futures::Stream;
 
 use restate_types::identifiers::{PartitionKey, ServiceId};
 

--- a/crates/storage-api/src/timer_table/mod.rs
+++ b/crates/storage-api/src/timer_table/mod.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::Result;
-use futures_util::Stream;
+use futures::Stream;
 use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
 use restate_types::invocation::{InvocationEpoch, ServiceInvocation};
 use restate_types::time::MillisSinceEpoch;

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -24,6 +24,7 @@ restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 
 ahash = { workspace = true }                                                    # Required to due a yanked version used by datafusion
+anyhow = { workspace = true}
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
@@ -40,12 +41,11 @@ prost = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true}
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
-strum = { workspace = true}
 tokio-stream = { workspace = true }
-anyhow = { workspace = true}
+tracing = { workspace = true }
 
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -16,7 +16,7 @@ use futures::Stream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::idempotency_table::{IdempotencyMetadata, ReadOnlyIdempotencyTable};
+use restate_storage_api::idempotency_table::{IdempotencyMetadata, ScanIdempotencyTable};
 use restate_types::identifiers::{IdempotencyId, PartitionKey};
 
 use super::row::append_idempotency_row;
@@ -65,7 +65,7 @@ impl ScanLocalPartition for IdempotencyScanner {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
     {
-        partition_store.all_idempotency_metadata(range)
+        partition_store.scan_idempotency_metadata(range)
     }
 
     fn append_row(

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -16,7 +16,7 @@ use futures::Stream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::inbox_table::{ReadOnlyInboxTable, SequenceNumberInboxEntry};
+use restate_storage_api::inbox_table::{ScanInboxTable, SequenceNumberInboxEntry};
 use restate_types::identifiers::PartitionKey;
 
 use crate::context::{QueryContext, SelectPartitions};
@@ -66,7 +66,7 @@ impl ScanLocalPartition for InboxScanner {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
     {
-        partition_store.all_inboxes(range)
+        partition_store.scan_inboxes(range)
     }
 
     fn append_row(row_builder: &mut Self::Builder, string_buffer: &mut String, value: Self::Item) {

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -16,9 +16,7 @@ use futures::Stream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
-};
+use restate_storage_api::invocation_status_table::{InvocationStatus, ScanInvocationStatusTable};
 use restate_types::identifiers::{InvocationId, PartitionKey};
 
 use crate::context::{QueryContext, SelectPartitions};
@@ -69,7 +67,7 @@ impl ScanLocalPartition for StatusScanner {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
     {
-        partition_store.all_invocation_statuses(range)
+        partition_store.scan_invocation_statuses(range)
     }
 
     fn append_row(

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -16,7 +16,7 @@ use futures::Stream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::promise_table::{OwnedPromiseRow, ReadOnlyPromiseTable};
+use restate_storage_api::promise_table::{OwnedPromiseRow, ScanPromiseTable};
 use restate_types::identifiers::PartitionKey;
 
 use super::row::append_promise_row;
@@ -63,7 +63,7 @@ impl ScanLocalPartition for PromiseScanner {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
     {
-        partition_store.all_promises(range)
+        partition_store.scan_promises(range)
     }
 
     fn append_row(row_builder: &mut Self::Builder, string_buffer: &mut String, value: Self::Item) {

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -31,7 +31,7 @@ use restate_invoker_api::InvokeInputJournal;
 use restate_partition_store::PartitionStore;
 use restate_storage_api::deduplication_table::EpochSequenceNumber;
 use restate_storage_api::invocation_status_table::{
-    InvokedInvocationStatusLite, ReadOnlyInvocationStatusTable,
+    InvokedInvocationStatusLite, ScanInvocationStatusTable,
 };
 use restate_storage_api::outbox_table::{OutboxMessage, OutboxTable};
 use restate_storage_api::timer_table::{TimerKey, TimerTable};
@@ -459,7 +459,7 @@ where
 
         {
             let invoked_invocations = partition_store
-                .all_invoked_invocations()
+                .scan_invoked_invocations()
                 .map_err(Error::Storage)?;
             tokio::pin!(invoked_invocations);
 


### PR DESCRIPTION

This also comes with two important benefits:

1. The Cleaner now uses the background iterators to avoid blocking the partiton runtime
2. Resuming invoked invocations when switching into leader state will also perform the scan in the background. This was one of the main reasons why the partition processor was running on its own runtime
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3432).
* #3436
* #3433
* __->__ #3432
* #3431
* #3429