### PR TITLE
Simplified invocation status zero-copy accessor approach

### DIFF
--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -11,7 +11,7 @@
 use std::ops::{ControlFlow, RangeInclusive};
 
 use futures::Stream;
-use restate_storage_api::protobuf_types::v1::InvocationStatusV2;
+use restate_storage_api::protobuf_types::v1::InvocationStatusV2Lazy;
 use tokio_stream::StreamExt;
 
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
@@ -172,15 +172,15 @@ impl ReadOnlyInvocationStatusTable for PartitionStore {
 }
 
 pub type ScanInvocationStatusAccessor<'a> = InvocationStatusAccessor<
-    &'a InvocationStatusV2,
-    &'a InvocationStatusV2,
-    &'a InvocationStatusV2,
+    &'a InvocationStatusV2Lazy,
+    &'a InvocationStatusV2Lazy,
+    &'a InvocationStatusV2Lazy,
 >;
 
 impl ScanInvocationStatusTable for PartitionStore {
-    type PreFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2;
-    type InFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2;
-    type CompletedInvocationMetadataAccessor<'a> = &'a InvocationStatusV2;
+    type PreFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
+    type InFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
+    type CompletedInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
 
     fn scan_invoked_invocations(
         &self,
@@ -257,7 +257,7 @@ impl ScanInvocationStatusTable for PartitionStore {
                         let inv_status_v2 = break_on_err(
                             restate_types::storage::StorageCodec::decode::<
                                 restate_storage_api::protobuf_types::ProtobufStorageWrapper<
-                                    restate_storage_api::protobuf_types::v1::InvocationStatusV2,
+                                    restate_storage_api::protobuf_types::v1::InvocationStatusV2Lazy,
                                 >,
                                 _,
                             >(&mut value)

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -197,17 +197,18 @@ message InvocationV2Lite {
 }
 
 // A somewhat slimmer version of InvocationStatusV2 with nested messages left
-// unparsed and utf8 left unvalidated.
+// unparsed, utf8 left unvalidated, and all bytes processed with our zerocopy
+// approach.
 message InvocationStatusV2Lazy {
   InvocationStatusV2.Status status = 1;
 
   // Common
-  optional bytes invocation_target_lazy = 2;
-  optional bytes source_lazy = 3;
-  optional bytes span_context_lazy = 4;
-  optional bytes completion_retention_duration_lazy = 11;
-  optional bytes journal_retention_duration_lazy = 29;
-  bytes created_using_restate_version = 30;
+  // optional bytes invocation_target_lazy = 2;
+  // optional bytes source_lazy = 3;
+  // optional bytes span_context_lazy = 4;
+  // optional bytes completion_retention_duration_lazy = 11;
+  // optional bytes journal_retention_duration_lazy = 29;
+  // bytes created_using_restate_version = 30;
 
   // Timestamps
   uint64 creation_time = 5;
@@ -219,17 +220,17 @@ message InvocationStatusV2Lazy {
 
   // Scheduled/Inboxed
   optional uint64 execution_time = 10;
-  optional bytes idempotency_key = 12;
+  // optional bytes idempotency_key = 12;
 
   // Invoked/Suspended
   uint32 journal_length = 14;
   uint32 commands = 26;
-  optional bytes deployment_id = 15;
+  // optional bytes deployment_id = 15;
   optional dev.restate.service.protocol.ServiceProtocolVersion
       service_protocol_version = 16;
 
   // Completed
-  optional bytes result_lazy = 18;
+  // optional bytes result_lazy = 18;
 }
 
 // TODO remove this after 1.1

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -62,8 +62,8 @@ message SequenceNumber { uint64 sequence_number = 1; }
 message RestateVersion { string version = 1; }
 
 message PartitionDurability {
-  // The partition has applied this LSN durably to the replica-set and/or has been
-  // persisted in a snapshot in the snapshot repository.
+  // The partition has applied this LSN durably to the replica-set and/or has
+  // been persisted in a snapshot in the snapshot repository.
   SequenceNumber durable_point = 1;
   // Timestamp which the durability point was updated
   uint64 modification_time = 2;
@@ -110,9 +110,7 @@ message Source {
 
   message Subscription { bytes subscription_id = 1; }
 
-  message RestartAsNew {
-    InvocationId invocation_id = 1;
-  }
+  message RestartAsNew { InvocationId invocation_id = 1; }
 
   oneof source {
     Ingress ingress = 9;
@@ -196,6 +194,42 @@ message InvocationV2Lite {
   InvocationStatusV2.Status status = 1;
   InvocationTarget invocation_target = 2;
   uint32 current_invocation_epoch = 27;
+}
+
+// A somewhat slimmer version of InvocationStatusV2 with nested messages left
+// unparsed and utf8 left unvalidated.
+message InvocationStatusV2Lazy {
+  InvocationStatusV2.Status status = 1;
+
+  // Common
+  optional bytes invocation_target_lazy = 2;
+  optional bytes source_lazy = 3;
+  optional bytes span_context_lazy = 4;
+  optional bytes completion_retention_duration_lazy = 11;
+  optional bytes journal_retention_duration_lazy = 29;
+  bytes created_using_restate_version = 30;
+
+  // Timestamps
+  uint64 creation_time = 5;
+  uint64 modification_time = 6;
+  optional uint64 inboxed_transition_time = 19;
+  optional uint64 scheduled_transition_time = 20;
+  optional uint64 running_transition_time = 21;
+  optional uint64 completed_transition_time = 22;
+
+  // Scheduled/Inboxed
+  optional uint64 execution_time = 10;
+  optional bytes idempotency_key = 12;
+
+  // Invoked/Suspended
+  uint32 journal_length = 14;
+  uint32 commands = 26;
+  optional bytes deployment_id = 15;
+  optional dev.restate.service.protocol.ServiceProtocolVersion
+      service_protocol_version = 16;
+
+  // Completed
+  optional bytes result_lazy = 18;
 }
 
 // TODO remove this after 1.1
@@ -304,6 +338,8 @@ message SpanContext {
   string trace_state = 5;
   optional SpanRelation span_relation = 6;
 }
+
+message SpanContextLite { bytes trace_id = 1; }
 
 message SpanRelation {
   message Parent { uint64 span_id = 1; }

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -993,12 +993,12 @@ impl<
         }
     }
 
-    pub fn idempotency_key(&self) -> Option<&str> {
+    pub fn idempotency_key(&self) -> std::result::Result<Option<&str>, ConversionError> {
         match self {
             Self::Scheduled(metadata) | Self::Inboxed(metadata) => metadata.idempotency_key(),
             Self::Invoked(metadata) | Self::Suspended(metadata) => metadata.idempotency_key(),
             Self::Completed(completed) => completed.idempotency_key(),
-            _ => None,
+            _ => Ok(None),
         }
     }
 }
@@ -1095,7 +1095,7 @@ impl<T: CompletedInvocationMetadataAccessor + ?Sized> CompletedInvocationMetadat
 
 pub trait InvocationMetadataAccessor: Send + Sync {
     fn invocation_target(&self) -> std::result::Result<InvocationTargetRef, ConversionError>;
-    fn idempotency_key(&self) -> Option<&str>;
+    fn idempotency_key(&self) -> std::result::Result<Option<&str>, ConversionError>;
 
     fn creation_time(&self) -> MillisSinceEpoch;
     fn modification_time(&self) -> MillisSinceEpoch;
@@ -1104,7 +1104,7 @@ pub trait InvocationMetadataAccessor: Send + Sync {
     fn running_transition_time(&self) -> Option<MillisSinceEpoch>;
     fn completed_transition_time(&self) -> Option<MillisSinceEpoch>;
 
-    fn created_using_restate_version(&self) -> &str;
+    fn created_using_restate_version(&self) -> std::result::Result<&str, ConversionError>;
     fn source(&self) -> std::result::Result<SourceRef, ConversionError>;
     fn execution_time(&self) -> Option<MillisSinceEpoch>;
     fn completion_retention_duration(&self) -> std::result::Result<Duration, ConversionError>;
@@ -1137,7 +1137,10 @@ impl<T: InvocationMetadataAccessor + ?Sized> InvocationMetadataAccessor for &T {
     ) -> std::result::Result<InvocationTargetRef, restate_types::errors::ConversionError> {
         (*self).invocation_target()
     }
-    fn idempotency_key(&self) -> Option<&str> {
+    fn idempotency_key(
+        &self,
+    ) -> std::result::Result<std::option::Option<&str>, restate_types::errors::ConversionError>
+    {
         (*self).idempotency_key()
     }
     fn creation_time(&self) -> MillisSinceEpoch {
@@ -1158,7 +1161,9 @@ impl<T: InvocationMetadataAccessor + ?Sized> InvocationMetadataAccessor for &T {
     fn completed_transition_time(&self) -> Option<MillisSinceEpoch> {
         (*self).completed_transition_time()
     }
-    fn created_using_restate_version(&self) -> &str {
+    fn created_using_restate_version(
+        &self,
+    ) -> std::result::Result<&str, restate_types::errors::ConversionError> {
         (*self).created_using_restate_version()
     }
     fn source(&self) -> std::result::Result<SourceRef, restate_types::errors::ConversionError> {

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
-use std::fmt::Display;
 use std::future::Future;
 use std::ops::{ControlFlow, RangeInclusive};
 use std::time::Duration;
@@ -17,23 +16,21 @@ use std::time::Duration;
 use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
-use opentelemetry::trace::TraceId;
 use rangemap::RangeInclusiveMap;
 
 use restate_types::RestateVersion;
 use restate_types::deployment::PinnedDeployment;
-use restate_types::errors::ConversionError;
-use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey, SubscriptionId};
+use restate_types::identifiers::{InvocationId, PartitionKey};
 use restate_types::invocation::{
     Header, InvocationEpoch, InvocationInput, InvocationTarget, ResponseResult, ServiceInvocation,
     ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
 };
 use restate_types::journal_v2::{CompletionId, EntryIndex, NotificationId};
-use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::time::MillisSinceEpoch;
 
 use crate::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
+use crate::protobuf_types::v1::lazy::InvocationStatusV2Lazy;
 
 /// Holds timestamps of the [`InvocationStatus`].
 #[derive(Debug, Clone, PartialEq)]
@@ -350,25 +347,6 @@ impl InvocationStatus {
             InvocationStatus::Suspended { .. } => Some(InvocationStatusDiscriminants::Suspended),
             InvocationStatus::Completed(_) => Some(InvocationStatusDiscriminants::Completed),
             InvocationStatus::Free => None,
-        }
-    }
-
-    pub fn accessor(
-        &self,
-    ) -> InvocationStatusAccessor<
-        &PreFlightInvocationMetadata,
-        &InFlightInvocationMetadata,
-        &CompletedInvocation,
-    > {
-        match self {
-            InvocationStatus::Scheduled(s) => InvocationStatusAccessor::Scheduled(&s.metadata),
-            InvocationStatus::Inboxed(i) => InvocationStatusAccessor::Inboxed(&i.metadata),
-            InvocationStatus::Invoked(metadata) => InvocationStatusAccessor::Invoked(metadata),
-            InvocationStatus::Suspended { metadata, .. } => {
-                InvocationStatusAccessor::Suspended(metadata)
-            }
-            InvocationStatus::Completed(c) => InvocationStatusAccessor::Completed(c),
-            InvocationStatus::Free => InvocationStatusAccessor::Free,
         }
     }
 }
@@ -761,26 +739,15 @@ pub trait ReadOnlyInvocationStatusTable {
 }
 
 pub trait ScanInvocationStatusTable {
-    type PreFlightInvocationMetadataAccessor<'a>: PreFlightInvocationMetadataAccessor;
-    type InFlightInvocationMetadataAccessor<'a>: InFlightInvocationMetadataAccessor;
-    type CompletedInvocationMetadataAccessor<'a>: CompletedInvocationMetadataAccessor;
-
     fn scan_invocation_statuses(
         &self,
         range: RangeInclusive<PartitionKey>,
     ) -> Result<impl Stream<Item = Result<(InvocationId, InvocationStatus)>> + Send>;
 
-    fn for_each_invocation_status<
+    fn for_each_invocation_status_lazy<
         E: Into<anyhow::Error>,
         F: for<'a> FnMut(
-                (
-                    InvocationId,
-                    InvocationStatusAccessor<
-                        Self::PreFlightInvocationMetadataAccessor<'a>,
-                        Self::InFlightInvocationMetadataAccessor<'a>,
-                        Self::CompletedInvocationMetadataAccessor<'a>,
-                    >,
-                ),
+                (InvocationId, InvocationStatusV2Lazy<'a>),
             ) -> ControlFlow<std::result::Result<(), E>>
             + Send
             + Sync
@@ -940,318 +907,6 @@ pub struct InvocationStatusV1(pub InvocationStatus);
 
 impl PartitionStoreProtobufValue for InvocationStatusV1 {
     type ProtobufType = crate::protobuf_types::v1::InvocationStatus;
-}
-
-pub enum InvocationStatusAccessor<
-    PreFlightInvocationMetadataAccessor,
-    InFlightInvocationMetadataAccessor,
-    CompletedInvocationMetadataAccessor,
-> {
-    Scheduled(PreFlightInvocationMetadataAccessor),
-    Inboxed(PreFlightInvocationMetadataAccessor),
-    Invoked(InFlightInvocationMetadataAccessor),
-    Suspended(InFlightInvocationMetadataAccessor),
-    Completed(CompletedInvocationMetadataAccessor),
-    Free,
-}
-
-impl<
-    P: PreFlightInvocationMetadataAccessor,
-    I: InFlightInvocationMetadataAccessor,
-    C: CompletedInvocationMetadataAccessor,
-> InvocationStatusAccessor<P, I, C>
-{
-    pub fn invocation_target(
-        &self,
-    ) -> std::result::Result<Option<InvocationTargetRef>, restate_types::errors::ConversionError>
-    {
-        match self {
-            Self::Scheduled(metadata) | Self::Inboxed(metadata) => {
-                Ok(Some(metadata.invocation_target()?))
-            }
-            Self::Invoked(metadata) | Self::Suspended(metadata) => {
-                Ok(Some(metadata.invocation_target()?))
-            }
-            Self::Completed(completed) => Ok(Some(completed.invocation_target()?)),
-            _ => Ok(None),
-        }
-    }
-
-    pub fn source(&self) -> std::result::Result<Option<SourceRef>, ConversionError> {
-        Ok(match self {
-            Self::Scheduled(metadata) | Self::Inboxed(metadata) => Some(metadata.source()?),
-            Self::Invoked(metadata) | Self::Suspended(metadata) => Some(metadata.source()?),
-            Self::Completed(completed) => Some(completed.source()?),
-            _ => None,
-        })
-    }
-
-    pub fn execution_time(&self) -> Option<MillisSinceEpoch> {
-        match self {
-            Self::Scheduled(metadata) | Self::Inboxed(metadata) => metadata.execution_time(),
-            _ => None,
-        }
-    }
-
-    pub fn idempotency_key(&self) -> std::result::Result<Option<&str>, ConversionError> {
-        match self {
-            Self::Scheduled(metadata) | Self::Inboxed(metadata) => metadata.idempotency_key(),
-            Self::Invoked(metadata) | Self::Suspended(metadata) => metadata.idempotency_key(),
-            Self::Completed(completed) => completed.idempotency_key(),
-            _ => Ok(None),
-        }
-    }
-}
-
-pub trait PreFlightInvocationMetadataAccessor: InvocationMetadataAccessor {}
-
-impl<T: PreFlightInvocationMetadataAccessor + InvocationMetadataAccessor + ?Sized>
-    PreFlightInvocationMetadataAccessor for &T
-{
-}
-
-pub trait JournalMetadataAccessor {
-    fn trace_id(&self) -> std::result::Result<TraceId, ConversionError>;
-    fn length(&self) -> u32;
-    fn commands(&self) -> u32;
-}
-
-impl<T: JournalMetadataAccessor + ?Sized> JournalMetadataAccessor for &T {
-    fn trace_id(&self) -> std::result::Result<TraceId, ConversionError> {
-        (*self).trace_id()
-    }
-    fn length(&self) -> u32 {
-        (*self).length()
-    }
-    fn commands(&self) -> u32 {
-        (*self).commands()
-    }
-}
-
-pub trait InFlightInvocationMetadataAccessor:
-    InvocationMetadataAccessor + JournalMetadataAccessor
-{
-    fn deployment_id(&self) -> std::result::Result<Option<DeploymentId>, ConversionError>;
-    fn service_protocol_version(
-        &self,
-    ) -> std::result::Result<Option<ServiceProtocolVersion>, ConversionError>;
-}
-
-impl<
-    T: InFlightInvocationMetadataAccessor
-        + InvocationMetadataAccessor
-        + JournalMetadataAccessor
-        + ?Sized,
-> InFlightInvocationMetadataAccessor for &T
-{
-    fn deployment_id(&self) -> std::result::Result<Option<DeploymentId>, ConversionError> {
-        (*self).deployment_id()
-    }
-    fn service_protocol_version(
-        &self,
-    ) -> std::result::Result<Option<ServiceProtocolVersion>, ConversionError> {
-        (*self).service_protocol_version()
-    }
-}
-
-pub trait CompletedInvocationMetadataAccessor:
-    InvocationMetadataAccessor + JournalMetadataAccessor
-{
-    fn response_result<'a>(&'a self)
-    -> std::result::Result<ResponseResultRef<'a>, ConversionError>;
-}
-
-pub enum ResponseResultRef<'a> {
-    Success,
-    Failure {
-        code: restate_types::errors::InvocationErrorCode,
-        message: BytesOrStr<'a>,
-    },
-}
-
-#[derive(derive_more::From)]
-pub enum BytesOrStr<'a> {
-    Str(&'a str),
-    Bytes(Bytes),
-}
-
-impl<'a> BytesOrStr<'a> {
-    pub fn as_str(&self, field_name: &'static str) -> std::result::Result<&str, ConversionError> {
-        match self {
-            BytesOrStr::Str(s) => Ok(s),
-            BytesOrStr::Bytes(bytes) => str::from_utf8(bytes.as_ref())
-                .map_err(|_| ConversionError::invalid_data(field_name)),
-        }
-    }
-}
-
-impl<T: CompletedInvocationMetadataAccessor + ?Sized> CompletedInvocationMetadataAccessor for &T {
-    fn response_result<'a>(
-        &'a self,
-    ) -> std::result::Result<ResponseResultRef<'a>, ConversionError> {
-        (*self).response_result()
-    }
-}
-
-pub trait InvocationMetadataAccessor: Send + Sync {
-    fn invocation_target(&self) -> std::result::Result<InvocationTargetRef, ConversionError>;
-    fn idempotency_key(&self) -> std::result::Result<Option<&str>, ConversionError>;
-
-    fn creation_time(&self) -> MillisSinceEpoch;
-    fn modification_time(&self) -> MillisSinceEpoch;
-    fn inboxed_transition_time(&self) -> Option<MillisSinceEpoch>;
-    fn scheduled_transition_time(&self) -> Option<MillisSinceEpoch>;
-    fn running_transition_time(&self) -> Option<MillisSinceEpoch>;
-    fn completed_transition_time(&self) -> Option<MillisSinceEpoch>;
-
-    fn created_using_restate_version(&self) -> std::result::Result<&str, ConversionError>;
-    fn source(&self) -> std::result::Result<SourceRef, ConversionError>;
-    fn execution_time(&self) -> Option<MillisSinceEpoch>;
-    fn completion_retention_duration(&self) -> std::result::Result<Duration, ConversionError>;
-    fn journal_retention_duration(&self) -> std::result::Result<Duration, ConversionError>;
-}
-
-pub enum SourceRef {
-    Ingress,
-    Subscription(SubscriptionId),
-    Service(InvocationId, InvocationTargetRef),
-    RestartAsNew(InvocationId),
-    Internal,
-}
-
-impl<'a> From<&'a Source> for SourceRef {
-    fn from(value: &'a Source) -> Self {
-        match value {
-            Source::Ingress(_) => Self::Ingress,
-            Source::Subscription(id) => Self::Subscription(*id),
-            Source::Service(id, target) => Self::Service(*id, target.into()),
-            Source::RestartAsNew(id) => Self::RestartAsNew(*id),
-            Source::Internal => Self::Internal,
-        }
-    }
-}
-
-impl<T: InvocationMetadataAccessor + ?Sized> InvocationMetadataAccessor for &T {
-    fn invocation_target(
-        &self,
-    ) -> std::result::Result<InvocationTargetRef, restate_types::errors::ConversionError> {
-        (*self).invocation_target()
-    }
-    fn idempotency_key(
-        &self,
-    ) -> std::result::Result<std::option::Option<&str>, restate_types::errors::ConversionError>
-    {
-        (*self).idempotency_key()
-    }
-    fn creation_time(&self) -> MillisSinceEpoch {
-        (*self).creation_time()
-    }
-    fn modification_time(&self) -> MillisSinceEpoch {
-        (*self).modification_time()
-    }
-    fn inboxed_transition_time(&self) -> Option<MillisSinceEpoch> {
-        (*self).inboxed_transition_time()
-    }
-    fn scheduled_transition_time(&self) -> Option<MillisSinceEpoch> {
-        (*self).scheduled_transition_time()
-    }
-    fn running_transition_time(&self) -> Option<MillisSinceEpoch> {
-        (*self).running_transition_time()
-    }
-    fn completed_transition_time(&self) -> Option<MillisSinceEpoch> {
-        (*self).completed_transition_time()
-    }
-    fn created_using_restate_version(
-        &self,
-    ) -> std::result::Result<&str, restate_types::errors::ConversionError> {
-        (*self).created_using_restate_version()
-    }
-    fn source(&self) -> std::result::Result<SourceRef, restate_types::errors::ConversionError> {
-        (*self).source()
-    }
-    fn execution_time(&self) -> Option<MillisSinceEpoch> {
-        (*self).execution_time()
-    }
-    fn completion_retention_duration(
-        &self,
-    ) -> std::result::Result<std::time::Duration, restate_types::errors::ConversionError> {
-        (*self).completion_retention_duration()
-    }
-    fn journal_retention_duration(
-        &self,
-    ) -> std::result::Result<std::time::Duration, restate_types::errors::ConversionError> {
-        (*self).journal_retention_duration()
-    }
-}
-
-pub struct InvocationTargetRef {
-    pub service_name: Bytes,
-    pub key: Bytes,
-    pub handler_name: Bytes,
-    pub service_ty: restate_types::invocation::ServiceType,
-}
-
-impl InvocationTargetRef {
-    pub fn service_name(
-        &self,
-    ) -> std::result::Result<&str, restate_types::errors::ConversionError> {
-        str::from_utf8(self.service_name.as_ref())
-            .map_err(|_| restate_types::errors::ConversionError::invalid_data("name"))
-    }
-    pub fn key(&self) -> std::result::Result<Option<&str>, restate_types::errors::ConversionError> {
-        if !self.service_ty().is_keyed() {
-            return Ok(None);
-        }
-
-        let key = str::from_utf8(self.key.as_ref())
-            .map_err(|_| restate_types::errors::ConversionError::invalid_data("key"))?;
-
-        Ok(Some(key))
-    }
-    pub fn handler_name(
-        &self,
-    ) -> std::result::Result<&str, restate_types::errors::ConversionError> {
-        str::from_utf8(self.handler_name.as_ref())
-            .map_err(|_| restate_types::errors::ConversionError::invalid_data("name"))
-    }
-    pub fn service_ty(&self) -> restate_types::invocation::ServiceType {
-        self.service_ty
-    }
-
-    pub fn target_fmt<'a>(
-        &'a self,
-    ) -> std::result::Result<TargetFormatter<'a>, restate_types::errors::ConversionError> {
-        let service_name = self.service_name()?;
-        let key = self.key()?;
-        let handler_name = self.handler_name()?;
-        Ok(TargetFormatter(service_name, key, handler_name))
-    }
-}
-
-pub struct TargetFormatter<'a>(&'a str, Option<&'a str>, &'a str);
-
-impl<'a> Display for TargetFormatter<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(key) = self.1 {
-            write!(f, "{}/{}/{}", self.0, key, self.2)
-        } else {
-            write!(f, "{}/{}", self.0, self.2)
-        }
-    }
-}
-
-impl From<&InvocationTarget> for InvocationTargetRef {
-    fn from(value: &InvocationTarget) -> Self {
-        Self {
-            service_name: value.service_name().as_bytes().clone(),
-            key: match value.key() {
-                Some(key) => key.as_bytes().clone(),
-                None => Bytes::new(),
-            },
-            handler_name: value.handler_name().as_bytes().clone(),
-            service_ty: value.service_ty(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -635,37 +635,28 @@ pub mod v1 {
         }
 
         impl InvocationStatusV2 {
-            pub fn accessor<'a>(
-                &'a self,
+            pub fn accessor(
+                &self,
             ) -> Result<
-                crate::invocation_status_table::InvocationStatusDynAccessor<'a>,
+                crate::invocation_status_table::InvocationStatusAccessor<&Self, &Self, &Self>,
                 ConversionError,
             > {
-                use crate::invocation_status_table::{
-                    CompletedInvocationMetadataAccessor, InFlightInvocationMetadataAccessor,
-                    InvocationStatusAccessor, PreFlightInvocationMetadataAccessor,
-                };
+                use crate::invocation_status_table::InvocationStatusAccessor;
                 match self.status() {
                     invocation_status_v2::Status::Scheduled => {
-                        Ok(InvocationStatusAccessor::Scheduled(
-                            self as &dyn PreFlightInvocationMetadataAccessor,
-                        ))
+                        Ok(InvocationStatusAccessor::Scheduled(self))
                     }
-                    invocation_status_v2::Status::Inboxed => Ok(InvocationStatusAccessor::Inboxed(
-                        self as &dyn PreFlightInvocationMetadataAccessor,
-                    )),
-                    invocation_status_v2::Status::Invoked => Ok(InvocationStatusAccessor::Invoked(
-                        self as &dyn InFlightInvocationMetadataAccessor,
-                    )),
+                    invocation_status_v2::Status::Inboxed => {
+                        Ok(InvocationStatusAccessor::Inboxed(self))
+                    }
+                    invocation_status_v2::Status::Invoked => {
+                        Ok(InvocationStatusAccessor::Invoked(self))
+                    }
                     invocation_status_v2::Status::Suspended => {
-                        Ok(InvocationStatusAccessor::Suspended(
-                            self as &dyn InFlightInvocationMetadataAccessor,
-                        ))
+                        Ok(InvocationStatusAccessor::Suspended(self))
                     }
                     invocation_status_v2::Status::Completed => {
-                        Ok(InvocationStatusAccessor::Completed(
-                            self as &dyn CompletedInvocationMetadataAccessor,
-                        ))
+                        Ok(InvocationStatusAccessor::Completed(self))
                     }
                     _ => Err(ConversionError::unexpected_enum_variant(
                         "status",

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -58,18 +58,28 @@ struct InboxScanner;
 impl ScanLocalPartition for InboxScanner {
     type Builder = SysInboxBuilder;
     type Item<'a> = SequenceNumberInboxEntry;
+    type ConversionError = std::convert::Infallible;
 
     fn for_each_row<
-        F: for<'a> FnMut(Self::Item<'a>) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+        F: for<'a> FnMut(
+                Self::Item<'a>,
+            ) -> std::ops::ControlFlow<Result<(), Self::ConversionError>>
+            + Send
+            + Sync
+            + 'static,
     >(
         partition_store: &PartitionStore,
         range: RangeInclusive<PartitionKey>,
-        f: F,
+        mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
-        partition_store.for_each_inbox(range, f)
+        partition_store.for_each_inbox(range, move |item| f(item).map_break(Result::unwrap))
     }
 
-    fn append_row<'a>(row_builder: &mut Self::Builder, value: Self::Item<'a>) {
+    fn append_row<'a>(
+        row_builder: &mut Self::Builder,
+        value: Self::Item<'a>,
+    ) -> Result<(), Self::ConversionError> {
         append_inbox_row(row_builder, value);
+        Ok(())
     }
 }

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -9,39 +9,59 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::invocation_status_table::{
-    InFlightInvocationMetadata, InvocationStatus, JournalMetadata, StatusTimestamps,
+    CompletedInvocationMetadataAccessor, InFlightInvocationMetadataAccessor,
+    InvocationMetadataAccessor, InvocationStatusAccessor, JournalMetadataAccessor,
+    PreFlightInvocationMetadataAccessor, ResponseResultRef, SourceRef,
 };
+use restate_types::errors::ConversionError;
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
-use restate_types::invocation::{
-    ResponseResult, ServiceInvocationSpanContext, ServiceType, Source, TraceId,
-};
+use restate_types::invocation::{ServiceType, TraceId};
 
 use crate::invocation_status::schema::{SysInvocationStatusBuilder, SysInvocationStatusRowBuilder};
 
 #[inline]
-pub(crate) fn append_invocation_status_row(
+pub(crate) fn append_invocation_status_row<
+    P: PreFlightInvocationMetadataAccessor,
+    I: InFlightInvocationMetadataAccessor,
+    C: CompletedInvocationMetadataAccessor,
+>(
     builder: &mut SysInvocationStatusBuilder,
     invocation_id: InvocationId,
-    invocation_status: InvocationStatus,
-) {
+    invocation_status: InvocationStatusAccessor<P, I, C>,
+) -> Result<(), ConversionError> {
     let mut row = builder.row();
 
-    row.partition_key(invocation_id.partition_key());
-    if let Some(invocation_target) = invocation_status.invocation_target() {
-        row.target_service_name(invocation_target.service_name());
-        if let Some(key) = invocation_target.key() {
-            row.target_service_key(key);
-        }
-        row.target_handler_name(invocation_target.handler_name());
-        if row.is_target_defined() {
-            row.fmt_target(invocation_target);
-        }
-        row.target_service_ty(match invocation_target.service_ty() {
-            ServiceType::Service => "service",
-            ServiceType::VirtualObject => "virtual_object",
-            ServiceType::Workflow => "workflow",
-        });
+    if row.is_partition_key_defined() {
+        row.partition_key(invocation_id.partition_key());
     }
+
+    if (row.is_target_service_name_defined()
+        || row.is_target_service_key_defined()
+        || row.is_target_handler_name_defined()
+        || row.is_target_defined()
+        || row.is_target_service_ty_defined())
+        && let Some(invocation_target) = invocation_status.invocation_target()? {
+            if row.is_target_service_name_defined() {
+                row.target_service_name(invocation_target.service_name()?);
+            }
+            if row.is_target_service_key_defined()
+                && let Some(key) = invocation_target.key()? {
+                    row.target_service_key(key);
+                }
+            if row.is_target_handler_name_defined() {
+                row.target_handler_name(invocation_target.handler_name()?);
+            }
+            if row.is_target_defined() {
+                row.fmt_target(invocation_target.target_fmt()?);
+            }
+            if row.is_target_service_ty_defined() {
+                row.target_service_ty(match invocation_target.service_ty() {
+                    ServiceType::Service => "service",
+                    ServiceType::VirtualObject => "virtual_object",
+                    ServiceType::Workflow => "workflow",
+                });
+            }
+        }
 
     // Invocation id
     if row.is_id_defined() {
@@ -54,143 +74,201 @@ pub(crate) fn append_invocation_status_row(
         row.idempotency_key(key)
     }
 
-    // Journal metadata
-    if let Some(journal_metadata) = invocation_status.get_journal_metadata() {
-        fill_journal_metadata(&mut row, journal_metadata)
-    }
-
-    // Stat
-    if let Some(timestamps) = invocation_status.get_timestamps() {
-        fill_timestamps(&mut row, timestamps);
-    }
-
     // Additional invocation metadata
     match invocation_status {
-        InvocationStatus::Scheduled(scheduled) => {
-            row.status("scheduled");
-            row.created_using_restate_version(
-                scheduled.metadata.created_using_restate_version.as_str(),
-            );
-            fill_invoked_by(&mut row, scheduled.metadata.source);
-            if let Some(execution_time) = scheduled.metadata.execution_time {
-                row.scheduled_start_at(execution_time.as_u64() as i64)
-            }
-            row.completion_retention(
-                scheduled.metadata.completion_retention_duration.as_millis() as i64
-            );
-            row.journal_retention(scheduled.metadata.journal_retention_duration.as_millis() as i64);
-        }
-        InvocationStatus::Inboxed(inboxed) => {
-            row.status("inboxed");
-            row.created_using_restate_version(
-                inboxed.metadata.created_using_restate_version.as_str(),
-            );
-            fill_invoked_by(&mut row, inboxed.metadata.source);
-            if let Some(execution_time) = inboxed.metadata.execution_time {
-                row.scheduled_start_at(execution_time.as_u64() as i64)
-            }
-            row.completion_retention(
-                inboxed.metadata.completion_retention_duration.as_millis() as i64
-            );
-            row.journal_retention(inboxed.metadata.journal_retention_duration.as_millis() as i64);
-        }
-        InvocationStatus::Invoked(metadata) => {
-            row.status("invoked");
-            fill_in_flight_invocation_metadata(&mut row, metadata);
-        }
-        InvocationStatus::Suspended { metadata, .. } => {
-            row.status("suspended");
-            fill_in_flight_invocation_metadata(&mut row, metadata);
-        }
-        InvocationStatus::Completed(completed) => {
-            row.status("completed");
-            row.created_using_restate_version(completed.created_using_restate_version.as_str());
-            fill_invoked_by(&mut row, completed.source);
-            if let Some(execution_time) = completed.execution_time {
-                row.scheduled_start_at(execution_time.as_u64() as i64)
-            }
-            row.completion_retention(completed.completion_retention_duration.as_millis() as i64);
-            row.journal_retention(completed.journal_retention_duration.as_millis() as i64);
+        InvocationStatusAccessor::Scheduled(scheduled) => {
+            fill_timestamps(&mut row, &scheduled);
 
-            match completed.response_result {
-                ResponseResult::Success(_) => {
-                    row.completion_result("success");
+            row.status("scheduled");
+            if row.is_created_using_restate_version_defined() {
+                row.created_using_restate_version(scheduled.created_using_restate_version());
+            }
+            if needs_invoked_by(&row) {
+                fill_invoked_by(&mut row, scheduled.source()?)?;
+            }
+            if row.is_scheduled_at_defined()
+                && let Some(execution_time) = scheduled.execution_time() {
+                    row.scheduled_start_at(execution_time.as_u64() as i64)
                 }
-                ResponseResult::Failure(failure) => {
-                    row.completion_result("failure");
-                    if row.is_completion_failure_defined() {
-                        row.fmt_completion_failure(failure);
+            if row.is_completion_retention_defined() {
+                row.completion_retention(
+                    scheduled.completion_retention_duration()?.as_millis() as i64
+                );
+            }
+            if row.is_journal_retention_defined() {
+                row.journal_retention(scheduled.journal_retention_duration()?.as_millis() as i64);
+            }
+        }
+        InvocationStatusAccessor::Inboxed(inboxed) => {
+            fill_timestamps(&mut row, &inboxed);
+
+            row.status("inboxed");
+            if row.is_created_using_restate_version_defined() {
+                row.created_using_restate_version(inboxed.created_using_restate_version());
+            }
+            if needs_invoked_by(&row) {
+                fill_invoked_by(&mut row, inboxed.source()?)?;
+            }
+            if row.is_scheduled_at_defined()
+                && let Some(execution_time) = inboxed.execution_time() {
+                    row.scheduled_start_at(execution_time.as_u64() as i64)
+                }
+            if row.is_completion_retention_defined() {
+                row.completion_retention(
+                    inboxed.completion_retention_duration()?.as_millis() as i64
+                );
+            }
+            if row.is_journal_retention_defined() {
+                row.journal_retention(inboxed.journal_retention_duration()?.as_millis() as i64);
+            }
+        }
+        InvocationStatusAccessor::Invoked(metadata) => {
+            fill_journal_metadata(&mut row, &metadata)?;
+            fill_timestamps(&mut row, &metadata);
+
+            row.status("invoked");
+            fill_in_flight_invocation_metadata(&mut row, metadata)?;
+        }
+        InvocationStatusAccessor::Suspended(metadata) => {
+            fill_journal_metadata(&mut row, &metadata)?;
+            fill_timestamps(&mut row, &metadata);
+
+            row.status("suspended");
+            fill_in_flight_invocation_metadata(&mut row, metadata)?;
+        }
+        InvocationStatusAccessor::Completed(completed) => {
+            fill_journal_metadata(&mut row, &completed)?;
+            fill_timestamps(&mut row, &completed);
+
+            row.status("completed");
+            if row.is_created_using_restate_version_defined() {
+                row.created_using_restate_version(completed.created_using_restate_version());
+            }
+            if needs_invoked_by(&row) {
+                fill_invoked_by(&mut row, completed.source()?)?;
+            }
+            if row.is_scheduled_at_defined()
+                && let Some(execution_time) = completed.execution_time() {
+                    row.scheduled_start_at(execution_time.as_u64() as i64)
+                }
+            if row.is_completion_retention_defined() {
+                row.completion_retention(
+                    completed.completion_retention_duration()?.as_millis() as i64
+                );
+            }
+            if row.is_journal_retention_defined() {
+                row.journal_retention(completed.journal_retention_duration()?.as_millis() as i64);
+            }
+
+            if row.is_completion_result_defined() || row.is_completion_failure_defined() {
+                match completed.response_result()? {
+                    ResponseResultRef::Success => {
+                        row.completion_result("success");
+                    }
+                    ResponseResultRef::Failure { code, message } => {
+                        row.completion_result("failure");
+                        if row.is_completion_failure_defined() {
+                            row.fmt_completion_failure(format_args!(
+                                "[{}] {}",
+                                code,
+                                message.as_str("result")?
+                            ));
+                        }
                     }
                 }
             }
         }
-        InvocationStatus::Free => {
+        InvocationStatusAccessor::Free => {
             row.status("free");
         }
     };
+
+    Ok(())
 }
 
 fn fill_in_flight_invocation_metadata(
     row: &mut SysInvocationStatusRowBuilder,
-    meta: InFlightInvocationMetadata,
-) {
-    row.created_using_restate_version(meta.created_using_restate_version.as_str());
+    meta: impl InFlightInvocationMetadataAccessor,
+) -> Result<(), ConversionError> {
+    if row.is_created_using_restate_version_defined() {
+        row.created_using_restate_version(meta.created_using_restate_version());
+    }
     // journal_metadata and stats are filled by other functions
-    if let Some(pinned_deployment) = meta.pinned_deployment {
-        if row.is_pinned_deployment_id_defined() {
-            row.fmt_pinned_deployment_id(pinned_deployment.deployment_id);
+    if row.is_pinned_deployment_id_defined()
+        && let Some(deployment_id) = meta.deployment_id()? {
+            row.fmt_pinned_deployment_id(deployment_id);
         }
-        row.pinned_service_protocol_version(
-            pinned_deployment
-                .service_protocol_version
-                .as_repr()
-                .unsigned_abs(),
-        );
+    if row.is_pinned_service_protocol_version_defined()
+        && let Some(service_protocol_version) = meta.service_protocol_version()? {
+            row.pinned_service_protocol_version(service_protocol_version.as_repr().unsigned_abs());
+        }
+    if needs_invoked_by(row) {
+        fill_invoked_by(row, meta.source()?)?;
     }
-    fill_invoked_by(row, meta.source);
-    if let Some(execution_time) = meta.execution_time {
-        row.scheduled_start_at(execution_time.as_u64() as i64)
+    if row.is_scheduled_at_defined()
+        && let Some(execution_time) = meta.execution_time() {
+            row.scheduled_start_at(execution_time.as_u64() as i64)
+        }
+    if row.is_completion_retention_defined() {
+        row.completion_retention(meta.completion_retention_duration()?.as_millis() as i64);
     }
-    row.completion_retention(meta.completion_retention_duration.as_millis() as i64);
-    row.journal_retention(meta.journal_retention_duration.as_millis() as i64);
+    if row.is_journal_retention_defined() {
+        row.journal_retention(meta.journal_retention_duration()?.as_millis() as i64);
+    }
+
+    Ok(())
+}
+
+fn needs_invoked_by(row: &SysInvocationStatusRowBuilder) -> bool {
+    row.is_invoked_by_defined()
+        || row.is_invoked_by_service_name_defined()
+        || row.is_invoked_by_id_defined()
+        || row.is_invoked_by_target_defined()
+        || row.is_invoked_by_subscription_id_defined()
+        || row.is_restarted_from_defined()
 }
 
 #[inline]
-fn fill_invoked_by(row: &mut SysInvocationStatusRowBuilder, source: Source) {
+fn fill_invoked_by(
+    row: &mut SysInvocationStatusRowBuilder,
+    source: SourceRef,
+) -> Result<(), ConversionError> {
     match source {
-        Source::Service(invocation_id, invocation_target) => {
+        SourceRef::Service(invocation_id, invocation_target) => {
             row.invoked_by("service");
-            row.invoked_by_service_name(invocation_target.service_name());
+            row.invoked_by_service_name(invocation_target.service_name()?);
             if row.is_invoked_by_id_defined() {
                 row.fmt_invoked_by_id(invocation_id);
             }
             if row.is_invoked_by_target_defined() {
-                row.fmt_invoked_by_target(invocation_target);
+                row.fmt_invoked_by_target(invocation_target.target_fmt()?);
             }
         }
-        Source::Ingress(_) => {
+        SourceRef::Ingress => {
             row.invoked_by("ingress");
         }
-        Source::Internal => {
+        SourceRef::Internal => {
             row.invoked_by("restate");
         }
-        Source::Subscription(sub_id) => {
+        SourceRef::Subscription(sub_id) => {
             row.invoked_by("subscription");
             if row.is_invoked_by_subscription_id_defined() {
                 row.fmt_invoked_by_subscription_id(sub_id)
             }
         }
-        Source::RestartAsNew(invocation_id) => {
+        SourceRef::RestartAsNew(invocation_id) => {
             row.invoked_by("restart_as_new");
             if row.is_restarted_from_defined() {
                 row.fmt_restarted_from(invocation_id)
             }
         }
     }
+
+    Ok(())
 }
 
 #[inline]
-fn fill_timestamps(row: &mut SysInvocationStatusRowBuilder, stat: &StatusTimestamps) {
+fn fill_timestamps(row: &mut SysInvocationStatusRowBuilder, stat: impl InvocationMetadataAccessor) {
     row.created_at(stat.creation_time().as_u64() as i64);
     row.modified_at(stat.modification_time().as_u64() as i64);
     if let Some(inboxed_at) = stat.inboxed_transition_time() {
@@ -210,22 +288,20 @@ fn fill_timestamps(row: &mut SysInvocationStatusRowBuilder, stat: &StatusTimesta
 #[inline]
 fn fill_journal_metadata(
     row: &mut SysInvocationStatusRowBuilder,
-    journal_metadata: &JournalMetadata,
-) {
-    fill_span_context(row, &journal_metadata.span_context);
-    row.journal_size(journal_metadata.length);
-    row.journal_commands_size(journal_metadata.commands);
-}
-
-#[inline]
-fn fill_span_context(
-    row: &mut SysInvocationStatusRowBuilder,
-    span_context: &ServiceInvocationSpanContext,
-) {
+    journal_metadata: &impl JournalMetadataAccessor,
+) -> Result<(), ConversionError> {
     if row.is_trace_id_defined() {
-        let tid = span_context.trace_id();
+        let tid = journal_metadata.trace_id()?;
         if tid != TraceId::INVALID {
             row.fmt_trace_id(tid);
         }
     }
+    if row.is_journal_size_defined() {
+        row.journal_size(journal_metadata.length());
+    }
+    if row.is_journal_commands_size_defined() {
+        row.journal_commands_size(journal_metadata.commands());
+    }
+
+    Ok(())
 }

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -71,7 +71,7 @@ pub(crate) fn append_invocation_status_row<
     }
 
     if row.is_idempotency_key_defined()
-        && let Some(key) = invocation_status.idempotency_key()
+        && let Some(key) = invocation_status.idempotency_key()?
     {
         row.idempotency_key(key)
     }
@@ -83,7 +83,7 @@ pub(crate) fn append_invocation_status_row<
 
             row.status("scheduled");
             if row.is_created_using_restate_version_defined() {
-                row.created_using_restate_version(scheduled.created_using_restate_version());
+                row.created_using_restate_version(scheduled.created_using_restate_version()?);
             }
             if needs_invoked_by(&row) {
                 fill_invoked_by(&mut row, scheduled.source()?)?;
@@ -107,7 +107,7 @@ pub(crate) fn append_invocation_status_row<
 
             row.status("inboxed");
             if row.is_created_using_restate_version_defined() {
-                row.created_using_restate_version(inboxed.created_using_restate_version());
+                row.created_using_restate_version(inboxed.created_using_restate_version()?);
             }
             if needs_invoked_by(&row) {
                 fill_invoked_by(&mut row, inboxed.source()?)?;
@@ -146,7 +146,7 @@ pub(crate) fn append_invocation_status_row<
 
             row.status("completed");
             if row.is_created_using_restate_version_defined() {
-                row.created_using_restate_version(completed.created_using_restate_version());
+                row.created_using_restate_version(completed.created_using_restate_version()?);
             }
             if needs_invoked_by(&row) {
                 fill_invoked_by(&mut row, completed.source()?)?;
@@ -196,7 +196,7 @@ fn fill_in_flight_invocation_metadata(
     meta: impl InFlightInvocationMetadataAccessor,
 ) -> Result<(), ConversionError> {
     if row.is_created_using_restate_version_defined() {
-        row.created_using_restate_version(meta.created_using_restate_version());
+        row.created_using_restate_version(meta.created_using_restate_version()?);
     }
     // journal_metadata and stats are filled by other functions
     if row.is_pinned_deployment_id_defined()

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -40,28 +40,30 @@ pub(crate) fn append_invocation_status_row<
         || row.is_target_handler_name_defined()
         || row.is_target_defined()
         || row.is_target_service_ty_defined())
-        && let Some(invocation_target) = invocation_status.invocation_target()? {
-            if row.is_target_service_name_defined() {
-                row.target_service_name(invocation_target.service_name()?);
-            }
-            if row.is_target_service_key_defined()
-                && let Some(key) = invocation_target.key()? {
-                    row.target_service_key(key);
-                }
-            if row.is_target_handler_name_defined() {
-                row.target_handler_name(invocation_target.handler_name()?);
-            }
-            if row.is_target_defined() {
-                row.fmt_target(invocation_target.target_fmt()?);
-            }
-            if row.is_target_service_ty_defined() {
-                row.target_service_ty(match invocation_target.service_ty() {
-                    ServiceType::Service => "service",
-                    ServiceType::VirtualObject => "virtual_object",
-                    ServiceType::Workflow => "workflow",
-                });
-            }
+        && let Some(invocation_target) = invocation_status.invocation_target()?
+    {
+        if row.is_target_service_name_defined() {
+            row.target_service_name(invocation_target.service_name()?);
         }
+        if row.is_target_service_key_defined()
+            && let Some(key) = invocation_target.key()?
+        {
+            row.target_service_key(key);
+        }
+        if row.is_target_handler_name_defined() {
+            row.target_handler_name(invocation_target.handler_name()?);
+        }
+        if row.is_target_defined() {
+            row.fmt_target(invocation_target.target_fmt()?);
+        }
+        if row.is_target_service_ty_defined() {
+            row.target_service_ty(match invocation_target.service_ty() {
+                ServiceType::Service => "service",
+                ServiceType::VirtualObject => "virtual_object",
+                ServiceType::Workflow => "workflow",
+            });
+        }
+    }
 
     // Invocation id
     if row.is_id_defined() {
@@ -87,9 +89,10 @@ pub(crate) fn append_invocation_status_row<
                 fill_invoked_by(&mut row, scheduled.source()?)?;
             }
             if row.is_scheduled_at_defined()
-                && let Some(execution_time) = scheduled.execution_time() {
-                    row.scheduled_start_at(execution_time.as_u64() as i64)
-                }
+                && let Some(execution_time) = scheduled.execution_time()
+            {
+                row.scheduled_start_at(execution_time.as_u64() as i64)
+            }
             if row.is_completion_retention_defined() {
                 row.completion_retention(
                     scheduled.completion_retention_duration()?.as_millis() as i64
@@ -110,9 +113,10 @@ pub(crate) fn append_invocation_status_row<
                 fill_invoked_by(&mut row, inboxed.source()?)?;
             }
             if row.is_scheduled_at_defined()
-                && let Some(execution_time) = inboxed.execution_time() {
-                    row.scheduled_start_at(execution_time.as_u64() as i64)
-                }
+                && let Some(execution_time) = inboxed.execution_time()
+            {
+                row.scheduled_start_at(execution_time.as_u64() as i64)
+            }
             if row.is_completion_retention_defined() {
                 row.completion_retention(
                     inboxed.completion_retention_duration()?.as_millis() as i64
@@ -148,9 +152,10 @@ pub(crate) fn append_invocation_status_row<
                 fill_invoked_by(&mut row, completed.source()?)?;
             }
             if row.is_scheduled_at_defined()
-                && let Some(execution_time) = completed.execution_time() {
-                    row.scheduled_start_at(execution_time.as_u64() as i64)
-                }
+                && let Some(execution_time) = completed.execution_time()
+            {
+                row.scheduled_start_at(execution_time.as_u64() as i64)
+            }
             if row.is_completion_retention_defined() {
                 row.completion_retention(
                     completed.completion_retention_duration()?.as_millis() as i64
@@ -195,20 +200,23 @@ fn fill_in_flight_invocation_metadata(
     }
     // journal_metadata and stats are filled by other functions
     if row.is_pinned_deployment_id_defined()
-        && let Some(deployment_id) = meta.deployment_id()? {
-            row.fmt_pinned_deployment_id(deployment_id);
-        }
+        && let Some(deployment_id) = meta.deployment_id()?
+    {
+        row.fmt_pinned_deployment_id(deployment_id);
+    }
     if row.is_pinned_service_protocol_version_defined()
-        && let Some(service_protocol_version) = meta.service_protocol_version()? {
-            row.pinned_service_protocol_version(service_protocol_version.as_repr().unsigned_abs());
-        }
+        && let Some(service_protocol_version) = meta.service_protocol_version()?
+    {
+        row.pinned_service_protocol_version(service_protocol_version.as_repr().unsigned_abs());
+    }
     if needs_invoked_by(row) {
         fill_invoked_by(row, meta.source()?)?;
     }
     if row.is_scheduled_at_defined()
-        && let Some(execution_time) = meta.execution_time() {
-            row.scheduled_start_at(execution_time.as_u64() as i64)
-        }
+        && let Some(execution_time) = meta.execution_time()
+    {
+        row.scheduled_start_at(execution_time.as_u64() as i64)
+    }
     if row.is_completion_retention_defined() {
         row.completion_retention(meta.completion_retention_duration()?.as_millis() as i64);
     }

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -12,10 +12,10 @@ use std::fmt::Debug;
 use std::ops::{ControlFlow, RangeInclusive};
 use std::sync::Arc;
 
-use restate_partition_store::invocation_status_table::ScanInvocationStatusAccessor;
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::invocation_status_table::ScanInvocationStatusTable;
+use restate_storage_api::protobuf_types::v1::lazy::InvocationStatusV2Lazy;
 use restate_types::errors::ConversionError;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 
@@ -60,7 +60,7 @@ struct StatusScanner;
 
 impl ScanLocalPartition for StatusScanner {
     type Builder = SysInvocationStatusBuilder;
-    type Item<'a> = (InvocationId, ScanInvocationStatusAccessor<'a>);
+    type Item<'a> = (InvocationId, InvocationStatusV2Lazy<'a>);
     type ConversionError = ConversionError;
 
     fn for_each_row<
@@ -73,7 +73,7 @@ impl ScanLocalPartition for StatusScanner {
         range: RangeInclusive<PartitionKey>,
         f: F,
     ) -> Result<impl Future<Output = Result<(), StorageError>> + Send, StorageError> {
-        partition_store.for_each_invocation_status(range, f)
+        partition_store.for_each_invocation_status_lazy(range, f)
     }
 
     fn append_row<'a>(

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -12,11 +12,10 @@ use std::fmt::Debug;
 use std::ops::{ControlFlow, RangeInclusive};
 use std::sync::Arc;
 
+use restate_partition_store::invocation_status_table::ScanInvocationStatusAccessor;
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::invocation_status_table::{
-    InvocationStatusDynAccessor, ScanInvocationStatusTable,
-};
+use restate_storage_api::invocation_status_table::ScanInvocationStatusTable;
 use restate_types::errors::ConversionError;
 use restate_types::identifiers::{InvocationId, PartitionKey};
 
@@ -61,7 +60,7 @@ struct StatusScanner;
 
 impl ScanLocalPartition for StatusScanner {
     type Builder = SysInvocationStatusBuilder;
-    type Item<'a> = (InvocationId, InvocationStatusDynAccessor<'a>);
+    type Item<'a> = (InvocationId, ScanInvocationStatusAccessor<'a>);
     type ConversionError = ConversionError;
 
     fn for_each_row<

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -57,18 +57,28 @@ struct StateScanner;
 impl ScanLocalPartition for StateScanner {
     type Builder = StateBuilder;
     type Item<'a> = (ServiceId, Bytes, &'a [u8]);
+    type ConversionError = std::convert::Infallible;
 
     fn for_each_row<
-        F: for<'a> FnMut(Self::Item<'a>) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+        F: for<'a> FnMut(
+                Self::Item<'a>,
+            ) -> std::ops::ControlFlow<Result<(), Self::ConversionError>>
+            + Send
+            + Sync
+            + 'static,
     >(
         partition_store: &PartitionStore,
         range: RangeInclusive<PartitionKey>,
-        f: F,
+        mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
-        partition_store.for_each_user_state(range, f)
+        partition_store.for_each_user_state(range, move |item| f(item).map_break(Result::unwrap))
     }
 
-    fn append_row<'a>(row_builder: &mut Self::Builder, value: Self::Item<'a>) {
+    fn append_row<'a>(
+        row_builder: &mut Self::Builder,
+        value: Self::Item<'a>,
+    ) -> Result<(), Self::ConversionError> {
         append_state_row(row_builder, value.0, value.1, value.2);
+        Ok(())
     }
 }

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -26,14 +26,16 @@ pub struct RestateVersionError(#[from] semver::Error);
 pub struct RestateVersion(Cow<'static, str>);
 
 impl RestateVersion {
+    pub const UNKNOWN_STR: &str = "0.0.0-unknown";
+
     /// The current version of the currently running binary
     pub fn current() -> Self {
         Self(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
     }
 
-    pub fn unknown() -> Self {
+    pub const fn unknown() -> Self {
         // We still provide a semver valid version here
-        Self(Cow::Borrowed("0.0.0-unknown"))
+        Self(Cow::Borrowed(Self::UNKNOWN_STR))
     }
 
     pub fn new(s: String) -> Self {

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -201,10 +201,9 @@ mod tests {
     use restate_storage_api::StorageError;
     use restate_storage_api::invocation_status_table::{
         CompletedInvocation, InFlightInvocationMetadata, InvocationStatus,
-        InvocationStatusAccessor, InvokedInvocationStatusLite, JournalMetadata,
-        ScanInvocationStatusTable,
+        InvokedInvocationStatusLite, JournalMetadata, ScanInvocationStatusTable,
     };
-    use restate_storage_api::protobuf_types::v1::InvocationStatusV2Lazy;
+    use restate_storage_api::protobuf_types::v1::lazy::InvocationStatusV2Lazy;
     use restate_types::Version;
     use restate_types::identifiers::{InvocationId, InvocationUuid};
     use restate_types::partition_table::{FindPartition, PartitionTable};
@@ -214,10 +213,6 @@ mod tests {
     struct MockInvocationStatusReader(Vec<(InvocationId, InvocationStatus)>);
 
     impl ScanInvocationStatusTable for MockInvocationStatusReader {
-        type PreFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
-        type InFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
-        type CompletedInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
-
         fn scan_invocation_statuses(
             &self,
             _: RangeInclusive<PartitionKey>,
@@ -228,17 +223,10 @@ mod tests {
             Ok(stream::iter(self.0.clone()).map(Ok))
         }
 
-        fn for_each_invocation_status<
+        fn for_each_invocation_status_lazy<
             E: Into<anyhow::Error>,
             F: for<'a> FnMut(
-                    (
-                        InvocationId,
-                        InvocationStatusAccessor<
-                            Self::PreFlightInvocationMetadataAccessor<'a>,
-                            Self::InFlightInvocationMetadataAccessor<'a>,
-                            Self::CompletedInvocationMetadataAccessor<'a>,
-                        >,
-                    ),
+                    (InvocationId, InvocationStatusV2Lazy<'a>),
                 ) -> std::ops::ControlFlow<std::result::Result<(), E>>
                 + Send
                 + Sync

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -204,7 +204,7 @@ mod tests {
         InvocationStatusAccessor, InvokedInvocationStatusLite, JournalMetadata,
         ScanInvocationStatusTable,
     };
-    use restate_storage_api::protobuf_types::v1::InvocationStatusV2;
+    use restate_storage_api::protobuf_types::v1::InvocationStatusV2Lazy;
     use restate_types::Version;
     use restate_types::identifiers::{InvocationId, InvocationUuid};
     use restate_types::partition_table::{FindPartition, PartitionTable};
@@ -214,9 +214,9 @@ mod tests {
     struct MockInvocationStatusReader(Vec<(InvocationId, InvocationStatus)>);
 
     impl ScanInvocationStatusTable for MockInvocationStatusReader {
-        type PreFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2;
-        type InFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2;
-        type CompletedInvocationMetadataAccessor<'a> = &'a InvocationStatusV2;
+        type PreFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
+        type InFlightInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
+        type CompletedInvocationMetadataAccessor<'a> = &'a InvocationStatusV2Lazy;
 
         fn scan_invocation_statuses(
             &self,
@@ -234,9 +234,9 @@ mod tests {
                     (
                         InvocationId,
                         InvocationStatusAccessor<
-                            Self::PreFlightInvocationMetadataAccessor<'static>,
-                            Self::InFlightInvocationMetadataAccessor<'static>,
-                            Self::CompletedInvocationMetadataAccessor<'static>,
+                            Self::PreFlightInvocationMetadataAccessor<'a>,
+                            Self::InFlightInvocationMetadataAccessor<'a>,
+                            Self::CompletedInvocationMetadataAccessor<'a>,
                         >,
                     ),
                 ) -> std::ops::ControlFlow<std::result::Result<(), E>>


### PR DESCRIPTION
This PR changes the status df table scanning to only do proto deserialisation and avoid most field transformations until the fields are needed. In addition, we create a new invocation status lazy shadow proto struct, which keeps strings as bytes, and keeps nested proto messages as bytes too. For all bytes fields, we do zero-copy deserialisation. 

Altogether this leads to a 2x speed up on topk(id)

We change the scanner interface slightly to make functions passed in to places like for_each_invocation_status fallible, so that they can produce conversion errors where previously they would have been produced up front before executing those functions.

Something to note is that we are now producing certain values in the df table in a totally different code path than how we'd produce them to put them in our InvocationStatus object. I've endeavoured to do things in the same way to how we were previously, but they could drift over time. IMO, thats ok, as there is nothing that mandates that the df fields are identical to InvocationStatus fields that are used in the pp.