### PR TITLE
Set default `MetadataServerState` to `Provisioning`

### DIFF
--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -609,7 +609,7 @@ fn nodes_configuration_for_metadata_cluster_seed(
             });
 
         let metadata_server_config = MetadataServerConfig {
-            metadata_server_state: MetadataServerState::Member,
+            metadata_server_state: MetadataServerState::Provisioning,
         };
 
         let node_config = NodeConfig::builder()

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -287,8 +287,7 @@ impl<'a> NodeInit<'a> {
                         let my_node_id = plain_node_id.with_generation(1);
 
                         let metadata_server_state = if config.metadata_server.auto_join {
-                            // todo change to MetadataServerState::Provisioning with v1.5.0
-                            MetadataServerState::Member
+                            MetadataServerState::Provisioning
                         } else {
                             MetadataServerState::Standby
                         };

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -645,9 +645,9 @@ pub enum MetadataServerState {
     /// decommissioned.
     Standby,
     /// The server is an active member of the metadata store cluster.
-    #[default]
     Member,
     /// The server should try to automatically join a metadata store cluster.
+    #[default]
     Provisioning,
 }
 


### PR DESCRIPTION
Set default `MetadataServerState` to `Provisioning`

Fixes #3554
