### PR TITLE
[WAL] WAL protocol deprecations and updates

### DIFF
--- a/crates/bifrost/benches/replicated_loglet_serde.rs
+++ b/crates/bifrost/benches/replicated_loglet_serde.rs
@@ -134,10 +134,10 @@ where
 
     let header = restate_wal_protocol::Header {
         source: restate_wal_protocol::Source::Processor {
-            partition_id: source_partition_id,
+            partition_id: Some(source_partition_id),
             partition_key: Some(partition_key),
             leader_epoch,
-            node_id: node_id.as_plain(),
+            node_id: Some(node_id.as_plain()),
             generational_node_id: Some(node_id),
         },
         dest: Destination::Processor {

--- a/crates/ingress-kafka/src/dispatcher.rs
+++ b/crates/ingress-kafka/src/dispatcher.rs
@@ -211,8 +211,8 @@ fn wrap_service_invocation_in_envelope(
 ) -> Envelope {
     let header = Header {
         source: Source::Ingress {
-            node_id: from_node_id,
-            nodes_config_version: Metadata::with_current(|m| m.nodes_config_version()),
+            node_id: Some(from_node_id),
+            nodes_config_version: Some(Metadata::with_current(|m| m.nodes_config_version())),
         },
         dest: Destination::Processor {
             partition_key,

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -43,22 +43,6 @@ impl Envelope {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Envelope {
-    pub fn to_bytes(&self) -> Result<bytes::Bytes, restate_types::storage::StorageEncodeError> {
-        let mut buf = bytes::BytesMut::default();
-        restate_types::storage::StorageCodec::encode(self, &mut buf)?;
-        Ok(buf.freeze())
-    }
-
-    pub fn from_bytes(
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<Self, restate_types::storage::StorageDecodeError> {
-        let mut bytes = bytes.as_ref();
-        restate_types::storage::StorageCodec::decode::<Self, _>(&mut bytes)
-    }
-}
-
 /// Header is set on every message
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -74,16 +58,27 @@ pub enum Source {
     /// Message is sent from another partition processor
     Processor {
         /// if possible, this is used to reroute responses in case of splits/merges
-        partition_id: PartitionId,
+        /// Marked as `Option` in v1.5. Note that v1.4 requires this to be set but as of v1.6
+        /// this can be safely set to `None`.
+        #[cfg_attr(feature = "serde", serde(default))]
+        partition_id: Option<PartitionId>,
+        #[cfg_attr(feature = "serde", serde(default))]
         partition_key: Option<PartitionKey>,
         /// The current epoch of the partition leader. Readers should observe this to decide which
         /// messages to accept. Readers should ignore messages coming from
         /// epochs lower than the max observed for a given partition id.
         leader_epoch: LeaderEpoch,
         /// Which node is this message from?
-        /// deprecated(v1.1): use generational_node_id instead.
-        node_id: PlainNodeId,
+        /// First deprecation in v1.1, but since v1.5 we switched to Option<PlainNodeId> and it's
+        /// still being set to Some(v) to maintain compatibility with v1.4.
+        ///
+        /// In v1.6 this field will be removed.
+        #[cfg_attr(feature = "serde", serde(default))]
+        node_id: Option<PlainNodeId>,
         /// From v1.1 this is always set, but maintained to support rollback to v1.0.
+        /// Deprecated(v1.5): It's set to Some(v) to maintain support for v1.4 but
+        /// will be removed in v1.6. Commands that need the node-id of the sender should
+        /// include the node-id in the command payload itself (e.g. in the [`AnnounceLeader`])
         #[cfg_attr(feature = "serde", serde(default))]
         generational_node_id: Option<GenerationalNodeId>,
     },
@@ -92,27 +87,23 @@ pub enum Source {
         /// The identity of the sender node. Generational for fencing. Ingress is
         /// stateless, so we shouldn't respond to requests from older generation
         /// if a new generation is alive.
-        node_id: GenerationalNodeId,
+        ///
+        /// Deprecated(v1.5): This field is set to Some(v) to maintain compatibility with v1.4.
+        /// but will be removed in v1.6.
+        #[cfg_attr(feature = "serde", serde(default))]
+        node_id: Option<GenerationalNodeId>,
         /// Last config version observed by sender. If this is a newer generation
         /// or an unknown ID, we might need to update our config.
-        nodes_config_version: Version,
+        ///
+        /// Deprecated(v1.5): This field is set to Some(v) to maintain compatibility with v1.4.
+        /// but will be removed in v1.6.
+        #[cfg_attr(feature = "serde", serde(default))]
+        nodes_config_version: Option<Version>,
     },
     /// Message is sent from some control plane component (controller, cli, etc.)
     ControlPlane {
         // Reserved for future use.
     },
-}
-
-impl Source {
-    pub fn is_processor_generational(&self) -> bool {
-        match self {
-            Source::Processor {
-                generational_node_id,
-                ..
-            } => generational_node_id.is_some(),
-            _ => false,
-        }
-    }
 }
 
 /// Identifies the intended destination of the message
@@ -122,6 +113,7 @@ pub enum Destination {
     /// Message is sent to partition processor
     Processor {
         partition_key: PartitionKey,
+        #[cfg_attr(feature = "serde", serde(default))]
         dedup: Option<DedupInformation>,
     },
 }
@@ -210,12 +202,7 @@ impl HasRecordKeys for Envelope {
             Command::UpdatePartitionDurability(_) => Keys::Single(self.partition_key()),
             Command::VersionBarrier(barrier) => barrier.partition_key_range.clone(),
             Command::AnnounceLeader(announce) => {
-                if let Some(range) = &announce.partition_key_range {
-                    Keys::RangeInclusive(range.clone())
-                } else {
-                    // Fallback for old restate servers that didn't have partition_key_range.
-                    Keys::Single(self.partition_key())
-                }
+                Keys::RangeInclusive(announce.partition_key_range.clone())
             }
             Command::PatchState(mutation) => Keys::Single(mutation.service_id.partition_key()),
             Command::TerminateInvocation(terminate) => {

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -70,10 +70,10 @@ where
 
         let my_node_id = Metadata::with_current(|m| m.my_node_id());
         let bifrost_envelope_source = Source::Processor {
-            partition_id,
+            partition_id: Some(partition_id),
             partition_key: None,
             leader_epoch,
-            node_id: my_node_id.as_plain(),
+            node_id: Some(my_node_id.as_plain()),
             generational_node_id: Some(my_node_id),
         };
 

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -215,11 +215,9 @@ where
 
     async fn announce_leadership(&mut self, leader_epoch: LeaderEpoch) -> Result<(), Error> {
         let announce_leader = Command::AnnounceLeader(Box::new(AnnounceLeader {
-            // todo: Still need to write generational id for supporting rolling back, can be removed
-            //  with the next release.
-            node_id: Some(my_node_id()),
+            node_id: my_node_id(),
             leader_epoch,
-            partition_key_range: Some(self.partition.key_range.clone()),
+            partition_key_range: self.partition.key_range.clone(),
         }));
 
         let mut self_proposer = SelfProposer::new(
@@ -731,9 +729,9 @@ mod tests {
         assert_eq!(
             *announce_leader,
             AnnounceLeader {
-                node_id: Some(NODE_ID),
+                node_id: NODE_ID,
                 leader_epoch,
-                partition_key_range: Some(PARTITION_KEY_RANGE),
+                partition_key_range: PARTITION_KEY_RANGE,
             }
         );
 

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -124,11 +124,10 @@ impl SelfProposer {
                 dedup: Some(DedupInformation::self_proposal(esn)),
             },
             source: Source::Processor {
-                partition_id: self.partition_id,
+                partition_id: Some(self.partition_id),
                 partition_key: Some(partition_key),
                 leader_epoch: self.epoch_sequence_number.leader_epoch,
-                // Kept for backward compatibility.
-                node_id: my_node_id.as_plain(),
+                node_id: Some(my_node_id.as_plain()),
                 generational_node_id: Some(my_node_id),
             },
         }

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -73,10 +73,10 @@ fn create_header(
     let my_node_id = Metadata::with_current(|m| m.my_node_id());
     Header {
         source: Source::Processor {
-            partition_id: shuffle_metadata.partition_id,
+            partition_id: Some(shuffle_metadata.partition_id),
             partition_key: None,
             leader_epoch: shuffle_metadata.leader_epoch,
-            node_id: my_node_id.as_plain(),
+            node_id: Some(my_node_id.as_plain()),
             generational_node_id: Some(my_node_id),
         },
         dest: Destination::Processor {


### PR DESCRIPTION

All changes are backwards compatible with v1.4.X.

Main changes:
- AnnounceLeader now require `node_id` to always be set. It's been always set to Some() since v1.1 anyway but it's not the canonical place to know the sender of the AnnounceLeader message.
- Remove `Option` from AnnounceLeader's partition_key_range.
- Prepare to remove the plain node-id and generational node-id from envelope's `Source::Processor` variant in v1.6.
- Prepare to remove `nodes_config_version from `Source::Ingress` in v1.6 by marking it optional.
- Allow `partition_id` and partition_key to be None-able in `Source::Processor`.
