### PR TITLE
Write batches inside the rocks iterator

### DIFF
--- a/crates/partition-store/src/error.rs
+++ b/crates/partition-store/src/error.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::ControlFlow;
+
 use codederror::CodedError;
 
 use restate_core::ShutdownError;
@@ -80,4 +82,13 @@ pub enum SnapshotErrorKind {
     Internal(#[source] anyhow::Error),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
+}
+
+pub(crate) fn break_on_err<T, E>(
+    r: std::result::Result<T, E>,
+) -> ControlFlow<std::result::Result<(), E>, T> {
+    match r {
+        Ok(val) => ControlFlow::Continue(val),
+        Err(err) => ControlFlow::Break(Err(err)),
+    }
 }

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -26,7 +26,7 @@ use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, Wit
 use crate::TableScan::FullScanPartitionKeyRange;
 use crate::keys::{KeyKind, TableKey, define_table_key};
 use crate::scan::TableScan;
-use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind};
+use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind, break_on_err};
 
 // TODO remove this once we remove the old InvocationStatus
 define_table_key!(
@@ -167,13 +167,6 @@ impl ReadOnlyInvocationStatusTable for PartitionStore {
     ) -> Result<InvocationStatus> {
         self.assert_partition_key(invocation_id)?;
         get_invocation_status(self, invocation_id)
-    }
-}
-
-fn break_on_err<T, E>(r: std::result::Result<T, E>) -> ControlFlow<std::result::Result<(), E>, T> {
-    match r {
-        Ok(val) => ControlFlow::Continue(val),
-        Err(err) => ControlFlow::Break(Err(err)),
     }
 }
 

--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -20,7 +20,8 @@ use crate::TableKind::Journal;
 use crate::keys::{KeyKind, TableKey, define_table_key};
 use crate::owned_iter::OwnedIterator;
 use crate::{
-    PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan, TableScanIterationDecision,
+    PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
+    TableScanIterationDecision, break_on_err,
 };
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
 use restate_storage_api::journal_table_v2::{
@@ -313,31 +314,38 @@ impl ReadOnlyJournalTable for PartitionStore {
 }
 
 impl ScanJournalTable for PartitionStore {
-    fn scan_journals(
+    fn for_each_journal<
+        F: FnMut(
+                (restate_types::identifiers::JournalEntryId, StoredRawEntry),
+            ) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<
-        impl Stream<Item = Result<(restate_types::identifiers::JournalEntryId, StoredRawEntry)>> + Send,
-    > {
-        self.run_iterator(
+        mut f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send> {
+        self.iterator_for_each(
             "df-v2-journal",
             Priority::Low,
             TableScan::FullScanPartitionKeyRange::<JournalKey>(range),
-            |(mut key, mut value)| {
-                let journal_key = JournalKey::deserialize_from(&mut key)?;
-                let journal_entry = StoredEntry::decode(&mut value)
-                    .map_err(|err| StorageError::Conversion(err.into()))?;
+            move |(mut key, mut value)| {
+                let journal_key = break_on_err(JournalKey::deserialize_from(&mut key))?;
+                let journal_entry = break_on_err(
+                    StoredEntry::decode(&mut value)
+                        .map_err(|err| StorageError::Conversion(err.into())),
+                )?;
 
                 let (partition_key, invocation_uuid, entry_index) =
-                    journal_key.into_inner_ok_or()?;
+                    break_on_err(journal_key.into_inner_ok_or())?;
 
-                Ok((
-                    JournalEntryId::from_parts(
-                        InvocationId::from_parts(partition_key, invocation_uuid),
-                        entry_index,
-                    ),
-                    journal_entry.0,
-                ))
+                let journal_entry_id = JournalEntryId::from_parts(
+                    InvocationId::from_parts(partition_key, invocation_uuid),
+                    entry_index,
+                );
+
+                f((journal_entry_id, journal_entry.0)).map_break(Ok)
             },
         )
         .map_err(|_| StorageError::OperationalError)

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ops::ControlFlow;
 use std::ops::RangeInclusive;
 use std::path::Path;
 use std::slice;
@@ -24,6 +25,7 @@ use rocksdb::{
 };
 use static_assertions::const_assert_eq;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, trace};
@@ -382,16 +384,12 @@ impl PartitionStore {
         }
     }
 
-    pub fn run_iterator<K: TableKey, O: Send + 'static>(
-        &self,
-        name: &'static str,
-        priority: Priority,
-        scan: TableScan<K>,
+    #[allow(clippy::type_complexity)]
+    fn iterator_step_map<O: Send + 'static>(
+        tx: mpsc::Sender<Result<O>>,
         f: impl Fn((&[u8], &[u8])) -> Result<O> + Send + 'static,
-    ) -> Result<ReceiverStream<Result<O>>, ShutdownError> {
-        let (tx, rx) = mpsc::channel(8);
-        let scan: PhysicalScan = scan.into();
-        let on_iter = move |item: Result<(&[u8], &[u8]), RocksError>| -> IterAction {
+    ) -> impl FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static {
+        move |item| {
             let res = match item {
                 // apply the caller's function
                 Ok((key, value)) => match f((key, value)) {
@@ -411,7 +409,93 @@ impl PartitionStore {
             }
             // the channel is not closed yet, keep iterating
             IterAction::Next
-        };
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn iterator_step_for_each(
+        tx: oneshot::Sender<StorageError>,
+        mut f: impl FnMut((&[u8], &[u8])) -> ControlFlow<Result<()>> + Send + 'static,
+    ) -> impl FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send {
+        let mut tx = Some(tx);
+        move |item| {
+            let mut must_send = |v| match tx.take() {
+                Some(tx) => tx.send(v),
+                None => panic!("Iterator continued after IterAction::Stop"),
+            };
+
+            match item {
+                // apply the caller's function
+                Ok((key, value)) => match f((key, value)) {
+                    ControlFlow::Continue(()) => match &mut tx {
+                        Some(tx_inner) if tx_inner.is_closed() => {
+                            tx = None;
+                            IterAction::Stop
+                        }
+                        // the channel is not closed yet, keep iterating
+                        Some(_) => IterAction::Next,
+                        None => panic!("Iterator continued after IterAction::Stop"),
+                    },
+                    ControlFlow::Break(Ok(())) => {
+                        // function doesn't need any more items
+                        tx = None;
+                        IterAction::Stop
+                    }
+                    ControlFlow::Break(Err(e)) => {
+                        let _ = must_send(e);
+                        IterAction::Stop
+                    }
+                },
+                Err(e) => {
+                    let _ = must_send(StorageError::Generic(e.into()));
+                    IterAction::Stop
+                }
+            }
+        }
+    }
+
+    pub fn iterator_for_each<K: TableKey>(
+        &self,
+        name: &'static str,
+        priority: Priority,
+        scan: TableScan<K>,
+        f: impl FnMut((&[u8], &[u8])) -> std::ops::ControlFlow<Result<()>> + Send + 'static,
+    ) -> Result<impl Future<Output = Result<()>>, ShutdownError> {
+        let (tx, rx) = oneshot::channel();
+        let on_iter = Self::iterator_step_for_each(tx, f);
+        self.run_iterator_internal(name, priority, scan, on_iter)?;
+        Ok(async {
+            match rx.await {
+                Ok(storage_err) => Err(storage_err),
+                Err(_recv_err) => {
+                    // iterator was dropped without sending an error; this is actually a success condition
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    pub fn run_iterator<K: TableKey, O: Send + 'static>(
+        &self,
+        name: &'static str,
+        priority: Priority,
+        scan: TableScan<K>,
+        f: impl Fn((&[u8], &[u8])) -> Result<O> + Send + 'static,
+    ) -> Result<ReceiverStream<Result<O>>, ShutdownError> {
+        let (tx, rx) = mpsc::channel(8);
+        let on_iter = Self::iterator_step_map(tx, f);
+        self.run_iterator_internal(name, priority, scan, on_iter)?;
+        Ok(ReceiverStream::new(rx))
+    }
+
+    fn run_iterator_internal<K: TableKey>(
+        &self,
+        name: &'static str,
+        priority: Priority,
+        scan: TableScan<K>,
+        on_iter: impl FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
+    ) -> Result<(), ShutdownError> {
+        let scan: PhysicalScan = scan.into();
         match scan {
             PhysicalScan::Prefix(table, key_kind, prefix) => {
                 assert!(table.has_key_kind(&prefix));
@@ -468,7 +552,7 @@ impl PartitionStore {
                 )?;
             }
         }
-        Ok(ReceiverStream::new(rx))
+        Ok(())
     }
 
     pub fn transaction(&mut self) -> PartitionStoreTransaction<'_> {

--- a/crates/rocksdb/src/iterator.rs
+++ b/crates/rocksdb/src/iterator.rs
@@ -51,7 +51,7 @@ pub struct RocksIterator<'a, F> {
 
 impl<'a, F> RocksIterator<'a, F>
 where
-    F: Fn(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
+    F: FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
 {
     pub fn new(iterator: DBRawIteratorWithThreadMode<'a, DB>, next_step: IterAction, f: F) -> Self {
         Self {

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -319,7 +319,7 @@ impl RocksDb {
         priority: Priority,
         initial_action: IterAction,
         mut read_options: rocksdb::ReadOptions,
-        on_item: impl Fn(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
+        mut on_item: impl FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
     ) -> Result<(), ShutdownError> {
         // ensure that we allow blocking IO.
         read_options.set_read_tier(rocksdb::ReadTier::All);

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -98,10 +98,13 @@ pub trait ReadOnlyInboxTable {
 }
 
 pub trait ScanInboxTable {
-    fn scan_inboxes(
+    fn for_each_inbox<
+        F: FnMut(SequenceNumberInboxEntry) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send>;
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
 pub trait InboxTable: ReadOnlyPromiseTable {

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -743,6 +743,17 @@ pub trait ScanInvocationStatusTable {
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(InvocationId, InvocationStatus)>> + Send>;
 
+    fn for_each_invocation_status<
+        F: FnMut((InvocationId, InvocationStatus)) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+    >(
+        &self,
+        range: RangeInclusive<PartitionKey>,
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
+
     fn scan_invoked_invocations(
         &self,
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send>;

--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -69,10 +69,13 @@ pub trait ReadOnlyJournalTable {
 }
 
 pub trait ScanJournalTable {
-    fn scan_journals(
+    fn for_each_journal<
+        F: FnMut((JournalEntryId, JournalEntry)) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<(JournalEntryId, JournalEntry)>> + Send>;
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
 pub trait JournalTable: ReadOnlyJournalTable {

--- a/crates/storage-api/src/journal_table_v2/mod.rs
+++ b/crates/storage-api/src/journal_table_v2/mod.rs
@@ -46,12 +46,18 @@ pub trait ReadOnlyJournalTable {
 }
 
 pub trait ScanJournalTable {
-    fn scan_journals(
+    fn for_each_journal<
+        F: FnMut(
+                (restate_types::identifiers::JournalEntryId, StoredRawEntry),
+            ) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<
-        impl Stream<Item = Result<(restate_types::identifiers::JournalEntryId, StoredRawEntry)>> + Send,
-    >;
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
 pub trait JournalTable: ReadOnlyJournalTable {

--- a/crates/storage-api/src/promise_table/mod.rs
+++ b/crates/storage-api/src/promise_table/mod.rs
@@ -13,7 +13,6 @@ use std::ops::RangeInclusive;
 
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures::Stream;
 
 use restate_types::errors::InvocationErrorCode;
 use restate_types::identifiers::{PartitionKey, ServiceId};
@@ -121,10 +120,13 @@ pub trait ReadOnlyPromiseTable {
 }
 
 pub trait ScanPromiseTable {
-    fn scan_promises(
+    fn for_each_promise<
+        F: FnMut(OwnedPromiseRow) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<OwnedPromiseRow>> + Send>;
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
 pub trait PromiseTable: ReadOnlyPromiseTable {

--- a/crates/storage-api/src/service_status_table/mod.rs
+++ b/crates/storage-api/src/service_status_table/mod.rs
@@ -11,8 +11,6 @@
 use std::future::Future;
 use std::ops::RangeInclusive;
 
-use futures::Stream;
-
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId};
 
 use crate::Result;
@@ -37,10 +35,16 @@ pub trait ReadOnlyVirtualObjectStatusTable {
 }
 
 pub trait ScanVirtualObjectStatusTable {
-    fn scan_virtual_object_statuses(
+    fn for_each_virtual_object_status<
+        F: FnMut((ServiceId, VirtualObjectStatus)) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<(ServiceId, VirtualObjectStatus)>> + Send>;
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
 pub trait VirtualObjectStatusTable: ReadOnlyVirtualObjectStatusTable {

--- a/crates/storage-api/src/state_table/mod.rs
+++ b/crates/storage-api/src/state_table/mod.rs
@@ -31,10 +31,13 @@ pub trait ReadOnlyStateTable {
 }
 
 pub trait ScanStateTable {
-    fn scan_all_user_states(
+    fn for_each_user_state<
+        F: FnMut((ServiceId, Bytes, &[u8])) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+    >(
         &self,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<(ServiceId, Bytes, Bytes)>> + Send>;
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
 pub trait StateTable: ReadOnlyStateTable {

--- a/crates/storage-query-datafusion/src/partition_store_scanner.rs
+++ b/crates/storage-query-datafusion/src/partition_store_scanner.rs
@@ -8,8 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt::Debug;
 use std::ops::RangeInclusive;
+use std::{fmt::Debug, ops::ControlFlow};
 
 use anyhow::anyhow;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -23,10 +23,11 @@ use restate_storage_api::StorageError;
 use restate_types::identifiers::{PartitionId, PartitionKey};
 
 use crate::table_providers::ScanPartition;
+use crate::table_util::BatchSender;
 
 pub trait ScanLocalPartition: Send + Sync + Debug + 'static {
-    type Builder;
-    type Item;
+    type Builder: crate::table_util::Builder + Send;
+    type Item: Send;
 
     fn scan_partition_store(
         partition_store: &PartitionStore,
@@ -36,14 +37,31 @@ pub trait ScanLocalPartition: Send + Sync + Debug + 'static {
     fn append_row(row_builder: &mut Self::Builder, value: Self::Item);
 }
 
-#[derive(Clone, derive_more::Debug)]
-pub struct LocalPartitionsScanner<S> {
-    #[debug(skip)]
-    partition_store_manager: PartitionStoreManager,
-    _marker: std::marker::PhantomData<S>,
+// ScanLocalPartitionInPlace can be used for large or performance sensitive tables to build batches on io threads (instead of sending rows cross-thread)
+pub trait ScanLocalPartitionInPlace: Send + Sync + Debug + 'static {
+    type Builder: crate::table_util::Builder + Send;
+    type Item: Send;
+
+    fn for_each_row<F: FnMut(Self::Item) -> ControlFlow<()> + Send + Sync + 'static>(
+        partition_store: &PartitionStore,
+        range: RangeInclusive<PartitionKey>,
+        f: F,
+    ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError>;
+
+    fn append_row(row_builder: &mut Self::Builder, value: Self::Item);
 }
 
-impl<S> LocalPartitionsScanner<S>
+pub struct ScanStream;
+pub struct ScanInPlace;
+
+#[derive(Clone, derive_more::Debug)]
+pub struct LocalPartitionsScanner<S, M = ScanStream> {
+    #[debug(skip)]
+    partition_store_manager: PartitionStoreManager,
+    _marker: std::marker::PhantomData<(S, M)>,
+}
+
+impl<S> LocalPartitionsScanner<S, ScanStream>
 where
     S: ScanLocalPartition,
 {
@@ -55,10 +73,22 @@ where
     }
 }
 
-impl<S, RB, T> ScanPartition for LocalPartitionsScanner<S>
+impl<S> LocalPartitionsScanner<S, ScanInPlace>
+where
+    S: ScanLocalPartitionInPlace,
+{
+    pub fn new_in_place(partition_store_manager: PartitionStoreManager, _scanner: S) -> Self {
+        Self {
+            partition_store_manager,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<S, RB, T> LocalPartitionsScanner<S, ScanStream>
 where
     S: ScanLocalPartition<Builder = RB, Item = T>,
-    RB: crate::table_util::Builder + Send,
+    RB: crate::table_util::Builder + Send + Sync + 'static,
     T: Send,
 {
     fn scan_partition(
@@ -110,5 +140,105 @@ where
         };
         stream_builder.spawn(background_task);
         Ok(stream_builder.build())
+    }
+}
+
+impl<S, RB, T> LocalPartitionsScanner<S, ScanInPlace>
+where
+    S: ScanLocalPartitionInPlace<Builder = RB, Item = T>,
+    RB: crate::table_util::Builder + Send + Sync + 'static,
+    T: Send,
+{
+    fn scan_partition(
+        &self,
+        partition_id: PartitionId,
+        range: RangeInclusive<PartitionKey>,
+        projection: SchemaRef,
+        batch_size: usize,
+        mut limit: Option<usize>,
+    ) -> anyhow::Result<SendableRecordBatchStream> {
+        let partition_store_manager = self.partition_store_manager.clone();
+        let mut stream_builder = RecordBatchReceiverStream::builder(projection.clone(), 1);
+        let tx = stream_builder.tx();
+
+        let background_task = async move {
+            let partition_store = partition_store_manager.get_partition_store(partition_id).await.ok_or_else(|| {
+                // make sure that the consumer of this stream to learn about the fact that this node does not have
+                // that partition anymore, so that it can decide how to react to this.
+                // for example, they can retry or fail the query with a useful message.
+                let err = anyhow!("partition {} doesn't exist on this node, this is benign if the partition is being transferred out of/into this node.", partition_id);
+                DataFusionError::External(err.into())
+            })?;
+
+            // will send the last batch on Drop.
+            let mut batch_sender = BatchSender::new(projection.clone(), tx);
+
+            S::for_each_row(&partition_store, range, move |row| {
+                if let Some(0) = limit {
+                    return ControlFlow::Break(());
+                }
+                S::append_row(batch_sender.builder_mut(), row);
+
+                if batch_sender.num_rows() >= batch_size && batch_sender.send().is_err() {
+                    // the other side has hung up on us.
+                    return ControlFlow::Break(());
+                }
+
+                match &mut limit {
+                    Some(limit) => {
+                        *limit -= 1; // we already checked for 0 above
+                        if *limit == 0 {
+                            ControlFlow::Break(())
+                        } else {
+                            ControlFlow::Continue(())
+                        }
+                    }
+                    None => ControlFlow::Continue(()),
+                }
+            })
+            .map_err(|err| DataFusionError::External(err.into()))?
+            .await
+            .map_err(|err| DataFusionError::External(err.into()))?;
+
+            Ok(())
+        };
+        stream_builder.spawn(background_task);
+        Ok(stream_builder.build())
+    }
+}
+
+impl<S, RB, T> ScanPartition for LocalPartitionsScanner<S, ScanStream>
+where
+    S: ScanLocalPartition<Builder = RB, Item = T>,
+    RB: crate::table_util::Builder + Send + Sync + 'static,
+    T: Send,
+{
+    fn scan_partition(
+        &self,
+        partition_id: PartitionId,
+        range: RangeInclusive<PartitionKey>,
+        projection: SchemaRef,
+        batch_size: usize,
+        limit: Option<usize>,
+    ) -> anyhow::Result<SendableRecordBatchStream> {
+        self.scan_partition(partition_id, range, projection, batch_size, limit)
+    }
+}
+
+impl<S, RB, T> ScanPartition for LocalPartitionsScanner<S, ScanInPlace>
+where
+    S: ScanLocalPartitionInPlace<Builder = RB, Item = T>,
+    RB: crate::table_util::Builder + Send + Sync + 'static,
+    T: Send,
+{
+    fn scan_partition(
+        &self,
+        partition_id: PartitionId,
+        range: RangeInclusive<PartitionKey>,
+        projection: SchemaRef,
+        batch_size: usize,
+        limit: Option<usize>,
+    ) -> anyhow::Result<SendableRecordBatchStream> {
+        self.scan_partition(partition_id, range, projection, batch_size, limit)
     }
 }

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -12,8 +12,6 @@ use std::fmt::Debug;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use futures::Stream;
-
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::promise_table::{OwnedPromiseRow, ScanPromiseTable};
@@ -56,17 +54,19 @@ struct PromiseScanner;
 
 impl ScanLocalPartition for PromiseScanner {
     type Builder = SysPromiseBuilder;
-    type Item = OwnedPromiseRow;
+    type Item<'a> = OwnedPromiseRow;
 
-    fn scan_partition_store(
+    fn for_each_row<
+        F: for<'a> FnMut(Self::Item<'a>) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+    >(
         partition_store: &PartitionStore,
         range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = restate_storage_api::Result<Self::Item>> + Send, StorageError>
-    {
-        partition_store.scan_promises(range)
+        f: F,
+    ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
+        partition_store.for_each_promise(range, f)
     }
 
-    fn append_row(row_builder: &mut Self::Builder, value: Self::Item) {
+    fn append_row<'a>(row_builder: &mut Self::Builder, value: Self::Item<'a>) {
         append_promise_row(row_builder, value);
     }
 }

--- a/crates/storage-query-datafusion/src/state/row.rs
+++ b/crates/storage-query-datafusion/src/state/row.rs
@@ -17,7 +17,7 @@ pub(crate) fn append_state_row(
     builder: &mut StateBuilder,
     service_id: ServiceId,
     state_key: Bytes,
-    state_value: Bytes,
+    state_value: &[u8],
 ) {
     let mut row = builder.row();
     row.partition_key(service_id.partition_key());
@@ -29,11 +29,11 @@ pub(crate) fn append_state_row(
         row.key(str);
     }
     if row.is_value_utf8_defined()
-        && let Ok(str) = std::str::from_utf8(&state_value)
+        && let Ok(str) = std::str::from_utf8(state_value)
     {
         row.value_utf8(str);
     }
     if row.is_value_defined() {
-        row.value(&state_value);
+        row.value(state_value);
     }
 }

--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -12,7 +12,9 @@ use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_expr::expressions::col;
 use datafusion::physical_expr::{PhysicalExpr, PhysicalSortExpr};
+use std::mem::ManuallyDrop;
 use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
 
 #[macro_export]
 macro_rules! log_data_corruption_error {
@@ -58,4 +60,47 @@ pub(crate) trait Builder {
     fn finish(self) -> datafusion::common::Result<RecordBatch>;
 
     fn finish_and_new(&mut self) -> datafusion::common::Result<RecordBatch>;
+}
+
+pub(crate) struct BatchSender<B: Builder> {
+    builder: ManuallyDrop<B>,
+    tx: Sender<datafusion::error::Result<RecordBatch>>,
+}
+
+impl<B: Builder> BatchSender<B> {
+    pub(crate) fn new(
+        projection: SchemaRef,
+        tx: Sender<datafusion::error::Result<RecordBatch>>,
+    ) -> Self {
+        let builder = B::new(projection);
+        Self {
+            builder: ManuallyDrop::new(builder),
+            tx,
+        }
+    }
+
+    pub(crate) fn send(
+        &mut self,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<datafusion::error::Result<RecordBatch>>>
+    {
+        self.tx.blocking_send(self.builder.finish_and_new())
+    }
+
+    pub(crate) fn builder_mut(&mut self) -> &mut B {
+        &mut self.builder
+    }
+
+    pub(crate) fn num_rows(&self) -> usize {
+        self.builder.num_rows()
+    }
+}
+
+impl<B: Builder> Drop for BatchSender<B> {
+    fn drop(&mut self) {
+        if !self.builder.empty() {
+            // Safety: self.builder is exclusively taken at drop time, and never accessed again.
+            let builder = unsafe { ManuallyDrop::take(&mut self.builder) };
+            let _ = self.tx.blocking_send(builder.finish());
+        }
+    }
 }

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -222,6 +222,30 @@ mod tests {
             Ok(stream::iter(self.0.clone()).map(Ok))
         }
 
+        fn for_each_invocation_status<
+            F: FnMut((InvocationId, InvocationStatus)) -> std::ops::ControlFlow<()>
+                + Send
+                + Sync
+                + 'static,
+        >(
+            &self,
+            _: RangeInclusive<PartitionKey>,
+            mut f: F,
+        ) -> restate_storage_api::Result<impl Future<Output = restate_storage_api::Result<()>> + Send>
+        {
+            let inner = self.0.clone();
+            Ok(async move {
+                for (id, status) in inner {
+                    match f((id, status)) {
+                        std::ops::ControlFlow::Continue(()) => continue,
+                        std::ops::ControlFlow::Break(()) => break,
+                    }
+                }
+
+                Ok(())
+            })
+        }
+
         fn scan_invoked_invocations(
             &self,
         ) -> restate_storage_api::Result<


### PR DESCRIPTION
This PR makes it possible to build record batches in-place inside the rocksdb iterator, essentially using a FnMut, sending them back between threads only when they are full. It leads to significant speedups, 3-5x, over sending each row between threads.

It also opens up the possibility to build batches from non-static types, in which case we can potentially avoid a lot of copying out of rocksdb and instead copy straight into the recordbatch (and not copy at all for unprojected fields).