### PR TITLE
Remove ingress dedicated runtime

### DIFF
--- a/crates/core/derive/src/tc_test.rs
+++ b/crates/core/derive/src/tc_test.rs
@@ -426,7 +426,6 @@ fn parse_knobs(mut input: ItemFn, config: FinalConfig) -> TokenStream {
 
     let mut tc_builder = quote_spanned! {last_stmt_start_span=>
         #crate_path::TaskCenterBuilder::default()
-            .ingress_runtime_handle(rt.handle().clone())
             .default_runtime_handle(rt.handle().clone())
     };
     let mut rt = match config.flavor {

--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -159,6 +159,9 @@ impl Handle {
         self.inner.spawn_child(kind, name, future)
     }
 
+    /// An unmanaged task is one that is not automatically cancelled by the task center on
+    /// shutdown. Moreover, the task ID will not be registered with task center and therefore
+    /// cannot be "taken" by calling [`TaskCenter::take_task`].
     pub fn spawn_unmanaged<F, T>(
         &self,
         kind: TaskKind,

--- a/crates/core/src/task_center/monitoring.rs
+++ b/crates/core/src/task_center/monitoring.rs
@@ -20,8 +20,6 @@ use super::Handle;
 pub trait TaskCenterMonitoring {
     fn default_runtime_metrics(&self) -> RuntimeMetrics;
 
-    fn ingress_runtime_metrics(&self) -> RuntimeMetrics;
-
     fn managed_runtime_metrics(&self) -> Vec<(SharedString, RuntimeMetrics)>;
 
     /// How long has the task-center been running?
@@ -34,10 +32,6 @@ pub trait TaskCenterMonitoring {
 impl TaskCenterMonitoring for Handle {
     fn default_runtime_metrics(&self) -> RuntimeMetrics {
         self.inner.default_runtime_handle.metrics()
-    }
-
-    fn ingress_runtime_metrics(&self) -> RuntimeMetrics {
-        self.inner.ingress_runtime_handle.metrics()
     }
 
     fn managed_runtime_metrics(&self) -> Vec<(SharedString, RuntimeMetrics)> {
@@ -56,7 +50,6 @@ impl TaskCenterMonitoring for Handle {
     /// Submit telemetry for all runtimes to metrics recorder
     fn submit_metrics(&self) {
         submit_runtime_metrics("default", self.default_runtime_metrics());
-        submit_runtime_metrics("ingress", self.ingress_runtime_metrics());
 
         // Partition processor runtimes
         let processor_runtimes = self.managed_runtime_metrics();

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -89,6 +89,7 @@ pub enum TaskKind {
     /// to shut down cleanly without waiting indefinitely.
     #[strum(props(OnCancel = "abort", runtime = "ingress"))]
     IngressServer,
+    WorkerRole,
     RoleRunner,
     /// Cluster controller is the first thing that gets stopped when the server is shut down
     ClusterController,

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -87,8 +87,8 @@ pub enum TaskKind {
     H2ClientStream,
     /// A type for ingress until we start enforcing timeouts for inflight requests. This enables us
     /// to shut down cleanly without waiting indefinitely.
-    #[strum(props(OnCancel = "abort", runtime = "ingress"))]
-    IngressServer,
+    #[strum(props(OnCancel = "abort"))]
+    HttpIngressRole,
     WorkerRole,
     RoleRunner,
     /// Cluster controller is the first thing that gets stopped when the server is shut down
@@ -96,7 +96,7 @@ pub enum TaskKind {
     #[strum(props(runtime = "default"))]
     FailureDetector,
     SystemService,
-    #[strum(props(OnCancel = "abort", runtime = "ingress"))]
+    #[strum(props(OnCancel = "abort"))]
     Ingress,
     /// Kafka ingestion related task
     Kafka,
@@ -183,7 +183,6 @@ impl TaskKind {
         match self.get_str("runtime").unwrap_or("inherit") {
             "inherit" => AsyncRuntime::Inherit,
             "default" => AsyncRuntime::Default,
-            "ingress" => AsyncRuntime::Ingress,
             _ => panic!("Invalid runtime for task kind: {self}"),
         }
     }
@@ -199,6 +198,4 @@ pub enum AsyncRuntime {
     Inherit,
     /// Run on the default runtime
     Default,
-    /// Run on ingress runtime
-    Ingress,
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -504,7 +504,11 @@ impl Node {
         }
 
         if let Some(ingress_role) = self.ingress_role {
-            TaskCenter::spawn(TaskKind::IngressServer, "ingress-http", ingress_role.run())?;
+            TaskCenter::spawn(
+                TaskKind::HttpIngressRole,
+                "ingress-http",
+                ingress_role.run(),
+            )?;
         }
 
         if let Some(worker_role) = self.worker_role {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -250,10 +250,7 @@ impl Node {
             Some(
                 WorkerRole::create(
                     tc.health().worker_status(),
-                    metadata.clone(),
-                    PartitionRouting::new(replica_set_states.clone(), tc.clone()),
                     replica_set_states.clone(),
-                    updateable_config.clone(),
                     &mut router_builder,
                     networking.clone(),
                     bifrost_svc.handle(),
@@ -511,7 +508,7 @@ impl Node {
         }
 
         if let Some(worker_role) = self.worker_role {
-            TaskCenter::spawn(TaskKind::SystemBoot, "worker-init", worker_role.start())?;
+            worker_role.start()?;
         }
 
         if let Some(admin_role) = self.admin_role {

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -14,20 +14,13 @@ use restate_bifrost::Bifrost;
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::Networking;
 use restate_core::network::TransportConnect;
-use restate_core::partitions::PartitionRouting;
 use restate_core::worker_api::ProcessorsManagerHandle;
-use restate_core::{Metadata, MetadataKind, cancellation_watcher};
 use restate_core::{MetadataWriter, TaskCenter};
 use restate_core::{ShutdownError, TaskKind};
 use restate_storage_query_datafusion::context::QueryContext;
-use restate_types::Version;
-use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
-use restate_types::live::Live;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
-use restate_types::schema::subscriptions::SubscriptionResolver;
-use restate_worker::SubscriptionController;
 use restate_worker::Worker;
 
 #[derive(Debug, thiserror::Error, CodedError)]
@@ -64,28 +57,20 @@ pub enum WorkerRoleBuildError {
 }
 
 pub struct WorkerRole {
-    metadata: Metadata,
     worker: Worker,
 }
 
 impl WorkerRole {
-    #[allow(clippy::too_many_arguments)]
     pub async fn create<T: TransportConnect>(
         health_status: HealthStatus<WorkerStatus>,
-        metadata: Metadata,
-        partition_routing: PartitionRouting,
         replica_set_states: PartitionReplicaSetStates,
-        updateable_config: Live<Configuration>,
         router_builder: &mut MessageRouterBuilder,
         networking: Networking<T>,
         bifrost: Bifrost,
         metadata_writer: MetadataWriter,
     ) -> Result<Self, WorkerRoleBuildError> {
         let worker = Worker::create(
-            updateable_config,
             health_status,
-            metadata.clone(),
-            partition_routing,
             replica_set_states,
             networking,
             bifrost,
@@ -94,7 +79,7 @@ impl WorkerRole {
         )
         .await?;
 
-        Ok(WorkerRole { worker, metadata })
+        Ok(WorkerRole { worker })
     }
 
     pub fn partition_processor_manager_handle(&self) -> ProcessorsManagerHandle {
@@ -105,51 +90,10 @@ impl WorkerRole {
         self.worker.storage_query_context()
     }
 
-    pub async fn start(self) -> anyhow::Result<()> {
-        // todo: only run subscriptions on node 0 once being distributed
-        TaskCenter::spawn_child(
-            TaskKind::MetadataBackgroundSync,
-            "subscription_controller",
-            Self::watch_subscriptions(self.metadata, self.worker.subscription_controller_handle()),
-        )?;
-
-        TaskCenter::spawn_child(TaskKind::RoleRunner, "worker-service", async {
+    pub fn start(self) -> anyhow::Result<()> {
+        TaskCenter::spawn(TaskKind::WorkerRole, "worker-service", async {
             self.worker.run().await
         })?;
-
-        Ok(())
-    }
-
-    async fn watch_subscriptions<SC>(
-        metadata: Metadata,
-        subscription_controller: SC,
-    ) -> anyhow::Result<()>
-    where
-        SC: SubscriptionController + Clone + Send + Sync,
-    {
-        let schema_view = metadata.updateable_schema();
-        let mut next_version = Version::MIN;
-        let cancellation_watcher = cancellation_watcher();
-        tokio::pin!(cancellation_watcher);
-
-        loop {
-            tokio::select! {
-                _ = &mut cancellation_watcher => {
-                    break;
-                },
-                version = metadata.wait_for_version(MetadataKind::Schema, next_version) => {
-                    next_version = version?.next();
-
-                    // This might return subscriptions belonging to a higher schema version. As a
-                    // result we might re-apply the same list of subscriptions. This is not a
-                    // problem, since update_subscriptions is idempotent.
-                    let subscriptions = schema_view.pinned().list_subscriptions(&[]);
-                    subscription_controller
-                        .update_subscriptions(subscriptions)
-                        .await?;
-                }
-            }
-        }
 
         Ok(())
     }

--- a/crates/partition-store/src/error.rs
+++ b/crates/partition-store/src/error.rs
@@ -72,10 +72,12 @@ pub enum SnapshotErrorKind {
     InvalidState,
     #[error("Snapshot repository is not configured")]
     RepositoryNotConfigured,
-    #[error("Snapshot export failed for partition")]
+    #[error("export error: {0}")]
     Export(#[source] anyhow::Error),
-    #[error("Snapshot repository IO error")]
+    #[error("snapshot repository IO error: {0}")]
     RepositoryIo(#[source] anyhow::Error),
-    #[error("Internal error")]
+    #[error("Internal error: {0}")]
     Internal(#[source] anyhow::Error),
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
 }

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -126,7 +126,7 @@ impl PartitionStoreManager {
                 .num_partitions_to_share_memory_budget() as usize;
 
         let state = Arc::new(SharedState::default());
-        let event_listener = DurableLsnEventListener::new(state.clone());
+        let event_listener = DurableLsnEventListener::new(&state);
 
         let mut db_opts = rocksdb::Options::default();
         db_opts.add_event_listener(event_listener);
@@ -157,7 +157,7 @@ impl PartitionStoreManager {
         Ok(Self {
             state,
             snapshots,
-            rocksdb: rocksdb.clone(),
+            rocksdb,
         })
     }
 

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -17,13 +17,13 @@ pub enum StorageError {
     Generic(#[from] anyhow::Error),
     #[error("failed to convert Rust objects to/from protobuf: {0}")]
     Conversion(anyhow::Error),
-    #[error("Integrity constraint is violated")]
+    #[error("integrity constraint is violated")]
     DataIntegrityError,
-    #[error("Operational error that can be caused during a graceful shutdown")]
+    #[error("operational error that can be caused during a graceful shutdown")]
     OperationalError,
-    #[error("Snapshot export failed: {0}")]
+    #[error("snapshot export failed: {0}")]
     SnapshotExport(anyhow::Error),
-    #[error("Precondition failed: {0}")]
+    #[error("precondition failed: {0}")]
     PreconditionFailed(anyhow::Error),
 }
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -20,8 +20,11 @@ mod subscription_controller;
 mod subscription_integration;
 
 use codederror::CodedError;
+use tracing::info;
 
 use restate_bifrost::Bifrost;
+use restate_core::MetadataKind;
+use restate_core::cancellation_watcher;
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::Networking;
 use restate_core::network::TransportConnect;
@@ -40,12 +43,13 @@ use restate_storage_query_datafusion::remote_query_scanner_manager::{
 };
 use restate_storage_query_datafusion::remote_query_scanner_server::RemoteQueryScannerServer;
 use restate_storage_query_postgres::service::PostgresQueryService;
+use restate_types::Version;
+use restate_types::Versioned;
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
-use restate_types::live::Live;
-use restate_types::live::LiveLoadExt;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
+use restate_types::schema::subscriptions::SubscriptionResolver;
 
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
 use crate::partition_processor_manager::PartitionProcessorManager;
@@ -97,7 +101,6 @@ pub enum Error {
 }
 
 pub struct Worker {
-    live_config: Live<Configuration>,
     storage_query_context: QueryContext,
     storage_query_postgres: Option<PostgresQueryService>,
     datafusion_remote_scanner: RemoteQueryScannerServer,
@@ -107,12 +110,8 @@ pub struct Worker {
 }
 
 impl Worker {
-    #[allow(clippy::too_many_arguments)]
     pub async fn create<T: TransportConnect>(
-        mut live_config: Live<Configuration>,
         health_status: HealthStatus<WorkerStatus>,
-        metadata: Metadata,
-        partition_routing: PartitionRouting,
         replica_set_states: PartitionReplicaSetStates,
         networking: Networking<T>,
         bifrost: Bifrost,
@@ -122,10 +121,13 @@ impl Worker {
         metric_definitions::describe_metrics();
         health_status.update(WorkerStatus::StartingUp);
 
+        let partition_routing =
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current());
+
         let partition_store_manager = PartitionStoreManager::create().await?;
 
-        let live_config_clone = live_config.clone();
-        let config = live_config.live_load();
+        let config = Configuration::pinned();
+        let metadata = Metadata::current();
 
         let schema = metadata.updateable_schema();
 
@@ -147,7 +149,7 @@ impl Worker {
 
         let partition_processor_manager = PartitionProcessorManager::new(
             health_status,
-            live_config_clone,
+            Configuration::live(),
             metadata_writer,
             partition_store_manager.clone(),
             replica_set_states,
@@ -164,7 +166,7 @@ impl Worker {
 
         let remote_scanner_manager = RemoteScannerManager::new(
             create_remote_scanner_service(networking),
-            create_partition_locator(partition_routing, metadata.clone()),
+            create_partition_locator(partition_routing, metadata),
         );
         let storage_query_context = QueryContext::with_user_tables(
             &config.admin.query_engine,
@@ -190,7 +192,6 @@ impl Worker {
             RemoteQueryScannerServer::new(remote_scanner_manager, router_builder);
 
         Ok(Self {
-            live_config,
             storage_query_context,
             storage_query_postgres,
             datafusion_remote_scanner,
@@ -198,10 +199,6 @@ impl Worker {
             subscription_controller_handle,
             partition_processor_manager,
         })
-    }
-
-    pub fn subscription_controller_handle(&self) -> SubscriptionControllerHandle {
-        self.subscription_controller_handle.clone()
     }
 
     pub fn storage_query_context(&self) -> &QueryContext {
@@ -213,6 +210,12 @@ impl Worker {
     }
 
     pub async fn run(self) -> anyhow::Result<()> {
+        TaskCenter::spawn_child(
+            TaskKind::MetadataBackgroundSync,
+            "subscription_controller",
+            Self::watch_subscriptions(self.subscription_controller_handle.clone()),
+        )?;
+
         // Postgres external server
         if let Some(postgres) = self.storage_query_postgres {
             TaskCenter::spawn_child(
@@ -234,14 +237,41 @@ impl Worker {
             TaskKind::SystemService,
             "kafka-ingress",
             self.ingress_kafka
-                .run(self.live_config.clone().map(|c| &c.ingress)),
+                .run(Configuration::map_live(|c| &c.ingress)),
         )?;
 
-        TaskCenter::spawn_child(
-            TaskKind::PartitionProcessorManager,
-            "partition-processor-manager",
-            self.partition_processor_manager.run(),
-        )?;
+        self.partition_processor_manager.run().await?;
+        info!("Worker role has stopped");
+
+        Ok(())
+    }
+
+    async fn watch_subscriptions<SC>(subscription_controller: SC) -> anyhow::Result<()>
+    where
+        SC: SubscriptionController + Clone + Send + Sync,
+    {
+        let metadata = Metadata::current();
+        let mut updateable_schema = metadata.updateable_schema();
+        let mut next_version = Version::MIN;
+        let mut cancellation_watcher = std::pin::pin!(cancellation_watcher());
+
+        loop {
+            tokio::select! {
+                _ = &mut cancellation_watcher => {
+                    break;
+                },
+                version = metadata.wait_for_version(MetadataKind::Schema, next_version) => {
+                    let _ = version?;
+                    let schema = updateable_schema.live_load();
+                    let subscriptions = schema.list_subscriptions(&[]);
+                    subscription_controller
+                        .update_subscriptions(subscriptions)
+                        .await?;
+
+                    next_version = schema.version().next();
+                }
+            }
+        }
 
         Ok(())
     }

--- a/server/tests/common/replicated_loglet.rs
+++ b/server/tests/common/replicated_loglet.rs
@@ -118,6 +118,8 @@ where
         log_server_count,
         true,
     );
+    // tests rely on manual control over the chain.
+    base_config.bifrost.disable_auto_improvement = true;
 
     // ensure base dir lives longer than the node, otherwise it sees shutdown errors
     // this will still respect LOCAL_CLUSTER_RUNNER_RETAIN_TEMPDIR=true

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -72,7 +72,6 @@ where
 
     let task_center = TaskCenterBuilder::default()
         .default_runtime_handle(tokio::runtime::Handle::current())
-        .ingress_runtime_handle(tokio::runtime::Handle::current())
         .options(config.common.clone())
         .build()
         .expect("task_center builds")


### PR DESCRIPTION

This PR removes the dedicated ingress runtime and allows ingress to share the runtime with `default`. This is a step towards reducing the number of runtimes, threads, and metric dimensions. In my testing, the impact of this change is negligible and in all cases we'd be improving poll latencies in default runtime by avoiding sync IO operations from log-server and metadata server soon.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3607).
* #3609
* __->__ #3607
* #3605
* #3610
* #3604
* #3601