### PR TITLE
Refactoring of RocksDb manager for a better ownership model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7522,6 +7522,7 @@ dependencies = [
  "threadpool",
  "tikv-jemalloc-sys",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -870,7 +870,6 @@ impl TaskCenterInner {
             return;
         }
         self.health.node_status().merge(NodeStatus::ShuttingDown);
-        let start = Instant::now();
         self.current_exit_code.store(exit_code, Ordering::Relaxed);
 
         if exit_code != 0 {
@@ -894,7 +893,6 @@ impl TaskCenterInner {
         self.cancel_tasks(None, None).await;
         // notify outer components that we have completed the shutdown.
         self.global_cancel_token.cancel();
-        info!("** Shutdown completed in {:?}", start.elapsed());
     }
 
     /// Take control over the running task from task-center. This returns None if the task was not

--- a/crates/metadata-server/src/local/storage.rs
+++ b/crates/metadata-server/src/local/storage.rs
@@ -360,10 +360,6 @@ impl RocksDbStorage {
             Ok(())
         }
     }
-
-    pub async fn close(self) {
-        self.rocksdb.close().await
-    }
 }
 
 pub fn db_options(_options: &MetadataServerOptions) -> rocksdb::Options {

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -543,8 +543,6 @@ impl RaftMetadataServer {
         if !local_storage.is_sealed() {
             local_storage.seal().await?;
         }
-        local_storage.close().await;
-
         Ok(())
     }
 

--- a/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
@@ -48,13 +48,9 @@ pub async fn build_rocksdb(
         .build()
         .expect("valid spec");
 
-    let db_name = db_spec.name().clone();
-    let _ = db_manager
+    db_manager
         .open_db(options.map(|options| &options.rocksdb), db_spec)
-        .await?;
-    Ok(db_manager
-        .get_db(db_name)
-        .expect("raft metadata store db is open"))
+        .await
 }
 
 pub fn db_options(_options: &MetadataServerOptions) -> rocksdb::Options {

--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -210,7 +210,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
     for db in &all_dbs {
         labels.push(format!(
             "db=\"{}\"",
-            formatting::sanitize_label_value(&db.name)
+            formatting::sanitize_label_value(db.name())
         ));
 
         // Tickers (Counters)

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -440,7 +440,7 @@ impl PartitionStore {
                 assert!(table.has_key_kind(&prefix));
                 let prefix = prefix.freeze();
                 let opts = self.new_prefix_iterator_opts(key_kind, prefix.clone());
-                self.rocksdb.run_background_iterator(
+                self.rocksdb.clone().run_background_iterator(
                     self.data_cf_name.clone(),
                     name,
                     priority,
@@ -454,7 +454,7 @@ impl PartitionStore {
                 let start = start.freeze();
                 let end = end.freeze();
                 let opts = self.new_range_iterator_opts(scan_mode, start.clone(), end);
-                self.rocksdb.run_background_iterator(
+                self.rocksdb.clone().run_background_iterator(
                     self.data_cf_name.clone(),
                     name,
                     priority,
@@ -480,7 +480,7 @@ impl PartitionStore {
                 let start = start.freeze();
                 let end = end.freeze();
                 let opts = self.new_range_iterator_opts(ScanMode::TotalOrder, start.clone(), end);
-                self.rocksdb.run_background_iterator(
+                self.rocksdb.clone().run_background_iterator(
                     self.data_cf_name.clone(),
                     name,
                     priority,
@@ -561,6 +561,7 @@ impl PartitionStore {
 
     pub async fn flush_memtables(&self, wait: bool) -> Result<()> {
         self.rocksdb
+            .clone()
             .flush_memtables(slice::from_ref(&self.data_cf_name), wait)
             .await
             .map_err(|err| StorageError::Generic(err.into()))?;
@@ -613,6 +614,7 @@ impl PartitionStore {
 
         let export_files = self
             .rocksdb
+            .clone()
             .export_cf(self.data_cf_name.clone(), snapshot_dir.clone())
             .await
             .map_err(|e| StorageError::SnapshotExport(e.into()))?;

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -128,7 +128,7 @@ impl PartitionStoreManager {
         if !already_exists {
             if open_mode == OpenMode::CreateIfMissing {
                 debug!("Initializing storage for partition {}", partition_id);
-                self.rocksdb.open_cf(cf_name.clone(), opts).await?;
+                self.rocksdb.clone().open_cf(cf_name.clone(), opts).await?;
             } else {
                 return Err(RocksError::AlreadyOpen);
             }
@@ -192,6 +192,7 @@ impl PartitionStoreManager {
         );
 
         self.rocksdb
+            .clone()
             .import_cf(cf_name.clone(), opts, import_metadata)
             .await?;
 

--- a/crates/rocksdb/Cargo.toml
+++ b/crates/rocksdb/Cargo.toml
@@ -33,6 +33,7 @@ strum = { workspace = true }
 thiserror = { workspace = true }
 threadpool = { version = "1.8" }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -10,12 +10,12 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
-use std::sync::{Arc, OnceLock};
-use std::time::Instant;
+use std::sync::{Arc, OnceLock, Weak};
 
 use parking_lot::RwLock;
 use rocksdb::{BlockBasedOptions, Cache, LogLevel, WriteBufferManager};
 use tokio::sync::mpsc;
+use tokio_util::task::TaskTracker;
 use tracing::{debug, info, warn};
 
 use restate_core::{ShutdownError, TaskCenter, TaskKind, cancellation_watcher};
@@ -49,9 +49,10 @@ pub struct RocksDbManager {
     // auto updates to changes in common.rocksdb_memory_limit and common.rocksdb_memtable_total_size_limit
     write_buffer_manager: WriteBufferManager,
     stall_detection_millis: AtomicUsize,
-    dbs: RwLock<HashMap<DbName, Arc<RocksDb>>>,
+    dbs: RwLock<HashMap<DbName, Weak<RocksDb>>>,
     watchdog_tx: mpsc::UnboundedSender<WatchdogCommand>,
     shutting_down: AtomicBool,
+    close_db_tasks: TaskTracker,
     high_pri_pool: threadpool::ThreadPool,
     low_pri_pool: threadpool::ThreadPool,
 }
@@ -114,6 +115,7 @@ impl RocksDbManager {
             dbs,
             watchdog_tx,
             shutting_down: AtomicBool::new(false),
+            close_db_tasks: TaskTracker::default(),
             high_pri_pool,
             low_pri_pool,
             stall_detection_millis,
@@ -132,7 +134,7 @@ impl RocksDbManager {
     }
 
     pub fn get_db(&self, name: DbName) -> Option<Arc<RocksDb>> {
-        self.dbs.read().get(&name).cloned()
+        self.dbs.read().get(&name).map(|db| db.upgrade())?
     }
 
     pub async fn open_db(
@@ -153,15 +155,11 @@ impl RocksDbManager {
         // use the spec default options as base then apply the config from the updateable.
         self.amend_db_options(&mut db_spec.db_options, &options);
 
-        // todo: move to bg thread pool
-        let db = Arc::new(rocksdb::DB::open_db(
-            &db_spec,
-            self.default_cf_options(&options),
-        )?);
-
         let path = db_spec.path.clone();
-        let wrapper = Arc::new(RocksDb::new(self, db_spec, db));
-        self.dbs.write().insert(name.clone(), wrapper.clone());
+        let wrapper = RocksDb::open(self, db_spec, self.default_cf_options(&options)).await?;
+        self.dbs
+            .write()
+            .insert(name.clone(), Arc::downgrade(&wrapper));
 
         if let Err(e) = self
             .watchdog_tx
@@ -216,11 +214,17 @@ impl RocksDbManager {
 
         if filter.is_empty() {
             for db in self.dbs.read().values() {
+                let Some(db) = db.upgrade() else {
+                    continue;
+                };
                 db.inner().record_memory_stats(&mut builder);
             }
         } else {
             for key in filter {
                 if let Some(db) = self.dbs.read().get(key) {
+                    let Some(db) = db.upgrade() else {
+                        continue;
+                    };
                     db.inner().record_memory_stats(&mut builder);
                 }
             }
@@ -230,44 +234,56 @@ impl RocksDbManager {
     }
 
     pub fn get_all_dbs(&self) -> Vec<Arc<RocksDb>> {
-        self.dbs.read().values().cloned().collect()
+        self.dbs.read().values().filter_map(Weak::upgrade).collect()
     }
 
-    pub(crate) async fn close_db(&self, name: &DbName) {
-        let Some(db) = self.dbs.write().remove(name) else {
+    /// Closes the database and waits for completion.
+    pub(crate) async fn close_db(&self, db: Arc<RocksDb>) -> Result<(), Arc<RocksDb>> {
+        let db = Arc::try_unwrap(db)?;
+        // unconditionally remove the db from the map
+        self.dbs.write().remove(db.name());
+        let handle = self.close_db_tasks.spawn_blocking(move || {
+            db.db.shutdown();
+        });
+        let _ = handle.await;
+        Ok(())
+    }
+
+    /// Closes the database in the background
+    ///
+    /// This is intended to be used by the [`RocksDb`] instance Drop impl to close the database.
+    /// If the database has already been removed from the map, then we'll assume that the shutdown
+    /// routine has already been executed by a previous call to [`RocksDb::close`] or by
+    /// [`RocksDbManager`]'s shutdown routine.
+    ///
+    /// if you need to wait for the shutdown, then use [`RocksDb::close`] instead.
+    pub(crate) fn background_close_db(&self, db: RocksAccess) {
+        let Some(_db) = self.dbs.write().remove(db.name()) else {
+            // database has already been closed via other means
             return;
         };
-        db.shutdown().await;
+        self.close_db_tasks.spawn_blocking(move || {
+            db.shutdown();
+        });
     }
 
     /// Ask all databases to shut down cleanly
     pub async fn shutdown(&'static self) {
-        let start = Instant::now();
-        let mut tasks = tokio::task::JoinSet::new();
+        self.close_db_tasks.close();
         for (name, db) in self.dbs.write().drain() {
-            tasks
-                .build_task()
-                .name("rocksdb-shutdown")
-                .spawn(async move {
-                    db.shutdown().await;
-                    name.clone()
-                })
-                .expect("to spawn RocksDb shutdown task");
+            let Some(db) = db.upgrade() else {
+                continue;
+            };
+
+            self.close_db_tasks.spawn_blocking(move || {
+                db.db.shutdown();
+                name.clone()
+            });
         }
         // wait for all tasks to complete
-        while let Some(res) = tasks.join_next().await {
-            match res {
-                Ok(name) => {
-                    debug!(
-                        db = %name,
-                        "Rocksdb database shutdown completed, {} remaining", tasks.len());
-                }
-                Err(e) => {
-                    warn!("Failed to shutdown db: {}", e);
-                }
-            }
-        }
-        info!("Rocksdb shutdown took {:?}", start.elapsed());
+        self.close_db_tasks.wait().await;
+        self.env.clone().join_all_threads();
+        info!("Rocksdb manager shutdown completed");
     }
 
     fn amend_db_options(&self, db_options: &mut rocksdb::Options, opts: &RocksDbOptions) {

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -25,6 +25,7 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
+use std::mem::ManuallyDrop;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -52,6 +53,7 @@ use self::background::StorageTask;
 use self::background::StorageTaskKind;
 use self::metric_definitions::*;
 
+pub type RawRocksDb = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
 type BoxedCfMatcher = Box<dyn CfNameMatch + Send + Sync>;
 type BoxedCfOptionUpdater = Box<dyn Fn(rocksdb::Options) -> rocksdb::Options + Send + Sync>;
 
@@ -86,41 +88,56 @@ pub enum IoMode {
 }
 
 #[derive(derive_more::Display, derive_more::Debug)]
-#[display("{}", name)]
-#[debug("RocksDb({} at {}", name, path.display())]
+#[display("{:?}", db)]
+#[debug("{:?}", db)]
 pub struct RocksDb {
     manager: &'static RocksDbManager,
-    pub name: DbName,
-    pub path: PathBuf,
-    pub db_options: rocksdb::Options,
-    cf_patterns: Box<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
-    flush_on_shutdown: Box<[BoxedCfMatcher]>,
-    db: Arc<dyn RocksAccess + Send + Sync + 'static>,
+    db: ManuallyDrop<RocksAccess>,
+}
+
+impl Drop for RocksDb {
+    fn drop(&mut self) {
+        // Safety: self.db is exclusives "taken" at drop time, so we know that it's
+        // still valid. We don't provide &mut access to db, and it's not a public field.
+        self.manager
+            .background_close_db(unsafe { ManuallyDrop::take(&mut self.db) })
+    }
 }
 
 static_assertions::assert_impl_all!(RocksDb: Send, Sync);
 
 impl RocksDb {
-    pub(crate) fn new<T>(manager: &'static RocksDbManager, spec: DbSpec, db: Arc<T>) -> Self
-    where
-        T: RocksAccess + Send + Sync + 'static,
-    {
-        Self {
+    pub fn name(&self) -> &DbName {
+        &self.db.spec().name
+    }
+
+    pub(crate) async fn open(
+        manager: &'static RocksDbManager,
+        spec: DbSpec,
+        default_cf_options: rocksdb::Options,
+    ) -> Result<Arc<Self>, RocksError> {
+        let task = StorageTask::default()
+            .kind(StorageTaskKind::OpenDb)
+            .op(move || {
+                let _x = RocksDbPerfGuard::new("open-db");
+                RocksAccess::open_db(spec, default_cf_options)
+            })
+            .build()
+            .unwrap();
+
+        let db = manager.async_spawn(task).await??;
+
+        Ok(Arc::new(Self {
             manager,
-            name: spec.name,
-            path: spec.path,
-            cf_patterns: spec.cf_patterns.into_boxed_slice(),
-            db,
-            db_options: spec.db_options,
-            flush_on_shutdown: spec.flush_on_shutdown.into_boxed_slice(),
-        }
+            db: ManuallyDrop::new(db),
+        }))
     }
 
     /// Returns the raw rocksdb handle, this should only be used for server operations that
     /// require direct access to rocksdb.
     ///
     /// todo: remove this once all access is migrated to this abstraction
-    pub fn inner(self: &Arc<Self>) -> &Arc<dyn RocksAccess + Send + Sync + 'static> {
+    pub fn inner(self: &Arc<Self>) -> &RocksAccess {
         &self.db
     }
 
@@ -128,7 +145,7 @@ impl RocksDb {
         self.db.cfs()
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn write_batch(
         self: &Arc<Self>,
         name: &'static str,
@@ -147,7 +164,7 @@ impl RocksDb {
         .await
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn write_batch_with_index(
         self: &Arc<Self>,
         name: &'static str,
@@ -175,9 +192,7 @@ impl RocksDb {
         write_op: OP,
     ) -> Result<(), RocksError>
     where
-        OP: Fn(&dyn RocksAccess, &rocksdb::WriteOptions) -> Result<(), rocksdb::Error>
-            + Send
-            + 'static,
+        OP: Fn(&RocksAccess, &rocksdb::WriteOptions) -> Result<(), rocksdb::Error> + Send + 'static,
     {
         //  depending on the IoMode, we decide how to do the write.
         match io_mode {
@@ -187,7 +202,7 @@ impl RocksDb {
                     "Blocking IO is allowed for write_batch, stall detection will not be used in this operation!"
                 );
                 write_options.set_no_slowdown(false);
-                write_op(self.db.as_ref(), &write_options)?;
+                write_op(&self.db, &write_options)?;
                 counter!(STORAGE_IO_OP,
                     DISPOSITION => DISPOSITION_MAYBE_BLOCKING,
                     OP_TYPE => StorageTaskKind::WriteBatch.as_static_str(),
@@ -206,7 +221,7 @@ impl RocksDb {
                     .kind(StorageTaskKind::WriteBatch)
                     .op(move || {
                         let _x = RocksDbPerfGuard::new(name);
-                        write_op(db.db.as_ref(), &write_options)
+                        write_op(&db.db, &write_options)
                     })
                     .build()
                     .unwrap();
@@ -223,7 +238,7 @@ impl RocksDb {
             IoMode::OnlyIfNonBlocking => {
                 let _x = RocksDbPerfGuard::new(name);
                 write_options.set_no_slowdown(true);
-                write_op(self.db.as_ref(), &write_options)?;
+                write_op(&self.db, &write_options)?;
                 counter!(STORAGE_IO_OP,
                     DISPOSITION => DISPOSITION_NON_BLOCKING,
                     OP_TYPE => StorageTaskKind::WriteBatch.as_static_str(),
@@ -240,7 +255,7 @@ impl RocksDb {
         write_options.set_no_slowdown(true);
 
         let perf_guard = RocksDbPerfGuard::new(name);
-        let result = write_op(self.db.as_ref(), &write_options);
+        let result = write_op(&self.db, &write_options);
         match result {
             Ok(_) => {
                 counter!(STORAGE_IO_OP,
@@ -271,7 +286,7 @@ impl RocksDb {
                     .kind(StorageTaskKind::WriteBatch)
                     .op(move || {
                         let _x = RocksDbPerfGuard::new(name);
-                        write_op(db.db.as_ref(), &write_options)
+                        write_op(&db.db, &write_options)
                     })
                     .build()
                     .unwrap();
@@ -290,7 +305,7 @@ impl RocksDb {
         }
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub fn run_background_iterator(
         self: Arc<Self>,
         cf: CfName,
@@ -346,7 +361,7 @@ impl RocksDb {
         manager.spawn(task)
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn flush_wal(self: Arc<Self>, sync: bool) -> Result<(), RocksError> {
         let manager = self.manager;
         let task = StorageTask::default()
@@ -361,7 +376,7 @@ impl RocksDb {
         manager.async_spawn(task).await?
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub fn run_bg_wal_sync(self: Arc<Self>) {
         let manager = self.manager;
         let task = StorageTask::default()
@@ -378,7 +393,7 @@ impl RocksDb {
         manager.spawn_unchecked(task);
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn flush_memtables(
         self: Arc<Self>,
         cfs: &[CfName],
@@ -395,7 +410,7 @@ impl RocksDb {
         manager.async_spawn(task).await?
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn flush_all(self: Arc<Self>) -> Result<(), RocksError> {
         let manager = self.manager;
         let task = StorageTask::default()
@@ -410,7 +425,7 @@ impl RocksDb {
         manager.async_spawn_unchecked(task).await?
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn compact_all(self: Arc<Self>) {
         let manager = self.manager;
         let task = StorageTask::default()
@@ -426,18 +441,18 @@ impl RocksDb {
     }
 
     pub fn get_histogram_data(&self, histogram: Histogram) -> HistogramData {
-        self.db_options.get_histogram_data(histogram)
+        self.db.db_options().get_histogram_data(histogram)
     }
 
     pub fn get_ticker_count(&self, ticker: Ticker) -> u64 {
-        self.db_options.get_ticker_count(ticker)
+        self.db.db_options().get_ticker_count(ticker)
     }
 
     pub fn get_statistics_str(&self) -> Option<String> {
-        self.db_options.get_statistics()
+        self.db.db_options().get_statistics()
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn open_cf(
         self: Arc<Self>,
         name: CfName,
@@ -445,17 +460,16 @@ impl RocksDb {
     ) -> Result<(), RocksError> {
         let manager = self.manager;
         let default_cf_options = self.manager.default_cf_options(opts);
-        // let cf_patterns = self.cf_patterns.clone();
         let task = StorageTask::default()
             .kind(StorageTaskKind::OpenColumnFamily)
-            .op(move || self.db.open_cf(name, default_cf_options, &self.cf_patterns))
+            .op(move || self.db.open_cf(name, default_cf_options))
             .build()
             .unwrap();
 
         manager.async_spawn(task).await?
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn import_cf(
         self: Arc<Self>,
         name: CfName,
@@ -469,8 +483,7 @@ impl RocksDb {
             .priority(Priority::Low)
             .op(move || {
                 let _x = RocksDbPerfGuard::new("import-column-family");
-                self.db
-                    .import_cf(name, default_cf_options, &self.cf_patterns, metadata)
+                self.db.import_cf(name, default_cf_options, metadata)
             })
             .build()
             .unwrap();
@@ -478,7 +491,7 @@ impl RocksDb {
         manager.async_spawn(task).await?
     }
 
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
     pub async fn export_cf(
         self: Arc<Self>,
         name: CfName,
@@ -519,67 +532,11 @@ impl RocksDb {
         manager.async_spawn(task).await?
     }
 
-    pub async fn close(self: &Arc<Self>) {
-        self.manager.close_db(&self.name).await
-    }
-
-    #[tracing::instrument(skip_all, fields(db = %self.name))]
-    async fn shutdown(self: Arc<Self>) {
-        let manager = self.manager;
-        let op = move || {
-            let _x = RocksDbPerfGuard::new("shutdown");
-            if let Err(e) = self.db.flush_wal(true) {
-                warn!(
-                    db = %self.name,
-                    "Failed to flush rocksdb WAL: {}",
-                    e
-                );
-            }
-
-            let cfs_to_flush = self
-                .cfs()
-                .into_iter()
-                .filter(|c| {
-                    self.flush_on_shutdown
-                        .iter()
-                        .any(|matcher| matcher.cf_matches(c))
-                })
-                .collect::<Vec<_>>();
-            if cfs_to_flush.is_empty() {
-                debug!(
-                    db = %self.name,
-                    "No column families to flush for db on shutdown"
-                );
-                return;
-            }
-            let start = Instant::now();
-
-            debug!(
-            db = %self.name,
-            "Number of column families to flush on shutdown: {}", cfs_to_flush.len());
-            if let Err(e) = self.db.flush_memtables(cfs_to_flush.as_slice(), true) {
-                warn!(
-                    db = %self.name,
-                    "Failed to flush memtables: {}",
-                    e
-                );
-            } else {
-                info!(
-                    db = %self.name,
-                    "{} column families flushed in {:?}",
-                    cfs_to_flush.len(),
-                    start.elapsed(),
-                );
-            }
-            self.db.cancel_all_background_work(true);
-        };
-        // intentionally ignore scheduling error
-        let task = StorageTask::default()
-            .kind(StorageTaskKind::Shutdown)
-            .op(op)
-            .build()
-            .unwrap();
-        let _ = manager.async_spawn_unchecked(task).await;
+    /// Performs a clean shutdown of the database and waits for completion.
+    ///
+    /// This fails if there other live references to the database.
+    pub async fn close(self: Arc<Self>) -> Result<(), Arc<Self>> {
+        self.manager.close_db(self).await
     }
 }
 

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -85,7 +85,7 @@ pub enum IoMode {
     Default,
 }
 
-#[derive(derive_more::Display, derive_more::Debug, Clone)]
+#[derive(derive_more::Display, derive_more::Debug)]
 #[display("{}", name)]
 #[debug("RocksDb({} at {}", name, path.display())]
 pub struct RocksDb {

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -46,7 +46,7 @@ pub trait RocksAccess {
         &self,
         name: CfName,
         default_cf_options: rocksdb::Options,
-        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        cf_patterns: &[(BoxedCfMatcher, BoxedCfOptionUpdater)],
     ) -> Result<(), RocksError>;
     /// Create a column family from a snapshot. The data files referenced by
     /// `metadata` will be moved into the RocksDB data directory.
@@ -54,7 +54,7 @@ pub trait RocksAccess {
         &self,
         name: CfName,
         default_cf_options: rocksdb::Options,
-        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        cf_patterns: &[(BoxedCfMatcher, BoxedCfOptionUpdater)],
         metadata: ExportImportFilesMetaData,
     ) -> Result<(), RocksError>;
     fn cfs(&self) -> Vec<CfName>;
@@ -151,9 +151,9 @@ impl RocksAccess for rocksdb::DB {
         &self,
         name: CfName,
         default_cf_options: rocksdb::Options,
-        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        cf_patterns: &[(BoxedCfMatcher, BoxedCfOptionUpdater)],
     ) -> Result<(), RocksError> {
-        let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
+        let options = prepare_cf_options(cf_patterns, default_cf_options, &name)?;
         Ok(Self::create_cf(self, name.as_str(), &options)?)
     }
 
@@ -161,10 +161,10 @@ impl RocksAccess for rocksdb::DB {
         &self,
         name: CfName,
         default_cf_options: rocksdb::Options,
-        cf_patterns: Arc<[(BoxedCfMatcher, BoxedCfOptionUpdater)]>,
+        cf_patterns: &[(BoxedCfMatcher, BoxedCfOptionUpdater)],
         metadata: ExportImportFilesMetaData,
     ) -> Result<(), RocksError> {
-        let options = prepare_cf_options(&cf_patterns, default_cf_options, &name)?;
+        let options = prepare_cf_options(cf_patterns, default_cf_options, &name)?;
 
         let mut import_opts = ImportColumnFamilyOptions::default();
         import_opts.set_move_files(true);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use clap::Parser;
 use codederror::CodedError;
 use rustls::crypto::aws_lc_rs;
+use tokio::time::Instant;
 use tracing::error;
 use tracing::{info, trace, warn};
 
@@ -253,6 +254,7 @@ fn main() {
                         shutdown = true;
                         let signal_reason = format!("received signal {signal_name}");
 
+                        let start = Instant::now();
                         let shutdown_with_timeout = tokio::time::timeout(
                             Configuration::pinned().common.shutdown_grace_period(),
                             async {
@@ -265,9 +267,10 @@ fn main() {
                         let shutdown_result = shutdown_with_timeout.await;
 
                         if shutdown_result.is_err() {
-                            warn!("Could not gracefully shut down Restate, terminating now.");
+                            warn!("Could not gracefully shutdown Restate, shutdown took {:?}",
+                                start.elapsed());
                         } else {
-                            info!("Restate has been gracefully shut down.");
+                            info!("Restate has been gracefully shutdown in {:?}", start.elapsed());
                         }
                     },
                     _ = config_update_watcher.changed() => {

--- a/server/src/signal.rs
+++ b/server/src/signal.rs
@@ -54,20 +54,19 @@ pub(super) async fn sighup_compact() {
         warn!("Received SIGHUP, flushing and compacting all databases");
         let manager = RocksDbManager::get();
         for db in manager.get_all_dbs() {
-            let db_name = db.name.clone();
             let _ = match db.clone().flush_all().await {
-                Ok(_) => writeln!(std::io::stderr(), "Database '{}' flushed", db_name),
+                Ok(_) => writeln!(std::io::stderr(), "Database '{}' flushed", db.name()),
                 Err(e) => writeln!(
                     std::io::stderr(),
                     "Database '{}' flush failed: {e}",
-                    db.name
+                    db.name()
                 ),
             };
+            let db_name = db.name().to_owned();
             db.compact_all().await;
             let _ = writeln!(
                 std::io::stderr(),
-                "Database '{}' compaction requested",
-                db_name
+                "Database '{db_name}' compaction requested",
             );
         }
     }

--- a/server/src/signal.rs
+++ b/server/src/signal.rs
@@ -54,8 +54,9 @@ pub(super) async fn sighup_compact() {
         warn!("Received SIGHUP, flushing and compacting all databases");
         let manager = RocksDbManager::get();
         for db in manager.get_all_dbs() {
-            let _ = match db.flush_all().await {
-                Ok(_) => writeln!(std::io::stderr(), "Database '{}' flushed", db.name),
+            let db_name = db.name.clone();
+            let _ = match db.clone().flush_all().await {
+                Ok(_) => writeln!(std::io::stderr(), "Database '{}' flushed", db_name),
                 Err(e) => writeln!(
                     std::io::stderr(),
                     "Database '{}' flush failed: {e}",
@@ -66,7 +67,7 @@ pub(super) async fn sighup_compact() {
             let _ = writeln!(
                 std::io::stderr(),
                 "Database '{}' compaction requested",
-                db.name
+                db_name
             );
         }
     }


### PR DESCRIPTION

- Remove unnecessary dynamic dispatch of rocksdb.
- Remove the extra pointer indirection to the raw database.
- Opening the database now happens in the background thread pool
- Background operations that need to own Arc<RocksDb> now take `self: Arc<RocksDb>` explicitly.
- The RocksDb now tracks the database lifetime. `Arc<RocksDb>` cleanly closes the
  database when the last reference is dropped. But explicit `RocksDb::close()` is
  available for "waiting" for clean close if needed.
- On shutdown, RocksDb manager now waits for rocksdb threads to finish (Probably not needed, but just in case)
- On shutdown, RocksDb manager waits for previously dropped rocksdb database to close, and and closes the rest of the open databases. This in combination with the auto-close on drop allows for some database flushes to happen concurrently while the system is still shutting down.
- Closing the database doesn't depend on the size of the background thread pool anymore. It uses tokio's blocking thread pool.
- Minor improvements to shutdown logging. This removes a couple of superfluous log messages.
- This opens up the possibility of integrating RocksDb manager with TaskCenter

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3539).
* #3542 (3 commits)
* #3540
* __->__ #3539 (3 commits)