### PR TITLE
feat: Implement configurable rate limiting for the invoker using token bucket throttling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "gardal"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b8247c95fe11f2dd5fdab7b096829e4662a0c2d8002f54dd392f9e49bf8791"
+checksum = "e29896fff51cce710a632bea22ca5b174ec76634c4459687949a26046d09d3e7"
 dependencies = [
  "futures",
  "likely_stable",
@@ -7312,6 +7312,8 @@ version = "1.5.0-dev"
 dependencies = [
  "bincode",
  "criterion",
+ "futures",
+ "pin-project",
  "restate-fs-util",
  "restate-types",
  "restate-workspace-hack",
@@ -7905,11 +7907,9 @@ dependencies = [
  "enumset",
  "enumset_derive",
  "flate2",
- "futures",
  "futures-channel",
  "futures-core",
  "futures-executor",
- "futures-io",
  "futures-sink",
  "futures-task",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ flexbuffers = { version = "25.2.10" }
 futures = "0.3.25"
 futures-sink = "0.3.25"
 futures-util = "0.3.25"
-gardal = "0.0.1-alpha.6"
+gardal = "0.0.1-alpha.7"
 googletest = { version = "0.10", features = ["anyhow"] }
 hostname = { version = "0.4.0" }
 http = "1.3.1"

--- a/crates/queue/Cargo.toml
+++ b/crates/queue/Cargo.toml
@@ -9,10 +9,11 @@ publish = false
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
-
 restate-fs-util = { workspace = true }
 
 bincode = { workspace = true, default-features = false, features = ["std", "serde"] }
+futures = { workspace = true }
+pin-project = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
 

--- a/crates/queue/benches/queue_benchmark.rs
+++ b/crates/queue/benches/queue_benchmark.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use futures::StreamExt;
 use restate_queue::SegmentQueue;
 use std::path;
 use std::time::Duration;
@@ -27,7 +28,10 @@ async fn writing_to_queue_reading_from_queue(base_path: &path::Path) {
     let mut counter = 0;
 
     for _ in 0..number_values {
-        let value = queue.dequeue().await;
+        if queue.is_empty() {
+            break;
+        }
+        let value = queue.next().await;
 
         if let Some(value) = value {
             counter += value;

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -323,6 +323,19 @@ pub struct InvokerOptions {
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     experimental_features_allow_protocol_v6: bool,
 
+    /// # Invocation throttling
+    ///
+    /// Configures throttling for service invocations at the node level.
+    /// This throttling mechanism uses a token bucket algorithm to control the rate
+    /// at which invocations can be processed, helping to prevent resource exhaustion
+    /// and maintain system stability under high load.
+    ///
+    /// The throttling limit is shared across all partitions running on this node,
+    /// providing a global rate limit for the entire node rather than per-partition limits.
+    /// When `unset`, no throttling is applied and invocations are processed
+    /// without throttling.
+    pub invocation_throttling: Option<ThrottlingOptions>,
+
     /// # Action throttling
     ///
     /// Configures rate limiting for service actions at the node level.
@@ -333,7 +346,7 @@ pub struct InvokerOptions {
     /// The throttling limit is shared across all partitions running on this node,
     /// providing a global rate limit for the entire node rather than per-partition limits.
     /// When `unset`, no throttling is applied and actions are processed
-    /// without rate limiting.
+    /// without throttling.
     pub action_throttling: Option<ThrottlingOptions>,
 }
 
@@ -396,6 +409,7 @@ impl Default for InvokerOptions {
             disable_eager_state: false,
             experimental_features_propose_events: false,
             experimental_features_allow_protocol_v6: false,
+            invocation_throttling: None,
             action_throttling: None,
         }
     }

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -45,6 +45,7 @@ pub struct SpawnPartitionProcessorTask {
     replica_set_states: PartitionReplicaSetStates,
     partition_store_manager: PartitionStoreManager,
     fast_forward_lsn: Option<Lsn>,
+    invocation_token_bucket: Option<TokenBucket>,
     action_token_bucket: Option<TokenBucket>,
 }
 
@@ -58,6 +59,7 @@ impl SpawnPartitionProcessorTask {
         replica_set_states: PartitionReplicaSetStates,
         partition_store_manager: PartitionStoreManager,
         fast_forward_lsn: Option<Lsn>,
+        invocation_token_bucket: Option<TokenBucket>,
         action_token_bucket: Option<TokenBucket>,
     ) -> Self {
         Self {
@@ -68,6 +70,7 @@ impl SpawnPartitionProcessorTask {
             replica_set_states,
             partition_store_manager,
             fast_forward_lsn,
+            invocation_token_bucket,
             action_token_bucket,
         }
     }
@@ -95,6 +98,7 @@ impl SpawnPartitionProcessorTask {
             replica_set_states,
             partition_store_manager,
             fast_forward_lsn,
+            invocation_token_bucket,
             action_token_bucket,
         } = self;
 
@@ -109,6 +113,7 @@ impl SpawnPartitionProcessorTask {
             &config.worker.invoker,
             EntryEnricher::new(schema.clone()),
             schema,
+            invocation_token_bucket,
             action_token_bucket,
         )?;
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -51,15 +51,13 @@ either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }
 enumset = { version = "1", default-features = false, features = ["serde"] }
 flate2 = { version = "1", features = ["zlib-rs"] }
-futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
-futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-gardal = { version = "0.0.1-alpha.6", features = ["async"] }
+gardal = { version = "0.0.1-alpha.7", features = ["async"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std", "wasm_js"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 half = { version = "2", default-features = false, features = ["num-traits"] }
@@ -180,15 +178,13 @@ enum-map = { version = "2", default-features = false, features = ["serde"] }
 enumset = { version = "1", default-features = false, features = ["serde"] }
 enumset_derive = { version = "0.11", default-features = false, features = ["serde"] }
 flate2 = { version = "1", features = ["zlib-rs"] }
-futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
-futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-gardal = { version = "0.0.1-alpha.6", features = ["async"] }
+gardal = { version = "0.0.1-alpha.7", features = ["async"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std", "wasm_js"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 half = { version = "2", default-features = false, features = ["num-traits"] }


### PR DESCRIPTION
feat: Implement configurable rate limiting for the invoker using token bucket throttling

## Summary
Adds rate limiting capabilities to prevent system overload during high-load scenarios by using a token bucket with configurable burst capacity and replenishment rates.

## Changes
- Add gardal crate dependency for token bucket implementation
- Integrate rate limiting into invoker service with shared bucket across partitions
- Add ThrottlingOptions configuration with burst and rate parameters

## Configuration
```yaml
worker:
  invoker:
    invocation_throttling:
      rate: 10/sec        # invocation per second
```

## Technical Details
- Uses gardal crate for efficient token bucket implementation
- Per-node rate limiting for better control in multi-node setups
- Non-blocking async implementation with streams
- Defaults to unlimited
