### PR TITLE
Format directly into the batch

### DIFF
--- a/crates/storage-query-datafusion/src/deployment/row.rs
+++ b/crates/storage-query-datafusion/src/deployment/row.rs
@@ -9,17 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use super::schema::SysDeploymentBuilder;
-use crate::table_util::format_using;
 use restate_types::schema::deployment::{Deployment, DeploymentType};
 
 #[inline]
-pub(crate) fn append_deployment_row(
-    builder: &mut SysDeploymentBuilder,
-    output: &mut String,
-    deployment: Deployment,
-) {
+pub(crate) fn append_deployment_row(builder: &mut SysDeploymentBuilder, deployment: Deployment) {
     let mut row = builder.row();
-    row.id(format_using(output, &deployment.id));
+    row.fmt_id(deployment.id);
 
     match deployment.metadata.ty {
         DeploymentType::Http { .. } => {
@@ -30,7 +25,7 @@ pub(crate) fn append_deployment_row(
         }
     }
 
-    row.endpoint(format_using(output, &deployment.metadata.address_display()));
+    row.fmt_endpoint(deployment.metadata.address_display());
     row.created_at(deployment.metadata.created_at.as_u64() as i64);
     row.min_service_protocol_version(
         deployment

--- a/crates/storage-query-datafusion/src/deployment/table.rs
+++ b/crates/storage-query-datafusion/src/deployment/table.rs
@@ -70,9 +70,8 @@ async fn for_each_state(
     batch_size: usize,
 ) {
     let mut builder = SysDeploymentBuilder::new(schema.clone());
-    let mut temp = String::new();
     for (deployment, _) in rows {
-        append_deployment_row(&mut builder, &mut temp, deployment);
+        append_deployment_row(&mut builder, deployment);
         if builder.num_rows() >= batch_size {
             let batch = builder.finish();
             if tx.send(batch).await.is_err() {

--- a/crates/storage-query-datafusion/src/idempotency/row.rs
+++ b/crates/storage-query-datafusion/src/idempotency/row.rs
@@ -10,14 +10,12 @@
 
 use super::schema::SysIdempotencyBuilder;
 
-use crate::table_util::format_using;
 use restate_storage_api::idempotency_table::IdempotencyMetadata;
 use restate_types::identifiers::{IdempotencyId, WithPartitionKey};
 
 #[inline]
 pub(crate) fn append_idempotency_row(
     builder: &mut SysIdempotencyBuilder,
-    output: &mut String,
     idempotency_id: IdempotencyId,
     idempotency_metadata: IdempotencyMetadata,
 ) {
@@ -34,6 +32,6 @@ pub(crate) fn append_idempotency_row(
     row.idempotency_key(&idempotency_id.idempotency_key);
 
     if row.is_invocation_id_defined() {
-        row.invocation_id(format_using(output, &idempotency_metadata.invocation_id));
+        row.fmt_invocation_id(idempotency_metadata.invocation_id);
     }
 }

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -70,14 +70,8 @@ impl ScanLocalPartition for IdempotencyScanner {
 
     fn append_row(
         row_builder: &mut Self::Builder,
-        string_buffer: &mut String,
         (idempotency_id, idempotency_metadata): Self::Item,
     ) {
-        append_idempotency_row(
-            row_builder,
-            string_buffer,
-            idempotency_id,
-            idempotency_metadata,
-        );
+        append_idempotency_row(row_builder, idempotency_id, idempotency_metadata);
     }
 }

--- a/crates/storage-query-datafusion/src/inbox/row.rs
+++ b/crates/storage-query-datafusion/src/inbox/row.rs
@@ -9,14 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use super::schema::SysInboxBuilder;
-use crate::table_util::format_using;
 use restate_storage_api::inbox_table::{InboxEntry, SequenceNumberInboxEntry};
 use restate_types::identifiers::WithPartitionKey;
 
 #[inline]
 pub(crate) fn append_inbox_row(
     builder: &mut SysInboxBuilder,
-    output: &mut String,
     inbox_entry: SequenceNumberInboxEntry,
 ) {
     let mut row = builder.row();
@@ -32,7 +30,7 @@ pub(crate) fn append_inbox_row(
         row.service_key(&service_id.key);
 
         if row.is_id_defined() {
-            row.id(format_using(output, &invocation_id));
+            row.fmt_id(invocation_id);
         }
 
         row.sequence_number(inbox_sequence_number);

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -69,7 +69,7 @@ impl ScanLocalPartition for InboxScanner {
         partition_store.scan_inboxes(range)
     }
 
-    fn append_row(row_builder: &mut Self::Builder, string_buffer: &mut String, value: Self::Item) {
-        append_inbox_row(row_builder, string_buffer, value);
+    fn append_row(row_builder: &mut Self::Builder, value: Self::Item) {
+        append_inbox_row(row_builder, value);
     }
 }

--- a/crates/storage-query-datafusion/src/invocation_state/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/row.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use crate::invocation_state::schema::SysInvocationStateBuilder;
-use crate::table_util::format_using;
 use restate_invoker_api::InvocationStatusReport;
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::service_protocol::ServiceProtocolVersion;
@@ -18,7 +17,6 @@ use restate_types::time::MillisSinceEpoch;
 #[inline]
 pub(crate) fn append_invocation_state_row(
     builder: &mut SysInvocationStateBuilder,
-    output: &mut String,
     status_row: InvocationStatusReport,
 ) {
     let mut row = builder.row();
@@ -27,7 +25,7 @@ pub(crate) fn append_invocation_state_row(
 
     row.partition_key(invocation_id.partition_key());
     if row.is_id_defined() {
-        row.id(format_using(output, &invocation_id));
+        row.fmt_id(invocation_id);
     }
     row.in_flight(status_row.in_flight());
     row.retry_count(status_row.retry_count() as u64);
@@ -43,7 +41,7 @@ pub(crate) fn append_invocation_state_row(
         row.next_retry_at(MillisSinceEpoch::as_u64(&next_retry_at.into()) as i64);
     }
     if let Some(last_retry_attempt_failure) = status_row.last_retry_attempt_failure() {
-        row.last_failure(format_using(output, &last_retry_attempt_failure.err));
+        row.fmt_last_failure(&last_retry_attempt_failure.err);
         if let Some(doc_error_code) = last_retry_attempt_failure.doc_error_code {
             row.last_failure_error_code(doc_error_code.code())
         }
@@ -65,10 +63,7 @@ pub(crate) fn append_invocation_state_row(
                 if row.is_last_failure_related_entry_type_defined() {
                     if let Some(related_entry_type) = &last_retry_attempt_failure.related_entry_type
                     {
-                        row.last_failure_related_entry_type(format_using(
-                            output,
-                            related_entry_type,
-                        ));
+                        row.fmt_last_failure_related_entry_type(related_entry_type);
                     }
                 }
             }
@@ -86,10 +81,7 @@ pub(crate) fn append_invocation_state_row(
                     if let Some(related_command_type) =
                         &last_retry_attempt_failure.related_entry_type
                     {
-                        row.last_failure_related_command_type(format_using(
-                            output,
-                            related_command_type,
-                        ));
+                        row.fmt_last_failure_related_command_type(related_command_type);
                     }
                 }
             }

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -135,9 +135,8 @@ async fn for_each_state<'a, I>(
     I: Iterator<Item = InvocationStatusReport> + 'a,
 {
     let mut builder = SysInvocationStateBuilder::new(schema.clone());
-    let mut temp = String::new();
     for row in rows {
-        append_invocation_state_row(&mut builder, &mut temp, row);
+        append_invocation_state_row(&mut builder, row);
         if builder.num_rows() >= batch_size {
             let batch = builder.finish();
             if tx.send(batch).await.is_err() {

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -70,11 +70,7 @@ impl ScanLocalPartition for StatusScanner {
         partition_store.scan_invocation_statuses(range)
     }
 
-    fn append_row(
-        row_builder: &mut Self::Builder,
-        string_buffer: &mut String,
-        (invocation_id, invocation_status): Self::Item,
-    ) {
-        append_invocation_status_row(row_builder, string_buffer, invocation_id, invocation_status)
+    fn append_row(row_builder: &mut Self::Builder, (invocation_id, invocation_status): Self::Item) {
+        append_invocation_status_row(row_builder, invocation_id, invocation_status)
     }
 }

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -83,13 +83,13 @@ impl ScanLocalPartition for JournalScanner {
         Ok(v1.merge(v2))
     }
 
-    fn append_row(row_builder: &mut Self::Builder, string_buffer: &mut String, value: Self::Item) {
+    fn append_row(row_builder: &mut Self::Builder, value: Self::Item) {
         match value.1 {
             ScannedEntry::V1(v1) => {
-                append_journal_row(row_builder, string_buffer, value.0, v1);
+                append_journal_row(row_builder, value.0, v1);
             }
             ScannedEntry::V2(v2) => {
-                append_journal_row_v2(row_builder, string_buffer, value.0, v2);
+                append_journal_row_v2(row_builder, value.0, v2);
             }
         }
     }

--- a/crates/storage-query-datafusion/src/keyed_service_status/row.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/row.rs
@@ -9,14 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use crate::keyed_service_status::schema::SysKeyedServiceStatusBuilder;
-use crate::table_util::format_using;
 use restate_storage_api::service_status_table::VirtualObjectStatus;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
 
 #[inline]
 pub(crate) fn append_virtual_object_status_row(
     builder: &mut SysKeyedServiceStatusBuilder,
-    output: &mut String,
     service_id: ServiceId,
     status: VirtualObjectStatus,
 ) {
@@ -29,7 +27,7 @@ pub(crate) fn append_virtual_object_status_row(
     // Invocation id
     if row.is_invocation_id_defined() {
         if let VirtualObjectStatus::Locked(invocation_id) = status {
-            row.invocation_id(format_using(output, &invocation_id));
+            row.fmt_invocation_id(invocation_id);
         }
     }
 }

--- a/crates/storage-query-datafusion/src/keyed_service_status/table.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/table.rs
@@ -73,7 +73,7 @@ impl ScanLocalPartition for VirtualObjectStatusScanner {
         partition_store.scan_virtual_object_statuses(range)
     }
 
-    fn append_row(row_builder: &mut Self::Builder, string_buffer: &mut String, value: Self::Item) {
-        append_virtual_object_status_row(row_builder, string_buffer, value.0, value.1)
+    fn append_row(row_builder: &mut Self::Builder, value: Self::Item) {
+        append_virtual_object_status_row(row_builder, value.0, value.1)
     }
 }

--- a/crates/storage-query-datafusion/src/log/row.rs
+++ b/crates/storage-query-datafusion/src/log/row.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::table_util::format_using;
-
 use super::schema::LogBuilder;
 use restate_types::{
     Version,
@@ -22,7 +20,6 @@ use restate_types::{
 
 pub(crate) fn append_segment_row(
     builder: &mut LogBuilder,
-    output: &mut String,
     ver: Version,
     id: LogId,
     segment: &Segment<'_>,
@@ -35,14 +32,14 @@ pub(crate) fn append_segment_row(
     row.log_id(id.into());
     row.segment_index(segment.config.index().into());
     row.base_lsn(segment.base_lsn.into());
-    row.kind(format_using(output, &segment.config.kind));
+    row.fmt_kind(segment.config.kind);
 
     if segment.config.kind == ProviderKind::Replicated {
         if let Some(LogletRef { params, .. }) = replicated_loglet_params {
-            row.loglet_id(format_using(output, &params.loglet_id));
-            row.sequencer(format_using(output, &params.sequencer));
-            row.replication(format_using(output, &params.replication));
-            row.nodeset(format_using(output, &params.nodeset));
+            row.fmt_loglet_id(params.loglet_id);
+            row.fmt_sequencer(params.sequencer);
+            row.fmt_replication(&params.replication);
+            row.fmt_nodeset(&params.nodeset);
         }
     }
 }

--- a/crates/storage-query-datafusion/src/log/table.rs
+++ b/crates/storage-query-datafusion/src/log/table.rs
@@ -67,7 +67,6 @@ async fn for_each_log(
     batch_size: usize,
 ) {
     let mut builder = LogBuilder::new(schema.clone());
-    let mut output = String::new();
     for (id, chain) in logs.iter() {
         for segment in chain.iter() {
             let loglet_id = LogletId::new(*id, segment.index());
@@ -75,7 +74,6 @@ async fn for_each_log(
 
             append_segment_row(
                 &mut builder,
-                &mut output,
                 logs.version(),
                 *id,
                 &segment,

--- a/crates/storage-query-datafusion/src/node/row.rs
+++ b/crates/storage-query-datafusion/src/node/row.rs
@@ -11,7 +11,6 @@
 use enumset::EnumSet;
 
 use super::schema::NodeBuilder;
-use crate::table_util::format_using;
 use restate_types::cluster_state::NodeState;
 use restate_types::{
     PlainNodeId, Version,
@@ -20,7 +19,6 @@ use restate_types::{
 
 pub(crate) fn append_node_row(
     builder: &mut NodeBuilder,
-    output: &mut String,
     ver: Version,
     node_id: PlainNodeId,
     node_config: &NodeConfig,
@@ -30,12 +28,12 @@ pub(crate) fn append_node_row(
 
     row.nodes_configuration_version(ver.into());
 
-    row.plain_node_id(format_using(output, &node_id));
-    row.gen_node_id(format_using(output, &node_config.current_generation));
-    row.state(format_using(output, &node_state));
-    row.name(format_using(output, &node_config.name));
-    row.address(format_using(output, &node_config.address));
-    row.location(format_using(output, &node_config.location));
+    row.fmt_plain_node_id(node_id);
+    row.fmt_gen_node_id(node_config.current_generation);
+    row.fmt_state(node_state);
+    row.fmt_name(&node_config.name);
+    row.fmt_address(&node_config.address);
+    row.fmt_location(&node_config.location);
 
     let all: EnumSet<Role> = EnumSet::all();
     for role in all {
@@ -46,28 +44,21 @@ pub(crate) fn append_node_row(
             Role::Worker => {
                 row.has_worker_role(node_config.has_role(role));
                 if node_config.has_role(role) {
-                    row.worker_state(format_using(
-                        output,
-                        &node_config.worker_config.worker_state,
-                    ));
+                    row.fmt_worker_state(node_config.worker_config.worker_state);
                 }
             }
             Role::LogServer => {
                 row.has_log_server_role(node_config.has_role(role));
                 if node_config.has_role(role) {
-                    row.storage_state(format_using(
-                        output,
-                        &node_config.log_server_config.storage_state,
-                    ));
+                    row.fmt_storage_state(node_config.log_server_config.storage_state);
                 }
             }
             Role::MetadataServer => {
                 row.has_metadata_server_role(node_config.has_role(role));
                 if node_config.has_role(role) {
-                    row.metadata_server_state(format_using(
-                        output,
-                        &node_config.metadata_server_config.metadata_server_state,
-                    ));
+                    row.fmt_metadata_server_state(
+                        node_config.metadata_server_config.metadata_server_state,
+                    );
                 }
             }
             Role::HttpIngress => {

--- a/crates/storage-query-datafusion/src/node/table.rs
+++ b/crates/storage-query-datafusion/src/node/table.rs
@@ -80,12 +80,10 @@ async fn for_each_state(
     batch_size: usize,
 ) {
     let mut builder = NodeBuilder::new(schema.clone());
-    let mut output = String::new();
     for (id, node_config) in nodes_config.iter() {
         let node_state = cluster_state.get_node_state(node_config.current_generation.into());
         append_node_row(
             &mut builder,
-            &mut output,
             nodes_config.version(),
             id,
             node_config,

--- a/crates/storage-query-datafusion/src/partition/row.rs
+++ b/crates/storage-query-datafusion/src/partition/row.rs
@@ -12,11 +12,9 @@ use restate_types::partitions::state::MembershipState;
 use restate_types::{Version, partition_table::Partition};
 
 use super::schema::PartitionBuilder;
-use crate::table_util::format_using;
 
 pub(crate) fn append_partition_row(
     builder: &mut PartitionBuilder,
-    output: &mut String,
     membership: MembershipState,
     ver: Version,
     partition: &Partition,
@@ -30,8 +28,8 @@ pub(crate) fn append_partition_row(
     row.db_name(partition.db_name());
     let leadership = membership.current_leader();
     if leadership.current_leader.is_valid() {
-        row.leader_gen_node_id(format_using(output, &leadership.current_leader));
-        row.leader_plain_node_id(format_using(output, &leadership.current_leader.as_plain()));
+        row.fmt_leader_gen_node_id(leadership.current_leader);
+        row.fmt_leader_plain_node_id(leadership.current_leader.as_plain());
     }
     row.v_current(membership.observed_current_membership.version.into());
     row.current_replica_set(itertools::join(
@@ -50,6 +48,6 @@ pub(crate) fn append_partition_row(
         ));
     }
 
-    row.leader_epoch(format_using(output, &leadership.current_leader_epoch));
+    row.fmt_leader_epoch(leadership.current_leader_epoch);
     row.partition_table_version(ver.into());
 }

--- a/crates/storage-query-datafusion/src/partition/table.rs
+++ b/crates/storage-query-datafusion/src/partition/table.rs
@@ -83,12 +83,10 @@ async fn for_each_partition(
 ) {
     let mut builder = PartitionBuilder::new(schema.clone());
 
-    let mut output = String::new();
     for (_, partition) in partition_table.iter() {
         let membership = replica_set_states.membership_state(partition.partition_id);
         append_partition_row(
             &mut builder,
-            &mut output,
             membership,
             partition_table.version(),
             partition,

--- a/crates/storage-query-datafusion/src/partition_replica_set/row.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/row.rs
@@ -14,11 +14,9 @@ use restate_types::partitions::state::{MemberState, MembershipState};
 use restate_types::{Version, partition_table::Partition};
 
 use super::schema::PartitionReplicaSetBuilder;
-use crate::table_util::format_using;
 
 pub(crate) fn append_replica_set_row(
     builder: &mut PartitionReplicaSetBuilder,
-    output: &mut String,
     membership: MembershipState,
     cluster_state: &ClusterState,
     partition: &Partition,
@@ -34,17 +32,17 @@ pub(crate) fn append_replica_set_row(
             if member.durable_lsn != Lsn::INVALID {
                 row.durable_lsn(member.durable_lsn.into());
             }
-            row.plain_node_id(format_using(output, &member.node_id));
+            row.fmt_plain_node_id(member.node_id);
 
             if let Some((gen_node_id, node_state)) =
                 cluster_state.get_node_state_and_generation(member.node_id)
             {
                 if node_state.is_alive() {
-                    row.alive_gen_node_id(format_using(output, &gen_node_id));
+                    row.fmt_alive_gen_node_id(gen_node_id);
                 }
                 if leadership.current_leader == gen_node_id {
                     row.is_leader(true);
-                    row.leader_epoch(format_using(output, &leadership.current_leader_epoch));
+                    row.fmt_leader_epoch(leadership.current_leader_epoch);
                 }
             }
         }

--- a/crates/storage-query-datafusion/src/partition_replica_set/table.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/table.rs
@@ -96,16 +96,9 @@ async fn for_each_partition(
 ) {
     let mut builder = PartitionReplicaSetBuilder::new(schema.clone());
 
-    let mut output = String::new();
     for (_, partition) in partition_table.iter() {
         let membership = replica_set_states.membership_state(partition.partition_id);
-        append_replica_set_row(
-            &mut builder,
-            &mut output,
-            membership,
-            &cluster_state,
-            partition,
-        );
+        append_replica_set_row(&mut builder, membership, &cluster_state, partition);
 
         if builder.num_rows() >= batch_size {
             let batch = builder.finish();

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::table_util::format_using;
-
 use super::schema::PartitionStateBuilder;
 use restate_types::{
     GenerationalNodeId, cluster::cluster_state::PartitionProcessorStatus, identifiers::PartitionId,
@@ -18,7 +16,6 @@ use restate_types::{
 #[inline]
 pub(crate) fn append_partition_row(
     builder: &mut PartitionStateBuilder,
-    output: &mut String,
     node_id: GenerationalNodeId,
     partition_id: PartitionId,
     state: &PartitionProcessorStatus,
@@ -26,11 +23,11 @@ pub(crate) fn append_partition_row(
     let mut row = builder.row();
 
     row.partition_id(partition_id.into());
-    row.plain_node_id(format_using(output, &node_id.as_plain()));
-    row.gen_node_id(format_using(output, &node_id));
-    row.target_mode(format_using(output, &state.planned_mode));
+    row.fmt_plain_node_id(node_id.as_plain());
+    row.fmt_gen_node_id(node_id);
+    row.fmt_target_mode(state.planned_mode);
 
-    row.effective_mode(format_using(output, &state.effective_mode));
+    row.fmt_effective_mode(state.effective_mode);
 
     row.updated_at(state.updated_at.as_u64() as i64);
     if let Some(epoch) = state.last_observed_leader_epoch {
@@ -38,7 +35,7 @@ pub(crate) fn append_partition_row(
     }
 
     if let Some(leader) = &state.last_observed_leader_node {
-        row.leader(format_using(output, leader));
+        row.fmt_leader(leader);
     }
 
     if let Some(lsn) = state.last_applied_log_lsn {
@@ -49,7 +46,7 @@ pub(crate) fn append_partition_row(
         row.last_record_applied_at(ts.as_u64() as i64);
     }
 
-    row.replay_status(format_using(output, &state.replay_status));
+    row.fmt_replay_status(state.replay_status);
     if let Some(lsn) = state.last_persisted_log_lsn {
         row.durable_log_lsn(lsn.into());
     }

--- a/crates/storage-query-datafusion/src/partition_state/table.rs
+++ b/crates/storage-query-datafusion/src/partition_state/table.rs
@@ -72,12 +72,10 @@ async fn for_each_partition(
     batch_size: usize,
 ) {
     let mut builder = PartitionStateBuilder::new(schema.clone());
-    let mut output = String::new();
     for alive in state.alive_nodes() {
         for (partition_id, partition_status) in alive.partitions.iter() {
             append_partition_row(
                 &mut builder,
-                &mut output,
                 alive.generational_node_id,
                 *partition_id,
                 partition_status,

--- a/crates/storage-query-datafusion/src/promise/row.rs
+++ b/crates/storage-query-datafusion/src/promise/row.rs
@@ -10,7 +10,6 @@
 
 use super::schema::SysPromiseBuilder;
 
-use crate::table_util::format_using;
 use restate_storage_api::promise_table::{OwnedPromiseRow, PromiseResult, PromiseState};
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::WithPartitionKey;
@@ -18,7 +17,6 @@ use restate_types::identifiers::WithPartitionKey;
 #[inline]
 pub(crate) fn append_promise_row(
     builder: &mut SysPromiseBuilder,
-    output: &mut String,
     owned_promise_row: OwnedPromiseRow,
 ) {
     let mut row = builder.row();
@@ -42,7 +40,7 @@ pub(crate) fn append_promise_row(
                 }
                 PromiseResult::Failure(c, m) => {
                     if row.is_completion_failure_defined() {
-                        row.completion_failure(format_using(output, &InvocationError::new(c, m)))
+                        row.fmt_completion_failure(InvocationError::new(c, m))
                     }
                 }
             }

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -66,7 +66,7 @@ impl ScanLocalPartition for PromiseScanner {
         partition_store.scan_promises(range)
     }
 
-    fn append_row(row_builder: &mut Self::Builder, string_buffer: &mut String, value: Self::Item) {
-        append_promise_row(row_builder, string_buffer, value);
+    fn append_row(row_builder: &mut Self::Builder, value: Self::Item) {
+        append_promise_row(row_builder, value);
     }
 }

--- a/crates/storage-query-datafusion/src/service/row.rs
+++ b/crates/storage-query-datafusion/src/service/row.rs
@@ -10,21 +10,19 @@
 
 use super::schema::SysServiceBuilder;
 
-use crate::table_util::format_using;
 use restate_types::invocation::ServiceType;
 use restate_types::schema::service::ServiceMetadata;
 
 #[inline]
 pub(crate) fn append_service_row(
     builder: &mut SysServiceBuilder,
-    output: &mut String,
     service_metadata: ServiceMetadata,
 ) {
     let mut row = builder.row();
     row.name(service_metadata.name);
     row.revision(service_metadata.revision as u64);
     row.public(service_metadata.public);
-    row.deployment_id(format_using(output, &service_metadata.deployment_id));
+    row.fmt_deployment_id(service_metadata.deployment_id);
     row.ty(match service_metadata.ty {
         ServiceType::Service => "service",
         ServiceType::VirtualObject => "virtual_object",

--- a/crates/storage-query-datafusion/src/service/table.rs
+++ b/crates/storage-query-datafusion/src/service/table.rs
@@ -70,9 +70,8 @@ async fn for_each_state(
     batch_size: usize,
 ) {
     let mut builder = SysServiceBuilder::new(schema.clone());
-    let mut temp = String::new();
     for service in rows {
-        append_service_row(&mut builder, &mut temp, service);
+        append_service_row(&mut builder, service);
         if builder.num_rows() >= batch_size {
             let batch = builder.finish();
             if tx.send(batch).await.is_err() {

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -67,7 +67,7 @@ impl ScanLocalPartition for StateScanner {
         partition_store.scan_all_user_states(range)
     }
 
-    fn append_row(row_builder: &mut Self::Builder, _: &mut String, value: Self::Item) {
+    fn append_row(row_builder: &mut Self::Builder, value: Self::Item) {
         append_state_row(row_builder, value.0, value.1, value.2);
     }
 }

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -45,6 +45,32 @@ macro_rules! define_builder {
     };
 }
 
+macro_rules! define_fmt {
+    ($element:ident, $name:ident, DataType::Utf8) => {
+        #[inline]
+        pub fn $name(&mut self, d: impl ::std::fmt::Display) {
+            if let Some(builder) = self.builder.arrays.$element.as_mut() {
+                use std::fmt::Write;
+                let _ = write!(builder, "{d}");
+                builder.append_value("");
+                self.flags.$element = true;
+            }
+        }
+    };
+    ($element:ident, $name:ident, DataType::LargeUtf8) => {
+        #[inline]
+        pub fn $name(&mut self, d: impl ::std::fmt::Display) {
+            if let Some(builder) = self.builder.arrays.$element.as_mut() {
+                use std::fmt::Write;
+                let _ = write!(builder, "{d}");
+                builder.append_value("");
+                self.flags.$element = true;
+            }
+        }
+    };
+    ($element:ident, $name:ident, $ty:ty) => {};
+}
+
 // This newtype is necessary to generate values with a UTC timezone, as it will default to having no timezone which can confuse downstream clients
 pub struct TimestampMillisecondUTCBuilder(::datafusion::arrow::array::TimestampMillisecondBuilder);
 
@@ -252,7 +278,15 @@ macro_rules! document_type {
 ///             self.flags.name = true;
 ///         }
 ///     }
-///
+///     #[inline]
+///     pub fn fmt_name(&mut self, d: impl ::std::fmt::Display) {
+///         if let Some(builder) = self.builder.arrays.name.as_mut() {
+///             use std::fmt::Write;
+///             let _ = builder.write_fmt(core::format_args!("{d}"));
+///             builder.append_value("");
+///             self.flags.name = true;
+///         }
+///     }
 ///     #[inline]
 ///     pub fn is_name_defined(&self) -> bool {
 ///         self.builder.arrays.name.is_some()
@@ -276,7 +310,6 @@ macro_rules! document_type {
 ///             self.flags.secret = true;
 ///         }
 ///     }
-///
 ///     #[inline]
 ///     pub fn is_secret_defined(&self) -> bool {
 ///         self.builder.arrays.secret.is_some()
@@ -462,7 +495,9 @@ macro_rules! define_table {
                                 builder.append_value(value);
                                 self.flags.$element = true;
                             }
-                       }
+                        }
+
+                        define_fmt!($element, [< fmt _ $element >], $ty);
 
                         #[inline]
                         pub fn [<is _ $element _ defined>](&self) -> bool {
@@ -629,6 +664,7 @@ macro_rules! define_sort_order {
 
 pub(crate) use define_builder;
 pub(crate) use define_data_type;
+pub(crate) use define_fmt;
 pub(crate) use define_primitive_trait;
 pub(crate) use define_sort_order;
 pub(crate) use define_table;

--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -12,9 +12,7 @@ use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_expr::expressions::col;
 use datafusion::physical_expr::{PhysicalExpr, PhysicalSortExpr};
-use std::fmt::Write;
 use std::sync::Arc;
-use tracing::error;
 
 #[macro_export]
 macro_rules! log_data_corruption_error {
@@ -48,15 +46,6 @@ pub(crate) fn make_ordering(columns: Vec<Arc<dyn PhysicalExpr>>) -> Vec<Physical
             options: Default::default(),
         })
         .collect()
-}
-
-#[inline]
-pub(crate) fn format_using<'a>(output: &'a mut String, what: &impl std::fmt::Display) -> &'a str {
-    output.clear();
-    if let Err(e) = write!(output, "{what}") {
-        error!(error = %e, "Cannot format the string")
-    }
-    output
 }
 
 pub(crate) trait Builder {


### PR DESCRIPTION
Instead of first formatting into a string buffer then writing that str into the batch, we can write directly into the batch, as stringbuilders implement fmt::Write. We just have to do append_value("") afterwards so that it knows that we are done with that row.