### PR TITLE
[Restate UI] Update to v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7825,8 +7825,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.4"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.4#41873314856594e45548bd7450f7d4d89c37d84f"
+version = "0.1.5"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.5#c9d044e9a144e198143fe96f54e11094bc532843"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -30,7 +30,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.4", tag = "v0.1.4" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.5", tag = "v0.1.5" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.5
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.5/ui-v0.1.5.zip