### PR TITLE
Clean up the SubscriptionValidator abstraction.

### DIFF
--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -56,8 +56,8 @@ use serde::Deserialize;
         from_type = "MetaApiError",
     )
 )]
-pub async fn create_deployment<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn create_deployment<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Extension(version): Extension<AdminApiVersion>,
     #[request_body(required = true)] Json(payload): Json<RegisterDeploymentRequest>,
 ) -> Result<impl IntoResponse, MetaApiError> {
@@ -181,8 +181,8 @@ pub async fn create_deployment<V, IC>(
         schema = "std::string::String"
     ))
 )]
-pub async fn get_deployment<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn get_deployment<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(deployment_id): Path<DeploymentId>,
 ) -> Result<Json<DetailedDeploymentResponse>, MetaApiError> {
     let (deployment, services) = state
@@ -200,8 +200,8 @@ pub async fn get_deployment<V, IC>(
     operation_id = "list_deployments",
     tags = "deployment"
 )]
-pub async fn list_deployments<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn list_deployments<IC>(
+    State(state): State<AdminServiceState<IC>>,
 ) -> Json<ListDeploymentsResponse> {
     let deployments = state
         .schema_registry
@@ -254,8 +254,8 @@ pub struct DeleteDeploymentParams {
         from_type = "MetaApiError",
     )
 )]
-pub async fn delete_deployment<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn delete_deployment<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(deployment_id): Path<DeploymentId>,
     Query(DeleteDeploymentParams { force }): Query<DeleteDeploymentParams>,
 ) -> Result<StatusCode, MetaApiError> {
@@ -286,8 +286,8 @@ pub async fn delete_deployment<V, IC>(
         schema = "std::string::String"
     ))
 )]
-pub async fn update_deployment<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn update_deployment<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Extension(version): Extension<AdminApiVersion>,
     method: Method,
     Path(deployment_id): Path<DeploymentId>,

--- a/crates/admin/src/rest_api/handlers.rs
+++ b/crates/admin/src/rest_api/handlers.rs
@@ -29,8 +29,8 @@ use restate_types::schema::service::HandlerMetadata;
         schema = "std::string::String"
     ))
 )]
-pub async fn list_service_handlers<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn list_service_handlers<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(service_name): Path<String>,
 ) -> Result<Json<ListServiceHandlersResponse>, MetaApiError> {
     match state.schema_registry.list_service_handlers(&service_name) {
@@ -58,8 +58,8 @@ pub async fn list_service_handlers<V, IC>(
         )
     )
 )]
-pub async fn get_service_handler<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn get_service_handler<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path((service_name, handler_name)): Path<(String, String)>,
 ) -> Result<Json<HandlerMetadata>, MetaApiError> {
     match state

--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -80,8 +80,8 @@ pub struct DeleteInvocationParams {
         from_type = "MetaApiError",
     )
 )]
-pub async fn delete_invocation<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn delete_invocation<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
     Query(DeleteInvocationParams { mode }): Query<DeleteInvocationParams>,
 ) -> Result<StatusCode, MetaApiError> {
@@ -139,8 +139,8 @@ generate_meta_api_error!(KillInvocationError: [InvocationNotFoundError, Invocati
         schema = "std::string::String"
     ))
 )]
-pub async fn kill_invocation<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn kill_invocation<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
 ) -> Result<(), KillInvocationError>
 where
@@ -199,8 +199,8 @@ generate_meta_api_error!(CancelInvocationError: [InvocationNotFoundError, Invoca
         from_type = "CancelInvocationError",
     )
 )]
-pub async fn cancel_invocation<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn cancel_invocation<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
 ) -> Result<StatusCode, CancelInvocationError>
 where
@@ -241,8 +241,8 @@ generate_meta_api_error!(PurgeInvocationError: [InvocationNotFoundError, Invocat
         schema = "std::string::String"
     ))
 )]
-pub async fn purge_invocation<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn purge_invocation<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
 ) -> Result<(), PurgeInvocationError>
 where
@@ -284,8 +284,8 @@ generate_meta_api_error!(PurgeJournalError: [InvocationNotFoundError, Invocation
         schema = "std::string::String"
     ))
 )]
-pub async fn purge_journal<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn purge_journal<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
 ) -> Result<(), PurgeJournalError>
 where
@@ -398,8 +398,8 @@ generate_meta_api_error!(RestartInvocationError: [
         ),
     )
 )]
-pub async fn restart_as_new_invocation<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn restart_as_new_invocation<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
     Query(RestartAsNewInvocationQueryParams { from, deployment }): Query<
         RestartAsNewInvocationQueryParams,
@@ -510,8 +510,8 @@ generate_meta_api_error!(ResumeInvocationError: [
         )
     )
 )]
-pub async fn resume_invocation<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn resume_invocation<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(invocation_id): Path<String>,
     Query(ResumeInvocationQueryParams { deployment }): Query<ResumeInvocationQueryParams>,
 ) -> Result<(), ResumeInvocationError>

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -25,16 +25,14 @@ use okapi_operation::okapi::openapi3::{ExternalDocs, Tag};
 use okapi_operation::*;
 use restate_types::identifiers::PartitionKey;
 use restate_types::invocation::client::InvocationClient;
-use restate_types::schema::subscriptions::SubscriptionValidator;
 use restate_wal_protocol::{Destination, Header, Source};
 
 use crate::state::AdminServiceState;
 
 pub use version::{MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION};
 
-pub fn create_router<V, IC>(state: AdminServiceState<V, IC>) -> axum::Router<()>
+pub fn create_router<IC>(state: AdminServiceState<IC>) -> axum::Router<()>
 where
-    V: SubscriptionValidator + Send + Sync + Clone + 'static,
     IC: InvocationClient + Send + Sync + Clone + 'static,
 {
     let mut router = axum_integration::Router::new()

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -35,8 +35,8 @@ use tracing::{debug, warn};
     operation_id = "list_services",
     tags = "service"
 )]
-pub async fn list_services<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn list_services<IC>(
+    State(state): State<AdminServiceState<IC>>,
 ) -> Result<Json<ListServicesResponse>, MetaApiError> {
     let services = state.schema_registry.list_services();
 
@@ -55,8 +55,8 @@ pub async fn list_services<V, IC>(
         schema = "std::string::String"
     ))
 )]
-pub async fn get_service<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn get_service<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(service_name): Path<String>,
 ) -> Result<Json<ServiceMetadata>, MetaApiError> {
     state
@@ -87,8 +87,8 @@ pub async fn get_service<V, IC>(
         from_type = "MetaApiError",
     )
 )]
-pub async fn get_service_openapi<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn get_service_openapi<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(service_name): Path<String>,
 ) -> Result<Json<serde_json::Value>, MetaApiError> {
     // TODO return correct vnd type
@@ -112,8 +112,8 @@ pub async fn get_service_openapi<V, IC>(
         schema = "std::string::String"
     ))
 )]
-pub async fn modify_service<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn modify_service<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(service_name): Path<String>,
     #[request_body(required = true)] Json(ModifyServiceRequest {
         public,
@@ -183,8 +183,8 @@ pub async fn modify_service<V, IC>(
         from_type = "MetaApiError",
     )
 )]
-pub async fn modify_service_state<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn modify_service_state<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(service_name): Path<String>,
     #[request_body(required = true)] Json(ModifyServiceStateRequest {
         version,

--- a/crates/admin/src/rest_api/subscriptions.rs
+++ b/crates/admin/src/rest_api/subscriptions.rs
@@ -12,7 +12,7 @@ use super::error::*;
 use crate::state::AdminServiceState;
 
 use restate_admin_rest_model::subscriptions::*;
-use restate_types::schema::subscriptions::{ListSubscriptionFilter, SubscriptionValidator};
+use restate_types::schema::subscriptions::ListSubscriptionFilter;
 
 use axum::extract::Query;
 use axum::extract::{Path, State};
@@ -41,8 +41,8 @@ use restate_types::identifiers::SubscriptionId;
         from_type = "MetaApiError",
     )
 )]
-pub async fn create_subscription<V: SubscriptionValidator, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn create_subscription<IC>(
+    State(state): State<AdminServiceState<IC>>,
     #[request_body(required = true)] Json(payload): Json<CreateSubscriptionRequest>,
 ) -> Result<impl axum::response::IntoResponse, MetaApiError> {
     let subscription = state
@@ -73,8 +73,8 @@ pub async fn create_subscription<V: SubscriptionValidator, IC>(
         schema = "std::string::String"
     ))
 )]
-pub async fn get_subscription<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn get_subscription<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(subscription_id): Path<SubscriptionId>,
 ) -> Result<Json<SubscriptionResponse>, MetaApiError> {
     let subscription = state
@@ -110,8 +110,8 @@ pub async fn get_subscription<V, IC>(
         )
     )
 )]
-pub async fn list_subscriptions<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn list_subscriptions<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Query(ListSubscriptionsParams { sink, source }): Query<ListSubscriptionsParams>,
 ) -> Json<ListSubscriptionsResponse> {
     let filters = match (sink, source) {
@@ -158,8 +158,8 @@ pub async fn list_subscriptions<V, IC>(
         from_type = "MetaApiError",
     )
 )]
-pub async fn delete_subscription<V, IC>(
-    State(state): State<AdminServiceState<V, IC>>,
+pub async fn delete_subscription<IC>(
+    State(state): State<AdminServiceState<IC>>,
     Path(subscription_id): Path<SubscriptionId>,
 ) -> Result<StatusCode, MetaApiError> {
     state

--- a/crates/admin/src/schema_registry/mod.rs
+++ b/crates/admin/src/schema_registry/mod.rs
@@ -31,7 +31,7 @@ use restate_types::schema::deployment::{
 };
 use restate_types::schema::service::{HandlerMetadata, ServiceMetadata, ServiceMetadataResolver};
 use restate_types::schema::subscriptions::{
-    ListSubscriptionFilter, Subscription, SubscriptionResolver, SubscriptionValidator,
+    ListSubscriptionFilter, Subscription, SubscriptionResolver,
 };
 pub(crate) use restate_types::schema::updater::RegisterDeploymentResult;
 use restate_types::schema::{Schema, updater};
@@ -119,25 +119,22 @@ pub(crate) enum UpdateDeploymentAddress {
 
 /// This is the business logic driving the Admin API schema related endpoints.
 #[derive(Clone)]
-pub struct SchemaRegistry<V> {
+pub struct SchemaRegistry {
     metadata_writer: MetadataWriter,
     service_discovery: ServiceDiscovery,
     telemetry_http_client: Option<HttpClient>,
-    subscription_validator: V,
 }
 
-impl<V> SchemaRegistry<V> {
+impl SchemaRegistry {
     pub fn new(
         metadata_writer: MetadataWriter,
         service_discovery: ServiceDiscovery,
         telemetry_http_client: Option<HttpClient>,
-        subscription_validator: V,
     ) -> Self {
         Self {
             metadata_writer,
             service_discovery,
             telemetry_http_client,
-            subscription_validator,
         }
     }
 
@@ -613,12 +610,7 @@ impl<V> SchemaRegistry<V> {
     pub fn list_subscriptions(&self, filters: &[ListSubscriptionFilter]) -> Vec<Subscription> {
         Metadata::with_current(|m| m.schema()).list_subscriptions(filters)
     }
-}
 
-impl<V> SchemaRegistry<V>
-where
-    V: SubscriptionValidator,
-{
     pub(crate) async fn create_subscription(
         &self,
         source: Uri,
@@ -641,7 +633,6 @@ where
                             source.clone(),
                             sink.clone(),
                             options.clone(),
-                            &self.subscription_validator,
                         )
                     },
                 )?;

--- a/crates/admin/src/state.rs
+++ b/crates/admin/src/state.rs
@@ -12,18 +12,14 @@ use crate::schema_registry::SchemaRegistry;
 use restate_bifrost::Bifrost;
 
 #[derive(Clone, derive_builder::Builder)]
-pub struct AdminServiceState<V, IC> {
-    pub schema_registry: SchemaRegistry<V>,
+pub struct AdminServiceState<IC> {
+    pub schema_registry: SchemaRegistry,
     pub invocation_client: IC,
     pub bifrost: Bifrost,
 }
 
-impl<V, IC> AdminServiceState<V, IC> {
-    pub fn new(
-        schema_registry: SchemaRegistry<V>,
-        invocation_client: IC,
-        bifrost: Bifrost,
-    ) -> Self {
+impl<IC> AdminServiceState<IC> {
+    pub fn new(schema_registry: SchemaRegistry, invocation_client: IC, bifrost: Bifrost) -> Self {
         Self {
             schema_registry,
             invocation_client,

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -32,7 +32,6 @@ use restate_storage_query_datafusion::remote_query_scanner_manager::{
     RemoteScannerManager, create_partition_locator,
 };
 use restate_types::config::Configuration;
-use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
 use restate_types::live::LiveLoadExt;
@@ -60,7 +59,7 @@ pub enum AdminRoleBuildError {
 pub struct AdminRole<T> {
     updateable_config: Live<Configuration>,
     controller: Option<cluster_controller::Service<T>>,
-    admin: AdminService<IngressOptions, PartitionProcessorInvocationClient<T>>,
+    admin: AdminService<PartitionProcessorInvocationClient<T>>,
     storage_accounting_task: Option<StorageAccountingTask>,
 }
 
@@ -123,7 +122,6 @@ impl<T: TransportConnect> AdminRole<T> {
                 partition_table,
                 partition_routing,
             ),
-            config.ingress.clone(),
             service_discovery,
             telemetry_http_client,
         )

--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -10,7 +10,7 @@
 
 use super::{ActiveServiceRevision, Deployment, Handler, Schema, ServiceRevision};
 
-use crate::config::Configuration;
+use crate::config::{Configuration, IngressOptions};
 use crate::endpoint_manifest::HandlerType;
 use crate::errors::GenericError;
 use crate::identifiers::{DeploymentId, SubscriptionId};
@@ -23,9 +23,7 @@ use crate::schema::invocation_target::{
     BadInputContentType, DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION,
     InputRules, InputValidationRule, OnMaxAttempts, OutputContentTypeRule, OutputRules,
 };
-use crate::schema::subscriptions::{
-    EventInvocationTargetTemplate, Sink, Source, Subscription, SubscriptionValidator,
-};
+use crate::schema::subscriptions::{EventInvocationTargetTemplate, Sink, Source, Subscription};
 use crate::{endpoint_manifest, identifiers};
 use http::{HeaderValue, Uri};
 use serde_json::Value;
@@ -795,13 +793,12 @@ impl SchemaUpdater {
         false
     }
 
-    pub fn add_subscription<V: SubscriptionValidator>(
+    pub fn add_subscription(
         &mut self,
         id: Option<SubscriptionId>,
         source: Uri,
         sink: Uri,
         metadata: Option<HashMap<String, String>>,
-        validator: &V,
     ) -> Result<SubscriptionId, SchemaError> {
         // generate id if not provided
         let id = id.unwrap_or_default();
@@ -900,8 +897,9 @@ impl SchemaUpdater {
             }
         };
 
-        let subscription = validator
-            .validate(Subscription::new(
+        let subscription = Configuration::pinned()
+            .ingress
+            .validate_subscription(Subscription::new(
                 id,
                 source,
                 sink,
@@ -1213,6 +1211,66 @@ fn validate_service_name(name: &str) -> Result<(), ServiceError> {
         Err(ServiceError::ReservedName(name.to_string()))
     } else {
         Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid option '{name}'. Reason: {reason}")]
+pub struct ValidationError {
+    name: &'static str,
+    reason: &'static str,
+}
+
+impl IngressOptions {
+    fn validate_subscription(
+        &self,
+        mut subscription: Subscription,
+    ) -> Result<Subscription, ValidationError> {
+        // Retrieve the cluster option and merge them with subscription metadata
+        let Source::Kafka { cluster, .. } = subscription.source();
+        let cluster_options = &self.get_kafka_cluster(cluster).ok_or(ValidationError {
+            name: "source",
+            reason: "specified cluster in the source URI does not exist. Make sure it is defined in the KafkaOptions",
+        })?.additional_options;
+
+        if cluster_options.contains_key("enable.auto.commit")
+            || subscription.metadata().contains_key("enable.auto.commit")
+        {
+            warn!(
+                "The configuration option enable.auto.commit should not be set and it will be ignored."
+            );
+        }
+        if cluster_options.contains_key("enable.auto.offset.store")
+            || subscription
+                .metadata()
+                .contains_key("enable.auto.offset.store")
+        {
+            warn!(
+                "The configuration option enable.auto.offset.store should not be set and it will be ignored."
+            );
+        }
+
+        // Set the group.id if unset
+        if !(cluster_options.contains_key("group.id")
+            || subscription.metadata().contains_key("group.id"))
+        {
+            let group_id = subscription.id().to_string();
+
+            subscription
+                .metadata_mut()
+                .insert("group.id".to_string(), group_id);
+        }
+
+        // Set client.id if unset
+        if !(cluster_options.contains_key("client.id")
+            || subscription.metadata().contains_key("client.id"))
+        {
+            subscription
+                .metadata_mut()
+                .insert("client.id".to_string(), "restate".to_string());
+        }
+
+        Ok(subscription)
     }
 }
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -132,10 +132,8 @@ impl Worker {
 
         // ingress_kafka
         let ingress_kafka = IngressKafkaService::new(bifrost.clone(), schema.clone());
-        let subscription_controller_handle = SubscriptionControllerHandle::new(
-            config.ingress.clone(),
-            ingress_kafka.create_command_sender(),
-        );
+        let subscription_controller_handle =
+            SubscriptionControllerHandle::new(ingress_kafka.create_command_sender());
 
         let snapshots_options = &config.worker.snapshots;
         if snapshots_options.snapshot_interval_num_records.is_some()

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -39,7 +39,6 @@ use restate_types::journal_v2::{EntryIndex, Signal};
 use restate_types::live::Constant;
 use restate_types::retries::RetryPolicy;
 use restate_types::schema::subscriptions::Subscription;
-use restate_types::schema::subscriptions::SubscriptionValidator;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_worker::SubscriptionController;
 use restate_worker::WorkerHandle;
@@ -93,14 +92,6 @@ impl SubscriptionController for Mock {
 
     async fn update_subscriptions(&self, _: Vec<Subscription>) -> Result<(), WorkerHandleError> {
         Ok(())
-    }
-}
-
-impl SubscriptionValidator for Mock {
-    type Error = WorkerHandleError;
-
-    fn validate(&self, _: Subscription) -> Result<Subscription, Self::Error> {
-        unimplemented!()
     }
 }
 
@@ -223,7 +214,6 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
     let admin_service = AdminService::new(
         node_env.metadata_writer.clone(),
         bifrost,
-        Mock,
         Mock,
         ServiceDiscovery::new(
             RetryPolicy::default(),


### PR DESCRIPTION
This is not a useful abstraction these days, it was introduced long ago when we didn't have `Configuration::pinned`.