### PR TITLE
Case simplifying optimizer

### DIFF
--- a/crates/storage-query-datafusion/src/analyzer.rs
+++ b/crates/storage-query-datafusion/src/analyzer.rs
@@ -9,11 +9,15 @@
 // by the Apache License, Version 2.0.
 
 use datafusion::common::Column;
-use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRewriter};
 use datafusion::config::ConfigOptions;
-use datafusion::logical_expr::{Join, LogicalPlan};
+use datafusion::logical_expr::utils::{conjunction, disjunction};
+use datafusion::logical_expr::{BinaryExpr, Case, Join, LogicalPlan, Operator};
 use datafusion::optimizer::analyzer::AnalyzerRule;
+use datafusion::optimizer::simplify_expressions::simplify_predicates;
+use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
 use datafusion::prelude::Expr;
+use datafusion::scalar::ScalarValue;
 
 #[derive(Debug)]
 pub(crate) struct UseSymmetricHashJoinWhenPartitionKeyIsPresent;
@@ -93,5 +97,292 @@ impl AnalyzerRule for UseSymmetricHashJoinWhenPartitionKeyIsPresent {
 
     fn name(&self) -> &str {
         "join_checker"
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CaseFilterSimplifier;
+
+impl CaseFilterSimplifier {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OptimizerRule for CaseFilterSimplifier {
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> datafusion::common::Result<Transformed<LogicalPlan>> {
+        plan.map_expressions(|expr| expr.rewrite(&mut Self::new()))
+    }
+
+    fn name(&self) -> &str {
+        "case_filter_simplifier"
+    }
+}
+
+impl TreeNodeRewriter for CaseFilterSimplifier {
+    type Node = Expr;
+
+    /// rewrite the expression simplifying any constant expressions
+    fn f_up(&mut self, expr: Expr) -> datafusion::common::Result<Transformed<Expr>> {
+        let Expr::BinaryExpr(BinaryExpr {
+            left,
+            op: op @ (Operator::Eq | Operator::NotEq),
+            right,
+        }) = &expr
+        else {
+            return Ok(Transformed::no(expr));
+        };
+
+        let (case, lit) = match (&**left, &**right) {
+            (Expr::Case(case), Expr::Literal(lit, _)) => (case, lit),
+            (Expr::Literal(lit, _), Expr::Case(case)) => (case, lit),
+            _ => return Ok(Transformed::no(expr)),
+        };
+
+        let Some(equals_condition) = simplify_case_equals(case, lit) else {
+            return Ok(Transformed::no(expr));
+        };
+
+        match op {
+            Operator::Eq => Ok(Transformed::yes(equals_condition)),
+            // equals condition is true if a = b, otherwise false, and we know a and b are nonnull
+            // in that case, not(equals_condition) is true iff a != b is true
+            Operator::NotEq => Ok(Transformed::yes(Expr::Not(Box::new(
+                equals_condition.clone(),
+            )))),
+            _ => Ok(Transformed::no(expr)),
+        }
+    }
+}
+
+pub fn simplify_case_equals(case: &Case, equals_lit: &ScalarValue) -> Option<Expr> {
+    if equals_lit.is_null() {
+        // we don't support comparison to null literals as they are hard to invert
+        return None;
+    }
+
+    if case.expr.is_some() {
+        // right now we only support `CASE WHEN field="foo"` and not `CASE field WHEN "foo"`
+        return None;
+    }
+
+    let Some(else_expr) = &case.else_expr else {
+        // we don't support cases without an ELSE as they may evaluate to null if nothing matches
+        return None;
+    };
+
+    // only case statements that always evaluate to non-null literals are supported
+    let else_lit = else_expr.as_literal()?;
+    if else_lit.is_null() {
+        return None;
+    }
+
+    let mut not_so_far: Vec<Expr> = Vec::new();
+    let mut whens: Vec<Expr> = Vec::new();
+
+    for (when, then) in &case.when_then_expr {
+        // only case statements that always evaluate to non-null literals are supported
+        let then_lit = then.as_literal()?;
+
+        if then_lit.is_null() {
+            return None;
+        }
+
+        if then_lit.eq(equals_lit) {
+            // if the then condition is true AND if no previous branches matched, we produce the target literal
+            let when_predicates: Vec<Expr> = not_so_far
+                .iter()
+                .cloned()
+                .chain(std::iter::once(Expr::clone(when).is_true()))
+                .collect();
+
+            let when_predicates = simplify_predicates(when_predicates).ok()?;
+
+            if let Some(when_predicate) = conjunction(when_predicates) {
+                whens.push(when_predicate)
+            } else {
+                // if the filter reduced down to nothing, then this case condition is always true
+                whens.push(Expr::Literal(ScalarValue::Boolean(Some(true)), None));
+            }
+        }
+
+        // case statements skip null when conditions, so for branch N to be matched, all earlier branches must evaluate to false or null; ie IsNotTrue
+        let not_when = Expr::clone(when).is_not_true();
+        not_so_far.push(not_when);
+    }
+
+    if else_lit.eq(equals_lit) {
+        // if no previous branches matched, we produce the target literal
+        let not_so_far = simplify_predicates(not_so_far).ok()?;
+        if let Some(when_predicate) = conjunction(not_so_far) {
+            whens.push(when_predicate)
+        } else {
+            // if the filter reduced down to nothing, then this case condition is always true
+            whens.push(Expr::Literal(ScalarValue::Boolean(Some(true)), None));
+        }
+    }
+
+    // this case expression always evaluates to a non null literal and is compared to a non null literal.
+    // as a result, we know that if no cases produce the target literal, the predicate evaluates to false (not null)
+    Some(disjunction(whens).unwrap_or(Expr::Literal(ScalarValue::Boolean(Some(false)), None)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use datafusion::arrow::array::{BooleanArray, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::execution::context::SessionContext;
+    use datafusion::logical_expr::LogicalPlan;
+    use datafusion::optimizer::OptimizerContext;
+
+    fn create_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("status", DataType::Utf8, true),
+            Field::new("priority", DataType::Utf8, true),
+            Field::new("active", DataType::Boolean, true),
+        ]))
+    }
+
+    fn create_test_data() -> RecordBatch {
+        let schema = create_test_schema();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![
+                    Some("pending"),
+                    Some("active"),
+                    Some("completed"),
+                    Some("failed"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("high"),
+                    Some("low"),
+                    Some("medium"),
+                    Some("high"),
+                ])),
+                Arc::new(BooleanArray::from(vec![
+                    Some(true),
+                    Some(true),
+                    Some(false),
+                    Some(false),
+                ])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_case_filter_simplifier() {
+        let optimizer = CaseFilterSimplifier::new();
+        let config = OptimizerContext::new();
+
+        // Test cases: (name, case_expr, select_expr, expected_predicate)
+        let test_cases = vec![
+            (
+                "simple_case_filter",
+                "CASE WHEN status = 'active' THEN 'running' WHEN status = 'pending' then 'waiting' ELSE 'other' END = 'running'",
+                "?table?.status = Utf8(\"active\") IS TRUE",
+            ),
+            (
+                "simple_case_antifilter",
+                "CASE WHEN status = 'active' THEN 'running' WHEN status = 'pending' then 'waiting' ELSE 'other' END != 'running'",
+                "NOT ?table?.status = Utf8(\"active\") IS TRUE",
+            ),
+            (
+                "else_case_filter",
+                "CASE WHEN status = 'active' THEN 'running' WHEN status = 'pending' then 'waiting' ELSE 'other' END = 'other'",
+                "?table?.status = Utf8(\"active\") IS NOT TRUE AND ?table?.status = Utf8(\"pending\") IS NOT TRUE",
+            ),
+            (
+                "else_case_antifilter",
+                "CASE WHEN status = 'active' THEN 'running' WHEN status = 'pending' then 'waiting' ELSE 'other' END != 'other'",
+                "NOT ?table?.status = Utf8(\"active\") IS NOT TRUE AND ?table?.status = Utf8(\"pending\") IS NOT TRUE",
+            ),
+            (
+                "multiple_case_filter",
+                "CASE WHEN status = 'active' THEN 'running_pending' WHEN status = 'pending' then 'running_pending' ELSE 'other' END = 'running_pending'",
+                "?table?.status = Utf8(\"active\") IS TRUE OR ?table?.status = Utf8(\"active\") IS NOT TRUE AND ?table?.status = Utf8(\"pending\") IS TRUE",
+            ),
+            (
+                "multiple_case_antifilter",
+                "CASE WHEN status = 'active' THEN 'running_pending' WHEN status = 'pending' then 'running_pending' ELSE 'other' END != 'running_pending'",
+                "NOT ?table?.status = Utf8(\"active\") IS TRUE OR ?table?.status = Utf8(\"active\") IS NOT TRUE AND ?table?.status = Utf8(\"pending\") IS TRUE",
+            ),
+            (
+                "null_case_filter",
+                "CASE when status = NULL THEN 'a' ELSE 'b' END = 'a'", // false
+                "?table?.status = NULL IS TRUE",                       // false
+            ),
+            (
+                "null_case_filter2",
+                "CASE when status = NULL THEN 'a' ELSE 'b' END = 'b'", // true
+                "?table?.status = NULL IS NOT TRUE",                   // true
+            ),
+            (
+                "null_case_antifilter",
+                "CASE when status = NULL THEN 'a' ELSE 'b' END != 'a'", // true
+                "NOT ?table?.status = NULL IS TRUE",                    // true
+            ),
+            (
+                "null_case_antifilter2",
+                "CASE when status = NULL THEN 'a' ELSE 'b' END != 'b'", // false
+                "NOT ?table?.status = NULL IS NOT TRUE",                // false
+            ),
+            (
+                "isnull_case_filter",
+                "CASE when status IS NULL THEN 'a' ELSE 'b' END = 'a'", // true if status is null
+                "?table?.status IS NULL IS TRUE",                       // true if status is null
+            ),
+            (
+                "isnull_case_filter2",
+                "CASE when status IS NULL THEN 'a' ELSE 'b' END = 'b'", // true if status is not null
+                "?table?.status IS NULL IS NOT TRUE", // true if status is not null
+            ),
+            (
+                "isnull_case_antifilter",
+                "CASE when status IS NULL THEN 'a' ELSE 'b' END != 'a'", // true if status is not null
+                "NOT ?table?.status IS NULL IS TRUE", // true if status is not null
+            ),
+            (
+                "isnull_case_antifilter2",
+                "CASE when status IS NULL THEN 'a' ELSE 'b' END != 'b'", // true if status is null
+                "NOT ?table?.status IS NULL IS NOT TRUE",                // true if status is null
+            ),
+        ];
+
+        for (name, select_expr, expected_predicate) in test_cases {
+            let ctx = SessionContext::new();
+            let batch = create_test_data();
+            let df = ctx.read_batch(batch).unwrap();
+
+            let parsed_expr = df.parse_sql_expr(select_expr).unwrap();
+
+            let input_plan = df.filter(parsed_expr).unwrap().logical_plan().clone();
+
+            let result = optimizer.rewrite(input_plan.clone(), &config).unwrap();
+
+            match (result.transformed, &result.data) {
+                (true, LogicalPlan::Filter(filter)) => {
+                    let predicate = filter.predicate.to_string();
+                    assert_eq!(predicate, expected_predicate, "{name}");
+                }
+                (true, _) => panic!("Expected Filter plan for: {}, got: {:?}", name, result.data),
+                (false, _) => {
+                    panic!("Transformation failed for: {}", name);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
allows queries like `select id from sys_invocation where status = 'completed'` to be pushed ddown

Before
```
 physical_plan  CoalesceBatchesExec: target_batch_size=8192
                FilterExec: CASE WHEN status@3 = inboxed THEN pending WHEN status@3 = scheduled THEN scheduled WHEN status@3 = completed THEN completed WHEN status@3 =
                suspended THEN suspended WHEN in_flight@0 THEN running WHEN status@3 = invoked AND retry_count@1 > 0 THEN backing-off ELSE ready END = completed,
                projection=[id@2]
                    CoalesceBatchesExec: target_batch_size=8192
                HashJoinExec: mode=Partitioned, join_type=Right, on=[(partition_key@0, partition_key@0), (id@1, id@1)], projection=[in_flight@2, retry_count@3, id@5,
                status@6]
                        PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_state" })
                        PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_status" })
```

After:
```
 physical_plan  CoalesceBatchesExec: target_batch_size=128
                  HashJoinExec: mode=CollectLeft, join_type=Right, on=[(partition_key@0, partition_key@0), (id@1, id@1)], projection=[id@3]
                    CoalescePartitionsExec
                      PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_state" })
                    CoalesceBatchesExec: target_batch_size=128
                FilterExec: (status@2 = inboxed) IS DISTINCT FROM true AND (status@2 = scheduled) IS DISTINCT FROM true AND (status@2 = completed) IS NOT DISTINCT FROM
                true, projection=[partition_key@0, id@1]
                        RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=8
                          PartitionedExecutionPlan(RemotePartitionsScanner { manager: RemoteScannerManager, table_name: "sys_invocation_status" })
```