### PR TITLE
Update currently applied DB configuration values after reload

### DIFF
--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -662,6 +662,8 @@ impl DbWatchdog {
 
         // todo: Apply other changes to the databases.
         // e.g. set write_buffer_size
+
+        self.current_common_opts = new_common_opts.clone();
     }
 }
 


### PR DESCRIPTION
I think this was missed in the original change. Without saving the new options, changing them again works only as long as the new values are not reverted to the originally loaded values. E.g. changing `rocksdb-enable-stall-on-memory-limit` from `false` to `true` works, but cannot be reverted back to `false` without a restart. It also incorrectly reports settings as changed if unrelated options change.