### PR TITLE
Upgrade Rust toolchain to 1.90

### DIFF
--- a/cli/src/commands/sql.rs
+++ b/cli/src/commands/sql.rs
@@ -18,8 +18,6 @@ use arrow::util::display::FormatOptions;
 use cling::prelude::*;
 use comfy_table::Cell;
 use comfy_table::Table;
-use serde::Deserialize;
-use serde::Serialize;
 
 use restate_cli_util::c_eprintln;
 use restate_cli_util::c_println;
@@ -46,11 +44,6 @@ pub struct Sql {
     /// Print result as json array instead of using the tabular format
     #[arg(long)]
     pub json: bool,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SqlQueryRequest {
-    pub query: String,
 }
 
 pub async fn run_sql(State(env): State<CliEnv>, opts: &Sql) -> Result<()> {

--- a/crates/metadata-server/src/raft/kv_memory_storage.rs
+++ b/crates/metadata-server/src/raft/kv_memory_storage.rs
@@ -259,10 +259,3 @@ impl KvMemoryStorage {
             .collect();
     }
 }
-
-#[serde_with::serde_as]
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct KvSnapshot {
-    #[serde_as(as = "serde_with::Seq<(_, _)>")]
-    kv_entries: HashMap<ByteString, VersionedValue>,
-}

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -587,7 +587,6 @@ macro_rules! define_table {
         // RowBuilder
         // --------------------------------------------------------------------------
 
-        #[automatically_derived]
         #[allow(dead_code)]
         #[allow(clippy::all)]
         impl<'a> [< $table_name:camel RowBuilder >]<'a> {
@@ -611,7 +610,6 @@ macro_rules! define_table {
                     )+
         }
 
-        #[automatically_derived]
         #[allow(dead_code)]
         #[allow(clippy::all)]
         impl<'a> Drop for [< $table_name:camel RowBuilder >]<'a> {
@@ -635,7 +633,6 @@ macro_rules! define_table {
         // ArrayBuilder
         // --------------------------------------------------------------------------
 
-        #[automatically_derived]
         #[allow(dead_code)]
         #[allow(clippy::all)]
         impl [< $table_name:camel ArrayBuilder >] {
@@ -687,7 +684,6 @@ macro_rules! define_table {
         // Builder
         // --------------------------------------------------------------------------
 
-        #[automatically_derived]
         #[allow(dead_code)]
         #[allow(clippy::all)]
         impl [< $table_name:camel Builder >] {

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -138,7 +138,7 @@ where
 
     async fn scan(
         &self,
-        state: &(dyn datafusion::catalog::Session),
+        state: &dyn datafusion::catalog::Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
@@ -407,7 +407,7 @@ impl TableProvider for GenericTableProvider {
 
     async fn scan(
         &self,
-        _state: &(dyn datafusion::catalog::Session),
+        _state: &dyn datafusion::catalog::Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,

--- a/crates/types/src/macros.rs
+++ b/crates/types/src/macros.rs
@@ -30,7 +30,6 @@ macro_rules! prefixed_ids {
             )+
         }
 
-        #[automatically_derived]
         impl $typename {
             #[doc = "The prefix string for this identifier"]
             pub const fn as_str(&self) -> &'static str {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Fixes up minor warnings resulting from https://github.com/restatedev/dev-tools/pull/22.