### PR TITLE
Add MetadataServerOptions::auto_join to control whether node joins metadata cluster on start

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -28,7 +28,7 @@ use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::partition_processor_manager::{
     ControlProcessor, ControlProcessors, ProcessorCommand,
 };
-use restate_types::nodes_config::{NodeConfig, NodesConfiguration};
+use restate_types::nodes_config::{NodeConfig, NodesConfiguration, WorkerState};
 use restate_types::partition_table::{PartitionReplication, PartitionTable};
 use restate_types::partitions::state::{PartitionReplicaSetStates, ReplicaSetState};
 use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter};
@@ -344,30 +344,35 @@ impl<T: TransportConnect> Scheduler<T> {
                 }
             };
 
-            // check whether we can transition from the current configuration to the next
-            // configuration, which is possible as soon as a single partition processor from the
-            // next configuration has become active
-            if let Some(next) = &occupied_entry.get().next {
-                if next.replica_set().iter().any(|node_id| {
-                    legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
-                }) {
-                    let partition_configuration_update = Self::complete_reconfiguration(
-                        self.metadata_writer.raw_metadata_store_client(),
+            let partition_state = occupied_entry.get();
+
+            if Self::should_complete_reconfiguration(
+                partition_id,
+                nodes_config,
+                partition_state,
+                legacy_cluster_state,
+            ) {
+                let partition_configuration_update = Self::complete_reconfiguration(
+                    self.metadata_writer.raw_metadata_store_client(),
+                    partition_id,
+                    occupied_entry.get().current.version(),
+                    occupied_entry
+                        .get()
+                        .next
+                        .as_ref()
+                        .expect("to be present")
+                        .version(),
+                )
+                .await?;
+                if occupied_entry.get_mut().update_configuration(
+                    partition_configuration_update.current,
+                    partition_configuration_update.next,
+                ) {
+                    Self::note_observed_membership_update(
                         partition_id,
-                        occupied_entry.get().current.version(),
-                        next.version(),
-                    )
-                    .await?;
-                    if occupied_entry.get_mut().update_configuration(
-                        partition_configuration_update.current,
-                        partition_configuration_update.next,
-                    ) {
-                        Self::note_observed_membership_update(
-                            partition_id,
-                            occupied_entry.get(),
-                            &self.replica_set_states,
-                        );
-                    }
+                        occupied_entry.get(),
+                        &self.replica_set_states,
+                    );
                 }
             }
 
@@ -376,6 +381,41 @@ impl<T: TransportConnect> Scheduler<T> {
         }
 
         Ok(())
+    }
+
+    /// Checks whether a pending reconfiguration should be completed. Conditions for doing this are:
+    ///
+    /// * All workers in the current configuration are disabled
+    /// * Any of the partition processors in the next configuration is active (== caught up)
+    ///
+    /// Note: We don't complete the reconfiguration if all current nodes are dead for some time,
+    /// because we might need any of them to send a partition store snapshot to the next nodes once
+    /// we support in-band snapshot exchanges and trimming based on durable lsns.
+    fn should_complete_reconfiguration(
+        partition_id: PartitionId,
+        nodes_config: &NodesConfiguration,
+        partition_state: &PartitionState,
+        legacy_cluster_state: &LegacyClusterState,
+    ) -> bool {
+        // we can only complete the reconfiguration if a next configuration has been set
+        let Some(next) = partition_state.next.as_ref() else {
+            return false;
+        };
+
+        let all_current_workers_disabled = partition_state
+            .current
+            .replica_set()
+            .iter()
+            .all(|node_id| nodes_config.get_worker_state(node_id) == WorkerState::Disabled);
+
+        // check whether we can transition from the current configuration to the next
+        // configuration, which is possible as soon as a single partition processor from the
+        // next configuration has become active
+        let any_next_pp_active = next.replica_set().iter().any(|node_id| {
+            legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+        });
+
+        all_current_workers_disabled || any_next_pp_active
     }
 
     fn partition_replication_to_replication_property(

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -25,15 +25,13 @@ use restate_metadata_server_grpc::grpc::{
     StatusResponse,
 };
 use restate_metadata_store::serialize_value;
+use restate_types::PlainNodeId;
 use restate_types::config::Configuration;
 use restate_types::errors::ConversionError;
 use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
-use restate_types::nodes_config::{
-    MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
-};
+use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;
-use restate_types::{GenerationalNodeId, PlainNodeId};
 
 use crate::metric_definitions::{
     METADATA_SERVER_DELETE_DURATION, METADATA_SERVER_DELETE_TOTAL, METADATA_SERVER_GET_DURATION,
@@ -42,71 +40,10 @@ use crate::metric_definitions::{
     STATUS_COMPLETED, STATUS_FAILED,
 };
 use crate::{
-    InvalidConfiguration, MetadataCommand, MetadataCommandSender, MetadataServerSummary,
-    MetadataStoreRequest, ProvisionError, ProvisionRequest, ProvisionSender, RequestError,
-    RequestSender, StatusWatch,
+    MetadataCommand, MetadataCommandSender, MetadataServerSummary, MetadataStoreRequest,
+    ProvisionError, ProvisionRequest, ProvisionSender, RequestError, RequestSender, StatusWatch,
+    prepare_initial_nodes_configuration,
 };
-
-/// Ensures that the initial nodes configuration contains the current node and has the right
-/// [`MetadataServerState`] set.
-fn prepare_initial_nodes_configuration(
-    configuration: &Configuration,
-    nodes_configuration: &mut NodesConfiguration,
-) -> Result<PlainNodeId, InvalidConfiguration> {
-    let plain_node_id = if let Some(node_config) =
-        nodes_configuration.find_node_by_name(configuration.common.node_name())
-    {
-        if let Some(force_node_id) = configuration.common.force_node_id {
-            if force_node_id != node_config.current_generation.as_plain() {
-                return Err(InvalidConfiguration(format!(
-                    "nodes configuration has wrong plain node id; expected: {}, actual: {}",
-                    force_node_id,
-                    node_config.current_generation.as_plain()
-                )));
-            }
-        }
-
-        let restate_node_id = node_config.current_generation.as_plain();
-
-        let mut node_config = node_config.clone();
-        node_config.metadata_server_config.metadata_server_state = MetadataServerState::Member;
-
-        nodes_configuration.upsert_node(node_config);
-
-        restate_node_id
-    } else {
-        // give precedence to the force node id
-        let current_generation = configuration
-            .common
-            .force_node_id
-            .map(|node_id| node_id.with_generation(1))
-            .unwrap_or_else(|| {
-                nodes_configuration
-                    .max_plain_node_id()
-                    .map(|node_id| node_id.next().with_generation(1))
-                    .unwrap_or(GenerationalNodeId::INITIAL_NODE_ID)
-            });
-
-        let metadata_server_config = MetadataServerConfig {
-            metadata_server_state: MetadataServerState::Member,
-        };
-
-        let node_config = NodeConfig::builder()
-            .name(configuration.common.node_name().to_owned())
-            .current_generation(current_generation)
-            .location(configuration.common.location().clone())
-            .address(configuration.common.advertised_address.clone())
-            .roles(configuration.common.roles)
-            .metadata_server_config(metadata_server_config)
-            .build();
-
-        nodes_configuration.upsert_node(node_config);
-
-        current_generation.as_plain()
-    };
-
-    Ok(plain_node_id)
-}
 
 /// Grpc svc handler for the metadata server.
 #[derive(Debug)]

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -42,7 +42,7 @@ use crate::metric_definitions::{
 use crate::{
     MetadataCommand, MetadataCommandSender, MetadataServerSummary, MetadataStoreRequest,
     ProvisionError, ProvisionRequest, ProvisionSender, RequestError, RequestSender, StatusWatch,
-    prepare_initial_nodes_configuration,
+    nodes_configuration_for_metadata_cluster_seed,
 };
 
 /// Grpc svc handler for the metadata server.
@@ -278,9 +278,12 @@ impl MetadataServerSvc for MetadataServerHandler {
                 StorageCodec::decode(&mut request.nodes_configuration)
                     .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
-            // Make sure that the NodesConfiguration our node and has the right metadata server state set.
-            prepare_initial_nodes_configuration(&Configuration::pinned(), &mut nodes_configuration)
-                .map_err(|err| Status::invalid_argument(err.to_string()))?;
+            // Make sure that the NodesConfiguration contains our node and has the MetadataServerState::Member
+            nodes_configuration_for_metadata_cluster_seed(
+                &Configuration::pinned(),
+                &mut nodes_configuration,
+            )
+            .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
             let versioned_value = serialize_value(&nodes_configuration)
                 .map_err(|err| Status::invalid_argument(err.to_string()))?;

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -566,9 +566,9 @@ impl SnapshotSummary {
     }
 }
 
-/// Ensures that the initial nodes configuration contains the current node and has the right
-/// [`MetadataServerState`] set.
-fn prepare_initial_nodes_configuration(
+/// Ensures that the initial nodes configuration contains the current node and sets this node to be
+/// a [`MetadataServerState::Member`] because it is the seed node for the metadata store cluster.
+fn nodes_configuration_for_metadata_cluster_seed(
     configuration: &Configuration,
     nodes_configuration: &mut NodesConfiguration,
 ) -> Result<PlainNodeId, InvalidConfiguration> {
@@ -594,6 +594,8 @@ fn prepare_initial_nodes_configuration(
 
         restate_node_id
     } else {
+        // We have to add ourselves to the NodesConfiguration because we aren't part of it yet.
+
         // give precedence to the force node id
         let current_generation = configuration
             .common

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -1034,6 +1034,14 @@ impl Member {
 
         trace!("Handle join request from node '{}'", joining_member_id);
 
+        if self.is_member(joining_member_id) {
+            let _ = response_tx.send(Ok(self
+                .kv_storage
+                .last_seen_nodes_configuration()
+                .version()));
+            return;
+        }
+
         // sanity checks
 
         if !self.is_leader {
@@ -1045,14 +1053,6 @@ impl Member {
 
         if self.raw_node.raft.has_pending_conf() {
             let _ = response_tx.send(Err(JoinClusterError::PendingReconfiguration));
-            return;
-        }
-
-        if self.is_member(joining_member_id) {
-            let _ = response_tx.send(Ok(self
-                .kv_storage
-                .last_seen_nodes_configuration()
-                .version()));
             return;
         }
 

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -2026,8 +2026,8 @@ impl Standby {
                             my_member_id = Some(member_id);
                         }
 
-                        if join_cluster.is_terminated() && matches!(node_config.metadata_server_config.metadata_server_state, MetadataServerState::Member) {
-                            debug!("Node is part of the metadata store cluster. Trying to join the raft cluster.");
+                        if join_cluster.is_terminated() && matches!(node_config.metadata_server_config.metadata_server_state, MetadataServerState::Member | MetadataServerState::Provisioning) {
+                            debug!("Node's metadata server state: {}. Trying to join the raft cluster.", node_config.metadata_server_config.metadata_server_state);
 
                             // Persist the latest NodesConfiguration so that we know about the MetadataServerState at least
                             // as of now when restarting.

--- a/crates/metadata-server/src/raft/storage/rocksdb.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb.rs
@@ -331,6 +331,7 @@ impl RocksDbStorage {
             .map_err(Into::into)
     }
 
+    #[allow(dead_code)]
     pub async fn store_raft_server_state(
         &mut self,
         raft_server_state: &RaftServerState,
@@ -647,6 +648,19 @@ impl<'a> Transaction<'a> {
 
     pub fn delete_raft_server_state(&mut self) -> Result<(), Error> {
         self.delete_metadata_cf(RAFT_SERVER_STATE_KEY);
+        Ok(())
+    }
+
+    pub fn store_nodes_configuration(
+        &mut self,
+        nodes_configuration: &NodesConfiguration,
+    ) -> Result<(), Error> {
+        self.put_bytes_metadata_cf(
+            NODES_CONFIGURATION_KEY,
+            &RocksDbStorage::serialize_value(nodes_configuration)
+                .map_err(|err| Error::Encode(err.into()))?,
+        );
+
         Ok(())
     }
 

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -58,6 +58,12 @@ pub struct MetadataServerOptions {
 
     #[serde(flatten)]
     pub raft_options: RaftOptions,
+
+    /// Auto join the metadata cluster when being started
+    ///
+    /// Defines whether this node should auto join the metadata store cluster when being started
+    /// for the first time.
+    pub auto_join: bool,
 }
 
 impl MetadataServerOptions {
@@ -115,6 +121,7 @@ impl Default for MetadataServerOptions {
             rocksdb_memory_ratio: 0.01,
             rocksdb,
             raft_options: RaftOptions::default(),
+            auto_join: true,
         }
     }
 }


### PR DESCRIPTION
This commit adds MetadataServerOptions::auto_join which controls whether a node tries to auto join the metadata cluster when being started for the first time. Auto join is enabled by default.