### PR TITLE
Introduce migration for InvocationStatusV1.

### DIFF
--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -12,7 +12,6 @@ use std::ops::RangeInclusive;
 
 use futures::Stream;
 use tokio_stream::StreamExt;
-use tracing::trace;
 
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
 use restate_storage_api::invocation_status_table::{
@@ -26,6 +25,7 @@ use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, Wit
 
 use crate::TableScan::FullScanPartitionKeyRange;
 use crate::keys::{KeyKind, TableKey, define_table_key};
+use crate::owned_iter::OwnedIterator;
 use crate::scan::TableScan;
 use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind};
 
@@ -38,13 +38,6 @@ define_table_key!(
         invocation_uuid: InvocationUuid
     )
 );
-
-// TODO remove this once we remove the old InvocationStatus
-fn create_invocation_status_key_v1(invocation_id: &InvocationId) -> InvocationStatusKeyV1 {
-    InvocationStatusKeyV1::default()
-        .partition_key(invocation_id.partition_key())
-        .invocation_uuid(invocation_id.invocation_uuid())
-}
 
 define_table_key!(
     TableKind::InvocationStatus,
@@ -59,21 +52,6 @@ fn create_invocation_status_key(invocation_id: &InvocationId) -> InvocationStatu
     InvocationStatusKey::default()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid())
-}
-
-// TODO remove this once we remove the old InvocationStatus
-fn invocation_id_from_v1_key_bytes<B: bytes::Buf>(bytes: &mut B) -> crate::Result<InvocationId> {
-    let mut key = InvocationStatusKeyV1::deserialize_from(bytes)?;
-    let partition_key = key
-        .partition_key
-        .take()
-        .ok_or(StorageError::DataIntegrityError)?;
-    Ok(InvocationId::from_parts(
-        partition_key,
-        key.invocation_uuid
-            .take()
-            .ok_or(StorageError::DataIntegrityError)?,
-    ))
 }
 
 fn invocation_id_from_key_bytes<B: bytes::Buf>(bytes: &mut B) -> crate::Result<InvocationId> {
@@ -107,47 +85,6 @@ fn get_invocation_status<S: StorageAccess>(
 ) -> Result<InvocationStatus> {
     let _x = RocksDbPerfGuard::new("get-invocation-status");
 
-    if let Some(s) =
-        storage.get_value::<_, InvocationStatus>(create_invocation_status_key(invocation_id))?
-    {
-        return Ok(s);
-    }
-
-    // todo: Remove this once we remove the old InvocationStatus
-    // The underlying assumption is that an invocation status will never exist in both old and new
-    // invocation status table.
-    storage
-        .get_value::<_, InvocationStatusV1>(create_invocation_status_key_v1(invocation_id))
-        .map(|value| {
-            if let Some(invocation_status) = value {
-                invocation_status.0
-            } else {
-                InvocationStatus::Free
-            }
-        })
-}
-
-fn try_migrate_and_get_invocation_status<S: StorageAccess>(
-    storage: &mut S,
-    invocation_id: &InvocationId,
-) -> Result<InvocationStatus> {
-    let _x = RocksDbPerfGuard::new("try-migrate-and-get-invocation-status");
-
-    let v1_key = create_invocation_status_key_v1(invocation_id);
-    if let Some(status_v1) = storage.get_value::<_, InvocationStatusV1>(v1_key.clone())? {
-        trace!("Migrating invocation {invocation_id} from InvocationStatus V1");
-        put_invocation_status(
-            storage,
-            &InvocationId::from_parts(
-                *v1_key.partition_key_ok_or()?,
-                *v1_key.invocation_uuid_ok_or()?,
-            ),
-            &status_v1.0,
-        )?;
-        storage.delete_key(&v1_key)?;
-        return Ok(status_v1.0);
-    }
-
     storage
         .get_value::<_, InvocationStatus>(create_invocation_status_key(invocation_id))
         .map(|value| {
@@ -163,26 +100,7 @@ fn delete_invocation_status<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
 ) -> Result<()> {
-    // TODO remove this once we remove the old InvocationStatus
-    storage.delete_key(&create_invocation_status_key_v1(invocation_id))?;
     storage.delete_key(&create_invocation_status_key(invocation_id))
-}
-
-// TODO remove this once we remove the old InvocationStatus
-fn read_invoked_v1_full_invocation_id(
-    mut kv: (&[u8], &[u8]),
-) -> Result<Option<InvokedInvocationStatusLite>> {
-    let invocation_id = invocation_id_from_v1_key_bytes(&mut kv.0)?;
-    let invocation_status = InvocationStatusV1::decode(&mut kv.1)?;
-    if let InvocationStatus::Invoked(invocation_meta) = invocation_status.0 {
-        Ok(Some(InvokedInvocationStatusLite {
-            invocation_id,
-            invocation_target: invocation_meta.invocation_target,
-            current_invocation_epoch: 0,
-        }))
-    } else {
-        Ok(None)
-    }
 }
 
 fn read_invoked_full_invocation_id(
@@ -201,6 +119,34 @@ fn read_invoked_full_invocation_id(
     }
 }
 
+pub(crate) async fn run_invocation_status_v1_migration(
+    storage: &mut PartitionStoreTransaction<'_>,
+) -> Result<()> {
+    let partition_key_range = storage.partition_key_range().clone();
+    let invocation_statuses: Result<Vec<_>> =
+        OwnedIterator::new(storage.iterator_from::<InvocationStatusKeyV1>(
+            FullScanPartitionKeyRange(partition_key_range),
+        )?)
+        .map(|(mut old_key, mut old_value)| {
+            Ok((
+                InvocationStatusKeyV1::deserialize_from(&mut old_key)?,
+                InvocationStatusV1::decode(&mut old_value)?,
+            ))
+        })
+        .collect();
+
+    for (key, value) in invocation_statuses? {
+        put_invocation_status(
+            storage,
+            &InvocationId::from_parts(*key.partition_key_ok_or()?, *key.invocation_uuid_ok_or()?),
+            &value.0,
+        )?;
+        storage.delete_key(&key)?;
+    }
+
+    Ok(())
+}
+
 impl ReadOnlyInvocationStatusTable for PartitionStore {
     async fn get_invocation_status(
         &mut self,
@@ -215,21 +161,7 @@ impl ScanInvocationStatusTable for PartitionStore {
     fn scan_invoked_invocations(
         &self,
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send> {
-        // Note: this is a high priority iterator because it's used by the leadership
-        // state machine when switching from candidate to leader.
-        let invocations_1 = self
-            .run_iterator(
-                "scan-all-invoked-v1",
-                Priority::High,
-                FullScanPartitionKeyRange::<InvocationStatusKeyV1>(
-                    self.partition_key_range().clone(),
-                ),
-                read_invoked_v1_full_invocation_id,
-            )
-            .map_err(|_| StorageError::OperationalError)?;
-        // fitler and map the stream from Result<Option<T>> to Result<T>
-
-        let invocations_2 = self
+        Ok(self
             .run_iterator(
                 "scan-all-invoked",
                 Priority::High,
@@ -238,10 +170,7 @@ impl ScanInvocationStatusTable for PartitionStore {
                 ),
                 read_invoked_full_invocation_id,
             )
-            .map_err(|_| StorageError::OperationalError)?;
-
-        Ok(invocations_1
-            .chain(invocations_2)
+            .map_err(|_| StorageError::OperationalError)?
             .filter_map(|result| match result {
                 Ok(Some(res)) => Some(Ok(res)),
                 Ok(None) => None,
@@ -253,43 +182,22 @@ impl ScanInvocationStatusTable for PartitionStore {
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(InvocationId, InvocationStatus)>> + Send> {
-        let old_status_keys = self
-            .run_iterator(
-                "df-invocation-status-v1",
-                Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<InvocationStatusKeyV1>(range.clone()),
-                |(mut key, mut value)| {
-                    let state_key = InvocationStatusKeyV1::deserialize_from(&mut key)?;
-                    let state_value = InvocationStatusV1::decode(&mut value)?;
+        self.run_iterator(
+            "df-invocation-status",
+            Priority::Low,
+            TableScan::FullScanPartitionKeyRange::<InvocationStatusKey>(range.clone()),
+            |(mut key, mut value)| {
+                let state_key = InvocationStatusKey::deserialize_from(&mut key)?;
+                let state_value = InvocationStatus::decode(&mut value)?;
 
-                    let (partition_key, invocation_uuid) = state_key.into_inner_ok_or()?;
-                    Ok((
-                        InvocationId::from_parts(partition_key, invocation_uuid),
-                        state_value.0,
-                    ))
-                },
-            )
-            .map_err(|_| StorageError::OperationalError)?;
-
-        let new_status_keys = self
-            .run_iterator(
-                "df-invocation-status",
-                Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<InvocationStatusKey>(range.clone()),
-                |(mut key, mut value)| {
-                    let state_key = InvocationStatusKey::deserialize_from(&mut key)?;
-                    let state_value = InvocationStatus::decode(&mut value)?;
-
-                    let (partition_key, invocation_uuid) = state_key.into_inner_ok_or()?;
-                    Ok((
-                        InvocationId::from_parts(partition_key, invocation_uuid),
-                        state_value,
-                    ))
-                },
-            )
-            .map_err(|_| StorageError::OperationalError)?;
-
-        Ok(old_status_keys.chain(new_status_keys))
+                let (partition_key, invocation_uuid) = state_key.into_inner_ok_or()?;
+                Ok((
+                    InvocationId::from_parts(partition_key, invocation_uuid),
+                    state_value,
+                ))
+            },
+        )
+        .map_err(|_| StorageError::OperationalError)
     }
 }
 
@@ -299,7 +207,7 @@ impl ReadOnlyInvocationStatusTable for PartitionStoreTransaction<'_> {
         invocation_id: &InvocationId,
     ) -> Result<InvocationStatus> {
         self.assert_partition_key(invocation_id)?;
-        try_migrate_and_get_invocation_status(self, invocation_id)
+        get_invocation_status(self, invocation_id)
     }
 }
 

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -18,6 +18,7 @@ pub mod invocation_status_table;
 pub mod journal_table;
 pub mod journal_table_v2;
 pub mod keys;
+mod migrations;
 pub mod outbox_table;
 mod owned_iter;
 mod partition_db;

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use strum::EnumCount;
+
+use crate::invocation_status_table::run_invocation_status_v1_migration;
+use crate::{PartitionStoreTransaction, Result};
+
+#[derive(Eq, PartialEq, strum::FromRepr, strum::EnumCount)]
+#[repr(u16)]
+pub(crate) enum LastExecutedMigration {
+    None = 0,
+    /// Invocation status V1 -> V2
+    V1_5 = 1,
+}
+
+pub(crate) const LATEST_MIGRATION: LastExecutedMigration =
+    LastExecutedMigration::from_repr((LastExecutedMigration::COUNT as u16) - 1).unwrap();
+
+impl From<u16> for LastExecutedMigration {
+    fn from(value: u16) -> Self {
+        LastExecutedMigration::from_repr(value).unwrap_or(LastExecutedMigration::V1_5)
+    }
+}
+
+impl LastExecutedMigration {
+    fn next(self) -> Self {
+        ((self as u16) + 1).into()
+    }
+
+    pub(crate) async fn run_all_migrations(
+        mut self,
+        storage: &mut PartitionStoreTransaction<'_>,
+    ) -> Result<Self> {
+        while self != LATEST_MIGRATION {
+            self.do_migration(storage).await?;
+            self = self.next();
+        }
+        Ok(self)
+    }
+
+    // Add migrations here!
+    async fn do_migration(&self, storage: &mut PartitionStoreTransaction<'_>) -> Result<()> {
+        match self {
+            LastExecutedMigration::None => {
+                run_invocation_status_v1_migration(storage).await?;
+            }
+            LastExecutedMigration::V1_5 => {}
+        }
+        Ok(())
+    }
+}

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -212,6 +212,9 @@ async fn test_migration() {
     .unwrap();
     txn.commit().await.unwrap();
 
+    // Now run the migrations
+    rocksdb.verify_and_run_migrations().await.unwrap();
+
     // Make sure we can read without mutating
     assert_eq!(
         status,

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -313,6 +313,10 @@ where
 
     async fn run_inner(&mut self) -> Result<(), ProcessorError> {
         let mut partition_store = self.partition_store.clone();
+
+        // Run migrations
+        partition_store.verify_and_run_migrations().await?;
+
         let last_applied_lsn = partition_store
             .get_applied_lsn()
             .await?


### PR DESCRIPTION
Part of #1852

Remove access to InvocationStatusV1 key range during PP execution. Now the migration is executed when the PP starts.