### PR TITLE
[Telemetry] Cleaning up low-signal and unused metrics

### DIFF
--- a/crates/core/src/metric_definitions.rs
+++ b/crates/core/src/metric_definitions.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use metrics::{Unit, describe_counter, describe_histogram};
+use metrics::{Unit, describe_counter};
 
 // value of label `kind` in TC_SPAWN are defined in [`crate::TaskKind`].
 pub const TC_SPAWN: &str = "restate.task_center.spawned.total";
@@ -17,18 +17,6 @@ pub const TC_FINISHED: &str = "restate.task_center.finished.total";
 // values of label `status` in METRICS
 pub const STATUS_COMPLETED: &str = "completed";
 pub const STATUS_FAILED: &str = "failed";
-
-pub(crate) const METADATA_CLIENT_GET_DURATION: &str = "restate.metadata_client.get.duration";
-pub(crate) const METADATA_CLIENT_GET_VERSION_DURATION: &str =
-    "restate.metadata_client.get_version.duration";
-pub(crate) const METADATA_CLIENT_PUT_DURATION: &str = "restate.metadata_client.put.duration";
-pub(crate) const METADATA_CLIENT_DELETE_DURATION: &str = "restate.metadata_client.delete.duration";
-
-pub(crate) const METADATA_CLIENT_GET_TOTAL: &str = "restate.metadata_client.get.total";
-pub(crate) const METADATA_CLIENT_GET_VERSION_TOTAL: &str =
-    "restate.metadata_client.get_version.total";
-pub(crate) const METADATA_CLIENT_PUT_TOTAL: &str = "restate.metadata_client.put.total";
-pub(crate) const METADATA_CLIENT_DELETE_TOTAL: &str = "restate.metadata_client.delete.total";
 
 pub fn describe_metrics() {
     describe_counter!(
@@ -41,53 +29,5 @@ pub fn describe_metrics() {
         TC_FINISHED,
         Unit::Count,
         "Number of tasks that finished with 'status'"
-    );
-
-    describe_histogram!(
-        METADATA_CLIENT_GET_DURATION,
-        Unit::Seconds,
-        "Metadata client get request duration in seconds"
-    );
-
-    describe_histogram!(
-        METADATA_CLIENT_GET_VERSION_DURATION,
-        Unit::Seconds,
-        "Metadata client get_version request duration in seconds"
-    );
-
-    describe_histogram!(
-        METADATA_CLIENT_PUT_DURATION,
-        Unit::Seconds,
-        "Metadata client put request duration in seconds"
-    );
-
-    describe_histogram!(
-        METADATA_CLIENT_DELETE_DURATION,
-        Unit::Seconds,
-        "Metadata client delete request duration in seconds"
-    );
-
-    describe_counter!(
-        METADATA_CLIENT_GET_TOTAL,
-        Unit::Count,
-        "Metadata client get request success count"
-    );
-
-    describe_counter!(
-        METADATA_CLIENT_GET_VERSION_TOTAL,
-        Unit::Count,
-        "Metadata client get_version request success count"
-    );
-
-    describe_counter!(
-        METADATA_CLIENT_PUT_TOTAL,
-        Unit::Count,
-        "Metadata client put request success count"
-    );
-
-    describe_counter!(
-        METADATA_CLIENT_DELETE_TOTAL,
-        Unit::Count,
-        "Metadata client delete request success count"
     );
 }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -21,8 +21,7 @@ use input_command::{InputCommand, InvokeCommand};
 use invocation_state_machine::InvocationStateMachine;
 use invocation_task::InvocationTask;
 use invocation_task::{InvocationTaskOutput, InvocationTaskOutputInner};
-use metric_definitions::{INVOKER_PENDING_TASKS, INVOKER_TASKS_IN_FLIGHT};
-use metrics::{counter, gauge};
+use metrics::counter;
 use restate_core::cancellation_watcher;
 use restate_errors::warn_it;
 use restate_invoker_api::{
@@ -349,9 +348,6 @@ where
     where
         F: Future<Output = ()>,
     {
-        gauge!(INVOKER_PENDING_TASKS).set(segmented_input_queue.len() as f64);
-        gauge!(INVOKER_TASKS_IN_FLIGHT).set(self.invocation_tasks.len() as f64);
-
         tokio::select! {
             Some(cmd) = self.status_rx.recv() => {
                 let keys = cmd.payload();

--- a/crates/invoker-impl/src/metric_definitions.rs
+++ b/crates/invoker-impl/src/metric_definitions.rs
@@ -13,12 +13,10 @@
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
 pub const INVOKER_ENQUEUE: &str = "restate.invoker.enqueue.total";
-pub const INVOKER_PENDING_TASKS: &str = "restate.invoker.pending_tasks";
 pub const INVOKER_INVOCATION_TASKS: &str = "restate.invoker.invocation_tasks.total";
 pub const INVOKER_AVAILABLE_SLOTS: &str = "restate.invoker.available_slots";
 pub const INVOKER_CONCURRENCY_LIMIT: &str = "restate.invoker.concurrency_limit";
 pub const INVOKER_TASK_DURATION: &str = "restate.invoker.task_duration.seconds";
-pub const INVOKER_TASKS_IN_FLIGHT: &str = "restate.invoker.inflight_tasks";
 
 pub const TASK_OP_STARTED: &str = "started";
 pub const TASK_OP_SUSPENDED: &str = "suspended";
@@ -30,12 +28,6 @@ pub(crate) fn describe_metrics() {
         INVOKER_ENQUEUE,
         Unit::Count,
         "Number of invocations that were added to the queue"
-    );
-
-    describe_gauge!(
-        INVOKER_PENDING_TASKS,
-        Unit::Count,
-        "Number of pending invocation tasks queued"
     );
 
     describe_gauge!(
@@ -60,11 +52,5 @@ pub(crate) fn describe_metrics() {
         INVOKER_TASK_DURATION,
         Unit::Seconds,
         "Time taken to complete an invoker task"
-    );
-
-    describe_gauge!(
-        INVOKER_TASKS_IN_FLIGHT,
-        Unit::Count,
-        "Number of inflight invoker tasks"
     );
 }

--- a/crates/log-server/src/metric_definitions.rs
+++ b/crates/log-server/src/metric_definitions.rs
@@ -8,39 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use metrics::{Unit, describe_counter, describe_histogram};
-
-pub(crate) const LOG_SERVER_STORE: &str = "restate.log_server.store.total";
-
-pub(crate) const LOG_SERVER_STORE_DURATION: &str = "restate.log_server.store_duration.seconds";
-
-pub(crate) const LOG_SERVER_WRITE_BATCH_COUNT: &str = "restate.log_server.write_batch_count";
+use metrics::{Unit, describe_histogram};
 
 pub(crate) const LOG_SERVER_WRITE_BATCH_SIZE_BYTES: &str =
     "restate.log_server.write_batch_size_bytes";
 
 pub(crate) fn describe_metrics() {
-    describe_counter!(
-        LOG_SERVER_STORE,
-        Unit::Count,
-        "Number of store requests to this log-server"
-    );
-
-    describe_histogram!(
-        LOG_SERVER_WRITE_BATCH_COUNT,
-        Unit::Count,
-        "Histogram of the number of records in each batch written to log-store"
-    );
-
     describe_histogram!(
         LOG_SERVER_WRITE_BATCH_SIZE_BYTES,
         Unit::Bytes,
         "Histogram of size in bytes of write batches written to log-store"
-    );
-
-    describe_histogram!(
-        LOG_SERVER_STORE_DURATION,
-        Unit::Seconds,
-        "Histogram of store requests processing latency"
     );
 }

--- a/crates/metadata-store/src/metric_definitions.rs
+++ b/crates/metadata-store/src/metric_definitions.rs
@@ -14,11 +14,14 @@ use metrics::{Unit, describe_counter, describe_histogram};
 pub const STATUS_COMPLETED: &str = "completed";
 pub const STATUS_FAILED: &str = "failed";
 
-pub(crate) const METADATA_CLIENT_GET_DURATION: &str = "restate.metadata_client.get.duration";
+pub(crate) const METADATA_CLIENT_GET_DURATION: &str =
+    "restate.metadata_client.get_duration.seconds";
 pub(crate) const METADATA_CLIENT_GET_VERSION_DURATION: &str =
-    "restate.metadata_client.get_version.duration";
-pub(crate) const METADATA_CLIENT_PUT_DURATION: &str = "restate.metadata_client.put.duration";
-pub(crate) const METADATA_CLIENT_DELETE_DURATION: &str = "restate.metadata_client.delete.duration";
+    "restate.metadata_client.get_version_duration.seconds";
+pub(crate) const METADATA_CLIENT_PUT_DURATION: &str =
+    "restate.metadata_client.put_duration.seconds";
+pub(crate) const METADATA_CLIENT_DELETE_DURATION: &str =
+    "restate.metadata_client.delete_duration.seconds";
 
 pub(crate) const METADATA_CLIENT_GET_TOTAL: &str = "restate.metadata_client.get.total";
 pub(crate) const METADATA_CLIENT_GET_VERSION_TOTAL: &str =

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -16,30 +16,19 @@ pub const PARTITION_LABEL: &str = "partition";
 
 pub const PARTITION_BLOCKED_FLARE: &str = "restate.partition.blocked_flare";
 
-pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command.seconds";
-pub const PARTITION_ACTUATOR_HANDLED: &str = "restate.partition.actuator_handled.total";
-pub const PARTITION_STORAGE_TX_CREATED: &str = "restate.partition.storage_tx_created.total";
-pub const PARTITION_STORAGE_TX_COMMITTED: &str = "restate.partition.storage_tx_committed.total";
+pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command_duration.seconds";
 pub const PARTITION_HANDLE_LEADER_ACTIONS: &str = "restate.partition.handle_leader_action.total";
 
 pub const NUM_PARTITIONS: &str = "restate.num_partitions";
 pub const NUM_ACTIVE_PARTITIONS: &str = "restate.num_active_partitions";
 pub const PARTITION_TIME_SINCE_LAST_STATUS_UPDATE: &str =
     "restate.partition.time_since_last_status_update";
-pub const PARTITION_TIME_SINCE_LAST_RECORD: &str = "restate.partition.time_since_last_record";
 pub const PARTITION_APPLIED_LSN: &str = "restate.partition.applied_lsn";
 pub const PARTITION_APPLIED_LSN_LAG: &str = "restate.partition.applied_lsn_lag";
 pub const PARTITION_DURABLE_LSN: &str = "restate.partition.durable_lsn";
 pub const PARTITION_IS_EFFECTIVE_LEADER: &str = "restate.partition.is_effective_leader";
 pub const PARTITION_IS_ACTIVE: &str = "restate.partition.is_active";
 
-pub const PARTITION_APPLY_COMMAND_DURATION: &str =
-    "restate.partition.apply_command_duration.seconds";
-pub const PARTITION_APPLY_COMMAND_BATCH_SIZE: &str = "restate.partition.apply_command_batch_size";
-pub const PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION: &str =
-    "restate.partition.handle_action_batch_duration.seconds";
-pub const PARTITION_HANDLE_INVOKER_EFFECT_COMMAND: &str =
-    "restate.partition.handle_invoker_effect.seconds";
 pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
     "restate.partition.record_committed_to_read_latency.seconds";
 
@@ -57,47 +46,11 @@ pub(crate) fn describe_metrics() {
         Unit::Seconds,
         "Time spent applying partition processor command"
     );
-    describe_counter!(
-        PARTITION_ACTUATOR_HANDLED,
-        Unit::Count,
-        "Number of actuator operation outputs processed"
-    );
-    describe_counter!(
-        PARTITION_STORAGE_TX_CREATED,
-        Unit::Count,
-        "Storage transactions created by from processing state machine commands"
-    );
-    describe_counter!(
-        PARTITION_STORAGE_TX_COMMITTED,
-        Unit::Count,
-        "Storage transactions committed by applying partition state machine commands"
-    );
-    describe_histogram!(
-        PARTITION_APPLY_COMMAND_DURATION,
-        Unit::Seconds,
-        "Time spent processing a single bifrost message"
-    );
-    describe_histogram!(
-        PARTITION_APPLY_COMMAND_BATCH_SIZE,
-        Unit::Count,
-        "Size of the applied command batch"
-    );
-    describe_histogram!(
-        PARTITION_LEADER_HANDLE_ACTION_BATCH_DURATION,
-        Unit::Seconds,
-        "Time spent applying actions/effects in a single iteration"
-    );
     describe_histogram!(
         PARTITION_HANDLE_LEADER_ACTIONS,
         Unit::Count,
         "Number of actions the leader has performed"
     );
-    describe_histogram!(
-        PARTITION_HANDLE_INVOKER_EFFECT_COMMAND,
-        Unit::Seconds,
-        "Time spent handling an invoker effect command"
-    );
-
     describe_histogram!(
         PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS,
         Unit::Seconds,
@@ -150,12 +103,6 @@ pub(crate) fn describe_metrics() {
         PARTITION_DURABLE_LSN,
         Unit::Count,
         "Raw value of the LSN that can be trimmed"
-    );
-
-    describe_gauge!(
-        PARTITION_TIME_SINCE_LAST_RECORD,
-        Unit::Seconds,
-        "Number of seconds since the last record was applied"
     );
 
     describe_counter!(

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -35,7 +35,6 @@ use crate::metric_definitions::PARTITION_DURABLE_LSN;
 use crate::metric_definitions::PARTITION_IS_ACTIVE;
 use crate::metric_definitions::PARTITION_IS_EFFECTIVE_LEADER;
 use crate::metric_definitions::PARTITION_LABEL;
-use crate::metric_definitions::PARTITION_TIME_SINCE_LAST_RECORD;
 use crate::metric_definitions::PARTITION_TIME_SINCE_LAST_STATUS_UPDATE;
 use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_APPLIED_LSN_LAG};
 use crate::metric_definitions::{NUM_PARTITIONS, PARTITION_APPLIED_LSN};
@@ -711,12 +710,6 @@ impl PartitionProcessorManager {
                     gauge!(PARTITION_DURABLE_LSN,
                         PARTITION_LABEL => partition_id.to_string())
                     .set(durable_lsn.as_u64() as f64);
-                }
-
-                if let Some(last_record_applied_at) = status.last_record_applied_at {
-                    gauge!(PARTITION_TIME_SINCE_LAST_RECORD,
-                        PARTITION_LABEL => partition_id.to_string())
-                    .set(last_record_applied_at.elapsed());
                 }
 
                 // it is a bit unfortunate that we share PartitionProcessorStatus between the


### PR DESCRIPTION

Thia also includes fixing metadata client metric naming convention, removing unused code and metrics.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3442).
* #3443
* __->__ #3442