### PR TITLE
[Restate UI] Update to v0.0.90

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8028,8 +8028,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.89"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.89#86e4c27ceab1f81f01688f9e880ac9462ca4fad1"
+version = "0.0.90"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.90#5226584a1c04a43810502707f2aa5b38c00dfa6b"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.89", tag = "v0.0.89" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.90", tag = "v0.0.90" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.90
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.90/ui-v0.0.90.zip