### PR TITLE
Add PodDisruptionBudget to the Helm chart

### DIFF
--- a/charts/restate-helm/templates/pdb.yaml
+++ b/charts/restate-helm/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "restate.fullname" . }}
+  labels:
+    {{- include "restate.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "restate.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+{{- end }}

--- a/charts/restate-helm/values.yaml
+++ b/charts/restate-helm/values.yaml
@@ -74,3 +74,8 @@ topologySpreadConstraints:
   maxSkew: 1
   topologyKey: topology.kubernetes.io/zone
   whenUnsatisfiable: ScheduleAnyway
+
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+# podDisruptionBudget:
+#   maxUnavailable: 1
+


### PR DESCRIPTION
Allow users to pass a 'podDisruptionBudget' object in chart values.