### PR TITLE
[s3metastore] Move ValueEncoding closer to where it is used

### DIFF
--- a/crates/metadata-providers/src/objstore/version_repository.rs
+++ b/crates/metadata-providers/src/objstore/version_repository.rs
@@ -8,11 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::str::FromStr;
-
 use bytes::Bytes;
 use bytestring::ByteString;
-use object_store::AttributeValue;
 
 use restate_types::errors::GenericError;
 
@@ -28,8 +25,6 @@ pub enum VersionRepositoryError {
     Network(GenericError),
     #[error("Unexpected condition {0}")]
     UnexpectedCondition(String),
-    #[error("Encoding error")]
-    Encoding(#[from] EncodingError),
 }
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
@@ -44,41 +39,6 @@ impl From<String> for Tag {
 impl Tag {
     pub(crate) fn as_string(&self) -> String {
         self.0.to_string()
-    }
-}
-
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum EncodingError {
-    #[error("Unknown encoding '{0}'")]
-    UnknownEncoding(String),
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) enum ValueEncoding {
-    #[default]
-    Cbor,
-    // TODO: Switch default to bilrost in v1.6.0
-    // Bilrost V1
-    Bilrost,
-}
-
-impl FromStr for ValueEncoding {
-    type Err = EncodingError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "binary/bilrost+v1" => Ok(Self::Bilrost),
-            "binary/cbor" => Ok(Self::Cbor),
-            _ => Err(EncodingError::UnknownEncoding(s.to_owned())),
-        }
-    }
-}
-
-impl From<ValueEncoding> for AttributeValue {
-    fn from(value: ValueEncoding) -> Self {
-        match value {
-            ValueEncoding::Bilrost => AttributeValue::from("binary/bilrost+v1"),
-            ValueEncoding::Cbor => AttributeValue::from("binary/cbor"),
-        }
     }
 }
 
@@ -97,7 +57,7 @@ impl TaggedValue {
 
 #[derive(Debug, Clone)]
 pub(crate) struct Content {
-    pub encoding: ValueEncoding,
+    pub encoding: Option<String>,
     pub bytes: Bytes,
 }
 


### PR DESCRIPTION
This is a followup for this comment: https://github.com/restatedev/restate/pull/3485#discussion_r2175527214

This PR is keeps the value encoding/decoding concerns outside of the `version_repository`.
And moves it closer to where it is actually used: `optimistic_store`

