### PR TITLE
Tokio task dump

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,11 +12,21 @@ rustflags = [
     "--cfg", "tokio_unstable", # Enable unstable tokio
 ]
 
+[target.x86_64-unknown-linux-gnu]
+# when changing these please also change .github/workflows/steps/release-build-setup.yml
+rustflags = [
+    "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
+    "--cfg", "uuid_unstable", # Enable unstable Uuid
+    "--cfg", "tokio_unstable", # Enable unstable tokio
+    "--cfg", "tokio_taskdump", # Enable unstable tokio taskdump
+]
+
 [target.aarch64-unknown-linux-gnu]
 rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
     "--cfg", "uuid_unstable", # Enable unstable Uuid
     "--cfg", "tokio_unstable", # Enable unstable tokio
+    "--cfg", "tokio_taskdump", # Enable unstable tokio taskdump
     "-C" , "force-frame-pointers=yes", # Enable frame pointers to support Parca (https://github.com/parca-dev/parca-agent/pull/1805)
 ]
 
@@ -25,6 +35,7 @@ rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
     "--cfg", "uuid_unstable", # Enable unstable Uuid
     "--cfg", "tokio_unstable", # Enable unstable tokio
+    "--cfg", "tokio_taskdump", # Enable unstable tokio taskdump
     "-C", "link-self-contained=yes", # Link statically
 ]
 
@@ -33,6 +44,7 @@ rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
     "--cfg", "uuid_unstable", # Enable unstable Uuid
     "--cfg", "tokio_unstable", # Enable unstable tokio
+    "--cfg", "tokio_taskdump", # Enable unstable tokio taskdump
     "-C", "force-frame-pointers=yes", # Enable frame pointers to support Parca (https://github.com/parca-dev/parca-agent/pull/1805)
     "-C", "link-self-contained=yes", # Link statically
 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,12 @@ jobs:
       - name: "Set up MACOSX_DEPLOYMENT_TARGET"
         if: "${{ runner.os == 'macOS' }}"
         run: "echo MACOSX_DEPLOYMENT_TARGET=\"10.14.0\" >> \"$GITHUB_ENV\""
-      - name: "Set up RUSTFLAGS"
+      - name: "Set up RUSTFLAGS (macOS)"
+        if: "${{ runner.os == 'macOS' }}"
         run: "echo RUSTFLAGS=\"-C force-unwind-tables --cfg uuid_unstable --cfg tokio_unstable\" >> \"$GITHUB_ENV\""
+      - name: "Set up RUSTFLAGS (Linux)"
+        if: "${{ runner.os == 'Linux' }}"
+        run: "echo RUSTFLAGS=\"-C force-unwind-tables --cfg uuid_unstable --cfg tokio_unstable --cfg tokio_taskdump\" >> \"$GITHUB_ENV\""
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/steps/release-build-setup.yml
+++ b/.github/workflows/steps/release-build-setup.yml
@@ -29,5 +29,10 @@
 
 # cargo-dist isn't currently able to take these from .cargo/config.toml
 # https://github.com/axodotdev/cargo-dist/issues/1571
-- name: Set up RUSTFLAGS
+- name: Set up RUSTFLAGS (macOS)
+  if: ${{ runner.os == 'macOS' }}
   run: echo RUSTFLAGS="-C force-unwind-tables --cfg uuid_unstable --cfg tokio_unstable" >> "$GITHUB_ENV"
+
+- name: Set up RUSTFLAGS (Linux)
+  if: ${{ runner.os == 'Linux' }}
+  run: echo RUSTFLAGS="-C force-unwind-tables --cfg uuid_unstable --cfg tokio_unstable --cfg tokio_taskdump" >> "$GITHUB_ENV"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,7 @@ path = "workspace-hack"
 
 [profile.release]
 opt-level = 3
+debug = 1
 lto = "thin"
 codegen-units = 1
 # Let's be defensive and abort on every panic

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -84,3 +84,6 @@ googletest = { workspace = true }
 test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_taskdump)'] }

--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -225,6 +225,10 @@ impl Handle {
         self.inner.shutdown_managed_runtimes()
     }
 
+    pub async fn dump_tasks(&self, writer: impl std::io::Write) {
+        self.inner.dump_tasks(writer).await
+    }
+
     /// Triggers a shutdown of the system. All running tasks will be asked gracefully
     /// to cancel but we will only wait for tasks with a TaskKind that has the property
     /// "OnCancel" set to "wait".

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,10 +78,13 @@ RUN --mount=type=secret,id=parca --mount=type=cache,target=/var/cache/sccache \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --only-keep-debug target/restate-server target/restate-server.debug && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate-server && \
+    $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --add-gnu-debuglink=target/restate-server.debug target/restate-server && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restatectl && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate && \
     parca-debuginfo upload --store-address=grpc.polarsignals.com:443 --bearer-token-file=/run/secrets/parca target/restate-server.debug && \
     rm target/restate-server.debug
+RUN cp docker/scripts/download-restate-debug-symbols.sh target/ && \
+    sed -i"" "s/BUILD_ID/$($(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-readelf -n target/restate-server | awk '/Build/{print $3}')/g" target/download-restate-debug-symbols.sh
 
 FROM upload-$UPLOAD_DEBUGINFO AS upload
 
@@ -94,6 +97,7 @@ COPY --from=upload /restate/LICENSE /LICENSE
 # copy OS roots
 COPY --from=upload /etc/ssl /etc/ssl
 COPY --from=upload /restate/target/restate-server /usr/local/bin
+COPY --from=upload /restate/target/*.sh /usr/local/bin
 COPY --from=upload /restate/target/restatectl /usr/local/bin
 COPY --from=upload /restate/target/restate /usr/local/bin
 WORKDIR /

--- a/docker/scripts/download-restate-debug-symbols.sh
+++ b/docker/scripts/download-restate-debug-symbols.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Downloading debug symbols for restate-server BUILD_ID to /usr/local/bin/.debug"
+mkdir -p /usr/local/bin/.debug/
+curl --compressed -sL https://4bafe29d-dd3e-4c65-ba1d-54be833b2b69.debuginfod.polarsignals.com/buildid/BUILD_ID/debuginfo -o /usr/local/bin/.debug/restate-server.debug

--- a/docs/dev/profiling-debugging.md
+++ b/docs/dev/profiling-debugging.md
@@ -17,3 +17,9 @@ When using GDB on a process that comes from a release docker image you can set
 `DEBUGINFOD_URLS=https://4bafe29d-dd3e-4c65-ba1d-54be833b2b69.debuginfod.polarsignals.com,https://debuginfod.elfutils.org/`.
 For other tools, obtain the debug symbols by finding the build ID with `readelf -n restate-server` and then get the symbols with
 `curl -sL https://4bafe29d-dd3e-4c65-ba1d-54be833b2b69.debuginfod.polarsignals.com/buildid/$BUILD_ID/debuginfo -o restate-server`.
+
+Alternatively, inside release docker images, debug symbols can be downloaded (to `/usr/local/bin/.debug/restate-server.debug`) using `download-restate-debug-symbols.sh`.
+
+## Dumping tokio tasks
+A backtrace of all tokio tasks can be obtained with `kill -usr2 <restate-pid>`.
+If in a release docker image, it is strongly recommended to first run `download-restate-debug-symbols.sh`, the backtraces should pick up the debug symbols and be much more useful.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -273,8 +273,9 @@ fn main() {
                     _ = config_update_watcher.changed() => {
                         tracing_guard.on_config_update();
                     },
+                    _ = signal::sighup_compact() => {},
                     _ = signal::sigusr1_dump_config() => {},
-                    _ = signal::sighusr2_compact() => {},
+                    _ = signal::sigusr2_tokio_dump() => {},
                     _ = task_center_watch.cancelled() => {
                         shutdown = true;
                         // Shutdown was requested by task center and it has completed.


### PR DESCRIPTION
In Linux, we can catch a signal and dump all tokio tasks to stderr. We use usr2 to this, moving the existing usr2 handler (compaction) to sighup. Note, by catching sighup, i think that it means that user logouts will not exit a running restate process in their shell. Which isn't necessarily a bad thing.... I often run `nohup restate-server &` anyway.

This relies somewhat on the ability to create good backtraces via the backtrace crate, which we do not have right now in release docker images as we strip all the symbols out and upload to polar signals. cargo build --release also does not appear to give enough debug info for tokio dump. Without the symbols, we still get tasks, but it loses loads of detail including whole paths, eg in a select, you will typically just see the cancellation watcher and not various other things you're polling. Possibly inlining related.

If we have set up the debuglink section in our binaries, then the backtrace crate will search various predefined directories for a symbol fine named restate-server.debug. If that file is present when we first do a dump (symbols are cached once obtained), we will get full backtraces. The debug file is something that we can easily curl down from polar signals - this PR adds a script `download-restate-debug-symbols.sh` in the Docker image that pull down the symbols to the right directory. NB it is like 1.5G typically.

Alternatively, objcopy --compress-debug-sections maintains the full backtrace support and yields a 400M binary (where stripped is 140M, with full debug symbols is 1.7G). If we were ok with 400M binaries, we could just keep the symbols in and it would make a lot of debugging things easier. Also to consider, we could compress the debug sections of the one we upload, or upload it separately, so its a faster download when its needed. Most tools seem to support the compressed sections, and objcopy can decompress anyway.