### PR TITLE
Change default df batch size to 64

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -350,6 +350,7 @@ impl QueryContext {
         }
 
         session_config = session_config
+            .with_batch_size(64)
             .with_information_schema(true)
             .with_default_catalog_and_schema("restate", "public");
 


### PR DESCRIPTION
This prevents memory issues when using topk, as it likes to keep references to a lot of batches, coalesce batch turning batches into size 8192 proves to be an issue.