### PR TITLE
Use smallvec 'union' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ smartstring = { version = "1.0.1" }
 static_assertions = { version = "1.1.0" }
 strum = { version = "0.27.1", features = ["derive"] }
 sync_wrapper = "1.0.1"
-smallvec = { version = "1.15.1", features = ["serde"] }
+smallvec = { version = "1.15.1", features = ["serde", "union"] }
 tempfile = "3.6.0"
 test-log = { version = "0.2.11", default-features = false, features = [
     "trace",

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -113,7 +113,7 @@ serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
 serde_json = { version = "1", features = ["alloc", "raw_value", "unbounded_depth"] }
 serde_with = { version = "3", features = ["hex", "json"] }
-smallvec = { version = "1", default-features = false, features = ["const_new", "serde"] }
+smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union"] }
 sqlparser = { version = "0.58", default-features = false, features = ["recursive-protection", "visitor"] }
 stable_deref_trait = { version = "1" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
@@ -243,7 +243,7 @@ serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
 serde_json = { version = "1", features = ["alloc", "raw_value", "unbounded_depth"] }
 serde_with = { version = "3", features = ["hex", "json"] }
-smallvec = { version = "1", default-features = false, features = ["const_new", "serde"] }
+smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union"] }
 sqlparser = { version = "0.58", default-features = false, features = ["recursive-protection", "visitor"] }
 stable_deref_trait = { version = "1" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }


### PR DESCRIPTION
>When the union feature is enabled smallvec will track its state (inline or spilled) without the use of an enum tag, reducing the size of the smallvec by one machine word. This means that there is potentially no space overhead compared to Vec. Note that smallvec can still be larger than Vec if the inline buffer is larger than two machine words.

> To use this feature add features = ["union"] in the smallvec section of Cargo.toml. Note that this feature requires Rust 1.49.

It appears this feature is off by default due to MSRV but it would save us a whole 8 bytes, wow.jpg