### PR TITLE
[Restate UI] Update to v0.0.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7995,8 +7995,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.78"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.78#eac51f9c72137c1b519a35036e2dfb8b96a68c44"
+version = "0.0.79"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.79#7511089c2ce4fdb265077a800bc1da478234d5ea"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.78", tag = "v0.0.78" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.79", tag = "v0.0.79" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.79
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.79/ui-v0.0.79.zip