### PR TITLE
Enable http-ingress role by default

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -265,26 +265,16 @@ impl Node {
             None
         };
 
-        if !config
-            .ingress
-            .experimental_feature_enable_separate_ingress_role
-            && config.has_role(Role::HttpIngress)
-        {
-            return Err(BuildError::InvalidConfiguration(anyhow::anyhow!(
-                "The http-ingress role is used but experimental-feature-enable-separate-ingress-role is not set."
-            )));
-        }
+        // In v1.4.0 we start ingress role even if not explicitly configured. This allows softer
+        // migration from v1.3.x to v1.4.0. In v1.5, ingress will be started _only_ if
+        // http-ingress role is explicitly configured.
+        let ingress_role = if config.has_role(Role::HttpIngress) || config.has_role(Role::Worker) {
+            if !config.has_role(Role::HttpIngress) {
+                info!(
+                    "!!! This node has a `worker` role and no explicit `http-ingress` role. `http-ingress` will be started anyway in this version. In v1.5, running ingress will require the role `http-ingress` to be set."
+                );
+            }
 
-        let ingress_role = if config
-            .ingress
-            .experimental_feature_enable_separate_ingress_role
-            && config.has_role(Role::HttpIngress)
-            // todo remove once the safe fallback version supports the HttpIngress role
-            || !config
-            .ingress
-            .experimental_feature_enable_separate_ingress_role
-            && config.has_role(Role::Worker)
-        {
             Some(IngressRole::create(
                 updateable_config
                     .clone()

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -429,9 +429,7 @@ impl CommonOptions {
 impl Default for CommonOptions {
     fn default() -> Self {
         Self {
-            // todo remove `- Role::Ingress` when the safe rollback version supports ingress
-            //   see "roles_compat_test" test below.
-            roles: EnumSet::all() - Role::HttpIngress,
+            roles: EnumSet::all(),
             node_name: None,
             location: None,
             force_node_id: None,
@@ -818,22 +816,12 @@ impl Default for TracingOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::CommonOptions;
     use crate::config::MetadataClientKind;
     use crate::config_loader::ConfigLoaderBuilder;
     use crate::net::AdvertisedAddress;
-    use crate::nodes_config::Role;
     use googletest::prelude::eq;
     use googletest::{assert_that, elements_are, pat};
     use http::Uri;
-
-    #[test]
-    fn roles_compat_test() {
-        let opts = CommonOptions::default();
-        // make sure we don't add ingress by default until previous version can parse nodes
-        // configuration with this role.
-        assert!(!opts.roles.contains(Role::HttpIngress));
-    }
 
     #[test]
     fn metadata_client_kind_backwards_compatibility() -> googletest::Result<()> {

--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -38,16 +38,6 @@ pub struct IngressOptions {
 
     kafka_clusters: Vec<KafkaClusterOptions>,
 
-    /// # Experimental feature to run the ingress independent of the worker role
-    ///
-    /// This feature is experimental and should be used with caution. It enables the HTTP ingress
-    /// to run role independently of the worker role. If you activate this feature, you will need
-    /// to specify the [`Role::HttpIngress`] role for nodes explicitly, and nodes that run
-    /// only [`Role::Worker`] will not accept HTTP ingress requests. If you enable this feature,
-    /// then you might not be able to roll back to a previous version.
-    #[cfg_attr(feature = "schemars", schemars(skip))]
-    pub experimental_feature_enable_separate_ingress_role: bool,
-
     /// # Ingress endpoint
     ///
     /// Ingress endpoint that the Web UI should use to interact with.
@@ -111,7 +101,6 @@ impl Default for IngressOptions {
             // max is limited by Tower's LoadShedLayer.
             concurrent_api_requests_limit: None,
             kafka_clusters: Default::default(),
-            experimental_feature_enable_separate_ingress_role: false,
             advertised_ingress_endpoint: None,
         }
     }

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -85,7 +85,7 @@ impl MetadataServerOptions {
     pub fn rocksdb_memory_budget(&self) -> usize {
         self.rocksdb_memory_budget
             .unwrap_or_else(|| {
-                warn!("MetadataStore rocksdb_memory_budget is not set, defaulting to 1MB");
+                warn!("metadata-server rocksdb_memory_budget is not set, defaulting to 1MB");
                 // 1MB minimum
                 NonZeroUsize::new(1024 * 1024).unwrap()
             })

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -86,8 +86,7 @@ pub enum Role {
     MetadataServer,
     /// Serves a log-server for replicated loglets
     LogServer,
-    /// [EXPERIMENTAL FEATURE] Serves HTTP ingress requests (requires
-    /// `experimental-feature-enable-separate-ingress-role` to be enabled)
+    /// Serves HTTP ingress requests
     HttpIngress,
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -158,9 +158,7 @@ fn main() {
             );
         }
 
-        // todo: this should be changed to HttpIngress
-        // once it's fully supported
-        if config.has_role(Role::Worker) {
+        if config.has_role(Role::HttpIngress) {
             let _ = writeln!(
                 &mut stdout,
                 "{:^40}",


### PR DESCRIPTION

This takes a slightly different approach than #3140 as it'll still start ingress even if the role `http-ingress` is not set. A notice message will be printed for nodes running with `worker` and without `http-ingress` to ease users into the change. In v1.5, http-ingress will not automatically start with worker and it'll require the role to be set explicitly.

In v1.4.0 the role `http-ingress` is added to the default set of roles so users starting with the default configuration will not see the notice.
