### PR TITLE
[ClusterState] Fixing is_alive() reporting true for failing-over nodes

### DIFF
--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -212,6 +212,6 @@ pub struct CsNode {
 
 impl NodeState {
     pub fn is_alive(self) -> bool {
-        matches!(self, Self::Alive | Self::FailingOver)
+        matches!(self, Self::Alive)
     }
 }


### PR DESCRIPTION

This was not correct. is_alive() should strictly return true if the node is alive and not failing-over. This fix improves cluster controller's failover response time, and allows it to fail-over leader partitions as soon as it observes that a node shutdown has _started_.

```
// intentionally empty
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3618).
* #3620
* #3619
* #3613
* #3612
* #3611
* __->__ #3618