### PR TITLE
Get batch sizes from global config

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -351,7 +351,7 @@ impl QueryContext {
         }
 
         session_config = session_config
-            .with_batch_size(64)
+            .with_batch_size(128)
             .with_information_schema(true)
             .with_default_catalog_and_schema("restate", "public");
 

--- a/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
@@ -131,6 +131,7 @@ pub fn create_remote_scanner_service<T: TransportConnect>(
 /// Given an implementation of a remote ScannerService, this function
 /// creates a DataFusion [[SendableRecordBatchStream]] that transports
 /// record batches via the RemoteScannerService API.
+#[allow(clippy::too_many_arguments)]
 pub fn remote_scan_as_datafusion_stream(
     service: Arc<dyn RemoteScannerService>,
     target_node_id: NodeId,
@@ -138,6 +139,7 @@ pub fn remote_scan_as_datafusion_stream(
     range: RangeInclusive<PartitionKey>,
     table_name: String,
     projection_schema: SchemaRef,
+    batch_size: usize,
     limit: Option<usize>,
 ) -> SendableRecordBatchStream {
     let mut builder = RecordBatchReceiverStream::builder(projection_schema.clone(), 1);
@@ -154,6 +156,7 @@ pub fn remote_scan_as_datafusion_stream(
             table: table_name,
             projection_schema_bytes: encode_schema(&projection_schema),
             limit: limit.map(|limit| u64::try_from(limit).expect("limit to fit in a u64")),
+            batch_size: u64::try_from(batch_size).expect("batch_size to fit in a u64"),
         };
 
         // RemoteScanner will auto close on drop. Please call forget() if you don't need this

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -180,6 +180,7 @@ impl ScanPartition for RemotePartitionsScanner {
         partition_id: PartitionId,
         range: RangeInclusive<PartitionKey>,
         projection: SchemaRef,
+        batch_size: usize,
         limit: Option<usize>,
     ) -> anyhow::Result<SendableRecordBatchStream> {
         match self.manager.get_partition_target_node(partition_id)? {
@@ -187,7 +188,7 @@ impl ScanPartition for RemotePartitionsScanner {
                 let scanner = self.manager.local_partition_scanner(&self.table_name).ok_or_else(
                     ||anyhow!("was expecting a local partition to be present on this node. It could be that this partition is being opened right now.")
                 )?;
-                Ok(scanner.scan_partition(partition_id, range, projection, limit)?)
+                Ok(scanner.scan_partition(partition_id, range, projection, batch_size, limit)?)
             }
             PartitionLocation::Remote { node_id } => Ok(remote_scan_as_datafusion_stream(
                 self.manager.remote_scanner.clone(),
@@ -196,6 +197,7 @@ impl ScanPartition for RemotePartitionsScanner {
                 range,
                 self.table_name.clone(),
                 projection,
+                batch_size,
                 limit,
             )),
         }

--- a/crates/storage-query-datafusion/src/scanner_task.rs
+++ b/crates/storage-query-datafusion/src/scanner_task.rs
@@ -60,6 +60,7 @@ impl ScannerTask {
             request.partition_id,
             request.range.clone(),
             Arc::new(schema),
+            usize::try_from(request.batch_size).expect("batch_size to fit in a usize"),
             request
                 .limit
                 .map(|limit| usize::try_from(limit).expect("limit to fit in a usize")),

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -397,13 +397,8 @@ macro_rules! document_type {
 ///     }
 ///
 ///     #[inline]
-///     pub fn default_capacity() -> usize {
-///         1024
-///     }
-///
-///     #[inline]
-///     pub fn full(&self) -> bool {
-///         self.rows_inserted_so_far >= Self::default_capacity()
+///     pub fn num_rows(&self) -> usize {
+///         self.rows_inserted_so_far
 ///     }
 ///
 ///     pub fn empty(&self) -> bool {
@@ -562,11 +557,6 @@ macro_rules! define_table {
                     ])
                 )
             }
-
-            #[inline]
-            pub fn default_capacity() -> usize {
-                64
-            }
         }
 
         #[automatically_derived]
@@ -582,8 +572,8 @@ macro_rules! define_table {
             }
 
             #[inline]
-            fn full(&self) -> bool {
-                self.rows_inserted_so_far >= Self::default_capacity()
+            fn num_rows(&self) -> usize {
+                self.rows_inserted_so_far
             }
 
             fn empty(&self) -> bool {

--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -62,7 +62,7 @@ pub(crate) fn format_using<'a>(output: &'a mut String, what: &impl std::fmt::Dis
 pub(crate) trait Builder {
     fn new(projected_schema: SchemaRef) -> Self;
 
-    fn full(&self) -> bool;
+    fn num_rows(&self) -> usize;
 
     fn empty(&self) -> bool;
 

--- a/crates/types/src/net/remote_query_scanner.rs
+++ b/crates/types/src/net/remote_query_scanner.rs
@@ -47,8 +47,16 @@ pub struct RemoteQueryScannerOpen {
     pub table: String,
     #[bilrost(tag(4), encoding(plainbytes))]
     pub projection_schema_bytes: Vec<u8>,
+    #[bilrost(tag(5))]
     #[serde(default)]
     pub limit: Option<u64>,
+    #[bilrost(tag(6))]
+    #[serde(default = "default_batch_size")]
+    pub batch_size: u64,
+}
+
+fn default_batch_size() -> u64 {
+    64
 }
 
 #[derive(


### PR DESCRIPTION
Instead of hardcoding the produced batch size in the macro, we will now start adapting reactively to the df config (passing the value through the remote scanner if needed)

This allows us to a) keep produced batches in size with the configured df value b) play with that configured df value via env var or at runtime.

We also increase the default df batch size to 128 as this appears to lead to a significant performance gain both locally and in cloud.