### PR TITLE
[Fabric] Adds ability to disable network compression via config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,16 +257,14 @@ path = "workspace-hack"
 opt-level = 3
 lto = "thin"
 codegen-units = 1
-# Let's be defensive and abort on every panic
-panic = "abort"
+panic = "unwind"
 
 [profile.release-debug]
 inherits = "release"
 debug = true
 
 [profile.dev]
-# Let's be defensive and abort on every panic
-panic = "abort"
+panic = "unwind"
 
 [profile.release.package.service-protocol-wireshark-dissector]
 opt-level = "z" # Optimize for size.

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -129,7 +129,7 @@ where
                     cluster_query_context,
                     replica_set_states.clone(),
                 )
-                .into_server(),
+                .into_server(&configuration.live_load().networking),
                 WaitForReady::new(health_status.clone(), AdminStatus::Ready),
             ),
             restate_core::protobuf::cluster_ctrl_svc::FILE_DESCRIPTOR_SET,

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -60,7 +60,7 @@ where
     pub fn start(self, name: &'static str) -> Result<AppenderHandle<T>, ShutdownError> {
         let (tx, rx) = tokio::sync::mpsc::channel(self.queue_capacity);
 
-        let handle = TaskCenter::spawn_unmanaged(
+        let handle = TaskCenter::spawn_unmanaged_child(
             restate_core::TaskKind::BifrostAppender,
             name,
             self.run(rx),

--- a/crates/bifrost/src/watchdog.rs
+++ b/crates/bifrost/src/watchdog.rs
@@ -170,7 +170,7 @@ impl Watchdog {
     fn spawn_trim(&self, mut trim_requests: TrimRequests) -> Result<TaskHandle<()>, ShutdownError> {
         let bifrost = self.inner.clone();
         let weak_writer_tx = self.chain_writer_tx.downgrade();
-        TaskCenter::spawn_unmanaged(
+        TaskCenter::spawn_unmanaged_child(
             TaskKind::BifrostBackgroundLowPriority,
             "trim-chains",
             async move {

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -13,6 +13,8 @@ use tokio_stream::StreamExt;
 use tonic::codec::CompressionEncoding;
 use tonic::{Request, Response, Status, Streaming};
 
+use restate_types::config::NetworkingOptions;
+
 use crate::network::ConnectionManager;
 use crate::network::protobuf::core_node_svc::core_node_svc_server::{
     CoreNodeSvc, CoreNodeSvcServer,
@@ -31,18 +33,23 @@ impl CoreNodeSvcHandler {
         Self { connections }
     }
 
-    pub fn into_server(self) -> CoreNodeSvcServer<Self> {
-        CoreNodeSvcServer::new(self)
+    pub fn into_server(self, config: &NetworkingOptions) -> CoreNodeSvcServer<Self> {
+        let server = CoreNodeSvcServer::new(self)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
             .max_encoding_message_size(MAX_MESSAGE_SIZE)
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+        if config.disable_compression {
+            server
+        } else {
             // note: the order of those calls defines the priority
             // deflate/gzip has significantly higher CPU overhead according to our CPU profiling,
             // so we prefer zstd over gzip.
-            .send_compressed(CompressionEncoding::Zstd)
-            .send_compressed(CompressionEncoding::Gzip)
+            server
+                .send_compressed(CompressionEncoding::Zstd)
+                .send_compressed(CompressionEncoding::Gzip)
+        }
     }
 }
 

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -78,7 +78,9 @@ pub enum RuntimeError {
 }
 
 /// Task center is used to manage long-running and background tasks and their lifecycle.
-pub struct TaskCenter {}
+pub struct TaskCenter {
+    _private: (),
+}
 
 impl TaskCenter {
     pub fn try_current() -> Option<Handle> {
@@ -165,6 +167,10 @@ impl TaskCenter {
     /// Spawn a new task that is a child of the current task. The child task will be cancelled if the parent
     /// task is cancelled. At the moment, the parent task will not automatically wait for children tasks to
     /// finish before completion, but this might change in the future if the need for that arises.
+    ///
+    /// If the parent task is being cancelled at the time of spawning, this call will fail.
+    /// Existing children tasks will receive cancellation signal but it's up to the task to react
+    /// to the `cancellation_token()` in a cooperative manner.
     #[track_caller]
     pub fn spawn_child<F>(
         kind: TaskKind,
@@ -175,6 +181,26 @@ impl TaskCenter {
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
         Self::with_current(|tc| tc.spawn_child(kind, name, future))
+    }
+
+    /// An unmanaged task is one that is not automatically cancelled by the task center on
+    /// shutdown. Moreover, the task ID will not be registered with task center and therefore
+    /// cannot be "taken" by calling [`TaskCenter::take_task`].
+    ///
+    /// This task is spawned as a child of the current task. If the current task is being cancelled,
+    /// this will fail to spawn, but already spawned tasks will continue to run unless they are
+    /// manually cancelled (hence the name "unmanaged").
+    #[track_caller]
+    pub fn spawn_unmanaged_child<F, T>(
+        kind: TaskKind,
+        name: impl Into<SharedString>,
+        future: F,
+    ) -> Result<TaskHandle<T>, ShutdownError>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        Self::with_current(|tc| tc.spawn_unmanaged_child(kind, name, future))
     }
 
     /// An unmanaged task is one that is not automatically cancelled by the task center on
@@ -294,6 +320,7 @@ struct TaskCenterInner {
     id: u16,
     /// Should we start new runtimes with paused clock?
     #[allow(dead_code)]
+    #[cfg(any(test, feature = "test-util"))]
     pause_time: bool,
     default_runtime_handle: tokio::runtime::Handle,
     managed_runtimes: Mutex<HashMap<SharedString, OwnedRuntimeHandle>>,
@@ -321,7 +348,7 @@ impl TaskCenterInner {
         default_runtime: Option<tokio::runtime::Runtime>,
         // used in tests to start all runtimes with clock paused. Note that this only impacts
         // partition processor runtimes
-        pause_time: bool,
+        #[cfg(any(test, feature = "test-util"))] pause_time: bool,
     ) -> Self {
         metric_definitions::describe_metrics();
         let root_task_context = TaskContext {
@@ -343,6 +370,7 @@ impl TaskCenterInner {
             global_metadata: OnceLock::new(),
             managed_runtimes: Mutex::new(HashMap::with_capacity(64)),
             root_task_context,
+            #[cfg(any(test, feature = "test-util"))]
             pause_time,
             cluster_state: Default::default(),
             health: Health::default(),
@@ -412,7 +440,7 @@ impl TaskCenterInner {
     pub fn spawn<F>(
         self: &Arc<Self>,
         kind: TaskKind,
-        name: &SharedString,
+        name: impl Into<SharedString>,
         future: F,
     ) -> Result<TaskId, ShutdownError>
     where
@@ -421,13 +449,33 @@ impl TaskCenterInner {
         if self.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
+        let name = name.into();
 
         // spawned tasks get their own unlinked cancellation tokens
         let cancel = CancellationToken::new();
         let (parent_id, parent_name, parent_partition) =
             self.with_task_context(|ctx| (ctx.id, ctx.name.clone(), ctx.partition_id));
 
-        let result = self.spawn_inner(kind, name, parent_id, parent_partition, cancel, future);
+        if self.root_task_context.cancellation_token.is_cancelled() {
+            debug!(
+                kind = ?kind,
+                name = %name,
+                parent_task = %parent_id,
+                parent_name = %parent_name,
+                "Cannot start new task \"{}\" because task-center is shutting down.",
+                name,
+            );
+            return Err(ShutdownError);
+        }
+
+        let result = self.spawn_inner(
+            kind,
+            name.clone(),
+            parent_id,
+            parent_partition,
+            cancel,
+            future,
+        );
 
         trace!(
             kind = ?kind,
@@ -454,6 +502,7 @@ impl TaskCenterInner {
         if self.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
+        let name = name.into();
 
         let (parent_id, parent_name, parent_kind, parent_partition, cancel) = self
             .with_task_context(|ctx| {
@@ -466,8 +515,26 @@ impl TaskCenterInner {
                 )
             });
 
-        let name = name.into();
-        let result = self.spawn_inner(kind, &name, parent_id, parent_partition, cancel, future);
+        if cancel.is_cancelled() {
+            debug!(
+                kind = ?kind,
+                name = %name,
+                parent_task = %parent_id,
+                parent_name = %parent_name,
+                "Cannot start new task {} in \"{}\" {} because parent has been cancelled.",
+                name, parent_name, parent_id,
+            );
+            return Err(ShutdownError);
+        }
+
+        let result = self.spawn_inner(
+            kind,
+            name.clone(),
+            parent_id,
+            parent_partition,
+            cancel,
+            future,
+        );
 
         trace!(
             kind = ?parent_kind,
@@ -492,7 +559,67 @@ impl TaskCenterInner {
         if self.shutdown_requested.load(Ordering::Relaxed) {
             return Err(ShutdownError);
         }
-        let parent_partition = self.with_task_context(|ctx| (ctx.partition_id));
+        let (parent_id, parent_name, parent_partition) =
+            self.with_task_context(|ctx| (ctx.id, ctx.name.clone(), ctx.partition_id));
+
+        if self.root_task_context.cancellation_token.is_cancelled() {
+            debug!(
+                kind = ?kind,
+                name = %name,
+                parent_task = %parent_id,
+                parent_name = %parent_name,
+                "Cannot start new task \"{}\" because task-center is shutting down.",
+                name,
+            );
+            return Err(ShutdownError);
+        }
+
+        let cancel = CancellationToken::new();
+        let id = TaskId::default();
+        let context = TaskContext {
+            id,
+            name: name.clone(),
+            kind,
+            partition_id: parent_partition,
+            cancellation_token: cancel.clone(),
+        };
+
+        let fut = unmanaged_wrapper(Arc::clone(self), context, future);
+
+        Ok(self.spawn_on_runtime(kind, name, cancel, fut))
+    }
+
+    pub fn spawn_unmanaged_child<F, T>(
+        self: &Arc<Self>,
+        kind: TaskKind,
+        name: &SharedString,
+        future: F,
+    ) -> Result<TaskHandle<T>, ShutdownError>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (parent_id, parent_name, parent_partition, is_parent_cancelled) = self
+            .with_task_context(|ctx| {
+                (
+                    ctx.id,
+                    ctx.name.clone(),
+                    ctx.partition_id,
+                    ctx.cancellation_token.is_cancelled(),
+                )
+            });
+
+        if is_parent_cancelled {
+            debug!(
+                kind = ?kind,
+                name = %name,
+                parent_task = %parent_id,
+                parent_name = %parent_name,
+                "Cannot start new task {} in \"{}\" {} because parent has been cancelled.",
+                name, parent_name, parent_id,
+            );
+            return Err(ShutdownError);
+        }
 
         let cancel = CancellationToken::new();
         let id = TaskId::default();
@@ -735,7 +862,7 @@ impl TaskCenterInner {
     fn spawn_inner<F>(
         self: &Arc<Self>,
         kind: TaskKind,
-        name: &SharedString,
+        name: SharedString,
         _parent_id: TaskId,
         partition_id: Option<PartitionId>,
         cancel: CancellationToken,
@@ -763,7 +890,7 @@ impl TaskCenterInner {
         let mut handle_mut = task.handle.lock();
 
         let fut = wrapper(inner, context, future);
-        *handle_mut = Some(self.spawn_on_runtime(kind, name, cancel, fut));
+        *handle_mut = Some(self.spawn_on_runtime(kind, &name, cancel, fut));
         // drop the lock
         drop(handle_mut);
         // Task is ready
@@ -925,6 +1052,7 @@ impl TaskCenterInner {
             .await;
         self.shutdown_managed_runtimes();
         // global shutdown trigger
+        self.root_task_context.cancel();
         self.cancel_tasks(None, None).await;
         // notify outer components that we have completed the shutdown.
         let on_shutdown = self.on_shutdown.lock().take();

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -446,9 +446,6 @@ impl TaskCenterInner {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        if self.shutdown_requested.load(Ordering::Relaxed) {
-            return Err(ShutdownError);
-        }
         let name = name.into();
 
         // spawned tasks get their own unlinked cancellation tokens
@@ -499,9 +496,6 @@ impl TaskCenterInner {
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
-        if self.shutdown_requested.load(Ordering::Relaxed) {
-            return Err(ShutdownError);
-        }
         let name = name.into();
 
         let (parent_id, parent_name, parent_kind, parent_partition, cancel) = self
@@ -556,9 +550,6 @@ impl TaskCenterInner {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        if self.shutdown_requested.load(Ordering::Relaxed) {
-            return Err(ShutdownError);
-        }
         let (parent_id, parent_name, parent_partition) =
             self.with_task_context(|ctx| (ctx.id, ctx.name.clone(), ctx.partition_id));
 
@@ -1044,12 +1035,26 @@ impl TaskCenterInner {
         // stop accepting ingress
         self.cancel_tasks(Some(TaskKind::HttpIngressRole), None)
             .await;
+        // stop admin server and in-flight query-server requests
+        self.cancel_tasks(Some(TaskKind::AdminApiServer), None)
+            .await;
         // Worker will shutdown running processors
         self.cancel_tasks(Some(TaskKind::WorkerRole), None).await;
+
         self.initiate_managed_runtimes_shutdown();
         // Ask bifrost to shutdown providers and loglets
+        self.cancel_tasks(Some(TaskKind::BifrostBackgroundLowPriority), None)
+            .await;
         self.cancel_tasks(Some(TaskKind::BifrostWatchdog), None)
             .await;
+
+        // Stop log-server role
+        self.cancel_tasks(Some(TaskKind::LogServerRole), None).await;
+
+        // stop metadata server
+        self.cancel_tasks(Some(TaskKind::MetadataServer), None)
+            .await;
+
         self.shutdown_managed_runtimes();
         // global shutdown trigger
         self.root_task_context.cancel();

--- a/crates/core/src/task_center/builder.rs
+++ b/crates/core/src/task_center/builder.rs
@@ -31,6 +31,7 @@ pub struct TaskCenterBuilder {
     default_runtime_handle: Option<tokio::runtime::Handle>,
     default_runtime: Option<tokio::runtime::Runtime>,
     options: Option<CommonOptions>,
+    #[cfg(any(test, feature = "test-util"))]
     pause_time: bool,
 }
 
@@ -52,11 +53,13 @@ impl TaskCenterBuilder {
         self
     }
 
+    #[cfg(any(test, feature = "test-util"))]
     pub fn pause_time(mut self, pause_time: bool) -> Self {
         self.pause_time = pause_time;
         self
     }
 
+    #[cfg(any(test, feature = "test-util"))]
     pub fn default_for_tests() -> Self {
         Self::default()
             .default_runtime_handle(tokio::runtime::Handle::current())
@@ -78,6 +81,7 @@ impl TaskCenterBuilder {
         Ok(OwnedHandle::new(TaskCenterInner::new(
             self.default_runtime_handle.unwrap(),
             self.default_runtime,
+            #[cfg(any(test, feature = "test-util"))]
             self.pause_time,
         )))
     }

--- a/crates/core/src/task_center/handle.rs
+++ b/crates/core/src/task_center/handle.rs
@@ -145,7 +145,7 @@ impl Handle {
         F: Future<Output = anyhow::Result<()>> + Send + 'static,
     {
         let name = name.into();
-        self.inner.spawn(kind, &name, future)
+        self.inner.spawn(kind, name, future)
     }
 
     /// Spawn a new task that is a child of the current task. The child task will be cancelled if the parent
@@ -178,6 +178,27 @@ impl Handle {
     {
         let name = name.into();
         self.inner.spawn_unmanaged(kind, &name, future)
+    }
+
+    /// An unmanaged task is one that is not automatically cancelled by the task center on
+    /// shutdown. Moreover, the task ID will not be registered with task center and therefore
+    /// cannot be "taken" by calling [`TaskCenter::take_task`].
+    ///
+    /// This task is spawned as a child of the current task. Therefore, if the parent task is
+    /// cancelled, the child task will also be cancelled. New child tasks will fail if the current
+    /// task is already being cancelled.
+    pub fn spawn_unmanaged_child<F, T>(
+        &self,
+        kind: TaskKind,
+        name: impl Into<SharedString>,
+        future: F,
+    ) -> Result<TaskHandle<T>, ShutdownError>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let name = name.into();
+        self.inner.spawn_unmanaged_child(kind, &name, future)
     }
 
     /// Must be called within a Localset-scoped task, not from a normal spawned task.

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -77,7 +77,7 @@ pub enum TaskKind {
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
     RpcServer,
-    #[strum(props(runtime = "default"))]
+    #[strum(props(OnError = "log", runtime = "default"))]
     SocketHandler,
     /// An http2 stream handler created by the server-side of the connection.
     #[strum(props(OnError = "log", runtime = "default"))]

--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -76,7 +76,9 @@ pub enum TaskKind {
     SystemBoot,
     #[strum(props(OnCancel = "abort"))]
     MetadataBackgroundSync,
-    RpcServer,
+    NodeRpcServer,
+    AdminApiServer,
+    LogServerRole,
     #[strum(props(OnError = "log", runtime = "default"))]
     SocketHandler,
     /// An http2 stream handler created by the server-side of the connection.

--- a/crates/local-cluster-runner/examples/three_nodes.rs
+++ b/crates/local-cluster-runner/examples/three_nodes.rs
@@ -8,7 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::pin::pin;
+use std::time::Duration;
+
 use futures::never::Never;
+use tracing::{error, info};
+
 use restate_core::TaskCenterBuilder;
 use restate_local_cluster_runner::cluster::StartedCluster;
 use restate_local_cluster_runner::{
@@ -19,9 +24,6 @@ use restate_local_cluster_runner::{
 use restate_types::config::{Configuration, LogFormat};
 use restate_types::config_loader::ConfigLoaderBuilder;
 use restate_types::logs::metadata::ProviderKind::Replicated;
-use std::pin::pin;
-use std::time::Duration;
-use tracing::{error, info};
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
@@ -85,6 +87,7 @@ fn main() -> anyhow::Result<()> {
 
         Ok(())
     })
+    .expect("panicked!")
 }
 
 async fn run_cluster(cluster: &StartedCluster) -> anyhow::Result<Never> {

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -47,7 +47,7 @@ pub struct LogServerService {
 impl LogServerService {
     pub async fn create(
         health_status: HealthStatus<LogServerStatus>,
-        updateable_config: Live<Configuration>,
+        mut updateable_config: Live<Configuration>,
         metadata: Metadata,
         record_cache: RecordCache,
         router_builder: &mut MessageRouterBuilder,
@@ -81,7 +81,7 @@ impl LogServerService {
         server_builder.register_grpc_service(
             TonicServiceFilter::new(
                 LogServerSvcHandler::new(log_store.clone(), state_map.clone(), record_cache)
-                    .into_server(),
+                    .into_server(&updateable_config.live_load().networking),
                 WaitForReady::new(health_status.clone(), LogServerStatus::Ready),
             ),
             crate::protobuf::FILE_DESCRIPTOR_SET,

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -111,8 +111,8 @@ impl LogServerService {
         let storage_state =
             Self::provision_node(&metadata, &mut log_store, &mut metadata_writer).await?;
 
-        let _ = TaskCenter::spawn_child(
-            TaskKind::SystemService,
+        let _ = TaskCenter::spawn(
+            TaskKind::LogServerRole,
             "log-server",
             request_pump.run(health_status, log_store, state_map, storage_state),
         )?;

--- a/crates/metadata-server/src/raft/network/networking.rs
+++ b/crates/metadata-server/src/raft/network/networking.rs
@@ -154,7 +154,7 @@ where
         address: AdvertisedAddress,
         networking_options: &NetworkingOptions,
     ) -> Result<TaskHandle<anyhow::Result<()>>, ShutdownError> {
-        TaskCenter::spawn_unmanaged(
+        TaskCenter::spawn_unmanaged_child(
             TaskKind::SocketHandler,
             "metadata-store-network-connection-attempt",
             {

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -179,12 +179,12 @@ impl RaftMetadataServer {
                 Arc::clone(&connection_manager),
                 Some(JoinClusterHandle::new(join_cluster_tx)),
             )
-            .into_server(),
+            .into_server(&Configuration::pinned().networking),
             network::FILE_DESCRIPTOR_SET,
         );
         server_builder.register_grpc_service(
             MetadataServerHandler::new(request_tx, Some(provision_tx), Some(status_rx), command_tx)
-                .into_server(),
+                .into_server(&Configuration::pinned().networking),
             restate_metadata_server_grpc::grpc::FILE_DESCRIPTOR_SET,
         );
 

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -118,7 +118,7 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
     )
     .await?;
 
-    TaskCenter::spawn_child(TaskKind::RpcServer, "node-rpc-server", async move {
+    TaskCenter::spawn_child(TaskKind::NodeRpcServer, "node-rpc-server", async move {
         server_builder
             .run(health.node_rpc_status(), &bind_address)
             .await

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -354,7 +354,7 @@ impl Node {
         spawn_metadata_manager(self.metadata_manager)?;
 
         // spawn the node rpc server first to enable connecting to the metadata store
-        TaskCenter::spawn(TaskKind::RpcServer, "node-rpc-server", {
+        TaskCenter::spawn(TaskKind::NodeRpcServer, "node-rpc-server", {
             let common_options = config.common.clone();
             let connection_manager = self.networking.connection_manager().clone();
             let metadata_writer = metadata_writer.clone();
@@ -504,11 +504,7 @@ impl Node {
         }
 
         if let Some(ingress_role) = self.ingress_role {
-            TaskCenter::spawn(
-                TaskKind::HttpIngressRole,
-                "ingress-http",
-                ingress_role.run(),
-            )?;
+            ingress_role.start()?;
         }
 
         if let Some(worker_role) = self.worker_role {
@@ -516,7 +512,7 @@ impl Node {
         }
 
         if let Some(admin_role) = self.admin_role {
-            TaskCenter::spawn(TaskKind::SystemBoot, "admin-init", admin_role.start())?;
+            admin_role.start()?;
         }
 
         let my_roles = my_node_config.roles;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -355,14 +355,12 @@ impl Node {
 
         // spawn the node rpc server first to enable connecting to the metadata store
         TaskCenter::spawn(TaskKind::NodeRpcServer, "node-rpc-server", {
-            let common_options = config.common.clone();
             let connection_manager = self.networking.connection_manager().clone();
             let metadata_writer = metadata_writer.clone();
             async move {
                 NetworkServer::run(
                     connection_manager,
                     self.server_builder,
-                    common_options,
                     metadata_writer,
                     self.prometheus,
                 )

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -141,18 +141,18 @@ impl<T: TransportConnect> AdminRole<T> {
         })
     }
 
-    pub async fn start(self) -> Result<(), anyhow::Error> {
+    pub fn start(self) -> Result<(), anyhow::Error> {
         if let Some(cluster_controller) = self.controller {
-            TaskCenter::spawn_child(
+            TaskCenter::spawn(
                 TaskKind::ClusterController,
                 "cluster-controller-service",
                 cluster_controller.run(),
             )?;
         }
 
-        TaskCenter::spawn_child(
-            TaskKind::RpcServer,
-            "admin-rpc-server",
+        TaskCenter::spawn(
+            TaskKind::AdminApiServer,
+            "admin-api-server",
             self.admin.run(self.updateable_config.map(|c| &c.admin)),
         )?;
 

--- a/crates/node/src/roles/ingress.rs
+++ b/crates/node/src/roles/ingress.rs
@@ -11,6 +11,7 @@
 use restate_core::network::{Networking, TransportConnect};
 use restate_core::partitions::PartitionRouting;
 use restate_core::worker_api::PartitionProcessorInvocationClient;
+use restate_core::{TaskCenter, TaskKind};
 use restate_ingress_http::{HyperServerIngress, InvocationClientRequestDispatcher};
 use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
@@ -50,7 +51,13 @@ impl<T: TransportConnect> IngressRole<T> {
         Self { ingress_http }
     }
 
-    pub async fn run(self) -> anyhow::Result<()> {
-        self.ingress_http.run().await
+    pub fn start(self) -> Result<(), anyhow::Error> {
+        TaskCenter::spawn(
+            TaskKind::HttpIngressRole,
+            "ingress-http",
+            self.ingress_http.run(),
+        )?;
+
+        Ok(())
     }
 }

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -60,6 +60,11 @@ pub struct NetworkingOptions {
     /// # HTTP/2 Adaptive Window
     pub http2_adaptive_window: bool,
 
+    /// # Disable Compression
+    ///
+    /// Disables Zstd compression for internal gRPC network connections
+    pub disable_compression: bool,
+
     /// # Data Stream Window Size
     ///
     /// Controls the number of bytes the can be sent on every data stream before inducing
@@ -103,6 +108,7 @@ impl Default for NetworkingOptions {
             http2_keep_alive_interval: Duration::from_secs(1).into(),
             http2_keep_alive_timeout: Duration::from_secs(3).into(),
             http2_adaptive_window: true,
+            disable_compression: false,
             // 2MiB
             data_stream_window_size: NonZeroByteCount::new(
                 NonZeroUsize::new(2 * 1024 * 1024).expect("Non zero number"),

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -212,6 +212,6 @@ pub struct CsNode {
 
 impl NodeState {
     pub fn is_alive(self) -> bool {
-        matches!(self, Self::Alive | Self::FailingOver)
+        matches!(self, Self::Alive)
     }
 }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1029,7 +1029,7 @@ impl PartitionProcessorManager {
                 } else {
                     Duration::from_millis(rand::rng().random_range(0..10_000))
                 };
-                let spawn_task_result = TaskCenter::spawn_unmanaged(
+                let spawn_task_result = TaskCenter::spawn_unmanaged_child(
                     TaskKind::PartitionSnapshotProducer,
                     "create-snapshot",
                     async move {

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -307,7 +307,7 @@ impl PartitionProcessorManager {
                     }
                 }
                 Some(event) = self.asynchronous_operations.join_next() => {
-                    self.on_asynchronous_event(event.expect("asynchronous operations must not panic"));
+                    self.on_asynchronous_event(event.context("asynchronous operations must not panic")?);
                 }
                 Some(partition_processor_rpc) = pp_rpc_rx.next() => {
                     self.on_partition_processor_rpc(partition_processor_rpc);

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -168,12 +168,12 @@ impl SpawnPartitionProcessorTask {
 
                     // Invoker needs to outlive the partition processor when shutdown signal is
                     // received. This is why it's not spawned as a "child".
-                    let invoker = TaskCenter::spawn_unmanaged(
+                    let invoker = TaskCenter::spawn_unmanaged_child(
                         TaskKind::SystemService,
                         invoker_name,
                         invoker.run(invoker_config),
                     )
-                    .map_err(|e| ProcessorError::from(anyhow::anyhow!(e)))? .into_guard();
+                    .map_err(|e| ProcessorError::from(anyhow::anyhow!(e)))?.into_guard();
 
                     let result = pp.run().await;
 

--- a/tools/restatectl/src/commands/log/dump_log.rs
+++ b/tools/restatectl/src/commands/log/dump_log.rs
@@ -102,7 +102,7 @@ async fn start_metadata_server(mut config: Configuration) -> anyhow::Result<Meta
 
     let rpc_server_health = if !server_builder.is_empty() {
         let rpc_server_health_status = HealthStatus::default();
-        TaskCenter::spawn(TaskKind::RpcServer, "metadata-rpc-server", {
+        TaskCenter::spawn(TaskKind::MetadataServer, "metadata-rpc-server", {
             let rpc_server_health_status = rpc_server_health_status.clone();
             async move {
                 server_builder

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -299,7 +299,8 @@ Tasks:
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let tc = TaskCenterBuilder::default_for_tests()
+    let tc = TaskCenterBuilder::default()
+        .default_runtime_handle(tokio::runtime::Handle::current())
         .build()
         .expect("building task-center should not fail")
         .into_handle();


### PR DESCRIPTION

Introduces `networking.disable_compression` that disables Zstd compression for grpc services.

```
// intentionally empty
```
