### PR TITLE
[fix] Fixes lookup index management of replicated loglet

### DIFF
--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -104,7 +104,7 @@ impl LookupIndex {
             entry
                 .get_mut()
                 .references
-                .retain(|(l, s)| *l != log_id && *s != segment_index);
+                .retain(|(l, s)| (*l, *s) != (log_id, segment_index));
             if entry.get().references.is_empty() {
                 entry.remove();
             }


### PR DESCRIPTION

This fixes a couple of bugs in lookup index management in the log chain, the only impact in production code is that the index for a loglet might remain present after the loglet has been trimmed, the other issues do not impact current production code.


Test Plan:
Added unit tests to cover the lookup index management code.
