### PR TITLE
Custom metrics macros with cardinality controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7361,6 +7361,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-metrics"
+version = "1.4.1-dev"
+dependencies = [
+ "metrics",
+ "workspace-hack",
+]
+
+[[package]]
 name = "restate-node"
 version = "1.4.1-dev"
 dependencies = [
@@ -10681,6 +10689,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "once_cell",
  "opentelemetry_sdk",
  "phf_shared",
  "pprof",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ restate-metadata-providers = { path = "crates/metadata-providers" }
 restate-metadata-server = { path = "crates/metadata-server" }
 restate-metadata-server-grpc = { path = "crates/metadata-server-grpc" }
 restate-metadata-store = { path = "crates/metadata-store" }
+restate-metrics = { path = "crates/metrics" }
 restate-node = { path = "crates/node" }
 restate-object-store-util = { path = "crates/object-store-util" }
 restate-partition-store = { path = "crates/partition-store" }

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "restate-metrics"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+metrics = { workspace = true }
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,0 +1,388 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod macros;
+
+use std::fmt::Display;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+pub use metrics;
+pub use metrics::{describe_counter, describe_gauge, describe_histogram};
+
+// Use a simple enum to represent the level as a u8
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Level {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+}
+
+impl FromStr for Level {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "trace" => Ok(Level::Trace),
+            "debug" => Ok(Level::Debug),
+            "info" => Ok(Level::Info),
+            "warn" | "warning" => Ok(Level::Warn),
+            "error" => Ok(Level::Error),
+            _ => Err(format!(
+                "Unknown level: '{}'. Expected one of: trace, debug, info, warn, error",
+                s
+            )),
+        }
+    }
+}
+
+impl Display for Level {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Level::Trace => write!(f, "trace"),
+            Level::Debug => write!(f, "debug"),
+            Level::Info => write!(f, "info"),
+            Level::Warn => write!(f, "warn"),
+            Level::Error => write!(f, "error"),
+        }
+    }
+}
+
+impl From<metrics::Level> for Level {
+    fn from(level: metrics::Level) -> Self {
+        match level {
+            metrics::Level::TRACE => Level::Trace,
+            metrics::Level::DEBUG => Level::Debug,
+            metrics::Level::INFO => Level::Info,
+            metrics::Level::WARN => Level::Warn,
+            metrics::Level::ERROR => Level::Error,
+        }
+    }
+}
+
+impl From<Level> for metrics::Level {
+    fn from(level_value: Level) -> Self {
+        match level_value {
+            Level::Trace => metrics::Level::TRACE,
+            Level::Debug => metrics::Level::DEBUG,
+            Level::Info => metrics::Level::INFO,
+            Level::Warn => metrics::Level::WARN,
+            Level::Error => metrics::Level::ERROR,
+        }
+    }
+}
+
+static METRICS_CARDINALITY_LEVEL: AtomicU8 = AtomicU8::new(Level::Info as u8);
+
+/// Sets the global metrics cardinality level.
+///
+/// This function allows you to dynamically change the metrics cardinality level globally.
+/// The level affects how metrics are filtered and processed.
+///
+/// # Examples
+///
+/// ```ignore
+/// use restate_metrics::{set_metrics_cardinality_level, get_metrics_cardinality_level, Level};
+///
+/// // Set the cardinality level to DEBUG
+/// set_metrics_cardinality_level(Level::Debug);
+/// assert_eq!(get_metrics_cardinality_level(), Level::Debug as u8);
+///
+/// // Set the cardinality level to ERROR
+/// set_metrics_cardinality_level(Level::Error);
+/// assert_eq!(get_metrics_cardinality_level(), Level::Debug as u8);
+/// ```
+pub fn set_metrics_cardinality_level(level: impl Into<Level>) {
+    let level: Level = level.into();
+    METRICS_CARDINALITY_LEVEL.store(level as u8, Ordering::Relaxed);
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn get_metrics_cardinality_level() -> u8 {
+    METRICS_CARDINALITY_LEVEL.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use metrics::{
+        Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+    };
+
+    use crate::{Level, counter, set_metrics_cardinality_level};
+
+    #[derive(Default, Clone)]
+    struct TestRecorder {
+        registry: Arc<Mutex<HashMap<String, Key>>>,
+    }
+
+    impl TestRecorder {
+        fn get_key(&self, key: &str) -> Option<Key> {
+            self.registry.lock().unwrap().get(key).cloned()
+        }
+
+        fn reset(&self) {
+            self.registry.lock().unwrap().clear();
+        }
+    }
+
+    impl Recorder for TestRecorder {
+        fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        }
+
+        fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+        fn describe_histogram(
+            &self,
+            _key: KeyName,
+            _unit: Option<Unit>,
+            _description: SharedString,
+        ) {
+        }
+
+        /// Registers a counter.
+        fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+            self.registry
+                .lock()
+                .unwrap()
+                .insert(key.name().to_string(), key.clone());
+            Counter::noop()
+        }
+
+        /// Registers a gauge.
+        fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+            self.registry
+                .lock()
+                .unwrap()
+                .insert(key.name().to_string(), key.clone());
+            Gauge::noop()
+        }
+
+        /// Registers a histogram.
+        fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+            self.registry
+                .lock()
+                .unwrap()
+                .insert(key.name().to_string(), key.clone());
+            Histogram::noop()
+        }
+    }
+
+    #[test]
+    fn test_metrics() {
+        let recorder = TestRecorder::default();
+        metrics::set_global_recorder(recorder.clone()).unwrap();
+
+        let _counter = counter!("my_counter", "label" => "value");
+        let key = recorder.get_key("my_counter");
+        assert!(key.is_some());
+        let key = key.unwrap();
+        let labels = key.labels().collect::<Vec<_>>();
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].key(), "label");
+        assert_eq!(labels[0].value(), "value");
+
+        recorder.reset();
+        // Set the cardinality level to info, so that the "info" label is included
+        set_metrics_cardinality_level(Level::Info);
+
+        let _counter = counter!("my_counter", "label" => "value", "info"; info => "value2", "debug"; debug => "value3");
+        let key = recorder.get_key("my_counter");
+        assert!(key.is_some());
+        let key = key.unwrap();
+        let labels = key.labels().collect::<Vec<_>>();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].key(), "label");
+        assert_eq!(labels[0].value(), "value");
+        assert_eq!(labels[1].key(), "info");
+        assert_eq!(labels[1].value(), "value2");
+
+        recorder.reset();
+        set_metrics_cardinality_level(Level::Warn);
+
+        let _counter = counter!(
+            "my_counter",
+            "label" => "value",
+            "info"; info => "value2",
+            "debug"; debug => "value3",
+            "warn"; warn => "value4",
+            "error"; error => "value5"
+        );
+
+        let key = recorder.get_key("my_counter");
+        assert!(key.is_some());
+        let key = key.unwrap();
+        let labels = key.labels().collect::<Vec<_>>();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].key(), "warn");
+        assert_eq!(labels[0].value(), "value4");
+        assert_eq!(labels[1].key(), "error");
+        assert_eq!(labels[1].value(), "value5");
+
+        recorder.reset();
+        set_metrics_cardinality_level(Level::Info);
+        let mut side_effect = 0;
+        let _counter = counter!("my_counter", "info" => "value", "debug"; debug => {
+            side_effect += 1;
+            "value3"
+        });
+
+        assert_eq!(side_effect, 0);
+        let key = recorder.get_key("my_counter");
+        assert!(key.is_some());
+        let key = key.unwrap();
+        let labels = key.labels().collect::<Vec<_>>();
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].key(), "info");
+        assert_eq!(labels[0].value(), "value");
+
+        recorder.reset();
+        set_metrics_cardinality_level(Level::Debug);
+        let mut side_effect = 0;
+        let _counter = counter!("my_counter", "info" => "value", "debug"; debug => {
+            side_effect += 1;
+            "value3"
+        });
+
+        assert_eq!(side_effect, 1);
+        let key = recorder.get_key("my_counter");
+        assert!(key.is_some());
+        let key = key.unwrap();
+        let labels = key.labels().collect::<Vec<_>>();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].key(), "info");
+        assert_eq!(labels[0].value(), "value");
+        assert_eq!(labels[1].key(), "debug");
+        assert_eq!(labels[1].value(), "value3");
+    }
+
+    #[test]
+    fn test_global_metrics_level() {
+        use super::{get_metrics_cardinality_level, set_metrics_cardinality_level};
+
+        // Test initial state
+        assert_eq!(get_metrics_cardinality_level(), Level::Info as u8);
+
+        // Test setting different levels
+        set_metrics_cardinality_level(metrics::Level::DEBUG);
+        assert_eq!(get_metrics_cardinality_level(), Level::Debug as u8);
+
+        set_metrics_cardinality_level(metrics::Level::ERROR);
+        assert_eq!(get_metrics_cardinality_level(), Level::Error as u8);
+
+        set_metrics_cardinality_level(metrics::Level::TRACE);
+        assert_eq!(get_metrics_cardinality_level(), Level::Trace as u8);
+
+        set_metrics_cardinality_level(metrics::Level::WARN);
+        assert_eq!(get_metrics_cardinality_level(), Level::Warn as u8);
+    }
+
+    #[test]
+    fn test_level_from_str() {
+        use super::Level;
+        use std::str::FromStr;
+
+        // Test valid lowercase strings
+        assert_eq!(Level::from_str("trace").unwrap(), Level::Trace);
+        assert_eq!(Level::from_str("debug").unwrap(), Level::Debug);
+        assert_eq!(Level::from_str("info").unwrap(), Level::Info);
+        assert_eq!(Level::from_str("warn").unwrap(), Level::Warn);
+        assert_eq!(Level::from_str("error").unwrap(), Level::Error);
+
+        // Test valid uppercase strings (should be case-insensitive)
+        assert_eq!(Level::from_str("TRACE").unwrap(), Level::Trace);
+        assert_eq!(Level::from_str("DEBUG").unwrap(), Level::Debug);
+        assert_eq!(Level::from_str("INFO").unwrap(), Level::Info);
+        assert_eq!(Level::from_str("WARN").unwrap(), Level::Warn);
+        assert_eq!(Level::from_str("ERROR").unwrap(), Level::Error);
+
+        // Test valid mixed case strings
+        assert_eq!(Level::from_str("Trace").unwrap(), Level::Trace);
+        assert_eq!(Level::from_str("Debug").unwrap(), Level::Debug);
+        assert_eq!(Level::from_str("Info").unwrap(), Level::Info);
+        assert_eq!(Level::from_str("Warn").unwrap(), Level::Warn);
+        assert_eq!(Level::from_str("Error").unwrap(), Level::Error);
+
+        // Test "warning" as an alias for "warn"
+        assert_eq!(Level::from_str("warning").unwrap(), Level::Warn);
+        assert_eq!(Level::from_str("WARNING").unwrap(), Level::Warn);
+        assert_eq!(Level::from_str("Warning").unwrap(), Level::Warn);
+
+        // Test invalid strings
+        assert!(Level::from_str("invalid").is_err());
+        assert!(Level::from_str("").is_err());
+        assert!(Level::from_str("TRAC").is_err());
+        assert!(Level::from_str("debugg").is_err());
+        assert!(Level::from_str("inf").is_err());
+        assert!(Level::from_str("warnings").is_err());
+        assert!(Level::from_str("errors").is_err());
+
+        // Test error message format
+        let err = Level::from_str("invalid").unwrap_err();
+        assert!(err.contains("Unknown level: 'invalid'"));
+        assert!(err.contains("Expected one of: trace, debug, info, warn, error"));
+    }
+
+    #[test]
+    fn test_level_display() {
+        use super::Level;
+        use std::fmt::Write;
+        use std::str::FromStr;
+
+        // Test each level displays correctly
+        assert_eq!(Level::Trace.to_string(), "trace");
+        assert_eq!(Level::Debug.to_string(), "debug");
+        assert_eq!(Level::Info.to_string(), "info");
+        assert_eq!(Level::Warn.to_string(), "warn");
+        assert_eq!(Level::Error.to_string(), "error");
+
+        // Test using format! macro
+        assert_eq!(format!("{}", Level::Trace), "trace");
+        assert_eq!(format!("{}", Level::Debug), "debug");
+        assert_eq!(format!("{}", Level::Info), "info");
+        assert_eq!(format!("{}", Level::Warn), "warn");
+        assert_eq!(format!("{}", Level::Error), "error");
+
+        // Test round-trip: Display -> FromStr
+        assert_eq!(
+            Level::from_str(&Level::Trace.to_string()).unwrap(),
+            Level::Trace
+        );
+        assert_eq!(
+            Level::from_str(&Level::Debug.to_string()).unwrap(),
+            Level::Debug
+        );
+        assert_eq!(
+            Level::from_str(&Level::Info.to_string()).unwrap(),
+            Level::Info
+        );
+        assert_eq!(
+            Level::from_str(&Level::Warn.to_string()).unwrap(),
+            Level::Warn
+        );
+        assert_eq!(
+            Level::from_str(&Level::Error.to_string()).unwrap(),
+            Level::Error
+        );
+
+        // Test writing to a string buffer
+        let mut buffer = String::new();
+        write!(&mut buffer, "{}", Level::Info).unwrap();
+        assert_eq!(buffer, "info");
+    }
+}

--- a/crates/metrics/src/macros.rs
+++ b/crates/metrics/src/macros.rs
@@ -1,0 +1,353 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// **NOTE** This macro is internal and should not be used directly.
+///
+/// Creates a metric label with optional level-based filtering.
+///
+/// This macro creates metric labels that can be conditionally included based on the current
+/// metrics label level configuration. Labels without a level are treated as `info` level by default.
+///
+/// # Syntax
+///
+/// ## Basic label (info level by default)
+/// ```ignore
+/// label!("key" => "value")
+/// ```
+///
+/// ## Label with explicit level
+/// ```ignore
+/// label!("key"; trace => "value");    // Only included if level >= trace
+/// label!("key"; debug => "value");    // Only included if level >= debug
+/// label!("key"; info => "value");     // Only included if level >= info
+/// label!("key"; warn => "value");     // Only included if level >= warn
+/// label!("key"; error => "value");    // Only included if level >= error
+/// ```
+///
+/// # Examples
+///
+/// ```ignore
+/// use restate_metrics::{label, set_metrics_cardinality_level, Level};
+///
+/// // Set the metrics label level to info
+/// set_metrics_cardinality_level(Level::Info);
+///
+/// // These labels will be included (info level >= current level)
+/// let label1 = label!("service" => "user-service");
+/// let label2 = label!("version"; info => "v1.0.0");
+///
+/// // This label will be filtered out (debug level < current level)
+/// let label3 = label!("debug_info"; debug => "detailed_debug_data");
+///
+/// // This label will be included (warn level >= current level)
+/// let label4 = label!("error_code"; warn => "connection_timeout");
+/// ```
+///
+/// # Level Hierarchy
+///
+/// The levels follow this hierarchy (from most to least verbose):
+/// - `trace` (most verbose)
+/// - `debug`
+/// - `info` (default for labels without level)
+/// - `warn`
+/// - `error` (least verbose)
+///
+/// Only labels with levels greater than or equal to the configured level are included.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! label {
+    (@filter $key:expr => $value:tt) => {{
+        let level = $crate::get_metrics_cardinality_level();
+        if $crate::Level::Info as u8 >= level {
+            Some($crate::label!(@label $key => $value))
+        } else {
+            None
+        }
+    }};
+    (@filter $key:expr; trace => $value:tt) => {{
+        let level = $crate::get_metrics_cardinality_level();
+        if $crate::Level::Trace as u8 >= level  {
+            Some($crate::label!(@label $key => $value))
+        } else {
+            None
+        }
+    }};
+    (@filter $key:expr; debug => $value:tt) => {{
+        let level = $crate::get_metrics_cardinality_level();
+        if $crate::Level::Debug as u8 >= level {
+            Some($crate::label!(@label $key => $value))
+        } else {
+            None
+        }
+    }};
+    (@filter $key:expr; info => $value:tt) => {{
+        let level = $crate::get_metrics_cardinality_level();
+        if $crate::Level::Info as u8 >= level {
+            Some($crate::label!(@label $key => $value))
+        } else {
+            None
+        }
+    }};
+    (@filter $key:expr; warn => $value:tt) => {{
+        let level = $crate::get_metrics_cardinality_level();
+        if $crate::Level::Warn as u8 >= level {
+            Some($crate::label!(@label $key => $value))
+        } else {
+            None
+        }
+    }};
+    (@filter $key:expr; error => $value:tt) => {{
+        let level = $crate::get_metrics_cardinality_level();
+        if $crate::Level::Error as u8 >= level {
+            Some($crate::label!(@label $key => $value))
+        } else {
+            None
+        }
+    }};
+
+    (@label $key:literal => $value:literal) => {{
+        $crate::metrics::Label::from_static_parts($key, $value)
+    }};
+
+    // Support for lazy evaluation of the value
+    // This is useful for cases where the value is expensive to compute
+    // and we want to avoid computing it if the label is not included
+    // in the metrics cardinality level.
+    (@label $key:expr => $value:block) => {{
+        $crate::metrics::Label::new($key, $value)
+    }};
+
+    (@label $key:expr => $value:expr) => {{
+        $crate::metrics::Label::new($key, $value)
+    }};
+}
+
+/// Records a histogram metric with level-based label filtering.
+///
+/// This macro creates histogram metrics that can include labels filtered by the current
+/// metrics label level configuration. It provides multiple syntax variants for different use cases.
+///
+/// # Syntax Variants
+///
+/// ## Standard metrics crate syntax (passes through to underlying metrics crate)
+/// ```ignore
+/// histogram!(target: "my_target", level: Level::INFO, "metric_name", "label" => "value");
+/// histogram!(target: "my_target", "metric_name", "label" => "value");
+/// histogram!(level: Level::INFO, "metric_name", "label" => "value");
+/// histogram!("metric_name", "label" => "value");
+/// ```
+///
+/// ## Custom syntax with level-based label filtering
+/// ```ignore
+/// histogram!("my_target",
+///     "service" => "user-service",
+///     "version"; info => "v1.0.0",
+///     "debug_info"; debug => "detailed_data",
+///     "error_code"; warn => "timeout"
+/// );
+/// ```
+///
+/// # Examples
+///
+/// ```ignore
+/// use restate_metrics::{histogram, set_metrics_cardinality_level, Level};
+/// use std::time::Instant;
+///
+/// // Set metrics label level to info
+/// set_metrics_cardinality_level(Level::Info);
+///
+/// // Record a histogram with basic labels
+/// histogram!("http_request_duration",
+///     "method" => "GET",
+///     "endpoint" => "/api/users"
+/// );
+///
+/// // Record a histogram with level-filtered labels
+/// histogram!("database_query_duration",
+///     "table" => "users",
+///     "query_type"; info => "select",
+///     "debug_sql"; debug => "SELECT * FROM users WHERE id = ?",
+///     "error_details"; warn => "connection_timeout"
+/// );
+///
+/// // Record with explicit target and level
+/// histogram!(target: "my_module", level: Level::DEBUG, "custom_metric", "label" => "value");
+/// ```
+///
+/// # Label Filtering
+///
+/// Labels are filtered based on the current metrics label level:
+/// - Labels without a level are treated as `info` level
+/// - Only labels with levels >= the configured level are included
+/// - This helps control metric cardinality in production environments
+#[macro_export]
+macro_rules! histogram {
+    (target: $target:expr, level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
+        $crate::metrics::histogram!(target: $target, level: $level, $name $(, $label_key $(=> $label_value)?)*)
+    }};
+    (target: $target:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::histogram!(target: $target, level: $crate::metrics::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    };
+    (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::histogram!(target: ::std::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
+    };
+    ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::histogram!(target: ::std::module_path!(), level: $crate::metrics::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    };
+
+    ($target:expr $(, $label_key:expr $(; $label_level:ident)? $(=> $label_value:tt)?)* $(,)?) => {{
+        let labels = vec![$($crate::label!(@filter $label_key $(; $label_level)? $(=> $label_value)?)),*]
+                .into_iter().filter_map(|x| x).collect::<Vec<_>>();
+        let metric_key = Key::from_parts($target, labels);
+        let metadata = $crate::metrics::metadata_var!($target, $crate::metrics::Level::INFO);
+        $crate::metrics::with_recorder(|recorder| recorder.register_histogram(&metric_key, metadata))
+    }};
+}
+
+/// Records a counter metric with level-based label filtering.
+///
+/// This macro creates counter metrics that can include labels filtered by the current
+/// metrics label level configuration. Counters are used to track cumulative values that
+/// only increase over time.
+///
+/// # Syntax Variants
+///
+/// ## Standard metrics crate syntax (passes through to underlying metrics crate)
+/// ```ignore
+/// counter!(target: "my_target", level: Level::INFO, "metric_name", "label" => "value");
+/// counter!(target: "my_target", "metric_name", "label" => "value");
+/// counter!(level: Level::INFO, "metric_name", "label" => "value");
+/// counter!("metric_name", "label" => "value");
+/// ```
+///
+/// ## Custom syntax with level-based label filtering
+/// ```ignore
+/// counter!("my_target",
+///     "operation" => "create_user",
+///     "user_type"; info => "premium",
+///     "debug_context"; debug => "detailed_context",
+///     "error_type"; warn => "validation_failed"
+/// );
+/// ```
+///
+/// # Examples
+///
+/// ```ignore
+/// use restate_metrics::{counter, set_metrics_cardinality_level, Level};
+///
+/// // Set metrics label level to info
+/// set_metrics_cardinality_level(Level::Info);
+///
+/// // Record a simple counter
+/// counter!("http_requests_total",
+///     "method" => "POST",
+///     "status" => "200"
+/// );
+///
+/// // Record a counter with level-filtered labels
+/// counter!("database_operations",
+///     "operation" => "insert",
+///     "table_name"; info => "users",
+///     "query_hash"; debug => "abc123def456",
+///     "error_code"; warn => "duplicate_key"
+/// );
+#[macro_export]
+macro_rules! counter {
+    (target: $target:expr, level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
+        $crate::metrics::counter!(target: $target, level: $level, $name $(, $label_key $(=> $label_value)?)*)
+    }};
+    (target: $target:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::counter!(target: $target, level: $crate::metrics::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    };
+    (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::counter!(target: ::std::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
+    };
+    ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::counter!(target: ::std::module_path!(), level: $crate::metrics::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    };
+
+    ($target:expr $(, $label_key:expr $(; $label_level:ident)? $(=> $label_value:tt)?)* $(,)?) => {{
+        let labels = vec![$($crate::label!(@filter $label_key $(; $label_level)? $(=> $label_value)?)),*]
+                .into_iter().filter_map(|x| x).collect::<Vec<_>>();
+        let metric_key = Key::from_parts($target, labels);
+        let metadata = $crate::metrics::metadata_var!($target, $crate::metrics::Level::INFO);
+        $crate::metrics::with_recorder(|recorder| recorder.register_counter(&metric_key, metadata))
+    }};
+}
+
+/// Records a gauge metric with level-based label filtering.
+///
+/// This macro creates gauge metrics that can include labels filtered by the current
+/// metrics label level configuration. Gauges are used to track values that can go up and down.
+///
+/// # Syntax Variants
+///
+/// ## Standard metrics crate syntax (passes through to underlying metrics crate)
+/// ```ignore
+/// gauge!(target: "my_target", level: Level::INFO, "metric_name", "label" => "value");
+/// gauge!(target: "my_target", "metric_name", "label" => "value");
+/// gauge!(level: Level::INFO, "metric_name", "label" => "value");
+/// gauge!("metric_name", "label" => "value");
+/// ```
+///
+/// ## Custom syntax with level-based label filtering
+/// ```ignore
+/// gauge!("my_target",
+///     "resource" => "memory",
+///     "component"; info => "cache",
+///     "debug_details"; debug => "detailed_memory_info",
+///     "warning_threshold"; warn => "80_percent"
+/// );
+/// ```
+///
+/// # Examples
+///
+/// ```ignore
+/// use restate_metrics::{gauge, set_metrics_cardinality_level, Level};
+///
+/// // Set metrics label level to info
+/// set_metrics_cardinality_level(Level::Info);
+///
+/// // Record a simple gauge
+/// gauge!("memory_usage_bytes",
+///     "component" => "database"
+/// ).set(1024 * 1024 * 100); // 100MB
+///
+/// // Record a gauge with level-filtered labels
+/// gauge!("connection_pool_size",
+///     "pool_name" => "main_db",
+///     "pool_type"; info => "read_write",
+///     "debug_config"; debug => "max_connections=50",
+///     "warning_state"; warn => "near_capacity"
+/// ).set(45);
+/// ```
+#[macro_export]
+macro_rules! gauge {
+    (target: $target:expr, level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
+        $crate::metrics::gauge!(target: $target, level: $level, $name $(, $label_key $(=> $label_value)?)*)
+    }};
+    (target: $target:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::gauge!(target: $target, level: $crate::metrics::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    };
+    (level: $level:expr, $name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::gauge!(target: ::std::module_path!(), level: $level, $name $(, $label_key $(=> $label_value)?)*)
+    };
+    ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {
+        $crate::metrics::gauge!(target: ::std::module_path!(), level: $crate::metrics::Level::INFO, $name $(, $label_key $(=> $label_value)?)*)
+    };
+
+    ($target:expr $(, $label_key:expr $(; $label_level:ident)? $(=> $label_value:tt)?)* $(,)?) => {{
+        let labels = vec![$($crate::label!(@filter $label_key $(; $label_level)? $(=> $label_value)?)),*]
+                .into_iter().filter_map(|x| x).collect::<Vec<_>>();
+        let metric_key = Key::from_parts($target, labels);
+        let metadata = $crate::metrics::metadata_var!($target, $crate::metrics::Level::INFO);
+        $crate::metrics::with_recorder(|recorder| recorder.register_gauge(&metric_key, metadata))
+    }};
+}

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -268,6 +268,7 @@ libc = { version = "0.2", default-features = false, features = ["use_std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
 num = { version = "0.4" }
+once_cell = { version = "1" }
 prost = { version = "0.13", default-features = false, features = ["no-recursion-limit"] }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["stdio", "termios"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "stdio", "termios"] }
@@ -279,6 +280,7 @@ libc = { version = "0.2", default-features = false, features = ["use_std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
 num = { version = "0.4" }
+once_cell = { version = "1" }
 prost = { version = "0.13", default-features = false, features = ["no-recursion-limit"] }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["stdio", "termios"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "stdio", "termios"] }
@@ -289,6 +291,7 @@ hyper-rustls = { version = "0.27", default-features = false, features = ["webpki
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
 num = { version = "0.4" }
+once_cell = { version = "1" }
 prost = { version = "0.13", default-features = false, features = ["no-recursion-limit"] }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["stdio", "termios"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "stdio", "termios"] }
@@ -299,6 +302,7 @@ hyper-rustls = { version = "0.27", default-features = false, features = ["webpki
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
 num = { version = "0.4" }
+once_cell = { version = "1" }
 prost = { version = "0.13", default-features = false, features = ["no-recursion-limit"] }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["stdio", "termios"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "stdio", "termios"] }


### PR DESCRIPTION
Custom metrics macros with cardinality controls

Summary:
This PR introduces a set of helper macros that allow developers
to control which labels are emitted based on the globally set
cardinality level.

Calling the macros without the `level` controls passes this through
to the underlying metrics crate without changes

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3449).
* #3450
* __->__ #3449