### PR TITLE
Always seal local metadata store on startup

### DIFF
--- a/crates/metadata-server/src/local/storage.rs
+++ b/crates/metadata-server/src/local/storage.rs
@@ -362,10 +362,8 @@ impl RocksDbStorage {
         }
     }
 
-    pub async fn close(self) -> Result<(), RocksError> {
-        self.rocksdb.shutdown().await;
-
-        Ok(())
+    pub async fn close(self) {
+        self.rocksdb.close().await
     }
 }
 

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -543,7 +543,7 @@ impl RaftMetadataServer {
         if !local_storage.is_sealed() {
             local_storage.seal().await?;
         }
-        local_storage.close().await?;
+        local_storage.close().await;
 
         Ok(())
     }

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -233,9 +233,11 @@ impl RocksDbManager {
         self.dbs.read().values().cloned().collect()
     }
 
-    /// Remove a database which has already been shut down
-    pub fn remove_db(&self, name: &DbName) -> Option<bool> {
-        self.dbs.write().remove(name).map(|_| true)
+    pub(crate) async fn close_db(&self, name: &DbName) {
+        let Some(db) = self.dbs.write().remove(name) else {
+            return;
+        };
+        db.shutdown().await;
     }
 
     /// Ask all databases to shut down cleanly

--- a/crates/rocksdb/src/error.rs
+++ b/crates/rocksdb/src/error.rs
@@ -53,8 +53,8 @@ impl RocksError {
         } else {
             if err_message.contains("Direct I/O is not supported") {
                 warn!(
-                    r#"""Direct I/O can be disabled by configuring rocks-db-disable-direct-io-for-reads 
-                        and rocksdb-disable-direct-io-for-flush-and-compactions. RocksDB is better run 
+                    r#"""Direct I/O can be disabled by configuring rocks-db-disable-direct-io-for-reads
+                        and rocksdb-disable-direct-io-for-flush-and-compactions. RocksDB is better run
                         with Direct I/O enabled, are you running on an encrypted fs?"""#
                 );
             }

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -510,8 +510,12 @@ impl RocksDb {
         self.manager.async_spawn(task).await?
     }
 
+    pub async fn close(&self) {
+        self.manager.close_db(&self.name).await
+    }
+
     #[tracing::instrument(skip_all, fields(db = %self.name))]
-    pub async fn shutdown(self: Arc<Self>) {
+    async fn shutdown(self: Arc<Self>) {
         let manager = self.manager;
         let op = move || {
             let _x = RocksDbPerfGuard::new("shutdown");
@@ -559,7 +563,6 @@ impl RocksDb {
                 );
             }
             self.db.cancel_all_background_work(true);
-            manager.remove_db(&self.name);
         };
         // intentionally ignore scheduling error
         let task = StorageTask::default()


### PR DESCRIPTION
With version 1.4, we default migrate to the replicated metadata store. Earlier versions will default to the local metadata store unless it has been explicitly sealed, creating a potential opportunity for metadata split-brain. This change makes it safe to revert to 1.3 if the server was initially provisioned under 1.4.

Start on 1.4.0-dev - note the sealing on startup (indirectly seen by the flush on shutdown) and the lack of flush of the local-metadata-store db on ^C:

```
2025-06-23T14:19:40.835357Z INFO restate_server
  Starting Restate Server 1.4.0-dev (debug) (818fcdca7 aarch64-apple-darwin 2025-06-23)
    node_name: "n1"
    config_source: [default]
    base_dir: /Users/pavel/restate/tmp/restate-data/n1/
on main
2025-06-23T14:19:41.068682Z INFO restate_core::network::net_util
  Server listening
on rs:worker-0
  in restate_core::network::net_util::server
    server_name: node-rpc-server
    net.host.addr: "0.0.0.0"
    net.host.port: 5122
2025-06-23T14:19:41.068997Z INFO restate_node::init
  Trying to join the cluster 'localcluster'
on rs:worker-0
2025-06-23T14:19:41.084329Z WARN restate_types::config::metadata_server
  MetadataStore rocksdb_memory_budget is not set, defaulting to 1MB
on rs:worker-5
2025-06-23T14:19:41.090490Z INFO restate_rocksdb
  2 column families flushed in 994.416µs
    db: local-metadata-store
on rs:io-lo
  in restate_rocksdb::shutdown
    db: local-metadata-store

...

2025-06-23T14:19:59.990895Z INFO restate_core::task_center
  ** Shutdown completed in 319.954416ms
on main
  in restate_core::task_center::handle::shutdown_node
    reason: "received signal SIGINT"
2025-06-23T14:19:59.991213Z INFO restate_rocksdb
  1 column families flushed in 25.583µs
    db: local-loglet
on rs:io-lo
  in restate_rocksdb::shutdown
    db: local-loglet
2025-06-23T14:19:59.995060Z INFO restate_rocksdb
  2 column families flushed in 3.824333ms
    db: replicated-metadata-server
on rs:io-lo
  in restate_rocksdb::shutdown
    db: replicated-metadata-server
2025-06-23T14:19:59.998161Z INFO restate_rocksdb
  2 column families flushed in 6.989667ms
    db: log-server
on rs:io-lo
  in restate_rocksdb::shutdown
    db: log-server
2025-06-23T14:20:00.009242Z INFO restate_rocksdb
  25 column families flushed in 18.04775ms
    db: db
on rs:io-lo
  in restate_rocksdb::shutdown
    db: db
2025-06-23T14:20:00.012347Z INFO restate_rocksdb::db_manager
  Rocksdb shutdown took 21.408ms
on main
2025-06-23T14:20:00.012370Z INFO restate_server
  Restate has been gracefully shut down.
on main
```

Then roll back to 1.3.2 with `docker run --net host -v ./restate-data:/restate-data restatedev/restate:1.3.2 --node-name n1`:

```
2025-06-23T14:20:46.881194Z INFO restate_server
  Starting Restate Server 1.3.2 (e554bc0 aarch64-unknown-linux-gnu 2025-04-18)
    node_name: "n1"
    config_source: [default]
    base_dir: /restate-data/n1/
on main
2025-06-23T14:20:46.903200Z INFO restate_metadata_server
  The local metadata server was migrated. Automatically switching to use the replicated metadata server.
on main
```