### PR TITLE
Allow to change pinned deployment on resumption

### DIFF
--- a/crates/core/src/worker_api/partition_processor_rpc_client.rs
+++ b/crates/core/src/worker_api/partition_processor_rpc_client.rs
@@ -21,8 +21,8 @@ use restate_types::identifiers::{
 use restate_types::invocation::client::{
     AttachInvocationResponse, CancelInvocationResponse, GetInvocationOutputResponse,
     InvocationClient, InvocationClientError, InvocationOutput, KillInvocationResponse,
-    PurgeInvocationResponse, RestartAsNewInvocationResponse, ResumeInvocationResponse,
-    SubmittedInvocationNotification,
+    PurgeInvocationResponse, RestartAsNewInvocationResponse, ResumeInvocationDeploymentId,
+    ResumeInvocationResponse, SubmittedInvocationNotification,
 };
 use restate_types::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use restate_types::journal_v2::Signal;
@@ -520,11 +520,15 @@ where
         &self,
         request_id: PartitionProcessorRpcRequestId,
         invocation_id: InvocationId,
+        deployment_id: ResumeInvocationDeploymentId,
     ) -> Result<ResumeInvocationResponse, InvocationClientError> {
         let response = self
             .resolve_partition_id_and_send(
                 request_id,
-                PartitionProcessorRpcRequestInner::ResumeInvocation { invocation_id },
+                PartitionProcessorRpcRequestInner::ResumeInvocation {
+                    invocation_id,
+                    deployment_id,
+                },
             )
             .await?;
 

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -14,8 +14,8 @@ pub mod client;
 
 use crate::errors::InvocationError;
 use crate::identifiers::{
-    EntryIndex, IdempotencyId, InvocationId, PartitionKey, PartitionProcessorRpcRequestId,
-    ServiceId, SubscriptionId, WithInvocationId, WithPartitionKey,
+    DeploymentId, EntryIndex, IdempotencyId, InvocationId, PartitionKey,
+    PartitionProcessorRpcRequestId, ServiceId, SubscriptionId, WithInvocationId, WithPartitionKey,
 };
 use crate::journal_v2::{CompletionId, GetInvocationOutputResult, Signal};
 use crate::time::MillisSinceEpoch;
@@ -973,7 +973,9 @@ impl WithInvocationId for PurgeInvocationRequest {
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ResumeInvocationRequest {
     pub invocation_id: InvocationId,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update_pinned_deployment_id: Option<DeploymentId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_sink: Option<InvocationMutationResponseSink>,
 }
 

--- a/crates/types/src/schema/deployment.rs
+++ b/crates/types/src/schema/deployment.rs
@@ -384,14 +384,12 @@ pub mod test_util {
     }
 
     impl MockDeploymentMetadataRegistry {
-        pub fn mock_service(&mut self, service: &str) {
-            self.mock_service_with_metadata(service, Deployment::mock());
+        pub fn mock_deployment(&mut self, deployment: Deployment) {
+            self.deployments.insert(deployment.id, deployment.metadata);
         }
 
-        pub fn mock_service_with_metadata(&mut self, service: &str, deployment: Deployment) {
-            self.latest_deployment
-                .insert(service.to_string(), deployment.id);
-            self.deployments.insert(deployment.id, deployment.metadata);
+        pub fn mock_latest_service(&mut self, service: &str, deployment_id: DeploymentId) {
+            self.latest_deployment.insert(service.into(), deployment_id);
         }
     }
 

--- a/crates/worker/src/partition/rpc/append_invocation.rs
+++ b/crates/worker/src/partition/rpc/append_invocation.rs
@@ -21,8 +21,8 @@ pub(super) struct Request {
     pub(super) append_invocation_reply_on: AppendInvocationReplyOn,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = PartitionProcessorRpcResponse;
     type Error = ();
@@ -109,7 +109,7 @@ mod tests {
 
         let (tx, _rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut ()),
+            RpcContext::new(&mut proposer, &(), &mut ()),
             Request {
                 request_id: Default::default(),
                 invocation_request: Arc::new(InvocationRequest::mock()),
@@ -147,7 +147,7 @@ mod tests {
 
         let (tx, _rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut ()),
+            RpcContext::new(&mut proposer, &(), &mut ()),
             Request {
                 request_id,
                 invocation_request: Arc::new(InvocationRequest::mock()),
@@ -187,7 +187,7 @@ mod tests {
 
         let (tx, _rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut ()),
+            RpcContext::new(&mut proposer, &(), &mut ()),
             Request {
                 request_id,
                 invocation_request: Arc::new(InvocationRequest::mock()),

--- a/crates/worker/src/partition/rpc/append_invocation_response.rs
+++ b/crates/worker/src/partition/rpc/append_invocation_response.rs
@@ -18,8 +18,8 @@ pub(super) struct Request {
     pub(super) invocation_response: InvocationResponse,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = PartitionProcessorRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/append_signal.rs
+++ b/crates/worker/src/partition/rpc/append_signal.rs
@@ -20,8 +20,8 @@ pub(super) struct Request {
     pub(super) signal: Signal,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = PartitionProcessorRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/cancel_invocation.rs
+++ b/crates/worker/src/partition/rpc/cancel_invocation.rs
@@ -22,8 +22,8 @@ pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = CancelInvocationRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/get_invocation_output.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_output.rs
@@ -34,7 +34,7 @@ pub(super) struct Request {
     pub(super) response_mode: GetInvocationOutputResponseMode,
 }
 
-impl<'a, TActuator, TStorage> RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator, TSchemas, TStorage> RpcContext<'a, TActuator, TSchemas, TStorage>
 where
     TActuator: Actuator,
     TStorage:
@@ -95,7 +95,8 @@ where
     }
 }
 
-impl<'a, Proposer: Actuator, Storage> RpcHandler<Request> for RpcContext<'a, Proposer, Storage>
+impl<'a, Proposer: Actuator, TSchemas, Storage> RpcHandler<Request>
+    for RpcContext<'a, Proposer, TSchemas, Storage>
 where
     Storage:
         ReadOnlyInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,

--- a/crates/worker/src/partition/rpc/kill_invocation.rs
+++ b/crates/worker/src/partition/rpc/kill_invocation.rs
@@ -22,8 +22,8 @@ pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = KillInvocationRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/purge_invocation.rs
+++ b/crates/worker/src/partition/rpc/purge_invocation.rs
@@ -21,8 +21,8 @@ pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = PurgeInvocationRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/purge_journal.rs
+++ b/crates/worker/src/partition/rpc/purge_journal.rs
@@ -21,8 +21,8 @@ pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 {
     type Output = PurgeInvocationRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -29,7 +29,8 @@ pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request> for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 where
     TActuator: Actuator,
     TStorage: ReadOnlyInvocationStatusTable + ReadOnlyJournalTable,
@@ -347,7 +348,7 @@ mod tests {
 
         let (tx, _rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id: old_invocation_id,
@@ -378,7 +379,7 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
@@ -422,7 +423,7 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
@@ -475,7 +476,7 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
@@ -523,7 +524,7 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
@@ -573,7 +574,7 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,

--- a/crates/worker/src/partition/rpc/resume_invocation.rs
+++ b/crates/worker/src/partition/rpc/resume_invocation.rs
@@ -10,22 +10,27 @@
 
 use super::*;
 use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
+    InFlightInvocationMetadata, InvocationStatus, ReadOnlyInvocationStatusTable,
 };
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::invocation::client::ResumeInvocationDeploymentId;
 use restate_types::invocation::{
     IngressInvocationResponseSink, InvocationMutationResponseSink, ResumeInvocationRequest,
 };
 use restate_types::net::partition_processor::ResumeInvocationRpcResponse;
+use restate_types::schema::deployment::DeploymentResolver;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
     pub(super) invocation_id: InvocationId,
+    pub(super) update_deployment_id: ResumeInvocationDeploymentId,
 }
 
-impl<'a, TActuator: Actuator, TStorage> RpcHandler<Request> for RpcContext<'a, TActuator, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 where
     TActuator: Actuator,
+    TSchemas: DeploymentResolver,
     TStorage: ReadOnlyInvocationStatusTable,
 {
     type Output = ResumeInvocationRpcResponse;
@@ -36,25 +41,96 @@ where
         Request {
             request_id,
             invocation_id,
+            update_deployment_id,
         }: Request,
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
         // -- Figure out the invocation status
         match self.storage.get_invocation_status(&invocation_id).await {
             Ok(InvocationStatus::Invoked(metadata)) => {
+                if !matches!(
+                    update_deployment_id,
+                    ResumeInvocationDeploymentId::KeepPinned
+                ) {
+                    replier.send(ResumeInvocationRpcResponse::CannotChangeDeploymentId);
+                    return Ok(());
+                }
+
                 // Let's poke the invoker to retry now, if possible
                 self.proposer
                     .notify_invoker_to_retry_now(invocation_id, metadata.current_invocation_epoch)
                     .await;
                 replier.send(ResumeInvocationRpcResponse::Ok);
             }
-            Ok(InvocationStatus::Suspended { .. }) | Ok(InvocationStatus::Paused(_)) => {
+            Ok(InvocationStatus::Suspended {
+                metadata:
+                    InFlightInvocationMetadata {
+                        invocation_target,
+                        pinned_deployment,
+                        ..
+                    },
+                ..
+            })
+            | Ok(InvocationStatus::Paused(InFlightInvocationMetadata {
+                invocation_target,
+                pinned_deployment,
+                ..
+            })) => {
+                // Let's look at the deployment id here, and see if we need to do some changes
+                let update_pinned_deployment_id = match (update_deployment_id, pinned_deployment) {
+                    (ResumeInvocationDeploymentId::KeepPinned, _) => {
+                        // If the request is to keep pinned, no change will be applied.
+                        None
+                    }
+                    (_, None) => {
+                        // No deployment is even pinned, return back the error
+                        replier.send(ResumeInvocationRpcResponse::CannotChangeDeploymentId);
+                        return Ok(());
+                    }
+                    (resume_invocation_deployment_id, Some(pinned_deployment)) => {
+                        let Some(deployment) = (match resume_invocation_deployment_id {
+                            ResumeInvocationDeploymentId::PinToLatest => {
+                                self.schemas.resolve_latest_deployment_for_service(
+                                    invocation_target.service_name(),
+                                )
+                            }
+                            ResumeInvocationDeploymentId::PinTo { id } => {
+                                self.schemas.get_deployment(&id)
+                            }
+                            ResumeInvocationDeploymentId::KeepPinned => {
+                                unreachable!()
+                            }
+                        }) else {
+                            replier.send(ResumeInvocationRpcResponse::DeploymentNotFound);
+                            return Ok(());
+                        };
+
+                        if !deployment
+                            .metadata
+                            .supported_protocol_versions
+                            .contains(&(pinned_deployment.service_protocol_version as i32))
+                        {
+                            replier.send(ResumeInvocationRpcResponse::IncompatibleDeploymentId {
+                                pinned_protocol_version: pinned_deployment.service_protocol_version
+                                    as i32,
+                                deployment_id: deployment.id,
+                                supported_protocol_versions: deployment
+                                    .metadata
+                                    .supported_protocol_versions,
+                            });
+                            return Ok(());
+                        }
+                        Some(deployment.id)
+                    }
+                };
+
                 // We need to propose the message, PP will deal with invoking this back
                 self.proposer
                     .handle_rpc_proposal_command(
                         invocation_id.partition_key(),
                         Command::ResumeInvocation(ResumeInvocationRequest {
                             invocation_id,
+                            update_pinned_deployment_id,
                             response_sink: Some(InvocationMutationResponseSink::Ingress(
                                 IngressInvocationResponseSink { request_id },
                             )),
@@ -96,6 +172,13 @@ mod tests {
         CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation,
         PreFlightInvocationMetadata, ScheduledInvocation,
     };
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{DeploymentId, ServiceRevision};
+    use restate_types::invocation::InvocationTarget;
+    use restate_types::schema::deployment::Deployment;
+    use restate_types::schema::deployment::test_util::MockDeploymentMetadataRegistry;
+    use restate_types::schema::service::ServiceMetadata;
+    use restate_types::service_protocol::ServiceProtocolVersion;
     use rstest::rstest;
     use std::collections::HashSet;
     use std::future::ready;
@@ -113,6 +196,29 @@ mod tests {
         ) -> impl Future<Output = restate_storage_api::Result<InvocationStatus>> + Send {
             assert_eq!(*inv_id, self.expected_invocation_id);
             ready(Ok(self.status.clone()))
+        }
+    }
+
+    struct NoopDeploymentResolver;
+
+    impl DeploymentResolver for NoopDeploymentResolver {
+        fn resolve_latest_deployment_for_service(&self, _: impl AsRef<str>) -> Option<Deployment> {
+            todo!()
+        }
+
+        fn get_deployment(&self, _: &DeploymentId) -> Option<Deployment> {
+            todo!()
+        }
+
+        fn get_deployment_and_services(
+            &self,
+            _: &DeploymentId,
+        ) -> Option<(Deployment, Vec<ServiceMetadata>)> {
+            todo!()
+        }
+
+        fn get_deployments(&self) -> Vec<(Deployment, Vec<(String, ServiceRevision)>)> {
+            todo!()
         }
     }
 
@@ -135,10 +241,11 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &NoopDeploymentResolver, &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
+                update_deployment_id: Default::default(),
             },
             Replier::new(tx),
         )
@@ -193,10 +300,11 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &NoopDeploymentResolver, &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
+                update_deployment_id: Default::default(),
             },
             Replier::new(tx),
         )
@@ -225,10 +333,11 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &NoopDeploymentResolver, &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
+                update_deployment_id: Default::default(),
             },
             Replier::new(tx),
         )
@@ -257,10 +366,11 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &NoopDeploymentResolver, &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
+                update_deployment_id: Default::default(),
             },
             Replier::new(tx),
         )
@@ -301,10 +411,11 @@ mod tests {
 
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &mut storage),
+            RpcContext::new(&mut proposer, &NoopDeploymentResolver, &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
+                update_deployment_id: Default::default(),
             },
             Replier::new(tx),
         )
@@ -316,6 +427,163 @@ mod tests {
             PartitionProcessorRpcResponse::ResumeInvocation(
                 ResumeInvocationRpcResponse::NotStarted
             )
+        );
+    }
+
+    #[rstest]
+    #[restate_core::test]
+    async fn override_incompatible_pinned_deployment(
+        #[values(true, false)] pin_to_specific: bool,
+        #[values(true, false)] suspended: bool,
+    ) {
+        let invocation_id = InvocationId::mock_random();
+        let invocation_target = InvocationTarget::mock_service();
+        let pinned_version = ServiceProtocolVersion::V5;
+
+        // Candidate deployment supports only up to V4 -> incompatible with V5
+        let mut dep = Deployment::mock();
+        dep.metadata.supported_protocol_versions = 1..=4;
+        let expected_deployment_id = dep.id;
+
+        let mut schemas = MockDeploymentMetadataRegistry::default();
+        schemas.mock_deployment(dep.clone());
+        if !pin_to_specific {
+            schemas.mock_latest_service(invocation_target.service_name(), dep.id);
+        }
+
+        let mut proposer = MockActuator::new();
+        proposer
+            .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
+            .never();
+
+        let metadata = InFlightInvocationMetadata {
+            invocation_target,
+            pinned_deployment: Some(PinnedDeployment::new(DeploymentId::new(), pinned_version)),
+            ..InFlightInvocationMetadata::mock()
+        };
+        let mut storage = MockStorage {
+            expected_invocation_id: invocation_id,
+            status: if suspended {
+                InvocationStatus::Suspended {
+                    metadata,
+                    waiting_for_notifications: Default::default(),
+                }
+            } else {
+                InvocationStatus::Paused(metadata)
+            },
+        };
+
+        let (tx, rx) = Reciprocal::mock();
+        let update_deployment_id = if pin_to_specific {
+            ResumeInvocationDeploymentId::PinTo {
+                id: expected_deployment_id,
+            }
+        } else {
+            ResumeInvocationDeploymentId::PinToLatest
+        };
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &schemas, &mut storage),
+            Request {
+                request_id: Default::default(),
+                invocation_id,
+                update_deployment_id,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert_that!(
+            rx.recv().await.unwrap(),
+            eq(PartitionProcessorRpcResponse::ResumeInvocation(
+                ResumeInvocationRpcResponse::IncompatibleDeploymentId {
+                    pinned_protocol_version: i32::from(pinned_version),
+                    deployment_id: expected_deployment_id,
+                    supported_protocol_versions: 1..=4,
+                }
+            ))
+        );
+    }
+
+    #[rstest]
+    #[restate_core::test]
+    async fn override_compatible_pinned_deployment_proposes_command(
+        #[values(true, false)] pin_to_specific: bool,
+        #[values(true, false)] suspended: bool,
+    ) {
+        let invocation_id = InvocationId::mock_random();
+        let invocation_target = InvocationTarget::mock_service();
+        let pinned_version = ServiceProtocolVersion::V4;
+
+        // Candidate deployment supports V4 -> Should be compatible
+        let mut dep = Deployment::mock();
+        dep.metadata.supported_protocol_versions = 1..=4;
+        let expected_deployment_id = dep.id;
+
+        let mut schemas = MockDeploymentMetadataRegistry::default();
+        schemas.mock_deployment(dep.clone());
+        if !pin_to_specific {
+            schemas.mock_latest_service(invocation_target.service_name(), dep.id);
+        }
+
+        let mut proposer = MockActuator::new();
+        proposer
+            .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
+            .return_once_st(move |_, cmd, request_id, replier| {
+                assert_that!(
+                    cmd,
+                    pat!(Command::ResumeInvocation(pat!(ResumeInvocationRequest {
+                        invocation_id: eq(invocation_id),
+                        update_pinned_deployment_id: some(eq(expected_deployment_id)),
+                        response_sink: some(eq(InvocationMutationResponseSink::Ingress(
+                            IngressInvocationResponseSink { request_id }
+                        )))
+                    })))
+                );
+                replier.send(ResumeInvocationRpcResponse::Ok);
+                ready(()).boxed()
+            });
+
+        let metadata = InFlightInvocationMetadata {
+            invocation_target,
+            pinned_deployment: Some(PinnedDeployment::new(DeploymentId::new(), pinned_version)),
+            ..InFlightInvocationMetadata::mock()
+        };
+        let mut storage = MockStorage {
+            expected_invocation_id: invocation_id,
+            status: if suspended {
+                InvocationStatus::Suspended {
+                    metadata,
+                    waiting_for_notifications: Default::default(),
+                }
+            } else {
+                InvocationStatus::Paused(metadata)
+            },
+        };
+
+        let (tx, rx) = Reciprocal::mock();
+        let update_deployment_id = if pin_to_specific {
+            ResumeInvocationDeploymentId::PinTo {
+                id: expected_deployment_id,
+            }
+        } else {
+            ResumeInvocationDeploymentId::PinToLatest
+        };
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &schemas, &mut storage),
+            Request {
+                request_id: Default::default(),
+                invocation_id,
+                update_deployment_id,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            PartitionProcessorRpcResponse::ResumeInvocation(ResumeInvocationRpcResponse::Ok)
         );
     }
 }

--- a/crates/worker/src/partition/state_machine/lifecycle/manual_resume.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/manual_resume.rs
@@ -11,12 +11,14 @@
 use crate::partition::state_machine::lifecycle::ResumeInvocationCommand;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
-use restate_types::identifiers::InvocationId;
+use restate_types::identifiers::{DeploymentId, InvocationId};
 use restate_types::invocation::InvocationMutationResponseSink;
 use restate_types::invocation::client::ResumeInvocationResponse;
+use tracing::trace;
 
 pub struct OnManualResumeCommand {
     pub invocation_id: InvocationId,
+    pub update_pinned_deployment_id: Option<DeploymentId>,
     pub response_sink: Option<InvocationMutationResponseSink>,
 }
 
@@ -28,6 +30,7 @@ where
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let OnManualResumeCommand {
             invocation_id,
+            update_pinned_deployment_id,
             response_sink,
         } = self;
         match ctx.get_invocation_status(&invocation_id).await? {
@@ -36,6 +39,20 @@ where
                 ctx.reply_to_resume_invocation(response_sink, ResumeInvocationResponse::Ok);
             }
             mut is @ InvocationStatus::Suspended { .. } | mut is @ InvocationStatus::Paused(_) => {
+                if let Some(new_pinned_deployment_id) = update_pinned_deployment_id {
+                    // Update pinned deployment only if set.
+                    // This was already previously checked by the RPC handler.
+                    if let Some(invocation_pinned_deploment) =
+                        &mut is.get_invocation_metadata_mut().unwrap().pinned_deployment
+                    {
+                        trace!(
+                            "Updating pinned deployment from {} to {} when resuming",
+                            invocation_pinned_deploment.deployment_id, new_pinned_deployment_id
+                        );
+                        invocation_pinned_deploment.deployment_id = new_pinned_deployment_id;
+                    }
+                }
+
                 // Resume
                 ResumeInvocationCommand {
                     invocation_id,
@@ -75,13 +92,17 @@ mod tests {
         invoker_entry_effect, invoker_suspended,
     };
     use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
+    use crate::partition::types::InvokerEffectKind;
     use googletest::prelude::{all, assert_that, contains, eq, pat};
+    use restate_invoker_api::Effect;
     use restate_storage_api::invocation_status_table::{
         InvocationStatusDiscriminants, ReadOnlyInvocationStatusTable,
     };
+    use restate_types::deployment::PinnedDeployment;
     use restate_types::identifiers::PartitionProcessorRpcRequestId;
     use restate_types::invocation::{IngressInvocationResponseSink, ResumeInvocationRequest};
     use restate_types::journal_v2::{NotificationId, SleepCommand};
+    use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_wal_protocol::Command;
     use std::time::{Duration, SystemTime};
 
@@ -106,6 +127,7 @@ mod tests {
         let actions = test_env
             .apply(Command::ResumeInvocation(ResumeInvocationRequest {
                 invocation_id,
+                update_pinned_deployment_id: None,
                 response_sink: Some(InvocationMutationResponseSink::Ingress(
                     IngressInvocationResponseSink { request_id },
                 )),
@@ -128,6 +150,72 @@ mod tests {
                 .await
                 .unwrap(),
             matchers::storage::is_variant(InvocationStatusDiscriminants::Invoked)
+        );
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn pause_then_resume_update_pinned_deployment() {
+        let mut test_env = TestEnv::create().await;
+        let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
+        let initial_deployment_id = DeploymentId::new();
+        // Pin deployment
+        let _ = test_env
+            .apply(Command::InvokerEffect(Box::new(Effect {
+                invocation_id,
+                invocation_epoch: 0,
+                kind: InvokerEffectKind::PinnedDeployment(PinnedDeployment {
+                    deployment_id: initial_deployment_id,
+                    service_protocol_version: ServiceProtocolVersion::V5,
+                }),
+            })))
+            .await;
+        // Mock paused
+        test_env
+            .modify_invocation_status(invocation_id, |invocation_status| {
+                // Mock the invocation to be paused
+                *invocation_status = InvocationStatus::Paused(
+                    invocation_status
+                        .get_invocation_metadata_mut()
+                        .unwrap()
+                        .clone(),
+                )
+            })
+            .await;
+
+        // Now on manual resume, we should resume the suspended invocation
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let new_deployment_id = DeploymentId::new();
+        let actions = test_env
+            .apply(Command::ResumeInvocation(ResumeInvocationRequest {
+                invocation_id,
+                update_pinned_deployment_id: Some(new_deployment_id),
+                response_sink: Some(InvocationMutationResponseSink::Ingress(
+                    IngressInvocationResponseSink { request_id },
+                )),
+            }))
+            .await;
+        assert_that!(
+            actions,
+            all!(
+                contains(matchers::actions::invoke_for_id(invocation_id)),
+                contains(pat!(Action::ForwardResumeInvocationResponse {
+                    request_id: eq(request_id),
+                    response: eq(ResumeInvocationResponse::Ok)
+                }))
+            )
+        );
+        assert_that!(
+            test_env
+                .storage
+                .get_invocation_status(&invocation_id)
+                .await
+                .unwrap(),
+            all!(
+                matchers::storage::is_variant(InvocationStatusDiscriminants::Invoked),
+                matchers::storage::pinned_deployment_id_eq(new_deployment_id)
+            )
         );
 
         test_env.shutdown().await;
@@ -172,6 +260,7 @@ mod tests {
         let actions = test_env
             .apply(Command::ResumeInvocation(ResumeInvocationRequest {
                 invocation_id,
+                update_pinned_deployment_id: None,
                 response_sink: Some(InvocationMutationResponseSink::Ingress(
                     IngressInvocationResponseSink { request_id },
                 )),

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -550,6 +550,8 @@ impl<S> StateMachineApplyContext<'_, S> {
             Command::ResumeInvocation(resume_invocation_request) => {
                 lifecycle::OnManualResumeCommand {
                     invocation_id: resume_invocation_request.invocation_id,
+                    update_pinned_deployment_id: resume_invocation_request
+                        .update_pinned_deployment_id,
                     response_sink: resume_invocation_request.response_sink,
                 }
                 .apply(self)

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -27,7 +27,8 @@ pub mod storage {
         InFlightInvocationMetadata, InvocationStatus, InvocationStatusDiscriminants,
     };
     use restate_storage_api::journal_table::JournalEntry;
-    use restate_types::identifiers::InvocationId;
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{DeploymentId, InvocationId};
     use restate_types::invocation::InvocationTarget;
     use restate_types::journal::Entry;
 
@@ -103,6 +104,17 @@ pub mod storage {
             "get_invocation_metadata()",
             some(inner),
         )
+    }
+
+    pub fn pinned_deployment_id_eq(
+        deployment_id: DeploymentId,
+    ) -> impl Matcher<ActualT = InvocationStatus> {
+        in_flight_metadata(field!(
+            InFlightInvocationMetadata.pinned_deployment,
+            some(pat!(PinnedDeployment {
+                deployment_id: eq(deployment_id)
+            }))
+        ))
     }
 }
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -29,8 +29,8 @@ use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId, S
 use restate_types::invocation::client::{
     AttachInvocationResponse, CancelInvocationResponse, GetInvocationOutputResponse,
     InvocationClient, InvocationClientError, InvocationOutput, KillInvocationResponse,
-    PurgeInvocationResponse, RestartAsNewInvocationResponse, ResumeInvocationResponse,
-    SubmittedInvocationNotification,
+    PurgeInvocationResponse, RestartAsNewInvocationResponse, ResumeInvocationDeploymentId,
+    ResumeInvocationResponse, SubmittedInvocationNotification,
 };
 use restate_types::invocation::{
     InvocationQuery, InvocationRequest, InvocationResponse, InvocationTermination,
@@ -201,6 +201,7 @@ impl InvocationClient for Mock {
         &self,
         _: PartitionProcessorRpcRequestId,
         _: InvocationId,
+        _: ResumeInvocationDeploymentId,
     ) -> impl Future<Output = Result<ResumeInvocationResponse, InvocationClientError>> + Send {
         pending()
     }


### PR DESCRIPTION
Followup of https://github.com/restatedev/restate/pull/3676, allows to change the pinned deployment on resumption, e.g.

```shell
# Resume on a specific deployment
http PATCH localhost:9070/invocations/inv_1bkkEY8Xuw5J4u8FaICqSuCxXvKIbAiBFL/resume\?deployment_id=dp_15goNXPjYKly1fmEjX43ZHr

# Resume on latest deployment for the service
http PATCH localhost:9070/invocations/inv_1bkkEY8Xuw5J4u8FaICqSuCxXvKIbAiBFL/resume\?deployment_id=latest
```