### PR TITLE
[fix] Fix invocation creation time non-determinisim

### DIFF
--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -662,8 +662,7 @@ pub mod v1 {
                         invocation_target: Some(invocation_target.into()),
                         source: Some(source.into()),
                         span_context: Some(span_context.into()),
-                        // SAFETY: We're only mapping data types here
-                        creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                        creation_time: timestamps.creation_time().as_u64(),
                         created_using_restate_version: created_using_restate_version.into_string(),
                         modification_time: unsafe { timestamps.modification_time() }.as_u64(),
                         inboxed_transition_time: unsafe { timestamps.inboxed_transition_time() }
@@ -725,8 +724,7 @@ pub mod v1 {
                         invocation_target: Some(invocation_target.into()),
                         source: Some(source.into()),
                         span_context: Some(span_context.into()),
-                        // SAFETY: We're only mapping data types here
-                        creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                        creation_time: timestamps.creation_time().as_u64(),
                         created_using_restate_version: created_using_restate_version.into_string(),
                         modification_time: unsafe { timestamps.modification_time() }.as_u64(),
                         inboxed_transition_time: unsafe { timestamps.inboxed_transition_time() }
@@ -795,8 +793,7 @@ pub mod v1 {
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
-                            // SAFETY: We're only mapping data types here
-                            creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                            creation_time: timestamps.creation_time().as_u64(),
                             created_using_restate_version: created_using_restate_version
                                 .into_string(),
                             modification_time: unsafe { timestamps.modification_time() }.as_u64(),
@@ -899,8 +896,7 @@ pub mod v1 {
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
-                            // SAFETY: We're only mapping data types here
-                            creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                            creation_time: timestamps.creation_time().as_u64(),
                             created_using_restate_version: created_using_restate_version
                                 .into_string(),
                             modification_time: unsafe { timestamps.modification_time() }.as_u64(),
@@ -981,8 +977,7 @@ pub mod v1 {
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
-                            // SAFETY: We're only mapping data types here
-                            creation_time: unsafe { timestamps.creation_time() }.as_u64(),
+                            creation_time: timestamps.creation_time().as_u64(),
                             created_using_restate_version: created_using_restate_version
                                 .into_string(),
                             modification_time: unsafe { timestamps.modification_time() }.as_u64(),

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -172,7 +172,7 @@ fn fill_timestamps(row: &mut SysInvocationStatusRowBuilder, stat: &StatusTimesta
     // SAFETY: All these unsafe usages to get timestamps are ok,
     //  as we don't use them as part of the PP state machine business logic.
 
-    row.created_at(unsafe { stat.creation_time() }.as_u64() as i64);
+    row.created_at(stat.creation_time().as_u64() as i64);
     row.modified_at(unsafe { stat.modification_time() }.as_u64() as i64);
     if let Some(inboxed_at) = unsafe { stat.inboxed_transition_time() } {
         row.inboxed_at(inboxed_at.as_u64() as i64);

--- a/crates/types/src/time.rs
+++ b/crates/types/src/time.rs
@@ -202,6 +202,12 @@ impl From<prost_types::Timestamp> for NanosSinceEpoch {
     }
 }
 
+impl From<NanosSinceEpoch> for MillisSinceEpoch {
+    fn from(value: NanosSinceEpoch) -> Self {
+        Self(value.0 / 1_000_000)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -64,7 +64,7 @@ use restate_types::net::partition_processor::{
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::retries::{RetryPolicy, with_jitter};
 use restate_types::storage::StorageDecodeError;
-use restate_types::time::MillisSinceEpoch;
+use restate_types::time::{MillisSinceEpoch, NanosSinceEpoch};
 use restate_types::{GenerationalNodeId, SemanticRestateVersion, invocation};
 use restate_wal_protocol::control::AnnounceLeader;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
@@ -283,7 +283,11 @@ pub enum ProcessorError {
     Other(#[from] anyhow::Error),
 }
 
-type LsnEnvelope = (Lsn, Envelope);
+struct LsnEnvelope {
+    pub lsn: Lsn,
+    pub created_at: NanosSinceEpoch,
+    pub envelope: Arc<Envelope>,
+}
 
 impl<InvokerSender> PartitionProcessor<InvokerSender>
 where
@@ -423,7 +427,8 @@ where
 
         // Telemetry setup
         let partition_id_str = SharedString::from(self.partition_id.to_string());
-        let record_write_to_read_latency = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, PARTITION_LABEL => partition_id_str.clone());
+        let leader_record_write_to_read_latency = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, PARTITION_LABEL => partition_id_str.clone(), "leader" => "1");
+        let follower_record_write_to_read_latency = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, PARTITION_LABEL => partition_id_str.clone(), "leader" => "0");
         let command_read_count =
             counter!(PARTITION_RECORD_READ_COUNT, PARTITION_LABEL => partition_id_str.clone());
         // Start reading after the last applied lsn
@@ -437,13 +442,14 @@ where
                     trace!(?entry, "Read entry");
                     let lsn = entry.sequence_number();
                     if entry.is_data_record() {
-                        entry.as_record().inspect(|record| {
-                            record_write_to_read_latency.record(record.created_at().elapsed());
-                        });
-                        entry
-                            .try_decode::<Envelope>()
-                            .map(|envelope| Ok((lsn, envelope?)))
-                            .expect("data record is present")
+                        let record = entry.into_record().unwrap();
+                        let created_at = record.created_at();
+                        let envelope = record.decode_arc()?;
+                        Ok(LsnEnvelope {
+                            lsn,
+                            created_at,
+                            envelope,
+                        })
                     } else {
                         Err(ProcessorError::TrimGapEncountered {
                             trim_gap_end: entry
@@ -455,13 +461,13 @@ where
                 }
                 Err(err) => Err(ProcessorError::from(err)),
             })
-            .try_take_while(|(_, envelope)| {
+            .try_take_while(|record| {
                 // a catch-all safety net if all lower layers didn't filter this record out. This
                 // could happen for old records that didn't store `Keys` in the log store.
                 //
                 // At some point, we should remove this and trust that stored records have Keys
                 // stored correctly.
-                std::future::ready(Ok(envelope.matches_key_query(&key_query)))
+                std::future::ready(Ok(record.envelope.matches_key_query(&key_query)))
             });
 
         // avoid synchronized timers.
@@ -525,12 +531,16 @@ where
                     // clear buffers used when applying the next record
                     action_collector.clear();
 
-                    for (lsn, envelope) in command_buffer.drain(..) {
-                        trace!(%lsn, "Processing bifrost record for '{}': {:?}", envelope.command.name(), envelope.header);
+                    for record in command_buffer.drain(..) {
+                        trace!(lsn = %record.lsn, "Processing bifrost record for '{}': {:?}", record.envelope.command.name(), record.envelope.header);
 
+                        if self.leadership_state.is_leader() {
+                            leader_record_write_to_read_latency.record(record.created_at.elapsed());
+                        } else {
+                            follower_record_write_to_read_latency.record(record.created_at.elapsed());
+                        }
                         let leadership_change = self.apply_record(
-                            lsn,
-                            envelope,
+                            record,
                             &mut transaction,
                             &mut action_collector).await?;
 
@@ -889,22 +899,21 @@ where
 
     async fn apply_record<'a, 'b: 'a>(
         &mut self,
-        lsn: Lsn,
-        envelope: Envelope,
+        record: LsnEnvelope,
         transaction: &mut PartitionStoreTransaction<'b>,
         action_collector: &mut ActionCollector,
     ) -> Result<Option<(Header, Box<AnnounceLeader>)>, state_machine::Error> {
-        transaction.put_applied_lsn(lsn).await?;
+        transaction.put_applied_lsn(record.lsn).await?;
 
         // Update replay status
-        self.status.last_applied_log_lsn = Some(lsn);
+        self.status.last_applied_log_lsn = Some(record.lsn);
         self.status.last_record_applied_at = Some(MillisSinceEpoch::now());
         match self.status.replay_status {
             ReplayStatus::CatchingUp
                 if self
                     .status
                     .target_tail_lsn
-                    .is_some_and(|tail| lsn.next() >= tail) =>
+                    .is_some_and(|tail| record.lsn.next() >= tail) =>
             {
                 // finished catching up
                 self.status.replay_status = ReplayStatus::Active;
@@ -913,13 +922,13 @@ where
             _ => {}
         };
 
-        if let Some(dedup_information) = self.is_targeted_to_me(&envelope.header) {
+        if let Some(dedup_information) = self.is_targeted_to_me(&record.envelope.header) {
             // deduplicate if deduplication information has been provided
             if let Some(dedup_information) = dedup_information {
                 if Self::is_outdated_or_duplicate(dedup_information, transaction).await? {
                     debug!(
                         "Ignoring outdated or duplicate message: {:?}",
-                        envelope.header
+                        record.envelope.header
                     );
                     return Ok(None);
                 }
@@ -932,6 +941,10 @@ where
                     .map_err(state_machine::Error::Storage)?;
             }
 
+            // todo: redesign to pass the arc (or reference) further down
+            let record_created_at = record.created_at;
+            let envelope = Arc::unwrap_or_clone(record.envelope);
+
             if let Command::AnnounceLeader(announce_leader) = envelope.command {
                 // leadership change detected, let's finish our transaction here
                 return Ok(Some((envelope.header, announce_leader)));
@@ -939,6 +952,7 @@ where
                 self.state_machine
                     .apply(
                         envelope.command,
+                        record_created_at,
                         transaction,
                         action_collector,
                         self.leadership_state.is_leader(),
@@ -949,7 +963,7 @@ where
             self.status.num_skipped_records += 1;
             trace!(
                 "Ignore message which is not targeted to me: {:?}",
-                envelope.header
+                record.envelope.header
             );
         }
 

--- a/crates/worker/src/partition/state_machine/lifecycle/migrate_journal_table.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/migrate_journal_table.rs
@@ -57,9 +57,7 @@ where
                 .into();
                 let mut new_raw_entry = new_entry.encode::<ServiceProtocolV4Codec>();
                 // Journal V1 hasn't append_time, so we set here as timestamp the invocation creation time.
-                // SAFETY: this timestamp is used only for observability, it's fine if it's not agreed among followers.
-                new_raw_entry.header_mut().append_time =
-                    unsafe { self.metadata.timestamps.creation_time() };
+                new_raw_entry.header_mut().append_time = self.metadata.timestamps.creation_time();
 
                 // Now write the entry in the new table, and remove it from the old one
                 journal_table_v2::JournalTable::put_journal_entry(

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -153,7 +153,13 @@ impl TestEnv {
         let mut transaction = self.storage.transaction();
         let mut action_collector = ActionCollector::default();
         self.state_machine
-            .apply(command, &mut transaction, &mut action_collector, true)
+            .apply(
+                command,
+                NanosSinceEpoch::now(),
+                &mut transaction,
+                &mut action_collector,
+                true,
+            )
             .await
             .unwrap();
 
@@ -166,7 +172,13 @@ impl TestEnv {
         let mut transaction = self.storage.transaction();
         let mut action_collector = ActionCollector::default();
         self.state_machine
-            .apply(command, &mut transaction, &mut action_collector, true)
+            .apply(
+                command,
+                NanosSinceEpoch::now(),
+                &mut transaction,
+                &mut action_collector,
+                true,
+            )
             .await?;
 
         transaction.commit().await?;


### PR DESCRIPTION

Invocation creation time is now set to rely on Bifrost's `created_at` field as a stable source of truth.
This fixes a bug where invocations can appear to be created at a later time than they actually when repaying the log.

Additionally, this commit also puts back the use of Arc for envelopes that was removed in #3361. This is to make sure
we don't forget to reduce the number of clones we are doing if the record is cached, and in downstream.
