### PR TITLE
[LogServer] Reduce payload copies by using vectored write batch operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.39.0+10.5.1"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=8873ba40ae687862dbe177e645e7b03c5ce025e3#8873ba40ae687862dbe177e645e7b03c5ce025e3"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=de8911652d398e9bfbb6bbc42a7b4f7296f6d101#de8911652d398e9bfbb6bbc42a7b4f7296f6d101"
 dependencies = [
  "bindgen 0.72.0",
  "bzip2-sys",
@@ -8119,12 +8119,13 @@ dependencies = [
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.43.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=8873ba40ae687862dbe177e645e7b03c5ce025e3#8873ba40ae687862dbe177e645e7b03c5ce025e3"
+version = "0.43.1"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=de8911652d398e9bfbb6bbc42a7b4f7296f6d101#de8911652d398e9bfbb6bbc42a7b4f7296f6d101"
 dependencies = [
  "libc",
  "parking_lot",
  "rust-librocksdb-sys",
+ "smallvec",
  "smartstring",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ rlimit = { version = "0.10.1" }
 rocksdb = { version = "0.43.0", package = "rust-rocksdb", features = [
     "multi-threaded-cf",
     "jemalloc",
-], git = "https://github.com/restatedev/rust-rocksdb", rev = "8873ba40ae687862dbe177e645e7b03c5ce025e3" }
+], git = "https://github.com/restatedev/rust-rocksdb", rev = "de8911652d398e9bfbb6bbc42a7b4f7296f6d101" }
 rstest = "0.24.0"
 rustls = { version = "0.23.26", default-features = false, features = ["ring"] }
 schemars = { version = "0.8", features = ["bytes", "enumset"] }

--- a/crates/types/src/logs/record.rs
+++ b/crates/types/src/logs/record.rs
@@ -42,7 +42,7 @@ impl Record {
         self.created_at
     }
 
-    pub fn keys(&self) -> &Keys {
+    pub const fn keys(&self) -> &Keys {
         &self.keys
     }
 

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -235,6 +235,20 @@ impl PolyBytes {
             }
         }
     }
+
+    #[tracing::instrument(skip_all)]
+    pub fn encode_to_bytes(&self, scratch: &mut BytesMut) -> Result<Bytes, StorageEncodeError> {
+        match self {
+            PolyBytes::Bytes(bytes) => Ok(bytes.clone()),
+            PolyBytes::Typed(typed) => {
+                // note: this currently doesn't do a good job of estimating the size but it's better than
+                // nothing.
+                scratch.reserve(self.estimated_encode_size());
+                StorageCodec::encode(&**typed, scratch)?;
+                Ok(scratch.split().freeze())
+            }
+        }
+    }
 }
 
 impl StorageEncode for PolyBytes {


### PR DESCRIPTION

This PR builds on top of https://github.com/restatedev/rust-rocksdb/pull/15 and allows the log-server to efficiently pass the payload to rocksdb after stitching the header. This removes an extra copy that was necessary to stitch the record header to the payload before writes.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3755).
* #3762
* #3758
* __->__ #3755