### PR TITLE
Add command and args to helm chart

### DIFF
--- a/charts/restate-helm/templates/statefulset.yaml
+++ b/charts/restate-helm/templates/statefulset.yaml
@@ -43,6 +43,14 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "restate.fullname" . }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end}}
           image: {{ .Values.image.repository }}:{{ include "restate.tag" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:


### PR DESCRIPTION
This allows us to specify clever entrypoint scripts that can do things like fetch the AZ from AWS.