### PR TITLE
[Restate UI] Update to v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7796,8 +7796,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.7"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.7#11fdce13a0a38b9d2969462b142d0898d6f6674b"
+version = "0.1.8"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.8#5a6dd7215dfe198816bc4960709aee986231071b"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -30,7 +30,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.7", tag = "v0.1.7" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.8", tag = "v0.1.8" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.8
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.8/ui-v0.1.8.zip