### PR TITLE
Cleanup `DeploymentTypeShadow`

### DIFF
--- a/crates/admin-rest-model/src/deployments.rs
+++ b/crates/admin-rest-model/src/deployments.rs
@@ -824,7 +824,7 @@ mod serde_hacks {
                     uri,
                     protocol_type,
                     http_version: http_version
-                        .unwrap_or_else(|| DeploymentType::backfill_http_version(protocol_type)),
+                        .unwrap_or_else(|| protocol_type.default_http_version()),
                     additional_headers,
                     created_at,
                     min_protocol_version,

--- a/crates/types/src/schema/deployment.rs
+++ b/crates/types/src/schema/deployment.rs
@@ -30,6 +30,16 @@ pub enum ProtocolType {
     BidiStream,
 }
 
+impl ProtocolType {
+    /// Returns the default http version for the given protocol type
+    pub fn default_http_version(&self) -> http::Version {
+        match self {
+            ProtocolType::BidiStream => http::Version::HTTP_2,
+            ProtocolType::RequestResponse => http::Version::HTTP_11,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DeliveryOptions {
@@ -67,7 +77,6 @@ pub struct DeploymentMetadata {
 
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(from = "DeploymentTypeShadow")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum DeploymentType {
     Http {
@@ -86,125 +95,7 @@ pub enum DeploymentType {
     },
 }
 
-#[derive(serde::Deserialize)]
-enum DeploymentTypeShadow {
-    Http {
-        #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
-        address: Uri,
-        protocol_type: ProtocolType,
-        #[serde(
-            default,
-            with = "serde_with::As::<Option<restate_serde_util::VersionSerde>>"
-        )]
-        // this field did not used to be stored, so we must consider it optional when deserialising
-        http_version: Option<http::Version>,
-    },
-    Lambda {
-        arn: LambdaARN,
-        assume_role_arn: Option<ByteString>,
-    },
-}
-
-impl From<DeploymentTypeShadow> for DeploymentType {
-    fn from(value: DeploymentTypeShadow) -> Self {
-        match value {
-            DeploymentTypeShadow::Http {
-                address,
-                protocol_type,
-                http_version,
-            } => Self::Http {
-                address,
-                protocol_type,
-                http_version: match http_version {
-                    Some(v) => v,
-                    None => Self::backfill_http_version(protocol_type),
-                },
-            },
-            DeploymentTypeShadow::Lambda {
-                arn,
-                assume_role_arn,
-            } => Self::Lambda {
-                arn,
-                assume_role_arn,
-            },
-        }
-    }
-}
-
-#[cfg(test)]
-mod serde_tests {
-    use crate::{identifiers::LambdaARN, storage::StorageCodec};
-    use bytestring::ByteString;
-    use http::Uri;
-
-    use super::{DeploymentType, ProtocolType};
-
-    #[derive(serde::Serialize, serde::Deserialize)]
-    enum OldDeploymentType {
-        Http {
-            #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
-            address: Uri,
-            protocol_type: ProtocolType,
-        },
-        Lambda {
-            arn: LambdaARN,
-            assume_role_arn: Option<ByteString>,
-        },
-    }
-
-    crate::flexbuffers_storage_encode_decode!(OldDeploymentType);
-    crate::flexbuffers_storage_encode_decode!(DeploymentType);
-
-    #[test]
-    fn can_deserialise_without_http_version() {
-        let mut buf = bytes::BytesMut::default();
-        StorageCodec::encode(
-            &OldDeploymentType::Http {
-                address: Uri::from_static("google.com"),
-                protocol_type: ProtocolType::BidiStream,
-            },
-            &mut buf,
-        )
-        .unwrap();
-        let dt: DeploymentType = StorageCodec::decode(&mut buf).unwrap();
-        assert_eq!(
-            DeploymentType::Http {
-                address: Uri::from_static("google.com"),
-                protocol_type: ProtocolType::BidiStream,
-                http_version: http::Version::HTTP_2,
-            },
-            dt
-        );
-
-        let mut buf = bytes::BytesMut::default();
-        StorageCodec::encode(
-            &OldDeploymentType::Http {
-                address: Uri::from_static("google.com"),
-                protocol_type: ProtocolType::RequestResponse,
-            },
-            &mut buf,
-        )
-        .unwrap();
-        let dt: DeploymentType = StorageCodec::decode(&mut buf).unwrap();
-        assert_eq!(
-            DeploymentType::Http {
-                address: Uri::from_static("google.com"),
-                protocol_type: ProtocolType::RequestResponse,
-                http_version: http::Version::HTTP_11,
-            },
-            dt
-        );
-    }
-}
-
 impl DeploymentType {
-    pub fn backfill_http_version(protocol_type: ProtocolType) -> http::Version {
-        match protocol_type {
-            ProtocolType::BidiStream => http::Version::HTTP_2,
-            ProtocolType::RequestResponse => http::Version::HTTP_11,
-        }
-    }
-
     pub fn protocol_type(&self) -> ProtocolType {
         match self {
             DeploymentType::Http { protocol_type, .. } => *protocol_type,


### PR DESCRIPTION
This was introduced 1 year ago and seems not needed anymore, as this migration should have been executed already between 1.0 and 1.1