### PR TITLE
Use point reads for invocation ls & estimate counts

### DIFF
--- a/cli/src/clients/datafusion_helpers/v2.rs
+++ b/cli/src/clients/datafusion_helpers/v2.rs
@@ -11,10 +11,12 @@
 //! A set of common queries needed by the CLI
 
 use std::collections::HashMap;
+use std::fmt::Display;
 
 use anyhow::Result;
 use bytes::Bytes;
 use chrono::{DateTime, Local};
+use restate_types::SemanticRestateVersion;
 use serde::Deserialize;
 use serde_with::serde_as;
 
@@ -262,7 +264,113 @@ struct InvocationQueryResult {
     completion_failure: Option<String>,
     #[serde(flatten)]
     invocation: Invocation,
-    full_count: usize,
+}
+
+impl From<InvocationQueryResult> for Invocation {
+    fn from(value: InvocationQueryResult) -> Self {
+        // Running duration
+        let current_attempt_duration = if value.invocation.status == InvocationState::Running {
+            value
+                .last_start_at
+                .map(|last_start| Local::now().signed_duration_since(last_start))
+        } else {
+            None
+        };
+
+        let last_attempt_started_at = if value.invocation.status == InvocationState::BackingOff {
+            value.last_start_at
+        } else {
+            None
+        };
+
+        Invocation {
+            current_attempt_duration,
+            last_attempt_started_at,
+            completion: InvocationCompletion::from_sql(
+                value.completion_result,
+                value.completion_failure,
+            ),
+            ..value.invocation
+        }
+    }
+}
+
+// we don't want to scan the table indefinitely to get a count, so we stop after this many rows are checked
+const COUNT_LIMIT: usize = 50000;
+
+pub enum CountEstimate {
+    Exact(usize),
+    LowerBound(usize),
+}
+
+impl CountEstimate {
+    fn from_rows(received_less_than_limit: bool, rows: usize, minimum_count: usize) -> Self {
+        if received_less_than_limit {
+            // if we receive less rows than we asked for, its the full set
+            Self::Exact(rows)
+        } else if rows > minimum_count {
+            // if we receive row_limit rows, and its more than our count estimate, then the rows must be very sparse.
+            // our best guess for a lower bound has to be the number of rows we received
+            Self::LowerBound(rows)
+        } else {
+            // otherwise, the count in the first 50k invocations is a pretty good lower bound
+            Self::LowerBound(minimum_count)
+        }
+    }
+}
+
+impl Display for CountEstimate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CountEstimate::Exact(count) => count.fmt(f),
+            CountEstimate::LowerBound(count) => write!(f, "{count}+"),
+        }
+    }
+}
+
+pub async fn find_and_count_active_invocations(
+    client: &DataFusionHttpClient,
+    filter: &str,
+    order: &str,
+    limit: usize,
+) -> Result<(Vec<Invocation>, CountEstimate)> {
+    let count_fut = count_active_invocations_lower_bound(client, filter);
+    let inv_fut = find_active_invocations(client, filter, order, limit);
+
+    let (count_lower_bound, inv) = tokio::join!(count_fut, inv_fut);
+    let count_lower_bound = count_lower_bound?;
+    let (invocations, received_less_than_limit) = inv?;
+
+    let count_estimate = CountEstimate::from_rows(
+        received_less_than_limit,
+        invocations.len(),
+        count_lower_bound as usize,
+    );
+
+    Ok((invocations, count_estimate))
+}
+
+pub async fn count_active_invocations_lower_bound(
+    client: &DataFusionHttpClient,
+    filter: &str,
+) -> Result<i64> {
+    // how does this work?
+    // 1. we take the first N unfiltered rows of the table. in practice this will probably be weighted
+    // towards local partitions, but for sufficiently large N we should get a good sample of invocations
+    // 2. we apply a filter to those <=N rows
+    // 3. we count how many rows matched that filter
+    // this ensures that we never scan more than N rows, even if the filter is very strict.
+    // we return a lower bound that is always <=N, but we will only use it if its more than limit on the main query.
+    let count_query = format!(
+        "SELECT COUNT(1) FROM (SELECT
+            *
+        FROM sys_invocation inv
+        LIMIT {COUNT_LIMIT}
+        )
+        {filter}"
+    );
+
+    Ok(client.run_count_agg_query(count_query).await?)
 }
 
 pub async fn find_active_invocations(
@@ -270,7 +378,24 @@ pub async fn find_active_invocations(
     filter: &str,
     order: &str,
     limit: usize,
-) -> Result<(Vec<Invocation>, usize)> {
+) -> Result<(Vec<Invocation>, bool)> {
+    if client
+        .server_version()
+        // any 1.5.x including prereleases
+        .is_equal_or_newer_than(&SemanticRestateVersion::new(1, 4, u64::MAX))
+    {
+        find_active_invocations_post_1_5(client, filter, order, limit).await
+    } else {
+        find_active_invocations_pre_1_5(client, filter, order, limit).await
+    }
+}
+
+async fn find_active_invocations_pre_1_5(
+    client: &DataFusionHttpClient,
+    filter: &str,
+    order: &str,
+    limit: usize,
+) -> Result<(Vec<Invocation>, bool)> {
     let has_restate_1_2_columns = client
         .check_columns_exists("sys_invocation", &["idempotency_key"])
         .await?;
@@ -280,8 +405,6 @@ pub async fn find_active_invocations(
         "CAST(NULL as STRING) AS idempotency_key"
     };
 
-    let mut full_count = 0;
-    let mut active = vec![];
     let query = format!(
         "WITH invocations as (SELECT
             inv.id,
@@ -306,8 +429,7 @@ pub async fn find_active_invocations(
             inv.invoked_by_target,
             inv.trace_id,
             inv.completion_result,
-            inv.completion_failure,
-            COUNT(1) OVER() AS full_count
+            inv.completion_failure
         FROM sys_invocation inv
         {filter}
         {order}
@@ -320,37 +442,112 @@ pub async fn find_active_invocations(
         RIGHT JOIN invocations inv ON dp.id = inv.pinned_deployment_id
         {order}"
     );
+
     let rows = client
         .run_json_query::<InvocationQueryResult>(query)
         .await?;
-    for row in rows {
-        // Running duration
-        let current_attempt_duration = if row.invocation.status == InvocationState::Running {
-            row.last_start_at
-                .map(|last_start| Local::now().signed_duration_since(last_start))
-        } else {
-            None
-        };
 
-        let last_attempt_started_at = if row.invocation.status == InvocationState::BackingOff {
-            row.last_start_at
-        } else {
-            None
-        };
+    let received_less_than_limit = rows.len() < limit;
 
-        active.push(Invocation {
-            current_attempt_duration,
-            last_attempt_started_at,
-            completion: InvocationCompletion::from_sql(
-                row.completion_result,
-                row.completion_failure,
-            ),
-            ..row.invocation
-        });
+    Ok((
+        rows.into_iter().map(Invocation::from).collect(),
+        received_less_than_limit,
+    ))
+}
 
-        full_count = row.full_count;
+async fn find_active_invocations_post_1_5(
+    client: &DataFusionHttpClient,
+    filter: &str,
+    order: &str,
+    limit: usize,
+) -> Result<(Vec<Invocation>, bool)> {
+    let id_query = format!(
+        "SELECT
+            id
+        FROM sys_invocation inv
+        {filter}
+        {order}
+        LIMIT {limit}"
+    );
+
+    #[derive(Deserialize)]
+    struct InvocationIdRow {
+        id: String,
     }
-    Ok((active, full_count))
+
+    let id_rows = client.run_json_query::<InvocationIdRow>(id_query).await?;
+
+    // to be sure we received less than the limit we have to consider the length of the id rows.
+    // as some invocations may not longer match the filters, invocations can be a smaller list
+    // than the id list, and that count dropping below $limit doesn't mean that we have a full set.
+    let received_less_than_limit = id_rows.len() < limit;
+
+    let invocations = describe_invocations_post_1_5(
+        client,
+        id_rows.into_iter().take(limit).map(|row| row.id).collect(),
+        filter,
+        order,
+    )
+    .await?;
+
+    Ok((invocations, received_less_than_limit))
+}
+
+// from 1.5, multipoint reads like `id in ("inv_a", "inv_b") are very efficient and can be used.
+// before 1.5, they are just another scan, so it generally doubles your query time
+async fn describe_invocations_post_1_5(
+    client: &DataFusionHttpClient,
+    invocation_ids: Vec<String>,
+    // we check the filter again, in case some rows no longer fit into it
+    filter: &str,
+    order: &str,
+) -> Result<Vec<Invocation>> {
+    if invocation_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let ids_filter = if filter.is_empty() {
+        format!("WHERE inv.id in ('{}')", invocation_ids.join("','"))
+    } else {
+        format!("{filter} AND inv.id in ('{}')", invocation_ids.join("','"))
+    };
+
+    // the join direction doesn't matter as both sides of the join are small
+    let query = format!(
+        "SELECT
+            inv.id,
+            inv.target,
+            inv.target_service_ty,
+            inv.idempotency_key,
+            inv.status,
+            inv.created_at,
+            inv.modified_at as state_modified_at,
+            inv.pinned_deployment_id,
+            inv.retry_count as num_retries,
+            inv.last_failure as last_failure_message,
+            inv.last_failure_related_entry_index as last_failure_entry_index,
+            inv.last_failure_related_entry_name as last_failure_entry_name,
+            inv.last_failure_related_entry_type as last_failure_entry_ty,
+            inv.last_attempt_deployment_id,
+            inv.last_attempt_server,
+            inv.next_retry_at,
+            inv.last_start_at,
+            inv.invoked_by_id,
+            inv.invoked_by_target,
+            inv.trace_id,
+            inv.completion_result,
+            inv.completion_failure,
+            dp.id IS NOT NULL as pinned_deployment_exists
+        FROM sys_invocation inv
+        LEFT JOIN sys_deployment dp ON dp.id = inv.pinned_deployment_id
+        {ids_filter}
+        {order}"
+    );
+    let rows = client
+        .run_json_query::<InvocationQueryResult>(query)
+        .await?;
+
+    Ok(rows.into_iter().map(Invocation::from).collect())
 }
 
 pub async fn get_service_invocations(

--- a/cli/src/clients/datafusion_http_client.rs
+++ b/cli/src/clients/datafusion_http_client.rs
@@ -23,6 +23,7 @@ use arrow::{
 };
 use bytes::Buf;
 use itertools::Itertools;
+use restate_types::SemanticRestateVersion;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, info};
@@ -100,10 +101,7 @@ impl DataFusionHttpClient {
             _ => {
                 return Err(Error::JSONSupport(
                     self.inner.base_url.clone(),
-                    self.inner
-                        .restate_server_version
-                        .clone()
-                        .unwrap_or_else(|| "unknown".into()),
+                    self.inner.restate_server_version.to_string(),
                 ));
             }
         }
@@ -178,6 +176,10 @@ impl DataFusionHttpClient {
             .await?;
 
         Ok(actual_count as usize == expected_count)
+    }
+
+    pub fn server_version(&self) -> &SemanticRestateVersion {
+        &self.inner.restate_server_version
     }
 }
 

--- a/cli/src/commands/invocations/list.rs
+++ b/cli/src/commands/invocations/list.rs
@@ -22,7 +22,7 @@ use restate_cli_util::ui::stylesheet::Style;
 use restate_cli_util::ui::watcher::Watch;
 
 use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::{InvocationState, find_active_invocations};
+use crate::clients::datafusion_helpers::{InvocationState, find_and_count_active_invocations};
 use crate::ui::invocations::render_invocation_compact;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
@@ -149,8 +149,9 @@ async fn list(env: &CliEnv, opts: &List) -> Result<()> {
     progress.enable_steady_tick(std::time::Duration::from_millis(120));
     progress.set_message("Finding invocations...");
 
-    let (mut results, total) =
-        find_active_invocations(&sql_client, &active_filter_str, order_by, opts.limit).await?;
+    let (mut results, count_estimate) =
+        find_and_count_active_invocations(&sql_client, &active_filter_str, order_by, opts.limit)
+            .await?;
 
     // Render Output UI
     progress.finish_and_clear();
@@ -167,7 +168,7 @@ async fn list(env: &CliEnv, opts: &List) -> Result<()> {
     c_eprintln!(
         "Showing {}/{} invocations. Query took {:?}",
         results.len(),
-        total,
+        count_estimate,
         Styled(Style::Notice, start_time.elapsed())
     );
 


### PR DESCRIPTION
Refactor the cli invocation list operations to use topk(id) instead of topk(*). Topk(id) is much better in terms of memory usage and also speed because of reduced projection.

We have to special case pre 1.5 as we had no efficient multipointread mechanism there, so a single scan is still faster.

For both pre and post 1.5 we can split out the counting logic to use a new count estimate behaviour based on scanning no more than 50k rows and then filtering the result. This is hopefully future proof as it still gives you a sense of scale but it doesn't need a full scan, which opens the door for dynamic filter pushdown optimisations