### PR TITLE
[fix] Default journal_retention to zero when reading old invoker effects

### DIFF
--- a/crates/types/src/journal_v2/raw/mod.rs
+++ b/crates/types/src/journal_v2/raw/mod.rs
@@ -175,6 +175,9 @@ pub struct CallOrSendMetadata {
     pub invocation_target: InvocationTarget,
     pub span_context: ServiceInvocationSpanContext,
     pub completion_retention_duration: Duration,
+    // Since v1.4.0. Messages older than v1.4.0 will have zero retention as that
+    // matches the default behaviour of <= 1.3.x.
+    #[serde(default)]
     pub journal_retention_duration: Duration,
 }
 


### PR DESCRIPTION

This fixes a bug where restate v1.4.0 would fail to deserialize old invoker effects from bifrost.

Example error:
```
2025-06-24T10:51:30.432763Z ERROR run: restate_types::storage::decode: Flexbuffers error at field command.InvokerEffect.kind.JournalEntryV2.entry.inner.Command.command_specific_metadata.CallOrSend err=command.InvokerEffect.kind.JournalEntryV2.entry.inner.Command.command_specific_metadata.CallOrSend: Serde Error: missing field `journal_retention_duration` partition_id=5
2025-06-24T10:51:30.432772Z ERROR run: restate_wal_protocol::envelope: FlexbuffersSerde decode failure (decoding Envelope) err=decoding failed: Serde Error: missing field `journal_retention_duration` partition_id=5
2025-06-24T10:51:30.432788Z  WARN run: restate_worker::partition: Shutting partition processor down because of error: decoding failed: Serde Error: missing field `journal_retention_duration` partition_id=5
```
