### PR TITLE
[PartitionStore] Decouple read and write service status table traits

### DIFF
--- a/crates/partition-store/src/service_status_table/mod.rs
+++ b/crates/partition-store/src/service_status_table/mod.rs
@@ -15,8 +15,8 @@ use bytestring::ByteString;
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::service_status_table::{
-    ReadOnlyVirtualObjectStatusTable, ScanVirtualObjectStatusTable, VirtualObjectStatus,
-    VirtualObjectStatusTable,
+    ReadVirtualObjectStatusTable, ScanVirtualObjectStatusTable, VirtualObjectStatus,
+    WriteVirtualObjectStatusTable,
 };
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
@@ -81,7 +81,7 @@ fn delete_virtual_object_status<S: StorageAccess>(
     storage.delete_key(&key)
 }
 
-impl ReadOnlyVirtualObjectStatusTable for PartitionStore {
+impl ReadVirtualObjectStatusTable for PartitionStore {
     async fn get_virtual_object_status(
         &mut self,
         service_id: &ServiceId,
@@ -122,7 +122,7 @@ impl ScanVirtualObjectStatusTable for PartitionStore {
     }
 }
 
-impl ReadOnlyVirtualObjectStatusTable for PartitionStoreTransaction<'_> {
+impl ReadVirtualObjectStatusTable for PartitionStoreTransaction<'_> {
     async fn get_virtual_object_status(
         &mut self,
         service_id: &ServiceId,
@@ -132,8 +132,8 @@ impl ReadOnlyVirtualObjectStatusTable for PartitionStoreTransaction<'_> {
     }
 }
 
-impl VirtualObjectStatusTable for PartitionStoreTransaction<'_> {
-    async fn put_virtual_object_status(
+impl WriteVirtualObjectStatusTable for PartitionStoreTransaction<'_> {
+    fn put_virtual_object_status(
         &mut self,
         service_id: &ServiceId,
         status: &VirtualObjectStatus,
@@ -142,7 +142,7 @@ impl VirtualObjectStatusTable for PartitionStoreTransaction<'_> {
         put_virtual_object_status(self, service_id, status)
     }
 
-    async fn delete_virtual_object_status(&mut self, service_id: &ServiceId) -> Result<()> {
+    fn delete_virtual_object_status(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
         delete_virtual_object_status(self, service_id)
     }

--- a/crates/partition-store/src/tests/virtual_object_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/virtual_object_status_table_test/mod.rs
@@ -9,28 +9,28 @@
 // by the Apache License, Version 2.0.
 
 use crate::PartitionStore;
-use restate_storage_api::service_status_table::{VirtualObjectStatus, VirtualObjectStatusTable};
+use restate_storage_api::service_status_table::{
+    ReadVirtualObjectStatusTable, VirtualObjectStatus, WriteVirtualObjectStatusTable,
+};
 use restate_types::identifiers::{InvocationId, InvocationUuid, ServiceId};
 
 const FIXTURE_INVOCATION: InvocationUuid = InvocationUuid::from_u128(12345678900001);
 
-async fn populate_data<T: VirtualObjectStatusTable>(txn: &mut T) {
+fn populate_data<T: WriteVirtualObjectStatusTable>(txn: &mut T) {
     txn.put_virtual_object_status(
         &ServiceId::with_partition_key(1337, "svc-1", "key-1"),
         &VirtualObjectStatus::Locked(InvocationId::from_parts(1337, FIXTURE_INVOCATION)),
     )
-    .await
     .expect("");
 
     txn.put_virtual_object_status(
         &ServiceId::with_partition_key(1337, "svc-1", "key-2"),
         &VirtualObjectStatus::Locked(InvocationId::from_parts(1337, FIXTURE_INVOCATION)),
     )
-    .await
     .expect("");
 }
 
-async fn verify_point_lookups<T: VirtualObjectStatusTable>(txn: &mut T) {
+async fn verify_point_lookups<T: ReadVirtualObjectStatusTable>(txn: &mut T) {
     let status = txn
         .get_virtual_object_status(&ServiceId::with_partition_key(1337, "svc-1", "key-1"))
         .await
@@ -44,7 +44,7 @@ async fn verify_point_lookups<T: VirtualObjectStatusTable>(txn: &mut T) {
 
 pub(crate) async fn run_tests(mut rocksdb: PartitionStore) {
     let mut txn = rocksdb.transaction();
-    populate_data(&mut txn).await;
+    populate_data(&mut txn);
 
     verify_point_lookups(&mut txn).await;
 }

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -82,7 +82,8 @@ pub trait Transaction:
     state_table::StateTable
     + invocation_status_table::ReadInvocationStatusTable
     + invocation_status_table::WriteInvocationStatusTable
-    + service_status_table::VirtualObjectStatusTable
+    + service_status_table::ReadVirtualObjectStatusTable
+    + service_status_table::WriteVirtualObjectStatusTable
     + inbox_table::InboxTable
     + outbox_table::WriteOutboxTable
     + deduplication_table::DeduplicationTable

--- a/crates/storage-api/src/service_status_table/mod.rs
+++ b/crates/storage-api/src/service_status_table/mod.rs
@@ -27,7 +27,7 @@ impl PartitionStoreProtobufValue for VirtualObjectStatus {
     type ProtobufType = crate::protobuf_types::v1::VirtualObjectStatus;
 }
 
-pub trait ReadOnlyVirtualObjectStatusTable {
+pub trait ReadVirtualObjectStatusTable {
     fn get_virtual_object_status(
         &mut self,
         service_id: &ServiceId,
@@ -47,15 +47,12 @@ pub trait ScanVirtualObjectStatusTable {
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }
 
-pub trait VirtualObjectStatusTable: ReadOnlyVirtualObjectStatusTable {
+pub trait WriteVirtualObjectStatusTable {
     fn put_virtual_object_status(
         &mut self,
         service_id: &ServiceId,
         status: &VirtualObjectStatus,
-    ) -> impl Future<Output = Result<()>> + Send;
+    ) -> Result<()>;
 
-    fn delete_virtual_object_status(
-        &mut self,
-        service_id: &ServiceId,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn delete_virtual_object_status(&mut self, service_id: &ServiceId) -> Result<()>;
 }

--- a/crates/worker/src/partition/rpc/get_invocation_output.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_output.rs
@@ -13,7 +13,7 @@ use restate_storage_api::StorageError;
 use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
 use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
 use restate_storage_api::service_status_table::{
-    ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus,
+    ReadVirtualObjectStatusTable, VirtualObjectStatus,
 };
 use restate_types::identifiers::WithPartitionKey;
 use restate_types::invocation;
@@ -35,8 +35,7 @@ pub(super) struct Request {
 impl<'a, TActuator, TSchemas, TStorage> RpcContext<'a, TActuator, TSchemas, TStorage>
 where
     TActuator: Actuator,
-    TStorage:
-        ReadInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+    TStorage: ReadInvocationStatusTable + ReadVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
 {
     async fn get_invocation_output(
         &mut self,
@@ -96,8 +95,7 @@ where
 impl<'a, Proposer: Actuator, TSchemas, Storage> RpcHandler<Request>
     for RpcContext<'a, Proposer, TSchemas, Storage>
 where
-    Storage:
-        ReadInvocationStatusTable + ReadOnlyVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
+    Storage: ReadInvocationStatusTable + ReadVirtualObjectStatusTable + ReadOnlyIdempotencyTable,
 {
     type Output = PartitionProcessorRpcResponse;
     type Error = ();

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -26,7 +26,7 @@ use restate_invoker_api::InvokerHandle;
 use restate_storage_api::idempotency_table::ReadOnlyIdempotencyTable;
 use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
 use restate_storage_api::journal_table_v2::ReadJournalTable;
-use restate_storage_api::service_status_table::ReadOnlyVirtualObjectStatusTable;
+use restate_storage_api::service_status_table::ReadVirtualObjectStatusTable;
 use restate_types::identifiers::{InvocationId, PartitionKey, PartitionProcessorRpcRequestId};
 use restate_types::invocation::{InvocationEpoch, InvocationRequest};
 use restate_types::net::partition_processor::{
@@ -184,7 +184,7 @@ where
     TActuator: Actuator,
     TSchemas: DeploymentResolver,
     TStorage: ReadInvocationStatusTable
-        + ReadOnlyVirtualObjectStatusTable
+        + ReadVirtualObjectStatusTable
         + ReadOnlyIdempotencyTable
         + ReadJournalTable,
 {

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_signal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_signal.rs
@@ -20,7 +20,7 @@ use restate_storage_api::journal_table;
 use restate_storage_api::journal_table_v2::{ReadJournalTable, WriteJournalTable};
 use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
-use restate_storage_api::service_status_table::VirtualObjectStatusTable;
+use restate_storage_api::service_status_table::WriteVirtualObjectStatusTable;
 use restate_storage_api::state_table::StateTable;
 use restate_storage_api::timer_table::TimerTable;
 use restate_types::identifiers::InvocationId;
@@ -49,7 +49,7 @@ where
         + TimerTable
         + ReadPromiseTable
         + WritePromiseTable
-        + VirtualObjectStatusTable,
+        + WriteVirtualObjectStatusTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let OnNotifySignalCommand {

--- a/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
@@ -20,7 +20,7 @@ use restate_storage_api::invocation_status_table::{
 use restate_storage_api::journal_events::JournalEventsTable;
 use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
-use restate_storage_api::service_status_table::VirtualObjectStatusTable;
+use restate_storage_api::service_status_table::WriteVirtualObjectStatusTable;
 use restate_storage_api::state_table::StateTable;
 use restate_storage_api::timer_table::TimerTable;
 use restate_storage_api::{journal_table as journal_table_v1, journal_table_v2};
@@ -48,7 +48,7 @@ where
         + StateTable
         + FsmTable
         + InboxTable
-        + VirtualObjectStatusTable
+        + WriteVirtualObjectStatusTable
         + JournalEventsTable
         + TimerTable
         + ReadPromiseTable

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -17,7 +17,7 @@ use restate_storage_api::journal_events::JournalEventsTable;
 use restate_storage_api::journal_table;
 use restate_storage_api::journal_table_v2::WriteJournalTable;
 use restate_storage_api::promise_table::WritePromiseTable;
-use restate_storage_api::service_status_table::VirtualObjectStatusTable;
+use restate_storage_api::service_status_table::WriteVirtualObjectStatusTable;
 use restate_storage_api::state_table::StateTable;
 use restate_types::identifiers::{IdempotencyId, InvocationId};
 use restate_types::invocation::client::PurgeInvocationResponse;
@@ -40,7 +40,7 @@ where
         + StateTable
         + journal_table::WriteJournalTable
         + IdempotencyTable
-        + VirtualObjectStatusTable
+        + WriteVirtualObjectStatusTable
         + WritePromiseTable
         + JournalEventsTable,
 {

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -23,7 +23,9 @@ use restate_storage_api::invocation_status_table::{
 };
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2::{ReadJournalTable, WriteJournalTable};
-use restate_storage_api::service_status_table::VirtualObjectStatusTable;
+use restate_storage_api::service_status_table::{
+    ReadVirtualObjectStatusTable, WriteVirtualObjectStatusTable,
+};
 use restate_storage_api::timer_table::TimerTable;
 use restate_types::identifiers::{DeploymentId, EntryIndex, InvocationId};
 use restate_types::invocation::client::RestartAsNewInvocationResponse;
@@ -72,7 +74,8 @@ where
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
         + FsmTable
-        + VirtualObjectStatusTable
+        + ReadVirtualObjectStatusTable
+        + WriteVirtualObjectStatusTable
         + TimerTable
         + InboxTable
         + journal_table_v1::WriteJournalTable,

--- a/crates/worker/src/partition/state_machine/tests/delayed_send.rs
+++ b/crates/worker/src/partition/state_machine/tests/delayed_send.rs
@@ -116,7 +116,6 @@ async fn send_with_delay_to_locked_virtual_object() {
         &invocation_target.as_keyed_service_id().unwrap(),
         &VirtualObjectStatus::Locked(InvocationId::mock_generate(&invocation_target)),
     )
-    .await
     .unwrap();
     tx.commit().await.unwrap();
 

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -514,7 +514,6 @@ async fn attach_inboxed_with_send_service_invocation() {
             &invocation_target.as_keyed_service_id().unwrap(),
             &VirtualObjectStatus::Locked(InvocationId::mock_generate(&invocation_target)),
         )
-        .await
         .unwrap();
         tx.commit().await.unwrap();
     }

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -43,7 +43,7 @@ use restate_storage_api::invocation_status_table::{
 use restate_storage_api::journal_table::{JournalEntry, ReadJournalTable};
 use restate_storage_api::outbox_table::ReadOutboxTable;
 use restate_storage_api::service_status_table::{
-    ReadOnlyVirtualObjectStatusTable, VirtualObjectStatus, VirtualObjectStatusTable,
+    ReadVirtualObjectStatusTable, VirtualObjectStatus, WriteVirtualObjectStatusTable,
 };
 use restate_storage_api::state_table::{ReadOnlyStateTable, StateTable};
 use restate_test_util::matchers::*;
@@ -340,8 +340,7 @@ async fn shared_invocation_skips_inbox() -> TestResult {
     tx.put_virtual_object_status(
         &invocation_target.as_keyed_service_id().unwrap(),
         &VirtualObjectStatus::Locked(InvocationId::mock_random()),
-    )
-    .await?;
+    )?;
     tx.commit().await.unwrap();
 
     // Start the invocation

--- a/crates/worker/src/partition/state_machine/tests/workflow.rs
+++ b/crates/worker/src/partition/state_machine/tests/workflow.rs
@@ -12,7 +12,7 @@ use super::*;
 
 use crate::partition::state_machine::tests::matchers::actions::forward_purge_invocation_response;
 use restate_storage_api::invocation_status_table::CompletedInvocation;
-use restate_storage_api::service_status_table::ReadOnlyVirtualObjectStatusTable;
+use restate_storage_api::service_status_table::ReadVirtualObjectStatusTable;
 use restate_types::errors::WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR;
 use restate_types::invocation::{
     AttachInvocationRequest, IngressInvocationResponseSink, InvocationQuery, InvocationTarget,
@@ -331,7 +331,6 @@ async fn purge_completed_workflow() {
         &invocation_target.as_keyed_service_id().unwrap(),
         &VirtualObjectStatus::Locked(invocation_id),
     )
-    .await
     .unwrap();
     txn.commit().await.unwrap();
 


### PR DESCRIPTION
[PartitionStore] Decouple read and write service status table traits

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3827).
* #3834
* #3833
* #3831
* #3830
* #3828
* __->__ #3827