### PR TITLE
objstore: instrument: ensure err(level=debug)

### DIFF
--- a/crates/metadata-providers/src/objstore/glue.rs
+++ b/crates/metadata-providers/src/objstore/glue.rs
@@ -116,7 +116,7 @@ impl Client {
 
 #[async_trait::async_trait]
 impl ProvisionedMetadataStore for Client {
-    #[instrument(level = "trace", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err(level = "debug"))]
     async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
         trace!(%key, "client sending Get");
 
@@ -129,7 +129,7 @@ impl ProvisionedMetadataStore for Client {
         rx.await.map_err(|_| ReadError::terminal(ShutdownError))?
     }
 
-    #[instrument(level = "trace", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err(level = "debug"))]
     async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
         trace!(%key, "client sending GetVersion");
 
@@ -142,7 +142,7 @@ impl ProvisionedMetadataStore for Client {
         rx.await.map_err(|_| ReadError::terminal(ShutdownError))?
     }
 
-    #[instrument(level = "trace", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err(level = "debug"))]
     async fn put(
         &self,
         key: ByteString,
@@ -165,7 +165,7 @@ impl ProvisionedMetadataStore for Client {
         rx.await.map_err(|_| WriteError::terminal(ShutdownError))?
     }
 
-    #[instrument(level = "trace", skip_all, err)]
+    #[instrument(level = "trace", skip_all, err(level = "debug"))]
     async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
         trace!(%key, %precondition, "client sending Delete");
 

--- a/crates/metadata-providers/src/objstore/in_memory_version_repository.rs
+++ b/crates/metadata-providers/src/objstore/in_memory_version_repository.rs
@@ -45,7 +45,7 @@ impl Default for InMemoryVersionRepository {
 
 #[async_trait::async_trait]
 impl VersionRepository for InMemoryVersionRepository {
-    #[instrument(level = "trace", skip(self, content), err)]
+    #[instrument(level = "trace", skip(self, content), err(level = "debug"))]
     async fn create(
         &self,
         key: ByteString,
@@ -63,7 +63,7 @@ impl VersionRepository for InMemoryVersionRepository {
         Ok(tag)
     }
 
-    #[instrument(level = "trace", skip(self), err)]
+    #[instrument(level = "trace", skip(self), err(level = "debug"))]
     async fn get(&self, key: ByteString) -> Result<TaggedValue, VersionRepositoryError> {
         debug!(%key, "get");
 
@@ -77,7 +77,7 @@ impl VersionRepository for InMemoryVersionRepository {
         }
     }
 
-    #[instrument(level = "trace", skip(self, content), err)]
+    #[instrument(level = "trace", skip(self, content), err(level = "debug"))]
     async fn put_if_tag_matches(
         &self,
         key: ByteString,
@@ -99,7 +99,7 @@ impl VersionRepository for InMemoryVersionRepository {
         }
     }
 
-    #[instrument(level = "trace", skip(self, content), err)]
+    #[instrument(level = "trace", skip(self, content), err(level = "debug"))]
     async fn put(&self, key: ByteString, content: Content) -> Result<Tag, VersionRepositoryError> {
         debug!(%key, size = content.bytes.len(), "put");
 
@@ -110,7 +110,7 @@ impl VersionRepository for InMemoryVersionRepository {
         Ok(tag)
     }
 
-    #[instrument(level = "trace", skip(self), err)]
+    #[instrument(level = "trace", skip(self), err(level = "debug"))]
     async fn delete(&self, key: ByteString) -> Result<(), VersionRepositoryError> {
         debug!(%key, "delete");
 
@@ -122,7 +122,7 @@ impl VersionRepository for InMemoryVersionRepository {
         }
     }
 
-    #[instrument(level = "trace", skip(self), err)]
+    #[instrument(level = "trace", skip(self), err(level = "debug"))]
     async fn delete_if_tag_matches(
         &self,
         key: ByteString,

--- a/crates/metadata-providers/src/objstore/object_store_version_repository.rs
+++ b/crates/metadata-providers/src/objstore/object_store_version_repository.rs
@@ -87,7 +87,7 @@ const DELETED_HEADER: Bytes = Bytes::from_static(b"d");
 
 #[async_trait::async_trait]
 impl VersionRepository for ObjectStoreVersionRepository {
-    #[instrument(level = "debug", skip(self, content), err)]
+    #[instrument(level = "debug", skip(self, content), err(level = "debug"))]
     async fn create(
         &self,
         key: ByteString,
@@ -143,7 +143,7 @@ impl VersionRepository for ObjectStoreVersionRepository {
         }
     }
 
-    #[instrument(level = "debug", skip(self), err)]
+    #[instrument(level = "debug", skip(self), err(level = "debug"))]
     async fn get(&self, key: ByteString) -> Result<TaggedValue, VersionRepositoryError> {
         let path = self.path(&key);
 
@@ -183,7 +183,7 @@ impl VersionRepository for ObjectStoreVersionRepository {
         }
     }
 
-    #[instrument(level = "debug", skip(self, new_content), err)]
+    #[instrument(level = "debug", skip(self, new_content), err(level = "debug"))]
     async fn put_if_tag_matches(
         &self,
         key: ByteString,
@@ -231,7 +231,7 @@ impl VersionRepository for ObjectStoreVersionRepository {
         }
     }
 
-    #[instrument(level = "debug", skip(self, new_content), err)]
+    #[instrument(level = "debug", skip(self, new_content), err(level = "debug"))]
     async fn put(
         &self,
         key: ByteString,
@@ -265,7 +265,7 @@ impl VersionRepository for ObjectStoreVersionRepository {
         }
     }
 
-    #[instrument(level = "debug", skip(self), err)]
+    #[instrument(level = "debug", skip(self), err(level = "debug"))]
     async fn delete(&self, key: ByteString) -> Result<(), VersionRepositoryError> {
         let path = self.path(&key);
 
@@ -281,7 +281,7 @@ impl VersionRepository for ObjectStoreVersionRepository {
         }
     }
 
-    #[instrument(level = "debug", skip(self), err)]
+    #[instrument(level = "debug", skip(self), err(level = "debug"))]
     async fn delete_if_tag_matches(
         &self,
         key: ByteString,

--- a/crates/metadata-providers/src/objstore/optimistic_store.rs
+++ b/crates/metadata-providers/src/objstore/optimistic_store.rs
@@ -61,7 +61,7 @@ struct SaltedVersionedValue {
     value: VersionedValue,
 }
 
-#[instrument(level = "trace", skip(tagged_value), err)]
+#[instrument(level = "trace", skip(tagged_value), err(level = "debug"))]
 fn tagged_value_to_versioned_value(
     tagged_value: TaggedValue,
 ) -> anyhow::Result<(Tag, VersionedValue)> {
@@ -125,7 +125,7 @@ impl OptimisticLockingMetadataStore {
         }
     }
 
-    #[instrument(level = "trace", skip(self, versioned_value), err)]
+    #[instrument(level = "trace", skip(self, versioned_value), err(level = "debug"))]
     fn serialize_versioned_value(
         &mut self,
         encoding: ValueEncoding,


### PR DESCRIPTION
This PR ensures that any events produced from the `err` part of an `#[instrument(..., err)]` directive always carry level=debug. By default, these events will always be at level=error, which was producing spurious ERROR logs under certain circumstances. 