### PR TITLE
[Restate UI] Update to v0.0.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8011,8 +8011,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.83"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.83#5b242de6cec1872f839d187adb6ea8289d4765c7"
+version = "0.0.86"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.86#dfc1ed26a91050cd2da764159260ffc6775cabc9"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.83", tag = "v0.0.83" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.86", tag = "v0.0.86" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.86
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.86/ui-v0.0.86.zip