### PR TITLE
New journal events key structure

### DIFF
--- a/crates/partition-store/src/journal_events/mod.rs
+++ b/crates/partition-store/src/journal_events/mod.rs
@@ -14,7 +14,6 @@ use crate::keys::{KeyKind, TableKey, define_table_key};
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan, TableScanIterationDecision,
 };
-use bytes::Bytes;
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
@@ -146,7 +145,7 @@ fn delete_journal_events<S: StorageAccess>(
 
     let keys = storage.for_each_key_value_in_place(
         TableScan::SinglePartitionKeyPrefix(invocation_id.partition_key(), prefix_key),
-        |k, _| TableScanIterationDecision::Emit(Ok(Bytes::copy_from_slice(k))),
+        |k, _| TableScanIterationDecision::Emit(Ok(Box::from(k))),
     )?;
 
     for k in keys {

--- a/crates/partition-store/src/journal_events/mod.rs
+++ b/crates/partition-store/src/journal_events/mod.rs
@@ -8,25 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
-use crate::TableKind::JournalEvent;
+use crate::TableKind::{JournalEvent, State};
 use crate::error::break_on_err;
 use crate::keys::{KeyKind, TableKey, define_table_key};
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan, TableScanIterationDecision,
 };
+use bytes::Bytes;
 use futures::Stream;
 use futures_util::stream;
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
 use restate_storage_api::journal_events::{
-    JournalEventsTable, ReadOnlyJournalEventsTable, ScanJournalEventsTable, StoredEvent,
+    EventView, JournalEventsTable, ReadOnlyJournalEventsTable, ScanJournalEventsTable,
 };
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
+use restate_storage_api::protobuf_types::v1::Event as PbEvent;
 use restate_storage_api::{Result, StorageError};
-use restate_types::identifiers::{
-    EntryIndex, InvocationId, InvocationUuid, JournalEventId, PartitionKey, WithPartitionKey,
-};
+use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
+use restate_types::journal_events::EventType;
+use restate_types::journal_events::raw::RawEvent;
+use restate_types::time::MillisSinceEpoch;
+use std::ops::RangeInclusive;
 
 define_table_key!(
     JournalEvent,
@@ -34,70 +36,100 @@ define_table_key!(
     JournalEventKey(
         partition_key: PartitionKey,
         invocation_uuid: InvocationUuid,
-        event_index: u32
+        event_type: u8,
+        timestamp: u64,
+        lsn: u64
     )
 );
 
-fn write_journal_event_key(invocation_id: &InvocationId, event_index: u32) -> JournalEventKey {
+/// Just a wrapper for the PartitionStoreProtobufValue trait
+#[derive(Clone)]
+struct EventWrapper(PbEvent);
+
+impl From<PbEvent> for EventWrapper {
+    fn from(t: PbEvent) -> Self {
+        Self(t)
+    }
+}
+impl From<EventWrapper> for PbEvent {
+    fn from(value: EventWrapper) -> Self {
+        value.0
+    }
+}
+impl PartitionStoreProtobufValue for EventWrapper {
+    type ProtobufType = PbEvent;
+}
+
+fn write_journal_event_key(
+    invocation_id: &InvocationId,
+    event_type: u8,
+    timestamp: u64,
+    lsn: u64,
+) -> JournalEventKey {
     JournalEventKey::default()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid())
-        .event_index(event_index)
+        .event_type(event_type)
+        .timestamp(timestamp)
+        .lsn(lsn)
 }
 
 fn put_journal_event<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
-    event_index: u32,
-    event: &StoredEvent,
+    event: EventView,
+    lsn: u64,
 ) -> Result<()> {
-    storage.put_kv(write_journal_event_key(invocation_id, event_index), event)
-}
-
-fn get_journal_event<S: StorageAccess>(
-    storage: &mut S,
-    invocation_id: &InvocationId,
-    event_index: u32,
-) -> Result<Option<StoredEvent>> {
-    let _x = RocksDbPerfGuard::new("get-journal-event");
-    let key = write_journal_event_key(invocation_id, event_index);
-    storage.get_value(key)
+    let (event_ty, event_value) = event.event.into_inner();
+    storage.put_kv(
+        write_journal_event_key(
+            invocation_id,
+            event_ty as u8,
+            event.append_time.as_u64(),
+            lsn,
+        ),
+        &EventWrapper(PbEvent {
+            content: event_value,
+            after_journal_entry_index: event.after_journal_entry_index,
+        }),
+    )
 }
 
 fn get_journal_events<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
-    events_length: u32,
-) -> Result<Vec<Result<(EntryIndex, StoredEvent)>>> {
-    if events_length == 0 {
-        return Ok(vec![]);
-    }
-
+) -> Result<Vec<Result<EventView>>> {
     let _x = RocksDbPerfGuard::new("get-journal-events");
     let key = JournalEventKey::default()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
 
-    let mut n = 0;
     storage.for_each_key_value_in_place(
         TableScan::SinglePartitionKeyPrefix(invocation_id.partition_key(), key),
         move |mut k, mut v| {
-            let key = JournalEventKey::deserialize_from(&mut k).map(|journal_key| {
-                journal_key
-                    .event_index
-                    .expect("The event index must be part of the journal key.")
-            });
-            let event =
-                StoredEvent::decode(&mut v).map_err(|error| StorageError::Generic(error.into()));
-
-            let result = key.and_then(|key| event.map(|entry| (key, entry)));
-
-            n += 1;
-            if n < events_length {
-                TableScanIterationDecision::Emit(result)
-            } else {
-                TableScanIterationDecision::BreakWith(result)
-            }
+            TableScanIterationDecision::Emit(
+                JournalEventKey::deserialize_from(&mut k)
+                    .and_then(|k| k.into_inner_ok_or())
+                    .and_then(|k_elements| {
+                        EventWrapper::decode(&mut v).map(|value| (k_elements, value.0))
+                    })
+                    .map(
+                        |(
+                            (_, _, event_type, timestamp, _),
+                            PbEvent {
+                                content,
+                                after_journal_entry_index,
+                            },
+                        )| EventView {
+                            event: RawEvent::new(
+                                EventType::from_repr(event_type).unwrap_or(EventType::Unknown),
+                                content,
+                            ),
+                            after_journal_entry_index,
+                            append_time: MillisSinceEpoch::new(timestamp),
+                        },
+                    ),
+            )
         },
     )
 }
@@ -105,46 +137,38 @@ fn get_journal_events<S: StorageAccess>(
 fn delete_journal_events<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
-    events_length: u32,
 ) -> Result<()> {
     let _x = RocksDbPerfGuard::new("delete-journal-events");
 
-    let mut key = write_journal_event_key(invocation_id, 0);
-    let k = &mut key;
-    for event_index in 0..events_length {
-        k.event_index = Some(event_index);
-        storage.delete_key(k)?;
+    let prefix_key = JournalEventKey::default()
+        .partition_key(invocation_id.partition_key())
+        .invocation_uuid(invocation_id.invocation_uuid());
+
+    let keys = storage.for_each_key_value_in_place(
+        TableScan::SinglePartitionKeyPrefix(invocation_id.partition_key(), prefix_key),
+        |k, _| TableScanIterationDecision::Emit(Ok(Bytes::copy_from_slice(k))),
+    )?;
+
+    for k in keys {
+        let key = k?;
+        storage.delete_cf(State, &key)?;
     }
 
     Ok(())
 }
 
 impl ReadOnlyJournalEventsTable for PartitionStore {
-    async fn get_journal_event(
-        &mut self,
-        invocation_id: InvocationId,
-        index: u32,
-    ) -> Result<Option<StoredEvent>> {
-        self.assert_partition_key(&invocation_id)?;
-        get_journal_event(self, &invocation_id, index)
-    }
-
     fn get_journal_events(
         &mut self,
         invocation_id: InvocationId,
-        length: u32,
-    ) -> Result<impl Stream<Item = Result<(EntryIndex, StoredEvent)>> + Send> {
-        Ok(stream::iter(get_journal_events(
-            self,
-            &invocation_id,
-            length,
-        )?))
+    ) -> Result<impl Stream<Item = Result<EventView>> + Send> {
+        Ok(stream::iter(get_journal_events(self, &invocation_id)?))
     }
 }
 
 impl ScanJournalEventsTable for PartitionStore {
     fn for_each_journal_event<
-        F: FnMut((JournalEventId, StoredEvent)) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+        F: FnMut((InvocationId, EventView)) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
         range: RangeInclusive<PartitionKey>,
@@ -155,18 +179,23 @@ impl ScanJournalEventsTable for PartitionStore {
             Priority::Low,
             TableScan::FullScanPartitionKeyRange::<JournalEventKey>(range),
             move |(mut key, mut value)| {
-                let journal_event_key = break_on_err(JournalEventKey::deserialize_from(&mut key))?;
-                let journal_event = break_on_err(StoredEvent::decode(&mut value))?;
+                let event_key = break_on_err(JournalEventKey::deserialize_from(&mut key))?;
+                let (pk, inv_uuid, event_type, timestamp, _) =
+                    break_on_err(event_key.into_inner_ok_or())?;
+                let stored_event = break_on_err(EventWrapper::decode(&mut value))?.0;
 
-                let (partition_key, invocation_uuid, event_index) =
-                    break_on_err(journal_event_key.into_inner_ok_or())?;
-
-                let journal_event_id = JournalEventId::from_parts(
-                    InvocationId::from_parts(partition_key, invocation_uuid),
-                    event_index,
-                );
-
-                f((journal_event_id, journal_event)).map_break(Ok)
+                f((
+                    InvocationId::from_parts(pk, inv_uuid),
+                    EventView {
+                        event: RawEvent::new(
+                            EventType::from_repr(event_type).unwrap_or(EventType::Unknown),
+                            stored_event.content,
+                        ),
+                        after_journal_entry_index: stored_event.after_journal_entry_index,
+                        append_time: MillisSinceEpoch::new(timestamp),
+                    },
+                ))
+                .map_break(Ok)
             },
         )
         .map_err(|_| StorageError::OperationalError)
@@ -174,25 +203,11 @@ impl ScanJournalEventsTable for PartitionStore {
 }
 
 impl ReadOnlyJournalEventsTable for PartitionStoreTransaction<'_> {
-    async fn get_journal_event(
-        &mut self,
-        invocation_id: InvocationId,
-        index: u32,
-    ) -> Result<Option<StoredEvent>> {
-        self.assert_partition_key(&invocation_id)?;
-        get_journal_event(self, &invocation_id, index)
-    }
-
     fn get_journal_events(
         &mut self,
         invocation_id: InvocationId,
-        length: u32,
-    ) -> Result<impl Stream<Item = Result<(EntryIndex, StoredEvent)>> + Send> {
-        Ok(stream::iter(get_journal_events(
-            self,
-            &invocation_id,
-            length,
-        )?))
+    ) -> Result<impl Stream<Item = Result<EventView>> + Send> {
+        Ok(stream::iter(get_journal_events(self, &invocation_id)?))
     }
 }
 
@@ -200,19 +215,15 @@ impl JournalEventsTable for PartitionStoreTransaction<'_> {
     async fn put_journal_event(
         &mut self,
         invocation_id: InvocationId,
-        event_index: u32,
-        entry: &StoredEvent,
+        event: EventView,
+        lsn: u64,
     ) -> Result<()> {
         self.assert_partition_key(&invocation_id)?;
-        put_journal_event(self, &invocation_id, event_index, entry)
+        put_journal_event(self, &invocation_id, event, lsn)
     }
 
-    async fn delete_journal_events(
-        &mut self,
-        invocation_id: InvocationId,
-        length: u32,
-    ) -> Result<()> {
+    async fn delete_journal_events(&mut self, invocation_id: InvocationId) -> Result<()> {
         self.assert_partition_key(&invocation_id)?;
-        delete_journal_events(self, &invocation_id, length)
+        delete_journal_events(self, &invocation_id)
     }
 }

--- a/crates/partition-store/src/keys.rs
+++ b/crates/partition-store/src/keys.rs
@@ -419,6 +419,21 @@ impl KeyCodec for u32 {
     }
 }
 
+impl KeyCodec for u8 {
+    fn encode<B: BufMut>(&self, target: &mut B) {
+        // store u8 in big-endian order to support byte-wise increment operation. See `crate::scan::try_increment`.
+        target.put_u8(*self);
+    }
+
+    fn decode<B: Buf>(source: &mut B) -> crate::Result<Self> {
+        Ok(source.get_u8())
+    }
+
+    fn serialized_length(&self) -> usize {
+        1
+    }
+}
+
 ///
 /// Blanket implementation for Option.
 ///

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -180,8 +180,6 @@ message InvocationStatusV2 {
   uint32 current_invocation_epoch = 27;
   // Used to reconstruct the completion_range_epoch_map
   repeated JournalTrimPoint trim_points = 28;
-  // The number of events stored for this invocation
-  uint32 events = 31;
 
   // Suspended
   repeated uint32 waiting_for_completions = 17;
@@ -614,18 +612,8 @@ message ResponseResult {
 }
 
 message Event {
-  enum EventType {
-    UNKNOWN_EVENT = 0;
-    TRANSIENT_ERROR = 1;
-    PAUSED = 2;
-  }
-
-  // Additional metadata for EVENT
-  EventType event_type = 1;
-  optional bytes event_deduplication_hash = 2;
-  bytes content = 3;
-  uint64 append_time = 4;
-  uint32 after_journal_entry_index = 5;
+  bytes content = 1;
+  uint32 after_journal_entry_index = 2;
 }
 
 // ---------------------------------------------------------------------

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -389,28 +389,20 @@ pub struct JournalMetadata {
     pub length: u32,
     /// Number of commands stored in the current journal
     pub commands: u32,
-    /// Number of events stored
-    pub events: u32,
     pub span_context: ServiceInvocationSpanContext,
 }
 
 impl JournalMetadata {
-    pub fn new(
-        length: u32,
-        commands: u32,
-        events: u32,
-        span_context: ServiceInvocationSpanContext,
-    ) -> Self {
+    pub fn new(length: u32, commands: u32, span_context: ServiceInvocationSpanContext) -> Self {
         Self {
             span_context,
             length,
             commands,
-            events,
         }
     }
 
     pub fn initialize(span_context: ServiceInvocationSpanContext) -> Self {
-        Self::new(0, 0, 0, span_context)
+        Self::new(0, 0, span_context)
     }
 
     pub fn empty() -> Self {

--- a/crates/storage-api/src/journal_events/mod.rs
+++ b/crates/storage-api/src/journal_events/mod.rs
@@ -8,33 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use futures::Stream;
 use std::ops::RangeInclusive;
 
-use futures::Stream;
-
 use crate::Result;
-use crate::protobuf_types::PartitionStoreProtobufValue;
-use restate_types::identifiers::{EntryIndex, InvocationId, JournalEventId, PartitionKey};
+use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey};
 use restate_types::journal_events::raw::RawEvent;
 use restate_types::time::MillisSinceEpoch;
 
 pub trait ReadOnlyJournalEventsTable {
-    fn get_journal_event(
-        &mut self,
-        invocation_id: InvocationId,
-        index: u32,
-    ) -> impl Future<Output = Result<Option<StoredEvent>>> + Send;
-
     fn get_journal_events(
         &mut self,
         invocation_id: InvocationId,
-        length: EntryIndex,
-    ) -> Result<impl Stream<Item = Result<(EntryIndex, StoredEvent)>> + Send>;
+    ) -> Result<impl Stream<Item = Result<EventView>> + Send>;
 }
 
 pub trait ScanJournalEventsTable {
     fn for_each_journal_event<
-        F: FnMut((JournalEventId, StoredEvent)) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
+        F: FnMut((InvocationId, EventView)) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
         range: RangeInclusive<PartitionKey>,
@@ -46,27 +37,26 @@ pub trait JournalEventsTable: ReadOnlyJournalEventsTable {
     fn put_journal_event(
         &mut self,
         invocation_id: InvocationId,
-        event_index: u32,
-        entry: &StoredEvent,
+        event: EventView,
+        lsn: u64,
     ) -> impl Future<Output = Result<()>> + Send;
 
     fn delete_journal_events(
         &mut self,
         invocation_id: InvocationId,
-        length: EntryIndex,
     ) -> impl Future<Output = Result<()>> + Send;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StoredEvent {
-    pub append_time: MillisSinceEpoch,
+pub struct EventView {
+    pub event: RawEvent,
     /// This field is added by the partition processor
     /// to establish the total order between journal entries and events.
     pub after_journal_entry_index: EntryIndex,
-    pub event: RawEvent,
+    pub append_time: MillisSinceEpoch,
 }
 
-impl StoredEvent {
+impl EventView {
     pub fn new(
         append_time: MillisSinceEpoch,
         after_journal_entry_index: EntryIndex,
@@ -78,8 +68,4 @@ impl StoredEvent {
             event: event.into(),
         }
     }
-}
-
-impl PartitionStoreProtobufValue for StoredEvent {
-    type ProtobufType = crate::protobuf_types::v1::Event;
 }

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -53,7 +53,7 @@ impl<T: prost::Message + 'static> StorageEncode for ProtobufStorageWrapper<T> {
 }
 
 impl<T: prost::Message + Default> StorageDecode for ProtobufStorageWrapper<T> {
-    fn decode<B: bytes::Buf>(
+    fn decode<B: Buf>(
         buf: &mut B,
         kind: restate_types::storage::StorageCodecKind,
     ) -> Result<Self, StorageDecodeError>
@@ -140,7 +140,7 @@ pub mod v1 {
         use restate_types::logs::Lsn;
         use restate_types::service_protocol::ServiceProtocolVersion;
         use restate_types::time::MillisSinceEpoch;
-        use restate_types::{GenerationalNodeId, journal_events, journal_v2};
+        use restate_types::{GenerationalNodeId, journal_v2};
 
         use super::dedup_sequence_number::Variant;
         use super::enriched_entry_header::{
@@ -172,7 +172,6 @@ pub mod v1 {
             outbox_message, promise, response_result, source, span_relation,
             submit_notification_sink, timer, virtual_object_status,
         };
-        use super::{Event, event};
         use crate::invocation_status_table::{CompletionRangeEpochMap, JournalMetadata};
         use crate::protobuf_types::ConversionError;
 
@@ -420,7 +419,6 @@ pub mod v1 {
                     inbox_sequence_number,
                     journal_length,
                     commands,
-                    events,
                     deployment_id,
                     service_protocol_version,
                     current_invocation_epoch,
@@ -523,7 +521,6 @@ pub mod v1 {
                                 journal_metadata: crate::invocation_status_table::JournalMetadata {
                                     length: journal_length,
                                     commands,
-                                    events,
                                     span_context: expect_or_fail!(span_context)?.try_into()?,
                                 },
                                 pinned_deployment: derive_pinned_deployment(
@@ -560,7 +557,6 @@ pub mod v1 {
                                 journal_metadata: crate::invocation_status_table::JournalMetadata {
                                     length: journal_length,
                                     commands,
-                                    events,
                                     span_context: expect_or_fail!(span_context)?.try_into()?,
                                 },
                                 pinned_deployment: derive_pinned_deployment(
@@ -613,7 +609,6 @@ pub mod v1 {
                                 journal_metadata: crate::invocation_status_table::JournalMetadata {
                                     length: journal_length,
                                     commands,
-                                    events,
                                     span_context: expect_or_fail!(span_context)?.try_into()?,
                                 },
                                 pinned_deployment: derive_pinned_deployment(
@@ -659,7 +654,6 @@ pub mod v1 {
                                 journal_metadata: crate::invocation_status_table::JournalMetadata {
                                     length: journal_length,
                                     commands,
-                                    events,
                                     span_context: expect_or_fail!(span_context)?.try_into()?,
                                 },
                                 pinned_deployment: derive_pinned_deployment(
@@ -730,7 +724,6 @@ pub mod v1 {
                         inbox_sequence_number: None,
                         journal_length: 0,
                         commands: 0,
-                        events: 0,
                         deployment_id: None,
                         service_protocol_version: None,
                         hotfix_apply_cancellation_after_deployment_is_pinned: false,
@@ -793,7 +786,6 @@ pub mod v1 {
                         inbox_sequence_number: Some(inbox_sequence_number),
                         journal_length: 0,
                         commands: 0,
-                        events: 0,
                         deployment_id: None,
                         service_protocol_version: None,
                         hotfix_apply_cancellation_after_deployment_is_pinned: false,
@@ -866,7 +858,6 @@ pub mod v1 {
                             inbox_sequence_number: None,
                             journal_length: journal_metadata.length,
                             commands: journal_metadata.commands,
-                            events: journal_metadata.events,
                             deployment_id,
                             service_protocol_version,
                             waiting_for_completions: vec![],
@@ -965,7 +956,6 @@ pub mod v1 {
                             inbox_sequence_number: None,
                             journal_length: journal_metadata.length,
                             commands: journal_metadata.commands,
-                            events: journal_metadata.events,
                             deployment_id,
                             service_protocol_version,
                             waiting_for_completions,
@@ -1045,7 +1035,6 @@ pub mod v1 {
                             inbox_sequence_number: None,
                             journal_length: journal_metadata.length,
                             commands: journal_metadata.commands,
-                            events: journal_metadata.events,
                             deployment_id,
                             service_protocol_version,
                             waiting_for_completions: vec![],
@@ -1119,7 +1108,6 @@ pub mod v1 {
                             inbox_sequence_number: None,
                             journal_length: journal_metadata.length,
                             commands: journal_metadata.commands,
-                            events: journal_metadata.events,
                             deployment_id,
                             service_protocol_version,
                             hotfix_apply_cancellation_after_deployment_is_pinned: false,
@@ -1771,7 +1759,6 @@ pub mod v1 {
                 Ok(crate::invocation_status_table::JournalMetadata {
                     length,
                     commands: 0,
-                    events: 0,
                     span_context,
                 })
             }
@@ -3590,74 +3577,6 @@ pub mod v1 {
                     append_time,
                     call_or_send_command_metadata,
                     notification_id,
-                }
-            }
-        }
-
-        impl From<journal_events::EventType> for event::EventType {
-            fn from(value: journal_events::EventType) -> Self {
-                match value {
-                    journal_events::EventType::TransientError => Self::TransientError,
-                    journal_events::EventType::Paused => Self::Paused,
-                    journal_events::EventType::Unknown => Self::UnknownEvent,
-                }
-            }
-        }
-
-        impl From<event::EventType> for journal_events::EventType {
-            fn from(value: event::EventType) -> Self {
-                match value {
-                    event::EventType::TransientError => Self::TransientError,
-                    event::EventType::Paused => Self::Paused,
-                    event::EventType::UnknownEvent => Self::Unknown,
-                }
-            }
-        }
-
-        impl TryFrom<Event> for crate::journal_events::StoredEvent {
-            type Error = ConversionError;
-
-            fn try_from(value: Event) -> Result<Self, Self::Error> {
-                let Event {
-                    event_type,
-                    event_deduplication_hash,
-                    content,
-                    append_time,
-                    after_journal_entry_index,
-                } = value;
-
-                let event_type = journal_events::EventType::from(
-                    event::EventType::try_from(event_type).unwrap_or_default(),
-                );
-
-                let mut event = journal_events::raw::RawEvent::new(event_type, content);
-                if let Some(deduplication_hash) = event_deduplication_hash {
-                    event.set_deduplication_hash(deduplication_hash);
-                }
-
-                Ok(Self {
-                    after_journal_entry_index,
-                    append_time: MillisSinceEpoch::from(append_time),
-                    event,
-                })
-            }
-        }
-
-        impl From<crate::journal_events::StoredEvent> for Event {
-            fn from(
-                crate::journal_events::StoredEvent {
-                    after_journal_entry_index,
-                    append_time,
-                    event,
-                }: crate::journal_events::StoredEvent,
-            ) -> Self {
-                let (ty, deduplication_hash, value) = event.into_inner();
-                Self {
-                    event_type: event::EventType::from(ty).into(),
-                    event_deduplication_hash: deduplication_hash,
-                    content: value,
-                    append_time: append_time.into(),
-                    after_journal_entry_index,
                 }
             }
         }

--- a/crates/storage-query-datafusion/src/journal_events/row.rs
+++ b/crates/storage-query-datafusion/src/journal_events/row.rs
@@ -9,23 +9,22 @@
 // by the Apache License, Version 2.0.
 
 use crate::journal_events::schema::SysJournalEventsBuilder;
-use restate_storage_api::journal_events::StoredEvent;
-use restate_types::identifiers::{JournalEventId, WithInvocationId, WithPartitionKey};
+use restate_storage_api::journal_events::EventView;
+use restate_types::identifiers::{InvocationId, WithPartitionKey};
 
 #[inline]
 pub(crate) fn append_journal_event_row(
     builder: &mut SysJournalEventsBuilder,
-    journal_event_id: JournalEventId,
-    journal_event: StoredEvent,
+    invocation_id: InvocationId,
+    journal_event: EventView,
 ) {
     let mut row = builder.row();
 
-    row.partition_key(journal_event_id.partition_key());
+    row.partition_key(invocation_id.partition_key());
     if row.is_id_defined() {
-        row.fmt_id(journal_event_id.invocation_id());
+        row.fmt_id(invocation_id);
     }
 
-    row.index(journal_event_id.event_index());
     row.appended_at(journal_event.append_time.as_u64() as i64);
     row.after_journal_entry_index(journal_event.after_journal_entry_index);
     row.fmt_event_type(journal_event.event.ty());

--- a/crates/storage-query-datafusion/src/journal_events/schema.rs
+++ b/crates/storage-query-datafusion/src/journal_events/schema.rs
@@ -21,9 +21,6 @@ define_table!(sys_journal_events (
     /// [Invocation ID](/operate/invocation#invocation-identifier).
     id: DataType::LargeUtf8,
 
-    /// The index of this journal event.
-    index: DataType::UInt32,
-
     /// The journal index after which this event happened. This can be used to establish a total order between events and journal entries.
     after_journal_entry_index: DataType::UInt32,
 

--- a/crates/storage-query-datafusion/src/journal_events/table.rs
+++ b/crates/storage-query-datafusion/src/journal_events/table.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_storage_api::journal_events::{ScanJournalEventsTable, StoredEvent};
-use restate_types::identifiers::{JournalEventId, PartitionKey};
+use restate_storage_api::journal_events::{EventView, ScanJournalEventsTable};
+use restate_types::identifiers::{InvocationId, PartitionKey};
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::journal_events::row::append_journal_event_row;
@@ -54,7 +54,7 @@ struct JournalEventsScanner;
 
 impl ScanLocalPartition for JournalEventsScanner {
     type Builder = SysJournalEventsBuilder;
-    type Item<'a> = (JournalEventId, StoredEvent);
+    type Item<'a> = (InvocationId, EventView);
     type ConversionError = std::convert::Infallible;
 
     fn for_each_row<

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -719,37 +719,6 @@ impl WithInvocationId for JournalEntryId {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
-pub struct JournalEventId {
-    invocation_id: InvocationId,
-    event_index: EntryIndex,
-}
-
-impl JournalEventId {
-    pub const fn from_parts(invocation_id: InvocationId, event_index: EntryIndex) -> Self {
-        Self {
-            invocation_id,
-            event_index,
-        }
-    }
-
-    pub fn event_index(&self) -> EntryIndex {
-        self.event_index
-    }
-}
-
-impl From<(InvocationId, EntryIndex)> for JournalEventId {
-    fn from(value: (InvocationId, EntryIndex)) -> Self {
-        Self::from_parts(value.0, value.1)
-    }
-}
-
-impl WithInvocationId for JournalEventId {
-    fn invocation_id(&self) -> InvocationId {
-        self.invocation_id
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, serde_with::SerializeDisplay, serde_with::DeserializeFromStr)]
 pub struct LambdaARN {
     arn: Arc<str>,

--- a/crates/types/src/journal_events/mod.rs
+++ b/crates/types/src/journal_events/mod.rs
@@ -12,18 +12,28 @@
 
 use crate::errors::InvocationErrorCode;
 use crate::journal_v2::CommandType;
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use strum::EnumString;
 
 pub mod raw;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, strum::Display, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    EnumString,
+    strum::Display,
+    Serialize,
+    Deserialize,
+    strum::FromRepr,
+)]
+#[repr(u8)]
 pub enum EventType {
-    TransientError,
-    Paused,
-    Unknown,
+    Unknown = 0,
+    TransientError = 1,
+    Paused = 2,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, derive_more::From)]
@@ -51,48 +61,6 @@ pub struct TransientErrorEvent {
     pub related_command_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub related_command_type: Option<CommandType>,
-}
-
-impl TransientErrorEvent {
-    pub fn deduplication_hash(&self) -> Bytes {
-        const HASH_SEPARATOR: u8 = 0x2c;
-
-        // WARNING: Changing this code will result in having duplicated events between restate versions.
-        let mut hasher = Sha256::new();
-        hasher.update(b"tee");
-        hasher.update([HASH_SEPARATOR]);
-        hasher.update(u16::from(self.error_code).to_le_bytes());
-        hasher.update([HASH_SEPARATOR]);
-        hasher.update(&self.error_message);
-        hasher.update([HASH_SEPARATOR]);
-        if let Some(error_code) = &self.restate_doc_error_code {
-            hasher.update(error_code);
-        } else {
-            hasher.update(b"-");
-        }
-        hasher.update([HASH_SEPARATOR]);
-        if let Some(command_index) = &self.related_command_index {
-            hasher.update(command_index.to_le_bytes());
-        } else {
-            hasher.update(b"-");
-        }
-        hasher.update([HASH_SEPARATOR]);
-        if let Some(command_name) = &self.related_command_name {
-            hasher.update(command_name);
-        } else {
-            hasher.update(b"-");
-        }
-        hasher.update([HASH_SEPARATOR]);
-        if let Some(command_type) = &self.related_command_type {
-            let str: &'static str = command_type.into();
-            hasher.update(str);
-        } else {
-            hasher.update(b"-");
-        }
-        let result = hasher.finalize();
-
-        result.to_vec().into()
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/types/src/journal_events/raw.rs
+++ b/crates/types/src/journal_events/raw.rs
@@ -17,45 +17,27 @@ use prost::Message;
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RawEvent {
     ty: EventType,
-    deduplication_hash: Option<Bytes>,
     value: Bytes,
 }
 
 impl RawEvent {
     pub fn new(ty: EventType, value: Bytes) -> Self {
-        RawEvent {
-            ty,
-            deduplication_hash: None,
-            value,
-        }
+        RawEvent { ty, value }
     }
 
     pub fn unknown() -> Self {
         RawEvent {
             ty: EventType::Unknown,
-            deduplication_hash: None,
             value: Bytes::default(),
         }
-    }
-
-    /// See [self.set_deduplication_hash].
-    pub fn deduplication_hash(&self) -> Option<&Bytes> {
-        self.deduplication_hash.as_ref()
-    }
-
-    /// When setting the deduplication hash, the Partition processor will try to deduplicate this event with the last event in the journal (if present) by matching the deduplication_hash.
-    ///
-    /// When unset, no deduplication will happen and the event is stored as is.
-    pub fn set_deduplication_hash(&mut self, hash: impl Into<Bytes>) {
-        self.deduplication_hash = Some(hash.into());
     }
 
     pub fn ty(&self) -> EventType {
         self.ty
     }
 
-    pub fn into_inner(self) -> (EventType, Option<Bytes>, Bytes) {
-        (self.ty, self.deduplication_hash, self.value)
+    pub fn into_inner(self) -> (EventType, Bytes) {
+        (self.ty, self.value)
     }
 
     pub fn into_event_or_unknown(self) -> Event {

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -291,7 +291,6 @@ mod tests {
                     journal_metadata: JournalMetadata {
                         length: 2,
                         commands: 2,
-                        events: 0,
                         span_context: Default::default(),
                     },
                     ..CompletedInvocation::mock_neo()

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -667,6 +667,7 @@ where
 
             // todo: redesign to pass the arc (or reference) further down
             let record_created_at = record.created_at;
+            let record_lsn = record.lsn;
             let envelope = Arc::unwrap_or_clone(record.envelope);
 
             if let Command::AnnounceLeader(announce_leader) = envelope.command {
@@ -699,6 +700,7 @@ where
                     .apply(
                         envelope.command,
                         record_created_at.into(),
+                        record_lsn,
                         transaction,
                         action_collector,
                         self.leadership_state.is_leader(),

--- a/crates/worker/src/partition/state_machine/lifecycle/event.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/event.rs
@@ -9,13 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, InvocationStatusTable, JournalMetadata,
-};
-use restate_storage_api::journal_events::{JournalEventsTable, StoredEvent};
+use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::journal_events::{EventView, JournalEventsTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::journal_events::raw::RawEvent;
-use tracing::trace;
 
 pub struct OnInvokerEventCommand {
     pub invocation_id: InvocationId,
@@ -52,61 +49,18 @@ impl<'ctx, 's: 'ctx, S: JournalEventsTable + InvocationStatusTable>
 
 pub(super) struct ApplyEventCommand<'e> {
     pub(super) invocation_id: InvocationId,
-    pub(super) invocation_status: &'e mut InvocationStatus,
+    pub(super) invocation_status: &'e InvocationStatus,
     pub(super) event: RawEvent,
 }
 
-impl ApplyEventCommand<'_> {
-    async fn should_store_event<'e, 's: 'e, S: JournalEventsTable>(
-        journal_metadata: &JournalMetadata,
-        invocation_id: InvocationId,
-        new_event: &RawEvent,
-        storage: &'s mut S,
-    ) -> Result<bool, Error> {
-        // --- Event deduplication logic
-        // Events get duplicated to avoid storing too many duplicate events.
-        if new_event.deduplication_hash().is_none() {
-            return Ok(true);
-        }
-        if journal_metadata.events == 0 {
-            return Ok(true);
-        }
-
-        let last_event_index = journal_metadata.events - 1;
-        let Some(last_event) = storage
-            .get_journal_event(invocation_id, last_event_index)
-            .await?
-        else {
-            return Ok(true);
-        };
-
-        Ok(!(last_event.event.ty() == new_event.ty()
-            && last_event.event.deduplication_hash() == new_event.deduplication_hash()))
-    }
-}
 impl<'e, 'ctx: 'e, 's: 'ctx, S: JournalEventsTable>
     CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>> for ApplyEventCommand<'e>
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
-        let Some(journal_metadata) = self.invocation_status.get_journal_metadata_mut() else {
+        let Some(journal_metadata) = self.invocation_status.get_journal_metadata() else {
             // No journal, no events
             return Ok(());
         };
-
-        if !Self::should_store_event(
-            journal_metadata,
-            self.invocation_id,
-            &self.event,
-            ctx.storage,
-        )
-        .await?
-        {
-            trace!(
-                "Deduplicating event {} because the last entry in the journal is an event, and its deduplication hash matches with the current event",
-                self.event.ty()
-            );
-            return Ok(());
-        }
 
         // To store the event, we need to give it a total order wrt journal.
         let after_journal_entry_index = journal_metadata.length.checked_sub(1).unwrap_or_default();
@@ -115,22 +69,14 @@ impl<'e, 'ctx: 'e, 's: 'ctx, S: JournalEventsTable>
         ctx.storage
             .put_journal_event(
                 self.invocation_id,
-                journal_metadata.events,
-                &StoredEvent {
+                EventView {
                     append_time: ctx.record_created_at,
                     after_journal_entry_index,
                     event: self.event,
                 },
+                ctx.record_lsn.as_u64(),
             )
             .await?;
-
-        // Update events length
-        journal_metadata.events += 1;
-
-        // Update timestamps
-        if let Some(timestamps) = self.invocation_status.get_timestamps_mut() {
-            timestamps.update(ctx.record_created_at);
-        }
 
         Ok(())
     }
@@ -138,18 +84,16 @@ impl<'e, 'ctx: 'e, 's: 'ctx, S: JournalEventsTable>
 
 #[cfg(test)]
 mod tests {
-    use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
+    use crate::partition::state_machine::tests::{TestEnv, fixtures};
     use crate::partition::types::InvokerEffectKind;
     use googletest::prelude::*;
     use restate_invoker_api::Effect;
-    use restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable;
-    use restate_storage_api::journal_events::ReadOnlyJournalEventsTable;
     use restate_types::journal_events::raw::RawEvent;
     use restate_types::journal_events::{Event, TransientErrorEvent};
     use restate_wal_protocol::Command;
 
     #[restate_core::test]
-    async fn store_event_then_get_deduplicated() {
+    async fn store_event() {
         let mut test_env = TestEnv::create().await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
         fixtures::mock_pinned_deployment_v5(&mut test_env, invocation_id).await;
@@ -164,91 +108,20 @@ mod tests {
             related_command_type: None,
         };
 
-        let deduplication_hash = transient_error_event.deduplication_hash();
-        let mut raw_event = RawEvent::from(Event::TransientError(transient_error_event.clone()));
-        raw_event.set_deduplication_hash(deduplication_hash);
-
         let _ = test_env
             .apply(Command::InvokerEffect(Box::new(Effect {
                 invocation_id,
                 invocation_epoch: 0,
                 kind: InvokerEffectKind::JournalEvent {
-                    event: raw_event.clone(),
-                },
-            })))
-            .await;
-
-        assert_eq!(
-            test_env.read_journal_event(invocation_id, 0).await,
-            Event::TransientError(transient_error_event.clone())
-        );
-
-        // --- Applying the same event the second time will result in deduplication
-
-        let _ = test_env
-            .apply(Command::InvokerEffect(Box::new(Effect {
-                invocation_id,
-                invocation_epoch: 0,
-                kind: InvokerEffectKind::JournalEvent { event: raw_event },
-            })))
-            .await;
-
-        assert_that!(
-            test_env.storage.get_invocation_status(&invocation_id).await,
-            ok(matchers::storage::has_events(1))
-        );
-        assert_eq!(
-            test_env.read_journal_event(invocation_id, 0).await,
-            Event::TransientError(transient_error_event.clone())
-        );
-        assert_that!(
-            test_env
-                .storage
-                .get_journal_event(invocation_id, 1)
-                .await
-                .unwrap(),
-            none()
-        );
-
-        // --- Applying a new event will result in a new entry
-
-        let another_transient_error_event = TransientErrorEvent {
-            error_code: 502u16.into(),
-            error_message: "my bad 2".to_string(),
-            error_stacktrace: Some("something something".to_string()),
-            restate_doc_error_code: Some("RT0001".to_string()),
-            related_command_index: None,
-            related_command_name: Some("my command 2".to_string()),
-            related_command_type: None,
-        };
-
-        let deduplication_hash = another_transient_error_event.deduplication_hash();
-        let mut another_raw_event =
-            RawEvent::from(Event::TransientError(another_transient_error_event.clone()));
-        another_raw_event.set_deduplication_hash(deduplication_hash);
-
-        let _ = test_env
-            .apply(Command::InvokerEffect(Box::new(Effect {
-                invocation_id,
-                invocation_epoch: 0,
-                kind: InvokerEffectKind::JournalEvent {
-                    event: another_raw_event,
+                    event: RawEvent::from(Event::TransientError(transient_error_event.clone()))
+                        .clone(),
                 },
             })))
             .await;
 
         assert_that!(
-            test_env.storage.get_invocation_status(&invocation_id).await,
-            ok(matchers::storage::has_events(2))
-        );
-        // Previous event didn't change
-        assert_eq!(
-            test_env.read_journal_event(invocation_id, 0).await,
-            Event::TransientError(transient_error_event)
-        );
-        assert_eq!(
-            test_env.read_journal_event(invocation_id, 1).await,
-            Event::TransientError(another_transient_error_event.clone())
+            test_env.read_journal_events(invocation_id).await,
+            elements_are![eq(Event::TransientError(transient_error_event.clone()))]
         );
 
         test_env.shutdown().await;

--- a/crates/worker/src/partition/state_machine/lifecycle/paused.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/paused.rs
@@ -123,9 +123,9 @@ mod tests {
                 ))
             )
         );
-        assert_eq!(
-            test_env.read_journal_event(invocation_id, 0).await,
-            paused_event
+        assert_that!(
+            test_env.read_journal_events(invocation_id).await,
+            elements_are![eq(paused_event)]
         );
 
         test_env.shutdown().await;

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -92,7 +92,6 @@ where
                     ctx.do_drop_journal(
                         invocation_id,
                         journal_metadata.length,
-                        journal_metadata.events,
                         should_remove_journal_table_v2,
                     )
                     .await?;

--- a/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
@@ -48,7 +48,6 @@ where
                     ctx.do_drop_journal(
                         invocation_id,
                         completed.journal_metadata.length,
-                        completed.journal_metadata.events,
                         should_remove_journal_table_v2,
                     )
                     .await?;

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -44,17 +44,6 @@ pub mod storage {
         )
     }
 
-    pub fn has_events(events: EntryIndex) -> impl Matcher<ActualT = InvocationStatus> {
-        predicate(move |is: &InvocationStatus| {
-            is.get_journal_metadata()
-                .is_some_and(|jm| jm.events == events)
-        })
-        .with_description(
-            format!("has journal events {events}"),
-            format!("hasn't journal events {events}"),
-        )
-    }
-
     pub fn has_commands(commands: EntryIndex) -> impl Matcher<ActualT = InvocationStatus> {
         predicate(move |is: &InvocationStatus| {
             is.get_journal_metadata()


### PR DESCRIPTION
Depends on #3676.

tl;dr

* The new key structure is `pk : inv uuid : ty : timestamp : lsn`.
* We don't deduplicate events anymore in PP, but we still read the invocation status to assign the total order index.
* The invoker still deduplicates, but just doing equality checks in memory. We don't deduplicate the first error event on leadership changes (this is fine from a DevEx POV) 