### PR TITLE
[cli] Simplify deployment type display in list

### DIFF
--- a/crates/types/src/schema/deployment.rs
+++ b/crates/types/src/schema/deployment.rs
@@ -23,10 +23,12 @@ use crate::identifiers::{DeploymentId, LambdaARN, ServiceRevision};
 use crate::schema::service::ServiceMetadata;
 use crate::time::MillisSinceEpoch;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, derive_more::Display)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProtocolType {
+    #[display("Request/Response")]
     RequestResponse,
+    #[display("Bidirectional Stream")]
     BidiStream,
 }
 


### PR DESCRIPTION
The `restate` cli now only prints a brief type in the deployments list view, and shows more detailed transport protocol details including HTTP version in the describe view. Thanks to https://github.com/restatedev/restate/pull/3642, the protocol version displayed now aligns to the version used by the runtime.

Fixes: #3364

---

```
~/restate/restate % cargo run --bin restate dep ls
 DEPLOYMENT                                                                                                                 TYPE    STATUS  ACTIVE-INVOCATIONS  ID                          CREATED-AT
 arn:aws:lambda:eu-central-1:663487780041:function:e2e-RestateCloud-eu1-ServiceDBC79909-NFdnEBg5RYVo:$LATEST                Lambda  Active  0                   dp_10tBkZFHXAI9ebjFy4IlZ61  2025-06-26T16:48:00.585000000Z

~/restate/restate % cargo run --bin restate dep describe dp_10tBkZFHXAI9ebjFy4IlZ61
📜 Deployment Information:
――――――――――――――――――――――――――
 ID:                          dp_10tBkZFHXAI9ebjFy4IlZ61
 Transport:                   AWS Lambda
 Protocol Style:              Request/Response
 Deployment Assume Role ARN:  arn:aws:iam::663487780041:role/e2e-RestateCloud-eu1-CloudEnvInvokerRole99692ABD-3nYzgN8Wb1WD
 Endpoint:                    arn:aws:lambda:eu-central-1:663487780041:function:e2e-RestateCloud-eu1-ServiceDBC79909-NFdnEBg5RYVo:$LATEST
 Created at:                  2025-06-26T16:48:00.585000000Z
 Protocol:                    5
 Status:                      Active
 Invocations:                 0


🤖 Services:
――――――――――――
  - Greeter
    Type: Service
    Revision: 1 [Latest]
     HANDLER  INPUT             OUTPUT            ACTIVE-INVOCATIONS
     greet    application/json  application/json  0

...

~/restate/restate % cargo run --bin restate dep ls
 DEPLOYMENT              TYPE  STATUS  ACTIVE-INVOCATIONS  ID                          CREATED-AT
 http://localhost:9080/  HTTP  Active  0                   dp_14MGBfxtq1CWHt6waBMwIuJ  2025-08-09T14:33:14.519000000Z

~/restate/restate % cargo run --bin restate dep describe dp_14MGBfxtq1CWHt6waBMwIuJ
📜 Deployment Information:
――――――――――――――――――――――――――
 ID:              dp_14MGBfxtq1CWHt6waBMwIuJ
 Transport:       HTTP/2.0
 Protocol Style:  Bidirectional Stream
 Endpoint:        http://localhost:9080/
 Created at:      2025-08-09T14:33:14.519000000Z
 Protocol:        5
 Status:          Active
 Invocations:     0


🤖 Services:
――――――――――――
  - SideEffect
    Type: Service
    Revision: 1 [Latest]
     HANDLER  INPUT             OUTPUT            ACTIVE-INVOCATIONS
     invoke   application/json  application/json  0
```