### PR TITLE
[perf] Faster to_string for all resource identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1958,7 +1958,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -3312,6 +3312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,7 +3960,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -7739,6 +7748,7 @@ dependencies = [
  "figment",
  "flexbuffers",
  "futures",
+ "generic-array 1.2.0",
  "googletest",
  "hostname",
  "http 1.3.1",
@@ -8037,6 +8047,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "typenum",
  "ulid",
  "url",
  "uuid",
@@ -8850,7 +8861,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9715,9 +9726,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typify"

--- a/crates/partition-store/src/keys.rs
+++ b/crates/partition-store/src/keys.rs
@@ -462,15 +462,15 @@ impl KeyCodec for InvocationUuid {
 
     fn decode<B: Buf>(source: &mut B) -> crate::Result<Self> {
         // note: this is a zero-copy when the source is bytes::Bytes.
-        if source.remaining() < InvocationUuid::SIZE_IN_BYTES {
+        if source.remaining() < InvocationUuid::RAW_BYTES_LEN {
             return Err(StorageError::DataIntegrityError);
         }
-        let bytes = source.copy_to_bytes(InvocationUuid::SIZE_IN_BYTES);
+        let bytes = source.copy_to_bytes(InvocationUuid::RAW_BYTES_LEN);
         InvocationUuid::from_slice(&bytes).map_err(|err| StorageError::Generic(err.into()))
     }
 
     fn serialized_length(&self) -> usize {
-        InvocationUuid::SIZE_IN_BYTES
+        InvocationUuid::RAW_BYTES_LEN
     }
 }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -46,6 +46,7 @@ enum_dispatch = "0.3.13"
 enumset = { workspace = true, features = ["serde"] }
 figment = { version = "0.10.8", features = ["env", "toml"] }
 flexbuffers = { workspace = true }
+generic-array = { version = "1.2.0" }
 hostname = { workspace = true }
 http = { workspace = true }
 humantime = { workspace = true }

--- a/crates/types/benches/id_encoding.rs
+++ b/crates/types/benches/id_encoding.rs
@@ -12,6 +12,7 @@ use std::fmt::Write;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+use restate_types::identifiers::AwakeableIdentifier;
 use restate_types::{IdEncoder, identifiers::InvocationId};
 
 pub fn id_encoding(c: &mut Criterion) {
@@ -23,6 +24,25 @@ pub fn id_encoding(c: &mut Criterion) {
                 buf.clear();
                 write!(&mut buf, "{id}")
             },
+            criterion::BatchSize::SmallInput,
+        );
+    })
+    .bench_function("invocation-id-to_string", |b| {
+        b.iter_batched(
+            InvocationId::mock_random,
+            |id| id.to_string(),
+            criterion::BatchSize::SmallInput,
+        );
+    })
+    .bench_function("awakeable-id-to_string", |b| {
+        b.iter_batched(
+            || {
+                let invocation_id = InvocationId::mock_random();
+                let entry_index = rand::random();
+
+                AwakeableIdentifier::new(invocation_id, entry_index)
+            },
+            |id| id.to_string(),
             criterion::BatchSize::SmallInput,
         );
     });

--- a/crates/types/benches/id_encoding.rs
+++ b/crates/types/benches/id_encoding.rs
@@ -13,11 +13,12 @@ use std::fmt::Write;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use restate_types::identifiers::AwakeableIdentifier;
-use restate_types::{IdEncoder, identifiers::InvocationId};
+use restate_types::identifiers::InvocationId;
+use restate_types::identifiers::ResourceId;
 
 pub fn id_encoding(c: &mut Criterion) {
     c.bench_function("invocation-id-display", |b| {
-        let mut buf = String::with_capacity(IdEncoder::<InvocationId>::estimate_buf_capacity());
+        let mut buf = String::with_capacity(InvocationId::str_encoded_len());
         b.iter_batched(
             InvocationId::mock_random,
             |id| {

--- a/crates/types/src/base62_util.rs
+++ b/crates/types/src/base62_util.rs
@@ -16,44 +16,91 @@ use std::mem::size_of;
 const BITS_PER_BASE62_CHAR: usize = 6;
 const BITS_PER_BYTE: usize = 8;
 
-/// Encodes a u64 into base62 string, this function pads the string with
-/// trailing zeros to ensure the string is of fixed length 11.
-pub fn base62_encode_fixed_width_u64(i: u64, mut f: impl std::fmt::Write) -> std::fmt::Result {
+const BASE: u64 = 62;
+const BASE_TO_2: u64 = BASE * BASE;
+const BASE_TO_3: u64 = BASE_TO_2 * BASE;
+const BASE_TO_4: u64 = BASE_TO_3 * BASE;
+const BASE_TO_5: u64 = BASE_TO_4 * BASE;
+const BASE_TO_6: u64 = BASE_TO_5 * BASE;
+const BASE_TO_7: u64 = BASE_TO_6 * BASE;
+const BASE_TO_8: u64 = BASE_TO_7 * BASE;
+const BASE_TO_9: u64 = BASE_TO_8 * BASE;
+const BASE_TO_10: u128 = (BASE_TO_9 * BASE) as u128;
+const BASE_TO_11: u128 = BASE_TO_10 * BASE as u128;
+const BASE_TO_12: u128 = BASE_TO_11 * BASE as u128;
+const BASE_TO_13: u128 = BASE_TO_12 * BASE as u128;
+const BASE_TO_14: u128 = BASE_TO_13 * BASE as u128;
+const BASE_TO_15: u128 = BASE_TO_14 * BASE as u128;
+const BASE_TO_16: u128 = BASE_TO_15 * BASE as u128;
+const BASE_TO_17: u128 = BASE_TO_16 * BASE as u128;
+const BASE_TO_18: u128 = BASE_TO_17 * BASE as u128;
+const BASE_TO_19: u128 = BASE_TO_18 * BASE as u128;
+const BASE_TO_20: u128 = BASE_TO_19 * BASE as u128;
+const BASE_TO_21: u128 = BASE_TO_20 * BASE as u128;
+
+fn digit_count(n: u128) -> usize {
+    const POWERS: [u128; 22] = [
+        0,
+        BASE as u128,
+        BASE_TO_2 as u128,
+        BASE_TO_3 as u128,
+        BASE_TO_4 as u128,
+        BASE_TO_5 as u128,
+        BASE_TO_6 as u128,
+        BASE_TO_7 as u128,
+        BASE_TO_8 as u128,
+        BASE_TO_9 as u128,
+        BASE_TO_10,
+        BASE_TO_11,
+        BASE_TO_12,
+        BASE_TO_13,
+        BASE_TO_14,
+        BASE_TO_15,
+        BASE_TO_16,
+        BASE_TO_17,
+        BASE_TO_18,
+        BASE_TO_19,
+        BASE_TO_20,
+        BASE_TO_21,
+    ];
+
+    match POWERS.binary_search(&n) {
+        Ok(n) => n.wrapping_add(1),
+        Err(n) => n,
+    }
+}
+
+/// Encodes a u64 into base62 string, this function offsets the string with
+/// enough bytes (assuming the input buffer is zeroed with b'0') to ensure the string is of fixed length 11.
+pub fn base62_encode_fixed_width_u64(i: u64, out: &mut [u8]) -> usize {
     const MAX_LENGTH: usize = base62_max_length_for_type::<u64>();
 
     let i = i.to_be();
 
-    let mut buf = [b'0'; MAX_LENGTH];
-    let digits =
-        base62::encode_alternative_bytes(i, &mut buf).expect("a u64 must fit into 11 digits");
+    let digits = digit_count(i.into());
+    let offset = MAX_LENGTH - digits;
 
-    if digits < MAX_LENGTH {
-        // SAFETY; the array was initialised with valid utf8 and encode_alternative_bytes only writes utf8
-        f.write_str(unsafe { std::str::from_utf8_unchecked(&buf[digits..]) })?;
-    }
+    let digits2 = base62::encode_alternative_bytes(i, &mut out[offset..offset + digits])
+        .expect("a u64 must fit into 11 digits");
+    debug_assert_eq!(digits, digits2);
 
-    // SAFETY; the array was initialised with valid utf8 and encode_alternative_bytes only writes utf8
-    f.write_str(unsafe { std::str::from_utf8_unchecked(&buf[0..digits]) })
+    MAX_LENGTH
 }
 
-/// Encodes a u128 into base62 string, this function pads the string with
-/// trailing zeros to ensure the string is of fixed length 22.
-pub fn base62_encode_fixed_width_u128(i: u128, mut f: impl std::fmt::Write) -> std::fmt::Result {
+/// Encodes a u128 into base62 string, this function offsets the string with
+/// enough bytes (assuming the input buffer is zeroed) to ensure the string is of fixed length 22.
+pub fn base62_encode_fixed_width_u128(i: u128, out: &mut [u8]) -> usize {
     const MAX_LENGTH: usize = base62_max_length_for_type::<u128>();
 
     let i = i.to_be();
+    let digits = digit_count(i);
+    let offset = MAX_LENGTH - digits;
 
-    let mut buf = [b'0'; MAX_LENGTH];
-    let digits =
-        base62::encode_alternative_bytes(i, &mut buf).expect("a u128 must fit into 22 digits");
+    let digits2 = base62::encode_alternative_bytes(i, &mut out[offset..offset + digits])
+        .expect("a u128 must fit into 22 digits");
+    debug_assert_eq!(digits, digits2);
 
-    if digits < MAX_LENGTH {
-        // SAFETY; the array was initialised with valid utf8 and encode_alternative_bytes only writes utf8
-        f.write_str(unsafe { std::str::from_utf8_unchecked(&buf[digits..]) })?;
-    }
-
-    // SAFETY; the array was initialised with valid utf8 and encode_alternative_bytes only writes utf8
-    f.write_str(unsafe { std::str::from_utf8_unchecked(&buf[0..digits]) })
+    MAX_LENGTH
 }
 
 /// Calculate the max number of chars needed to encode this type as base62

--- a/crates/types/src/deployment.rs
+++ b/crates/types/src/deployment.rs
@@ -34,7 +34,6 @@ impl PinnedDeployment {
 mod tests {
     use super::*;
 
-    use crate::IdEncoder;
     use crate::identifiers::{ResourceId, TimestampAwareId};
 
     #[test]
@@ -43,11 +42,7 @@ mod tests {
         assert!(a.timestamp().as_u64() > 0);
         let a_str = a.to_string();
         assert!(a_str.starts_with("dp_"));
-        assert_eq!(DeploymentId::STRING_CAPACITY_HINT + 4, a_str.len());
-        assert_eq!(
-            a_str.len(),
-            IdEncoder::<DeploymentId>::estimate_buf_capacity()
-        );
+        assert_eq!(a_str.len(), DeploymentId::str_encoded_len(),);
         assert_eq!(26, a_str.len());
     }
 

--- a/crates/types/src/id_util.rs
+++ b/crates/types/src/id_util.rs
@@ -12,6 +12,8 @@
 
 use std::str::FromStr;
 
+use generic_array::GenericArray;
+use generic_array::sequence::GenericSequence;
 use num_traits::PrimInt;
 
 use crate::base62_util::{
@@ -24,9 +26,8 @@ use crate::macros::prefixed_ids;
 pub const ID_RESOURCE_SEPARATOR: char = '_';
 
 ///  versions of the ID encoding scheme that we use to generate user-facing ID tokens.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum IdSchemeVersion {
-    #[default]
     /// V1 is the first version of the ID encoding scheme.
     ///
     /// V1 IDs are encoded as follows:
@@ -35,6 +36,12 @@ pub enum IdSchemeVersion {
     /// - 1c for the codec version, currently `1`
     /// - A type-specific base62 encoded string for the ID type.
     V1,
+}
+
+impl IdSchemeVersion {
+    pub const fn latest() -> Self {
+        Self::V1
+    }
 }
 
 prefixed_ids! {
@@ -133,6 +140,7 @@ impl<'a> IdStrCursor<'a> {
 }
 
 pub struct IdDecoder<'a> {
+    #[allow(unused)]
     pub version: IdSchemeVersion,
     pub resource_type: IdResourceType,
     pub cursor: IdStrCursor<'a>,
@@ -176,53 +184,67 @@ impl<'a> IdDecoder<'a> {
     }
 }
 
-pub struct IdEncoder<T: ?Sized, W = String> {
-    buf: W,
+pub struct IdEncoder<T: ResourceId + ?Sized> {
+    buf: GenericArray<u8, <T as ResourceId>::StrEncodedLen>,
+    pos: usize,
     _marker: std::marker::PhantomData<T>,
 }
 
-impl<T: ResourceId + ?Sized, W> IdEncoder<T, W> {
-    /// Estimates the capacity of string buffer needed to encode this ResourceId
-    pub const fn estimate_buf_capacity() -> usize {
-        T::RESOURCE_TYPE.as_str().len() + /* separator =*/1 + /* version =*/ 1 + T::STRING_CAPACITY_HINT
-    }
-}
+impl<T: ResourceId + ?Sized> IdEncoder<T> {
+    pub(crate) fn new() -> IdEncoder<T> {
+        use std::io::{IoSlice, Write};
 
-impl<T: ResourceId + ?Sized, W: std::fmt::Write> IdEncoder<T, W> {
-    pub fn new_fmt(mut buf: W) -> Result<IdEncoder<T, W>, std::fmt::Error> {
-        // prefix token
-        buf.write_str(T::RESOURCE_TYPE.as_str())?;
-        // Separator
-        buf.write_char(ID_RESOURCE_SEPARATOR)?;
+        static SEP_AND_VER: [u8; 2] = [
+            ID_RESOURCE_SEPARATOR as u8,
+            IdSchemeVersion::latest().as_char() as u8,
+        ];
 
-        // ID Scheme Version
-        buf.write_char(IdSchemeVersion::default().as_char())?;
+        let buf = generic_array::GenericArray::generate(|_| b'0');
 
-        Ok(Self {
+        let mut encoder = Self {
             buf,
+            pos: 0,
             _marker: std::marker::PhantomData,
-        })
-    }
+        };
 
+        let pos = (&mut encoder.buf[..])
+            .write_vectored(&[
+                // prefix token
+                IoSlice::new(T::RESOURCE_TYPE.as_str().as_bytes()),
+                // Separator + ID Scheme Version
+                IoSlice::new(&SEP_AND_VER),
+            ])
+            .expect("buf must fit");
+
+        encoder.pos = pos;
+        encoder
+    }
     /// Appends a u64 value as a padded base62 encoded string to the underlying buffer
-    pub fn encode_fixed_width_u64(&mut self, i: u64) -> std::fmt::Result {
-        base62_encode_fixed_width_u64(i, &mut self.buf)
+    pub(crate) fn push_u64(&mut self, i: u64) {
+        let width = base62_encode_fixed_width_u64(i, &mut self.buf[self.pos..]);
+        self.pos += width;
+        debug_assert!(self.pos <= self.buf.len());
     }
 
     /// Appends a u128 value as a padded base62 encoded string to the underlying buffer
-    pub fn encode_fixed_width_u128(&mut self, i: u128) -> std::fmt::Result {
-        base62_encode_fixed_width_u128(i, &mut self.buf)
+    pub(crate) fn push_u128(&mut self, i: u128) {
+        let width = base62_encode_fixed_width_u128(i, &mut self.buf[self.pos..]);
+        self.pos += width;
+        debug_assert!(self.pos <= self.buf.len());
     }
 
-    /// Adds the given string to the end of the buffer
-    pub fn push_str<S>(&mut self, i: S) -> std::fmt::Result
-    where
-        S: AsRef<str>,
-    {
-        self.buf.write_str(i.as_ref())
+    pub(crate) fn remaining_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.pos..]
     }
 
-    pub fn finalize(self) -> W {
-        self.buf
+    pub(crate) fn advance(&mut self, cnt: usize) {
+        self.pos += cnt;
+    }
+
+    pub fn as_str(&self) -> &str {
+        debug_assert!(self.pos <= self.buf.len());
+        // SAFETY; the array was initialised with valid utf8 and we only write valid utf8 to the
+        // buffer.
+        unsafe { std::str::from_utf8_unchecked(&self.buf[..self.pos]) }
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -55,7 +55,7 @@ pub mod storage;
 pub mod time;
 pub mod timer;
 
-pub use id_util::{IdDecoder, IdEncoder, IdResourceType, IdStrCursor};
+pub use id_util::IdResourceType;
 pub use node_id::*;
 pub use restate_version::*;
 pub use version::*;

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -131,6 +131,7 @@ tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot"] }
+typenum = { version = "1", default-features = false, features = ["const-generics"] }
 ulid = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["js", "serde", "v4", "v7"] }
@@ -260,6 +261,7 @@ tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot"] }
+typenum = { version = "1", default-features = false, features = ["const-generics"] }
 ulid = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["js", "serde", "v4", "v7"] }


### PR DESCRIPTION

Allocation free to_string and Display impls for all resource identifiers. While the previous version was great for pre-allocated buffers to Fmt into, it could perform better in `to_string()` scenario by being fully allocation free.

```console
~/w/r/restate ❯❯❯ cargo bench -p restate-types  --bench id_encoding
    Finished `bench` profile [optimized + debuginfo] target(s) in 55.61s
     Running benches/id_encoding.rs (target/release/deps/id_encoding-e2f9e9fd3134760e)
invocation-id-display   time:   [38.700 ns 38.745 ns 38.798 ns]
                        change: [-11.835% -11.510% -11.170%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low severe
  1 (1.00%) low mild
  7 (7.00%) high mild
  2 (2.00%) high severe

invocation-id-to_string time:   [44.330 ns 44.712 ns 45.320 ns]
                        change: [-55.251% -54.827% -54.181%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

awakeable-id-to_string  time:   [25.942 ns 26.095 ns 26.263 ns]
                        change: [-74.492% -74.147% -73.829%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

```
