### PR TITLE
Upgrade to NodeJS 22 (LTS)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: "Download GitHub Artifacts"
@@ -117,7 +117,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,7 +365,7 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: "22.x"
           registry-url: 'https://registry.npmjs.org'
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,8 +365,8 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
-          registry-url: "https://registry.npmjs.org"
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)

--- a/npm/restate-server/package.json
+++ b/npm/restate-server/package.json
@@ -28,11 +28,11 @@
     "skipTraversal": true
   },
   "devDependencies": {
-    "@types/node": "^18.11.18",
+    "@types/node": "^22.13.14",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
-    "typescript": "^4.9.4"
+    "typescript": "^5.9.2"
   },
   "optionalDependencies": {
     "@restatedev/restate-server-linux-x64": "0.5.1",

--- a/npm/restate/package.json
+++ b/npm/restate/package.json
@@ -32,7 +32,7 @@
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
-    "typescript": "5.9.2"
+    "typescript": "^5.9.2"
   },
   "optionalDependencies": {
     "@restatedev/restate-linux-x64": "0.5.1",

--- a/npm/restate/package.json
+++ b/npm/restate/package.json
@@ -28,11 +28,11 @@
     "skipTraversal": true
   },
   "devDependencies": {
-    "@types/node": "^18.11.18",
+    "@types/node": "^22.13.14",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
-    "typescript": "^4.9.4"
+    "typescript": "5.9.2"
   },
   "optionalDependencies": {
     "@restatedev/restate-linux-x64": "0.5.1",

--- a/npm/restatectl/package.json
+++ b/npm/restatectl/package.json
@@ -28,11 +28,11 @@
     "skipTraversal": true
   },
   "devDependencies": {
-    "@types/node": "^18.11.18",
+    "@types/node": "^22.13.14",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
-    "typescript": "^4.9.4"
+    "typescript": "^5.9.2"
   },
   "optionalDependencies": {
     "@restatedev/restatectl-linux-x64": "0.5.1",

--- a/scripts/loadtest-environment/package.json
+++ b/scripts/loadtest-environment/package.json
@@ -7,13 +7,13 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.14.9",
+    "@types/node": "^22.13.14",
     "aws-cdk": "^2.177.0",
     "aws-cdk-lib": "^2.177.0",
     "constructs": "^10.0.0",
     "prettier": "^3.3.3",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.0"
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
Updates references of the [setup-node](https://github.com/actions/setup-node) action in workflow files to use v22 (current LTS) rather than older v18 & v20 references.

Also bumps the npm packages to reflect via `@types/node` and `typescript`.

Resolves #3142 