### PR TITLE
Complete reconfiguration if all current workers are disabled

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -28,7 +28,7 @@ use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::partition_processor_manager::{
     ControlProcessor, ControlProcessors, ProcessorCommand,
 };
-use restate_types::nodes_config::{NodeConfig, NodesConfiguration};
+use restate_types::nodes_config::{NodeConfig, NodesConfiguration, WorkerState};
 use restate_types::partition_table::{PartitionReplication, PartitionTable};
 use restate_types::partitions::state::{PartitionReplicaSetStates, ReplicaSetState};
 use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter};
@@ -344,30 +344,35 @@ impl<T: TransportConnect> Scheduler<T> {
                 }
             };
 
-            // check whether we can transition from the current configuration to the next
-            // configuration, which is possible as soon as a single partition processor from the
-            // next configuration has become active
-            if let Some(next) = &occupied_entry.get().next {
-                if next.replica_set().iter().any(|node_id| {
-                    legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
-                }) {
-                    let partition_configuration_update = Self::complete_reconfiguration(
-                        self.metadata_writer.raw_metadata_store_client(),
+            let partition_state = occupied_entry.get();
+
+            if Self::should_complete_reconfiguration(
+                partition_id,
+                nodes_config,
+                partition_state,
+                legacy_cluster_state,
+            ) {
+                let partition_configuration_update = Self::complete_reconfiguration(
+                    self.metadata_writer.raw_metadata_store_client(),
+                    partition_id,
+                    occupied_entry.get().current.version(),
+                    occupied_entry
+                        .get()
+                        .next
+                        .as_ref()
+                        .expect("to be present")
+                        .version(),
+                )
+                .await?;
+                if occupied_entry.get_mut().update_configuration(
+                    partition_configuration_update.current,
+                    partition_configuration_update.next,
+                ) {
+                    Self::note_observed_membership_update(
                         partition_id,
-                        occupied_entry.get().current.version(),
-                        next.version(),
-                    )
-                    .await?;
-                    if occupied_entry.get_mut().update_configuration(
-                        partition_configuration_update.current,
-                        partition_configuration_update.next,
-                    ) {
-                        Self::note_observed_membership_update(
-                            partition_id,
-                            occupied_entry.get(),
-                            &self.replica_set_states,
-                        );
-                    }
+                        occupied_entry.get(),
+                        &self.replica_set_states,
+                    );
                 }
             }
 
@@ -376,6 +381,41 @@ impl<T: TransportConnect> Scheduler<T> {
         }
 
         Ok(())
+    }
+
+    /// Checks whether a pending reconfiguration should be completed. Conditions for doing this are:
+    ///
+    /// * All workers in the current configuration are disabled
+    /// * Any of the partition processors in the next configuration is active (== caught up)
+    ///
+    /// Note: We don't complete the reconfiguration if all current nodes are dead for some time,
+    /// because we might need any of them to send a partition store snapshot to the next nodes once
+    /// we support in-band snapshot exchanges and trimming based on durable lsns.
+    fn should_complete_reconfiguration(
+        partition_id: PartitionId,
+        nodes_config: &NodesConfiguration,
+        partition_state: &PartitionState,
+        legacy_cluster_state: &LegacyClusterState,
+    ) -> bool {
+        // we can only complete the reconfiguration if a next configuration has been set
+        let Some(next) = partition_state.next.as_ref() else {
+            return false;
+        };
+
+        let all_current_workers_disabled = partition_state
+            .current
+            .replica_set()
+            .iter()
+            .all(|node_id| nodes_config.get_worker_state(node_id) == WorkerState::Disabled);
+
+        // check whether we can transition from the current configuration to the next
+        // configuration, which is possible as soon as a single partition processor from the
+        // next configuration has become active
+        let any_next_pp_active = next.replica_set().iter().any(|node_id| {
+            legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+        });
+
+        all_current_workers_disabled || any_next_pp_active
     }
 
     fn partition_replication_to_replication_property(


### PR DESCRIPTION
This commit extends when to complete a partition reconfiguration by checking whether all current workers are disabled. If this is the case (e.g. when all current nodes have been removed from the cluster), we can complete the reconfiguration because we are sure that none of the current nodes will come back. Hence, there is no need to wait for any of the next pps to become active.

This additional condition helps us fix a problem where pps reading from a partially sealed loglet get stuck if there is nobody writing to the log and the system requires any of the catching up pps to become the leader (because all current workers are permanently removed from the cluster).

This fixes #3529.