### PR TITLE
Lazy opening of local-loglet log store

### DIFF
--- a/crates/bifrost/src/providers/local_loglet/provider.rs
+++ b/crates/bifrost/src/providers/local_loglet/provider.rs
@@ -12,8 +12,8 @@ use std::collections::{HashMap, hash_map};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use parking_lot::Mutex;
 use tracing::debug;
+use tokio::sync::Mutex;
 
 use restate_types::config::LocalLogletOptions;
 use restate_types::live::BoxLiveLoad;
@@ -47,23 +47,26 @@ impl LogletProviderFactory for Factory {
     async fn create(self: Box<Self>) -> Result<Arc<dyn LogletProvider>, OperationError> {
         metric_definitions::describe_metrics();
         let Factory { options } = *self;
-        let log_store = RocksDbLogStore::create(options.clone())
-            .await
-            .map_err(OperationError::other)?;
-        let log_writer = log_store.create_writer().start(options)?;
+        
         debug!("Started a bifrost local loglet provider");
         Ok(Arc::new(LocalLogletProvider {
-            log_store,
+            options,
+            log_store: Mutex::new(None),
             active_loglets: Default::default(),
-            log_writer,
         }))
     }
 }
 
-pub(crate) struct LocalLogletProvider {
+#[derive(Clone)]
+struct RocksDbLogStoreBundle {
     log_store: RocksDbLogStore,
-    active_loglets: Mutex<HashMap<(LogId, SegmentIndex), Arc<LocalLoglet>>>,
     log_writer: RocksDbLogWriterHandle,
+}
+
+pub(crate) struct LocalLogletProvider {
+    options: BoxLiveLoad<LocalLogletOptions>,
+    log_store: Mutex<Option<RocksDbLogStoreBundle>>,
+    active_loglets: Mutex<HashMap<(LogId, SegmentIndex), Arc<LocalLoglet>>>,
 }
 
 #[async_trait]
@@ -74,17 +77,40 @@ impl LogletProvider for LocalLogletProvider {
         segment_index: SegmentIndex,
         params: &LogletParams,
     ) -> Result<Arc<dyn Loglet>, Error> {
-        let mut guard = self.active_loglets.lock();
+        let mut guard = self.active_loglets.lock().await;
         let loglet = match guard.entry((log_id, segment_index)) {
             hash_map::Entry::Vacant(entry) => {
+                let mut log_store_guard = self.log_store.lock().await;
+                let log_store = match &*log_store_guard {
+                    Some(log_store) => {
+                        log_store.clone()
+                    }
+                    None => {
+                        debug!("Creating local loglet log store");
+                        let log_store = RocksDbLogStore::create(self.options.clone())
+                            .await
+                            .map_err(OperationError::other)?;
+
+                        let log_writer = log_store.create_writer().start(self.options.clone())?;
+
+                        let log_store = RocksDbLogStoreBundle {
+                            log_store,
+                            log_writer,
+                        };
+
+                        *log_store_guard = Some(log_store.clone());
+                        log_store
+                    }
+                };
+                
                 // Create loglet
                 // NOTE: local-loglet expects params to be a `u64` string-encoded unique identifier under the hood.
                 let loglet = LocalLoglet::create(
                     params
                         .parse()
                         .expect("loglet params can be converted into u64"),
-                    self.log_store.clone(),
-                    self.log_writer.clone(),
+                    log_store.log_store,
+                    log_store.log_writer,
                 )?;
                 let loglet = entry.insert(Arc::new(loglet));
                 Arc::clone(loglet)

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -645,9 +645,9 @@ pub enum MetadataServerState {
     /// decommissioned.
     Standby,
     /// The server is an active member of the metadata store cluster.
-    #[default]
     Member,
     /// The server should try to automatically join a metadata store cluster.
+    #[default]
     Provisioning,
 }
 


### PR DESCRIPTION
Lazy opening of local-loglet log store

Summary:
Save resources by lazily opening local-loglet log store only
if it's used.
