### PR TITLE
[Fix] Fix query-engine deadlock when contending on lo-pri thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7770,6 +7770,7 @@ dependencies = [
  "bytestring",
  "chrono",
  "codederror",
+ "dashmap",
  "datafusion",
  "datafusion-functions-json",
  "derive_more",

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -152,6 +152,8 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     // -- Log-server tasks
     LogletWriter,
+    // - Datafusion
+    DfScanner,
 }
 
 impl TaskKind {

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -30,6 +30,7 @@ bytes = { workspace = true }
 bytestring = { workspace = true }
 chrono = { workspace = true }
 codederror = { workspace = true }
+dashmap = { workspace = true }
 datafusion = { workspace = true }
 datafusion-functions-json = { version = "0.48.0" }
 derive_more = { workspace = true }

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -27,6 +27,7 @@ mod partition_replica_set;
 mod partition_state;
 mod partition_store_scanner;
 mod promise;
+mod scanner_task;
 mod service;
 mod state;
 #[cfg(feature = "table_docs")]

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use super::context::QueryContext;
 use crate::context::SelectPartitions;
-use crate::remote_query_scanner_client::RemoteScannerService;
+use crate::remote_query_scanner_client::{RemoteScanner, RemoteScannerService};
 use crate::remote_query_scanner_manager::{
     PartitionLocation, PartitionLocator, RemoteScannerManager,
 };
@@ -35,10 +35,7 @@ use restate_types::errors::GenericError;
 use restate_types::identifiers::{DeploymentId, PartitionId, PartitionKey, ServiceRevision};
 use restate_types::invocation::ServiceType;
 use restate_types::live::{Constant, Live};
-use restate_types::net::remote_query_scanner::{
-    RemoteQueryScannerClose, RemoteQueryScannerClosed, RemoteQueryScannerNext,
-    RemoteQueryScannerNextResult, RemoteQueryScannerOpen, RemoteQueryScannerOpened,
-};
+use restate_types::net::remote_query_scanner::RemoteQueryScannerOpen;
 use restate_types::partition_table::Partition;
 use restate_types::schema::deployment::test_util::MockDeploymentMetadataRegistry;
 use restate_types::schema::deployment::{Deployment, DeploymentResolver};
@@ -131,23 +128,7 @@ impl RemoteScannerService for NoopSvc {
         &self,
         _peer: NodeId,
         _req: RemoteQueryScannerOpen,
-    ) -> Result<RemoteQueryScannerOpened, DataFusionError> {
-        panic!("remote service should not be used")
-    }
-
-    async fn next_batch(
-        &self,
-        _peer: NodeId,
-        _req: RemoteQueryScannerNext,
-    ) -> Result<RemoteQueryScannerNextResult, DataFusionError> {
-        panic!("remote service should not be used")
-    }
-
-    async fn close(
-        &self,
-        _peer: NodeId,
-        _req: RemoteQueryScannerClose,
-    ) -> Result<RemoteQueryScannerClosed, DataFusionError> {
+    ) -> Result<RemoteScanner, DataFusionError> {
         panic!("remote service should not be used")
     }
 }

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, bail};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::SendableRecordBatchStream;
+
 use restate_core::Metadata;
 use restate_core::partitions::PartitionRouting;
 use restate_types::NodeId;

--- a/crates/storage-query-datafusion/src/scanner_task.rs
+++ b/crates/storage-query-datafusion/src/scanner_task.rs
@@ -1,0 +1,165 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use anyhow::Context;
+use datafusion::execution::SendableRecordBatchStream;
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt as TokioStreamExt;
+use tracing::{debug, warn};
+
+use restate_core::network::{Oneshot, Reciprocal};
+use restate_core::{TaskCenter, TaskKind};
+use restate_types::GenerationalNodeId;
+use restate_types::net::remote_query_scanner::{
+    RemoteQueryScannerNextResult, RemoteQueryScannerOpen, ScannerBatch, ScannerFailure, ScannerId,
+};
+
+use crate::remote_query_scanner_manager::RemoteScannerManager;
+use crate::remote_query_scanner_server::ScannerMap;
+use crate::{decode_schema, encode_record_batch};
+
+const SCANNER_EXPIRATION: Duration = Duration::from_secs(60);
+
+type NextReciprocal = Reciprocal<Oneshot<RemoteQueryScannerNextResult>>;
+
+pub(crate) type ScannerHandle = mpsc::UnboundedSender<NextReciprocal>;
+
+// Tracks a single scanner's lifecycle running in [`RemoteQueryScannerServer`]
+pub(crate) struct ScannerTask {
+    peer: GenerationalNodeId,
+    scanner_id: ScannerId,
+    stream: SendableRecordBatchStream,
+    rx: mpsc::UnboundedReceiver<NextReciprocal>,
+    scanners: Weak<ScannerMap>,
+}
+
+impl ScannerTask {
+    /// Spawns the scanner task and registers the scanner in the scanners map.
+    pub fn spawn(
+        scanner_id: ScannerId,
+        remote_scanner_manager: &RemoteScannerManager,
+        peer: GenerationalNodeId,
+        scanners: &Arc<ScannerMap>,
+        request: RemoteQueryScannerOpen,
+    ) -> anyhow::Result<()> {
+        let scanner = remote_scanner_manager
+            .local_partition_scanner(&request.table)
+            .context("not registered scanner for a table")?;
+        let schema = decode_schema(&request.projection_schema_bytes).context("bad schema bytes")?;
+        let stream = scanner.scan_partition(
+            request.partition_id,
+            request.range.clone(),
+            Arc::new(schema),
+            request
+                .limit
+                .map(|limit| usize::try_from(limit).expect("limit to fit in a usize")),
+        )?;
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut task = Self {
+            peer,
+            scanner_id,
+            stream,
+            rx,
+            scanners: Arc::downgrade(scanners),
+        };
+
+        scanners.insert(scanner_id, tx);
+
+        // make sure we add before we spawn.
+        TaskCenter::spawn_unmanaged(TaskKind::DfScanner, "df-scanner-task", async move {
+            task.run().await
+        })?;
+
+        Ok(())
+    }
+
+    async fn run(&mut self) {
+        // Monitor the cluster state of the scanner peer to ensure we dispose the scanner if the
+        // node was observed as dead.
+        let mut peer_watch =
+            TaskCenter::with_current(|tc| tc.cluster_state().watch(self.peer.as_plain()));
+
+        let mut watch_fut = std::pin::pin!(
+            peer_watch.conditional_wait_for(self.peer.generation(), |state| !state.is_alive())
+        );
+
+        loop {
+            let reciprocal = tokio::select! {
+                _ = &mut watch_fut => {
+                    // peer is dead, dispose the scanner
+                    debug!("Removing scanner due to peer {} being dead", self.peer);
+                    return;
+                }
+                maybe_request = self.rx.recv() => {
+                    match maybe_request {
+                            Some(request) => request,
+                            None => {
+                                // scanner has been closed.
+                                return;
+                            }
+                        }
+                }
+                () = tokio::time::sleep(SCANNER_EXPIRATION) => {
+                    warn!("Removing scanner due to a long inactivity {}", self.scanner_id);
+                    return;
+                }
+            };
+
+            // connection/request has been closed, don't bother with driving the stream.
+            if reciprocal.is_closed() {
+                continue;
+            }
+
+            let record_batch = match self.stream.next().await {
+                Some(Ok(record_batch)) => record_batch,
+                Some(Err(e)) => {
+                    warn!("Error while scanning {}: {e}", self.scanner_id);
+
+                    reciprocal.send(RemoteQueryScannerNextResult::Failure(ScannerFailure {
+                        scanner_id: self.scanner_id,
+                        message: e.to_string(),
+                    }));
+                    return;
+                }
+                None => {
+                    reciprocal.send(RemoteQueryScannerNextResult::NoMoreRecords(self.scanner_id));
+                    return;
+                }
+            };
+            match encode_record_batch(&self.stream.schema(), record_batch) {
+                Ok(record_batch) => {
+                    reciprocal.send(RemoteQueryScannerNextResult::NextBatch(ScannerBatch {
+                        scanner_id: self.scanner_id,
+                        record_batch,
+                    }))
+                }
+                Err(e) => {
+                    reciprocal.send(RemoteQueryScannerNextResult::Failure(ScannerFailure {
+                        scanner_id: self.scanner_id,
+                        message: e.to_string(),
+                    }));
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ScannerTask {
+    fn drop(&mut self) {
+        if let Some(scanners) = self.scanners.upgrade() {
+            let _ = scanners.remove(&self.scanner_id);
+        }
+    }
+}

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -19,8 +19,6 @@ mod partition_processor_manager;
 mod subscription_controller;
 mod subscription_integration;
 
-use std::time::Duration;
-
 use codederror::CodedError;
 
 use restate_bifrost::Bifrost;
@@ -190,11 +188,8 @@ impl Worker {
             None => None,
         };
 
-        let datafusion_remote_scanner = RemoteQueryScannerServer::new(
-            Duration::from_secs(60),
-            remote_scanner_manager,
-            router_builder,
-        );
+        let datafusion_remote_scanner =
+            RemoteQueryScannerServer::new(remote_scanner_manager, router_builder);
 
         Ok(Self {
             live_config,


### PR DESCRIPTION

This PR fixes a deadlock that can occur when remoq query server's network service loop gets blocked trying to open a new iterator when the low-priority thread pool is exhausted by currently open scanners. The deadlock happens because the existing iterators cannot make progress or expire because they are managed by the top-level `tokio::select!`.

The fix addresses this issue by moving into a concurrent design (remote scanners as independent tasks). Each scanner manages its own expiration and lifecycle.


Additionally, the PR fixes another issue where cancellation of in-flight query didn't remove the scanner from the list of active scanners.
This means that Ctrl+C of a long `restate sql` would block the low-priority threads until those scanners expire (60s by default).

The cancellation signal from the admin node is now propagated correctly to the remote scanner's node if it's possible to do so.
Additionally, the remote scanner will now monitor if the peer node is dead and will auto-remove the remote scanner (aka. the iterator) when the peer is marked as dead in gossip. This addresses
the scenario where the admin node is killed/shutdown while the query is still running, causing the remote scanners on peers to linger until the expiration to kick in.

```
// intentionally empty
```
