### PR TITLE
[Restate UI] Update to v0.0.95

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,8 +7776,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.0.94"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.94#f735c111179efab9ac3551213ec19e51bd10e432"
+version = "0.0.95"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.0.95#3188b05d56906d7a9261c8a440add8133d479b14"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -28,7 +28,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.94", tag = "v0.0.94" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.0.95", tag = "v0.0.95" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.0.95
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.0.95/ui-v0.0.95.zip