### PR TITLE
[Restate UI] Update to v0.0.83

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8011,8 +8011,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.82"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.82#5b12dfc89fa8db8035df3602b78b77e59986f68b"
+version = "0.0.83"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.83#5b242de6cec1872f839d187adb6ea8289d4765c7"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.82", tag = "v0.0.82" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.83", tag = "v0.0.83" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.83
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.83/ui-v0.0.83.zip