### PR TITLE
[Core] Always unwind and ensure rocksdb's WAL is flushed on panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,16 +257,14 @@ path = "workspace-hack"
 opt-level = 3
 lto = "thin"
 codegen-units = 1
-# Let's be defensive and abort on every panic
-panic = "abort"
+panic = "unwind"
 
 [profile.release-debug]
 inherits = "release"
 debug = true
 
 [profile.dev]
-# Let's be defensive and abort on every panic
-panic = "abort"
+panic = "unwind"
 
 [profile.release.package.service-protocol-wireshark-dissector]
 opt-level = "z" # Optimize for size.

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -77,7 +77,7 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
-    #[strum(props(runtime = "default"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     SocketHandler,
     /// An http2 stream handler created by the server-side of the connection.
     #[strum(props(OnError = "log", runtime = "default"))]

--- a/crates/local-cluster-runner/examples/three_nodes.rs
+++ b/crates/local-cluster-runner/examples/three_nodes.rs
@@ -8,7 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::pin::pin;
+use std::time::Duration;
+
 use futures::never::Never;
+use tracing::{error, info};
+
 use restate_core::TaskCenterBuilder;
 use restate_local_cluster_runner::cluster::StartedCluster;
 use restate_local_cluster_runner::{
@@ -19,9 +24,6 @@ use restate_local_cluster_runner::{
 use restate_types::config::{Configuration, LogFormat};
 use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::logs::metadata::ProviderKind::Replicated;
-use std::pin::pin;
-use std::time::Duration;
-use tracing::{error, info};
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
@@ -85,6 +87,7 @@ fn main() -> anyhow::Result<()> {
 
         Ok(())
     })
+    .expect("panicked!")
 }
 
 async fn run_cluster(cluster: &StartedCluster) -> anyhow::Result<Never> {

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -212,6 +212,6 @@ pub struct CsNode {
 
 impl NodeState {
     pub fn is_alive(self) -> bool {
-        matches!(self, Self::Alive | Self::FailingOver)
+        matches!(self, Self::Alive)
     }
 }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -307,7 +307,7 @@ impl PartitionProcessorManager {
                     }
                 }
                 Some(event) = self.asynchronous_operations.join_next() => {
-                    self.on_asynchronous_event(event.expect("asynchronous operations must not panic"));
+                    self.on_asynchronous_event(event.context("asynchronous operations must not panic")?);
                 }
                 Some(partition_processor_rpc) = pp_rpc_rx.next() => {
                     self.on_partition_processor_rpc(partition_processor_rpc);


### PR DESCRIPTION

This introduces a few crucial changes to how we handle panics in restate. Prior to this change, we would abort the process at panic time without considering a clean shutdown nor rocksdb wal fsync.

The summary of changes is as follows:
- We now always unwind the stack on panics. TaskCenter is designed to catch panics of important tasks and trigger a clean shutdown and reports a non-zero exit code.
- Ensure that on graceful shutdown timeout that we attempt to cleanly flush/shutdown rocksdb manager. This is important to avoid massive backfills of lost memtables on unclean shutdown.
- Catch panics at top-level task-center runtime control loop and trigger an emergency rocksdb WAL fsync to ensure that we flush the WAL to avoid loss of in-memory WAL buffer if/when we add support to manual wal flushing in the future.
- Makes sure that panics from network connection tasks do not trigger a system shutdown, instead, they are caught and properly logged. This avoids a situation where a network bad request/handler can cause the entire node to panic.
- In situations where tracing might have been lost/dropped, ensure that we also log critical information on stderr.
- Allow the user to send a second signal (SIGTERM or SIGINT) to terminate restate to force the shutdown.
- Shutdown timeout is controlled by TaskCenter itself, this means that self-triggered shutdown will also respect the timeout.

This hardens restate against unclean crashes and ensures we perform a clean handoff to other cluster members in case of an unrecoverable crash.

Other PRs in this stack focus on more granular control over the shutdown process to unlock better hand-off and cleaner shutdowns.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3611).
* #3620
* #3619
* #3613
* #3612
* __->__ #3611
* #3618