### PR TITLE
Add 'extraVolumes' and 'extraVolumeMounts' to Helm chart values

### DIFF
--- a/charts/restate-helm/templates/statefulset.yaml
+++ b/charts/restate-helm/templates/statefulset.yaml
@@ -90,6 +90,9 @@ spec:
               mountPath: /opt/private.pem
               subPath: {{ .Values.identityPrivateKey.keyName }}
         {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+        {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+        {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -103,6 +106,9 @@ spec:
           secret:
             secretName: {{ .Values.identityPrivateKey.secretName }}
             defaultMode: 420
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
   # It's important to start multiple pods at the same time in case multiple pods died. Otherwise, we risk
   # unavailability of an already configured metadata cluster

--- a/charts/restate-helm/values.yaml
+++ b/charts/restate-helm/values.yaml
@@ -59,6 +59,9 @@ storage:
 
 extraInitContainers: []
 
+extraVolumes: []
+extraVolumeMounts: []
+
 identityPrivateKey:
   enabled: false
   secretName: ""


### PR DESCRIPTION
Additional volumes and their mounts can now be specified on deployments of the Helm chart. This enables users to mount additional secrets or config maps as they desire.