### PR TITLE
[Restate UI] Update to v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7763,8 +7763,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.5"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.5#c9d044e9a144e198143fe96f54e11094bc532843"
+version = "0.1.6"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.6#995d8a5e65c51c7f48d2b327b0bdec91413f01b8"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -30,7 +30,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.5", tag = "v0.1.5" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.6", tag = "v0.1.6" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.6
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.6/ui-v0.1.6.zip