### PR TITLE
[WIP] PartitionStoreManager exclusive ownership by Worker role

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,16 +257,14 @@ path = "workspace-hack"
 opt-level = 3
 lto = "thin"
 codegen-units = 1
-# Let's be defensive and abort on every panic
-panic = "abort"
+panic = "unwind"
 
 [profile.release-debug]
 inherits = "release"
 debug = true
 
 [profile.dev]
-# Let's be defensive and abort on every panic
-panic = "abort"
+panic = "unwind"
 
 [profile.release.package.service-protocol-wireshark-dissector]
 opt-level = "z" # Optimize for size.

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -847,7 +847,11 @@ impl TaskCenterInner {
             // Note that the task itself has been already removed from the task map, so shutdown
             // will not wait for its completion.
             self.shutdown_node(
-                &format!("task {} failed and requested a shutdown", task.name()),
+                &format!(
+                    "task {}({}) failed and requested a shutdown",
+                    task.name(),
+                    task.id()
+                ),
                 EXIT_CODE_FAILURE,
             )
             .await;
@@ -886,6 +890,7 @@ impl TaskCenterInner {
         // global shutdown trigger
         self.cancel_tasks(None, None).await;
         // notify outer components that we have completed the shutdown.
+        info!("Task center has stopped");
         self.global_cancel_token.cancel();
     }
 

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -77,7 +77,7 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
-    #[strum(props(runtime = "default"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     SocketHandler,
     /// An http2 stream handler created by the server-side of the connection.
     #[strum(props(OnError = "log", runtime = "default"))]

--- a/crates/local-cluster-runner/examples/three_nodes.rs
+++ b/crates/local-cluster-runner/examples/three_nodes.rs
@@ -8,7 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::pin::pin;
+use std::time::Duration;
+
 use futures::never::Never;
+use tracing::{error, info};
+
 use restate_core::TaskCenterBuilder;
 use restate_local_cluster_runner::cluster::StartedCluster;
 use restate_local_cluster_runner::{
@@ -19,9 +24,6 @@ use restate_local_cluster_runner::{
 use restate_types::config::{Configuration, LogFormat};
 use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::logs::metadata::ProviderKind::Replicated;
-use std::pin::pin;
-use std::time::Duration;
-use tracing::{error, info};
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
@@ -85,6 +87,7 @@ fn main() -> anyhow::Result<()> {
 
         Ok(())
     })
+    .expect("panicked!")
 }
 
 async fn run_cluster(cluster: &StartedCluster) -> anyhow::Result<Never> {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -292,17 +292,10 @@ impl Node {
                 AdminRole::create(
                     tc.health().admin_status(),
                     bifrost.clone(),
-                    updateable_config.clone(),
-                    PartitionRouting::new(replica_set_states.clone(), tc),
-                    metadata.updateable_partition_table(),
                     replica_set_states.clone(),
                     networking.clone(),
-                    metadata,
                     metadata_manager.writer(),
                     &mut server_builder,
-                    worker_role
-                        .as_ref()
-                        .map(|worker_role| worker_role.storage_query_context().clone()),
                 )
                 .await?,
             )

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -17,7 +17,6 @@ use restate_core::network::TransportConnect;
 use restate_core::worker_api::ProcessorsManagerHandle;
 use restate_core::{MetadataWriter, TaskCenter};
 use restate_core::{ShutdownError, TaskKind};
-use restate_storage_query_datafusion::context::QueryContext;
 use restate_types::health::HealthStatus;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
@@ -84,10 +83,6 @@ impl WorkerRole {
 
     pub fn partition_processor_manager_handle(&self) -> ProcessorsManagerHandle {
         self.worker.partition_processor_manager_handle()
-    }
-
-    pub fn storage_query_context(&self) -> &QueryContext {
-        self.worker.storage_query_context()
     }
 
     pub fn start(self) -> anyhow::Result<()> {

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -103,6 +103,7 @@ impl SharedState {
     }
 }
 
+/// PartitionStoreManager is owned exclusively by the worker role.
 #[derive(Clone)]
 pub struct PartitionStoreManager {
     state: Arc<SharedState>,

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, OnceLock, Weak};
+use std::time::Duration;
 
 use parking_lot::RwLock;
 use rocksdb::{BlockBasedOptions, Cache, LogLevel, WriteBufferManager};
@@ -299,6 +300,24 @@ impl RocksDbManager {
         self.close_db_tasks.wait().await;
         self.env.clone().join_all_threads();
         info!("Rocksdb manager shutdown completed");
+    }
+
+    /// Emergency shutdown is ongoing, this will ensure rocksdb's wal is fsynced.
+    pub fn on_ungraceful_shutdown(&'static self) {
+        let Some(guard) = self.dbs.try_read_for(Duration::from_secs(1)) else {
+            eprintln!("[rocksdb] couldn't acquire rwlock to flush the WAL in time");
+            return;
+        };
+        for (name, db) in guard.iter() {
+            let Some(db) = db.upgrade() else {
+                continue;
+            };
+            if let Err(e) = db.db.flush_wal(true) {
+                eprintln!("[rocksdb] failed to flush WAL of {name}: {e}");
+            } else {
+                eprintln!("[rocksdb] flushed WAL of {name}");
+            }
+        }
     }
 
     fn amend_db_options(&self, db_options: &mut rocksdb::Options, opts: &RocksDbOptions) {

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -307,7 +307,7 @@ impl PartitionProcessorManager {
                     }
                 }
                 Some(event) = self.asynchronous_operations.join_next() => {
-                    self.on_asynchronous_event(event.expect("asynchronous operations must not panic"));
+                    self.on_asynchronous_event(event.context("asynchronous operations must not panic")?);
                 }
                 Some(partition_processor_rpc) = pp_rpc_rx.next() => {
                     self.on_partition_processor_rpc(partition_processor_rpc);


### PR DESCRIPTION

This allows the worker to flush rocksdb as soon as the worker role is stopped and before the rest of the system is shut down. In order to achieve this, datafusion queries will always use the remote scanner even on worker nodes. This adds serialization/memory cost that would have been otherwise avoided but potentially can be optimized in future PRs.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3606).
* #3613
* #3612
* __->__ #3606
* #3611