### PR TITLE
Avoid sending None invocations from the io thread

### DIFF
--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -175,21 +175,13 @@ impl ScanInvocationStatusTable for PartitionStore {
     fn scan_invoked_invocations(
         &self,
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send> {
-        Ok(self
-            .run_iterator(
-                "scan-all-invoked",
-                Priority::High,
-                FullScanPartitionKeyRange::<InvocationStatusKey>(
-                    self.partition_key_range().clone(),
-                ),
-                read_invoked_full_invocation_id,
-            )
-            .map_err(|_| StorageError::OperationalError)?
-            .filter_map(|result| match result {
-                Ok(Some(res)) => Some(Ok(res)),
-                Ok(None) => None,
-                Err(e) => Some(Err(e)),
-            }))
+        self.iterator_filter_map(
+            "scan-all-invoked",
+            Priority::High,
+            FullScanPartitionKeyRange::<InvocationStatusKey>(self.partition_key_range().clone()),
+            read_invoked_full_invocation_id,
+        )
+        .map_err(|_| StorageError::OperationalError)
     }
 
     fn scan_invocation_statuses(

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -459,6 +459,7 @@ where
                 .map_err(Error::Storage)?;
             tokio::pin!(invoked_invocations);
 
+            let start = tokio::time::Instant::now();
             let mut count = 0;
             while let Some(invoked_invocation) = invoked_invocations.next().await {
                 let InvokedInvocationStatusLite {
@@ -478,7 +479,11 @@ where
                     .map_err(Error::Invoker)?;
                 count += 1;
             }
-            debug!("Leader partition resumed {} invocations", count);
+            debug!(
+                "Leader partition resumed {} invocations in {:?}",
+                count,
+                start.elapsed(),
+            );
         }
 
         Ok(ReceiverStream::new(invoker_rx))


### PR DESCRIPTION
The in place iteration doesn't achieve much difference here, as we are building owned objects and we have to transfer them to the calling thread anyway. However, currently we also transfer millions of Nones via the blocking send, because most invocations are completed in a typical retention enabled environment. Those Nones just get filtered out by scan_invoked_invocations. So, by avoiding sending the None we get a big speedup

Before this PR, with 5m completed invocations in 8 partitions, no running invocations, on an 8 core node:
```
  Leader partition resumed 0 invocations in 4.213329983s
  Leader partition resumed 0 invocations in 4.223999323s
  Leader partition resumed 0 invocations in 4.553144678s
  Leader partition resumed 0 invocations in 4.599526967s
  Leader partition resumed 0 invocations in 4.641617688s
  Leader partition resumed 0 invocations in 4.67134803s
  Leader partition resumed 0 invocations in 4.708281453s
  Leader partition resumed 0 invocations in 4.676482223s
```
Pretty slow! After this PR:
```
  Leader partition resumed 0 invocations in 702.687614ms
  Leader partition resumed 0 invocations in 737.809902ms
  Leader partition resumed 0 invocations in 742.419638ms
  Leader partition resumed 0 invocations in 742.912192ms
  Leader partition resumed 0 invocations in 745.79924ms
  Leader partition resumed 0 invocations in 750.633238ms
  Leader partition resumed 0 invocations in 760.038402ms
  Leader partition resumed 0 invocations in 770.076618ms
```