### PR TITLE
[Restate UI] Update to v0.0.81

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7995,8 +7995,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.80"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.80#702355c0ced0a576c18072a3b85dd913a497f61e"
+version = "0.0.81"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.81#73bc0af6034030dfbe66339e0a05e8c06deb8f61"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.80", tag = "v0.0.80" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.81", tag = "v0.0.81" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.81
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.81/ui-v0.0.81.zip