### PR TITLE
Tunnel client should support new drain functionality

### DIFF
--- a/cli/src/commands/cloud/environments/tunnel/local.rs
+++ b/cli/src/commands/cloud/environments/tunnel/local.rs
@@ -108,7 +108,15 @@ pub(crate) async fn run_local(
 
                 let handler = handler.clone();
 
-                async move { Err(handler.serve(tunnel_url, CancellationToken::new()).await) }
+                async move {
+                    Err(handler
+                        .serve(
+                            tunnel_url,
+                            CancellationToken::new(),
+                            CancellationToken::new(),
+                        )
+                        .await)
+                }
             },
             |err: &ServeError| {
                 if !err.is_retryable() {


### PR DESCRIPTION
The CLI tunnel doesn't need to use this as availability isn't critical, but a standalone tunnel client will want to be notified when the server is going away.