### PR TITLE
Consistent schema across partitions

### DIFF
--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -88,7 +88,7 @@ impl SemanticRestateVersion {
         Self(semver::Version::parse("0.0.0-unknown").unwrap())
     }
 
-    pub fn new(major: u64, minor: u64, patch: u64) -> Self {
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
         Self(semver::Version::new(major, minor, patch))
     }
 

--- a/crates/types/src/schema/metadata/mod.rs
+++ b/crates/types/src/schema/metadata/mod.rs
@@ -46,8 +46,9 @@ use crate::{Version, Versioned, identifiers};
 /// Serializable data structure representing the schema registry
 ///
 /// Do not leak the representation as this data structure, as it strictly depends on SchemaUpdater, SchemaRegistry and the Admin API.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(from = "serde_hacks::Schema", into = "serde_hacks::Schema")]
+#[debug("Schema(version: {version})")]
 pub struct Schema {
     /// This gets bumped on each update.
     version: Version,

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -12,6 +12,7 @@ use std::ops::RangeInclusive;
 
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
 use restate_types::logs::{Keys, Lsn};
+use restate_types::schema::Schema;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::{GenerationalNodeId, SemanticRestateVersion};
 
@@ -61,4 +62,14 @@ pub struct PartitionDurability {
     pub durable_point: Lsn,
     /// Timestamp which the durability point was updated
     pub modification_time: MillisSinceEpoch,
+}
+
+/// Consistently store schema across partition replicas.
+///
+/// Since v1.6.0.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UpsertSchema {
+    pub partition_key_range: Keys,
+    pub schema: Schema,
 }

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -15,12 +15,12 @@ use restate_types::invocation::{
     InvocationTermination, NotifySignalRequest, PurgeInvocationRequest,
     RestartAsNewInvocationRequest, ResumeInvocationRequest, ServiceInvocation,
 };
-use restate_types::logs;
 use restate_types::logs::{HasRecordKeys, Keys, MatchKeyQuery};
 use restate_types::message::MessageIndex;
 use restate_types::state_mut::ExternalStateMutation;
+use restate_types::{flexbuffers_storage_encode_decode, logs};
 
-use crate::control::{AnnounceLeader, VersionBarrier};
+use crate::control::{AnnounceLeader, UpsertSchema, VersionBarrier};
 use crate::timer::TimerKeyValue;
 
 use self::control::PartitionDurability;
@@ -29,12 +29,14 @@ pub mod control;
 pub mod timer;
 
 /// The primary envelope for all messages in the system.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Envelope {
     pub header: Header,
     pub command: Command,
 }
+
+flexbuffers_storage_encode_decode!(Envelope);
 
 impl Envelope {
     pub fn new(header: Header, command: Command) -> Self {
@@ -125,7 +127,7 @@ pub enum Destination {
 }
 
 /// State machine input commands
-#[derive(Debug, Clone, PartialEq, Eq, strum::EnumDiscriminants, strum::VariantNames)]
+#[derive(Debug, Clone, strum::EnumDiscriminants, strum::VariantNames)]
 #[strum_discriminants(derive(strum::IntoStaticStr))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Command {
@@ -183,6 +185,10 @@ pub enum Command {
     NotifyGetInvocationOutputResponse(GetInvocationOutputResponse),
     /// Notify a signal.
     NotifySignal(NotifySignalRequest),
+
+    /// Upsert schema for consistent schema across replicas
+    /// *Since v1.6.0
+    UpsertSchema(UpsertSchema),
 }
 
 impl Command {
@@ -233,6 +239,7 @@ impl HasRecordKeys for Envelope {
             Command::InvocationResponse(response) => Keys::Single(response.partition_key()),
             Command::NotifySignal(sig) => Keys::Single(sig.partition_key()),
             Command::NotifyGetInvocationOutputResponse(res) => Keys::Single(res.partition_key()),
+            Command::UpsertSchema(schema) => schema.partition_key_range.clone(),
         }
     }
 }
@@ -240,399 +247,5 @@ impl HasRecordKeys for Envelope {
 impl MatchKeyQuery for Envelope {
     fn matches_key_query(&self, query: &logs::KeyFilter) -> bool {
         self.record_keys().matches_key_query(query)
-    }
-}
-
-#[cfg(feature = "serde")]
-mod envelope {
-    use bilrost::{Message, OwnedMessage};
-    use bytes::{Buf, Bytes, BytesMut};
-
-    use restate_storage_api::protobuf_types::v1 as protobuf;
-    use restate_types::storage::decode::{decode_bilrost, decode_serde};
-    use restate_types::storage::encode::{encode_bilrost, encode_serde};
-    use restate_types::storage::{
-        StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError,
-    };
-
-    use crate::Command;
-
-    impl StorageEncode for crate::Envelope {
-        fn encode(&self, buf: &mut BytesMut) -> Result<(), StorageEncodeError> {
-            use bytes::BufMut;
-            match self.default_codec() {
-                StorageCodecKind::FlexbuffersSerde => encode_serde(self, buf, self.default_codec()),
-                StorageCodecKind::Custom => {
-                    buf.put_slice(&encode(self)?);
-                    Ok(())
-                }
-                _ => unreachable!("developer error"),
-            }
-        }
-
-        fn default_codec(&self) -> StorageCodecKind {
-            // todo: Could be changed in v1.6
-            StorageCodecKind::FlexbuffersSerde
-        }
-    }
-
-    impl StorageDecode for crate::Envelope {
-        fn decode<B: ::bytes::Buf>(
-            buf: &mut B,
-            kind: StorageCodecKind,
-        ) -> Result<Self, StorageDecodeError>
-        where
-            Self: Sized,
-        {
-            match kind {
-                StorageCodecKind::Json
-                | StorageCodecKind::BincodeSerde
-                | StorageCodecKind::FlexbuffersSerde => decode_serde(buf, kind).map_err(|err| {
-                    tracing::error!(%err, "{} decode failure (decoding Envelope)", kind);
-                    err
-                }),
-                StorageCodecKind::LengthPrefixedRawBytes
-                | StorageCodecKind::Protobuf
-                | StorageCodecKind::Bilrost => Err(StorageDecodeError::UnsupportedCodecKind(kind)),
-                StorageCodecKind::Custom => decode(buf),
-            }
-        }
-    }
-
-    #[derive(Debug, thiserror::Error)]
-    enum DecodeError {
-        #[error("missing field codec")]
-        MissingFieldCodec,
-        #[error("unknown command kind")]
-        UnknownCommandKind,
-        #[error("unexpected codec kind {0}")]
-        UnexpectedCodec(StorageCodecKind),
-    }
-
-    impl From<DecodeError> for StorageDecodeError {
-        fn from(value: DecodeError) -> Self {
-            Self::DecodeValue(value.into())
-        }
-    }
-
-    #[derive(PartialEq, Eq, bilrost::Enumeration)]
-    enum CommandKind {
-        Unknown = 0,
-        AnnounceLeader = 1,                     // flexbuffers
-        PatchState = 2,                         // protobuf
-        TerminateInvocation = 3,                // flexbuffers
-        PurgeInvocation = 4,                    // flexbuffers
-        Invoke = 5,                             // protobuf
-        TruncateOutbox = 6,                     // flexbuffers
-        ProxyThrough = 7,                       // protobuf
-        AttachInvocation = 8,                   // protobuf
-        InvokerEffect = 9,                      // flexbuffers
-        Timer = 10,                             // flexbuffers
-        ScheduleTimer = 11,                     // flexbuffers
-        InvocationResponse = 12,                // protobuf
-        NotifyGetInvocationOutputResponse = 13, // bilrost
-        NotifySignal = 14,                      // protobuf
-        PurgeJournal = 15,                      // flexbuffers
-        VersionBarrier = 16,                    // bilrost
-        UpdatePartitionDurability = 17,         // bilrost
-        ResumeInvocation = 18,                  // flexbuffers
-        RestartAsNewInvocation = 19,            // flexbuffers
-    }
-
-    #[derive(bilrost::Message)]
-    struct Field {
-        #[bilrost(1)]
-        codec: Option<StorageCodecKind>,
-        #[bilrost(2)]
-        bytes: Bytes,
-    }
-
-    impl Field {
-        fn encode_serde<T: serde::Serialize>(
-            codec: StorageCodecKind,
-            value: &T,
-        ) -> Result<Self, StorageEncodeError> {
-            let mut buf = BytesMut::new();
-            encode_serde(value, &mut buf, codec)?;
-
-            Ok(Self {
-                codec: Some(codec),
-                bytes: buf.freeze(),
-            })
-        }
-
-        fn encode_bilrost<T: bilrost::Message>(value: &T) -> Result<Self, StorageEncodeError> {
-            Ok(Self {
-                codec: Some(StorageCodecKind::Bilrost),
-                bytes: encode_bilrost(value),
-            })
-        }
-
-        fn encode_protobuf<T: prost::Message>(value: &T) -> Result<Self, StorageEncodeError> {
-            let mut buf = BytesMut::new();
-            value
-                .encode(&mut buf)
-                .map_err(|err| StorageEncodeError::EncodeValue(err.into()))?;
-
-            Ok(Self {
-                codec: Some(StorageCodecKind::Protobuf),
-                bytes: buf.freeze(),
-            })
-        }
-
-        fn decode_serde<T: serde::de::DeserializeOwned>(mut self) -> Result<T, StorageDecodeError> {
-            let codec = self.codec()?;
-            if !matches!(
-                codec,
-                StorageCodecKind::Json
-                    | StorageCodecKind::FlexbuffersSerde
-                    | StorageCodecKind::BincodeSerde
-            ) {
-                return Err(StorageDecodeError::UnsupportedCodecKind(codec));
-            }
-
-            decode_serde(
-                &mut self.bytes,
-                self.codec.ok_or(DecodeError::MissingFieldCodec)?,
-            )
-        }
-
-        fn decode_bilrost<T: bilrost::OwnedMessage>(mut self) -> Result<T, StorageDecodeError> {
-            let codec = self.codec()?;
-            if codec != StorageCodecKind::Bilrost {
-                return Err(StorageDecodeError::UnsupportedCodecKind(codec));
-            }
-
-            decode_bilrost(&mut self.bytes)
-        }
-
-        fn decode_protobuf<T: prost::Message + Default>(self) -> Result<T, StorageDecodeError> {
-            let codec = self.codec()?;
-            if codec != StorageCodecKind::Protobuf {
-                return Err(StorageDecodeError::UnsupportedCodecKind(codec));
-            }
-
-            T::decode(self.bytes).map_err(|err| StorageDecodeError::DecodeValue(err.into()))
-        }
-
-        fn codec(&self) -> Result<StorageCodecKind, DecodeError> {
-            self.codec.ok_or(DecodeError::MissingFieldCodec)
-        }
-    }
-
-    #[derive(bilrost::Message)]
-    struct Envelope {
-        #[bilrost(1)]
-        header: Field,
-        #[bilrost(2)]
-        command_kind: CommandKind,
-        #[bilrost(3)]
-        command: Field,
-    }
-
-    macro_rules! codec_or_error {
-        ($field:expr, $expected:path) => {{
-            let codec = $field.codec()?;
-            if !matches!(codec, $expected) {
-                return Err(DecodeError::UnexpectedCodec(codec).into());
-            }
-        }};
-    }
-
-    pub fn encode(envelope: &super::Envelope) -> Result<Bytes, StorageEncodeError> {
-        // todo(azmy): avoid clone? this will require change to `From` implementation
-        let (command_kind, command) = match &envelope.command {
-            Command::UpdatePartitionDurability(value) => (
-                CommandKind::UpdatePartitionDurability,
-                Field::encode_bilrost(value),
-            ),
-            Command::VersionBarrier(value) => {
-                (CommandKind::VersionBarrier, Field::encode_bilrost(value))
-            }
-            Command::AnnounceLeader(value) => (
-                CommandKind::AnnounceLeader,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::PatchState(value) => {
-                let value = protobuf::StateMutation::from(value.clone());
-                (CommandKind::PatchState, Field::encode_protobuf(&value))
-            }
-            Command::TerminateInvocation(value) => (
-                CommandKind::TerminateInvocation,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::PurgeInvocation(value) => (
-                CommandKind::PurgeInvocation,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::ResumeInvocation(value) => (
-                CommandKind::ResumeInvocation,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::RestartAsNewInvocation(value) => (
-                CommandKind::RestartAsNewInvocation,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::PurgeJournal(value) => (
-                CommandKind::PurgeJournal,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::Invoke(value) => {
-                let value = protobuf::ServiceInvocation::from(value.as_ref());
-                (CommandKind::Invoke, Field::encode_protobuf(&value))
-            }
-            Command::TruncateOutbox(value) => (
-                CommandKind::TruncateOutbox,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::ProxyThrough(value) => {
-                let value = protobuf::ServiceInvocation::from(value.as_ref());
-                (CommandKind::ProxyThrough, Field::encode_protobuf(&value))
-            }
-            Command::AttachInvocation(value) => {
-                let value = protobuf::outbox_message::AttachInvocationRequest::from(value.clone());
-                (
-                    CommandKind::AttachInvocation,
-                    Field::encode_protobuf(&value),
-                )
-            }
-            Command::InvokerEffect(value) => (
-                CommandKind::InvokerEffect,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::Timer(value) => (
-                CommandKind::Timer,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::ScheduleTimer(value) => (
-                CommandKind::ScheduleTimer,
-                Field::encode_serde(StorageCodecKind::FlexbuffersSerde, value),
-            ),
-            Command::InvocationResponse(value) => {
-                let value =
-                    protobuf::outbox_message::OutboxServiceInvocationResponse::from(value.clone());
-                (
-                    CommandKind::InvocationResponse,
-                    Field::encode_protobuf(&value),
-                )
-            }
-            Command::NotifyGetInvocationOutputResponse(value) => (
-                CommandKind::NotifyGetInvocationOutputResponse,
-                Field::encode_bilrost(value),
-            ),
-            Command::NotifySignal(value) => {
-                let value = protobuf::outbox_message::NotifySignal::from(value.clone());
-                (CommandKind::NotifySignal, Field::encode_protobuf(&value))
-            }
-        };
-
-        let dto = Envelope {
-            header: Field::encode_serde(StorageCodecKind::FlexbuffersSerde, &envelope.header)?,
-            command_kind,
-            command: command?,
-        };
-
-        Ok(dto.encode_contiguous().into_vec().into())
-    }
-
-    pub fn decode<B: Buf>(buf: B) -> Result<super::Envelope, StorageDecodeError> {
-        let envelope =
-            Envelope::decode(buf).map_err(|err| StorageDecodeError::DecodeValue(err.into()))?;
-
-        // header is encoded with serde
-        codec_or_error!(envelope.header, StorageCodecKind::FlexbuffersSerde);
-        let header = envelope.header.decode_serde::<super::Header>()?;
-
-        let command = match envelope.command_kind {
-            CommandKind::Unknown => return Err(DecodeError::UnknownCommandKind.into()),
-            CommandKind::UpdatePartitionDurability => {
-                codec_or_error!(envelope.command, StorageCodecKind::Bilrost);
-                Command::UpdatePartitionDurability(envelope.command.decode_bilrost()?)
-            }
-            CommandKind::VersionBarrier => {
-                codec_or_error!(envelope.command, StorageCodecKind::Bilrost);
-                Command::VersionBarrier(envelope.command.decode_bilrost()?)
-            }
-            CommandKind::AnnounceLeader => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::AnnounceLeader(envelope.command.decode_serde()?)
-            }
-            CommandKind::PatchState => {
-                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
-                let value: protobuf::StateMutation = envelope.command.decode_protobuf()?;
-                Command::PatchState(value.try_into()?)
-            }
-            CommandKind::TerminateInvocation => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::TerminateInvocation(envelope.command.decode_serde()?)
-            }
-            CommandKind::PurgeInvocation => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::PurgeInvocation(envelope.command.decode_serde()?)
-            }
-            CommandKind::ResumeInvocation => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::ResumeInvocation(envelope.command.decode_serde()?)
-            }
-            CommandKind::RestartAsNewInvocation => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::RestartAsNewInvocation(envelope.command.decode_serde()?)
-            }
-            CommandKind::PurgeJournal => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::PurgeJournal(envelope.command.decode_serde()?)
-            }
-            CommandKind::Invoke => {
-                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
-                let value: protobuf::ServiceInvocation = envelope.command.decode_protobuf()?;
-                Command::Invoke(Box::new(value.try_into()?))
-            }
-            CommandKind::TruncateOutbox => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::TruncateOutbox(envelope.command.decode_serde()?)
-            }
-            CommandKind::ProxyThrough => {
-                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
-                let value: protobuf::ServiceInvocation = envelope.command.decode_protobuf()?;
-                Command::ProxyThrough(Box::new(value.try_into()?))
-            }
-            CommandKind::AttachInvocation => {
-                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
-                let value: protobuf::outbox_message::AttachInvocationRequest =
-                    envelope.command.decode_protobuf()?;
-                Command::AttachInvocation(value.try_into()?)
-            }
-            CommandKind::InvokerEffect => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::InvokerEffect(envelope.command.decode_serde()?)
-            }
-            CommandKind::Timer => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::Timer(envelope.command.decode_serde()?)
-            }
-            CommandKind::ScheduleTimer => {
-                codec_or_error!(envelope.command, StorageCodecKind::FlexbuffersSerde);
-                Command::ScheduleTimer(envelope.command.decode_serde()?)
-            }
-            CommandKind::InvocationResponse => {
-                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
-                let value: protobuf::outbox_message::OutboxServiceInvocationResponse =
-                    envelope.command.decode_protobuf()?;
-                Command::InvocationResponse(value.try_into()?)
-            }
-            CommandKind::NotifyGetInvocationOutputResponse => {
-                codec_or_error!(envelope.command, StorageCodecKind::Bilrost);
-                Command::NotifyGetInvocationOutputResponse(envelope.command.decode_bilrost()?)
-            }
-            CommandKind::NotifySignal => {
-                codec_or_error!(envelope.command, StorageCodecKind::Protobuf);
-                let value: protobuf::outbox_message::NotifySignal =
-                    envelope.command.decode_protobuf()?;
-
-                Command::NotifySignal(value.try_into()?)
-            }
-        };
-
-        Ok(super::Envelope { header, command })
     }
 }

--- a/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
@@ -64,6 +64,7 @@ mod tests {
             PartitionKey::MIN..=PartitionKey::MAX,
             SemanticRestateVersion::unknown().clone(),
             Default::default(),
+            None,
         );
         // this is fine as we are always above the unknown version (current > 0.0.0)
         let mut test_env = TestEnv::create_with_state_machine(state_machine).await;
@@ -106,6 +107,7 @@ mod tests {
             PartitionKey::MIN..=PartitionKey::MAX,
             SemanticRestateVersion::unknown().clone(),
             Default::default(),
+            None,
         );
         // this is fine as we are always above the unknown version (current > 0.0.0)
         let mut test_env = TestEnv::create_with_state_machine(state_machine).await;

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -99,6 +99,7 @@ impl TestEnv {
             PartitionKey::MIN..=PartitionKey::MAX,
             SemanticRestateVersion::unknown().clone(),
             experimental_features,
+            None,
         ))
         .await
     }
@@ -1099,6 +1100,7 @@ async fn truncate_outbox_with_gap() -> Result<(), Error> {
         PartitionKey::MIN..=PartitionKey::MAX,
         SemanticRestateVersion::unknown().clone(),
         EnumSet::empty(),
+        None,
     ))
     .await;
 


### PR DESCRIPTION
Consistent schema across partitions

Summary:
This PR make sure that PPs have a consistent service schema by writing
and upsert-schema record to bifrost. The leader processor makes sure
to write this record to bifrost when schema changes are detected
