### PR TITLE
[Restate UI] Update to v0.0.93

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7997,8 +7997,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.92"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.92#3d4e2f09ced1945d607e6767d622e184edcbdbfa"
+version = "0.0.93"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.93#16ac00bd212039bf290334cfd5c245d675ab3b5d"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -28,7 +28,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.92", tag = "v0.0.92" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.93", tag = "v0.0.93" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.93
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.93/ui-v0.0.93.zip