### PR TITLE
[datafusion] Add sort order to sys_invocation_state

### DIFF
--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -213,7 +213,8 @@ impl StatusHandle for ChannelStatusReader {
             return itertools::Either::Left(std::iter::empty::<InvocationStatusReport>());
         }
 
-        if let Ok(status_vec) = rx.await {
+        if let Ok(mut status_vec) = rx.await {
+            status_vec.sort_by(|a, b| a.invocation_id().cmp(b.invocation_id()));
             itertools::Either::Right(status_vec.into_iter())
         } else {
             itertools::Either::Left(std::iter::empty::<InvocationStatusReport>())

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -12,6 +12,8 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
+define_sort_order!(sys_invocation_state(partition_key, id));
+
 define_table!(sys_invocation_state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -25,7 +25,7 @@ use restate_types::identifiers::{PartitionId, PartitionKey};
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::invocation_state::row::append_invocation_state_row;
-use crate::invocation_state::schema::SysInvocationStateBuilder;
+use crate::invocation_state::schema::{SysInvocationStateBuilder, sys_invocation_state_sort_order};
 use crate::partition_filter::FirstMatchingPartitionKeyExtractor;
 use crate::remote_query_scanner_manager::RemoteScannerManager;
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
@@ -59,7 +59,7 @@ pub(crate) fn register_self(
     let status_table = PartitionedTableProvider::new(
         partition_selector,
         SysInvocationStateBuilder::schema(),
-        vec![],
+        sys_invocation_state_sort_order(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_partition_scanner),
         FirstMatchingPartitionKeyExtractor::default().with_invocation_id("id"),
     );
@@ -97,7 +97,7 @@ impl<S: StatusHandle + Send + Sync + Debug + Clone + 'static> ScanPartition for 
         let status = self.status_handle.clone();
         let partition_store_manager = self.partition_store_manager.clone();
         let schema = projection.clone();
-        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 2);
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection, 1);
         let tx = stream_builder.tx();
 
         let background_task = async move {


### PR DESCRIPTION
This commit adds a sort order to the invocation_state table, invocation state is already accessed per-partition. With that we can eliminate a shuffle and a sort when accessing this table.

with this commit:

```
                ┌─────────────┴─────────────┐                              
                │        HashJoinExec       │                              
                │    --------------------   │                              
                │      join_type: Right     │                              
                │                           │                              
                │            on:            ├──────────────┐               
                │      (partition_key =     │              │               
                │       partition_key)      │              │               
                │        , (id = id)        │              │               
                └─────────────┬─────────────┘              │               
                ┌─────────────┴─────────────┐┌─────────────┴─────────────┐ 
                │  PartitionedExecutionPlan ││  PartitionedExecutionPlan │ 
                │    --------------------   ││    --------------------   │ 
                │  PartitionedExecutionPlan ││  PartitionedExecutionPlan │ 
                │                           ││                           │ 
                │          scanner:         ││          scanner:         │ 
                │ RemotePartitionsScanner { ││ RemotePartitionsScanner { │ 
                │          manager:         ││          manager:         │ 
                │         RemoteScan        ││         RemoteScan        │ 
                │  nerManager, table_name:  ││  nerManager, table_name:  │ 
                │  "sys_invocation_state" } ││  "sys_invocation_status"  │ 
                │                           ││              }            │ 
                └───────────────────────────┘└───────────────────────────┘ 

```

without this commit:

```
 physical_plan                            
               ┌─────────────┴─────────────┐                              
                │        HashJoinExec       │                              
                │    --------------------   │                              
                │      join_type: Right     │                              
                │                           │                              
                │            on:            ├──────────────┐               
                │      (partition_key =     │              │               
                │       partition_key)      │              │               
                │        , (id = id)        │              │               
                └─────────────┬─────────────┘              │               
                ┌─────────────┴─────────────┐┌─────────────┴─────────────┐ 
                │    CoalesceBatchesExec    ││  PartitionedExecutionPlan │ 
                │    --------------------   ││    --------------------   │ 
                │     target_batch_size:    ││  PartitionedExecutionPlan │ 
                │            8192           ││                           │ 
                │                           ││          scanner:         │ 
                │                           ││ RemotePartitionsScanner { │ 
                │                           ││          manager:         │ 
                │                           ││         RemoteScan        │ 
                │                           ││  nerManager, table_name:  │ 
                │                           ││  "sys_invocation_status"  │ 
                │                           ││              }            │ 
                └─────────────┬─────────────┘└───────────────────────────┘ 
                ┌─────────────┴─────────────┐                              
                │      RepartitionExec      │                              
                │    --------------------   │                              
                │ partition_count(in->out): │                              
                │           2 -> 2          │                              
                │                           │                              
                │    partitioning_scheme:   │                              
                │ Hash([partition_key@0, id │                              
                │          @1], 2)          │                              
                └─────────────┬─────────────┘                              
                ┌─────────────┴─────────────┐                              
                │  PartitionedExecutionPlan │                              
                │    --------------------   │                              
                │  PartitionedExecutionPlan │                              
                │                           │                              
                │          scanner:         │                              
                │ RemotePartitionsScanner { │                              
                │          manager:         │                              
                │         RemoteScan        │                              
                │  nerManager, table_name:  │                              
                │  "sys_invocation_state" } │                              
                └───────────────────────────┘                                 
                                                 
```
