### PR TITLE
fix: make clippy works

### DIFF
--- a/crates/cli-util/Cargo.toml
+++ b/crates/cli-util/Cargo.toml
@@ -27,7 +27,7 @@ dialoguer = { workspace = true }
 dotenvy = { version = "0.15" }
 lambda_runtime = "0.13.0"
 serde = { workspace = true }
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["time", "process"] }
 tracing = { workspace = true }
 tracing-log = { version = "0.2.0" }
 tracing-subscriber = { workspace = true }

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -34,7 +34,8 @@ pub struct AnnounceLeader {
 /// Readers before v1.4.0 will crash when reading this command. For v1.4.0+, the barrier defines the
 /// minimum version of restate server that can progress after this command. It also updates the FSM
 /// in case command has been trimmed.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]
+#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VersionBarrier {
     /// The minimum version required (inclusive) to progress after this barrier.
     pub version: SemanticRestateVersion,
@@ -51,7 +52,8 @@ mod tests {
     use restate_types::storage::StorageCodec;
     use restate_types::{GenerationalNodeId, flexbuffers_storage_encode_decode};
 
-    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    #[derive(Debug, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     struct OldAnnounceLeader {
         pub node_id: GenerationalNodeId,
         pub leader_epoch: LeaderEpoch,


### PR DESCRIPTION
At https://github.com/restatedev/restate/actions/runs/15790044676/job/44514156585#step:12:515 ，it failed with:

```
  error[E0433]: failed to resolve: could not find `process` in `tokio`
  Error:    --> crates/cli-util/src/lambda.rs:51:38
      |
  51  |                 let mut cmd = tokio::process::Command::new(state.exe.as_os_str());
      |                                      ^^^^^^^ could not find `process` in `tokio`
```