### PR TITLE
Don't send unexpired invocations across threads

### DIFF
--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -417,7 +417,7 @@ impl PartitionStore {
     #[allow(clippy::type_complexity)]
     fn iterator_step_filter_map<O: Send + 'static>(
         tx: mpsc::Sender<Result<O>>,
-        f: impl Fn((&[u8], &[u8])) -> Result<Option<O>> + Send + 'static,
+        mut f: impl FnMut((&[u8], &[u8])) -> Result<Option<O>> + Send + 'static,
     ) -> impl FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static {
         move |item| {
             let res = match item {
@@ -530,7 +530,7 @@ impl PartitionStore {
         name: &'static str,
         priority: Priority,
         scan: TableScan<K>,
-        f: impl Fn((&[u8], &[u8])) -> Result<Option<O>> + Send + 'static,
+        f: impl FnMut((&[u8], &[u8])) -> Result<Option<O>> + Send + 'static,
     ) -> Result<ReceiverStream<Result<O>>, ShutdownError> {
         let (tx, rx) = mpsc::channel(8);
         let on_iter = Self::iterator_step_filter_map(tx, f);

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -757,6 +757,13 @@ pub struct InvokedInvocationStatusLite {
     pub current_invocation_epoch: InvocationEpoch,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ExpiredInvocation {
+    pub invocation_id: InvocationId,
+    pub invocation_expired: bool,
+    pub journal_expired: bool,
+}
+
 pub trait ReadOnlyInvocationStatusTable {
     fn get_invocation_status(
         &mut self,
@@ -765,11 +772,6 @@ pub trait ReadOnlyInvocationStatusTable {
 }
 
 pub trait ScanInvocationStatusTable {
-    fn scan_invocation_statuses(
-        &self,
-        range: RangeInclusive<PartitionKey>,
-    ) -> Result<impl Stream<Item = Result<(InvocationId, InvocationStatus)>> + Send>;
-
     fn for_each_invocation_status_lazy<
         E: Into<anyhow::Error>,
         F: for<'a> FnMut(
@@ -787,6 +789,11 @@ pub trait ScanInvocationStatusTable {
     fn scan_invoked_invocations(
         &self,
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send>;
+
+    fn scan_expired_invocations(
+        &self,
+        range: RangeInclusive<PartitionKey>,
+    ) -> Result<impl Stream<Item = Result<ExpiredInvocation>> + Send>;
 }
 
 pub trait InvocationStatusTable: ReadOnlyInvocationStatusTable {

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -4375,23 +4375,23 @@ pub mod v1 {
         pub struct InvocationStatusV2Lazy<'a> {
             pub inner: super::InvocationStatusV2Lazy,
             // 2
-            invocation_target_lazy: Option<&'a [u8]>,
+            pub invocation_target_lazy: Option<&'a [u8]>,
             // 3
-            source_lazy: Option<&'a [u8]>,
+            pub source_lazy: Option<&'a [u8]>,
             // 4
-            span_context_lazy: Option<&'a [u8]>,
+            pub span_context_lazy: Option<&'a [u8]>,
             // 11
-            completion_retention_duration_lazy: Option<&'a [u8]>,
+            pub completion_retention_duration_lazy: Option<&'a [u8]>,
             // 12
-            idempotency_key: Option<&'a [u8]>,
+            pub idempotency_key: Option<&'a [u8]>,
             // 15
-            deployment_id: Option<&'a [u8]>,
+            pub deployment_id: Option<&'a [u8]>,
             // 18
-            result_lazy: Option<&'a [u8]>,
+            pub result_lazy: Option<&'a [u8]>,
             // 29
-            journal_retention_duration_lazy: Option<&'a [u8]>,
+            pub journal_retention_duration_lazy: Option<&'a [u8]>,
             // 30
-            created_using_restate_version: &'a [u8],
+            pub created_using_restate_version: &'a [u8],
         }
 
         impl<'a> InvocationStatusV2Lazy<'a> {

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -110,7 +110,8 @@ where
         let mut purged_invocation_count = 0;
         let mut purged_journal_count = 0;
 
-        let invocations_stream = storage.scan_expired_invocations(partition_key_range)?;
+        let invocations_stream =
+            storage.filter_map_invocation_status_lazy(partition_key_range, read_expired)?;
         tokio::pin!(invocations_stream);
 
         while let Some(expired_invocation) = invocations_stream
@@ -187,8 +188,7 @@ struct ExpiredInvocation {
 }
 
 fn read_expired(
-    invocation_id: InvocationId,
-    invocation_status_v2_lazy: InvocationStatusV2Lazy,
+    (invocation_id, invocation_status_v2_lazy): (InvocationId, InvocationStatusV2Lazy),
 ) -> Result<Option<ExpiredInvocation>, ConversionError> {
     let restate_storage_api::protobuf_types::v1::invocation_status_v2::Status::Completed =
         invocation_status_v2_lazy.inner.status()
@@ -231,6 +231,10 @@ fn read_expired(
         false
     };
 
+    if !invocation_expired && !journal_expired {
+        return Ok(None);
+    }
+
     Ok(Some(ExpiredInvocation {
         invocation_id,
         invocation_expired,
@@ -244,18 +248,30 @@ mod tests {
 
     use futures::{Stream, stream};
     use googletest::prelude::*;
+    use prost::Message;
     use restate_core::{Metadata, TaskCenter, TaskKind, TestCoreEnvBuilder};
     use restate_storage_api::invocation_status_table::{
-        ExpiredInvocation, InvokedInvocationStatusLite, ScanInvocationStatusTable,
+        InvokedInvocationStatusLite, ScanInvocationStatusTable,
     };
     use restate_storage_api::protobuf_types::v1::lazy::InvocationStatusV2Lazy;
+    use restate_storage_api::{StorageError, protobuf_types};
     use restate_types::Version;
     use restate_types::identifiers::{InvocationId, InvocationUuid};
     use restate_types::partition_table::{FindPartition, PartitionTable};
+    use restate_types::time::MillisSinceEpoch;
     use test_log::test;
 
+    #[derive(Clone)]
+    struct MockCompletedInvocation {
+        invocation_id: InvocationId,
+        completed_transition_time: Option<u64>,
+        completion_retention_duration: Duration,
+        journal_retention_duration: Duration,
+        journal_length: u32,
+    }
+
     #[allow(dead_code)]
-    struct MockInvocationStatusReader(Vec<ExpiredInvocation>);
+    struct MockInvocationStatusReader(Vec<MockCompletedInvocation>);
 
     impl ScanInvocationStatusTable for MockInvocationStatusReader {
         fn for_each_invocation_status_lazy<
@@ -278,21 +294,65 @@ mod tests {
             Ok(std::future::pending())
         }
 
+        fn filter_map_invocation_status_lazy<
+            O: Send + 'static,
+            E: Into<anyhow::Error>,
+            F: for<'a> FnMut(
+                    (InvocationId, InvocationStatusV2Lazy<'a>),
+                ) -> std::result::Result<Option<O>, E>
+                + Send
+                + Sync
+                + 'static,
+        >(
+            &self,
+            _: RangeInclusive<PartitionKey>,
+            mut f: F,
+        ) -> restate_storage_api::Result<impl Stream<Item = restate_storage_api::Result<O>> + Send>
+        {
+            Ok(
+                stream::iter(self.0.clone()).filter_map(move |expired_invocation| {
+                    let completion_retention_duration = protobuf_types::v1::Duration::from(
+                        expired_invocation.completion_retention_duration,
+                    )
+                    .encode_to_vec();
+                    let journal_retention_duration = protobuf_types::v1::Duration::from(
+                        expired_invocation.journal_retention_duration,
+                    )
+                    .encode_to_vec();
+
+                    std::future::ready({
+                        match f((
+                            expired_invocation.invocation_id,
+                            InvocationStatusV2Lazy {
+                                inner: protobuf_types::v1::InvocationStatusV2Lazy {
+                                    status: 5,
+                                    completed_transition_time: expired_invocation
+                                        .completed_transition_time,
+                                    journal_length: expired_invocation.journal_length,
+                                    ..Default::default()
+                                },
+                                completion_retention_duration_lazy: Some(
+                                    &completion_retention_duration,
+                                ),
+                                journal_retention_duration_lazy: Some(&journal_retention_duration),
+                                ..Default::default()
+                            },
+                        )) {
+                            Ok(Some(val)) => Some(Ok(val)),
+                            Ok(None) => None,
+                            Err(err) => Some(Err(StorageError::Conversion(err.into()))),
+                        }
+                    })
+                }),
+            )
+        }
+
         fn scan_invoked_invocations(
             &self,
         ) -> restate_storage_api::Result<
             impl Stream<Item = restate_storage_api::Result<InvokedInvocationStatusLite>> + Send,
         > {
             Ok(stream::empty())
-        }
-
-        fn scan_expired_invocations(
-            &self,
-            _: RangeInclusive<PartitionKey>,
-        ) -> restate_storage_api::Result<
-            impl Stream<Item = restate_storage_api::Result<ExpiredInvocation>> + Send,
-        > {
-            Ok(stream::iter(self.0.clone()).map(Ok))
         }
     }
 
@@ -314,22 +374,39 @@ mod tests {
             InvocationId::from_parts(PartitionKey::MIN, InvocationUuid::mock_random());
         let not_expired_invocation_1 =
             InvocationId::from_parts(PartitionKey::MIN, InvocationUuid::mock_random());
+        let not_expired_invocation_2 =
+            InvocationId::from_parts(PartitionKey::MIN, InvocationUuid::mock_random());
+
+        let now = MillisSinceEpoch::now().as_u64();
 
         let mock_storage = MockInvocationStatusReader(vec![
-            ExpiredInvocation {
+            MockCompletedInvocation {
                 invocation_id: expired_invocation,
-                invocation_expired: true,
-                journal_expired: false,
+                completed_transition_time: Some(now),
+                completion_retention_duration: Duration::ZERO,
+                journal_retention_duration: Duration::ZERO,
+                journal_length: 0,
             },
-            ExpiredInvocation {
+            MockCompletedInvocation {
                 invocation_id: expired_journal,
-                invocation_expired: false,
-                journal_expired: true,
+                completed_transition_time: Some(now),
+                completion_retention_duration: Duration::MAX,
+                journal_retention_duration: Duration::ZERO,
+                journal_length: 2,
             },
-            ExpiredInvocation {
+            MockCompletedInvocation {
                 invocation_id: not_expired_invocation_1,
-                invocation_expired: false,
-                journal_expired: false,
+                completed_transition_time: Some(now),
+                completion_retention_duration: Duration::MAX,
+                journal_retention_duration: Duration::ZERO,
+                journal_length: 0,
+            },
+            MockCompletedInvocation {
+                invocation_id: not_expired_invocation_2,
+                completed_transition_time: None,
+                completion_retention_duration: Duration::ZERO,
+                journal_retention_duration: Duration::ZERO,
+                journal_length: 0,
             },
         ]);
 


### PR DESCRIPTION
The cleaner suffers from a lot of contention due to sending all invocations, including unexpired ones, from the io thread to the worker thread. It's better if we can check for expiry inside the io thread, but we don't want to put all that logic inside the partition store crate. So we use a filter_map method to identify the invocations we care about and send them back to the worker.

Before:
```
  Executed completed invocations cleanup in 3.598163684s
  Executed completed invocations cleanup in 3.786564823s
  Executed completed invocations cleanup in 3.70789558s
  Executed completed invocations cleanup in 3.35952469s
  Executed completed invocations cleanup in 3.56261731s
  Executed completed invocations cleanup in 3.851260922s
  Executed completed invocations cleanup in 3.873757502s
  Executed completed invocations cleanup in 3.653827479s
```

After:
```
  Executed completed invocations cleanup in 274.850528ms
  Executed completed invocations cleanup in 257.149421ms
  Executed completed invocations cleanup in 399.182153ms
  Executed completed invocations cleanup in 377.276183ms
  Executed completed invocations cleanup in 375.380197ms
  Executed completed invocations cleanup in 382.006936ms
  Executed completed invocations cleanup in 440.970359ms
  Executed completed invocations cleanup in 444.923974ms
```