### PR TITLE
[restatectl] Add retry mechanism and proper error handling for node removal

### DIFF
--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -359,6 +359,9 @@ impl MetadataServerSvc for MetadataServerHandler {
             .await
             .map_err(|_| Status::unavailable("metadata server is shut down"))?;
 
+        // todo(azmy): MetadataCommandError has useful information like (known leader)
+        // which can be attached to the status of this grpc call.
+        // also return proper error codes.
         node_removed_rx
             .await
             .map_err(|_| Status::unavailable("metadata server is shut down"))?

--- a/tools/restatectl/src/commands/metadata_server/nodes.rs
+++ b/tools/restatectl/src/commands/metadata_server/nodes.rs
@@ -8,16 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+use std::time::Duration;
+
 use anyhow::Context;
 use clap::Parser;
 use cling::{Collect, Run};
+use tonic::Status;
 use tracing::debug;
 
 use restate_cli_util::{c_print, c_println};
 use restate_metadata_server_grpc::grpc::RemoveNodeRequest;
 use restate_metadata_server_grpc::grpc::metadata_server_svc_client::MetadataServerSvcClient;
 use restate_types::PlainNodeId;
-use restate_types::nodes_config::{MetadataServerState, Role};
+use restate_types::nodes_config::{MetadataServerState, NodeConfig, Role};
+use restate_types::retries::RetryPolicy;
 
 use crate::connection::ConnectionInfo;
 
@@ -75,51 +80,52 @@ async fn remove_node(
 ) -> anyhow::Result<()> {
     let nodes_configuration = connection_info.get_nodes_configuration().await?;
 
+    let mut metadata_node_set = nodes_configuration
+        .iter_role(Role::MetadataServer)
+        .filter(|(_, config)| {
+            config.metadata_server_config.metadata_server_state == MetadataServerState::Member
+        })
+        .collect::<HashMap<_, _>>();
+
+    let retry_policy = RetryPolicy::exponential(
+        Duration::from_millis(200),
+        2.0,
+        Some(10),
+        Some(Duration::from_millis(1500)),
+    );
+
+    // one_node_failed is set to true if any node removal fails
+    let mut one_node_failed = false;
     for node_to_remove in &remove_node_opts.nodes {
-        let mut success = false;
-        let mut errors = vec![];
+        let mut errors = None;
 
-        // check that we know the specified node
-        let _ = nodes_configuration
-            .find_node_by_id(*node_to_remove)
-            .context(format!(
-                "failed to remove unknown node {node_to_remove} from the metadata cluster"
-            ))?;
+        if metadata_node_set.is_empty() {
+            anyhow::bail!(
+                "No metadata servers available to remove node '{node_to_remove}' from the metadata cluster"
+            );
+        }
 
-        // todo try to figure out who's the current leader and directly reach out to the leader
-        //  based on the metadata server status call
-        for (server_id, node_config) in nodes_configuration.iter_role(Role::MetadataServer) {
-            if node_config.metadata_server_config.metadata_server_state
-                == MetadataServerState::Member
-            {
-                let channel = connection_info.connect(&node_config.address).await?;
+        for sleep in std::iter::once(Duration::ZERO).chain(retry_policy.iter()) {
+            if sleep > Duration::ZERO {
+                tokio::time::sleep(sleep).await;
+            }
 
-                let mut client = MetadataServerSvcClient::new(channel);
-                // todo think about whether to run these calls in parallel
-
-                match client
-                    .remove_node(RemoveNodeRequest {
-                        plain_node_id: u32::from(*node_to_remove),
-                        created_at_millis: None,
-                    })
-                    .await
-                {
-                    Ok(_response) => {
-                        success = true;
-                        break;
-                    }
-                    Err(err) => {
-                        debug!(%err, "Failed removing node from the metadata cluster. Trying different metadata server.");
-                        errors.push((server_id, err));
-                    }
+            match try_remove_node(*node_to_remove, &metadata_node_set, connection_info).await {
+                Ok(_) => {
+                    errors = None;
+                    metadata_node_set.remove(node_to_remove);
+                    break;
+                }
+                Err(err) => {
+                    errors = Some(err);
                 }
             }
         }
 
-        if success {
-            c_println!("Removed node '{node_to_remove}' from the metadata cluster");
-        } else {
+        if let Some(errors) = errors {
+            one_node_failed = true;
             c_println!("Failed removing node '{node_to_remove}' from the metadata cluster",);
+
             for (server_id, error) in errors {
                 c_print!("  ├─ {}: {}", server_id, error.code());
 
@@ -130,8 +136,63 @@ async fn remove_node(
 
                 c_println!("");
             }
+        } else {
+            c_println!("Removed node '{node_to_remove}' from the metadata cluster");
         }
     }
 
+    if one_node_failed {
+        return Err(anyhow::anyhow!(
+            "Failed removing some nodes from the metadata cluster"
+        ));
+    }
+
     Ok(())
+}
+
+async fn try_remove_node(
+    node_to_remove: PlainNodeId,
+    metadata_node_set: &HashMap<PlainNodeId, &NodeConfig>,
+    connection_info: &ConnectionInfo,
+) -> Result<(), HashMap<PlainNodeId, Status>> {
+    assert!(
+        !metadata_node_set.is_empty(),
+        "metadata cluster is not empty"
+    );
+
+    let mut errors = HashMap::new();
+    // todo try to figure out who's the current leader and directly reach out to the leader
+    //  based on the metadata server status call
+    for (server_id, node_config) in metadata_node_set.iter() {
+        let channel = match connection_info.connect(&node_config.address).await {
+            Ok(channel) => channel,
+            Err(err) => {
+                errors.insert(*server_id, Status::unavailable(err.to_string()));
+                continue;
+            }
+        };
+        let mut client = MetadataServerSvcClient::new(channel);
+
+        match client
+            .remove_node(RemoveNodeRequest {
+                plain_node_id: u32::from(node_to_remove),
+                created_at_millis: None,
+            })
+            .await
+        {
+            Ok(_response) => {
+                return Ok(());
+            }
+            Err(err) if err.message().contains("is not a member") => {
+                // todo(azmy): grpc server should return proper error codes.
+                return Ok(());
+            }
+            Err(err) => {
+                debug!(%err, "Failed removing node from the metadata cluster. Trying different metadata server.");
+                errors.insert(*server_id, err);
+            }
+        }
+    }
+
+    Err(errors)
 }


### PR DESCRIPTION
[restatectl] Add retry mechanism and proper error handling for node removal

Summary:
his commit improves the node removal functionality in restatectl by:

- Adding exponential backoff retry policy for failed node removal attempts
- Ensuring the command exits with appropriate exit codes on failures

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3687).
* #3691
* __->__ #3687