### PR TITLE
Extension trait for `Duration` for friendly display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,6 +6511,7 @@ dependencies = [
  "restate-service-protocol",
  "restate-storage-query-datafusion",
  "restate-test-util",
+ "restate-time-util",
  "restate-types",
  "restate-wal-protocol",
  "restate-web-ui",
@@ -6676,6 +6677,7 @@ dependencies = [
  "restate-cli-util",
  "restate-cloud-tunnel-client",
  "restate-serde-util",
+ "restate-time-util",
  "restate-types",
  "restate-workspace-hack",
  "rustls",
@@ -6908,6 +6910,7 @@ dependencies = [
  "restate-errors",
  "restate-serde-util",
  "restate-test-util",
+ "restate-time-util",
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-workspace-hack",
@@ -7394,8 +7397,8 @@ dependencies = [
  "bytesize",
  "http 1.3.1",
  "http-serde",
- "jiff",
  "prost",
+ "restate-time-util",
  "restate-workspace-hack",
  "schemars 0.8.22",
  "serde",
@@ -7625,6 +7628,15 @@ dependencies = [
  "prost-types",
  "rand 0.9.1",
  "restate-workspace-hack",
+]
+
+[[package]]
+name = "restate-time-util"
+version = "1.5.0-dev"
+dependencies = [
+ "jiff",
+ "restate-workspace-hack",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ restate-service-protocol-v4 = { path = "crates/service-protocol-v4" }
 restate-storage-api = { path = "crates/storage-api" }
 restate-storage-query-datafusion = { path = "crates/storage-query-datafusion" }
 restate-test-util = { path = "crates/test-util" }
+restate-time-util = { path = "crates/time-util" }
 restate-timer = { path = "crates/timer" }
 restate-timer-queue = { path = "crates/timer-queue" }
 restate-tracing-instrumentation = { path = "crates/tracing-instrumentation" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ restate-admin-rest-model = { workspace = true }
 restate-cli-util = { workspace = true }
 restate-cloud-tunnel-client = { workspace = true }
 restate-serde-util = { workspace = true }
+restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 
 anyhow = { workspace = true }

--- a/cli/src/commands/services/config/edit.rs
+++ b/cli/src/commands/services/config/edit.rs
@@ -54,12 +54,8 @@ async fn edit(env: &CliEnv, opts: &Edit) -> Result<()> {
     )
     .context("Cannot parse the edited config file")?;
 
-    super::patch::apply_service_configuration_patch(
-        opts.service.clone(),
-        admin_client,
-        modify_request,
-    )
-    .await
+    super::patch::apply_service_configuration_patch(&opts.service, admin_client, modify_request)
+        .await
 }
 
 // TODO generate this file from the JsonSchema

--- a/cli/src/commands/services/config/view.rs
+++ b/cli/src/commands/services/config/view.rs
@@ -8,16 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cli_env::CliEnv;
-use crate::clients::{AdminClient, AdminClientInterface};
 use anyhow::Result;
 use cling::prelude::*;
 use comfy_table::Table;
 use indoc::indoc;
+
 use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::{c_println, c_tip};
-use restate_serde_util::DurationString;
+use restate_time_util::DurationExt;
 use restate_types::invocation::ServiceType;
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
 
 // TODO we could infer this text from the OpenAPI docs!
 pub(super) const PUBLIC_DESCRIPTION: &str = indoc! {
@@ -94,7 +96,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
     let mut table = Table::new_styled();
     table.add_kv_row(
         "Idempotent requests retention:",
-        DurationString::display(service.idempotency_retention),
+        service.idempotency_retention.friendly(),
     );
     c_println!("{table}");
     c_tip!("{}", IDEMPOTENCY_RETENTION);
@@ -104,11 +106,10 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
         let mut table = Table::new_styled();
         table.add_kv_row(
             "Workflow retention time:",
-            DurationString::display(
-                service
-                    .workflow_completion_retention
-                    .expect("Workflows must have a well defined retention"),
-            ),
+            service
+                .workflow_completion_retention
+                .expect("Workflows must have a well defined retention")
+                .friendly(),
         );
         c_println!("{table}");
         c_tip!("{}", WORKFLOW_RETENTION);
@@ -120,7 +121,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
         "Journal retention:",
         service
             .journal_retention
-            .map(DurationString::display)
+            .map(|d| d.friendly().to_string())
             .unwrap_or_else(|| "<UNSET>".to_string()),
     );
     c_println!("{table}");
@@ -128,19 +129,13 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
     c_println!();
 
     let mut table = Table::new_styled();
-    table.add_kv_row(
-        "Inactivity timeout:",
-        DurationString::display(service.inactivity_timeout),
-    );
+    table.add_kv_row("Inactivity timeout:", service.inactivity_timeout.friendly());
     c_println!("{table}");
     c_tip!("{}", INACTIVITY_TIMEOUT);
     c_println!();
 
     let mut table = Table::new_styled();
-    table.add_kv_row(
-        "Abort timeout:",
-        DurationString::display(service.abort_timeout),
-    );
+    table.add_kv_row("Abort timeout:", service.abort_timeout.friendly());
     c_println!("{table}");
     c_tip!("{}", ABORT_TIMEOUT);
     c_println!();

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -27,6 +27,7 @@ restate-serde-util = { workspace = true }
 restate-service-client = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }
+restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
 restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.4", tag = "v0.1.4" }

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -16,9 +16,9 @@ use restate_admin_rest_model::version::AdminApiVersion;
 use restate_bifrost::Bifrost;
 use restate_core::MetadataWriter;
 use restate_core::network::net_util;
-use restate_serde_util::DurationString;
 use restate_service_client::HttpClient;
 use restate_service_protocol::discovery::ServiceDiscovery;
+use restate_time_util::DurationExt;
 use restate_types::config::AdminOptions;
 use restate_types::invocation::client::InvocationClient;
 use restate_types::live::LiveLoad;
@@ -134,7 +134,7 @@ where
                             name: "access-log",
                             target: "restate_admin::api",
                             parent: span,
-                            { http.response.status_code = response.status().as_u16(), http.response.latency = DurationString::display(latency) },
+                            { http.response.status_code = response.status().as_u16(), http.response.latency = %latency.friendly().to_seconds_span() },
                             "Replied"
                         )
                     },
@@ -150,7 +150,7 @@ where
                                     name: "access-log",
                                     target: "restate_admin::api",
                                     parent: span,
-                                    { error.type = error_string, http.response.latency = DurationString::display(latency) },
+                                    { error.type = error_string, http.response.latency = %latency.friendly().to_seconds_span() },
                                     "Failed processing"
                                 )
                             }

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -18,6 +18,7 @@ restate-workspace-hack = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-serde-util = { workspace = true }
+restate-time-util = { workspace = true }
 restate-tracing-instrumentation = { workspace = true }
 restate-types = { workspace = true }
 

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -17,7 +17,7 @@ use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto;
 use restate_core::{TaskCenter, TaskKind, cancellation_watcher};
-use restate_serde_util::DurationString;
+use restate_time_util::DurationExt;
 use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
@@ -169,7 +169,7 @@ where
                                 name: "access-log",
                                 target: "restate_ingress_http::api",
                                 parent: span,
-                                { http.response.status_code = response.status().as_u16(), http.response.latency = DurationString::display(latency) },
+                                { http.response.status_code = response.status().as_u16(), http.response.latency = %latency.friendly().to_seconds_span() },
                                 "Replied"
                             )
                         },
@@ -185,7 +185,7 @@ where
                                         name: "access-log",
                                         target: "restate_ingress_http::api",
                                         parent: span,
-                                        { error.type = error_string, http.response.latency = DurationString::display(latency) },
+                                        { error.type = error_string, http.response.latency = %latency.friendly().to_seconds_span() },
                                         "Failed processing"
                                     )
                                 }

--- a/crates/serde-util/Cargo.toml
+++ b/crates/serde-util/Cargo.toml
@@ -14,6 +14,7 @@ proto = ["dep:prost", "dep:bytes"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
+restate-time-util = { workspace = true }
 
 bytes = { workspace = true, optional = true }
 bytesize = { workspace = true }
@@ -24,7 +25,6 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true }
-jiff = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/serde-util/src/duration.rs
+++ b/crates/serde-util/src/duration.rs
@@ -8,73 +8,48 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::str::FromStr as _;
 use std::time::Duration;
 
-use jiff::fmt::friendly::{Designator, SpanPrinter};
-use jiff::{Span, SpanRelativeTo};
-use serde::de::{Error, IntoDeserializer};
-use serde::{Deserialize, Deserializer, Serializer};
+use restate_time_util::{DurationExt, FriendlyDuration};
+
+use serde::de::Error;
+use serde::{Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
 /// Serializable/Deserializable duration for use with serde_with.
 ///
-/// Deserialization uses [`jiff::Span`]'s parsing to support both human-friendly and ISO8601
+/// Deserialization uses [`restate_time_util::FriendlyDuration`]'s parsing to support both human-friendly and ISO8601
 /// inputs. Days are the largest supported unit of time, and are interpreted as 24 hours long when
 /// converting the parsed span into an actual duration.
 ///
-/// Serialization is performed using [`jiff::fmt::friendly`] for output.
+/// Serialization is performed using [`restate_time_util::FriendlyDuration::to_days_span`] for output.
 pub struct DurationString;
 
-impl DurationString {
-    /// Parse a duration from a string using the [`jiff::fmt::friendly`] format, allowing units of
-    /// up to days to be used.
-    pub fn parse_duration(s: &str) -> Result<Duration, serde::de::value::Error> {
-        serde_with::As::<DurationString>::deserialize(s.into_deserializer())
-    }
-
-    /// Prints a duration as a string using the [`jiff::fmt::friendly`] format, using units up to
-    /// days.
-    pub fn display(duration: Duration) -> String {
-        // jiff's SignedDuration pretty-print will add up units up to hours but not to days,
-        // so we use a Span to get finer control over the display output and use calendar units
-        // up to days (which we consider to be 24 hours in duration)
-        let mut span = Span::try_from(duration).expect("fits i64");
-        if span.get_seconds() >= 60 {
-            let minutes = span.get_seconds() / 60;
-            let seconds = span.get_seconds() % 60;
-            span = span.minutes(minutes).seconds(seconds);
-        }
-        if span.get_minutes() >= 60 {
-            let hours = span.get_minutes() / 60;
-            let minutes = span.get_minutes() % 60;
-            span = span.hours(hours).minutes(minutes);
-        }
-        if span.get_hours() >= 24 {
-            let days = span.get_hours() / 24;
-            let hours = span.get_hours() % 24;
-            span = span.days(days).hours(hours);
-        };
-
-        let printer = SpanPrinter::new().designator(Designator::Compact);
-        printer.span_to_string(&span)
-    }
-}
-
-impl<'de> DeserializeAs<'de, std::time::Duration> for DurationString {
+impl<'de> DeserializeAs<'de, Duration> for DurationString {
     fn deserialize_as<D>(deserializer: D) -> Result<std::time::Duration, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let span: Span = String::deserialize(deserializer)?
-            .parse()
-            .map_err(Error::custom)?;
-        if span.get_years() > 0 || span.get_months() > 0 {
-            return Err(Error::custom("Please use units of days or smaller"));
+        struct Helper;
+        impl serde::de::Visitor<'_> for Helper {
+            type Value = Duration;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a human-friendly duration string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                FriendlyDuration::from_str(value)
+                    .map_err(Error::custom)
+                    .map(|d| d.to_std())
+            }
         }
-        let signed_duration = span
-            .to_duration(SpanRelativeTo::days_are_24_hours())
-            .map_err(Error::custom)?;
-        Duration::try_from(signed_duration).map_err(Error::custom)
+
+        deserializer.deserialize_str(Helper)
     }
 }
 
@@ -83,7 +58,7 @@ impl SerializeAs<std::time::Duration> for DurationString {
     where
         S: Serializer,
     {
-        serializer.collect_str(&DurationString::display(*source))
+        serializer.collect_str(&source.friendly().to_days_span())
     }
 }
 
@@ -103,6 +78,8 @@ impl schemars::JsonSchema for DurationString {
         metadata.examples = vec![
             serde_json::Value::String("10 hours".to_owned()),
             serde_json::Value::String("5 days".to_owned()),
+            serde_json::Value::String("5d".to_owned()),
+            serde_json::Value::String("1h 4m".to_owned()),
             serde_json::Value::String("P40D".to_owned()),
         ];
         schema.into()
@@ -113,7 +90,6 @@ impl schemars::JsonSchema for DurationString {
 mod tests {
     use super::*;
 
-    use jiff::{SignedDuration, ToSpan};
     use serde::{Deserialize, Serialize};
 
     use serde_with::serde_as;
@@ -122,53 +98,6 @@ mod tests {
     #[derive(Serialize, Deserialize)]
     #[serde(transparent)]
     struct MyDuration(#[serde_as(as = "DurationString")] std::time::Duration);
-
-    #[test]
-    fn parse_duration_input_formats() {
-        let duration = DurationString::parse_duration("10 min");
-        assert_eq!(Ok(Duration::from_secs(600)), duration);
-
-        // we don't support "1 month" as months have variable length
-        let duration = DurationString::parse_duration("P1M");
-        assert_eq!(
-            Err(serde::de::Error::custom(
-                "Please use units of days or smaller"
-            )),
-            duration
-        );
-
-        // we can, however, use "30 days" instead - we fix those to 24 hours
-        let duration = DurationString::parse_duration("P30D");
-        assert_eq!(Ok(Duration::from_secs(30 * 24 * 3600)), duration);
-
-        // we should not render larger units which are unsupported as inputs
-        let duration = DurationString::parse_duration("30 days 48 hours").unwrap();
-        assert_eq!(
-            30.days()
-                .hours(48)
-                .to_duration(SpanRelativeTo::days_are_24_hours())
-                .unwrap(),
-            SignedDuration::try_from(duration).unwrap()
-        );
-        let duration_str = DurationString::display(duration);
-        assert_eq!("32d", duration_str);
-
-        // more complex inputs are also supported - but will be serialized as a more humane output
-        let duration = DurationString::parse_duration("P30DT10H30M15S");
-        assert_eq!(
-            Ok(Duration::from_secs(
-                30 * 24 * 3600 + 10 * 3600 + 30 * 60 + 15
-            )),
-            duration
-        );
-        assert_eq!(
-            serde_json::from_str::<String>(
-                &serde_json::to_string(&MyDuration(duration.unwrap())).unwrap()
-            )
-            .unwrap(),
-            "30d 10h 30m 15s"
-        );
-    }
 
     #[test]
     fn serialize_friendly() {

--- a/crates/time-util/Cargo.toml
+++ b/crates/time-util/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "restate-time-util"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+jiff = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/time-util/src/duration.rs
+++ b/crates/time-util/src/duration.rs
@@ -1,0 +1,453 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::marker::PhantomData;
+use std::str::FromStr;
+use std::time::Duration;
+
+use jiff::fmt::{friendly, temporal};
+use jiff::{Span, SpanRelativeTo, SpanRound};
+
+static VERBOSE_PRINTER: friendly::SpanPrinter = friendly::SpanPrinter::new()
+    .designator(friendly::Designator::Verbose)
+    .spacing(friendly::Spacing::BetweenUnitsAndDesignators);
+static COMPACT_PRINTER: friendly::SpanPrinter =
+    friendly::SpanPrinter::new().designator(friendly::Designator::Compact);
+
+#[inline]
+fn print_inner(span: &Span, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let printer = if f.alternate() {
+        &VERBOSE_PRINTER
+    } else {
+        &COMPACT_PRINTER
+    };
+
+    printer
+        .print_span(span, jiff::fmt::StdFmtWrite(f))
+        .map_err(|_| std::fmt::Error)
+}
+
+/// Extension trait for [`std::time::Duration`] that provides abstractions for human-friendly
+/// printing.
+pub trait DurationExt {
+    /// zero-cost conversion to [`FriendlyDuration`]
+    ///
+    /// [`FriendlyDuration`] provides human-friendly options to formatting a duration.
+    fn friendly(&self) -> FriendlyDuration;
+}
+
+/// Displays a time span with 'days' as the maximum unit.
+pub struct Days;
+/// Displays a time span with 'seconds' as the maximum unit.
+pub struct Seconds;
+/// Displays a time span in 'HH::MM::SS[.fff]' format.
+pub struct Hms;
+/// Displays a time span in ISO 8601 format.
+pub struct Iso8601;
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Days {}
+    impl Sealed for super::Seconds {}
+    impl Sealed for super::Hms {}
+    impl Sealed for super::Iso8601 {}
+}
+
+/// A sealed trait for the different displayable time-span styles.
+pub trait Style: private::Sealed {
+    fn print_span(span: &Span, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+}
+
+impl Style for Days {
+    fn print_span(span: &Span, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        print_inner(span, f)
+    }
+}
+
+impl Style for Seconds {
+    fn print_span(span: &Span, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        print_inner(span, f)
+    }
+}
+
+impl Style for Hms {
+    fn print_span(span: &Span, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        static HMS_PRINTER: friendly::SpanPrinter =
+            friendly::SpanPrinter::new().hours_minutes_seconds(true);
+
+        HMS_PRINTER
+            .print_span(span, jiff::fmt::StdFmtWrite(f))
+            .map_err(|_| std::fmt::Error)
+    }
+}
+
+impl Style for Iso8601 {
+    fn print_span(span: &Span, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        static ISO_PRINTER: temporal::SpanPrinter = temporal::SpanPrinter::new();
+
+        ISO_PRINTER
+            .print_span(span, jiff::fmt::StdFmtWrite(f))
+            .map_err(|_| std::fmt::Error)
+    }
+}
+
+impl DurationExt for Duration {
+    /// panics if the duration is negative or too large to fit into i64
+    fn friendly(&self) -> FriendlyDuration {
+        FriendlyDuration::from(*self)
+    }
+}
+
+/// A wrapper around [`std::time::Duration`] that provides human-friendly display options.
+///
+/// # Display
+///
+/// The default display behaves the same as `to_days_span()`. But you can also use the following
+/// conversions to customize the display behaviour:
+///
+/// - Use [`FriendlyDuration::to_days_span`] to display a duration as a span with its maximum unit
+///   set to days.
+/// - Use [`FriendlyDuration::to_seconds_span`] to display a duration as a span with its maximum
+///   unit set to seconds.
+/// - Use [`FriendlyDuration::to_hms_span`] to display a duration as a span that's displayed as
+///   `HH:MM:SS`.
+/// - Use [`FriendlyDuration::to_iso8601_span`] to display a duration as a span that's displayed as
+///   `HH:MM:SS`.
+///
+/// # Parsing
+///
+/// This uses [`jiff::Span`]'s parsing to support both human-friendly and ISO8601
+/// inputs. Days are the largest supported unit of time, and are interpreted as 24 hours long when
+/// converting the parsed span into an actual duration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct FriendlyDuration(Duration);
+
+impl PartialEq<Duration> for FriendlyDuration {
+    fn eq(&self, other: &Duration) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<FriendlyDuration> for Duration {
+    fn eq(&self, other: &FriendlyDuration) -> bool {
+        self == &other.0
+    }
+}
+
+impl PartialOrd<Duration> for FriendlyDuration {
+    fn partial_cmp(&self, other: &Duration) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<FriendlyDuration> for Duration {
+    fn partial_cmp(&self, other: &FriendlyDuration) -> Option<std::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+impl From<Duration> for FriendlyDuration {
+    fn from(d: Duration) -> FriendlyDuration {
+        FriendlyDuration(d)
+    }
+}
+
+impl From<FriendlyDuration> for Duration {
+    fn from(d: FriendlyDuration) -> Duration {
+        d.0
+    }
+}
+
+impl std::fmt::Display for FriendlyDuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_days_span().print(f)
+    }
+}
+
+impl FriendlyDuration {
+    /// Returns a span with its maximum unit set to days.
+    pub fn to_days_span(&self) -> TimeSpan<Days> {
+        TimeSpan::<Days>::new(Span::try_from(self.0).unwrap())
+    }
+
+    /// Returns a span with its maximum unit set to seconds.
+    pub fn to_seconds_span(&self) -> TimeSpan<Seconds> {
+        TimeSpan::<Seconds>::new(Span::try_from(self.0).unwrap())
+    }
+
+    /// Returns a span that's displayed as `HH:MM:SS`
+    pub fn to_hms_span(&self) -> TimeSpan<Hms> {
+        TimeSpan::<Hms>::new(Span::try_from(self.0).unwrap())
+    }
+
+    /// Returns a span that's displayed as `HH:MM:SS`
+    pub fn to_iso8601_span(&self) -> TimeSpan<Iso8601> {
+        TimeSpan::<Iso8601>::new(Span::try_from(self.0).unwrap())
+    }
+
+    pub fn as_std(&self) -> &Duration {
+        &self.0
+    }
+
+    pub fn to_std(self) -> Duration {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error(transparent)]
+pub struct DurationParseError(#[from] jiff::Error);
+
+impl FromStr for FriendlyDuration {
+    type Err = DurationParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // jiff cannot parse "0" without "0s" which is mildly annoying. Handling this case to remove
+        // generational user pain.
+        if s == "0" {
+            return Ok(FriendlyDuration(Duration::ZERO));
+        }
+
+        let span: Span = s.parse()?;
+        if span.get_years() > 0 || span.get_months() > 0 {
+            return Err(DurationParseError(jiff::Error::from_args(format_args!(
+                "Please use units of days or smaller"
+            ))));
+        }
+
+        span.to_duration(SpanRelativeTo::days_are_24_hours())
+            .and_then(Duration::try_from)
+            .map(FriendlyDuration)
+            .map_err(DurationParseError)
+    }
+}
+
+/// A zero-cost abstraction of a time span with a maximum unit of time.
+#[derive(Clone, Copy)]
+pub struct TimeSpan<T: Style>(Span, PhantomData<T>);
+
+impl<T: Style> TimeSpan<T> {
+    /// Makes this span represent a duration in the opposite direction.
+    /// By default, the span is positive.
+    ///
+    /// When a span is negative, it's display representation will reflect that. For instance,
+    /// a duration of `5s` will be displayed as `5s ago` when formatted with [`TimeSpan<Seconds>`]
+    /// or [`TimeSpan<Days>`].
+    ///
+    pub fn negated(self) -> TimeSpan<T> {
+        TimeSpan(self.0.negate(), PhantomData)
+    }
+
+    #[inline]
+    pub fn print(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        T::print_span(&self.0, f)
+    }
+
+    /// Returns `true` if the duration is negative.
+    pub fn is_negative(&self) -> bool {
+        self.0.is_negative()
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+
+    pub fn days(&self) -> i32 {
+        self.0.get_days()
+    }
+
+    pub fn hours(&self) -> i32 {
+        self.0.get_hours()
+    }
+
+    pub fn minutes(&self) -> i64 {
+        self.0.get_minutes()
+    }
+
+    pub fn seconds(&self) -> i64 {
+        self.0.get_seconds()
+    }
+
+    pub fn milliseconds(&self) -> i64 {
+        self.0.get_milliseconds()
+    }
+
+    pub fn microseconds(&self) -> i64 {
+        self.0.get_microseconds()
+    }
+
+    pub fn nanoseconds(&self) -> i64 {
+        self.0.get_nanoseconds()
+    }
+}
+
+impl TimeSpan<Seconds> {
+    fn new(span: Span) -> TimeSpan<Seconds> {
+        let span = span
+            .round(
+                SpanRound::new()
+                    .largest(jiff::Unit::Second)
+                    .days_are_24_hours(),
+            )
+            .unwrap();
+        TimeSpan(span, PhantomData)
+    }
+}
+
+impl TimeSpan<Days> {
+    fn new(span: Span) -> TimeSpan<Days> {
+        let span = span
+            .round(
+                SpanRound::new()
+                    .largest(jiff::Unit::Day)
+                    .days_are_24_hours(),
+            )
+            .unwrap();
+        TimeSpan(span, PhantomData)
+    }
+}
+
+impl TimeSpan<Hms> {
+    fn new(span: Span) -> TimeSpan<Hms> {
+        let span = span
+            .round(
+                SpanRound::new()
+                    .largest(jiff::Unit::Hour)
+                    .days_are_24_hours(),
+            )
+            .unwrap();
+        TimeSpan(span, PhantomData)
+    }
+}
+
+impl TimeSpan<Iso8601> {
+    fn new(span: Span) -> TimeSpan<Iso8601> {
+        let span = span
+            .round(
+                SpanRound::new()
+                    .largest(jiff::Unit::Day)
+                    .days_are_24_hours(),
+            )
+            .unwrap();
+        TimeSpan(span, PhantomData)
+    }
+}
+
+impl<T: Style> std::fmt::Display for TimeSpan<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.print(f)
+    }
+}
+
+impl<T: Style> From<TimeSpan<T>> for Duration {
+    fn from(value: TimeSpan<T>) -> Self {
+        let inner = if value.0.is_negative() {
+            value.0.negate()
+        } else {
+            value.0
+        };
+
+        inner
+            .to_duration(SpanRelativeTo::days_are_24_hours())
+            .and_then(Duration::try_from)
+            .expect("duration is positive and fits in std::time::Duration")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn friendly_conversion() {
+        let friendly = Duration::from_nanos(22).friendly();
+        assert_eq!("22ns", friendly.to_days_span().to_string());
+    }
+
+    #[test]
+    fn duration_display() {
+        let dur = FriendlyDuration::from_str("36h 4m 2s").unwrap();
+        assert_eq!(dur, Duration::from_secs(129842));
+        assert_eq!("129842s", dur.to_seconds_span().to_string());
+        // alternate format is more verbose
+        assert_eq!("129842 seconds", format!("{:#}", dur.to_seconds_span()));
+
+        // days
+        assert_eq!("1d 12h 4m 2s", dur.to_days_span().to_string());
+        // alternate format is more verbose
+        assert_eq!(
+            "1 day 12 hours 4 minutes 2 seconds",
+            format!("{:#}", dur.to_days_span())
+        );
+
+        // negated
+        assert_eq!("1d 12h 4m 2s ago", dur.to_days_span().negated().to_string());
+
+        assert_eq!(
+            "1 day 12 hours 4 minutes 2 seconds ago",
+            format!("{:#}", dur.to_days_span().negated())
+        );
+    }
+
+    #[test]
+    fn hms_duration() {
+        let dur = FriendlyDuration::from_str("3h 4m 2s").unwrap();
+        assert_eq!(11042, dur.as_std().as_secs());
+        assert_eq!("03:04:02", dur.to_hms_span().to_string());
+
+        // with microseconds
+        let dur = FriendlyDuration::from_str("1h 24us").unwrap();
+        assert_eq!(3600000024, dur.as_std().as_micros());
+        assert_eq!("01:00:00.000024", dur.to_hms_span().to_string());
+    }
+
+    #[test]
+    fn iso8601_duration() {
+        let dur = FriendlyDuration::from_str("3h 4m 2s").unwrap();
+        assert_eq!(11042, dur.as_std().as_secs());
+        assert_eq!("PT3H4M2S", dur.to_iso8601_span().to_string());
+    }
+
+    #[test]
+    fn parse_friendly_duration_input_formats() {
+        // parsing ZERO
+        let duration = FriendlyDuration::from_str("0").unwrap();
+        assert_eq!(Duration::ZERO, duration);
+        let duration = FriendlyDuration::from_str("0s").unwrap();
+        assert_eq!(Duration::ZERO, duration);
+
+        let duration = FriendlyDuration::from_str("10 min").unwrap();
+        assert_eq!(Duration::from_secs(600), duration);
+
+        // we don't support "1 month" as months have variable length
+        let duration = FriendlyDuration::from_str("P1M");
+        assert_eq!(
+            "Please use units of days or smaller",
+            duration.unwrap_err().to_string()
+        );
+
+        // we can, however, use "30 days" instead - we fix those to 24 hours
+        let duration = FriendlyDuration::from_str("P30D");
+        assert_eq!(Duration::from_secs(30 * 24 * 3600), duration.unwrap());
+
+        // we should not render larger units which are unsupported as inputs
+        let duration = FriendlyDuration::from_str("30 days 48 hours").unwrap();
+        assert_eq!(Duration::from_secs(30 * 24 * 3600 + 48 * 3600), duration);
+        assert_eq!("32d", duration.to_days_span().to_string());
+
+        // more complex inputs are also supported - but will be serialized as a more humane output
+        let duration = FriendlyDuration::from_str("P30DT10H30M15S");
+        assert_eq!(
+            Duration::from_secs(30 * 24 * 3600 + 10 * 3600 + 30 * 60 + 15),
+            duration.unwrap()
+        );
+    }
+}

--- a/crates/time-util/src/lib.rs
+++ b/crates/time-util/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod duration;
+
+pub use duration::*;


### PR DESCRIPTION

Introduces a crate for time utilities (`serde-time-util`). The crate currently provides a trait `DurationExt` which provides a `friendly()` method for formatting a `Duration` as a human-readable string. It also allows parsing a human-friendly duration into a string.


Additionally, this removes the helpers from `DurationString` and keeps `restate-serde-util`'s DurationString as a serialization helper only.

Minor but relevant changes:
- Fixed parsing "0" as a duration. Previously, it was required to write "0s" to parse a zero duration.
- Some debug traces that reported the response latency now use the `to_seconds_span()` since it's cheaper to compute.
- Fixed typos in restate CLI service config commands
- More efficient serialization for DurationString that avoids an extra String allocation.
- Used jiff's native span rounding feature to round a duration to "days" instead of the manual calculation.
- Added a `negated()` method to the time span types to support "ago" formatting.
- Migrateed all uses of `DurationString` to `DurationExt::friendly()` including in CLI argument parsing.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3738).
* #3745
* #3743
* __->__ #3738