### PR TITLE
Re-use df batch array capacities

### DIFF
--- a/crates/storage-query-datafusion/src/deployment/table.rs
+++ b/crates/storage-query-datafusion/src/deployment/table.rs
@@ -73,14 +73,13 @@ async fn for_each_state(
     for (deployment, _) in rows {
         append_deployment_row(&mut builder, deployment);
         if builder.num_rows() >= batch_size {
-            let batch = builder.finish();
+            let batch = builder.finish_and_new();
             if tx.send(batch).await.is_err() {
                 // not sure what to do here?
                 // the other side has hung up on us.
                 // we probably don't want to panic, is it will cause the entire process to exit
                 return;
             }
-            builder = SysDeploymentBuilder::new(schema.clone());
         }
     }
     if !builder.empty() {

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -138,14 +138,13 @@ async fn for_each_state<'a, I>(
     for row in rows {
         append_invocation_state_row(&mut builder, row);
         if builder.num_rows() >= batch_size {
-            let batch = builder.finish();
+            let batch = builder.finish_and_new();
             if tx.send(batch).await.is_err() {
                 // not sure what to do here?
                 // the other side has hung up on us.
                 // we probably don't want to panic, is it will cause the entire process to exit
                 return;
             }
-            builder = SysInvocationStateBuilder::new(schema.clone());
         }
     }
     if !builder.empty() {

--- a/crates/storage-query-datafusion/src/log/table.rs
+++ b/crates/storage-query-datafusion/src/log/table.rs
@@ -81,14 +81,13 @@ async fn for_each_log(
             );
 
             if builder.num_rows() >= batch_size {
-                let batch = builder.finish();
+                let batch = builder.finish_and_new();
                 if tx.send(batch).await.is_err() {
                     // not sure what to do here?
                     // the other side has hung up on us.
                     // we probably don't want to panic, is it will cause the entire process to exit
                     return;
                 }
-                builder = LogBuilder::new(schema.clone());
             }
         }
     }

--- a/crates/storage-query-datafusion/src/node/table.rs
+++ b/crates/storage-query-datafusion/src/node/table.rs
@@ -91,14 +91,13 @@ async fn for_each_state(
         );
 
         if builder.num_rows() >= batch_size {
-            let batch = builder.finish();
+            let batch = builder.finish_and_new();
             if tx.send(batch).await.is_err() {
                 // not sure what to do here?
                 // the other side has hung up on us.
                 // we probably don't want to panic, is it will cause the entire process to exit
                 return;
             }
-            builder = NodeBuilder::new(schema.clone());
         }
     }
     if !builder.empty() {

--- a/crates/storage-query-datafusion/src/partition/table.rs
+++ b/crates/storage-query-datafusion/src/partition/table.rs
@@ -93,14 +93,13 @@ async fn for_each_partition(
         );
 
         if builder.num_rows() >= batch_size {
-            let batch = builder.finish();
+            let batch = builder.finish_and_new();
             if tx.send(batch).await.is_err() {
                 // not sure what to do here?
                 // the other side has hung up on us.
                 // we probably don't want to panic, is it will cause the entire process to exit
                 return;
             }
-            builder = PartitionBuilder::new(schema.clone());
         }
     }
 

--- a/crates/storage-query-datafusion/src/partition_replica_set/table.rs
+++ b/crates/storage-query-datafusion/src/partition_replica_set/table.rs
@@ -101,14 +101,13 @@ async fn for_each_partition(
         append_replica_set_row(&mut builder, membership, &cluster_state, partition);
 
         if builder.num_rows() >= batch_size {
-            let batch = builder.finish();
+            let batch = builder.finish_and_new();
             if tx.send(batch).await.is_err() {
                 // not sure what to do here?
                 // the other side has hung up on us.
                 // we probably don't want to panic, is it will cause the entire process to exit
                 return;
             }
-            builder = PartitionReplicaSetBuilder::new(schema.clone());
         }
     }
 

--- a/crates/storage-query-datafusion/src/partition_state/table.rs
+++ b/crates/storage-query-datafusion/src/partition_state/table.rs
@@ -81,14 +81,13 @@ async fn for_each_partition(
                 partition_status,
             );
             if builder.num_rows() >= batch_size {
-                let batch = builder.finish();
+                let batch = builder.finish_and_new();
                 if tx.send(batch).await.is_err() {
                     // not sure what to do here?
                     // the other side has hung up on us.
                     // we probably don't want to panic, is it will cause the entire process to exit
                     return;
                 }
-                builder = PartitionStateBuilder::new(schema.clone());
             }
         }
     }

--- a/crates/storage-query-datafusion/src/partition_store_scanner.rs
+++ b/crates/storage-query-datafusion/src/partition_store_scanner.rs
@@ -93,14 +93,13 @@ where
             while let Some(Ok(row)) = rows.next().await {
                 S::append_row(&mut builder, row);
                 if builder.num_rows() >= batch_size {
-                    let batch = builder.finish();
+                    let batch = builder.finish_and_new();
                     if tx.send(batch).await.is_err() {
                         // not sure what to do here?
                         // the other side has hung up on us.
                         // we probably don't want to panic, is it will cause the entire process to exit
                         return Ok(());
                     }
-                    builder = S::Builder::new(projection.clone());
                 }
             }
             if !builder.empty() {

--- a/crates/storage-query-datafusion/src/service/table.rs
+++ b/crates/storage-query-datafusion/src/service/table.rs
@@ -73,14 +73,13 @@ async fn for_each_state(
     for service in rows {
         append_service_row(&mut builder, service);
         if builder.num_rows() >= batch_size {
-            let batch = builder.finish();
+            let batch = builder.finish_and_new();
             if tx.send(batch).await.is_err() {
                 // not sure what to do here?
                 // the other side has hung up on us.
                 // we probably don't want to panic, is it will cause the entire process to exit
                 return;
             }
-            builder = SysServiceBuilder::new(schema.clone());
         }
     }
     if !builder.empty() {

--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -56,4 +56,6 @@ pub(crate) trait Builder {
     fn empty(&self) -> bool;
 
     fn finish(self) -> datafusion::common::Result<RecordBatch>;
+
+    fn finish_and_new(&mut self) -> datafusion::common::Result<RecordBatch>;
 }


### PR DESCRIPTION
The idea here is to make each batch with a capacity set to the length of the previous batch, to reduce how often we have to resize the arrays. 

For the primitive arrays, the capacity will just become 'batch size', and given that previously the arrays all defaulted to 1024 item capacity, this will lead to a nice memory reduction given our default batch size is 128. 

Care is needed for byte arrays as they have lens for both value (number of strs, again it will become the batch size) and data (total bytes across all str). Both of these defaulted to 1024 previously, which meant any string field with >4 chars on average led to 1 realloc, and any with > 8 chars led to two reallocs. Invocation IDs, which are 27 chars, led to three reallocs.