### PR TITLE
[Restate UI] Update to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7813,8 +7813,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.0"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.0#de4e3eae11b291f90554514384828353dae4a6eb"
+version = "0.1.2"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.2#fd85d28f79301e47e3a0f9ca942bd0013f6671da"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.0", tag = "v0.1.0" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.2", tag = "v0.1.2" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.2
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.2/ui-v0.1.2.zip