### PR TITLE
[PartitionStore] Decouple read and write invocation status traits

### DIFF
--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -16,9 +16,9 @@ use tokio_stream::StreamExt;
 
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
 use restate_storage_api::invocation_status_table::{
-    InvocationLite, InvocationStatus, InvocationStatusDiscriminants, InvocationStatusTable,
-    InvocationStatusV1, InvokedInvocationStatusLite, ReadOnlyInvocationStatusTable,
-    ScanInvocationStatusTable,
+    InvocationLite, InvocationStatus, InvocationStatusDiscriminants, InvocationStatusV1,
+    InvokedInvocationStatusLite, ReadInvocationStatusTable, ScanInvocationStatusTable,
+    WriteInvocationStatusTable,
 };
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::{Result, StorageError, Transaction};
@@ -161,7 +161,7 @@ pub(crate) async fn run_invocation_status_v1_migration(storage: &mut PartitionSt
     Ok(())
 }
 
-impl ReadOnlyInvocationStatusTable for PartitionStore {
+impl ReadInvocationStatusTable for PartitionStore {
     async fn get_invocation_status(
         &mut self,
         invocation_id: &InvocationId,
@@ -266,7 +266,7 @@ impl ScanInvocationStatusTable for PartitionStore {
     }
 }
 
-impl ReadOnlyInvocationStatusTable for PartitionStoreTransaction<'_> {
+impl ReadInvocationStatusTable for PartitionStoreTransaction<'_> {
     async fn get_invocation_status(
         &mut self,
         invocation_id: &InvocationId,
@@ -276,8 +276,8 @@ impl ReadOnlyInvocationStatusTable for PartitionStoreTransaction<'_> {
     }
 }
 
-impl InvocationStatusTable for PartitionStoreTransaction<'_> {
-    async fn put_invocation_status(
+impl WriteInvocationStatusTable for PartitionStoreTransaction<'_> {
+    fn put_invocation_status(
         &mut self,
         invocation_id: &InvocationId,
         status: &InvocationStatus,
@@ -286,7 +286,7 @@ impl InvocationStatusTable for PartitionStoreTransaction<'_> {
         put_invocation_status(self, invocation_id, status)
     }
 
-    async fn delete_invocation_status(&mut self, invocation_id: &InvocationId) -> Result<()> {
+    fn delete_invocation_status(&mut self, invocation_id: &InvocationId) -> Result<()> {
         self.assert_partition_key(invocation_id)?;
         delete_invocation_status(self, invocation_id)
     }

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -23,8 +23,8 @@ use bytestring::ByteString;
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
 use restate_storage_api::invocation_status_table::{
-    CompletionRangeEpochMap, InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
-    InvocationStatusV1, JournalMetadata, ReadOnlyInvocationStatusTable, StatusTimestamps,
+    CompletionRangeEpochMap, InFlightInvocationMetadata, InvocationStatus, InvocationStatusV1,
+    JournalMetadata, ReadInvocationStatusTable, StatusTimestamps, WriteInvocationStatusTable,
 };
 use restate_types::RestateVersion;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId, WithPartitionKey};
@@ -134,37 +134,33 @@ fn suspended_status(invocation_target: InvocationTarget) -> InvocationStatus {
     }
 }
 
-async fn populate_data<T: InvocationStatusTable>(txn: &mut T) {
+async fn populate_data<T: WriteInvocationStatusTable>(txn: &mut T) {
     txn.put_invocation_status(
         &INVOCATION_ID_1,
         &invoked_status(INVOCATION_TARGET_1.clone()),
     )
-    .await
     .unwrap();
 
     txn.put_invocation_status(
         &INVOCATION_ID_2,
         &invoked_status(INVOCATION_TARGET_2.clone()),
     )
-    .await
     .expect("");
 
     txn.put_invocation_status(
         &INVOCATION_ID_3,
         &suspended_status(INVOCATION_TARGET_3.clone()),
     )
-    .await
     .unwrap();
 
     txn.put_invocation_status(
         &INVOCATION_ID_4,
         &suspended_status(INVOCATION_TARGET_4.clone()),
     )
-    .await
     .unwrap();
 }
 
-async fn verify_point_lookups<T: InvocationStatusTable>(txn: &mut T) {
+async fn verify_point_lookups<T: ReadInvocationStatusTable>(txn: &mut T) {
     assert_eq!(
         txn.get_invocation_status(&INVOCATION_ID_1)
             .await

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -856,7 +856,7 @@ pub struct InvokedInvocationStatusLite {
     pub current_invocation_epoch: InvocationEpoch,
 }
 
-pub trait ReadOnlyInvocationStatusTable {
+pub trait ReadInvocationStatusTable {
     fn get_invocation_status(
         &mut self,
         invocation_id: &InvocationId,
@@ -888,17 +888,14 @@ pub trait ScanInvocationStatusTable {
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send>;
 }
 
-pub trait InvocationStatusTable: ReadOnlyInvocationStatusTable {
+pub trait WriteInvocationStatusTable {
     fn put_invocation_status(
         &mut self,
         invocation_id: &InvocationId,
         status: &InvocationStatus,
-    ) -> impl Future<Output = Result<()>> + Send;
+    ) -> Result<()>;
 
-    fn delete_invocation_status(
-        &mut self,
-        invocation_id: &InvocationId,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn delete_invocation_status(&mut self, invocation_id: &InvocationId) -> Result<()>;
 }
 
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -80,7 +80,8 @@ pub trait Storage {
 
 pub trait Transaction:
     state_table::StateTable
-    + invocation_status_table::InvocationStatusTable
+    + invocation_status_table::ReadInvocationStatusTable
+    + invocation_status_table::WriteInvocationStatusTable
     + service_status_table::VirtualObjectStatusTable
     + inbox_table::InboxTable
     + outbox_table::OutboxTable

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -23,7 +23,7 @@ use restate_invoker_api::status_handle::test_util::MockStatusHandle;
 use restate_invoker_api::{InvocationErrorReport, InvocationStatusReport};
 use restate_storage_api::Transaction;
 use restate_storage_api::invocation_status_table::{
-    CompletedInvocation, InFlightInvocationMetadata, InvocationStatus, InvocationStatusTable,
+    CompletedInvocation, InFlightInvocationMetadata, InvocationStatus, WriteInvocationStatusTable,
 };
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::PartitionId;
@@ -73,7 +73,6 @@ async fn query_sys_invocation() {
             ..InFlightInvocationMetadata::mock()
         }),
     )
-    .await
     .unwrap();
     tx.commit().await.unwrap();
 
@@ -205,7 +204,6 @@ async fn query_sys_invocation_with_protocol_v4() {
             ..InFlightInvocationMetadata::mock()
         }),
     )
-    .await
     .unwrap();
     tx.commit().await.unwrap();
 
@@ -269,7 +267,6 @@ async fn query_sys_invocation_status_completed() {
         &invocation_id_1,
         &InvocationStatus::Completed(completed_invocation_1.clone()),
     )
-    .await
     .unwrap();
     tx.put_invocation_status(
         &invocation_id_2,
@@ -279,7 +276,6 @@ async fn query_sys_invocation_status_completed() {
             ..completed_invocation_1.clone()
         }),
     )
-    .await
     .unwrap();
     tx.put_invocation_status(
         &invocation_id_3,
@@ -289,7 +285,6 @@ async fn query_sys_invocation_status_completed() {
             ..completed_invocation_1
         }),
     )
-    .await
     .unwrap();
     tx.commit().await.unwrap();
 

--- a/crates/worker/src/partition/invoker_storage_reader.rs
+++ b/crates/worker/src/partition/invoker_storage_reader.rs
@@ -14,9 +14,7 @@ use restate_invoker_api::JournalMetadata;
 use restate_invoker_api::invocation_reader::{
     EagerState, InvocationReader, InvocationReaderTransaction,
 };
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
-};
+use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
 use restate_storage_api::state_table::ReadOnlyStateTable;
 use restate_storage_api::{IsolationLevel, journal_table as journal_table_v1, journal_table_v2};
 use restate_types::identifiers::InvocationId;

--- a/crates/worker/src/partition/rpc/get_invocation_output.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_output.rs
@@ -11,9 +11,7 @@
 use super::*;
 use restate_storage_api::StorageError;
 use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
-};
+use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
 use restate_storage_api::service_status_table::{
     ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus,
 };
@@ -38,7 +36,7 @@ impl<'a, TActuator, TSchemas, TStorage> RpcContext<'a, TActuator, TSchemas, TSto
 where
     TActuator: Actuator,
     TStorage:
-        ReadOnlyInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+        ReadInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
 {
     async fn get_invocation_output(
         &mut self,
@@ -99,7 +97,7 @@ impl<'a, Proposer: Actuator, TSchemas, Storage> RpcHandler<Request>
     for RpcContext<'a, Proposer, TSchemas, Storage>
 where
     Storage:
-        ReadOnlyInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+        ReadInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
 {
     type Output = PartitionProcessorRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -24,7 +24,7 @@ use crate::partition::leadership::LeadershipState;
 use restate_core::network::{Oneshot, Reciprocal};
 use restate_invoker_api::InvokerHandle;
 use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
-use restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable;
+use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
 use restate_storage_api::journal_table_v2::ReadOnlyJournalTable;
 use restate_storage_api::service_status_table::ReadOnlyVirtualObjectStatusTable;
 use restate_types::identifiers::{InvocationId, PartitionKey, PartitionProcessorRpcRequestId};
@@ -183,7 +183,7 @@ impl<'a, TActuator, TSchemas, TStorage> RpcHandler<PartitionProcessorRpcRequest>
 where
     TActuator: Actuator,
     TSchemas: DeploymentResolver,
-    TStorage: ReadOnlyInvocationStatusTable
+    TStorage: ReadInvocationStatusTable
         + ReadOnlyVirtualObjectStatusTable
         + ReadOnlyIdempotencyTable
         + ReadOnlyJournalTable,

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -11,9 +11,7 @@
 use super::*;
 use opentelemetry::trace::Span;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
-use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadOnlyInvocationStatusTable,
-};
+use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
 use restate_storage_api::journal_table_v2::ReadOnlyJournalTable;
 use restate_types::identifiers::{EntryIndex, InvocationId, InvocationUuid, WithPartitionKey};
 use restate_types::invocation::client::PatchDeploymentId;
@@ -50,7 +48,7 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
 where
     TActuator: Actuator,
     TSchemas: DeploymentResolver,
-    TStorage: ReadOnlyInvocationStatusTable + ReadOnlyJournalTable,
+    TStorage: ReadInvocationStatusTable + ReadOnlyJournalTable,
 {
     type Output = RestartAsNewInvocationRpcResponse;
     type Error = ();
@@ -508,7 +506,7 @@ mod tests {
         }
     }
 
-    impl ReadOnlyInvocationStatusTable for MockStorage {
+    impl ReadInvocationStatusTable for MockStorage {
         fn get_invocation_status(
             &mut self,
             _: &InvocationId,

--- a/crates/worker/src/partition/rpc/resume_invocation.rs
+++ b/crates/worker/src/partition/rpc/resume_invocation.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 use restate_storage_api::invocation_status_table::{
-    InFlightInvocationMetadata, InvocationStatus, ReadOnlyInvocationStatusTable,
+    InFlightInvocationMetadata, InvocationStatus, ReadInvocationStatusTable,
 };
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
 use restate_types::invocation::client::PatchDeploymentId;
@@ -31,7 +31,7 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
 where
     TActuator: Actuator,
     TSchemas: DeploymentResolver,
-    TStorage: ReadOnlyInvocationStatusTable,
+    TStorage: ReadInvocationStatusTable,
 {
     type Output = ResumeInvocationRpcResponse;
     type Error = ();
@@ -184,7 +184,7 @@ mod tests {
         status: InvocationStatus,
     }
 
-    impl ReadOnlyInvocationStatusTable for MockStorage {
+    impl ReadInvocationStatusTable for MockStorage {
         fn get_invocation_status(
             &mut self,
             inv_id: &InvocationId,

--- a/crates/worker/src/partition/state_machine/entries/mod.rs
+++ b/crates/worker/src/partition/state_machine/entries/mod.rs
@@ -31,7 +31,9 @@ use tracing::debug;
 
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_storage_api::fsm_table::FsmTable;
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2::JournalTable;
 use restate_storage_api::outbox_table::OutboxTable;
@@ -104,7 +106,8 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
 where
     S: JournalTable
         + journal_table_v1::JournalTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + TimerTable
         + FsmTable
         + OutboxTable
@@ -377,7 +380,6 @@ where
         // Store invocation status
         ctx.storage
             .put_invocation_status(&self.invocation_id, &self.invocation_status)
-            .await
             .map_err(Error::Storage)?;
 
         Ok(())
@@ -404,7 +406,7 @@ mod tests {
     use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
     use bytes::Bytes;
     use googletest::prelude::*;
-    use restate_storage_api::invocation_status_table::ReadOnlyInvocationStatusTable;
+    use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
     use restate_types::identifiers::{InvocationId, ServiceId};
     use restate_types::invocation::{
         Header, InvocationResponse, InvocationTarget, JournalCompletionTarget, ResponseResult,

--- a/crates/worker/src/partition/state_machine/entries/notification.rs
+++ b/crates/worker/src/partition/state_machine/entries/notification.rs
@@ -207,7 +207,7 @@ mod tests {
     use googletest::prelude::*;
     use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
     use restate_storage_api::invocation_status_table::{
-        InvocationStatus, InvocationStatusDiscriminants, ReadOnlyInvocationStatusTable,
+        InvocationStatus, InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
     use restate_storage_api::journal_table_v2::ReadOnlyJournalTable;
     use restate_types::invocation::{

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -12,7 +12,9 @@ use crate::partition::state_machine::entries::OnJournalEntryCommand;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_storage_api::fsm_table::FsmTable;
 use restate_storage_api::inbox_table::InboxTable;
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_events::JournalEventsTable;
 use restate_storage_api::journal_table;
 use restate_storage_api::journal_table_v2::JournalTable;
@@ -38,7 +40,8 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
     for OnCancelCommand
 where
     S: JournalTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + InboxTable
         + FsmTable
         + StateTable
@@ -119,7 +122,7 @@ mod tests {
     use googletest::prelude::{assert_that, contains, eq, ge, not, some};
     use restate_invoker_api::Effect;
     use restate_storage_api::invocation_status_table::{
-        InvocationStatus, ReadOnlyInvocationStatusTable,
+        InvocationStatus, ReadInvocationStatusTable,
     };
     use restate_types::deployment::PinnedDeployment;
     use restate_types::errors::CANCELED_INVOCATION_ERROR;

--- a/crates/worker/src/partition/state_machine/lifecycle/event.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/event.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{InvocationStatus, WriteInvocationStatusTable};
 use restate_storage_api::journal_events::{EventView, JournalEventsTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::journal_events::raw::RawEvent;
@@ -20,7 +20,7 @@ pub struct OnInvokerEventCommand {
     pub event: RawEvent,
 }
 
-impl<'ctx, 's: 'ctx, S: JournalEventsTable + InvocationStatusTable>
+impl<'ctx, 's: 'ctx, S: JournalEventsTable + WriteInvocationStatusTable>
     CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>> for OnInvokerEventCommand
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
@@ -40,7 +40,6 @@ impl<'ctx, 's: 'ctx, S: JournalEventsTable + InvocationStatusTable>
         // Store invocation status
         ctx.storage
             .put_invocation_status(&invocation_id, &invocation_status)
-            .await
             .map_err(Error::Storage)?;
 
         Ok(())

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_get_invocation_output_response.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_get_invocation_output_response.rs
@@ -12,7 +12,9 @@ use crate::debug_if_leader;
 use crate::partition::state_machine::invocation_status_ext::InvocationStatusExt;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext, entries};
 use restate_storage_api::fsm_table::FsmTable;
-use restate_storage_api::invocation_status_table::InvocationStatusTable;
+use restate_storage_api::invocation_status_table::{
+    ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2;
 use restate_storage_api::outbox_table::OutboxTable;
@@ -29,7 +31,8 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
 where
     S: journal_table_v1::JournalTable
         + journal_table_v2::JournalTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + TimerTable
         + FsmTable
         + PromiseTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_invocation_response.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_invocation_response.rs
@@ -12,7 +12,9 @@ use crate::debug_if_leader;
 use crate::partition::state_machine::invocation_status_ext::InvocationStatusExt;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext, entries};
 use restate_storage_api::fsm_table::FsmTable;
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2;
 use restate_storage_api::outbox_table::OutboxTable;
@@ -43,8 +45,9 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
 where
     S: journal_table_v1::JournalTable
         + journal_table_v2::JournalTable
-        + InvocationStatusTable
         + TimerTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + FsmTable
         + PromiseTable
         + StateTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_signal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_signal.rs
@@ -12,7 +12,9 @@ use crate::partition::state_machine::entries::OnJournalEntryCommand;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_storage_api::fsm_table::FsmTable;
 use restate_storage_api::inbox_table::InboxTable;
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_events::JournalEventsTable;
 use restate_storage_api::journal_table;
 use restate_storage_api::journal_table_v2::JournalTable;
@@ -34,7 +36,8 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
     for OnNotifySignalCommand
 where
     S: JournalTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + InboxTable
         + FsmTable
         + StateTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_sleep_completion.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_sleep_completion.rs
@@ -12,7 +12,9 @@ use crate::debug_if_leader;
 use crate::partition::state_machine::invocation_status_ext::InvocationStatusExt;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext, entries};
 use restate_storage_api::fsm_table::FsmTable;
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2;
 use restate_storage_api::outbox_table::OutboxTable;
@@ -35,7 +37,8 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
 where
     S: journal_table_v1::JournalTable
         + journal_table_v2::JournalTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + TimerTable
         + FsmTable
         + PromiseTable

--- a/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
@@ -14,7 +14,9 @@ use crate::debug_if_leader;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_storage_api::fsm_table::FsmTable;
 use restate_storage_api::inbox_table::InboxTable;
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
 use restate_storage_api::journal_events::JournalEventsTable;
 use restate_storage_api::outbox_table::OutboxTable;
 use restate_storage_api::promise_table::PromiseTable;
@@ -38,7 +40,8 @@ impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>
 where
     S: journal_table_v1::JournalTable
         + journal_table_v2::JournalTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + OutboxTable
         + StateTable
         + FsmTable
@@ -85,7 +88,6 @@ where
                 &self.invocation_id,
                 &InvocationStatus::Invoked(in_flight_invocation_metadata),
             )
-            .await
             .map_err(Error::Storage)?;
 
         if should_apply_cancellation_hotfix {

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -17,8 +17,9 @@ use restate_storage_api::fsm_table::FsmTable;
 use restate_storage_api::idempotency_table::IdempotencyTable;
 use restate_storage_api::inbox_table::InboxTable;
 use restate_storage_api::invocation_status_table::{
-    InvocationStatus, InvocationStatusTable, JournalMetadata, PreFlightInvocationArgument,
-    PreFlightInvocationJournal, PreFlightInvocationMetadata, StatusTimestamps,
+    InvocationStatus, JournalMetadata, PreFlightInvocationArgument, PreFlightInvocationJournal,
+    PreFlightInvocationMetadata, ReadInvocationStatusTable, StatusTimestamps,
+    WriteInvocationStatusTable,
 };
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2::{JournalTable, ReadOnlyJournalTable};
@@ -66,10 +67,10 @@ impl<'ctx, 's: 'ctx, S> StateMachineApplyContext<'s, S> {
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for OnRestartAsNewInvocationCommand
 where
-    S: InvocationStatusTable
-        + JournalTable
+    S: JournalTable
         + IdempotencyTable
-        + InvocationStatusTable
+        + ReadInvocationStatusTable
+        + WriteInvocationStatusTable
         + OutboxTable
         + FsmTable
         + VirtualObjectStatusTable
@@ -283,7 +284,7 @@ mod tests {
     use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
     use googletest::prelude::*;
     use restate_storage_api::invocation_status_table::{
-        InFlightInvocationMetadata, InvocationStatusDiscriminants, ReadOnlyInvocationStatusTable,
+        InFlightInvocationMetadata, InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
     use restate_types::identifiers::{
         DeploymentId, InvocationId, InvocationUuid, PartitionProcessorRpcRequestId,

--- a/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::invocation_status_table::{InvocationStatus, InvocationStatusTable};
+use restate_storage_api::invocation_status_table::{InvocationStatus, WriteInvocationStatusTable};
 use restate_storage_api::journal_table_v2::ReadOnlyJournalTable;
 use restate_types::identifiers::InvocationId;
 use restate_types::journal_v2::NotificationId;
@@ -25,7 +25,7 @@ pub struct OnSuspendCommand {
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for OnSuspendCommand
 where
-    S: ReadOnlyJournalTable + InvocationStatusTable,
+    S: ReadOnlyJournalTable + WriteInvocationStatusTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         debug_assert!(
@@ -85,7 +85,6 @@ where
         // Store invocation status
         ctx.storage
             .put_invocation_status(&self.invocation_id, &invocation_status)
-            .await
             .map_err(Error::Storage)
     }
 }

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -252,7 +252,6 @@ async fn complete_already_completed_invocation() {
             random_seed: None,
         }),
     )
-    .await
     .unwrap();
     txn.commit().await.unwrap();
 
@@ -770,7 +769,6 @@ async fn purge_completed_idempotent_invocation() {
             ..CompletedInvocation::mock_neo()
         }),
     )
-    .await
     .unwrap();
     txn.commit().await.unwrap();
 

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -229,8 +229,7 @@ async fn kill_call_tree() -> anyhow::Result<()> {
     .await?;
     let mut invocation_status = tx.get_invocation_status(&invocation_id).await?;
     invocation_status.get_journal_metadata_mut().unwrap().length = 4;
-    tx.put_invocation_status(&invocation_id, &invocation_status)
-        .await?;
+    tx.put_invocation_status(&invocation_id, &invocation_status)?;
     tx.commit().await?;
 
     // Now let's send the termination command
@@ -354,8 +353,7 @@ async fn cancel_invoked_invocation() -> Result<(), Error> {
     let mut invocation_status = tx.get_invocation_status(&invocation_id).await?;
     invocation_status.get_journal_metadata_mut().unwrap().length =
         (journal_length + 1) as EntryIndex;
-    tx.put_invocation_status(&invocation_id, &invocation_status)
-        .await?;
+    tx.put_invocation_status(&invocation_id, &invocation_status)?;
     // Add timer
     tx.put_timer(
         &TimerKey {
@@ -494,8 +492,7 @@ async fn cancel_suspended_invocation() -> Result<(), Error> {
                 NotificationId::for_completion(9),
             ]),
         },
-    )
-    .await?;
+    )?;
     // Add timer
     tx.put_timer(
         &TimerKey {
@@ -606,7 +603,6 @@ async fn cancel_invocation_entry_referring_to_previous_entry() {
     let mut invocation_status = tx.get_invocation_status(&invocation_id).await.unwrap();
     invocation_status.get_journal_metadata_mut().unwrap().length = 3;
     tx.put_invocation_status(&invocation_id, &invocation_status)
-        .await
         .unwrap();
     tx.commit().await.unwrap();
 

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -326,7 +326,6 @@ async fn purge_completed_workflow() {
             ..CompletedInvocation::mock_neo()
         }),
     )
-    .await
     .unwrap();
     txn.put_virtual_object_status(
         &invocation_target.as_keyed_service_id().unwrap(),


### PR DESCRIPTION

This is a step towards replacing all the table traits with individual read/write traits. The separation
enables us to be selective about the API shape available when operating on a transaction/write-batch vs. on
the partition store itself. In particular, we would remove the need for `async` when applying changes to the
write-batch. This makes it easier to spot where we might be performing blocking operations. For instance,
if a write is implemented directly on partition store, then it would need a different API/trait to reflect that
it is async-blocking.
