### PR TITLE
Disable registration of old SDKs

### DIFF
--- a/crates/service-protocol/src/discovery.rs
+++ b/crates/service-protocol/src/discovery.rs
@@ -39,8 +39,8 @@ use restate_types::service_discovery::{
     ServiceDiscoveryProtocolVersion,
 };
 use restate_types::service_protocol::{
-    MAX_SERVICE_PROTOCOL_VERSION, MAX_SERVICE_PROTOCOL_VERSION_VALUE, MIN_SERVICE_PROTOCOL_VERSION,
-    ServiceProtocolVersion,
+    MAX_SERVICE_PROTOCOL_VERSION, MAX_SERVICE_PROTOCOL_VERSION_VALUE,
+    MIN_DISCOVERABLE_SERVICE_PROTOCOL_VERSION, ServiceProtocolVersion,
 };
 
 // TODO(slinkydeveloper) move this code somewhere else!
@@ -160,8 +160,8 @@ pub enum DiscoveryError {
     #[error("cannot read body: {0}")]
     BodyError(GenericError),
     #[error(
-        "unsupported service protocol versions: [{min_version}, {max_version}]. Supported versions by this runtime are [{}, {}]",
-        i32::from(MIN_SERVICE_PROTOCOL_VERSION),
+        "unsupported service protocol versions: [{min_version}, {max_version}]. Supported versions by this runtime are [{}, {}]. Please upgrade the SDK and try registering again.",
+        i32::from(MIN_DISCOVERABLE_SERVICE_PROTOCOL_VERSION),
         i32::from(MAX_SERVICE_PROTOCOL_VERSION)
     )]
     UnsupportedServiceProtocol { min_version: i32, max_version: i32 },
@@ -403,7 +403,7 @@ impl ServiceDiscovery {
             }
         }
 
-        if !ServiceProtocolVersion::is_compatible(min_version, max_version) {
+        if !ServiceProtocolVersion::is_acceptable_for_discovery(min_version, max_version) {
             return Err(DiscoveryError::UnsupportedServiceProtocol {
                 min_version,
                 max_version,

--- a/crates/types/src/service_protocol.rs
+++ b/crates/types/src/service_protocol.rs
@@ -15,6 +15,8 @@ use std::ops::RangeInclusive;
 
 // Range of supported service protocol versions by this server
 pub const MIN_SERVICE_PROTOCOL_VERSION: ServiceProtocolVersion = ServiceProtocolVersion::V1;
+pub const MIN_DISCOVERABLE_SERVICE_PROTOCOL_VERSION: ServiceProtocolVersion =
+    ServiceProtocolVersion::V5;
 pub const MAX_SERVICE_PROTOCOL_VERSION: ServiceProtocolVersion = ServiceProtocolVersion::V5;
 
 pub const MAX_SERVICE_PROTOCOL_VERSION_VALUE: i32 = i32::MAX;
@@ -26,7 +28,12 @@ impl ServiceProtocolVersion {
         i32::from(*self)
     }
 
-    pub fn is_compatible(min_version: i32, max_version: i32) -> bool {
+    pub fn is_acceptable_for_discovery(min_version: i32, max_version: i32) -> bool {
+        min_version <= i32::from(MAX_SERVICE_PROTOCOL_VERSION)
+            && max_version >= i32::from(MIN_DISCOVERABLE_SERVICE_PROTOCOL_VERSION)
+    }
+
+    fn is_compatible(min_version: i32, max_version: i32) -> bool {
         min_version <= i32::from(MAX_SERVICE_PROTOCOL_VERSION)
             && max_version >= i32::from(MIN_SERVICE_PROTOCOL_VERSION)
     }


### PR DESCRIPTION
Part of #3184.

This won't affect already registered endpoints, nor in-flight invocations, this will only prevent registration of SDKs using protocol <= 4.