### PR TITLE
[Restate UI] Update to v0.0.94

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7997,8 +7997,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.93"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.93#16ac00bd212039bf290334cfd5c245d675ab3b5d"
+version = "0.0.94"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.94#f735c111179efab9ac3551213ec19e51bd10e432"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -28,7 +28,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.93", tag = "v0.0.93" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.94", tag = "v0.0.94" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.94
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.94/ui-v0.0.94.zip