### PR TITLE
Remove inv ls post-filters

### DIFF
--- a/cli/src/clients/datafusion_helpers/mod.rs
+++ b/cli/src/clients/datafusion_helpers/mod.rs
@@ -95,7 +95,6 @@ pub struct Invocation {
 
     // If it **requires** this deployment.
     pub pinned_deployment_id: Option<String>,
-    #[serde(skip)]
     pub pinned_deployment_exists: bool,
     // Last attempted deployment
     pub last_attempt_deployment_id: Option<String>,


### PR DESCRIPTION
Instead of post filters we can do extra joins via subqueries. These are not very efficient with lots of invocations as the join direction is wrong (inv will be build side, if/until we start reporting statistics properly, see #3759) but as its isolated to these very unusual flags (which didn't work between 1.3 and now), that seems ok.

This is a prerequisite to move inv ls towards an id-scan then point-read approach