### PR TITLE
Remove unused PartitionProcessorRpcError::Busy

### DIFF
--- a/crates/core/src/worker_api/partition_processor_rpc_client.rs
+++ b/crates/core/src/worker_api/partition_processor_rpc_client.rs
@@ -153,7 +153,6 @@ impl From<PartitionProcessorRpcError> for RpcErrorKind {
         match value {
             PartitionProcessorRpcError::NotLeader(_) => RpcErrorKind::NotLeader,
             PartitionProcessorRpcError::LostLeadership(_) => RpcErrorKind::LostLeadership,
-            PartitionProcessorRpcError::Busy => RpcErrorKind::Busy,
             PartitionProcessorRpcError::Internal(msg) => RpcErrorKind::Internal(msg),
             PartitionProcessorRpcError::Starting => RpcErrorKind::Starting,
             PartitionProcessorRpcError::Stopping => RpcErrorKind::Stopping,

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -131,10 +131,9 @@ pub enum PartitionProcessorRpcError {
     NotLeader(PartitionId),
     #[error("not leader anymore for partition '{0}'")]
     LostLeadership(PartitionId),
-    // todo: remove in 1.5
-    #[error("rejecting rpc because too busy")]
-    // #[deprecated(since = "1.4.0", note = "retained for backwards compatibility with <= 1.3.2 nodes, remove in 1.5")]
-    Busy,
+    // Removed in 1.6.0. Kept here to prevent reintroduction at a later point.
+    //#[error("rejecting rpc because too busy")]
+    //Busy,
     #[error("internal error: {0}")]
     Internal(String),
     #[error("partition processor starting")]
@@ -149,7 +148,6 @@ impl PartitionProcessorRpcError {
             PartitionProcessorRpcError::NotLeader(_) => true,
             PartitionProcessorRpcError::LostLeadership(_) => true,
             PartitionProcessorRpcError::Stopping => true,
-            PartitionProcessorRpcError::Busy => false,
             PartitionProcessorRpcError::Internal(_) => false,
             PartitionProcessorRpcError::Starting => false,
         }


### PR DESCRIPTION
We can remove the PartitionProcessorRpcError::Busy because we use flexbuffers to encode the error variants when sending them over the wire and flexbuffers encodes the variants by name.