### PR TITLE
Switching to `Custom` encoding for Envelope

### DIFF
--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -271,8 +271,8 @@ mod envelope {
         }
 
         fn default_codec(&self) -> StorageCodecKind {
-            // TODO(azmy): Change to `Custom` in v1.5
-            StorageCodecKind::FlexbuffersSerde
+            // Switched to `Custom` in v1.5 to allow for more flexibility in the future.
+            StorageCodecKind::Custom
         }
     }
 


### PR DESCRIPTION
Switching to `Custom` encoding for Envelope

Summary:
Fixes #3503

Tested rolling back to v1.4.3
