### PR TITLE
feat: add action throttling configuration and implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,6 +3251,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gardal"
+version = "0.0.1-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08b8247c95fe11f2dd5fdab7b096829e4662a0c2d8002f54dd392f9e49bf8791"
+dependencies = [
+ "futures",
+ "likely_stable",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,6 +4404,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "likely_stable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61f7017d8abea1fc23ff7f01a8147b2656dea3aeb24d519aab6e2177eaf671c"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -6923,6 +6944,7 @@ dependencies = [
  "bytestring",
  "codederror",
  "futures",
+ "gardal",
  "googletest",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -6931,6 +6953,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "opentelemetry",
+ "pin-project-lite",
  "restate-core",
  "restate-errors",
  "restate-futures-util",
@@ -7786,6 +7809,7 @@ dependencies = [
  "derive_more",
  "enumset",
  "futures",
+ "gardal",
  "googletest",
  "humantime",
  "itertools 0.14.0",
@@ -10149,7 +10173,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ flexbuffers = { version = "25.2.10" }
 futures = "0.3.25"
 futures-sink = "0.3.25"
 futures-util = "0.3.25"
+gardal = "0.0.1-alpha.6"
 googletest = { version = "0.10", features = ["anyhow"] }
 hostname = { version = "0.4.0" }
 http = "1.3.1"
@@ -252,7 +253,7 @@ url = { version = "2.5" }
 urlencoding = { version = "2.1" }
 uuid = { version = "1.3.0", features = ["v7", "serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-zstd = {version = "0.13"}
+zstd = { version = "0.13" }
 
 [patch.crates-io.restate-workspace-hack]
 path = "workspace-hack"

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -30,14 +30,17 @@ bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
 futures = { workspace = true }
+gardal = { workspace = true , features = ["async"]}
 humantime = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }
+pin-project-lite = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -310,6 +310,19 @@ pub struct InvokerOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     experimental_features_allow_protocol_v6: bool,
+
+    /// # Action throttling
+    ///
+    /// Configures rate limiting for service actions at the node level.
+    /// This throttling mechanism uses a token bucket algorithm to control the rate
+    /// at which actions can be processed, helping to prevent resource exhaustion
+    /// and maintain system stability under high load.
+    ///
+    /// The throttling limit is shared across all partitions running on this node,
+    /// providing a global rate limit for the entire node rather than per-partition limits.
+    /// When `unset`, no throttling is applied and actions are processed
+    /// without rate limiting.
+    pub action_throttling: Option<ThrottlingOptions>,
 }
 
 impl InvokerOptions {
@@ -371,6 +384,7 @@ impl Default for InvokerOptions {
             disable_eager_state: false,
             experimental_features_propose_events: false,
             experimental_features_allow_protocol_v6: false,
+            action_throttling: None,
         }
     }
 }
@@ -592,5 +606,36 @@ impl SnapshotsOptions {
 
     pub fn snapshots_dir(&self, partition_id: PartitionId) -> PathBuf {
         super::data_dir("db-snapshots").join(partition_id.to_string())
+    }
+}
+
+/// # Throttling options
+///
+/// Throttling options per invoker.
+#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(rename = "ThrottlingOptions", default))]
+#[builder(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct ThrottlingOptions {
+    /// # Burst capacity
+    ///
+    /// The maximum number of tokens the bucket can hold.
+    pub capacity: NonZeroU32,
+
+    /// # Refill rate
+    ///
+    /// The rate in seconds at which the tokens are replenished.
+    pub rate: NonZeroU32,
+}
+
+impl Default for ThrottlingOptions {
+    fn default() -> Self {
+        // using some sane values just to have Default implementation for
+        // schema generation
+        Self {
+            capacity: NonZeroU32::new(1000000).unwrap(),
+            rate: NonZeroU32::new(100000).unwrap(),
+        }
     }
 }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -53,6 +53,7 @@ datafusion = { workspace = true }
 derive_more = { workspace = true }
 enumset = { workspace = true }
 futures = { workspace = true }
+gardal = { workspace = true }
 humantime = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }


### PR DESCRIPTION
feat: add action throttling configuration and implementation

Summary:
This commit introduces action throttling functionality. The changes include:

**Configuration Changes:**
- Add `action_throttling` field to `InvokerOptions` with comprehensive documentation
- Set default values to `None` for both invocation and action throttling

**Implementation Changes:**
- Add `action_token_bucket` parameter throughout the invocation task pipeline
- Integrate throttling into service protocol runner v4 with proper backpressure
- Implement token consumption for each processed action/message

**Key Features:**
- Node-level rate limiting shared across all partitions
- Backpressure mechanism to prevent overwhelming downstream components
- Optional throttling (disabled when set to `None`)

**Technical Details:**
- Throttling is applied at the message processing level in the service protocol
- Uses `gardal` crate for token bucket implementation
- Maintains existing unlimited behavior when throttling is disabled

This enhancement provides better resource management and system stability
under high load conditions while maintaining backward compatibility.
