### PR TITLE
[Bifrost] Capture details of why a chain marker was created

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -223,6 +223,8 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
             .seal_chain(
                 request.log_id.into(),
                 request.segment_index.map(SegmentIndex::from),
+                false, /* permanent_seal */
+                request.context,
             )
             .await
             .map_err(|_| Status::aborted("Node is shutting down"))?

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -21,7 +21,9 @@ use tracing::{info, instrument, warn};
 #[cfg(all(any(test, feature = "test-util"), feature = "local-loglet"))]
 use restate_types::live::LiveLoadExt;
 
-use restate_core::{Metadata, MetadataWriter, ShutdownError};
+use restate_core::MetadataWriter;
+use restate_core::my_node_id;
+use restate_core::{Metadata, ShutdownError};
 use restate_types::config::Configuration;
 use restate_types::logs::metadata::SealMetadata;
 use restate_types::logs::metadata::{LogletParams, Logs, SegmentIndex};
@@ -436,7 +438,11 @@ impl BifrostInner {
                         // loglet is sealed but chain is not sealed yet.
                         // let's seal the chain.
                         match BifrostAdmin::new(self)
-                            .seal(log_id, loglet.segment_index(), SealMetadata::default())
+                            .seal(
+                                log_id,
+                                loglet.segment_index(),
+                                SealMetadata::new("find-tail", my_node_id()),
+                            )
                             .await
                         {
                             Ok(lsn) => {

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -156,7 +156,7 @@ message SealChainRequest {
   // segment_index will be automatically selected (to the index of last segment)
   // if not set.
   optional uint32 segment_index = 2;
-  // todo: allow user to pass human context
+  map<string, string> context = 3;
   // todo: option for permanently sealing the chain when this is fully supported
 }
 

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -286,7 +286,15 @@ pub fn render_loglet_notes(segment: &Segment<'_>) -> Cell {
     if segment.config.kind.is_seal_marker() {
         match SealMetadata::deserialize_from(segment.config.params.as_bytes()) {
             Ok(metadata) => {
-                let mut cell = Cell::new(format!("At {}", metadata.sealed_at.into_timestamp()));
+                let seal_ctx = metadata
+                    .context
+                    .into_iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .join(", ");
+                let mut cell = Cell::new(format!(
+                    "At {} {seal_ctx}",
+                    metadata.sealed_at.into_timestamp()
+                ));
                 if metadata.permanent_seal {
                     cell = cell.fg(Color::Green);
                 }


### PR DESCRIPTION

Allows the system to capture the "source" and the "node" for chain seal markers. There is also a new `--reason` flag to `restatectl log seal` to specify the reason, and the reason + the node id will be printed in `restatectl logs describe <id>` output.
