### PR TITLE
[PartitionStore] Decouple read and write fsm table traits

### DIFF
--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -10,7 +10,7 @@
 
 use restate_storage_api::Result;
 use restate_storage_api::fsm_table::{
-    FsmTable, PartitionDurability, ReadOnlyFsmTable, SequenceNumber,
+    PartitionDurability, ReadFsmTable, SequenceNumber, WriteFsmTable,
 };
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_types::SemanticRestateVersion;
@@ -111,7 +111,7 @@ pub(crate) async fn put_schema_version<S: StorageAccess>(
     )
 }
 
-impl ReadOnlyFsmTable for PartitionStore {
+impl ReadFsmTable for PartitionStore {
     async fn get_inbox_seq_number(&mut self) -> Result<MessageIndex> {
         get::<SequenceNumber, _>(self, self.partition_id(), fsm_variable::INBOX_SEQ_NUMBER)
             .map(|opt| opt.map(Into::into).unwrap_or_default())
@@ -145,8 +145,8 @@ impl ReadOnlyFsmTable for PartitionStore {
     }
 }
 
-impl FsmTable for PartitionStoreTransaction<'_> {
-    async fn put_applied_lsn(&mut self, lsn: Lsn) -> Result<()> {
+impl WriteFsmTable for PartitionStoreTransaction<'_> {
+    fn put_applied_lsn(&mut self, lsn: Lsn) -> Result<()> {
         put(
             self,
             self.partition_id(),
@@ -155,7 +155,7 @@ impl FsmTable for PartitionStoreTransaction<'_> {
         )
     }
 
-    async fn put_inbox_seq_number(&mut self, seq_number: MessageIndex) -> Result<()> {
+    fn put_inbox_seq_number(&mut self, seq_number: MessageIndex) -> Result<()> {
         put(
             self,
             self.partition_id(),
@@ -164,7 +164,7 @@ impl FsmTable for PartitionStoreTransaction<'_> {
         )
     }
 
-    async fn put_outbox_seq_number(&mut self, seq_number: MessageIndex) -> Result<()> {
+    fn put_outbox_seq_number(&mut self, seq_number: MessageIndex) -> Result<()> {
         put(
             self,
             self.partition_id(),
@@ -173,7 +173,7 @@ impl FsmTable for PartitionStoreTransaction<'_> {
         )
     }
 
-    async fn put_min_restate_version(&mut self, version: &SemanticRestateVersion) -> Result<()> {
+    fn put_min_restate_version(&mut self, version: &SemanticRestateVersion) -> Result<()> {
         put(
             self,
             self.partition_id(),
@@ -182,7 +182,7 @@ impl FsmTable for PartitionStoreTransaction<'_> {
         )
     }
 
-    async fn put_partition_durability(&mut self, durability: &PartitionDurability) -> Result<()> {
+    fn put_partition_durability(&mut self, durability: &PartitionDurability) -> Result<()> {
         put(
             self,
             self.partition_id(),

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -30,7 +30,7 @@ use tracing::{debug, trace};
 
 use restate_core::ShutdownError;
 use restate_rocksdb::{IoMode, IterAction, Priority, RocksDb, RocksError};
-use restate_storage_api::fsm_table::ReadOnlyFsmTable;
+use restate_storage_api::fsm_table::ReadFsmTable;
 use restate_storage_api::protobuf_types::{PartitionStoreProtobufValue, ProtobufStorageWrapper};
 use restate_storage_api::{IsolationLevel, Storage, StorageError, Transaction};
 use restate_types::config::Configuration;

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -17,7 +17,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, error, info, instrument, warn};
 
 use restate_rocksdb::{CfPrefixPattern, DbSpecBuilder, RocksDb, RocksDbManager, RocksError};
-use restate_storage_api::fsm_table::ReadOnlyFsmTable;
+use restate_storage_api::fsm_table::ReadFsmTable;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{PartitionId, SnapshotId};
 use restate_types::logs::{Lsn, SequenceNumber};

--- a/crates/partition-store/src/tests/barrier_test.rs
+++ b/crates/partition-store/src/tests/barrier_test.rs
@@ -3,7 +3,7 @@ use googletest::prelude::*;
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::{
     Transaction,
-    fsm_table::{FsmTable, ReadOnlyFsmTable},
+    fsm_table::{ReadFsmTable, WriteFsmTable},
 };
 use restate_types::{
     SemanticRestateVersion,
@@ -40,8 +40,7 @@ async fn barrier_fsm() -> googletest::Result<()> {
 
     let mut txn = partition_store.transaction();
     // lets update it to current.
-    txn.put_min_restate_version(SemanticRestateVersion::current())
-        .await?;
+    txn.put_min_restate_version(SemanticRestateVersion::current())?;
 
     // commit.
     txn.commit().await?;

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 use tempfile::tempdir;
 
 use restate_storage_api::Transaction;
-use restate_storage_api::fsm_table::{FsmTable, ReadOnlyFsmTable};
+use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
 use restate_types::identifiers::{PartitionKey, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
 use restate_types::partitions::Partition;
@@ -85,7 +85,7 @@ pub(crate) async fn run_tests(
 
 async fn insert_test_data(partition: &mut PartitionStore) {
     let mut txn = partition.transaction();
-    txn.put_applied_lsn(Lsn::new(100)).await.unwrap();
+    txn.put_applied_lsn(Lsn::new(100)).unwrap();
     txn.commit().await.expect("commit succeeds");
 }
 

--- a/crates/storage-api/src/fsm_table/mod.rs
+++ b/crates/storage-api/src/fsm_table/mod.rs
@@ -18,7 +18,7 @@ use restate_types::time::MillisSinceEpoch;
 use crate::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
 
-pub trait ReadOnlyFsmTable {
+pub trait ReadFsmTable {
     fn get_inbox_seq_number(&mut self) -> impl Future<Output = Result<MessageIndex>> + Send + '_;
 
     fn get_outbox_seq_number(&mut self) -> impl Future<Output = Result<MessageIndex>> + Send + '_;
@@ -34,28 +34,16 @@ pub trait ReadOnlyFsmTable {
     ) -> impl Future<Output = Result<Option<PartitionDurability>>> + Send + '_;
 }
 
-pub trait FsmTable {
-    fn put_applied_lsn(&mut self, lsn: Lsn) -> impl Future<Output = Result<()>> + Send;
+pub trait WriteFsmTable {
+    fn put_applied_lsn(&mut self, lsn: Lsn) -> Result<()>;
 
-    fn put_inbox_seq_number(
-        &mut self,
-        seq_number: MessageIndex,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn put_inbox_seq_number(&mut self, seq_number: MessageIndex) -> Result<()>;
 
-    fn put_outbox_seq_number(
-        &mut self,
-        seq_number: MessageIndex,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn put_outbox_seq_number(&mut self, seq_number: MessageIndex) -> Result<()>;
 
-    fn put_min_restate_version(
-        &mut self,
-        version: &SemanticRestateVersion,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn put_min_restate_version(&mut self, version: &SemanticRestateVersion) -> Result<()>;
 
-    fn put_partition_durability(
-        &mut self,
-        durability: &PartitionDurability,
-    ) -> impl Future<Output = Result<()>> + Send;
+    fn put_partition_durability(&mut self, durability: &PartitionDurability) -> Result<()>;
 }
 
 #[derive(Debug, Clone, Copy, derive_more::From, derive_more::Into)]

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -92,7 +92,7 @@ pub trait Transaction:
     + journal_table::ReadJournalTable
     + journal_table_v2::WriteJournalTable
     + journal_table_v2::ReadJournalTable
-    + fsm_table::FsmTable
+    + fsm_table::WriteFsmTable
     + timer_table::WriteTimerTable
     + idempotency_table::IdempotencyTable
     + promise_table::ReadPromiseTable

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -32,7 +32,7 @@ use restate_errors::NotRunningError;
 use restate_invoker_api::InvokeInputJournal;
 use restate_partition_store::PartitionStore;
 use restate_storage_api::deduplication_table::EpochSequenceNumber;
-use restate_storage_api::fsm_table::ReadOnlyFsmTable;
+use restate_storage_api::fsm_table::ReadFsmTable;
 use restate_storage_api::invocation_status_table::{
     InvokedInvocationStatusLite, ScanInvocationStatusTable,
 };

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -38,7 +38,7 @@ use restate_storage_api::deduplication_table::{
     DedupInformation, DedupSequenceNumber, DeduplicationTable, ProducerId,
     ReadOnlyDeduplicationTable,
 };
-use restate_storage_api::fsm_table::{FsmTable, PartitionDurability, ReadOnlyFsmTable};
+use restate_storage_api::fsm_table::{PartitionDurability, ReadFsmTable, WriteFsmTable};
 use restate_storage_api::outbox_table::ReadOutboxTable;
 use restate_storage_api::{StorageError, Transaction};
 use restate_time_util::DurationExt;
@@ -650,7 +650,7 @@ where
         };
 
         // make sure we advance the FSM, even if it's a filtered gap.
-        transaction.put_applied_lsn(lsn).await?;
+        transaction.put_applied_lsn(lsn)?;
         // Update replay status
         self.status.last_applied_log_lsn = Some(lsn);
         self.status.last_record_applied_at = Some(MillisSinceEpoch::now());
@@ -731,9 +731,7 @@ where
                     durable_point: partition_durability.durable_point,
                 };
                 if self.trim_queue.push(&partition_durability) {
-                    transaction
-                        .put_partition_durability(&partition_durability)
-                        .await?;
+                    transaction.put_partition_durability(&partition_durability)?;
                 }
             } else {
                 self.state_machine

--- a/crates/worker/src/partition/state_machine/entries/attach_invocation_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/attach_invocation_command.rs
@@ -10,7 +10,7 @@
 
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
 use restate_storage_api::timer_table::WriteTimerTable;
 use restate_types::invocation::{AttachInvocationRequest, ServiceInvocationResponseSink};
@@ -22,7 +22,7 @@ pub(super) type ApplyAttachInvocationCommand<'e> =
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyAttachInvocationCommand<'e>
 where
-    S: WriteTimerTable + WriteOutboxTable + FsmTable,
+    S: WriteTimerTable + WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         ctx.handle_outgoing_message(OutboxMessage::AttachInvocation(AttachInvocationRequest {

--- a/crates/worker/src/partition/state_machine/entries/call_commands.rs
+++ b/crates/worker/src/partition/state_machine/entries/call_commands.rs
@@ -11,7 +11,7 @@
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::invocation_status_table::InvocationStatus;
 use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
 use restate_types::identifiers::InvocationId;
@@ -27,7 +27,7 @@ pub(super) type ApplyCallCommand<'e> = ApplyJournalCommandEffect<'e, CallCommand
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyJournalCommandEffect<'e, CallCommand>
 where
-    S: WriteOutboxTable + FsmTable,
+    S: WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         _ApplyCallCommand {
@@ -49,7 +49,7 @@ pub(super) type ApplyOneWayCallCommand<'e> = ApplyJournalCommandEffect<'e, OneWa
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyJournalCommandEffect<'e, OneWayCallCommand>
 where
-    S: WriteOutboxTable + FsmTable,
+    S: WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let execution_time = if self.entry.invoke_time == MillisSinceEpoch::UNIX_EPOCH {
@@ -84,7 +84,7 @@ struct _ApplyCallCommand<'e> {
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for _ApplyCallCommand<'e>
 where
-    S: WriteOutboxTable + FsmTable,
+    S: WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let caller_invocation_metadata = self

--- a/crates/worker/src/partition/state_machine/entries/complete_awakeable_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/complete_awakeable_command.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
 use restate_storage_api::state_table::WriteStateTable;
 use restate_types::invocation::{NotifySignalRequest, ResponseResult};
@@ -26,7 +26,7 @@ pub(super) type ApplyCompleteAwakeableCommand<'e> =
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyCompleteAwakeableCommand<'e>
 where
-    S: WriteStateTable + WriteOutboxTable + FsmTable,
+    S: WriteStateTable + WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         ctx.handle_outgoing_message(match self.entry.id {

--- a/crates/worker/src/partition/state_machine/entries/complete_promise_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/complete_promise_command.rs
@@ -11,7 +11,7 @@
 use crate::debug_if_leader;
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
 use restate_storage_api::promise_table::{
     Promise, PromiseState, ReadPromiseTable, WritePromiseTable,
@@ -31,7 +31,7 @@ pub(super) type ApplyCompletePromiseCommand<'e> =
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyCompletePromiseCommand<'e>
 where
-    S: ReadStateTable + ReadPromiseTable + WritePromiseTable + FsmTable + WriteOutboxTable,
+    S: ReadStateTable + ReadPromiseTable + WritePromiseTable + WriteFsmTable + WriteOutboxTable,
 {
     async fn apply(mut self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let invocation_metadata = self

--- a/crates/worker/src/partition/state_machine/entries/get_invocation_output_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/get_invocation_output_command.rs
@@ -10,7 +10,7 @@
 
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
 use restate_storage_api::timer_table::WriteTimerTable;
 use restate_types::invocation::{AttachInvocationRequest, ServiceInvocationResponseSink};
@@ -22,7 +22,7 @@ pub(super) type ApplyGetInvocationOutputCommand<'e> =
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyGetInvocationOutputCommand<'e>
 where
-    S: WriteTimerTable + WriteOutboxTable + FsmTable,
+    S: WriteTimerTable + WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         ctx.handle_outgoing_message(OutboxMessage::AttachInvocation(AttachInvocationRequest {

--- a/crates/worker/src/partition/state_machine/entries/mod.rs
+++ b/crates/worker/src/partition/state_machine/entries/mod.rs
@@ -30,7 +30,7 @@ use metrics::counter;
 use tracing::debug;
 
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
 };
@@ -111,7 +111,7 @@ where
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
         + WriteTimerTable
-        + FsmTable
+        + WriteFsmTable
         + WriteOutboxTable
         + ReadPromiseTable
         + WritePromiseTable

--- a/crates/worker/src/partition/state_machine/entries/send_signal_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/send_signal_command.rs
@@ -10,7 +10,7 @@
 
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
 use restate_storage_api::state_table::WriteStateTable;
 use restate_types::invocation::NotifySignalRequest;
@@ -21,7 +21,7 @@ pub(super) type ApplySendSignalCommand<'e> = ApplyJournalCommandEffect<'e, SendS
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplySendSignalCommand<'e>
 where
-    S: WriteStateTable + WriteOutboxTable + FsmTable,
+    S: WriteStateTable + WriteOutboxTable + WriteFsmTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         ctx.handle_outgoing_message(OutboxMessage::NotifySignal(NotifySignalRequest {

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -10,7 +10,7 @@
 
 use crate::partition::state_machine::entries::OnJournalEntryCommand;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::inbox_table::WriteInboxTable;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
@@ -44,7 +44,7 @@ where
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
         + WriteInboxTable
-        + FsmTable
+        + WriteFsmTable
         + ReadStateTable
         + WriteStateTable
         + WriteOutboxTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_get_invocation_output_response.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_get_invocation_output_response.rs
@@ -11,7 +11,7 @@
 use crate::debug_if_leader;
 use crate::partition::state_machine::invocation_status_ext::InvocationStatusExt;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext, entries};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::invocation_status_table::{
     ReadInvocationStatusTable, WriteInvocationStatusTable,
 };
@@ -36,7 +36,7 @@ where
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
         + WriteTimerTable
-        + FsmTable
+        + WriteFsmTable
         + ReadPromiseTable
         + WritePromiseTable
         + ReadStateTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_invocation_response.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_invocation_response.rs
@@ -11,7 +11,7 @@
 use crate::debug_if_leader;
 use crate::partition::state_machine::invocation_status_ext::InvocationStatusExt;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext, entries};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
 };
@@ -50,7 +50,7 @@ where
         + WriteTimerTable
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
-        + FsmTable
+        + WriteFsmTable
         + ReadPromiseTable
         + WritePromiseTable
         + ReadStateTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_signal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_signal.rs
@@ -10,7 +10,7 @@
 
 use crate::partition::state_machine::entries::OnJournalEntryCommand;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::inbox_table::WriteInboxTable;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
@@ -40,7 +40,7 @@ where
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
         + WriteInboxTable
-        + FsmTable
+        + WriteFsmTable
         + ReadStateTable
         + WriteStateTable
         + WriteOutboxTable

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_sleep_completion.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_sleep_completion.rs
@@ -11,7 +11,7 @@
 use crate::debug_if_leader;
 use crate::partition::state_machine::invocation_status_ext::InvocationStatusExt;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext, entries};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
 };
@@ -42,7 +42,7 @@ where
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
         + WriteTimerTable
-        + FsmTable
+        + WriteFsmTable
         + ReadPromiseTable
         + WritePromiseTable
         + ReadStateTable

--- a/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
@@ -12,7 +12,7 @@ use super::VerifyOrMigrateJournalTableToV2Command;
 
 use crate::debug_if_leader;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::inbox_table::WriteInboxTable;
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
@@ -47,7 +47,7 @@ where
         + WriteOutboxTable
         + ReadStateTable
         + WriteStateTable
-        + FsmTable
+        + WriteFsmTable
         + WriteInboxTable
         + WriteVirtualObjectStatusTable
         + JournalEventsTable

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -13,7 +13,7 @@ use crate::partition::state_machine::{Action, CommandHandler, Error, StateMachin
 use ahash::HashSet;
 use opentelemetry::trace::Span;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::idempotency_table::IdempotencyTable;
 use restate_storage_api::inbox_table::WriteInboxTable;
 use restate_storage_api::invocation_status_table::{
@@ -73,7 +73,7 @@ where
         + IdempotencyTable
         + ReadInvocationStatusTable
         + WriteInvocationStatusTable
-        + FsmTable
+        + WriteFsmTable
         + ReadVirtualObjectStatusTable
         + WriteVirtualObjectStatusTable
         + WriteTimerTable

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -35,7 +35,7 @@ use restate_invoker_api::InvokeInputJournal;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_storage_api::Result as StorageResult;
-use restate_storage_api::fsm_table::FsmTable;
+use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::idempotency_table::{IdempotencyTable, ReadOnlyIdempotencyTable};
 use restate_storage_api::inbox_table::{InboxEntry, WriteInboxTable};
 use restate_storage_api::invocation_status_table::{
@@ -426,7 +426,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteTimerTable
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable
@@ -617,14 +617,14 @@ impl<S> StateMachineApplyContext<'_, S> {
     where
         S: IdempotencyTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable
             + WriteTimerTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteJournalTable,
     {
         let invocation_id = service_invocation.invocation_id;
@@ -677,12 +677,12 @@ impl<S> StateMachineApplyContext<'_, S> {
     where
         S: IdempotencyTable
             + WriteInvocationStatusTable
-            + FsmTable
+            + WriteFsmTable
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable
             + WriteTimerTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteJournalTable,
     {
         // A pre-flight invocation has been already deduplicated
@@ -755,7 +755,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable
             + WriteOutboxTable
-            + FsmTable,
+            + WriteFsmTable,
     {
         let invocation_id = service_invocation.invocation_id;
         let is_workflow_run = service_invocation.invocation_target.invocation_target_ty()
@@ -935,7 +935,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteVirtualObjectStatusTable
             + WriteInvocationStatusTable
             + WriteInboxTable
-            + FsmTable,
+            + WriteFsmTable,
     {
         if metadata.invocation_target.invocation_target_ty()
             == InvocationTargetType::VirtualObject(VirtualObjectHandlerType::Exclusive)
@@ -1110,7 +1110,7 @@ impl<S> StateMachineApplyContext<'_, S> {
 
     async fn enqueue_into_inbox(&mut self, inbox_entry: InboxEntry) -> Result<MessageIndex, Error>
     where
-        S: WriteInboxTable + FsmTable,
+        S: WriteInboxTable + WriteFsmTable,
     {
         let seq_number = *self.inbox_seq_number;
         debug_if_leader!(
@@ -1125,7 +1125,6 @@ impl<S> StateMachineApplyContext<'_, S> {
         // need to store the next inbox sequence number
         self.storage
             .put_inbox_seq_number(seq_number + 1)
-            .await
             .map_err(Error::Storage)?;
         *self.inbox_seq_number += 1;
         Ok(seq_number)
@@ -1139,7 +1138,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         S: ReadStateTable
             + WriteStateTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable,
     {
@@ -1172,7 +1171,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadStateTable
             + WriteStateTable
             + ReadJournalTable
@@ -1204,14 +1203,14 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadStateTable
             + WriteStateTable
             + ReadJournalTable
             + WriteJournalTable
             + WriteOutboxTable
             + WriteTimerTable
-            + FsmTable
+            + WriteFsmTable
             + journal_table_v2::WriteJournalTable
             + journal_table_v2::ReadJournalTable
             + JournalEventsTable,
@@ -1275,7 +1274,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadStateTable
             + WriteStateTable
             + WriteJournalTable
@@ -1432,7 +1431,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         S: WriteInvocationStatusTable
             + WriteInboxTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteJournalTable
             + journal_table_v2::WriteJournalTable
             + JournalEventsTable,
@@ -1512,7 +1511,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         S: WriteInvocationStatusTable
             + WriteTimerTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteJournalTable
             + journal_table_v2::WriteJournalTable
             + JournalEventsTable,
@@ -1602,7 +1601,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteJournalTable
             + ReadJournalTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + journal_table_v2::WriteJournalTable
             + journal_table_v2::ReadJournalTable
             + JournalEventsTable,
@@ -1636,7 +1635,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteJournalTable
             + ReadJournalTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + journal_table_v2::WriteJournalTable
             + journal_table_v2::ReadJournalTable
             + JournalEventsTable,
@@ -1661,7 +1660,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         metadata: &InFlightInvocationMetadata,
     ) -> Result<(), Error>
     where
-        S: WriteOutboxTable + FsmTable + ReadJournalTable + journal_table_v2::ReadJournalTable,
+        S: WriteOutboxTable + WriteFsmTable + ReadJournalTable + journal_table_v2::ReadJournalTable,
     {
         let invocation_ids_to_kill: Vec<InvocationId> = if metadata
             .pinned_deployment
@@ -1731,7 +1730,11 @@ impl<S> StateMachineApplyContext<'_, S> {
         journal_length: EntryIndex,
     ) -> Result<bool, Error>
     where
-        S: ReadJournalTable + WriteJournalTable + WriteOutboxTable + FsmTable + WriteTimerTable,
+        S: ReadJournalTable
+            + WriteJournalTable
+            + WriteOutboxTable
+            + WriteFsmTable
+            + WriteTimerTable,
     {
         let journal_entries_to_cancel: Vec<(EntryIndex, EnrichedRawEntry)> = self
             .storage
@@ -1858,12 +1861,12 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable
             + WriteTimerTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadJournalTable
             + WriteJournalTable
             + ReadPromiseTable
@@ -1931,7 +1934,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadInvocationStatusTable
             + WriteInvocationStatusTable
             + WriteInboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteJournalTable,
     {
         debug_if_leader!(
@@ -1992,7 +1995,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadPromiseTable
             + WritePromiseTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteTimerTable
             + WriteInboxTable
             + WriteVirtualObjectStatusTable
@@ -2023,7 +2026,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadPromiseTable
             + WritePromiseTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteTimerTable
             + WriteInboxTable
             + WriteVirtualObjectStatusTable
@@ -2211,7 +2214,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteJournalTable
             + ReadJournalTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + ReadStateTable
             + WriteStateTable
             + journal_table_v2::WriteJournalTable
@@ -2331,7 +2334,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         invocation_target: Option<&InvocationTarget>,
     ) -> Result<(), Error>
     where
-        S: WriteOutboxTable + FsmTable,
+        S: WriteOutboxTable + WriteFsmTable,
     {
         let result = res.into();
         for response_sink in response_sinks {
@@ -2461,7 +2464,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadPromiseTable
             + WritePromiseTable
             + WriteOutboxTable
-            + FsmTable
+            + WriteFsmTable
             + WriteTimerTable
             + WriteJournalTable
             + ReadJournalTable
@@ -3200,7 +3203,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         entry: CancelInvocationEntry,
     ) -> Result<(), Error>
     where
-        S: WriteOutboxTable + FsmTable + ReadJournalTable,
+        S: WriteOutboxTable + WriteFsmTable + ReadJournalTable,
     {
         let target_invocation_id = match entry.target {
             CancelInvocationTarget::InvocationId(id) => {
@@ -3332,7 +3335,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteJournalTable
             + WriteInvocationStatusTable
             + WriteTimerTable
-            + FsmTable
+            + WriteFsmTable
             + WriteOutboxTable,
     {
         match status {
@@ -3502,7 +3505,7 @@ impl<S> StateMachineApplyContext<'_, S> {
 
     async fn handle_outgoing_message(&mut self, message: OutboxMessage) -> Result<(), Error>
     where
-        S: WriteOutboxTable + FsmTable,
+        S: WriteOutboxTable + WriteFsmTable,
     {
         // TODO Here we could add an optimization to immediately execute outbox message command
         //  for partition_key within the range of this PP, but this is problematic due to how we tie
@@ -3533,7 +3536,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteInvocationStatusTable
             + ReadVirtualObjectStatusTable
             + WriteOutboxTable
-            + FsmTable,
+            + WriteFsmTable,
     {
         debug_assert!(
             self.partition_key_range
@@ -3925,7 +3928,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         message: OutboxMessage,
     ) -> Result<(), Error>
     where
-        S: WriteOutboxTable + FsmTable,
+        S: WriteOutboxTable + WriteFsmTable,
     {
         match &message {
             OutboxMessage::ServiceInvocation(service_invocation) => {
@@ -4002,7 +4005,6 @@ impl<S> StateMachineApplyContext<'_, S> {
         // need to store the next outbox sequence number
         self.storage
             .put_outbox_seq_number(seq_number + 1)
-            .await
             .map_err(Error::Storage)?;
 
         self.action_collector.push(Action::NewOutboxMessage {


### PR DESCRIPTION
[PartitionStore] Decouple read and write fsm table traits

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3833).
* #3834
* __->__ #3833