### PR TITLE
[Restate UI] Update to v0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7941,8 +7941,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.8"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.8#5a6dd7215dfe198816bc4960709aee986231071b"
+version = "0.1.9"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.9#251e217a27e4701df0a5e641c42e19f3321c74e3"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.8", tag = "v0.1.8" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.9", tag = "v0.1.9" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.9
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.9/ui-v0.1.9.zip