### PR TITLE
Lock down dev-tools version and update Docker base image to trixie

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,11 @@
 
 ARG UPLOAD_DEBUGINFO=false
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS planner
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.4 AS planner
 COPY . .
 RUN just chef-prepare
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS base
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.4 AS base
 COPY --from=planner /restate/recipe.json recipe.json
 COPY justfile justfile
 
@@ -89,7 +89,7 @@ RUN cp docker/scripts/download-restate-debug-symbols.sh target/ && \
 FROM upload-$UPLOAD_DEBUGINFO AS upload
 
 # We do not need the Rust toolchain to run the server binary!
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 # useful for health checks
 RUN apt-get update && apt-get install --no-install-recommends -y jq curl && rm -rf /var/lib/apt/lists/*
 COPY --from=upload /restate/NOTICE /NOTICE

--- a/docker/debug.Dockerfile
+++ b/docker/debug.Dockerfile
@@ -8,11 +8,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS planner
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.4 AS planner
 COPY . .
 RUN just chef-prepare
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:latest AS base
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.4 AS base
 COPY --from=planner /restate/recipe.json recipe.json
 COPY justfile justfile
 
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/var/cache/sccache \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/debug/restate target/restate
 
 # We do not need the Rust toolchain to run the server binary!
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 COPY --from=builder /restate/target/restate-server /usr/local/bin
 COPY --from=builder /restate/target/restatectl /usr/local/bin
 COPY --from=builder /restate/target/restate /usr/local/bin


### PR DESCRIPTION
Switch the base image of the restate-server to Debian trixie to keep up with the latest dev-tools image:

```
~/restate/restate % docker run --entrypoint=/bin/bash localhost/restatedev/restate:HEAD.6ddbe4dd8 -c "ldd /usr/local/bin/restate-server"
	linux-vdso.so.1 (0x0000ffffbed0c000)
	libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffffaefa0000)
	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffffaef60000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffffaeeb0000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffaecf0000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffffbecd0000)

~/restate/restate % docker run localhost/restatedev/restate:HEAD.6ddbe4dd8 --version
restate-server 1.5.1-dev
```