### PR TITLE
PartitionProcessor RPC handlers reorganization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8023,6 +8023,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "metrics",
+ "mockall",
  "opentelemetry",
  "parking_lot",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ metrics-exporter-prometheus = { version = "0.17", default-features = false, feat
 ] }
 metrics-util = { version = "0.19.0" }
 moka = "0.12.5"
-mockall = "0.13.1"
+mockall = { version = "0.13.1" }
 num-traits = { version = "0.2.17" }
 object_store = { version = "0.12.2", features = ["aws"] }
 opentelemetry = { version = "0.27" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ metrics-exporter-prometheus = { version = "0.17", default-features = false, feat
 ] }
 metrics-util = { version = "0.19.0" }
 moka = "0.12.5"
+mockall = "0.13.1"
 num-traits = { version = "0.2.17" }
 object_store = { version = "0.12.2", features = ["aws"] }
 opentelemetry = { version = "0.27" }

--- a/crates/core/src/network/incoming.rs
+++ b/crates/core/src/network/incoming.rs
@@ -693,3 +693,25 @@ impl<O: WatchResponse + WireEncode> Reciprocal<Updates<O>> {
         });
     }
 }
+
+#[cfg(feature = "test-util")]
+mod test_util {
+    use super::*;
+
+    impl<O: RpcResponse + WireEncode> Reciprocal<Oneshot<O>> {
+        pub fn mock() -> (Self, oneshot::Receiver<ReplyEnvelope>) {
+            let (tx, rx) = RpcReplyPort::new();
+            (
+                Reciprocal {
+                    protocol_version: Default::default(),
+                    reply_port: Oneshot {
+                        inner: tx,
+                        _phantom: PhantomData,
+                    },
+                    _phantom: PhantomData,
+                },
+                rx,
+            )
+        }
+    }
+}

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -55,7 +55,7 @@ restate-core = { workspace = true, features = ["test-util"] }
 restate-test-util = { workspace = true }
 restate-types = { workspace = true, features = ["test-util"] }
 
-mockall = "0.13.0"
+mockall = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }
 tracing-test = { workspace = true }

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -1465,6 +1465,30 @@ mod mocks {
             }
         }
     }
+
+    impl InvocationRequest {
+        pub fn mock() -> Self {
+            Self {
+                header: InvocationRequestHeader::mock(),
+                body: Default::default(),
+            }
+        }
+    }
+
+    impl InvocationRequestHeader {
+        pub fn mock() -> Self {
+            Self {
+                id: InvocationId::mock_random(),
+                target: InvocationTarget::mock_service(),
+                headers: vec![],
+                span_context: Default::default(),
+                idempotency_key: None,
+                execution_time: None,
+                completion_retention_duration: Default::default(),
+                journal_retention_duration: Default::default(),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -160,6 +160,12 @@ impl From<CancelInvocationResponse> for CancelInvocationRpcResponse {
     }
 }
 
+impl From<CancelInvocationRpcResponse> for PartitionProcessorRpcResponse {
+    fn from(value: CancelInvocationRpcResponse) -> Self {
+        Self::CancelInvocation(value)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KillInvocationRpcResponse {
     Ok,
@@ -187,6 +193,12 @@ impl From<KillInvocationResponse> for KillInvocationRpcResponse {
     }
 }
 
+impl From<KillInvocationRpcResponse> for PartitionProcessorRpcResponse {
+    fn from(value: KillInvocationRpcResponse) -> Self {
+        Self::KillInvocation(value)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PurgeInvocationRpcResponse {
     Ok,
@@ -211,6 +223,12 @@ impl From<PurgeInvocationResponse> for PurgeInvocationRpcResponse {
             PurgeInvocationResponse::NotFound => Self::NotFound,
             PurgeInvocationResponse::NotCompleted => Self::NotCompleted,
         }
+    }
+}
+
+impl From<PurgeInvocationRpcResponse> for PartitionProcessorRpcResponse {
+    fn from(value: PurgeInvocationRpcResponse) -> Self {
+        Self::PurgeInvocation(value)
     }
 }
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -85,6 +85,7 @@ restate-test-util = { workspace = true, features = ["prost"] }
 restate-types = { workspace = true, features = ["test-util"] }
 
 googletest = { workspace = true }
+mockall = { workspace = true }
 prost = { workspace = true }
 rocksdb = { workspace = true }
 rstest = { workspace = true }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -552,6 +552,7 @@ where
         Ok(())
     }
 }
+
 impl<I> LeadershipState<I> {
     pub async fn handle_rpc_proposal_command(
         &mut self,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -551,7 +551,8 @@ where
 
         Ok(())
     }
-
+}
+impl<I> LeadershipState<I> {
     pub async fn handle_rpc_proposal_command(
         &mut self,
         request_id: PartitionProcessorRpcRequestId,

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -43,15 +43,7 @@ use restate_storage_api::outbox_table::ReadOnlyOutboxTable;
 use restate_storage_api::{StorageError, Transaction};
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
 use restate_types::config::Configuration;
-use restate_types::identifiers::{LeaderEpoch, PartitionProcessorRpcRequestId, WithPartitionKey};
-use restate_types::invocation::client::{InvocationOutput, InvocationOutputResponse};
-use restate_types::invocation::{
-    AttachInvocationRequest, IngressInvocationResponseSink, InvocationMutationResponseSink,
-    InvocationQuery, InvocationTarget, InvocationTargetType, InvocationTermination,
-    NotifySignalRequest, PurgeInvocationRequest, ResponseResult, ServiceInvocation,
-    ServiceInvocationResponseSink, SubmitNotificationSink, TerminationFlavor, WorkflowHandlerType,
-};
-use restate_types::identifiers::{LeaderEpoch, PartitionKey};
+use restate_types::identifiers::LeaderEpoch;
 use restate_types::logs::MatchKeyQuery;
 use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
 use restate_types::net::RpcRequest;

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -11,6 +11,7 @@
 mod cleaner;
 pub mod invoker_storage_reader;
 mod leadership;
+mod rpc;
 pub mod shuffle;
 mod state_machine;
 pub mod types;
@@ -38,14 +39,7 @@ use restate_storage_api::deduplication_table::{
     ReadOnlyDeduplicationTable,
 };
 use restate_storage_api::fsm_table::{FsmTable, PartitionDurability, ReadOnlyFsmTable};
-use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
-};
 use restate_storage_api::outbox_table::ReadOnlyOutboxTable;
-use restate_storage_api::service_status_table::{
-    ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus,
-};
 use restate_storage_api::{StorageError, Transaction};
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
 use restate_types::config::Configuration;
@@ -57,19 +51,19 @@ use restate_types::invocation::{
     NotifySignalRequest, PurgeInvocationRequest, ResponseResult, ServiceInvocation,
     ServiceInvocationResponseSink, SubmitNotificationSink, TerminationFlavor, WorkflowHandlerType,
 };
+use restate_types::identifiers::{LeaderEpoch, PartitionKey};
 use restate_types::logs::MatchKeyQuery;
 use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
 use restate_types::net::RpcRequest;
 use restate_types::net::partition_processor::{
-    AppendInvocationReplyOn, GetInvocationOutputResponseMode, PartitionLeaderService,
-    PartitionProcessorRpcError, PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner,
+    PartitionLeaderService, PartitionProcessorRpcError, PartitionProcessorRpcRequest,
     PartitionProcessorRpcResponse,
 };
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::retries::{RetryPolicy, with_jitter};
 use restate_types::storage::StorageDecodeError;
 use restate_types::time::{MillisSinceEpoch, NanosSinceEpoch};
-use restate_types::{GenerationalNodeId, SemanticRestateVersion, invocation};
+use restate_types::{GenerationalNodeId, SemanticRestateVersion};
 use restate_wal_protocol::control::AnnounceLeader;
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
 
@@ -616,8 +610,6 @@ where
         Ok(())
     }
 
-    // --- RPC Handling
-
     async fn on_rpc(
         &mut self,
         response_tx: Reciprocal<
@@ -626,260 +618,12 @@ where
         body: PartitionProcessorRpcRequest,
         partition_store: &mut PartitionStore,
     ) {
-        let PartitionProcessorRpcRequest {
-            request_id, inner, ..
-        } = body;
-        match inner {
-            PartitionProcessorRpcRequestInner::AppendInvocation(
-                invocation_request,
-                AppendInvocationReplyOn::Appended,
-            ) => {
-                let service_invocation = ServiceInvocation::from_request(
-                    Arc::unwrap_or_clone(invocation_request),
-                    invocation::Source::ingress(request_id),
-                );
-
-                self.leadership_state
-                    .self_propose_and_respond_asynchronously(
-                        service_invocation.partition_key(),
-                        Command::Invoke(Box::new(service_invocation)),
-                        response_tx,
-                    )
-                    .await;
-            }
-            PartitionProcessorRpcRequestInner::AppendInvocation(
-                invocation_request,
-                AppendInvocationReplyOn::Submitted,
-            ) => {
-                let mut service_invocation = ServiceInvocation::from_request(
-                    Arc::unwrap_or_clone(invocation_request),
-                    invocation::Source::ingress(request_id),
-                );
-                service_invocation.submit_notification_sink =
-                    Some(SubmitNotificationSink::Ingress { request_id });
-
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        service_invocation.partition_key(),
-                        Command::Invoke(Box::new(service_invocation)),
-                    )
-                    .await
-            }
-            PartitionProcessorRpcRequestInner::AppendInvocation(
-                invocation_request,
-                AppendInvocationReplyOn::Output,
-            ) => {
-                let mut service_invocation = ServiceInvocation::from_request(
-                    Arc::unwrap_or_clone(invocation_request),
-                    invocation::Source::ingress(request_id),
-                );
-                service_invocation.response_sink =
-                    Some(ServiceInvocationResponseSink::Ingress { request_id });
-
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        service_invocation.partition_key(),
-                        Command::Invoke(Box::new(service_invocation)),
-                    )
-                    .await
-            }
-            PartitionProcessorRpcRequestInner::GetInvocationOutput(
-                invocation_query,
-                GetInvocationOutputResponseMode::BlockWhenNotReady,
-            ) => {
-                // Try to get invocation output now, if it's ready reply immediately with it
-                if let Ok(ready_result @ PartitionProcessorRpcResponse::Output(_)) = self
-                    .handle_rpc_get_invocation_output(
-                        request_id,
-                        invocation_query.clone(),
-                        partition_store,
-                    )
-                    .await
-                {
-                    response_tx.send(Ok(ready_result));
-                    return;
-                }
-
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        invocation_query.partition_key(),
-                        Command::AttachInvocation(AttachInvocationRequest {
-                            invocation_query,
-                            block_on_inflight: true,
-                            response_sink: ServiceInvocationResponseSink::Ingress { request_id },
-                        }),
-                    )
-                    .await
-            }
-            PartitionProcessorRpcRequestInner::GetInvocationOutput(
-                invocation_query,
-                GetInvocationOutputResponseMode::ReplyIfNotReady,
-            ) => {
-                response_tx.send(
-                    self.handle_rpc_get_invocation_output(
-                        request_id,
-                        invocation_query,
-                        partition_store,
-                    )
-                    .await
-                    .map_err(|err| PartitionProcessorRpcError::Internal(err.to_string())),
-                );
-            }
-            PartitionProcessorRpcRequestInner::AppendInvocationResponse(invocation_response) => {
-                self.leadership_state
-                    .self_propose_and_respond_asynchronously(
-                        invocation_response.partition_key(),
-                        Command::InvocationResponse(invocation_response),
-                        response_tx,
-                    )
-                    .await;
-            }
-            PartitionProcessorRpcRequestInner::AppendSignal(invocation_id, signal) => {
-                self.leadership_state
-                    .self_propose_and_respond_asynchronously(
-                        invocation_id.partition_key(),
-                        Command::NotifySignal(NotifySignalRequest {
-                            invocation_id,
-                            signal,
-                        }),
-                        response_tx,
-                    )
-                    .await;
-            }
-            PartitionProcessorRpcRequestInner::CancelInvocation { invocation_id } => {
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        invocation_id.partition_key(),
-                        Command::TerminateInvocation(InvocationTermination {
-                            invocation_id,
-                            flavor: TerminationFlavor::Cancel,
-                            response_sink: Some(InvocationMutationResponseSink::Ingress(
-                                IngressInvocationResponseSink { request_id },
-                            )),
-                        }),
-                    )
-                    .await
-            }
-            PartitionProcessorRpcRequestInner::KillInvocation { invocation_id } => {
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        invocation_id.partition_key(),
-                        Command::TerminateInvocation(InvocationTermination {
-                            invocation_id,
-                            flavor: TerminationFlavor::Kill,
-                            response_sink: Some(InvocationMutationResponseSink::Ingress(
-                                IngressInvocationResponseSink { request_id },
-                            )),
-                        }),
-                    )
-                    .await
-            }
-            PartitionProcessorRpcRequestInner::PurgeInvocation { invocation_id } => {
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        invocation_id.partition_key(),
-                        Command::PurgeInvocation(PurgeInvocationRequest {
-                            invocation_id,
-                            response_sink: Some(InvocationMutationResponseSink::Ingress(
-                                IngressInvocationResponseSink { request_id },
-                            )),
-                        }),
-                    )
-                    .await
-            }
-            PartitionProcessorRpcRequestInner::PurgeJournal { invocation_id } => {
-                self.leadership_state
-                    .handle_rpc_proposal_command(
-                        request_id,
-                        response_tx,
-                        invocation_id.partition_key(),
-                        Command::PurgeJournal(PurgeInvocationRequest {
-                            invocation_id,
-                            response_sink: Some(InvocationMutationResponseSink::Ingress(
-                                IngressInvocationResponseSink { request_id },
-                            )),
-                        }),
-                    )
-                    .await
-            }
-        };
-    }
-
-    async fn handle_rpc_get_invocation_output(
-        &self,
-        request_id: PartitionProcessorRpcRequestId,
-        invocation_query: InvocationQuery,
-        partition_store: &mut PartitionStore,
-    ) -> Result<PartitionProcessorRpcResponse, StorageError> {
-        // We can handle this immediately by querying the partition store, no need to go through proposals
-        let invocation_id = match invocation_query {
-            InvocationQuery::Invocation(iid) => iid,
-            ref q @ InvocationQuery::Workflow(ref sid) => {
-                // TODO We need this query for backward compatibility, remove when we remove the idempotency table
-                match partition_store.get_virtual_object_status(sid).await? {
-                    VirtualObjectStatus::Locked(iid) => iid,
-                    VirtualObjectStatus::Unlocked => {
-                        // Try the deterministic id
-                        q.to_invocation_id()
-                    }
-                }
-            }
-            ref q @ InvocationQuery::IdempotencyId(ref iid) => {
-                // TODO We need this query for backward compatibility, remove when we remove the idempotency table
-                match partition_store.get_idempotency_metadata(iid).await? {
-                    Some(idempotency_metadata) => idempotency_metadata.invocation_id,
-                    None => {
-                        // Try the deterministic id
-                        q.to_invocation_id()
-                    }
-                }
-            }
-        };
-
-        let invocation_status = partition_store
-            .get_invocation_status(&invocation_id)
-            .await?;
-
-        match invocation_status {
-            InvocationStatus::Free => Ok(PartitionProcessorRpcResponse::NotFound),
-            is if is.idempotency_key().is_none()
-                && is
-                    .invocation_target()
-                    .map(InvocationTarget::invocation_target_ty)
-                    != Some(InvocationTargetType::Workflow(
-                        WorkflowHandlerType::Workflow,
-                    )) =>
-            {
-                Ok(PartitionProcessorRpcResponse::NotSupported)
-            }
-            InvocationStatus::Completed(completed) => {
-                let completion_expiry_time = completed.completion_expiry_time();
-                Ok(PartitionProcessorRpcResponse::Output(InvocationOutput {
-                    request_id,
-                    response: match completed.response_result.clone() {
-                        ResponseResult::Success(res) => {
-                            InvocationOutputResponse::Success(completed.invocation_target, res)
-                        }
-                        ResponseResult::Failure(err) => InvocationOutputResponse::Failure(err),
-                    },
-                    invocation_id: Some(invocation_id),
-                    completion_expiry_time,
-                }))
-            }
-            _ => Ok(PartitionProcessorRpcResponse::NotReady),
-        }
+        let _ = rpc::RpcHandler::handle(
+            rpc::RpcContext::new(&mut self.leadership_state, partition_store),
+            body,
+            rpc::Replier::new(response_tx),
+        )
+        .await;
     }
 
     // --- Apply new commands/records

--- a/crates/worker/src/partition/rpc/append_invocation.rs
+++ b/crates/worker/src/partition/rpc/append_invocation.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::WithPartitionKey;
+use restate_types::invocation;
+use restate_types::invocation::{
+    ServiceInvocation, ServiceInvocationResponseSink, SubmitNotificationSink,
+};
+
+pub(super) struct Request {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
+    pub(super) invocation_request: Arc<InvocationRequest>,
+    pub(super) append_invocation_reply_on: AppendInvocationReplyOn,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = PartitionProcessorRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            request_id,
+            invocation_request,
+            append_invocation_reply_on,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        let mut service_invocation = ServiceInvocation::from_request(
+            Arc::unwrap_or_clone(invocation_request),
+            invocation::Source::ingress(request_id),
+        );
+
+        match append_invocation_reply_on {
+            AppendInvocationReplyOn::Appended => {
+                self.proposer
+                    .self_propose_and_respond_asynchronously(
+                        service_invocation.partition_key(),
+                        Command::Invoke(Box::new(service_invocation)),
+                        replier,
+                    )
+                    .await;
+                return Ok(());
+            }
+            AppendInvocationReplyOn::Submitted => {
+                service_invocation.submit_notification_sink =
+                    Some(SubmitNotificationSink::Ingress { request_id });
+            }
+            AppendInvocationReplyOn::Output => {
+                service_invocation.response_sink =
+                    Some(ServiceInvocationResponseSink::Ingress { request_id });
+            }
+        };
+
+        self.proposer
+            .handle_rpc_proposal_command(
+                service_invocation.partition_key(),
+                Command::Invoke(Box::new(service_invocation)),
+                request_id,
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/append_invocation.rs
+++ b/crates/worker/src/partition/rpc/append_invocation.rs
@@ -74,3 +74,127 @@ impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::partition::rpc::MockCommandProposer;
+    use futures::FutureExt;
+    use googletest::prelude::*;
+    use restate_test_util::let_assert;
+    use std::future::ready;
+    use test_log::test;
+
+    #[test(restate_core::test)]
+    async fn reply_on_appended() {
+        let mut proposer = MockCommandProposer::new();
+        proposer
+            .expect_self_propose_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
+            .return_once_st(|_, cmd, _| {
+                let_assert!(Command::Invoke(service_invocation) = cmd);
+                assert_that!(
+                    service_invocation,
+                    points_to(all!(
+                        field!(ServiceInvocation.response_sink, none()),
+                        field!(ServiceInvocation.submit_notification_sink, none()),
+                    ))
+                );
+                ready(()).boxed()
+            });
+        proposer
+            .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
+            .never();
+
+        let (tx, _rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &mut ()),
+            Request {
+                request_id: Default::default(),
+                invocation_request: Arc::new(InvocationRequest::mock()),
+                append_invocation_reply_on: AppendInvocationReplyOn::Appended,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[test(restate_core::test)]
+    async fn reply_on_submitted() {
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let mut proposer = MockCommandProposer::new();
+        proposer
+            .expect_self_propose_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
+            .never();
+        proposer
+            .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
+            .return_once_st(|_, cmd, req_id, _| {
+                let_assert!(Command::Invoke(service_invocation) = cmd);
+                assert_that!(
+                    service_invocation,
+                    points_to(all!(
+                        field!(ServiceInvocation.response_sink, none()),
+                        field!(
+                            ServiceInvocation.submit_notification_sink,
+                            some(eq(SubmitNotificationSink::Ingress { request_id: req_id }))
+                        ),
+                    ))
+                );
+                ready(()).boxed()
+            });
+
+        let (tx, _rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &mut ()),
+            Request {
+                request_id,
+                invocation_request: Arc::new(InvocationRequest::mock()),
+                append_invocation_reply_on: AppendInvocationReplyOn::Submitted,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[test(restate_core::test)]
+    async fn reply_on_output() {
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let mut proposer = MockCommandProposer::new();
+        proposer
+            .expect_self_propose_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
+            .never();
+        proposer
+            .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
+            .return_once_st(|_, cmd, req_id, _| {
+                let_assert!(Command::Invoke(service_invocation) = cmd);
+                assert_that!(
+                    service_invocation,
+                    points_to(all!(
+                        field!(
+                            ServiceInvocation.response_sink,
+                            some(eq(ServiceInvocationResponseSink::Ingress {
+                                request_id: req_id
+                            }))
+                        ),
+                        field!(ServiceInvocation.submit_notification_sink, none()),
+                    ))
+                );
+                ready(()).boxed()
+            });
+
+        let (tx, _rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &mut ()),
+            Request {
+                request_id,
+                invocation_request: Arc::new(InvocationRequest::mock()),
+                append_invocation_reply_on: AppendInvocationReplyOn::Output,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+    }
+}

--- a/crates/worker/src/partition/rpc/append_invocation_response.rs
+++ b/crates/worker/src/partition/rpc/append_invocation_response.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::WithPartitionKey;
+use restate_types::invocation::InvocationResponse;
+use restate_types::net::partition_processor::PartitionProcessorRpcResponse;
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) invocation_response: InvocationResponse,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = PartitionProcessorRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            invocation_response,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        self.proposer
+            .self_propose_and_respond_asynchronously(
+                invocation_response.partition_key(),
+                Command::InvocationResponse(invocation_response),
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/append_signal.rs
+++ b/crates/worker/src/partition/rpc/append_signal.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::invocation::NotifySignalRequest;
+use restate_types::journal_v2::Signal;
+use restate_types::net::partition_processor::PartitionProcessorRpcResponse;
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) invocation_id: InvocationId,
+    pub(super) signal: Signal,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = PartitionProcessorRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            invocation_id,
+            signal,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        self.proposer
+            .self_propose_and_respond_asynchronously(
+                invocation_id.partition_key(),
+                Command::NotifySignal(NotifySignalRequest {
+                    invocation_id,
+                    signal,
+                }),
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/cancel_invocation.rs
+++ b/crates/worker/src/partition/rpc/cancel_invocation.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::invocation::{
+    IngressInvocationResponseSink, InvocationMutationResponseSink, InvocationTermination,
+    TerminationFlavor,
+};
+use restate_types::net::partition_processor::CancelInvocationRpcResponse;
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
+    pub(super) invocation_id: InvocationId,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = CancelInvocationRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            request_id,
+            invocation_id,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        self.proposer
+            .handle_rpc_proposal_command(
+                invocation_id.partition_key(),
+                Command::TerminateInvocation(InvocationTermination {
+                    invocation_id,
+                    flavor: TerminationFlavor::Cancel,
+                    response_sink: Some(InvocationMutationResponseSink::Ingress(
+                        IngressInvocationResponseSink { request_id },
+                    )),
+                }),
+                request_id,
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/get_invocation_output.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_output.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_storage_api::StorageError;
+use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadOnlyInvocationStatusTable,
+};
+use restate_storage_api::service_status_table::{
+    ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus,
+};
+use restate_types::identifiers::WithPartitionKey;
+use restate_types::invocation;
+use restate_types::invocation::client::{InvocationOutput, InvocationOutputResponse};
+use restate_types::invocation::{
+    AttachInvocationRequest, InvocationQuery, InvocationTarget, InvocationTargetType,
+    ServiceInvocationResponseSink, WorkflowHandlerType,
+};
+use restate_types::net::partition_processor::{
+    GetInvocationOutputResponseMode, PartitionProcessorRpcError, PartitionProcessorRpcResponse,
+};
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
+    pub(super) invocation_query: InvocationQuery,
+    pub(super) response_mode: GetInvocationOutputResponseMode,
+}
+
+impl<'a, Proposer, Storage> RpcContext<'a, Proposer, Storage>
+where
+    Proposer: CommandProposer,
+    Storage:
+        ReadOnlyInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+{
+    async fn get_invocation_output(
+        &mut self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_query: InvocationQuery,
+    ) -> Result<PartitionProcessorRpcResponse, StorageError> {
+        // We can handle this immediately by querying the partition store, no need to go through proposals
+        let invocation_id = match invocation_query {
+            InvocationQuery::Invocation(iid) => iid,
+            ref q @ InvocationQuery::Workflow(ref sid) => {
+                // TODO We need this query for backward compatibility, remove when we remove the idempotency table
+                match self.storage.get_virtual_object_status(sid).await? {
+                    VirtualObjectStatus::Locked(iid) => iid,
+                    VirtualObjectStatus::Unlocked => {
+                        // Try the deterministic id
+                        q.to_invocation_id()
+                    }
+                }
+            }
+            ref q @ InvocationQuery::IdempotencyId(ref iid) => {
+                // TODO We need this query for backward compatibility, remove when we remove the idempotency table
+                match self.storage.get_idempotency_metadata(iid).await? {
+                    Some(idempotency_metadata) => idempotency_metadata.invocation_id,
+                    None => {
+                        // Try the deterministic id
+                        q.to_invocation_id()
+                    }
+                }
+            }
+        };
+
+        let invocation_status = self.storage.get_invocation_status(&invocation_id).await?;
+
+        match invocation_status {
+            InvocationStatus::Free => Ok(PartitionProcessorRpcResponse::NotFound),
+            is if is.idempotency_key().is_none()
+                && is
+                    .invocation_target()
+                    .map(InvocationTarget::invocation_target_ty)
+                    != Some(InvocationTargetType::Workflow(
+                        WorkflowHandlerType::Workflow,
+                    )) =>
+            {
+                Ok(PartitionProcessorRpcResponse::NotSupported)
+            }
+            InvocationStatus::Completed(completed) => {
+                let completion_expiry_time = completed.completion_expiry_time();
+                Ok(PartitionProcessorRpcResponse::Output(InvocationOutput {
+                    request_id,
+                    response: match completed.response_result.clone() {
+                        invocation::ResponseResult::Success(res) => {
+                            InvocationOutputResponse::Success(completed.invocation_target, res)
+                        }
+                        invocation::ResponseResult::Failure(err) => {
+                            InvocationOutputResponse::Failure(err)
+                        }
+                    },
+                    invocation_id: Some(invocation_id),
+                    completion_expiry_time,
+                }))
+            }
+            _ => Ok(PartitionProcessorRpcResponse::NotReady),
+        }
+    }
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+where
+    Storage:
+        ReadOnlyInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+{
+    type Output = PartitionProcessorRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        mut self,
+        Request {
+            request_id,
+            invocation_query,
+            response_mode,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        match response_mode {
+            GetInvocationOutputResponseMode::BlockWhenNotReady => {
+                // Try to get invocation output now, if it's ready reply immediately with it
+                if let Ok(ready_result @ PartitionProcessorRpcResponse::Output(_)) = self
+                    .get_invocation_output(request_id, invocation_query.clone())
+                    .await
+                {
+                    replier.send(ready_result);
+                    return Ok(());
+                }
+
+                self.proposer
+                    .handle_rpc_proposal_command(
+                        invocation_query.partition_key(),
+                        Command::AttachInvocation(AttachInvocationRequest {
+                            invocation_query,
+                            block_on_inflight: true,
+                            response_sink: ServiceInvocationResponseSink::Ingress { request_id },
+                        }),
+                        request_id,
+                        replier,
+                    )
+                    .await;
+            }
+            GetInvocationOutputResponseMode::ReplyIfNotReady => {
+                replier.send_result(
+                    self.get_invocation_output(request_id, invocation_query)
+                        .await
+                        .map_err(|err| PartitionProcessorRpcError::Internal(err.to_string())),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/kill_invocation.rs
+++ b/crates/worker/src/partition/rpc/kill_invocation.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::invocation::{
+    IngressInvocationResponseSink, InvocationMutationResponseSink, InvocationTermination,
+    TerminationFlavor,
+};
+use restate_types::net::partition_processor::KillInvocationRpcResponse;
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
+    pub(super) invocation_id: InvocationId,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = KillInvocationRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            request_id,
+            invocation_id,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        self.proposer
+            .handle_rpc_proposal_command(
+                invocation_id.partition_key(),
+                Command::TerminateInvocation(InvocationTermination {
+                    invocation_id,
+                    flavor: TerminationFlavor::Kill,
+                    response_sink: Some(InvocationMutationResponseSink::Ingress(
+                        IngressInvocationResponseSink { request_id },
+                    )),
+                }),
+                request_id,
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -32,21 +32,22 @@ use restate_wal_protocol::Command;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+#[cfg_attr(test, mockall::automock)]
 pub(super) trait CommandProposer {
-    async fn self_propose_and_respond_asynchronously<O>(
+    fn self_propose_and_respond_asynchronously<O: 'static>(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
         replier: Replier<O>,
-    );
+    ) -> impl Future<Output = ()>;
 
-    async fn handle_rpc_proposal_command<O>(
+    fn handle_rpc_proposal_command<O: 'static>(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
         request_id: PartitionProcessorRpcRequestId,
         replier: Replier<O>,
-    );
+    ) -> impl Future<Output = ()>;
 }
 
 impl<I> CommandProposer for LeadershipState<I> {

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -1,0 +1,244 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod append_invocation;
+mod append_invocation_response;
+mod append_signal;
+mod cancel_invocation;
+mod get_invocation_output;
+mod kill_invocation;
+mod purge_invocation;
+mod purge_journal;
+
+use crate::partition::leadership::LeadershipState;
+use restate_core::network::{Oneshot, Reciprocal};
+use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
+use restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable;
+use restate_storage_api::service_status_table::ReadOnlyVirtualObjectStatusTable;
+use restate_types::identifiers::{PartitionKey, PartitionProcessorRpcRequestId};
+use restate_types::invocation::InvocationRequest;
+use restate_types::net::partition_processor::{
+    AppendInvocationReplyOn, PartitionProcessorRpcError, PartitionProcessorRpcRequest,
+    PartitionProcessorRpcRequestInner, PartitionProcessorRpcResponse,
+};
+use restate_wal_protocol::Command;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+pub(super) trait CommandProposer {
+    async fn self_propose_and_respond_asynchronously<O>(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+        replier: Replier<O>,
+    );
+
+    async fn handle_rpc_proposal_command<O>(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+        request_id: PartitionProcessorRpcRequestId,
+        replier: Replier<O>,
+    );
+}
+
+impl<I> CommandProposer for LeadershipState<I> {
+    async fn self_propose_and_respond_asynchronously<O>(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+        replier: Replier<O>,
+    ) {
+        LeadershipState::self_propose_and_respond_asynchronously(
+            self,
+            partition_key,
+            cmd,
+            replier.0,
+        )
+        .await
+    }
+
+    async fn handle_rpc_proposal_command<O>(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+        request_id: PartitionProcessorRpcRequestId,
+        replier: Replier<O>,
+    ) {
+        LeadershipState::handle_rpc_proposal_command(
+            self,
+            request_id,
+            replier.0,
+            partition_key,
+            cmd,
+        )
+        .await
+    }
+}
+
+pub(super) struct RpcContext<'a, Proposer, Storage> {
+    proposer: &'a mut Proposer,
+    storage: &'a mut Storage,
+}
+
+impl<'a, Proposer, Storage> RpcContext<'a, Proposer, Storage> {
+    pub(super) fn new(proposer: &'a mut Proposer, storage: &'a mut Storage) -> Self {
+        Self { proposer, storage }
+    }
+}
+
+pub(super) struct Replier<O>(
+    Reciprocal<Oneshot<Result<PartitionProcessorRpcResponse, PartitionProcessorRpcError>>>,
+    PhantomData<O>,
+);
+
+impl<O: Into<PartitionProcessorRpcResponse>> Replier<O> {
+    pub fn new(
+        reciprocal: Reciprocal<
+            Oneshot<Result<PartitionProcessorRpcResponse, PartitionProcessorRpcError>>,
+        >,
+    ) -> Self {
+        Self(reciprocal, Default::default())
+    }
+
+    pub fn send(self, msg: O) {
+        self.0.send(Ok(msg.into()));
+    }
+
+    pub fn send_result(self, res: Result<O, PartitionProcessorRpcError>) {
+        self.0.send(res.map(|msg| msg.into()));
+    }
+
+    pub fn map<U: Into<PartitionProcessorRpcResponse>>(self) -> Replier<U> {
+        Replier::new(self.0)
+    }
+}
+
+pub(super) trait RpcHandler<Input> {
+    type Output: Into<PartitionProcessorRpcResponse>;
+    type Error;
+
+    fn handle(
+        self,
+        input: Input,
+        response_tx: Replier<Self::Output>,
+    ) -> impl Future<Output = Result<(), Self::Error>>;
+}
+
+impl<'a, Proposer, Storage> RpcHandler<PartitionProcessorRpcRequest>
+    for RpcContext<'a, Proposer, Storage>
+where
+    Proposer: CommandProposer,
+    Storage:
+        ReadOnlyInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+{
+    type Output = PartitionProcessorRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        PartitionProcessorRpcRequest {
+            request_id,
+            partition_id: _,
+            inner,
+        }: PartitionProcessorRpcRequest,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        match inner {
+            PartitionProcessorRpcRequestInner::AppendInvocation(
+                invocation_request,
+                append_invocation_reply_on,
+            ) => {
+                self.handle(
+                    append_invocation::Request {
+                        request_id,
+                        invocation_request,
+                        append_invocation_reply_on,
+                    },
+                    replier,
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::GetInvocationOutput(
+                invocation_query,
+                response_mode,
+            ) => {
+                self.handle(
+                    get_invocation_output::Request {
+                        request_id,
+                        invocation_query,
+                        response_mode,
+                    },
+                    replier,
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::AppendInvocationResponse(invocation_response) => {
+                self.handle(
+                    append_invocation_response::Request {
+                        invocation_response,
+                    },
+                    replier,
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::AppendSignal(invocation_id, signal) => {
+                self.handle(
+                    append_signal::Request {
+                        invocation_id,
+                        signal,
+                    },
+                    replier,
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::CancelInvocation { invocation_id } => {
+                self.handle(
+                    cancel_invocation::Request {
+                        request_id,
+                        invocation_id,
+                    },
+                    replier.map(),
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::KillInvocation { invocation_id } => {
+                self.handle(
+                    kill_invocation::Request {
+                        request_id,
+                        invocation_id,
+                    },
+                    replier.map(),
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::PurgeInvocation { invocation_id } => {
+                self.handle(
+                    purge_invocation::Request {
+                        request_id,
+                        invocation_id,
+                    },
+                    replier.map(),
+                )
+                .await
+            }
+            PartitionProcessorRpcRequestInner::PurgeJournal { invocation_id } => {
+                self.handle(
+                    purge_journal::Request {
+                        request_id,
+                        invocation_id,
+                    },
+                    replier.map(),
+                )
+                .await
+            }
+        }
+    }
+}

--- a/crates/worker/src/partition/rpc/purge_invocation.rs
+++ b/crates/worker/src/partition/rpc/purge_invocation.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::invocation::{
+    IngressInvocationResponseSink, InvocationMutationResponseSink, PurgeInvocationRequest,
+};
+use restate_types::net::partition_processor::PurgeInvocationRpcResponse;
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
+    pub(super) invocation_id: InvocationId,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = PurgeInvocationRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            request_id,
+            invocation_id,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        self.proposer
+            .handle_rpc_proposal_command(
+                invocation_id.partition_key(),
+                Command::PurgeInvocation(PurgeInvocationRequest {
+                    invocation_id,
+                    response_sink: Some(InvocationMutationResponseSink::Ingress(
+                        IngressInvocationResponseSink { request_id },
+                    )),
+                }),
+                request_id,
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}

--- a/crates/worker/src/partition/rpc/purge_journal.rs
+++ b/crates/worker/src/partition/rpc/purge_journal.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::invocation::{
+    IngressInvocationResponseSink, InvocationMutationResponseSink, PurgeInvocationRequest,
+};
+use restate_types::net::partition_processor::PurgeInvocationRpcResponse;
+use restate_wal_protocol::Command;
+
+pub(super) struct Request {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
+    pub(super) invocation_id: InvocationId,
+}
+
+impl<'a, Proposer: CommandProposer, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, Storage>
+{
+    type Output = PurgeInvocationRpcResponse;
+    type Error = ();
+
+    async fn handle(
+        self,
+        Request {
+            request_id,
+            invocation_id,
+        }: Request,
+        replier: Replier<Self::Output>,
+    ) -> Result<(), Self::Error> {
+        self.proposer
+            .handle_rpc_proposal_command(
+                invocation_id.partition_key(),
+                Command::PurgeJournal(PurgeInvocationRequest {
+                    invocation_id,
+                    response_sink: Some(InvocationMutationResponseSink::Ingress(
+                        IngressInvocationResponseSink { request_id },
+                    )),
+                }),
+                request_id,
+                replier,
+            )
+            .await;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR reorganizes the code of the PP RPC handlers in a more modular way, to enable unit testing those. No fundamental changes.

This is in preparation of the work for restart as new. 