### PR TITLE
Update bilrost to 0.1014 & simplify enum encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autotools"
@@ -1082,7 +1082,18 @@ version = "0.1013.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640b021fedf44f44640771b2c3e5ec53ff0122d89b3fd1448e6880da0ace787b"
 dependencies = [
- "bilrost-derive",
+ "bilrost-derive 0.1013.0",
+ "bytes",
+ "bytestring",
+ "thin-vec",
+]
+
+[[package]]
+name = "bilrost"
+version = "0.1014.0-dev"
+dependencies = [
+ "autocfg",
+ "bilrost-derive 0.1014.0-dev",
  "bytes",
  "bytestring",
  "thin-vec",
@@ -1093,6 +1104,17 @@ name = "bilrost-derive"
 version = "0.1013.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9910598cd6a5c5ee053af712bbb3385e96b4eb4adc043b24a69b6c37004ba22"
+dependencies = [
+ "eyre",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "bilrost-derive"
+version = "0.1014.0-dev"
 dependencies = [
  "eyre",
  "itertools 0.14.0",
@@ -6823,7 +6845,7 @@ dependencies = [
 name = "restate-encoding"
 version = "1.5.0-dev"
 dependencies = [
- "bilrost",
+ "bilrost 0.1014.0-dev",
  "bytes",
  "bytestring",
  "rand 0.9.1",
@@ -7107,7 +7129,7 @@ version = "1.5.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
- "bilrost",
+ "bilrost 0.1014.0-dev",
  "bytes",
  "bytestring",
  "ciborium",
@@ -7697,7 +7719,7 @@ dependencies = [
  "arc-swap",
  "base62",
  "base64 0.22.1",
- "bilrost",
+ "bilrost 0.1014.0-dev",
  "bincode",
  "bitflags 2.9.1",
  "bytes",
@@ -7796,7 +7818,7 @@ name = "restate-wal-protocol"
 version = "1.5.0-dev"
 dependencies = [
  "anyhow",
- "bilrost",
+ "bilrost 0.1014.0-dev",
  "bytes",
  "bytestring",
  "enum-map",
@@ -7908,7 +7930,7 @@ dependencies = [
  "axum",
  "axum-core",
  "base64 0.22.1",
- "bilrost",
+ "bilrost 0.1013.0",
  "bitflags 2.9.1",
  "byteorder",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,22 +1078,12 @@ dependencies = [
 
 [[package]]
 name = "bilrost"
-version = "0.1013.0"
+version = "0.1014.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640b021fedf44f44640771b2c3e5ec53ff0122d89b3fd1448e6880da0ace787b"
-dependencies = [
- "bilrost-derive 0.1013.0",
- "bytes",
- "bytestring",
- "thin-vec",
-]
-
-[[package]]
-name = "bilrost"
-version = "0.1014.0-dev"
+checksum = "b1ec781b82aaa1ead5e8c6ab1cf7b3485f8909e76521f87eb3091a8db5bc00df"
 dependencies = [
  "autocfg",
- "bilrost-derive 0.1014.0-dev",
+ "bilrost-derive",
  "bytes",
  "bytestring",
  "thin-vec",
@@ -1101,20 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "bilrost-derive"
-version = "0.1013.0"
+version = "0.1014.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9910598cd6a5c5ee053af712bbb3385e96b4eb4adc043b24a69b6c37004ba22"
-dependencies = [
- "eyre",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "bilrost-derive"
-version = "0.1014.0-dev"
+checksum = "7f96db92d1373235cede86875c0589f1e053eb36f8e26f2fc131690bf7d03de6"
 dependencies = [
  "eyre",
  "itertools 0.14.0",
@@ -4413,7 +4392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6845,7 +6824,7 @@ dependencies = [
 name = "restate-encoding"
 version = "1.5.0-dev"
 dependencies = [
- "bilrost 0.1014.0-dev",
+ "bilrost",
  "bytes",
  "bytestring",
  "rand 0.9.1",
@@ -7129,7 +7108,7 @@ version = "1.5.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
- "bilrost 0.1014.0-dev",
+ "bilrost",
  "bytes",
  "bytestring",
  "ciborium",
@@ -7719,7 +7698,7 @@ dependencies = [
  "arc-swap",
  "base62",
  "base64 0.22.1",
- "bilrost 0.1014.0-dev",
+ "bilrost",
  "bincode",
  "bitflags 2.9.1",
  "bytes",
@@ -7818,7 +7797,7 @@ name = "restate-wal-protocol"
 version = "1.5.0-dev"
 dependencies = [
  "anyhow",
- "bilrost 0.1014.0-dev",
+ "bilrost",
  "bytes",
  "bytestring",
  "enum-map",
@@ -7930,7 +7909,7 @@ dependencies = [
  "axum",
  "axum-core",
  "base64 0.22.1",
- "bilrost 0.1013.0",
+ "bilrost",
  "bitflags 2.9.1",
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ aws-smithy-async = { version = "1.2.5", default-features = false }
 aws-smithy-runtime-api = "1.7.4"
 aws-smithy-types = "1.3.0"
 base64 = "0.22"
-bilrost = { version = "0.1013" }
+bilrost = { version = "0.1014.0-dev", path = "../bilrost" }
 bincode = { version = "2.0.1", default-features = false }
 bitflags = { version = "2.6.0" }
 bytes = { version = "1.7", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ aws-smithy-async = { version = "1.2.5", default-features = false }
 aws-smithy-runtime-api = "1.7.4"
 aws-smithy-types = "1.3.0"
 base64 = "0.22"
-bilrost = { version = "0.1014.0-dev", path = "../bilrost" }
+bilrost = { version = "0.1014" }
 bincode = { version = "2.0.1", default-features = false }
 bitflags = { version = "2.6.0" }
 bytes = { version = "1.7", features = ["serde"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -33,7 +33,7 @@ aws-smithy-types = { version = "1", default-features = false, features = ["byte-
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
 base64 = { version = "0.22" }
-bilrost = { version = "0.1013", features = ["bytestring"] }
+bilrost = { version = "0.1014", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 bytestring = { version = "1", default-features = false, features = ["serde"] }
@@ -159,7 +159,7 @@ aws-smithy-types = { version = "1", default-features = false, features = ["byte-
 axum = { version = "0.7", features = ["http2"] }
 axum-core = { version = "0.4", default-features = false, features = ["tracing"] }
 base64 = { version = "0.22" }
-bilrost = { version = "0.1013", features = ["bytestring"] }
+bilrost = { version = "0.1014", features = ["bytestring"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 bytestring = { version = "1", default-features = false, features = ["serde"] }


### PR DESCRIPTION
bilrost 0.1014 is released with the ability to derive `Oneof` for enums with message variants, having any number of fields. this allows removing at least a couple "dto" types for `BilrostAs` encoding.

this release also comes with built-in support for `Range<T>` and `RangeInclusive<T>`, simplifying at least one more without the need for custom encodings. A third type, `MaybeRecord`, was using a "dto" type only to wrap itself as an encodable message; this is already available for `bilrost::Oneof` by simply also deriving `bilrost::Message` for the same type.