### PR TITLE
[Restate UI] Update to v0.0.82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6856,7 +6856,7 @@ dependencies = [
 
 [[package]]
 name = "restate-cloud-tunnel-client"
-version = "1.4.0-dev"
+version = "1.4.2-dev"
 dependencies = [
  "anyhow",
  "bs58",
@@ -8011,8 +8011,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.81"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.81#73bc0af6034030dfbe66339e0a05e8c06deb8f61"
+version = "0.0.82"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.82#5b12dfc89fa8db8035df3602b78b77e59986f68b"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.81", tag = "v0.0.81" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.82", tag = "v0.0.82" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.82
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.82/ui-v0.0.82.zip