### PR TITLE
[Bifrost][experimental] Add support for chain sealing marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7885,6 +7885,7 @@ dependencies = [
  "humantime",
  "indexmap 2.9.0",
  "itertools 0.14.0",
+ "jiff",
  "jsonptr 0.7.1",
  "metrics",
  "moka",

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -26,7 +26,7 @@ use tokio::time;
 use tokio::time::{Instant, Interval, MissedTickBehavior};
 use tracing::{debug, info, warn};
 
-use restate_bifrost::{Bifrost, SealedSegment};
+use restate_bifrost::{Bifrost, MaybeSealedSegment};
 use restate_core::cancellation_token;
 use restate_core::network::tonic_service_filter::{TonicServiceFilter, WaitForReady};
 use restate_core::network::{
@@ -43,7 +43,7 @@ use restate_types::identifiers::PartitionId;
 use restate_types::live::Live;
 use restate_types::logs::metadata::{
     LogletParams, Logs, LogsConfiguration, ProviderConfiguration, ProviderKind,
-    ReplicatedLogletConfig, SegmentIndex,
+    ReplicatedLogletConfig, SealMetadata, SegmentIndex,
 };
 use restate_types::logs::{LogId, LogletId, Lsn};
 use restate_types::net::node::NodeState;
@@ -194,7 +194,12 @@ enum ClusterControllerCommand {
         log_id: LogId,
         min_version: Version,
         extension: Option<ChainExtension>,
-        response_tx: oneshot::Sender<anyhow::Result<SealedSegment>>,
+        response_tx: oneshot::Sender<anyhow::Result<MaybeSealedSegment>>,
+    },
+    SealChain {
+        log_id: LogId,
+        segment_index: Option<SegmentIndex>,
+        response_tx: oneshot::Sender<anyhow::Result<Lsn>>,
     },
 }
 
@@ -290,12 +295,31 @@ impl ClusterControllerHandle {
         response_rx.await.map_err(|_| ShutdownError)
     }
 
+    pub async fn seal_chain(
+        &self,
+        log_id: LogId,
+        segment_index: Option<SegmentIndex>,
+    ) -> Result<anyhow::Result<Lsn>, ShutdownError> {
+        let (response_tx, response_rx) = oneshot::channel();
+
+        let _ = self
+            .tx
+            .send(ClusterControllerCommand::SealChain {
+                log_id,
+                segment_index,
+                response_tx,
+            })
+            .await;
+
+        response_rx.await.map_err(|_| ShutdownError)
+    }
+
     pub async fn seal_and_extend_chain(
         &self,
         log_id: LogId,
         min_version: Version,
         extension: Option<ChainExtension>,
-    ) -> Result<anyhow::Result<SealedSegment>, ShutdownError> {
+    ) -> Result<anyhow::Result<MaybeSealedSegment>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let _ = self
@@ -499,6 +523,27 @@ impl<T: TransportConnect> Service<T> {
                         Ok(())
                     });
             }
+            ClusterControllerCommand::SealChain {
+                log_id,
+                segment_index,
+                response_tx,
+            } => {
+                let bifrost = self.bifrost.clone();
+
+                // receiver will get error if response_tx is dropped
+                _ = TaskCenter::spawn(TaskKind::Disposable, "seal-chain", async move {
+                    let result = SealChainTask {
+                        log_id,
+                        segment_index,
+                        bifrost,
+                    }
+                    .run()
+                    .await;
+
+                    _ = response_tx.send(result);
+                    Ok(())
+                });
+            }
             ClusterControllerCommand::SealAndExtendChain {
                 log_id,
                 min_version,
@@ -672,6 +717,33 @@ where
     }
 }
 
+struct SealChainTask {
+    log_id: LogId,
+    segment_index: Option<SegmentIndex>,
+    bifrost: Bifrost,
+}
+
+impl SealChainTask {
+    async fn run(self) -> anyhow::Result<Lsn> {
+        let logs = Metadata::with_current(|m| m.logs_ref());
+        let actual_tail_segment = logs
+            .chain(&self.log_id)
+            .ok_or_else(|| anyhow::anyhow!("Unknown log id"))?
+            .tail()
+            .index();
+
+        let segment_index = self.segment_index.unwrap_or(actual_tail_segment);
+
+        let tail_lsn = self
+            .bifrost
+            .admin()
+            .seal(self.log_id, segment_index, SealMetadata::default())
+            .await?;
+
+        Ok(tail_lsn)
+    }
+}
+
 struct SealAndExtendTask {
     log_id: LogId,
     min_version: Version,
@@ -681,7 +753,7 @@ struct SealAndExtendTask {
 }
 
 impl SealAndExtendTask {
-    async fn run(self) -> anyhow::Result<SealedSegment> {
+    async fn run(self) -> anyhow::Result<MaybeSealedSegment> {
         let last_segment_index = self
             .extension
             .as_ref()
@@ -713,7 +785,7 @@ impl SealAndExtendTask {
             .tail();
 
         let next_loglet_id = LogletId::new(self.log_id, segment.index().next());
-        let previous_params = if matches!(segment.config.kind, ProviderKind::Replicated) {
+        let previous_params = if segment.config.kind == ProviderKind::Replicated {
             let replicated_loglet_params =
                 ReplicatedLogletParams::deserialize_from(segment.config.params.as_bytes())
                     .context("Invalid replicated loglet params")?;

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -126,7 +126,7 @@ impl Appender {
             let loglet = match self.loglet_cache.as_mut() {
                 None => self
                     .loglet_cache
-                    .insert(self.bifrost_inner.writeable_loglet(self.log_id).await?),
+                    .insert(self.bifrost_inner.tail_loglet(self.log_id).await?),
                 Some(wrapper) => wrapper,
             };
             match loglet.append_batch(batch.clone()).await {
@@ -255,7 +255,7 @@ impl Appender {
                 .into();
 
             let loglet = bifrost_inner
-                .writeable_loglet_from_metadata(log_metadata, log_id)
+                .tail_loglet_from_metadata(log_metadata, log_id)
                 .await?;
             // Do we think that the last tail loglet is different and unsealed?
             if loglet.tail_lsn.is_none() && loglet.segment_index() > current_segment {
@@ -325,7 +325,7 @@ impl Appender {
                 .into();
 
             let loglet = bifrost_inner
-                .writeable_loglet_from_metadata(log_metadata, log_id)
+                .tail_loglet_from_metadata(log_metadata, log_id)
                 .await?;
             let tone_escalated = start.elapsed() > auto_recovery_threshold;
             // Do we think that the last tail loglet is different and unsealed?

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -15,7 +15,9 @@ use tracing::{debug, instrument, warn};
 use restate_core::{Metadata, MetadataKind};
 use restate_types::Version;
 use restate_types::config::Configuration;
-use restate_types::logs::metadata::{Chain, LogletParams, Logs, ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::{
+    Chain, InternalKind, LogletParams, Logs, ProviderKind, SealMetadata, SegmentIndex,
+};
 use restate_types::logs::{LogId, Lsn, TailState};
 
 use crate::bifrost::BifrostInner;
@@ -31,9 +33,9 @@ pub struct BifrostAdmin<'a> {
 }
 
 #[derive(Debug)]
-pub struct SealedSegment {
+pub struct MaybeSealedSegment {
     pub segment_index: SegmentIndex,
-    pub provider: ProviderKind,
+    pub provider: InternalKind,
     pub params: LogletParams,
     pub tail: TailState,
 }
@@ -105,7 +107,7 @@ impl<'a> BifrostAdmin<'a> {
             .ok_or(Error::UnknownLogId(log_id))?;
 
         let sealed_segment = loop {
-            let sealed_segment = self.seal(log_id, segment_index).await?;
+            let sealed_segment = self.seal_inner(log_id, segment_index, None).await?;
             if sealed_segment.tail.is_sealed() {
                 break sealed_segment;
             }
@@ -144,7 +146,7 @@ impl<'a> BifrostAdmin<'a> {
         min_version: Version,
         provider: ProviderKind,
         params: LogletParams,
-    ) -> Result<SealedSegment> {
+    ) -> Result<MaybeSealedSegment> {
         self.inner.fail_if_shutting_down()?;
         let metadata = Metadata::current();
         let _ = metadata
@@ -156,7 +158,7 @@ impl<'a> BifrostAdmin<'a> {
             .ok_or(Error::UnknownLogId(log_id))?;
 
         let sealed_segment = loop {
-            let sealed_segment = self.seal(log_id, segment_index).await?;
+            let sealed_segment = self.seal_inner(log_id, segment_index, None).await?;
             if sealed_segment.tail.is_sealed() {
                 break sealed_segment;
             }
@@ -176,14 +178,18 @@ impl<'a> BifrostAdmin<'a> {
     }
 
     pub async fn writeable_loglet(&self, log_id: LogId) -> Result<LogletWrapper> {
-        self.inner.writeable_loglet(log_id).await
+        self.inner.tail_loglet(log_id).await
     }
 
-    #[instrument(level = "debug", skip(self))]
-    pub async fn seal(&self, log_id: LogId, segment_index: SegmentIndex) -> Result<SealedSegment> {
+    async fn seal_inner(
+        &self,
+        log_id: LogId,
+        segment_index: SegmentIndex,
+        seal_metadata: Option<SealMetadata>,
+    ) -> Result<MaybeSealedSegment> {
         self.inner.fail_if_shutting_down()?;
         // first find the tail segment for this log.
-        let loglet = self.inner.writeable_loglet(log_id).await?;
+        let loglet = self.inner.tail_loglet(log_id).await?;
 
         if segment_index != loglet.segment_index() {
             // Not the same segment. Bail!
@@ -192,6 +198,16 @@ impl<'a> BifrostAdmin<'a> {
                 found: loglet.segment_index(),
             }
             .into());
+        }
+
+        // This loglet has already been sealed.
+        if let Some(tail_lsn) = loglet.tail_lsn {
+            return Ok(MaybeSealedSegment {
+                segment_index: loglet.segment_index(),
+                provider: loglet.config.kind,
+                params: loglet.config.params,
+                tail: TailState::Sealed(tail_lsn),
+            });
         }
 
         if let Err(err) = loglet.seal().await {
@@ -208,14 +224,49 @@ impl<'a> BifrostAdmin<'a> {
                 }
             }
         }
-        let tail = loglet.find_tail(FindTailOptions::default()).await?;
 
-        Ok(SealedSegment {
+        let tail = loglet.find_tail(FindTailOptions::ConsistentRead).await?;
+
+        if let Some(seal_metadata) = seal_metadata
+            && tail.is_sealed()
+            && Configuration::pinned().bifrost.experimental_chain_sealing
+        {
+            let tail_lsn = self
+                .inner
+                .seal_log_chain(log_id, segment_index, tail.offset(), seal_metadata)
+                .await?;
+
+            return Ok(MaybeSealedSegment {
+                segment_index: loglet.segment_index(),
+                provider: loglet.config.kind,
+                params: loglet.config.params,
+                tail: TailState::Sealed(tail_lsn),
+            });
+        }
+
+        Ok(MaybeSealedSegment {
             segment_index: loglet.segment_index(),
             provider: loglet.config.kind,
             params: loglet.config.params,
             tail,
         })
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub async fn seal(
+        &self,
+        log_id: LogId,
+        segment_index: SegmentIndex,
+        metadata: SealMetadata,
+    ) -> Result<Lsn> {
+        let maybe_sealed = self
+            .seal_inner(log_id, segment_index, Some(metadata))
+            .await?;
+        if let TailState::Sealed(lsn) = maybe_sealed.tail {
+            Ok(lsn)
+        } else {
+            Err(AdminError::ChainSealIncomplete.into())
+        }
     }
 
     /// Adds a segment to the end of the chain

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
     AdminError(#[from] AdminError),
     #[error(transparent)]
     MetadataStoreError(#[from] Arc<ReadWriteError>),
+    #[error("{0}")]
+    Other(String),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -57,6 +59,8 @@ pub enum EnqueueError<T> {
 pub enum AdminError {
     #[error("log {0} is permanently sealed")]
     ChainPermanentlySealed(LogId),
+    #[error("could not seal the loglet or the chain")]
+    ChainSealIncomplete,
     #[error("log {0} already exists")]
     LogAlreadyExists(LogId),
     #[error("segment conflicts with existing segment with base_lsn={0}")]

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -19,6 +19,7 @@ mod loglet_wrapper;
 pub mod providers;
 mod read_stream;
 mod record;
+mod sealed_loglet;
 mod service;
 mod types;
 mod watchdog;
@@ -26,18 +27,20 @@ mod watchdog;
 pub use appender::Appender;
 pub use background_appender::{AppenderHandle, BackgroundAppender, CommitToken, LogSender};
 pub use bifrost::{Bifrost, ErrorRecoveryStrategy};
-pub use bifrost_admin::{BifrostAdmin, SealedSegment};
+pub use bifrost_admin::{BifrostAdmin, MaybeSealedSegment};
 pub use error::{Error, Result};
 pub use read_stream::LogReadStream;
 pub use record::{InputRecord, LogEntry};
+pub use service::BifrostService;
+pub use types::*;
+
+use std::sync::Arc;
+
 use restate_core::{Metadata, ShutdownError};
 use restate_types::Version;
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::logs::{LogId, Lsn};
 use restate_types::partition_table::{FindPartition, PartitionTableError};
-pub use service::BifrostService;
-use std::sync::Arc;
-pub use types::*;
 
 pub const SMALL_BATCH_THRESHOLD_COUNT: usize = 4;
 

--- a/crates/bifrost/src/loglet.rs
+++ b/crates/bifrost/src/loglet.rs
@@ -28,8 +28,7 @@ use futures::stream::BoxStream;
 use futures::{FutureExt, Stream};
 use tokio::sync::oneshot;
 
-use restate_types::logs::metadata::ProviderKind;
-use restate_types::logs::{KeyFilter, LogletId, LogletOffset, Record, TailState};
+use restate_types::logs::{KeyFilter, LogletOffset, Record, TailState};
 
 use crate::LogEntry;
 use crate::Result;
@@ -70,6 +69,9 @@ use crate::Result;
 
 #[async_trait]
 pub trait Loglet: Send + Sync {
+    /// A string describing this instance of the loglet, used for debugging purposes.
+    fn debug_str(&self) -> Cow<'static, str>;
+
     /// Create a read stream that streams record from a single loglet instance.
     ///
     /// `to`: The offset of the last record to be read (inclusive). If `None`, the
@@ -80,12 +82,6 @@ pub trait Loglet: Send + Sync {
         from: LogletOffset,
         to: Option<LogletOffset>,
     ) -> Result<SendableLogletReadStream, OperationError>;
-
-    /// A string representation of the id of this loglet
-    fn id(&self) -> LogletId;
-
-    /// What is the provider of this loglet
-    fn provider(&self) -> ProviderKind;
 
     /// Create a stream watching the state of tail for this loglet
     ///

--- a/crates/bifrost/src/loglet_wrapper.rs
+++ b/crates/bifrost/src/loglet_wrapper.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::task::Poll;
 
 use std::pin::Pin;
@@ -48,7 +49,7 @@ pub struct LogletWrapper {
     pub(crate) tail_lsn: Option<Lsn>,
     #[debug(skip)]
     pub(crate) config: LogletConfig,
-    #[debug("{}/{}", loglet.provider(), loglet.id())]
+    #[debug("{}", loglet.debug_str())]
     loglet: Arc<dyn Loglet>,
 }
 
@@ -69,14 +70,12 @@ impl LogletWrapper {
         }
     }
 
-    /// Panics if `tail_lsn` is lower than the loglet's `base_lsn`
-    pub fn set_tail_lsn(&mut self, tail_lsn: Lsn) {
-        debug_assert!(tail_lsn >= self.base_lsn);
-        self.tail_lsn = Some(tail_lsn)
-    }
-
     pub fn segment_index(&self) -> SegmentIndex {
         self.segment_index
+    }
+
+    pub fn debug_str(&self) -> Cow<'static, str> {
+        self.loglet.debug_str()
     }
 
     pub async fn create_read_stream(
@@ -263,7 +262,7 @@ impl LogletReadStreamWrapper {
     }
 
     pub fn set_tail_lsn(&mut self, tail_lsn: Lsn) {
-        self.loglet.set_tail_lsn(tail_lsn)
+        self.loglet.tail_lsn = Some(tail_lsn)
     }
 
     #[inline(always)]

--- a/crates/bifrost/src/providers/local_loglet/mod.rs
+++ b/crates/bifrost/src/providers/local_loglet/mod.rs
@@ -19,6 +19,7 @@ mod record_format;
 
 pub use self::provider::Factory;
 
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -30,7 +31,6 @@ use tracing::{debug, warn};
 
 use restate_core::ShutdownError;
 use restate_types::logs::TailOffsetWatch;
-use restate_types::logs::metadata::ProviderKind;
 use restate_types::logs::{KeyFilter, LogletId, LogletOffset, Record, SequenceNumber, TailState};
 
 use self::log_store::LogStoreError;
@@ -124,12 +124,8 @@ impl LocalLoglet {
 
 #[async_trait]
 impl Loglet for LocalLoglet {
-    fn id(&self) -> LogletId {
-        LogletId::from(self.loglet_id)
-    }
-
-    fn provider(&self) -> ProviderKind {
-        ProviderKind::Local
+    fn debug_str(&self) -> Cow<'static, str> {
+        Cow::from(format!("local/{}", LogletId::from(self.loglet_id)))
     }
 
     async fn create_read_stream(

--- a/crates/bifrost/src/providers/memory_loglet.rs
+++ b/crates/bifrost/src/providers/memory_loglet.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, hash_map};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -327,13 +328,10 @@ impl Stream for MemoryReadStream {
 
 #[async_trait]
 impl Loglet for MemoryLoglet {
-    fn id(&self) -> LogletId {
-        self.loglet_id
+    fn debug_str(&self) -> Cow<'static, str> {
+        Cow::from(format!("in-memory/{}", self.loglet_id))
     }
 
-    fn provider(&self) -> ProviderKind {
-        ProviderKind::InMemory
-    }
     async fn create_read_stream(
         self: Arc<Self>,
         filter: KeyFilter,

--- a/crates/bifrost/src/providers/replicated_loglet/loglet.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/loglet.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -18,10 +19,9 @@ use tracing::{debug, info, instrument, trace};
 
 use restate_core::my_node_id;
 use restate_core::network::{Networking, TransportConnect};
-use restate_types::logs::metadata::{ProviderKind, SegmentIndex};
+use restate_types::logs::metadata::SegmentIndex;
 use restate_types::logs::{
-    KeyFilter, LogId, LogletId, LogletOffset, Record, RecordCache, SequenceNumber, TailOffsetWatch,
-    TailState,
+    KeyFilter, LogId, LogletOffset, Record, RecordCache, SequenceNumber, TailOffsetWatch, TailState,
 };
 use restate_types::replicated_loglet::ReplicatedLogletParams;
 
@@ -269,12 +269,8 @@ impl<T: TransportConnect> ReplicatedLoglet<T> {
 
 #[async_trait]
 impl<T: TransportConnect> Loglet for ReplicatedLoglet<T> {
-    fn id(&self) -> LogletId {
-        self.my_params.loglet_id
-    }
-
-    fn provider(&self) -> ProviderKind {
-        ProviderKind::Replicated
+    fn debug_str(&self) -> Cow<'static, str> {
+        Cow::from(format!("replicated/{}", self.my_params.loglet_id))
     }
 
     async fn create_read_stream(

--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -18,6 +18,7 @@ use restate_core::network::{
 use restate_core::{Metadata, MetadataKind, TaskCenter, TaskKind};
 use restate_types::Version;
 use restate_types::errors::MaybeRetryableError;
+use restate_types::logs::metadata::ProviderKind;
 use restate_types::logs::{LogletOffset, SequenceNumber, TailOffsetWatch};
 use restate_types::net::RpcRequest;
 use restate_types::net::replicated_loglet::{
@@ -233,10 +234,10 @@ fn create_loglet<T: TransportConnect>(
         .ok_or(SequencerStatus::UnknownLogId)?;
 
     let segment = chain
-        .iter()
-        .rev()
-        .find(|segment| segment.index() == header.segment_index)
+        .find_segment_by_index(header.segment_index, ProviderKind::Replicated)
         .ok_or(SequencerStatus::UnknownSegmentIndex)?;
+
+    debug_assert_eq!(segment.config.kind, ProviderKind::Replicated);
 
     provider
         .get_or_create_loglet(header.log_id, header.segment_index, &segment.config.params)

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -315,18 +315,18 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
 
         // use the last loglet if it was replicated as a source for preferred nodes to reduce data
         // scatter for this log.
-        let mut preferred_nodes = match chain {
-            Some(chain) if chain.tail().config.kind == ProviderKind::Replicated => {
-                let tail = chain.tail();
-                // Json serde
-                let params =
-                    ReplicatedLogletParams::deserialize_from(tail.config.params.as_bytes())
-                        .map_err(|e| {
-                            ReplicatedLogletError::LogletParamsParsingError(log_id, tail.index(), e)
-                        })?;
-                params.nodeset
-            }
-            _ => NodeSet::new(),
+        let mut preferred_nodes = if let Some(chain) = chain
+            && let Some(tail) = chain.non_special_tail()
+            && tail.config.kind == ProviderKind::Replicated
+        {
+            // Json serde
+            let params = ReplicatedLogletParams::deserialize_from(tail.config.params.as_bytes())
+                .map_err(|e| {
+                    ReplicatedLogletError::LogletParamsParsingError(log_id, tail.index(), e)
+                })?;
+            params.nodeset
+        } else {
+            NodeSet::new()
         };
 
         let new_segment_index = chain

--- a/crates/bifrost/src/sealed_loglet.rs
+++ b/crates/bifrost/src/sealed_loglet.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::borrow::Cow;
+use std::sync::{Arc, LazyLock};
+use std::task::Poll;
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream};
+use futures::{Stream, StreamExt};
+
+use restate_types::logs::{KeyFilter, LogletOffset, Record, SequenceNumber, TailState};
+
+use crate::LogEntry;
+use crate::Result;
+use crate::loglet::{
+    FindTailOptions, Loglet, LogletCommit, LogletReadStream, OperationError,
+    SendableLogletReadStream,
+};
+
+static SEALED_LOGLET: LazyLock<Arc<SealedLoglet>> = LazyLock::new(|| Arc::new(SealedLoglet));
+
+#[derive(derive_more::Debug)]
+pub struct SealedLoglet;
+
+impl SealedLoglet {
+    pub fn get() -> Arc<dyn Loglet> {
+        SEALED_LOGLET.clone() as Arc<dyn Loglet>
+    }
+}
+
+struct SealedLogletReadStream;
+
+impl LogletReadStream for SealedLogletReadStream {
+    /// Current read pointer. This points to the next offset to be read.
+    fn read_pointer(&self) -> LogletOffset {
+        LogletOffset::OLDEST
+    }
+    /// Returns true if the stream is terminated.
+    fn is_terminated(&self) -> bool {
+        false
+    }
+}
+
+impl Stream for SealedLogletReadStream {
+    type Item = Result<LogEntry<LogletOffset>, OperationError>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+}
+
+#[async_trait]
+impl Loglet for SealedLoglet {
+    fn debug_str(&self) -> Cow<'static, str> {
+        Cow::from("sealed")
+    }
+
+    async fn create_read_stream(
+        self: Arc<Self>,
+        _filter: KeyFilter,
+        _from: LogletOffset,
+        _to: Option<LogletOffset>,
+    ) -> Result<SendableLogletReadStream, OperationError> {
+        Ok(Box::pin(SealedLogletReadStream))
+    }
+
+    fn watch_tail(&self) -> BoxStream<'static, TailState<LogletOffset>> {
+        Box::pin(
+            stream::once(async { TailState::Open(LogletOffset::OLDEST) })
+                // The stream must continue to be pending. If the stream is terminated
+                // bifrost will consider the system to be shutting down.
+                .chain(stream::pending()),
+        )
+    }
+
+    async fn enqueue_batch(
+        &self,
+        _payloads: Arc<[Record]>,
+    ) -> Result<LogletCommit, OperationError> {
+        Ok(LogletCommit::reconfiguration_needed(
+            "a sealed loglet cannot be appended to",
+        ))
+    }
+
+    async fn find_tail(
+        &self,
+        _: FindTailOptions,
+    ) -> Result<TailState<LogletOffset>, OperationError> {
+        // Important: Returns `Sealed` because we want to allow seal() and reconfiguration
+        // to complete without special handling.
+        //
+        // On the other hand, the read stream will observe that the tail is Open because we report
+        // that in the `watch_tail()` stream. The reader will hop off this stream once the log
+        // chain is updated and a new segment replaces this one (if any).
+        //
+        // The read stream is not expected to seal the chain until it observes a "partial seal". A
+        // partial seal happens when the loglet is reporting sealed but the chain is still open.
+        // For that reason, this (sealed) loglet always returns TailState::Open to read streams.
+        //
+        // The benefit is that the read stream will move to AwaitingReconfiguration only when real
+        // loglets start reporting that they are sealing. That state can then have a timeout
+        // to trigger a seal() operation if the chain was not sealed in a timely manner.
+        Ok(TailState::Sealed(LogletOffset::OLDEST))
+    }
+
+    /// Find the head (oldest) record in the loglet.
+    async fn get_trim_point(&self) -> Result<Option<LogletOffset>, OperationError> {
+        Ok(None)
+    }
+
+    async fn trim(&self, _new_trim_point: LogletOffset) -> Result<(), OperationError> {
+        Ok(())
+    }
+
+    async fn seal(&self) -> Result<(), OperationError> {
+        Ok(())
+    }
+}

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -30,6 +30,8 @@ service ClusterCtrlSvc {
   rpc SealAndExtendChain(SealAndExtendChainRequest)
       returns (SealAndExtendChainResponse);
 
+  rpc SealChain(SealChainRequest) returns (SealChainResponse);
+
   rpc FindTail(FindTailRequest) returns (FindTailResponse);
 
   rpc GetClusterConfiguration(GetClusterConfigurationRequest)
@@ -147,6 +149,20 @@ message SealedSegment {
 message SealAndExtendChainResponse {
   uint32 new_segment_index = 1;
   SealedSegment sealed_segment = 2;
+}
+
+message SealChainRequest {
+  uint32 log_id = 1;
+  // segment_index will be automatically selected (to the index of last segment)
+  // if not set.
+  optional uint32 segment_index = 2;
+  // todo: allow user to pass human context
+  // todo: option for permanently sealing the chain when this is fully supported
+}
+
+message SealChainResponse {
+  // tail offset lsn
+  uint64 tail_offset = 1;
 }
 
 message FindTailRequest { uint32 log_id = 1; }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -51,6 +51,7 @@ http = { workspace = true }
 humantime = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
+jiff = { workspace = true }
 metrics = { workspace = true }
 moka = { workspace = true, features = ["sync", "logging"] }
 notify = { version = "8.0.0" }

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -93,6 +93,12 @@ pub struct BifrostOptions {
     /// of replicas, or for other reasons.
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub disable_auto_improvement: bool,
+
+    // Should be enabled by default in v1.5 or v1.6 depending on whether we'll
+    // allow rolling back to a release prior to <v1.4.3 or not.
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub experimental_chain_sealing: bool,
 }
 
 impl BifrostOptions {
@@ -129,6 +135,7 @@ impl Default for BifrostOptions {
             seal_retry_interval: Duration::from_secs(2).into(),
             record_cache_memory_size: ByteCount::from(250u64 * 1024 * 1024), // 250 MiB
             disable_auto_improvement: false,
+            experimental_chain_sealing: false,
         }
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -180,6 +180,10 @@ pub struct Configuration {
 }
 
 impl Configuration {
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set(c: Configuration) {
+        set_current_config(c);
+    }
     /// Potentially fast access to a snapshot, should be used if an Updateable<T>
     /// isn't possible (Updateable trait is not object-safe, and requires mut to load()).
     /// Guard acquired doesn't track config updates. ~10x slower than Updateable's load().

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -112,6 +112,17 @@ impl Lsn {
     }
 }
 
+// Allows using Lsn as a range bound
+impl std::ops::RangeBounds<Lsn> for std::ops::Range<std::ops::Bound<Lsn>> {
+    fn start_bound(&self) -> std::ops::Bound<&Lsn> {
+        self.start.as_ref()
+    }
+
+    fn end_bound(&self) -> std::ops::Bound<&Lsn> {
+        self.end.as_ref()
+    }
+}
+
 impl From<crate::protobuf::common::Lsn> for Lsn {
     fn from(lsn: crate::protobuf::common::Lsn) -> Self {
         Self::from(lsn.value)

--- a/crates/types/src/time.rs
+++ b/crates/types/src/time.rs
@@ -58,6 +58,13 @@ impl MillisSinceEpoch {
         self.0
     }
 
+    /// Note, this doesn't fail if the timestamp is higher than Timestamp::MAX instead
+    /// it returns the default value (now). There are no practical cases where this can happen
+    /// so it's decided to do this for API convenience.
+    pub fn into_timestamp(self) -> jiff::Timestamp {
+        jiff::Timestamp::from_millisecond(self.0 as i64).unwrap_or_default()
+    }
+
     /// Returns zero duration if self is in the future. Should not be used where monotonic
     /// clock/duration is expected.
     pub fn elapsed(&self) -> Duration {

--- a/crates/worker/src/partition/leadership/trim_queue.rs
+++ b/crates/worker/src/partition/leadership/trim_queue.rs
@@ -15,7 +15,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use jiff::Timestamp;
 use parking_lot::Mutex;
 use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, info, instrument, warn};
@@ -114,9 +113,7 @@ impl LogTrimmer {
                 "Trimmed log {} to {:?}. This Lsn was reported durable at {}",
                 self.log_id,
                 durability.durable_point,
-                Timestamp::from_millisecond(durability.modification_time.as_u64() as i64)
-                    .unwrap_or_default()
-                    .to_string()
+                durability.modification_time.into_timestamp().to_string()
             );
             true
         }

--- a/tools/restatectl/src/commands/log/seal.rs
+++ b/tools/restatectl/src/commands/log/seal.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use cling::prelude::*;
+use tracing::error;
+
+use restate_cli_util::c_println;
+use restate_core::protobuf::cluster_ctrl_svc::{SealChainRequest, new_cluster_ctrl_client};
+use restate_types::logs::LogId;
+use restate_types::nodes_config::Role;
+
+use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "seal")]
+pub struct SealOpts {
+    /// Option segment index to seal. The tail segment is chosen automatically if not provided.
+    #[clap(long, short = 'i')]
+    segment_index: Option<u32>,
+    /// The log id or range to seal and extend, e.g. "0", "1-4".
+    #[clap(required = true)]
+    log_id: Vec<RangeParam>,
+}
+
+async fn seal(connection: &ConnectionInfo, opts: &SealOpts) -> anyhow::Result<()> {
+    for log_id in opts.log_id.iter().flatten().map(LogId::from) {
+        if let Err(err) = inner_seal(connection, opts, log_id).await {
+            error!("Failed to seal log chain for log={log_id}: {err}");
+        }
+        c_println!("");
+    }
+
+    Ok(())
+}
+
+async fn inner_seal(
+    connection: &ConnectionInfo,
+    opts: &SealOpts,
+    log_id: LogId,
+) -> anyhow::Result<()> {
+    let request = SealChainRequest {
+        log_id: log_id.into(),
+        segment_index: opts.segment_index,
+    };
+
+    let response = connection
+        .try_each(Some(Role::Admin), |channel| async {
+            new_cluster_ctrl_client(channel).seal_chain(request).await
+        })
+        .await?
+        .into_inner();
+
+    c_println!("✅ log={log_id} chain has been sealed");
+    c_println!(" ├ Tail LSN: {}", response.tail_offset);
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/node/disable_node_checker.rs
+++ b/tools/restatectl/src/commands/node/disable_node_checker.rs
@@ -10,7 +10,7 @@
 
 use restate_types::PlainNodeId;
 use restate_types::logs::LogletId;
-use restate_types::logs::metadata::{Logs, ProviderKind};
+use restate_types::logs::metadata::{InternalKind, Logs, ProviderKind};
 use restate_types::nodes_config::{
     MetadataServerState, NodesConfigError, NodesConfiguration, Role, StorageState,
 };
@@ -123,21 +123,21 @@ impl<'a, 'b> DisableNodeChecker<'a, 'b> {
                 match segment.config.kind {
                     // we assume that the given node runs the local and memory loglet and, therefore,
                     // cannot be disabled
-                    ProviderKind::InMemory => {
+                    InternalKind::InMemory => {
                         return Err(DisableNodeError::LocalLoglet {
-                            provider_kind: segment.config.kind,
+                            provider_kind: segment.config.kind.try_into().unwrap(),
                             loglet_id: LogletId::new(*log_id, segment.index()),
                             node_id,
                         });
                     }
-                    ProviderKind::Local => {
+                    InternalKind::Local => {
                         return Err(DisableNodeError::LocalLoglet {
-                            provider_kind: segment.config.kind,
+                            provider_kind: segment.config.kind.try_into().unwrap(),
                             loglet_id: LogletId::new(*log_id, segment.index()),
                             node_id,
                         });
                     }
-                    ProviderKind::Replicated => {
+                    InternalKind::Replicated => {
                         if self
                             .logs
                             .get_replicated_loglet(&LogletId::new(*log_id, segment.index()))
@@ -152,6 +152,7 @@ impl<'a, 'b> DisableNodeChecker<'a, 'b> {
                             )));
                         }
                     }
+                    InternalKind::Sealed => {}
                 }
             }
         }


### PR DESCRIPTION

This changeset adds support for chain sealing marker. An experimental feature (to be enabled in v1.6) that allows a log chain to be sealed with a special marker in metadata without requiring a new segment (reconfiguration).

The sealing marker enables readers to detect that a log chain is partially sealed and in future PRs it will be able to seal the chain to allow readers to reach the tail of the log without requiring a reconfiguration to take place.
This also will allow the creation of empty logs (log chains with no segments), or logs to trim all their segments which can be useful in tricky snapshot+reconfiguration scenarios where historical nodesets would cause safety checker
to trip even that all data has been trimmed if this is the last segment.

Additionally, this will allow the creation of a new cluster that's seeded with initial LSN offsets to allow seamless restore of partition stores without requiring historical fake segments.

To facilitate this, a new `SealedLoglet` kind has been added but it's hidden from all user-facing APIs/surfaces by duplicating the ProviderKind enum into two. A `ProviderKind` is still used to for user-facing surfaces,
and `InternalKind` is the union of ProviderKind and special kinds (currently only `Sealed`).


The sealed segment has a special property that it shares the same segment index as the previous segment. So ReadStream has been updated to enable switching segments even if the segment_index is the same.

In this changeset, only `bifrost.find_tail()` will automatically seal the chain if the underlying loglet is sealed while the chain is still open (gated by the experimental flag). In future PRs, this will also happen by readers when they detect
partial sealing (reconfiguration) that is seemingly stuck for extended time.

Also a new `restatectl` command `restatectl log seal <LOG-IDs>` has been added to trigger chain sealing from the CLI (and a corresponding ClusterCtrl gRPC API).


```
// intentionally empty
```
