### PR TITLE
Explicitly set journal append_time based on Bifrost's record creation time

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -32,7 +32,7 @@ use restate_types::invocation::{
     InvocationTarget, ServiceInvocation, ServiceInvocationSpanContext,
 };
 use restate_types::journal_v2::CommandType;
-use restate_types::journal_v2::raw::{RawCommand, RawEntry, RawEntryHeader, RawEntryInner};
+use restate_types::journal_v2::raw::{RawCommand, RawEntry};
 use restate_types::logs::{LogId, LogletId, LogletOffset, Record, SequenceNumber};
 use restate_types::net::codec::{WireDecode, WireEncode};
 use restate_types::net::log_server::{LogServerRequestHeader, Store, StoreFlags};
@@ -113,16 +113,13 @@ fn invoker_effect_cmd() -> Command {
             Some(&idempotency_key),
         ),
         invocation_epoch: random(),
-        kind: EffectKind::JournalEntryV2 {
-            entry: RawEntry::new(
-                RawEntryHeader::new(),
-                RawEntryInner::Command(RawCommand::new(
-                    CommandType::SetState,
-                    Bytes::copy_from_slice(&data),
-                )),
-            ),
-            command_index_to_ack: Some(random()),
-        },
+        kind: EffectKind::journal_entry(
+            RawEntry::Command(RawCommand::new(
+                CommandType::SetState,
+                Bytes::copy_from_slice(&data),
+            )),
+            Some(random()),
+        ),
     }))
 }
 

--- a/crates/invoker-api/src/invocation_reader.rs
+++ b/crates/invoker-api/src/invocation_reader.rs
@@ -15,7 +15,7 @@ use restate_types::identifiers::{InvocationId, ServiceId};
 use restate_types::invocation::{InvocationEpoch, ServiceInvocationSpanContext};
 use restate_types::journal::EntryIndex;
 use restate_types::journal::raw::PlainRawEntry;
-use restate_types::journal_v2::raw::RawEntry;
+use restate_types::storage::StoredRawEntry;
 use restate_types::time::MillisSinceEpoch;
 use std::future::Future;
 
@@ -54,7 +54,7 @@ impl JournalMetadata {
 #[derive(Debug, Eq, PartialEq)]
 pub enum JournalEntry {
     JournalV1(PlainRawEntry),
-    JournalV2(RawEntry),
+    JournalV2(StoredRawEntry),
 }
 
 /// Read information about invocations from the underlying storage.

--- a/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
@@ -28,6 +28,8 @@ use restate_types::journal_v2::{
     EntryType, Event, NotificationId, NotificationType, OneWayCallCommand, SleepCommand,
     SleepCompletion, TransientErrorEvent,
 };
+use restate_types::storage::{StoredRawEntry, StoredRawEntryHeader};
+use restate_types::time::MillisSinceEpoch;
 
 const MOCK_INVOCATION_ID_1: InvocationId =
     InvocationId::from_parts(1, InvocationUuid::from_u128(12345678900001));
@@ -94,7 +96,10 @@ async fn populate_sleep_journal<T: JournalTable>(txn: &mut T) {
         txn.put_journal_entry(
             MOCK_INVOCATION_ID_1,
             i,
-            &mock_sleep_command(i).encode::<ServiceProtocolV4Codec>(),
+            &StoredRawEntry::new(
+                StoredRawEntryHeader::new(MillisSinceEpoch::now()),
+                mock_sleep_command(i).encode::<ServiceProtocolV4Codec>(),
+            ),
             &[i],
         )
         .await
@@ -104,7 +109,10 @@ async fn populate_sleep_journal<T: JournalTable>(txn: &mut T) {
         txn.put_journal_entry(
             MOCK_INVOCATION_ID_1,
             i,
-            &mock_sleep_completion(i - 5).encode::<ServiceProtocolV4Codec>(),
+            &StoredRawEntry::new(
+                StoredRawEntryHeader::new(MillisSinceEpoch::now()),
+                mock_sleep_completion(i - 5).encode::<ServiceProtocolV4Codec>(),
+            ),
             &[],
         )
         .await
@@ -245,7 +253,10 @@ async fn test_call_journal() {
     txn.put_journal_entry(
         MOCK_INVOCATION_ID_1,
         0,
-        &mock_call_command(0, 1).encode::<ServiceProtocolV4Codec>(),
+        &StoredRawEntry::new(
+            StoredRawEntryHeader::new(MillisSinceEpoch::now()),
+            mock_call_command(0, 1).encode::<ServiceProtocolV4Codec>(),
+        ),
         &[0, 1],
     )
     .await
@@ -253,7 +264,10 @@ async fn test_call_journal() {
     txn.put_journal_entry(
         MOCK_INVOCATION_ID_1,
         1,
-        &mock_one_way_call_command(2).encode::<ServiceProtocolV4Codec>(),
+        &StoredRawEntry::new(
+            StoredRawEntryHeader::new(MillisSinceEpoch::now()),
+            mock_one_way_call_command(2).encode::<ServiceProtocolV4Codec>(),
+        ),
         &[2],
     )
     .await
@@ -321,7 +335,10 @@ async fn test_event() {
     txn.put_journal_entry(
         MOCK_INVOCATION_ID_1,
         0,
-        &Entry::Event(event.clone()).encode::<ServiceProtocolV4Codec>(),
+        &StoredRawEntry::new(
+            StoredRawEntryHeader::new(MillisSinceEpoch::now()),
+            Entry::Event(event.clone()).encode::<ServiceProtocolV4Codec>(),
+        ),
         &[],
     )
     .await

--- a/crates/storage-query-datafusion/src/journal/row.rs
+++ b/crates/storage-query-datafusion/src/journal/row.rs
@@ -20,8 +20,8 @@ use restate_types::journal::enriched::EnrichedEntryHeader;
 use restate_types::journal::{CompletePromiseEntry, GetPromiseEntry, PeekPromiseEntry};
 use restate_types::journal_v2;
 use restate_types::journal_v2::EntryMetadata;
-use restate_types::journal_v2::raw::RawEntry;
 use restate_types::journal_v2::{CommandMetadata, Decoder};
+use restate_types::storage::StoredRawEntry;
 
 #[inline]
 pub(crate) fn append_journal_row(
@@ -144,7 +144,7 @@ pub(crate) fn append_journal_row_v2(
     builder: &mut SysJournalBuilder,
     output: &mut String,
     journal_entry_id: JournalEntryId,
-    raw_entry: RawEntry,
+    raw_entry: StoredRawEntry,
 ) {
     let mut row = builder.row();
     row.version(2);
@@ -163,7 +163,7 @@ pub(crate) fn append_journal_row_v2(
 
     if row.is_entry_lite_json_defined() {
         // We need to parse the entry
-        let Ok(entry_lite) = ServiceProtocolV4Codec::decode_entry_lite(&raw_entry) else {
+        let Ok(entry_lite) = ServiceProtocolV4Codec::decode_entry_lite(&raw_entry.inner) else {
             log_data_corruption_error!(
                 "sys_journal",
                 &journal_entry_id.invocation_id(),

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -21,7 +21,7 @@ use restate_storage_api::journal_table::JournalEntry;
 use restate_storage_api::journal_table::ScanJournalTable;
 use restate_storage_api::journal_table_v2::ScanJournalTable as ScanJournalTableV2;
 use restate_types::identifiers::{JournalEntryId, PartitionKey};
-use restate_types::journal_v2::raw::RawEntry;
+use restate_types::storage::StoredRawEntry;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::journal::row::{append_journal_row, append_journal_row_v2};
@@ -59,7 +59,7 @@ pub(crate) fn register_self(
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum ScannedEntry {
     V1(JournalEntry),
-    V2(RawEntry),
+    V2(StoredRawEntry),
 }
 
 #[derive(Debug, Clone)]

--- a/crates/worker/src/partition/state_machine/entries/mod.rs
+++ b/crates/worker/src/partition/state_machine/entries/mod.rs
@@ -357,6 +357,12 @@ where
                 entry.ty()
             );
 
+            // Make sure that a deterministic append time is set based on Bifrost's record creation
+            // time. This ensures that the append time does not depend on the application time of
+            // the record and ensures that subsequent journal entries have monotonically increasing
+            // append times.
+            entry.header_mut().append_time = ctx.record_created_at;
+
             // Store journal entry
             JournalTable::put_journal_entry(
                 ctx.storage,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -1874,7 +1874,15 @@ impl<S> StateMachineApplyContext<'_, S> {
             InvokerEffectKind::JournalEntryV2 {
                 command_index_to_ack,
                 entry,
+                raw_entry,
             } => {
+                // Starting from v1.5.0 the system is populating the raw_entry field instead of the
+                // entry field. For backwards compatibility we fall back to entry if raw_entry is
+                // not set.
+                let entry = raw_entry
+                    .or(entry.map(|entry| entry.inner))
+                    .expect("Either the raw_entry field or the legacy entry field must be set");
+
                 entries::OnJournalEntryCommand::from_raw_entry(
                     effect.invocation_id,
                     invocation_status,

--- a/crates/worker/src/partition/state_machine/tests/fixtures.rs
+++ b/crates/worker/src/partition/state_machine/tests/fixtures.rs
@@ -88,10 +88,10 @@ pub fn invoker_entry_effect_for_epoch(
     Command::InvokerEffect(Box::new(Effect {
         invocation_id,
         invocation_epoch,
-        kind: InvokerEffectKind::JournalEntryV2 {
-            entry: entry.into().encode::<ServiceProtocolV4Codec>(),
-            command_index_to_ack: None,
-        },
+        kind: InvokerEffectKind::journal_entry(
+            entry.into().encode::<ServiceProtocolV4Codec>(),
+            None,
+        ),
     }))
 }
 

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -192,7 +192,6 @@ pub mod actions {
         let notification = notif
             .into()
             .encode::<ServiceProtocolV4Codec>()
-            .inner
             .try_as_notification()
             .unwrap();
         pat!(Action::ForwardNotification {


### PR DESCRIPTION
Currently, journal entries derived from signals use now as the append time for the created
RawEntryHeader. This is unlike other journal entries which set create the RawEntryHeader before
writing the journal entry to Bifrost. Due to this, the append time of signals is set at
application time which can be different than the other journal entries' append time. To ensure
that the append time is monotonoically increasing, this commit overwrites the RawEntry's append
time with Bifrost's record creation time.

This fixes https://github.com/restatedev/restate/issues/3487.