### PR TITLE
Rename workspace-hack to restate-workspace-hack

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -1,7 +1,8 @@
 # This file contains settings for `cargo hakari`.
 # See https://docs.rs/cargo-hakari/latest/cargo_hakari/config for a full list of options.
 
-hakari-package = "workspace-hack"
+hakari-package = "restate-workspace-hack"
+workspace-hack-line-style = "workspace-dotted"
 
 # Format version for hakari's output. Version 4 requires cargo-hakari 0.9.22 or above.
 dep-format-version = "4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "restate-test-util",
  "restate-tracing-instrumentation",
  "restate-types",
+ "restate-workspace-hack",
  "rlimit",
  "rust-rocksdb",
  "serde",
@@ -1078,7 +1079,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1648,8 +1648,8 @@ name = "codederror"
 version = "1.4.2-dev"
 dependencies = [
  "codederror-derive",
+ "restate-workspace-hack",
  "thiserror 2.0.12",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1658,8 +1658,8 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "restate-workspace-hack",
  "syn 1.0.109",
- "workspace-hack",
 ]
 
 [[package]]
@@ -4785,13 +4785,13 @@ dependencies = [
  "prost",
  "restate-service-protocol",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6645,6 +6645,7 @@ dependencies = [
  "restate-types",
  "restate-wal-protocol",
  "restate-web-ui",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -6655,7 +6656,6 @@ dependencies = [
  "tonic",
  "tower 0.5.2",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6669,12 +6669,12 @@ dependencies = [
  "humantime",
  "restate-serde-util",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_with",
  "strum 0.27.1",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6682,7 +6682,7 @@ name = "restate-base64-util"
 version = "1.4.2-dev"
 dependencies = [
  "base64 0.22.1",
- "workspace-hack",
+ "restate-workspace-hack",
 ]
 
 [[package]]
@@ -6703,13 +6703,13 @@ dependencies = [
  "restate-rocksdb",
  "restate-tracing-instrumentation",
  "restate-types",
+ "restate-workspace-hack",
  "rlimit",
  "serde_json",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6748,6 +6748,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "restate-wal-protocol",
+ "restate-workspace-hack",
  "rlimit",
  "rust-rocksdb",
  "serde",
@@ -6765,7 +6766,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "workspace-hack",
  "xxhash-rust",
 ]
 
@@ -6808,6 +6808,7 @@ dependencies = [
  "restate-cloud-tunnel-client",
  "restate-serde-util",
  "restate-types",
+ "restate-workspace-hack",
  "rustls",
  "serde",
  "serde_json",
@@ -6824,7 +6825,6 @@ dependencies = [
  "url",
  "uuid",
  "vergen",
- "workspace-hack",
  "zip 0.6.6",
 ]
 
@@ -6845,13 +6845,13 @@ dependencies = [
  "dotenvy",
  "lambda_runtime",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "tokio",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
  "unicode-width 0.1.14",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6867,6 +6867,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "jsonwebtoken",
+ "restate-workspace-hack",
  "rustls",
  "serde",
  "thiserror 2.0.12",
@@ -6874,7 +6875,6 @@ dependencies = [
  "tokio-util",
  "tower 0.5.2",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6923,6 +6923,7 @@ dependencies = [
  "restate-object-store-util",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_with",
@@ -6943,7 +6944,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "url",
- "workspace-hack",
  "xxhash-rust",
 ]
 
@@ -6953,8 +6953,8 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "restate-workspace-hack",
  "syn 2.0.101",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6966,8 +6966,8 @@ dependencies = [
  "bytestring",
  "rand 0.9.1",
  "restate-encoding-derive",
+ "restate-workspace-hack",
  "static_assertions",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6976,8 +6976,8 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "restate-workspace-hack",
  "syn 2.0.101",
- "workspace-hack",
 ]
 
 [[package]]
@@ -6986,21 +6986,21 @@ version = "1.4.2-dev"
 dependencies = [
  "codederror",
  "paste",
+ "restate-workspace-hack",
  "test-log",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
 name = "restate-fs-util"
 version = "1.4.2-dev"
 dependencies = [
+ "restate-workspace-hack",
  "tokio",
  "tracing",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7012,13 +7012,13 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "restate-test-util",
+ "restate-workspace-hack",
  "test-log",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7049,6 +7049,7 @@ dependencies = [
  "restate-test-util",
  "restate-tracing-instrumentation",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -7063,7 +7064,6 @@ dependencies = [
  "tracing-test",
  "url",
  "urlencoding",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7086,12 +7086,12 @@ dependencies = [
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-wal-protocol",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7106,10 +7106,10 @@ dependencies = [
  "num-traits",
  "restate-errors",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "thiserror 2.0.12",
  "tokio",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7140,6 +7140,7 @@ dependencies = [
  "restate-test-util",
  "restate-timer-queue",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -7150,7 +7151,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7175,6 +7175,7 @@ dependencies = [
  "restate-metadata-server-grpc",
  "restate-metadata-store",
  "restate-types",
+ "restate-workspace-hack",
  "rev_lines",
  "rlimit",
  "serde",
@@ -7187,7 +7188,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typed-builder",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7218,6 +7218,7 @@ dependencies = [
  "restate-rocksdb",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "rust-rocksdb",
  "serde",
  "serde_json",
@@ -7235,7 +7236,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "workspace-hack",
  "xxhash-rust",
 ]
 
@@ -7245,9 +7245,9 @@ version = "1.4.2-dev"
 dependencies = [
  "prost",
  "restate-types",
+ "restate-workspace-hack",
  "tonic",
  "tonic-build",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7270,6 +7270,7 @@ dependencies = [
  "restate-metadata-store",
  "restate-object-store-util",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "serde_json",
  "test-log",
@@ -7278,7 +7279,6 @@ dependencies = [
  "tonic",
  "tracing",
  "url",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7314,6 +7314,7 @@ dependencies = [
  "restate-metadata-store",
  "restate-rocksdb",
  "restate-types",
+ "restate-workspace-hack",
  "rust-rocksdb",
  "serde",
  "serde_json",
@@ -7330,7 +7331,6 @@ dependencies = [
  "tracing",
  "tracing-slog",
  "ulid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7344,6 +7344,7 @@ dependencies = [
  "prost",
  "prost-dto",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -7352,7 +7353,6 @@ dependencies = [
  "tonic-build",
  "tracing",
  "ulid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7366,13 +7366,13 @@ dependencies = [
  "metrics",
  "prost",
  "restate-types",
+ "restate-workspace-hack",
  "static_assertions",
  "thiserror 2.0.12",
  "tokio",
  "tonic",
  "tonic-build",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7415,6 +7415,7 @@ dependencies = [
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-worker",
+ "restate-workspace-hack",
  "rust-rocksdb",
  "schemars 0.8.22",
  "semver",
@@ -7428,7 +7429,6 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7444,9 +7444,9 @@ dependencies = [
  "futures",
  "object_store",
  "restate-types",
+ "restate-workspace-hack",
  "tracing",
  "url",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7479,6 +7479,7 @@ dependencies = [
  "restate-storage-api",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "rust-rocksdb",
  "serde",
  "serde_json",
@@ -7491,7 +7492,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7502,10 +7502,10 @@ dependencies = [
  "criterion",
  "restate-fs-util",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "tempfile",
  "tokio",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7527,6 +7527,7 @@ dependencies = [
  "restate-serde-util",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "rust-rocksdb",
  "smartstring",
  "static_assertions",
@@ -7536,7 +7537,6 @@ dependencies = [
  "tikv-jemalloc-sys",
  "tokio",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7551,11 +7551,11 @@ dependencies = [
  "iso8601",
  "jiff",
  "prost",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_with",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7600,6 +7600,7 @@ dependencies = [
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-worker",
+ "restate-workspace-hack",
  "rlimit",
  "rust-rocksdb",
  "rustls",
@@ -7622,7 +7623,6 @@ dependencies = [
  "ulid",
  "url",
  "vergen",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7650,6 +7650,7 @@ dependencies = [
  "jsonwebtoken",
  "pem",
  "restate-types",
+ "restate-workspace-hack",
  "ring",
  "rustls",
  "schemars 0.8.22",
@@ -7661,7 +7662,6 @@ dependencies = [
  "tower 0.5.2",
  "tower-service",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7683,6 +7683,7 @@ dependencies = [
  "restate-service-protocol",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "serde_json",
  "size",
@@ -7690,7 +7691,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7710,6 +7710,7 @@ dependencies = [
  "restate-errors",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "serde_json",
  "size",
@@ -7717,7 +7718,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "typify 0.3.0",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7736,10 +7736,10 @@ dependencies = [
  "prost-types",
  "rangemap",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "strum 0.27.1",
  "thiserror 2.0.12",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7770,6 +7770,7 @@ dependencies = [
  "restate-service-protocol-v4",
  "restate-storage-api",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -7778,7 +7779,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7803,13 +7803,13 @@ dependencies = [
  "restate-storage-api",
  "restate-storage-query-datafusion",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7821,7 +7821,7 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "prost-types",
- "workspace-hack",
+ "restate-workspace-hack",
 ]
 
 [[package]]
@@ -7835,6 +7835,7 @@ dependencies = [
  "priority-queue",
  "restate-test-util",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "test-log",
@@ -7844,7 +7845,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7852,8 +7852,8 @@ name = "restate-timer-queue"
 version = "1.4.2-dev"
 dependencies = [
  "futures",
+ "restate-workspace-hack",
  "tokio",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7874,6 +7874,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "restate-types",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
  "thiserror 2.0.12",
@@ -7884,7 +7885,6 @@ dependencies = [
  "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7947,6 +7947,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "restate-utoipa",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "semver",
  "serde",
@@ -7973,7 +7974,6 @@ dependencies = [
  "typed-builder",
  "typify 0.4.1",
  "ulid",
- "workspace-hack",
  "xxhash-rust",
 ]
 
@@ -7984,9 +7984,9 @@ dependencies = [
  "assert-json-diff",
  "indexmap 2.9.0",
  "restate-utoipa",
+ "restate-workspace-hack",
  "serde",
  "serde_json",
- "workspace-hack",
 ]
 
 [[package]]
@@ -8002,11 +8002,11 @@ dependencies = [
  "restate-invoker-api",
  "restate-storage-api",
  "restate-types",
+ "restate-workspace-hack",
  "serde",
  "strum 0.27.1",
  "thiserror 2.0.12",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]
@@ -8065,6 +8065,7 @@ dependencies = [
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-wal-protocol",
+ "restate-workspace-hack",
  "rstest",
  "rust-rocksdb",
  "schemars 0.8.22",
@@ -8083,7 +8084,143 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "url",
- "workspace-hack",
+]
+
+[[package]]
+name = "restate-workspace-hack"
+version = "0.0.1"
+dependencies = [
+ "ahash 0.8.11",
+ "arrayvec",
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-schema",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-sigv4",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "axum",
+ "axum-core",
+ "base64 0.22.1",
+ "bilrost",
+ "bitflags 2.9.1",
+ "byteorder",
+ "bytes",
+ "bytestring",
+ "bzip2-sys",
+ "cc",
+ "chrono",
+ "clap",
+ "clap_builder",
+ "comfy-table",
+ "criterion",
+ "crossbeam-epoch",
+ "datafusion-common",
+ "digest",
+ "either",
+ "enum-map",
+ "enumset",
+ "enumset_derive",
+ "flate2",
+ "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "getrandom 0.2.15",
+ "getrandom 0.3.1",
+ "half",
+ "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
+ "hdrhistogram",
+ "hex",
+ "hmac",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "idna",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "itertools 0.10.5",
+ "itertools 0.14.0",
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "libc",
+ "libz-sys",
+ "log",
+ "md-5",
+ "memchr",
+ "metrics-util",
+ "mio",
+ "nix 0.29.0",
+ "nom 7.1.3",
+ "num",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "object_store",
+ "opentelemetry_sdk",
+ "phf_shared",
+ "pprof",
+ "proc-macro2",
+ "prost",
+ "prost-types",
+ "protobuf",
+ "quanta",
+ "quote",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "regex",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+ "reqwest",
+ "ring",
+ "rustix 0.38.44",
+ "rustix 1.0.7",
+ "rustls",
+ "rustls-webpki",
+ "schemars 0.8.22",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "stable_deref_trait",
+ "syn 1.0.109",
+ "syn 2.0.101",
+ "sync_wrapper",
+ "time",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "toml_datetime",
+ "toml_edit 0.22.27",
+ "tonic",
+ "tower 0.4.13",
+ "tower 0.5.2",
+ "tower-http",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "ulid",
+ "url",
+ "uuid",
+ "zerocopy 0.7.35",
+ "zeroize",
+ "zstd 0.13.2",
+ "zstd-safe 7.2.1",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -8124,6 +8261,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "restate-wal-protocol",
+ "restate-workspace-hack",
  "rlimit",
  "rustls",
  "serde",
@@ -8135,7 +8273,6 @@ dependencies = [
  "tonic",
  "tracing",
  "vergen",
- "workspace-hack",
 ]
 
 [[package]]
@@ -10617,143 +10754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "workspace-hack"
-version = "0.1.0"
-dependencies = [
- "ahash 0.8.11",
- "arrayvec",
- "arrow",
- "arrow-array",
- "arrow-cast",
- "arrow-ipc",
- "arrow-schema",
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sts",
- "aws-sigv4",
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "axum",
- "axum-core",
- "base64 0.22.1",
- "bilrost",
- "bitflags 2.9.1",
- "byteorder",
- "bytes",
- "bytestring",
- "bzip2-sys",
- "cc",
- "chrono",
- "clap",
- "clap_builder",
- "comfy-table",
- "criterion",
- "crossbeam-epoch",
- "datafusion-common",
- "digest",
- "either",
- "enum-map",
- "enumset",
- "enumset_derive",
- "flate2",
- "futures",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
- "getrandom 0.2.15",
- "getrandom 0.3.1",
- "half",
- "hashbrown 0.14.5",
- "hashbrown 0.15.2",
- "hdrhistogram",
- "hex",
- "hmac",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "idna",
- "indexmap 1.9.3",
- "indexmap 2.9.0",
- "itertools 0.10.5",
- "itertools 0.14.0",
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "libc",
- "libz-sys",
- "log",
- "md-5",
- "memchr",
- "metrics-util",
- "mio",
- "nix 0.29.0",
- "nom 7.1.3",
- "num",
- "num-bigint",
- "num-integer",
- "num-traits",
- "object_store",
- "opentelemetry_sdk",
- "phf_shared",
- "pprof",
- "proc-macro2",
- "prost",
- "prost-types",
- "protobuf",
- "quanta",
- "quote",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "regex",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
- "reqwest",
- "ring",
- "rustix 0.38.44",
- "rustix 1.0.7",
- "rustls",
- "rustls-webpki",
- "schemars 0.8.22",
- "semver",
- "serde",
- "serde_json",
- "serde_with",
- "smallvec",
- "stable_deref_trait",
- "syn 1.0.109",
- "syn 2.0.101",
- "sync_wrapper",
- "time",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "toml_datetime",
- "toml_edit 0.22.27",
- "tonic",
- "tower 0.4.13",
- "tower 0.5.2",
- "tower-http",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
- "ulid",
- "url",
- "uuid",
- "zerocopy 0.7.35",
- "zeroize",
- "zstd 0.13.2",
- "zstd-safe 7.2.1",
- "zstd-sys",
-]
-
-[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10795,11 +10795,11 @@ dependencies = [
  "restate-storage-query-datafusion",
  "restate-types",
  "restate-worker",
+ "restate-workspace-hack",
  "schemars 0.8.22",
  "serde_json",
  "tokio",
  "tonic",
- "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,10 @@ restate-utoipa = { path = "crates/utoipa" }
 restate-wal-protocol = { path = "crates/wal-protocol" }
 restate-worker = { path = "crates/worker" }
 
+# this workspace-hack package is overridden by a patch below to use workspace-hack subdir when building in this repo
+# outside this repo, the crates.io restate-workspace-hack (an empty package) will be used instead
+restate-workspace-hack = "0.0.1"
+
 # External crates
 ahash = "0.8.5"
 anyhow = "1.0.68"
@@ -229,6 +233,9 @@ ulid = { version = "1.2.0" }
 url = { version = "2.5" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
+[patch.crates-io.restate-workspace-hack]
+path = "workspace-hack"
 
 [profile.release]
 opt-level = 3

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ typify = "0.1.0"
 url = { workspace = true }
 uuid = { workspace = true }
 zip = "0.6"
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 [dev-dependencies]
 restate-cli-util = { workspace = true, features = ["test-util"] }

--- a/crates/admin-rest-model/Cargo.toml
+++ b/crates/admin-rest-model/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 schema = ["dep:schemars", "restate-serde-util/schema", "restate-types/schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-types = { workspace = true }
 restate-serde-util = { workspace = true }

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -16,7 +16,7 @@ metadata-api = []
 restate-web-ui = ["dep:restate-web-ui"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-admin-rest-model = { workspace = true, features = ["schema"] }
 restate-bifrost = { workspace = true, features = ["local-loglet", "replicated-loglet"] }

--- a/crates/base64-util/Cargo.toml
+++ b/crates/base64-util/Cargo.toml
@@ -8,6 +8,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 base64 = { workspace = true }

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -15,7 +15,7 @@ memory-loglet = []
 test-util = ["memory-loglet", "dep:googletest", "dep:restate-test-util", "restate-core/test-util"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-futures-util = { workspace = true }

--- a/crates/cli-util/Cargo.toml
+++ b/crates/cli-util/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 test-util = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 anyhow = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/cloud-tunnel-client/Cargo.toml
+++ b/crates/cloud-tunnel-client/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 anyhow = { workspace = true }
 bs58 = { version = "0.5.0" }

--- a/crates/codederror/Cargo.toml
+++ b/crates/codederror/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 codederror-derive = { version = "0.1.0", path = "derive" }
 

--- a/crates/codederror/derive/Cargo.toml
+++ b/crates/codederror/derive/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
-workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
+restate-workspace-hack = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,7 +18,7 @@ test-util = [
 options_schema = ["dep:schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core-derive = { workspace = true, optional = true }
 restate-futures-util = { workspace = true }

--- a/crates/core/derive/Cargo.toml
+++ b/crates/core/derive/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1"
 syn = { version = "2.0", features = ["full"] }
-workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
+restate-workspace-hack = { workspace = true }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 bilrost = { workspace = true }
 bytes = { workspace = true }
 restate-encoding-derive = { version = "0.1.0", path = "derive" }
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 bytestring = { workspace = true }
 
 [dev-dependencies]

--- a/crates/encoding/derive/Cargo.toml
+++ b/crates/encoding/derive/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-workspace-hack = { version = "0.1", path = "../../../workspace-hack" }
+restate-workspace-hack = { workspace = true }

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 include_doc = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 codederror = { workspace = true }
 paste = { workspace = true }

--- a/crates/fs-util/Cargo.toml
+++ b/crates/fs-util/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }

--- a/crates/futures-util/Cargo.toml
+++ b/crates/futures-util/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 anyhow = { workspace = true }
 futures = { workspace = true }

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 options_schema = ["dep:schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 # Restate
 restate-core = { workspace = true }
 restate-errors = { workspace = true }

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 options_schema = ["dep:schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-bifrost = { workspace = true }
 restate-core = { workspace = true }

--- a/crates/invoker-api/Cargo.toml
+++ b/crates/invoker-api/Cargo.toml
@@ -13,7 +13,7 @@ test-util = ["restate-types/test-util"]
 serde = ["dep:serde"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-errors = { workspace = true }
 restate-types = { workspace = true }

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 options_schema = ["dep:schemars", "restate-types/schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-errors = { workspace = true }

--- a/crates/local-cluster-runner/Cargo.toml
+++ b/crates/local-cluster-runner/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-metadata-store = { workspace = true }

--- a/crates/log-server-grpc/Cargo.toml
+++ b/crates/log-server-grpc/Cargo.toml
@@ -17,7 +17,7 @@ restate-types = { workspace = true }
 
 prost = { workspace = true }
 tonic = { workspace = true, features = ["codegen", "prost"] }
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -13,7 +13,7 @@ clients = []
 test-util = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-bifrost = { workspace = true }
 restate-core = { workspace = true }

--- a/crates/metadata-providers/Cargo.toml
+++ b/crates/metadata-providers/Cargo.toml
@@ -32,7 +32,7 @@ replicated = [
 ]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-metadata-store = { workspace = true, features = ["grpc-client"] }
 restate-types = { workspace = true }

--- a/crates/metadata-server-grpc/Cargo.toml
+++ b/crates/metadata-server-grpc/Cargo.toml
@@ -14,7 +14,7 @@ grpc-client = ["tonic/transport", "tonic/gzip", "tonic/zstd"]
 grpc-server = ["tonic/server"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-types = { workspace = true }
 

--- a/crates/metadata-server/Cargo.toml
+++ b/crates/metadata-server/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 test-util = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-metadata-providers = { workspace = true, features = ["replicated"] }

--- a/crates/metadata-store/Cargo.toml
+++ b/crates/metadata-store/Cargo.toml
@@ -14,7 +14,7 @@ grpc-client = ["tonic/transport", "tonic/gzip", "tonic/zstd", "prost"]
 grpc-server = ["tonic/server", "prost"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-types = { workspace = true }
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -17,7 +17,7 @@ options_schema = [
 ]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-admin = { workspace = true, features = ["storage-query"]}
 restate-bifrost = { workspace = true, features = ["local-loglet", "replicated-loglet"] }

--- a/crates/object-store-util/Cargo.toml
+++ b/crates/object-store-util/Cargo.toml
@@ -21,4 +21,4 @@ object_store = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/queue/Cargo.toml
+++ b/crates/queue/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-fs-util = { workspace = true }
 

--- a/crates/rocksdb/Cargo.toml
+++ b/crates/rocksdb/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 test-util = ["restate-types/test-util"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-errors = { workspace = true }

--- a/crates/serde-util/Cargo.toml
+++ b/crates/serde-util/Cargo.toml
@@ -13,7 +13,7 @@ schema = ["dep:schemars"]
 proto = ["dep:prost", "dep:bytes"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 bytes = { workspace = true, optional = true }
 bytesize = { workspace = true }

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 options_schema = ["dep:schemars", "restate-types/schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 arc-swap = { workspace = true }
 aws-config = { workspace = true }

--- a/crates/service-protocol-v4/Cargo.toml
+++ b/crates/service-protocol-v4/Cargo.toml
@@ -13,7 +13,7 @@ entry-codec = ["dep:bytestring", "dep:assert2"]
 message-codec = ["dep:bytes-utils", "dep:codederror", "dep:restate-errors", "dep:size", "dep:tracing", "dep:paste"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-errors = { workspace = true, optional = true }
 restate-types = { workspace = true }

--- a/crates/service-protocol/Cargo.toml
+++ b/crates/service-protocol/Cargo.toml
@@ -15,7 +15,7 @@ message = ["dep:restate-types", "dep:bytes-utils", "dep:codederror", "dep:restat
 test-util = ["restate-types/test-util"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-errors = { workspace = true, optional = true }
 restate-service-client = { workspace = true, optional = true }

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 test-util = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-types = { workspace = true }
 prost = { workspace = true }

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -13,7 +13,7 @@ options_schema = ["dep:schemars"]
 table_docs = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-invoker-api = { workspace = true }

--- a/crates/storage-query-postgres/Cargo.toml
+++ b/crates/storage-query-postgres/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 options_schema = ["dep:schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-errors = { workspace = true }

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 prost = ["dep:prost"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 assert2 = { workspace = true }
 googletest = { workspace = true }

--- a/crates/timer-queue/Cargo.toml
+++ b/crates/timer-queue/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 futures = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/crates/timer/Cargo.toml
+++ b/crates/timer/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 options_schema = ["dep:schemars"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-types = { workspace = true }
 

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -26,7 +26,7 @@ prometheus = [
 ]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-types = { workspace = true }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -15,7 +15,7 @@ unsafe-mutable-config = []
 test-util = ["unsafe-mutable-config", "dep:tempfile", "dep:restate-test-util"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-base64-util = { workspace = true }
 restate-errors = { workspace = true }

--- a/crates/utoipa/Cargo.toml
+++ b/crates/utoipa/Cargo.toml
@@ -11,7 +11,7 @@ default = ["debug"]
 debug = []
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -12,7 +12,7 @@ default = ["serde"]
 serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde"]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 restate-invoker-api = { workspace = true }
 restate-storage-api = { workspace = true }
 restate-types = { workspace = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -20,7 +20,7 @@ options_schema = [
 ]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-bifrost = { workspace = true }
 restate-core = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -74,7 +74,7 @@ tracing = { workspace = true }
 tracing-panic = { version = "0.1.2" }
 ulid = { workspace = true }
 url = { version = "2.5.4", features = [] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 [dev-dependencies]
 restate-bifrost = { workspace = true, features = ["test-util"] }

--- a/tools/bifrost-benchpress/Cargo.toml
+++ b/tools/bifrost-benchpress/Cargo.toml
@@ -50,7 +50,7 @@ tokio-stream = { workspace = true }
 toml = { version = "0.8" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true, features = ["unprefixed_malloc_on_supported_platforms"] }

--- a/tools/mock-service-endpoint/Cargo.toml
+++ b/tools/mock-service-endpoint/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 [lib]
 path = "src/lib.rs"

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -28,7 +28,7 @@ dump-local-log = [
 ]
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }
 
 restate-cli-util = { workspace = true }
 restate-core = { workspace = true }

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -24,4 +24,4 @@ schemars = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+restate-workspace-hack = { workspace = true }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -3,8 +3,9 @@
 #     cargo hakari generate
 
 [package]
-name = "workspace-hack"
-version = "0.1.0"
+name = "restate-workspace-hack"
+# must be 0.0.1 to work with cargo-chef
+version = "0.0.1"
 edition = "2021"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.


### PR DESCRIPTION
This will allow importers of the repo to avoid including workspace-hack, once we have published restate-workspace-hack to crates.io.

https://docs.rs/cargo-hakari/latest/cargo_hakari/patch_directive/index.html