### PR TITLE
Clarify meaning of max_attempts in new retry policy configuration options.

### DIFF
--- a/crates/types/src/config/invocation.rs
+++ b/crates/types/src/config/invocation.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -69,7 +70,7 @@ pub struct InvocationOptions {
     ///
     /// `None` means no limit, that is infinite retries is enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_retry_policy_max_attempts: Option<usize>,
+    pub max_retry_policy_max_attempts: Option<NonZeroUsize>,
 }
 
 impl Default for InvocationOptions {
@@ -113,9 +114,9 @@ pub struct InvocationRetryPolicyOptions {
 
     /// # Max attempts
     ///
-    /// Number of maximum attempts before giving up. Infinite retries if unset. No retries if set to 0.
+    /// Number of maximum attempts (including the initial) before giving up. Infinite retries if unset. No retries if set to 1.
     #[serde(default = "default_max_attempts")]
-    pub(crate) max_attempts: Option<usize>,
+    pub(crate) max_attempts: Option<NonZeroUsize>,
 
     /// # On max attempts
     ///
@@ -153,8 +154,8 @@ fn default_initial_interval() -> Duration {
     Duration::from_millis(500)
 }
 
-fn default_max_attempts() -> Option<usize> {
-    Some(20)
+fn default_max_attempts() -> Option<NonZeroUsize> {
+    Some(NonZeroUsize::new(20).unwrap())
 }
 
 fn default_exponentiation_factor() -> f32 {

--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -33,6 +33,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::error::Error;
+use std::num::NonZeroUsize;
 use std::ops::{Not, RangeInclusive};
 use std::sync::Arc;
 use std::time::Duration;
@@ -728,7 +729,9 @@ impl SchemaUpdater {
             retry_policy_exponentiation_factor
         );
         let retry_policy_max_attempts = resolve_optional_config_option!(
-            service.retry_policy_max_attempts.map(|n| n as usize),
+            service
+                .retry_policy_max_attempts
+                .map(|n| NonZeroUsize::new(n as usize).unwrap_or(NonZeroUsize::MIN)),
             retry_policy_max_attempts
         );
         let retry_policy_on_max_attempts = resolve_optional_config_option!(
@@ -1079,7 +1082,9 @@ impl Handler {
         let retry_policy_max_interval = handler.retry_policy_max_interval();
         let retry_policy_exponentiation_factor =
             handler.retry_policy_exponentiation_factor.map(|f| f as f32);
-        let retry_policy_max_attempts = handler.retry_policy_max_attempts.map(|n| n as usize);
+        let retry_policy_max_attempts = handler
+            .retry_policy_max_attempts
+            .map(|n| NonZeroUsize::new(n as usize).unwrap_or(NonZeroUsize::MIN));
         let retry_policy_on_max_attempts = handler.retry_policy_on_max_attempts.map(|f| match f {
             endpoint_manifest::RetryPolicyOnMaxAttempts::Pause => OnMaxAttempts::Pause,
             endpoint_manifest::RetryPolicyOnMaxAttempts::Kill => OnMaxAttempts::Kill,

--- a/crates/types/src/schema/service.rs
+++ b/crates/types/src/schema/service.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -228,9 +229,9 @@ pub struct ServiceRetryPolicyMetadata {
 
     /// # Max attempts
     ///
-    /// Number of maximum attempts before giving up. Infinite retries if unset.
+    /// Number of maximum attempts (including the initial) before giving up. Infinite retries if unset. No retries if set to 1.
     #[serde(default)]
-    pub max_attempts: Option<usize>,
+    pub max_attempts: Option<NonZeroUsize>,
 
     /// # Max interval
     ///
@@ -471,9 +472,9 @@ pub struct HandlerRetryPolicyMetadata {
 
     /// # Max attempts
     ///
-    /// Number of maximum attempts before giving up. Infinite retries if unset.
+    /// Number of maximum attempts (including the initial) before giving up. Infinite retries if unset. No retries if set to 1.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_attempts: Option<usize>,
+    pub max_attempts: Option<NonZeroUsize>,
 
     /// # Max interval
     ///


### PR DESCRIPTION
This aligns with the behavior of `ctx.run` retry policy.

* `max attempts = 1` -> no retries
* `max attempts = 2` -> 1 retry
* and so on

* `max attempts = 0` is a special case and silently converts it to `1` in the discovery logic. SDKs can introduce additional validation via typing and/or runtime check.