### PR TITLE
[fingerprint] Generate cluster fingerprint for new clusters

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -1019,7 +1019,7 @@ mod tests {
     use restate_types::net::node::{GetNodeState, GossipService, NodeStateResponse};
     use restate_types::net::partition_processor_manager::PartitionManagerService;
     use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
-    use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+    use restate_types::{GenerationalNodeId, PlainNodeId};
 
     #[test(restate_core::test)]
     async fn manual_log_trim() -> anyhow::Result<()> {
@@ -1561,7 +1561,7 @@ mod tests {
         let mut cs_updater = TaskCenter::with_current(|h| h.cluster_state_updater());
         let mut write_guard = cs_updater.write();
 
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         for i in 1..=num_nodes {
             let node_id = GenerationalNodeId::new(i as u32, i as u32);
             nodes_config.upsert_node(

--- a/crates/bifrost/src/providers/replicated_loglet/test_util.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/test_util.rs
@@ -11,7 +11,7 @@
 use restate_types::nodes_config::{
     LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState,
 };
-use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+use restate_types::{GenerationalNodeId, PlainNodeId};
 
 pub fn generate_logserver_node(
     id: impl Into<PlainNodeId>,
@@ -32,7 +32,7 @@ pub fn generate_logserver_nodes_config(
     num_nodes: u32,
     storage_state: StorageState,
 ) -> NodesConfiguration {
-    let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+    let mut nodes_config = NodesConfiguration::new_for_testing();
     // all_authoritative
     for i in 1..=num_nodes {
         nodes_config.upsert_node(generate_logserver_node(i, storage_state));

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -507,7 +507,7 @@ mod tests {
     }
 
     fn create_mock_nodes_config() -> NodesConfiguration {
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         let address = AdvertisedAddress::from_str("http://127.0.0.1:5122/").unwrap();
         let node_id = GenerationalNodeId::new(1, 1);
         let roles = Role::Admin | Role::Worker;

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -305,7 +305,7 @@ impl ConnectionManager {
             && let Some(cluster_fingerprint) = nodes_config.cluster_fingerprint()
             && incoming_fingerprint != cluster_fingerprint
         {
-            return Err(HandshakeError::Failed("Cluster fingerprint mismatch".to_owned()).into());
+            return Err(HandshakeError::Failed("cluster fingerprint mismatch".to_owned()).into());
         }
 
         // NodeId **must** be generational at this layer, we may support accepting connections from
@@ -317,7 +317,7 @@ impl ConnectionManager {
 
         // we don't allow node-id 0 in this version.
         if peer_node_id.id == 0 {
-            return Err(HandshakeError::Failed("Peer cannot have node Id of 0".to_owned()).into());
+            return Err(HandshakeError::Failed("peer cannot have node Id of 0".to_owned()).into());
         }
 
         if peer_node_id.generation == 0 {
@@ -798,7 +798,7 @@ mod tests {
         assert_that!(
             err,
             pat!(AcceptError::Handshake(pat!(HandshakeError::Failed(eq(
-                "cluster name mismatch"
+                "cluster fingerprint mismatch"
             )))))
         );
         Ok(())
@@ -844,7 +844,7 @@ mod tests {
 
     #[test(restate_core::test(start_paused = true))]
     async fn fetching_metadata_updates_through_message_headers() -> Result<()> {
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
 
         let node_id = GenerationalNodeId::new(42, 42);
         let node_config = NodeConfig::builder()

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -69,7 +69,7 @@ impl<T: TransportConnect> TestCoreEnvBuilder<T> {
             MetadataManager::new(metadata_builder, metadata_store_client.clone());
         let metadata_writer = metadata_manager.writer();
         let router_builder = MessageRouterBuilder::default();
-        let nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let nodes_config = NodesConfiguration::new_for_testing();
         let partition_table = PartitionTable::with_equally_sized_partitions(Version::MIN, 10);
         TaskCenter::try_set_global_metadata(metadata.clone());
 
@@ -236,7 +236,7 @@ impl<T: TransportConnect> TestCoreEnv<T> {
 }
 
 pub fn create_mock_nodes_config(node_id: u32, generation: u32) -> NodesConfiguration {
-    let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+    let mut nodes_config = NodesConfiguration::new_for_testing();
     let address = AdvertisedAddress::from_str("http://127.0.0.1:5122/").unwrap();
     let node_id = GenerationalNodeId::new(node_id, generation);
     let roles = Role::Admin | Role::Worker;

--- a/crates/metadata-server/src/raft/tests.rs
+++ b/crates/metadata-server/src/raft/tests.rs
@@ -58,8 +58,7 @@ async fn migration_local_to_replicated() -> googletest::Result<()> {
 
     let my_generation = 1;
     let zero_plain_node_id = PlainNodeId::from(0);
-    let mut nodes_configuration =
-        NodesConfiguration::new(Version::MIN, "migration-local-to-replicated".to_owned());
+    let mut nodes_configuration = NodesConfiguration::new_for_testing();
     let my_node_config = NodeConfig::builder()
         .name(Configuration::pinned().common.node_name().to_owned())
         .current_generation(

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -324,7 +324,7 @@ mod tests {
     use googletest::matchers::{contains_substring, displays_as, err};
     use restate_core::TestCoreEnvBuilder;
     use restate_types::config::{Configuration, set_current_config};
-    use restate_types::nodes_config::{NodeConfig, NodesConfiguration};
+    use restate_types::nodes_config::{ClusterFingerprint, NodeConfig, NodesConfiguration};
     use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
     #[test_log::test(restate_core::test)]
@@ -343,7 +343,8 @@ mod tests {
             .address("http://localhost:1337".parse().unwrap())
             .roles(EnumSet::default())
             .build();
-        let mut nodes_configuration = NodesConfiguration::new(Version::MIN, cluster_name);
+        let mut nodes_configuration =
+            NodesConfiguration::new(Version::MIN, cluster_name, ClusterFingerprint::generate());
         nodes_configuration.upsert_node(node_config);
 
         let builder = TestCoreEnvBuilder::with_incoming_only_connector()
@@ -373,7 +374,11 @@ mod tests {
         config.common.set_node_name(&node_name);
         set_current_config(config);
 
-        let nodes_configuration = NodesConfiguration::new(Version::MIN, other_cluster_name);
+        let nodes_configuration = NodesConfiguration::new(
+            Version::MIN,
+            other_cluster_name,
+            ClusterFingerprint::generate(),
+        );
 
         let builder = TestCoreEnvBuilder::with_incoming_only_connector()
             .set_nodes_config(nodes_configuration);

--- a/crates/types/src/replication/checker.rs
+++ b/crates/types/src/replication/checker.rs
@@ -784,7 +784,7 @@ mod tests {
     use crate::nodes_config::{
         LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState,
     };
-    use crate::{GenerationalNodeId, PlainNodeId, Version};
+    use crate::{GenerationalNodeId, PlainNodeId};
 
     fn generate_logserver_node(
         id: impl Into<PlainNodeId>,
@@ -807,7 +807,7 @@ mod tests {
         const NUM_NODES: u32 = 10;
         const LOCATION: &str = "";
         // all_authoritative, all flat structure (no location)
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // all_authoritative
         for i in 1..=NUM_NODES {
             nodes_config.upsert_node(generate_logserver_node(
@@ -852,7 +852,7 @@ mod tests {
         const NUM_NODES: u32 = 2;
         const LOCATION: &str = "";
         // all_authoritative, all flat structure (no location)
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // all_authoritative
         for i in 1..=NUM_NODES {
             nodes_config.upsert_node(generate_logserver_node(
@@ -943,7 +943,7 @@ mod tests {
     fn nodeset_checker_non_existent_nodes() -> Result<()> {
         const LOCATION: &str = "";
         // all_authoritative, all flat structure (no location)
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // add 2 nodes to config N1, N2
         for i in 1..=2 {
             nodes_config.upsert_node(generate_logserver_node(
@@ -988,7 +988,7 @@ mod tests {
     fn nodeset_checker_mixed() -> Result<()> {
         const LOCATION: &str = "";
         // still flat
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         nodes_config.upsert_node(generate_logserver_node(1, StorageState::Disabled, LOCATION));
         nodes_config.upsert_node(generate_logserver_node(
             2,
@@ -1067,7 +1067,7 @@ mod tests {
     fn nodeset_checker_non_authoritative() -> Result<()> {
         const LOCATION: &str = "";
         // still flat
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         nodes_config.upsert_node(generate_logserver_node(1, StorageState::Disabled, LOCATION));
         nodes_config.upsert_node(generate_logserver_node(
             2,
@@ -1165,7 +1165,7 @@ mod tests {
         const NUM_NODES: u32 = 1;
         const LOCATION: &str = "";
         // all_authoritative, all flat structure (no location)
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // all_authoritative
         for i in 1..=NUM_NODES {
             nodes_config.upsert_node(generate_logserver_node(
@@ -1195,7 +1195,7 @@ mod tests {
         const NUM_NODES: u32 = 3;
         const LOCATION: &str = "";
         // all_authoritative, all flat structure (no location)
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // all_authoritative
         for i in 1..=NUM_NODES {
             nodes_config.upsert_node(generate_logserver_node(
@@ -1232,7 +1232,7 @@ mod tests {
         // region2
         //      .az1  [N7, N8, N9]
         // -         [N10(Provisioning/Not In Config) N11(D)]  - D = Disabled
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // all authoritative
         // region1.az1
         for i in 1..=3 {
@@ -1406,7 +1406,7 @@ mod tests {
         // region2
         //      .az1  [N7, N8, N9]
         // -         [N10, N11(P)] - P = Provisioning
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // region1.az1
         nodes_config.upsert_node(generate_logserver_node(
             1,
@@ -1478,7 +1478,7 @@ mod tests {
         //      .az1  [N8, N9, N10]
         // region3
         //      .az1  [N11]
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // region1.az1
         for i in 1..=4 {
             nodes_config.upsert_node(generate_logserver_node(
@@ -1576,7 +1576,7 @@ mod tests {
         //      .az1  [N11]
         // region4 -- region is Disabled
         //      .az1  [N12(D)]
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         // region1.az1
         nodes_config.upsert_node(generate_logserver_node(
             1,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1435,7 +1435,7 @@ mod tests {
     /// more details.
     #[test(restate_core::test)]
     async fn proper_partition_processor_lifecycle() -> googletest::Result<()> {
-        let mut nodes_config = NodesConfiguration::new(Version::MIN, "test-cluster".to_owned());
+        let mut nodes_config = NodesConfiguration::new_for_testing();
         let node_id = GenerationalNodeId::new(42, 42);
         let node_config = NodeConfig::builder()
             .name("42".to_owned())


### PR DESCRIPTION

New cluster provisioned with v1.5.0 will have the cluster fingerprint automatically generated at provisioning time. Fingerprints have been added to the various data types in 1.3.x for the purpose of making
this process easier.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3723).
* #3732
* #3728
* #3727
* #3726
* __->__ #3723