### PR TITLE
[Bifrost] making get_loglet a sync call

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -309,15 +309,14 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         let request = request.into_inner();
         let log_id: LogId = request.log_id.into();
 
-        let writable_loglet = self
-            .bifrost
-            .admin()
-            .writeable_loglet(log_id)
-            .await
-            .map_err(|err| match err {
-                BiforstError::UnknownLogId(_) => Status::invalid_argument("Unknown log-id"),
-                err => Status::internal(err.to_string()),
-            })?;
+        let writable_loglet =
+            self.bifrost
+                .admin()
+                .tail_loglet(log_id)
+                .map_err(|err| match err {
+                    BiforstError::UnknownLogId(_) => Status::invalid_argument("Unknown log-id"),
+                    err => Status::internal(err.to_string()),
+                })?;
 
         let tail_state = writable_loglet
             .find_tail(FindTailOptions::default())

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -1011,7 +1011,7 @@ mod tests {
         const LOG_ID: LogId = LogId::new(0);
         let builder = TestCoreEnvBuilder::with_incoming_only_connector();
         let bifrost_svc = BifrostService::new(builder.metadata_writer.clone())
-            .with_factory(memory_loglet::Factory::default());
+            .with_factory(memory_loglet::Factory);
         let bifrost = bifrost_svc.handle();
 
         let replica_set_states = PartitionReplicaSetStates::default();
@@ -1524,7 +1524,7 @@ mod tests {
         restate_types::config::set_current_config(config);
         let builder = TestCoreEnvBuilder::with_incoming_only_connector();
         let bifrost_svc = BifrostService::new(builder.metadata_writer.clone())
-            .with_factory(memory_loglet::Factory::default());
+            .with_factory(memory_loglet::Factory);
         let bifrost = bifrost_svc.handle();
 
         let mut server_builder = NetworkServerBuilder::default();

--- a/crates/bifrost/src/appender.rs
+++ b/crates/bifrost/src/appender.rs
@@ -126,7 +126,7 @@ impl Appender {
             let loglet = match self.loglet_cache.as_mut() {
                 None => self
                     .loglet_cache
-                    .insert(self.bifrost_inner.tail_loglet(self.log_id).await?),
+                    .insert(self.bifrost_inner.tail_loglet(self.log_id)?),
                 Some(wrapper) => wrapper,
             };
             match loglet.append_batch(batch.clone()).await {
@@ -254,9 +254,7 @@ impl Appender {
                 .auto_recovery_interval
                 .into();
 
-            let loglet = bifrost_inner
-                .tail_loglet_from_metadata(log_metadata, log_id)
-                .await?;
+            let loglet = bifrost_inner.tail_loglet_from_metadata(log_metadata, log_id)?;
             // Do we think that the last tail loglet is different and unsealed?
             if loglet.tail_lsn.is_none() && loglet.segment_index() > current_segment {
                 return Ok(loglet);
@@ -324,9 +322,7 @@ impl Appender {
                 .auto_recovery_interval
                 .into();
 
-            let loglet = bifrost_inner
-                .tail_loglet_from_metadata(log_metadata, log_id)
-                .await?;
+            let loglet = bifrost_inner.tail_loglet_from_metadata(log_metadata, log_id)?;
             let tone_escalated = start.elapsed() > auto_recovery_threshold;
             // Do we think that the last tail loglet is different and unsealed?
             if loglet.tail_lsn.is_none() && loglet.segment_index() > sealed_segment {

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -177,8 +177,8 @@ impl<'a> BifrostAdmin<'a> {
         Ok(sealed_segment)
     }
 
-    pub async fn writeable_loglet(&self, log_id: LogId) -> Result<LogletWrapper> {
-        self.inner.tail_loglet(log_id).await
+    pub fn tail_loglet(&self, log_id: LogId) -> Result<LogletWrapper> {
+        self.inner.tail_loglet(log_id)
     }
 
     async fn seal_inner(
@@ -189,7 +189,7 @@ impl<'a> BifrostAdmin<'a> {
     ) -> Result<MaybeSealedSegment> {
         self.inner.fail_if_shutting_down()?;
         // first find the tail segment for this log.
-        let loglet = self.inner.tail_loglet(log_id).await?;
+        let loglet = self.tail_loglet(log_id)?;
 
         if segment_index != loglet.segment_index() {
             // Not the same segment. Bail!

--- a/crates/bifrost/src/loglet/provider.rs
+++ b/crates/bifrost/src/loglet/provider.rs
@@ -41,7 +41,7 @@ pub enum Improvement {
 #[async_trait]
 pub trait LogletProvider: Send + Sync {
     /// Create a loglet client for a given segment and configuration.
-    async fn get_loglet(
+    fn get_loglet(
         &self,
         log_id: LogId,
         segment_index: SegmentIndex,

--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -68,7 +68,7 @@ pub(crate) struct LocalLogletProvider {
 
 #[async_trait]
 impl LogletProvider for LocalLogletProvider {
-    async fn get_loglet(
+    fn get_loglet(
         &self,
         log_id: LogId,
         segment_index: SegmentIndex,

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -194,7 +194,7 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
 
 #[async_trait]
 impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
-    async fn get_loglet(
+    fn get_loglet(
         &self,
         log_id: LogId,
         segment_index: SegmentIndex,

--- a/crates/bifrost/src/service.rs
+++ b/crates/bifrost/src/service.rs
@@ -66,7 +66,7 @@ impl BifrostService {
 
     #[cfg(any(test, feature = "memory-loglet"))]
     pub fn enable_in_memory_loglet(mut self) -> Self {
-        let factory = memory_loglet::Factory::default();
+        let factory = memory_loglet::Factory;
         self.factories.insert(factory.kind(), Box::new(factory));
         self
     }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1437,7 +1437,7 @@ mod tests {
         RocksDbManager::init(Constant::new(CommonOptions::default()));
 
         let bifrost_svc = BifrostService::new(env_builder.metadata_writer.clone())
-            .with_factory(memory_loglet::Factory::default());
+            .with_factory(memory_loglet::Factory);
         let bifrost = bifrost_svc.handle();
 
         let replica_set_states = PartitionReplicaSetStates::default();


### PR DESCRIPTION

Loglet instantiation always happen in the background, let's make this very clear in the API. The sync API also reduces downstream complexity and makes the interface more predictable.


The only case for get_loglet being async was in a single test case that isn't relevant anymore. That used to be relevant back when local loglet creation happened during the call of get_loglet. This is not the case anymore.
