### PR TITLE
[invoker] Attach deployment id to the invoker error

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -29,8 +29,25 @@ use std::ops::RangeInclusive;
 use std::time::Duration;
 use tokio::task::JoinError;
 
+#[derive(Debug)]
+pub struct InvokerError {
+    pub kind: InvokerErrorKind,
+    // Deployment ID associated with the error, if any.
+    #[allow(dead_code)]
+    pub deployment_id: Option<DeploymentId>,
+}
+
+impl From<InvokerErrorKind> for InvokerError {
+    fn from(source: InvokerErrorKind) -> Self {
+        Self {
+            kind: source,
+            deployment_id: None,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error, codederror::CodedError)]
-pub(crate) enum InvokerError {
+pub(crate) enum InvokerErrorKind {
     #[error("no deployment was found to process the invocation")]
     #[code(restate_errors::RT0011)]
     NoDeploymentForService,
@@ -169,14 +186,21 @@ pub(crate) enum InvokerError {
     ServiceUnavailable(http::StatusCode),
 }
 
-impl InvokerError {
+impl InvokerErrorKind {
+    pub(crate) fn into_invoker_error(self, deployment_id: DeploymentId) -> InvokerError {
+        InvokerError {
+            kind: self,
+            deployment_id: Some(deployment_id),
+        }
+    }
+
     pub(crate) fn error_stacktrace(&self) -> Option<&str> {
         match self {
-            InvokerError::Sdk(s) => s
+            InvokerErrorKind::Sdk(s) => s
                 .error
                 .stacktrace()
                 .and_then(|s| if s.is_empty() { None } else { Some(s) }),
-            InvokerError::SdkV2(s) => s
+            InvokerErrorKind::SdkV2(s) => s
                 .error
                 .stacktrace()
                 .and_then(|s| if s.is_empty() { None } else { Some(s) }),
@@ -185,30 +209,30 @@ impl InvokerError {
     }
 
     pub(crate) fn is_transient(&self) -> bool {
-        !matches!(self, InvokerError::NotInvoked)
+        !matches!(self, InvokerErrorKind::NotInvoked)
     }
 
     pub(crate) fn should_bump_start_message_retry_count_since_last_stored_entry(&self) -> bool {
         !matches!(
             self,
-            InvokerError::NotInvoked
-                | InvokerError::JournalReader(_)
-                | InvokerError::StateReader(_)
-                | InvokerError::NoDeploymentForService
-                | InvokerError::BadNegotiatedServiceProtocolVersion(_)
-                | InvokerError::UnknownDeployment(_)
-                | InvokerError::ResumeWithWrongServiceProtocolVersion(_)
-                | InvokerError::IncompatibleServiceEndpoint(_, _)
+            InvokerErrorKind::NotInvoked
+                | InvokerErrorKind::JournalReader(_)
+                | InvokerErrorKind::StateReader(_)
+                | InvokerErrorKind::NoDeploymentForService
+                | InvokerErrorKind::BadNegotiatedServiceProtocolVersion(_)
+                | InvokerErrorKind::UnknownDeployment(_)
+                | InvokerErrorKind::ResumeWithWrongServiceProtocolVersion(_)
+                | InvokerErrorKind::IncompatibleServiceEndpoint(_, _)
         )
     }
 
     pub(crate) fn next_retry_interval_override(&self) -> Option<Duration> {
         match self {
-            InvokerError::Sdk(SdkInvocationError {
+            InvokerErrorKind::Sdk(SdkInvocationError {
                 next_retry_interval_override,
                 ..
             }) => *next_retry_interval_override,
-            InvokerError::SdkV2(SdkInvocationErrorV2 {
+            InvokerErrorKind::SdkV2(SdkInvocationErrorV2 {
                 next_retry_interval_override,
                 ..
             }) => *next_retry_interval_override,
@@ -218,9 +242,9 @@ impl InvokerError {
 
     pub(crate) fn into_invocation_error(self) -> InvocationError {
         match self {
-            InvokerError::Sdk(sdk_error) => sdk_error.error,
-            InvokerError::SdkV2(sdk_error) => sdk_error.error,
-            InvokerError::EntryEnrichment(entry_index, entry_type, e) => {
+            InvokerErrorKind::Sdk(sdk_error) => sdk_error.error,
+            InvokerErrorKind::SdkV2(sdk_error) => sdk_error.error,
+            InvokerErrorKind::EntryEnrichment(entry_index, entry_type, e) => {
                 let msg = format!(
                     "Error when processing entry {} of type {}: {}",
                     entry_index,
@@ -233,7 +257,7 @@ impl InvokerError {
                 }
                 err
             }
-            e @ InvokerError::BadNegotiatedServiceProtocolVersion(_) => {
+            e @ InvokerErrorKind::BadNegotiatedServiceProtocolVersion(_) => {
                 InvocationError::new(codes::UNSUPPORTED_MEDIA_TYPE, e)
             }
             e => InvocationError::internal(e),
@@ -243,11 +267,11 @@ impl InvokerError {
     pub(crate) fn into_invocation_error_report(mut self) -> InvocationErrorReport {
         let doc_error_code = codederror::CodedError::code(&self);
         let maybe_related_entry = match self {
-            InvokerError::Sdk(SdkInvocationError {
+            InvokerErrorKind::Sdk(SdkInvocationError {
                 ref mut related_entry,
                 ..
             }) => related_entry.take(),
-            InvokerError::SdkV2(SdkInvocationErrorV2 {
+            InvokerErrorKind::SdkV2(SdkInvocationErrorV2 {
                 related_command: ref mut related_entry,
                 ..
             }) => related_entry

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -56,7 +56,8 @@ use restate_types::service_protocol::ServiceProtocolVersion;
 
 use crate::Notification;
 use crate::error::{
-    CommandPreconditionError, InvocationErrorRelatedCommandV2, InvokerError, SdkInvocationErrorV2,
+    CommandPreconditionError, InvocationErrorRelatedCommandV2, InvokerErrorKind,
+    SdkInvocationErrorV2,
 };
 use crate::invocation_task::{
     InvocationTask, InvocationTaskOutputInner, InvokerBodyStream, InvokerRequestStreamSender,
@@ -214,7 +215,7 @@ where
         // Sanity check of the stream decoder
         if self.decoder.has_remaining() {
             warn_it!(
-                InvokerError::WriteAfterEndOfStream,
+                InvokerErrorKind::WriteAfterEndOfStream,
                 "The read buffer is non empty after the stream has been closed."
             );
         }
@@ -383,7 +384,7 @@ where
                         ResponseChunk::Data(buf) => crate::shortcircuit!(self.handle_read(parent_span_context, buf)),
                         ResponseChunk::End => {
                             // Response stream was closed without SuspensionMessage, EndMessage or ErrorMessage
-                            return TerminalLoopState::Failed(InvokerError::SdkV2(SdkInvocationErrorV2::unknown()))
+                            return TerminalLoopState::Failed(InvokerErrorKind::SdkV2(SdkInvocationErrorV2::unknown()))
                         }
                     }
                 },
@@ -410,13 +411,13 @@ where
                         ResponseChunk::Data(buf) => crate::shortcircuit!(self.handle_read(parent_span_context, buf)),
                         ResponseChunk::End => {
                             // Response stream was closed without SuspensionMessage, EndMessage or ErrorMessage
-                            return TerminalLoopState::Failed(InvokerError::SdkV2(SdkInvocationErrorV2::unknown()))
+                            return TerminalLoopState::Failed(InvokerErrorKind::SdkV2(SdkInvocationErrorV2::unknown()))
                         }
                     }
                 },
                 _ = tokio::time::sleep(self.invocation_task.abort_timeout) => {
                     warn!("Inactivity detected, going to close invocation");
-                    return TerminalLoopState::Failed(InvokerError::AbortTimeoutFired(self.invocation_task.abort_timeout.into()))
+                    return TerminalLoopState::Failed(InvokerErrorKind::AbortTimeoutFired(self.invocation_task.abort_timeout.into()))
                 },
             }
         }
@@ -431,7 +432,7 @@ where
         state_entries: EagerState<I>,
         retry_count_since_last_stored_entry: u32,
         duration_since_last_stored_entry: Duration,
-    ) -> Result<(), InvokerError> {
+    ) -> Result<(), InvokerErrorKind> {
         let is_partial = state_entries.is_partial();
 
         // Send the invoke frame
@@ -458,7 +459,7 @@ where
         &mut self,
         http_stream_tx: &mut InvokerRequestStreamSender,
         entry: RawEntry,
-    ) -> Result<(), InvokerError> {
+    ) -> Result<(), InvokerErrorKind> {
         // TODO(slinkydeveloper) could this code be improved a tad bit more introducing something to our magic macro in message_codec?
         match entry.inner {
             RawEntryInner::Command(cmd) => {
@@ -489,12 +490,12 @@ where
         &mut self,
         http_stream_tx: &mut InvokerRequestStreamSender,
         msg: Message,
-    ) -> Result<(), InvokerError> {
+    ) -> Result<(), InvokerErrorKind> {
         trace!(restate.protocol.message = ?msg, "Sending message");
         let buf = self.encoder.encode(msg);
 
         if http_stream_tx.send(Ok(Frame::data(buf))).await.is_err() {
-            return Err(InvokerError::UnexpectedClosedRequestStream);
+            return Err(InvokerErrorKind::UnexpectedClosedRequestStream);
         };
         Ok(())
     }
@@ -504,12 +505,12 @@ where
         http_stream_tx: &mut InvokerRequestStreamSender,
         ty: MessageType,
         buf: Bytes,
-    ) -> Result<(), InvokerError> {
+    ) -> Result<(), InvokerErrorKind> {
         trace!(restate.protocol.message = ?ty, "Sending message");
         let buf = self.encoder.encode_raw(ty, buf);
 
         if http_stream_tx.send(Ok(Frame::data(buf))).await.is_err() {
-            return Err(InvokerError::UnexpectedClosedRequestStream);
+            return Err(InvokerErrorKind::UnexpectedClosedRequestStream);
         };
         Ok(())
     }
@@ -517,24 +518,24 @@ where
     fn handle_response_headers(
         &mut self,
         mut parts: http::response::Parts,
-    ) -> Result<(), InvokerError> {
+    ) -> Result<(), InvokerErrorKind> {
         // if service is running behind a gateway, the service can be down
         // but we still get a response code from the gateway itself. In that
         // case we still need to return the proper error
         if GATEWAY_ERRORS_CODES.contains(&parts.status) {
-            return Err(InvokerError::ServiceUnavailable(parts.status));
+            return Err(InvokerErrorKind::ServiceUnavailable(parts.status));
         }
 
         // otherwise we return generic UnexpectedResponse
         if !parts.status.is_success() {
             // Decorate the error in case of UNSUPPORTED_MEDIA_TYPE, as it probably is the incompatible protocol version
             if parts.status == StatusCode::UNSUPPORTED_MEDIA_TYPE {
-                return Err(InvokerError::BadNegotiatedServiceProtocolVersion(
+                return Err(InvokerErrorKind::BadNegotiatedServiceProtocolVersion(
                     self.service_protocol_version,
                 ));
             }
 
-            return Err(InvokerError::UnexpectedResponse(parts.status));
+            return Err(InvokerErrorKind::UnexpectedResponse(parts.status));
         }
 
         let content_type = parts.headers.remove(http::header::CONTENT_TYPE);
@@ -545,14 +546,14 @@ where
             {
                 #[allow(clippy::borrow_interior_mutable_const)]
                 if ct != expected_content_type {
-                    return Err(InvokerError::UnexpectedContentType(
+                    return Err(InvokerErrorKind::UnexpectedContentType(
                         Some(ct),
                         expected_content_type,
                     ));
                 }
             }
             None => {
-                return Err(InvokerError::UnexpectedContentType(
+                return Err(InvokerErrorKind::UnexpectedContentType(
                     None,
                     expected_content_type,
                 ));
@@ -563,7 +564,7 @@ where
             self.invocation_task
                 .send_invoker_tx(InvocationTaskOutputInner::ServerHeaderReceived(
                     hv.to_str()
-                        .map_err(|e| InvokerError::BadHeader(X_RESTATE_SERVER, e))?
+                        .map_err(|e| InvokerErrorKind::BadHeader(X_RESTATE_SERVER, e))?
                         .to_owned(),
                 ))
         }
@@ -611,11 +612,11 @@ where
         match message {
             // Control messages
             Message::Start { .. } => {
-                TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(MessageType::Start))
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(MessageType::Start))
             }
-            Message::CommandAck(_) => TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(
-                MessageType::CommandAck,
-            )),
+            Message::CommandAck(_) => TerminalLoopState::Failed(
+                InvokerErrorKind::UnexpectedMessageV4(MessageType::CommandAck),
+            ),
             Message::Suspension(suspension) => self.handle_suspension_message(suspension),
             Message::Error(e) => self.handle_error_message(e),
             Message::End(_) => TerminalLoopState::Closed,
@@ -627,7 +628,7 @@ where
                     result: match crate::shortcircuit!(
                         run_completion
                             .result
-                            .ok_or(InvokerError::MalformedProposeRunCompletion)
+                            .ok_or(InvokerErrorKind::MalformedProposeRunCompletion)
                     ) {
                         proto::propose_run_completion_message::Result::Value(b) => {
                             RunResult::Success(b)
@@ -709,11 +710,13 @@ where
                                 span_relation: parent_span_context.as_linked()
                             }
                         )
-                        .map_err(|e| InvokerError::CommandPrecondition(
-                            self.command_index,
-                            EntryType::Command(CommandType::OneWayCall),
-                            e
-                        ))
+                        .map_err(
+                            |e| InvokerErrorKind::CommandPrecondition(
+                                self.command_index,
+                                EntryType::Command(CommandType::OneWayCall),
+                                e
+                            )
+                        )
                     ),
                     invoke_time: cmd.invoke_time.into(),
                     invocation_id_completion_id: cmd.invocation_id_notification_idx,
@@ -745,11 +748,13 @@ where
                                 span_relation: parent_span_context.as_parent()
                             }
                         )
-                        .map_err(|e| InvokerError::CommandPrecondition(
-                            self.command_index,
-                            EntryType::Command(CommandType::Call),
-                            e
-                        ))
+                        .map_err(
+                            |e| InvokerErrorKind::CommandPrecondition(
+                                self.command_index,
+                                EntryType::Command(CommandType::Call),
+                                e
+                            )
+                        )
                     ),
                     invocation_id_completion_id: cmd.invocation_id_notification_idx,
                     result_completion_id: cmd.result_completion_id,
@@ -891,51 +896,57 @@ where
                 TerminalLoopState::Continue(())
             }
             Message::SignalNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::SignalNotification),
+                InvokerErrorKind::UnexpectedMessageV4(MessageType::SignalNotification),
             ),
             Message::GetInvocationOutputCompletionNotification(_) => {
-                TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
                     MessageType::GetInvocationOutputCompletionNotification,
                 ))
             }
             Message::AttachInvocationCompletionNotification(_) => {
-                TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
                     MessageType::AttachInvocationCompletionNotification,
                 ))
             }
             Message::RunCompletionNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::RunCompletionNotification),
+                InvokerErrorKind::UnexpectedMessageV4(MessageType::RunCompletionNotification),
             ),
             Message::CallCompletionNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::CallCompletionNotification),
+                InvokerErrorKind::UnexpectedMessageV4(MessageType::CallCompletionNotification),
             ),
             Message::CallInvocationIdCompletionNotification(_) => {
-                TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
                     MessageType::CallInvocationIdCompletionNotification,
                 ))
             }
             Message::SleepCompletionNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::SleepCompletionNotification),
+                InvokerErrorKind::UnexpectedMessageV4(MessageType::SleepCompletionNotification),
             ),
             Message::CompletePromiseCompletionNotification(_) => {
-                TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
                     MessageType::CompletePromiseCompletionNotification,
                 ))
             }
-            Message::PeekPromiseCompletionNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::PeekPromiseCompletionNotification),
-            ),
-            Message::GetPromiseCompletionNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::GetPromiseCompletionNotification),
-            ),
+            Message::PeekPromiseCompletionNotification(_) => {
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
+                    MessageType::PeekPromiseCompletionNotification,
+                ))
+            }
+            Message::GetPromiseCompletionNotification(_) => {
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
+                    MessageType::GetPromiseCompletionNotification,
+                ))
+            }
             Message::GetLazyStateKeysCompletionNotification(_) => {
-                TerminalLoopState::Failed(InvokerError::UnexpectedMessageV4(
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
                     MessageType::GetLazyStateKeysCompletionNotification,
                 ))
             }
-            Message::GetLazyStateCompletionNotification(_) => TerminalLoopState::Failed(
-                InvokerError::UnexpectedMessageV4(MessageType::GetLazyStateCompletionNotification),
-            ),
+            Message::GetLazyStateCompletionNotification(_) => {
+                TerminalLoopState::Failed(InvokerErrorKind::UnexpectedMessageV4(
+                    MessageType::GetLazyStateCompletionNotification,
+                ))
+            }
             Message::Custom(_, _) => {
                 unimplemented!()
             }
@@ -967,13 +978,13 @@ where
             .collect();
         // We currently don't support empty suspension_indexes set
         if suspension_indexes.is_empty() {
-            return TerminalLoopState::Failed(InvokerError::EmptySuspensionMessage);
+            return TerminalLoopState::Failed(InvokerErrorKind::EmptySuspensionMessage);
         }
         TerminalLoopState::SuspendedV2(suspension_indexes)
     }
 
     fn handle_error_message(&mut self, error: proto::ErrorMessage) -> TerminalLoopState<()> {
-        TerminalLoopState::Failed(InvokerError::SdkV2(SdkInvocationErrorV2 {
+        TerminalLoopState::Failed(InvokerErrorKind::SdkV2(SdkInvocationErrorV2 {
             related_command: Some(InvocationErrorRelatedCommandV2 {
                 related_command_index: error.related_command_index,
                 related_command_name: error.related_command_name.clone(),
@@ -1075,9 +1086,9 @@ fn check_workflow_type(
     command_index: CommandIndex,
     entry_type: &EntryType,
     service_type: &ServiceType,
-) -> Result<(), InvokerError> {
+) -> Result<(), InvokerErrorKind> {
     if *service_type != ServiceType::Workflow {
-        return Err(InvokerError::CommandPrecondition(
+        return Err(InvokerErrorKind::CommandPrecondition(
             command_index,
             *entry_type,
             CommandPreconditionError::NoWorkflowOperations,
@@ -1091,9 +1102,9 @@ fn can_read_state(
     command_index: CommandIndex,
     entry_type: &EntryType,
     invocation_target_type: &InvocationTargetType,
-) -> Result<(), InvokerError> {
+) -> Result<(), InvokerErrorKind> {
     if !invocation_target_type.can_read_state() {
-        return Err(InvokerError::CommandPrecondition(
+        return Err(InvokerErrorKind::CommandPrecondition(
             command_index,
             *entry_type,
             CommandPreconditionError::NoStateOperations,
@@ -1107,10 +1118,10 @@ fn can_write_state(
     command_index: CommandIndex,
     entry_type: &EntryType,
     invocation_target_type: &InvocationTargetType,
-) -> Result<(), InvokerError> {
+) -> Result<(), InvokerErrorKind> {
     can_read_state(command_index, entry_type, invocation_target_type)?;
     if !invocation_target_type.can_write_state() {
-        return Err(InvokerError::CommandPrecondition(
+        return Err(InvokerErrorKind::CommandPrecondition(
             command_index,
             *entry_type,
             CommandPreconditionError::NoWriteStateOperations,

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -52,12 +52,12 @@ use tokio::task::{AbortHandle, JoinSet};
 use tracing::{debug, trace};
 use tracing::{error, instrument};
 
-use crate::error::SdkInvocationErrorV2;
+use crate::error::{InvokerError, SdkInvocationErrorV2};
 use crate::metric_definitions::{
     INVOKER_ENQUEUE, INVOKER_INVOCATION_TASKS, TASK_OP_COMPLETED, TASK_OP_FAILED, TASK_OP_STARTED,
     TASK_OP_SUSPENDED,
 };
-use error::InvokerError;
+use error::InvokerErrorKind;
 pub use input_command::ChannelStatusReader;
 pub use input_command::InvokerHandle;
 use restate_invoker_api::invocation_reader::InvocationReader;
@@ -1090,7 +1090,7 @@ where
             .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
         {
             debug_assert_eq!(invocation_epoch, ism.invocation_epoch);
-            self.handle_error_event(options, partition, invocation_id, error, ism)
+            self.handle_error_event(options, partition, invocation_id, error.kind, ism)
                 .await;
         } else {
             // If no state machine, this might be a result for an aborted invocation.
@@ -1176,7 +1176,7 @@ where
         options: &InvokerOptions,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        error: InvokerError,
+        error: InvokerErrorKind,
         mut ism: InvocationStateMachine,
     ) {
         match ism.handle_task_error(
@@ -1211,7 +1211,7 @@ where
                 let next_retry_at = SystemTime::now() + next_retry_timer_duration;
 
                 let journal_v2_related_command_type =
-                    if let InvokerError::SdkV2(SdkInvocationErrorV2 {
+                    if let InvokerErrorKind::SdkV2(SdkInvocationErrorV2 {
                         related_command: Some(ref related_entry),
                         ..
                     }) = error
@@ -1436,7 +1436,7 @@ mod tests {
     use restate_types::schema::invocation_target::InvocationTargetMetadata;
     use restate_types::schema::service::{InvocationAttemptOptions, ServiceMetadata};
 
-    use crate::error::{InvokerError, SdkInvocationErrorV2};
+    use crate::error::{InvokerErrorKind, SdkInvocationErrorV2};
     use crate::quota::InvokerConcurrencyQuota;
 
     // -- Mocks
@@ -1893,7 +1893,7 @@ mod tests {
                 MOCK_PARTITION,
                 invocation_id,
                 0,
-                InvokerError::EmptySuspensionMessage, /* any error is fine */
+                InvokerErrorKind::EmptySuspensionMessage.into(), /* any error is fine */
             )
             .await;
 
@@ -1947,7 +1947,7 @@ mod tests {
                 MOCK_PARTITION,
                 invocation_id,
                 0,
-                InvokerError::SdkV2(SdkInvocationErrorV2::unknown()),
+                InvokerErrorKind::SdkV2(SdkInvocationErrorV2::unknown()).into(),
             )
             .await;
         assert_eq!(


### PR DESCRIPTION
[invoker] Attach deployment id to the invoker error

This is used in the next PR to associate the deployment unreachable
failure with the deployment id

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3439).
* #3426
* __->__ #3439