### PR TITLE
Inv status deserialisation speedups

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -231,15 +231,15 @@ impl InvokerError {
                     e.message()
                 );
                 let mut err = InvocationError::new(e.code(), msg);
-                if let Some(desc) = e.stacktrace() {
+                if let Some(desc) = e.into_stacktrace() {
                     err = err.with_stacktrace(desc);
                 }
                 err
             }
             e @ InvokerError::BadNegotiatedServiceProtocolVersion(_) => {
-                InvocationError::new(codes::UNSUPPORTED_MEDIA_TYPE, e)
+                InvocationError::new(codes::UNSUPPORTED_MEDIA_TYPE, e.to_string())
             }
-            e => InvocationError::internal(e),
+            e => InvocationError::internal(e.to_string()),
         }
     }
 

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -3845,10 +3845,13 @@ pub mod v1 {
                         restate_types::invocation::ResponseResult::Success(success.value)
                     }
                     response_result::ResponseResult::ResponseFailure(failure) => {
+                        // we should be able to turn the incoming Bytes into a String without a copy
+                        let failure_message = Vec::<u8>::from(failure.failure_message);
+                        let failure_message = String::from_utf8(failure_message)
+                            .map_err(ConversionError::invalid_data)?;
                         restate_types::invocation::ResponseResult::Failure(InvocationError::new(
                             failure.failure_code,
-                            ByteString::try_from(failure.failure_message)
-                                .map_err(ConversionError::invalid_data)?,
+                            failure_message,
                         ))
                     }
                 };

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -119,7 +119,9 @@ pub(crate) fn append_invocation_status_row(
                 }
                 ResponseResult::Failure(failure) => {
                     row.completion_result("failure");
-                    row.completion_failure(format_using(output, &failure));
+                    if row.is_completion_failure_defined() {
+                        row.completion_failure(format_using(output, &failure));
+                    }
                 }
             }
         }
@@ -137,7 +139,9 @@ fn fill_in_flight_invocation_metadata(
     row.created_using_restate_version(meta.created_using_restate_version.as_str());
     // journal_metadata and stats are filled by other functions
     if let Some(pinned_deployment) = meta.pinned_deployment {
-        row.pinned_deployment_id(pinned_deployment.deployment_id.to_string());
+        if row.is_pinned_deployment_id_defined() {
+            row.pinned_deployment_id(format_using(output, &pinned_deployment.deployment_id));
+        }
         row.pinned_service_protocol_version(
             pinned_deployment
                 .service_protocol_version
@@ -174,11 +178,15 @@ fn fill_invoked_by(row: &mut SysInvocationStatusRowBuilder, output: &mut String,
         }
         Source::Subscription(sub_id) => {
             row.invoked_by("subscription");
-            row.invoked_by_subscription_id(format_using(output, &sub_id))
+            if row.is_invoked_by_subscription_id_defined() {
+                row.invoked_by_subscription_id(format_using(output, &sub_id))
+            }
         }
         Source::RestartAsNew(invocation_id) => {
             row.invoked_by("restart_as_new");
-            row.restarted_from(format_using(output, &invocation_id))
+            if row.is_restarted_from_defined() {
+                row.restarted_from(format_using(output, &invocation_id))
+            }
         }
     }
 }

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -217,18 +217,18 @@ impl InvocationError {
         }
     }
 
-    pub fn new(code: impl Into<InvocationErrorCode>, message: impl fmt::Display) -> Self {
+    pub fn new(code: impl Into<InvocationErrorCode>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
-            message: Cow::Owned(message.to_string()),
+            message: Cow::Owned(message.into()),
             stacktrace: None,
         }
     }
 
-    pub fn internal(message: impl fmt::Display) -> Self {
+    pub fn internal(message: impl Into<String>) -> Self {
         Self {
             code: codes::INTERNAL,
-            message: Cow::Owned(message.to_string()),
+            message: Cow::Owned(message.into()),
             stacktrace: None,
         }
     }
@@ -261,13 +261,13 @@ impl InvocationError {
         self
     }
 
-    pub fn with_message(mut self, message: impl fmt::Display) -> InvocationError {
-        self.message = Cow::Owned(message.to_string());
+    pub fn with_message(mut self, message: impl Into<String>) -> InvocationError {
+        self.message = Cow::Owned(message.into());
         self
     }
 
-    pub fn with_stacktrace(mut self, stacktrace: impl fmt::Display) -> InvocationError {
-        self.stacktrace = Some(Cow::Owned(stacktrace.to_string()));
+    pub fn with_stacktrace(mut self, stacktrace: impl Into<String>) -> InvocationError {
+        self.stacktrace = Some(Cow::Owned(stacktrace.into()));
         self
     }
 
@@ -282,11 +282,15 @@ impl InvocationError {
     pub fn stacktrace(&self) -> Option<&str> {
         self.stacktrace.as_deref()
     }
+
+    pub fn into_stacktrace(self) -> Option<Cow<'static, str>> {
+        self.stacktrace
+    }
 }
 
 impl From<anyhow::Error> for InvocationError {
     fn from(error: anyhow::Error) -> Self {
-        InvocationError::internal(error)
+        InvocationError::internal(error.to_string())
     }
 }
 

--- a/crates/worker/src/invoker_integration.rs
+++ b/crates/worker/src/invoker_integration.rs
@@ -64,7 +64,7 @@ where
         span_relation: SpanRelation,
     ) -> Result<CallEnrichmentResult, InvocationError> {
         let entry = Codec::deserialize(entry_type, serialized_entry.clone())
-            .map_err(InvocationError::internal)?;
+            .map_err(|e| InvocationError::internal(e.to_string()))?;
         let request = request_extractor(entry);
 
         let meta = self
@@ -252,7 +252,7 @@ where
             PlainEntryHeader::CompleteAwakeable { .. } => {
                 let entry =
                     Codec::deserialize(EntryType::CompleteAwakeable, serialized_entry.clone())
-                        .map_err(InvocationError::internal)?;
+                        .map_err(|e| InvocationError::internal(e.to_string()))?;
                 let_assert!(Entry::CompleteAwakeable(CompleteAwakeableEntry { id, .. }) = entry);
 
                 let (invocation_id, entry_index) = if let Ok(old_awk_id) =
@@ -288,7 +288,7 @@ where
                 // Validate the invocation id is valid
                 let entry =
                     Codec::deserialize(EntryType::CancelInvocation, serialized_entry.clone())
-                        .map_err(InvocationError::internal)?;
+                        .map_err(|e| InvocationError::internal(e.to_string()))?;
                 let_assert!(Entry::CancelInvocation(CancelInvocationEntry { target }) = entry);
                 if let CancelInvocationTarget::InvocationId(id) = target {
                     if let Err(e) = id.parse::<InvocationId>() {
@@ -305,7 +305,7 @@ where
                 // Validate the invocation id is valid
                 let entry =
                     Codec::deserialize(EntryType::AttachInvocation, serialized_entry.clone())
-                        .map_err(InvocationError::internal)?;
+                        .map_err(|e| InvocationError::internal(e.to_string()))?;
                 let_assert!(Entry::AttachInvocation(AttachInvocationEntry { target, .. }) = entry);
                 if let AttachInvocationTarget::InvocationId(id) = target {
                     if let Err(e) = id.parse::<InvocationId>() {
@@ -322,7 +322,7 @@ where
                 // Validate the invocation id is valid
                 let entry =
                     Codec::deserialize(EntryType::GetInvocationOutput, serialized_entry.clone())
-                        .map_err(InvocationError::internal)?;
+                        .map_err(|e| InvocationError::internal(e.to_string()))?;
                 let_assert!(
                     Entry::GetInvocationOutput(GetInvocationOutputEntry { target, .. }) = entry
                 );


### PR DESCRIPTION
Two noticeable things in profiles:
1. We are calling `format_using` on rows we didn't actually project
2. We are copying failure messages unnecessarily. NB that these can be quite long. And in my testing every invocation failed so I particularly hammer this. The InvocationError type accepts an impl fmt::Display, which will always copy the message, even if we have it as an owned string. In the main case in the profile, we had it as a Bytes (ref count presumably 1) and we were turning it into a bytestring (free) then formatting it (copy). If we instead turn the Bytes into a Vec<u8> we should be able to avoid a copy. There are other cases of passing ByteString to InvocationError and it will probably copy, but unless those show up in a profile too I'll leave them for now.