### PR TITLE
[sql] Don't force a default query parallelism 2.

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -343,7 +343,9 @@ impl QueryContext {
         // build the session
         //
         let mut session_config = SessionConfig::new();
-        session_config = session_config.with_target_partitions(default_parallelism.unwrap_or(2));
+        if let Some(target_partitions) = default_parallelism {
+            session_config = session_config.with_target_partitions(target_partitions);
+        }
 
         session_config = session_config
             .with_information_schema(true)

--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -39,7 +39,7 @@ pub struct QueryEngineOptions {
 
     /// # Default query parallelism
     ///
-    /// The number of parallel partitions to use for a query execution
+    /// The degree of parallelism to use for query execution (Defaults to the number of available cores).
     query_parallelism: Option<NonZeroUsize>,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]


### PR DESCRIPTION
Currently we set the default query parallelism in datafusion to 2. This parameter controls the number of parallel work that datafusion does while processing a single query.
We used to set it to the minimum possible to aggressively limit the resources used while processing a query, however recent work around datafusion and rocksdb has affective limits set elsewhere, and with that the query duration has become noticeably slower. With this commit, we remove this default and let datafusion to use the number of cores as the default parallelism.
And we still have the configuration key to limit that.