### PR TITLE
[restatectl] Idempotent metadata node-add

### DIFF
--- a/tools/restatectl/src/commands/metadata_server/nodes.rs
+++ b/tools/restatectl/src/commands/metadata_server/nodes.rs
@@ -64,11 +64,25 @@ async fn add_node(
             .context(format!("failed connecting to node {node_to_add}"))?;
         let mut client = MetadataServerSvcClient::new(channel);
         // todo think about whether to run these calls in parallel
-        client.add_node(()).await.context(format!(
-            "failed adding node {node_to_add} to metadata cluster"
-        ))?;
+        match client.add_node(()).await {
+            Ok(_) => {
+                c_println!("Added node '{node_to_add}' to the metadata cluster",);
+            }
+            Err(status)
+                if status.code() == tonic::Code::AlreadyExists
+                    || status.message().contains(
+                        "cannot add node because it is still a member of the metadata cluster",
+                    ) =>
+            {
+                // the check (status.message().contains()) is a for backward compatibility in case
+                // running against an older version that did not return proper error codes.
 
-        c_println!("Added node '{node_to_add}' to the metadata cluster",);
+                c_println!("Node '{node_to_add}' is already a member of the metadata cluster");
+            }
+            Err(status) => {
+                anyhow::bail!("failed adding node {node_to_add} to metadata cluster: {status}");
+            }
+        }
     }
 
     Ok(())
@@ -185,6 +199,7 @@ async fn try_remove_node(
             }
             Err(err) if err.message().contains("is not a member") => {
                 // todo(azmy): grpc server should return proper error codes.
+                c_println!("Node '{node_to_remove}' is not a member of the metadata cluster");
                 return Ok(());
             }
             Err(err) => {


### PR DESCRIPTION
[restatectl] Idempotent metadata node-add

Summary:
Handle the case when you are adding metadata nodes that
already a member of the cluster
