### PR TITLE
Avoid parsing opentelemetry tracestate when reading inv status

### DIFF
--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -190,7 +190,7 @@ where
             // Prepare service invocation
             let mut invocation_request_header =
                 InvocationRequestHeader::initialize(invocation_id, invocation_target);
-            invocation_request_header.with_related_span(SpanRelation::Parent(ingress_span_context));
+            invocation_request_header.with_related_span(SpanRelation::parent(ingress_span_context));
             invocation_request_header.with_retention(invocation_retention);
             if let Some(key) = idempotency_key {
                 invocation_request_header.idempotency_key = Some(key);

--- a/crates/ingress-http/src/handler/tracing.rs
+++ b/crates/ingress-http/src/handler/tracing.rs
@@ -38,7 +38,7 @@ pub(crate) fn prepare_tracing_span<B>(
     // if the inbound span is set (`traceparent`) we use that as
     // parent to the ingress span.
     let relation = if inbound_span.span_context().is_valid() {
-        SpanRelation::Parent(inbound_span.span_context().clone())
+        SpanRelation::parent(inbound_span.span_context())
     } else {
         SpanRelation::None
     };

--- a/crates/ingress-kafka/src/dispatcher.rs
+++ b/crates/ingress-kafka/src/dispatcher.rs
@@ -128,7 +128,7 @@ impl KafkaIngressEvent {
             invocation_target,
             restate_types::invocation::Source::Subscription(subscription.id()),
         ));
-        service_invocation.with_related_span(SpanRelation::Parent(ingress_span_context));
+        service_invocation.with_related_span(SpanRelation::parent(ingress_span_context));
         service_invocation.argument = payload;
         service_invocation.headers = headers;
         service_invocation.with_retention(invocation_retention);
@@ -240,7 +240,7 @@ pub(crate) fn prepare_tracing_span(
     let inbound_span = tracing_context.span();
 
     let relation = if inbound_span.span_context().is_valid() {
-        SpanRelation::Parent(inbound_span.span_context().clone())
+        SpanRelation::parent(inbound_span.span_context())
     } else {
         SpanRelation::None
     };

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -254,7 +254,9 @@ where
                 if let Ok(header_value) = HeaderValue::try_from(header_value) {
                     headers.insert("traceparent", header_value);
                 }
-                if let Ok(tracestate) = HeaderValue::try_from(span_context.trace_state().header()) {
+                if let Ok(tracestate) =
+                    HeaderValue::from_str(span_context.trace_state().header().as_ref())
+                {
                     headers.insert("tracestate", tracestate);
                 }
             }

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -266,7 +266,9 @@ where
                 if let Ok(header_value) = HeaderValue::try_from(header_value) {
                     headers.insert("traceparent", header_value);
                 }
-                if let Ok(tracestate) = HeaderValue::try_from(span_context.trace_state().header()) {
+                if let Ok(tracestate) =
+                    HeaderValue::from_str(span_context.trace_state().header().as_ref())
+                {
                     headers.insert("tracestate", tracestate);
                 }
             }

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -546,15 +546,15 @@ macro_rules! invocation_span {
                     .clone(),
             )];
 
-            if let SpanRelation::Linked(ref ctx) = $relation {
-                links.push(Link::new(ctx.clone(), vec![KeyValue::new("restate.runtime", true)], 0));
-            }
-
-            let builder = builder.with_links(links);
-
             let span = match $relation {
-                SpanRelation::None | SpanRelation::Linked(_) => builder.start(&tracer),
-                SpanRelation::Parent(ctx) => builder.start_with_context(&tracer,&Context::new().with_remote_span_context(ctx)),
+                SpanRelation::None => {
+                    builder.with_links(links).start(&tracer)
+                }
+                SpanRelation::Linked(ctx) => {
+                     links.push(Link::new(ctx.into(), vec![KeyValue::new("restate.runtime", true)], 0));
+                     builder.with_links(links).start(&tracer)
+                }
+                SpanRelation::Parent(ctx) => builder.with_links(links).start_with_context(&tracer,&Context::new().with_remote_span_context(ctx.into())),
             };
 
             span

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -168,9 +168,8 @@ where
             completion_retention: completed_invocation.completion_retention_duration,
             journal_retention: completed_invocation.journal_retention_duration,
         });
-        invocation_request_header.with_related_span(SpanRelation::Parent(
-            restart_as_new_span.span_context().clone(),
-        ));
+        invocation_request_header
+            .with_related_span(SpanRelation::parent(restart_as_new_span.span_context()));
 
         // Final bundling of the service invocation
         let invocation_request =

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -2733,7 +2733,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 );
 
                 if let SpanRelation::Linked(ctx) = span_context.causing_span_relation() {
-                    span.add_link(ctx, Vec::default());
+                    span.add_link(ctx.into(), Vec::default());
                 }
 
                 let service_invocation = Box::new(ServiceInvocation {


### PR DESCRIPTION
The goal here is to keep tracestate as a string if we provided it as a string (eg, it came from storage) and only parse it to proper tracestate if someone asks for it.