### PR TITLE
feat: add shell completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,7 +4442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6791,6 +6800,7 @@ dependencies = [
  "chrono-humanize",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
  "cling",
  "comfy-table",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ async-trait = "0.1.88"
 axum = { version = "0.7.9", default-features = false }
 aws-config = "1.8.0"
 aws-credential-types = "1.2.2"
-aws-smithy-async = {version = "1.2.5", default-features = false}
+aws-smithy-async = { version = "1.2.5", default-features = false }
 aws-smithy-runtime-api = "1.7.4"
 aws-smithy-types = "1.3.0"
 base64 = "0.22"
@@ -115,6 +115,7 @@ comfy-table = { version = "7.1" }
 chrono-humanize = { version = "0.2.3" }
 clap = { version = "4", default-features = false }
 clap-verbosity-flag = { version = "3.0.2" }
+clap_complete = { version = "4.5" }
 cling = { version = "0.1.3", default-features = false, features = ["derive"] }
 criterion = "0.5"
 crossterm = { version = "0.29.0" }
@@ -185,13 +186,20 @@ rangemap = "1.5.1"
 rayon = { version = "1.10" }
 regex = { version = "1.11" }
 regress = { version = "0.10" }
-reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "stream", ] }
+reqwest = { version = "0.12.5", default-features = false, features = [
+    "json",
+    "rustls-tls",
+    "stream",
+] }
 rlimit = { version = "0.10.1" }
-rocksdb = { version = "0.41.0", package = "rust-rocksdb", features = ["multi-threaded-cf", "jemalloc"], git = "https://github.com/restatedev/rust-rocksdb", rev = "309f749c033731c21a520f5b47773fe31deafd79" }
+rocksdb = { version = "0.41.0", package = "rust-rocksdb", features = [
+    "multi-threaded-cf",
+    "jemalloc",
+], git = "https://github.com/restatedev/rust-rocksdb", rev = "309f749c033731c21a520f5b47773fe31deafd79" }
 rstest = "0.24.0"
 rustls = { version = "0.23.26", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }
-semver = {  version = "1.0", features = ["serde"] }
+semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.8"
@@ -206,7 +214,10 @@ tempfile = "3.6.0"
 test-log = { version = "0.2.11", default-features = false, features = [
     "trace",
 ] }
-tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms", "profiling"] }
+tikv-jemallocator = { version = "0.6", features = [
+    "unprefixed_malloc_on_supported_platforms",
+    "profiling",
+] }
 tikv-jemalloc-sys = { version = "0.6", features = ["profiling"] }
 thiserror = "2.0"
 tokio = { version = "1.45.0", default-features = false, features = [
@@ -226,7 +237,11 @@ tower = "0.5.2"
 tower-http = { version = "0.6.2", default-features = false }
 tracing = { version = "0.1" }
 tracing-opentelemetry = { version = "0.28.0" }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "parking_lot"] }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "fmt",
+    "parking_lot",
+] }
 tracing-test = { version = "0.2.5" }
 typed-builder = "0.21.0"
 ulid = { version = "1.2.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,6 +41,7 @@ chrono = { workspace = true }
 chrono-humanize = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help", "color", "std", "suggestions", "usage"] }
 clap-verbosity-flag = { workspace = true }
+clap_complete = { workspace = true }
 cling = { workspace = true }
 comfy-table = { workspace = true }
 const_format = "0.2.32"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -71,6 +71,10 @@ pub enum Command {
     #[clap(subcommand)]
     State(state::ServiceState),
 
+    /// Generate shell completions
+    #[clap(subcommand)]
+    Completions(completions::Completions),
+
     /// Manage CLI config
     #[clap(subcommand, alias = "conf")]
     Config(config::Config),

--- a/cli/src/commands/completions/mod.rs
+++ b/cli/src/commands/completions/mod.rs
@@ -1,0 +1,385 @@
+use anyhow::{Context, Result};
+use clap::CommandFactory;
+use clap_complete::{Shell, generate};
+use cling::prelude::*;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use crate::CliApp;
+use crate::cli_env::CliEnv;
+
+/// Generate shell completions for the Restate CLI
+#[derive(Run, Subcommand, Clone)]
+pub enum Completions {
+    /// Generate completions to stdout
+    Generate(Generate),
+    /// Install completions automatically to shell configuration
+    Install(Install),
+}
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_generate")]
+pub struct Generate {
+    /// Shell to generate completions for (auto-detect if not specified)
+    #[arg(value_enum)]
+    shell: Option<Shell>,
+}
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_install")]
+pub struct Install {
+    /// Shell to install completions for (auto-detect if not specified)
+    #[arg(value_enum)]
+    shell: Option<Shell>,
+}
+
+/// Get shell from options or detect it
+fn get_shell_or_detect(shell: Option<Shell>) -> Shell {
+    shell.unwrap_or_else(|| detect_shell().unwrap_or(Shell::Bash))
+}
+
+pub async fn run_generate(State(_env): State<CliEnv>, opts: &Generate) -> Result<()> {
+    let detected_shell = get_shell_or_detect(opts.shell);
+
+    let mut cmd = CliApp::command();
+    let cmd_name = cmd.get_name().to_string();
+    generate(detected_shell, &mut cmd, &cmd_name, &mut io::stdout());
+
+    Ok(())
+}
+
+pub async fn run_install(State(_env): State<CliEnv>, opts: &Install) -> Result<()> {
+    let detected_shell = get_shell_or_detect(opts.shell);
+    install_completions(detected_shell)?;
+    Ok(())
+}
+
+fn detect_shell() -> Result<Shell> {
+    // Try to detect shell from environment variables
+    if let Ok(shell_path) = env::var("SHELL") {
+        let shell_name = shell_path.rsplit('/').next().unwrap_or(&shell_path);
+        match shell_name {
+            "bash" => return Ok(Shell::Bash),
+            "zsh" => return Ok(Shell::Zsh),
+            "fish" => return Ok(Shell::Fish),
+            _ => {}
+        }
+    }
+
+    // Try PowerShell on Windows
+    if cfg!(target_os = "windows") {
+        Ok(Shell::PowerShell)
+    } else {
+        Ok(Shell::Bash)
+    }
+}
+
+/// Configuration for shell completion installation
+struct CompletionConfig<'a> {
+    shell: Shell,
+    name: &'a str,
+    completion_dir: PathBuf,
+    file_name: String,
+    post_install_message: &'a str,
+}
+
+/// Generate and write completion file
+fn write_completion_file(cmd: &mut clap::Command, config: &CompletionConfig) -> Result<()> {
+    // Create completion directory if it doesn't exist
+    fs::create_dir_all(&config.completion_dir)
+        .with_context(|| format!("Failed to create {} completion directory", config.shell))?;
+
+    let completion_file = config.completion_dir.join(&config.file_name);
+
+    // Generate completions with pre-allocated buffer
+    let mut output = Vec::with_capacity(8192);
+    generate(config.shell, cmd, config.name.to_string(), &mut output);
+
+    // Write to completion file
+    fs::write(&completion_file, &output)
+        .with_context(|| format!("Failed to write {} completion file", config.shell))?;
+
+    println!(
+        "{} completions installed to: {}",
+        config.shell,
+        completion_file.display()
+    );
+    println!("{}", config.post_install_message);
+
+    Ok(())
+}
+
+fn get_zsh_completion_dir(home: &str) -> PathBuf {
+    // Try common zsh completion directories
+    let completion_dirs = [
+        PathBuf::from(home).join(".local/share/zsh/site-functions"),
+        PathBuf::from(home).join(".zsh/completions"),
+    ];
+
+    completion_dirs
+        .iter()
+        .find(|dir| dir.exists())
+        .cloned()
+        .unwrap_or_else(|| completion_dirs[0].clone())
+}
+
+fn install_completions(shell: Shell) -> Result<()> {
+    let mut cmd = CliApp::command();
+    let name = cmd.get_bin_name().unwrap_or("restate").to_string();
+
+    match shell {
+        Shell::Bash => {
+            let home = env::var("HOME").context("HOME environment variable not set")?;
+            let config = CompletionConfig {
+                shell: Shell::Bash,
+                name: &name,
+                completion_dir: PathBuf::from(&home)
+                    .join(".local/share/bash-completion/completions"),
+                file_name: name.to_string(),
+                post_install_message: "You may need to restart your shell or source your ~/.bashrc",
+            };
+            write_completion_file(&mut cmd, &config)
+        }
+        Shell::Zsh => {
+            let home = env::var("HOME").context("HOME environment variable not set")?;
+            let config = CompletionConfig {
+                shell: Shell::Zsh,
+                name: &name,
+                completion_dir: get_zsh_completion_dir(&home),
+                file_name: format!("_{name}"),
+                post_install_message: "You may need to restart your shell or run: autoload -U compinit && compinit",
+            };
+            write_completion_file(&mut cmd, &config)
+        }
+        Shell::Fish => {
+            let home = env::var("HOME").context("HOME environment variable not set")?;
+            let config = CompletionConfig {
+                shell: Shell::Fish,
+                name: &name,
+                completion_dir: PathBuf::from(&home).join(".config/fish/completions"),
+                file_name: format!("{name}.fish"),
+                post_install_message: "Completions should be available immediately in new fish sessions",
+            };
+            write_completion_file(&mut cmd, &config)
+        }
+        Shell::PowerShell => {
+            // PowerShell is special - just print to stdout
+            let mut output = Vec::with_capacity(8192);
+            generate(Shell::PowerShell, &mut cmd, name.to_string(), &mut output);
+
+            let completion_script = String::from_utf8(output)
+                .context("Failed to convert PowerShell completions to string")?;
+
+            println!(
+                "PowerShell completions generated. To install, add the following to your PowerShell profile:"
+            );
+            println!("You can find your profile location by running: echo $PROFILE");
+            println!("\n{completion_script}");
+            Ok(())
+        }
+        Shell::Elvish => {
+            anyhow::bail!(
+                "Automatic installation for Elvish is not supported yet. Please use 'generate' command and manually install the completions."
+            );
+        }
+        _ => {
+            anyhow::bail!(
+                "Automatic installation for this shell is not supported yet. Please use 'generate' command and manually install the completions."
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn get_expected_package_name() -> String {
+        env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "restate-cli".to_string())
+    }
+
+    #[test]
+    fn test_detect_shell_from_env() {
+        // Test bash detection
+        unsafe { env::set_var("SHELL", "/bin/bash") };
+        let shell = detect_shell().unwrap();
+        assert_eq!(shell, Shell::Bash);
+
+        // Test zsh detection
+        unsafe { env::set_var("SHELL", "/usr/bin/zsh") };
+        let shell = detect_shell().unwrap();
+        assert_eq!(shell, Shell::Zsh);
+
+        // Test fish detection
+        unsafe { env::set_var("SHELL", "/usr/local/bin/fish") };
+        let shell = detect_shell().unwrap();
+        assert_eq!(shell, Shell::Fish);
+
+        // Test default fallback
+        unsafe { env::set_var("SHELL", "/some/unknown/shell") };
+        let shell = detect_shell().unwrap();
+        assert_eq!(shell, Shell::Bash);
+    }
+
+    #[test]
+    fn test_detect_shell_no_env() {
+        // Remove SHELL env var
+        unsafe { env::remove_var("SHELL") };
+        let shell = detect_shell().unwrap();
+        // Should default to bash (or PowerShell on Windows)
+        if cfg!(target_os = "windows") {
+            assert_eq!(shell, Shell::PowerShell);
+        } else {
+            assert_eq!(shell, Shell::Bash);
+        }
+    }
+
+    #[test]
+    fn test_bash_completion_paths() {
+        let temp_dir = tempdir().unwrap();
+        let home_dir = temp_dir.path().to_str().unwrap();
+
+        // Set temporary HOME
+        unsafe { env::set_var("HOME", home_dir) };
+
+        let completion_dir =
+            PathBuf::from(home_dir).join(".local/share/bash-completion/completions");
+
+        // The directory should be created by install_bash_completions
+        assert!(!completion_dir.exists());
+
+        // Test that the expected path is constructed correctly
+        let package_name = get_expected_package_name();
+        let expected_file = completion_dir.join(&package_name);
+        assert_eq!(expected_file.extension(), None);
+        assert_eq!(expected_file.file_name().unwrap(), package_name.as_str());
+    }
+
+    #[test]
+    fn test_zsh_completion_paths() {
+        let temp_dir = tempdir().unwrap();
+        let home_dir = temp_dir.path().to_str().unwrap();
+
+        // Set temporary HOME
+        unsafe { env::set_var("HOME", home_dir) };
+
+        let completion_dir = PathBuf::from(home_dir).join(".local/share/zsh/site-functions");
+        let package_name = get_expected_package_name();
+        let expected_file = completion_dir.join(format!("_{package_name}"));
+
+        assert_eq!(
+            expected_file.file_name().unwrap(),
+            format!("_{package_name}").as_str()
+        );
+        assert!(expected_file.to_str().unwrap().contains("site-functions"));
+    }
+
+    #[test]
+    fn test_fish_completion_paths() {
+        let temp_dir = tempdir().unwrap();
+        let home_dir = temp_dir.path().to_str().unwrap();
+
+        // Set temporary HOME
+        unsafe { env::set_var("HOME", home_dir) };
+
+        let completion_dir = PathBuf::from(home_dir).join(".config/fish/completions");
+        let package_name = get_expected_package_name();
+        let expected_file = completion_dir.join(format!("{package_name}.fish"));
+
+        assert_eq!(expected_file.extension().unwrap(), "fish");
+        assert_eq!(expected_file.file_stem().unwrap(), package_name.as_str());
+    }
+
+    #[test]
+    fn test_install_completions_unsupported_shell() {
+        // Test that Elvish returns an error
+        let result = install_completions(Shell::Elvish);
+        assert!(result.is_err());
+        // Just check that it's an error, not the specific message
+    }
+
+    #[test]
+    fn test_install_bash_completions() {
+        let temp_dir = tempdir().unwrap();
+        let home_dir = temp_dir.path().to_str().unwrap();
+
+        // Set temporary HOME
+        unsafe { env::set_var("HOME", home_dir) };
+
+        let result = install_completions(Shell::Bash);
+
+        assert!(result.is_ok());
+
+        // Check that the completion file was created
+        let completion_file = PathBuf::from(home_dir)
+            .join(".local/share/bash-completion/completions")
+            .join("restate");
+
+        assert!(completion_file.exists());
+
+        // Check that file has content
+        let content = fs::read_to_string(&completion_file).unwrap();
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn test_install_zsh_completions() {
+        let temp_dir = tempdir().unwrap();
+        let home_dir = temp_dir.path().to_str().unwrap();
+
+        // Set temporary HOME
+        unsafe { env::set_var("HOME", home_dir) };
+
+        let result = install_completions(Shell::Zsh);
+
+        assert!(result.is_ok());
+
+        // Check that the completion file was created
+        let completion_file = PathBuf::from(home_dir)
+            .join(".local/share/zsh/site-functions")
+            .join("_restate");
+
+        assert!(completion_file.exists());
+
+        // Check that file has content
+        let content = fs::read_to_string(&completion_file).unwrap();
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn test_install_fish_completions() {
+        let temp_dir = tempdir().unwrap();
+        let home_dir = temp_dir.path().to_str().unwrap();
+
+        // Set temporary HOME
+        unsafe { env::set_var("HOME", home_dir) };
+
+        let result = install_completions(Shell::Fish);
+
+        assert!(result.is_ok());
+
+        // Check that the completion file was created
+        let completion_file = PathBuf::from(home_dir)
+            .join(".config/fish/completions")
+            .join("restate.fish");
+
+        assert!(completion_file.exists());
+
+        // Check that file has content
+        let content = fs::read_to_string(&completion_file).unwrap();
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn test_install_powershell_completions() {
+        let result = install_completions(Shell::PowerShell);
+
+        // PowerShell installation should always succeed (it just prints to stdout)
+        assert!(result.is_ok());
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -10,6 +10,7 @@
 
 #[cfg(feature = "cloud")]
 pub mod cloud;
+pub mod completions;
 pub mod config;
 pub mod deployments;
 pub mod examples;


### PR DESCRIPTION
## Summary

This PR adds shell completion support to the Restate CLI using `clap_complete`, addressing #3494.

## Motivation

Shell completions significantly improve the developer experience by:

- Enabling tab completion for commands, subcommands, and flags
- Reducing typing errors
- Helping users discover available CLI features
- Following modern CLI tool standards

## Implementation Plan

- [ ]  Add clap_complete dependency to cli/Cargo.toml
- [ ]  Add completions subcommand to generate completion scripts
- [ ]  Support major shells: Bash, Zsh, Fish, PowerShell, Elvish
- [ ]  Update documentation with installation instructions
- [ ]  Add tests for the completions subcommand

