### PR TITLE
[CLI] Add `--extra` flag for `deployment describe`

### DIFF
--- a/cli/src/clients/admin_interface.rs
+++ b/cli/src/clients/admin_interface.rs
@@ -197,6 +197,13 @@ pub enum Deployment {
 }
 
 impl Deployment {
+    pub fn created_at(&self) -> humantime::Timestamp {
+        match self {
+            Self::Http { created_at, .. } => *created_at,
+            Self::Lambda { created_at, .. } => *created_at,
+        }
+    }
+
     pub fn from_deployment_response(
         deployment_response: DeploymentResponse,
     ) -> (DeploymentId, Self, Vec<ServiceNameRevPair>) {

--- a/cli/src/commands/deployments/describe.rs
+++ b/cli/src/commands/deployments/describe.rs
@@ -41,6 +41,10 @@ pub struct Describe {
 
     #[clap(flatten)]
     watch: Watch,
+
+    // Show additional information
+    #[clap(long)]
+    extra: bool,
 }
 
 pub async fn run_describe(State(env): State<CliEnv>, opts: &Describe) -> Result<()> {
@@ -66,31 +70,40 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     let (deployment_id, deployment, services) =
         Deployment::from_detailed_deployment_response(deployment);
 
-    let sql_client = crate::clients::DataFusionHttpClient::from(client);
-    let active_inv = count_deployment_active_inv_by_method(&sql_client, &deployment_id).await?;
-    let total_active_inv = active_inv.iter().map(|x| x.inv_count).sum();
-
-    let service_rev_pairs: Vec<_> = services
-        .iter()
-        .map(|s| ServiceNameRevPair {
-            name: s.name.clone(),
-            revision: s.revision,
-        })
-        .collect();
-
-    let status = calculate_deployment_status(
-        &deployment_id,
-        &service_rev_pairs,
-        total_active_inv,
-        &latest_services,
-    );
-
     let mut table = Table::new_styled();
     table.add_kv_row("ID:", deployment_id);
 
     add_deployment_to_kv_table(&deployment, &mut table);
-    table.add_kv_row("Status:", render_deployment_status(status));
-    table.add_kv_row("Invocations:", render_active_invocations(total_active_inv));
+
+    let active_inv = if opts.extra {
+        let sql_client = crate::clients::DataFusionHttpClient::from(client);
+        let active_inv = count_deployment_active_inv_by_method(&sql_client, &deployment_id).await?;
+        Some(active_inv)
+    } else {
+        None
+    };
+
+    if opts.extra {
+        let total_active_inv = active_inv.iter().flatten().map(|x| x.inv_count).sum();
+
+        let service_rev_pairs: Vec<_> = services
+            .iter()
+            .map(|s| ServiceNameRevPair {
+                name: s.name.clone(),
+                revision: s.revision,
+            })
+            .collect();
+
+        let status = calculate_deployment_status(
+            &deployment_id,
+            &service_rev_pairs,
+            total_active_inv,
+            &latest_services,
+        );
+
+        table.add_kv_row("Status:", render_deployment_status(status));
+        table.add_kv_row("Invocations:", render_active_invocations(total_active_inv));
+    }
 
     c_title!("📜", "Deployment Information");
     c_println!("{}", table);
@@ -99,6 +112,11 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
     c_println!();
 
     c_title!("🤖", "Services");
+    let mut methods_header = vec!["HANDLER", "INPUT", "OUTPUT"];
+    if opts.extra {
+        methods_header.push("ACTIVE-INVOCATIONS");
+    }
+
     for service in services {
         let Some(latest_service) = latest_services.get(&service.name) else {
             // if we can't find this service in the latest set of services, something is off. A
@@ -137,23 +155,30 @@ async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
             latest_revision_message
         );
         let mut methods_table = Table::new_styled();
-        methods_table.set_styled_header(vec!["HANDLER", "INPUT", "OUTPUT", "ACTIVE-INVOCATIONS"]);
+
+        methods_table.set_styled_header(methods_header.clone());
 
         for handler in service.handlers.values() {
-            // how many inv pinned on this deployment+service+method.
-            let active_inv = active_inv
-                .iter()
-                .filter(|x| x.service == service.name && x.handler == handler.name)
-                .map(|x| x.inv_count)
-                .next()
-                .unwrap_or(0);
-
-            methods_table.add_row(vec![
+            let mut row = vec![
                 Cell::new(&handler.name),
                 Cell::new(&handler.input_description),
                 Cell::new(&handler.output_description),
-                render_active_invocations(active_inv),
-            ]);
+            ];
+
+            if opts.extra {
+                // how many inv pinned on this deployment+service+method.
+                let active_inv = active_inv
+                    .iter()
+                    .flatten()
+                    .filter(|x| x.service == service.name && x.handler == handler.name)
+                    .map(|x| x.inv_count)
+                    .next()
+                    .unwrap_or(0);
+
+                row.push(render_active_invocations(active_inv));
+            }
+
+            methods_table.add_row(row);
         }
         c_indent_table!(2, methods_table);
         c_println!();

--- a/cli/src/commands/deployments/list.rs
+++ b/cli/src/commands/deployments/list.rs
@@ -8,11 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp::Reverse;
 use std::collections::HashMap;
 
 use anyhow::Result;
 use cling::prelude::*;
-use comfy_table::{Cell, Table};
+use comfy_table::{Cell, Row, Table};
 
 use restate_admin_rest_model::deployments::ServiceNameRevPair;
 use restate_cli_util::c_error;
@@ -71,63 +72,80 @@ async fn list(env: &CliEnv, list_opts: &List) -> Result<()> {
     for service in services {
         latest_services.insert(service.name.clone(), service);
     }
-    //
-    let mut table = Table::new_styled();
-    let mut header = vec![
-        "DEPLOYMENT",
-        "TYPE",
-        "STATUS",
-        "ACTIVE-INVOCATIONS",
-        "ID",
-        "CREATED-AT",
-    ];
-    if list_opts.extra {
-        header.push("SERVICES");
-    }
-    table.set_styled_header(header);
 
-    let mut enriched_deployments: Vec<(
-        DeploymentId,
-        Deployment,
-        Vec<ServiceNameRevPair>,
-        DeploymentStatus,
-        i64,
-    )> = Vec::with_capacity(deployments.len());
+    let mut table = Table::new_styled();
+
+    table.set_styled_header(DeploymentRow::headers(list_opts.extra));
+
+    let mut enriched_deployments: Vec<EnrichedDeployment> = Vec::with_capacity(deployments.len());
 
     for deployment in deployments {
         let (deployment_id, deployment, services) =
             Deployment::from_deployment_response(deployment);
 
+        let mut enriched_deployment = EnrichedDeployment {
+            deployment_id,
+            deployment,
+            services,
+            active_invocations: None,
+            status: None,
+        };
         // calculate status and counters.
-        let active_inv = count_deployment_active_inv(&sql_client, &deployment_id).await?;
-        let status =
-            calculate_deployment_status(&deployment_id, &services, active_inv, &latest_services);
-        enriched_deployments.push((deployment_id, deployment, services, status, active_inv));
-    }
-    // Sort by active, draining, then drained.
-    enriched_deployments.sort_unstable_by_key(|(_, _, _, status, _)| match status {
-        DeploymentStatus::Active => 0,
-        DeploymentStatus::Draining => 1,
-        DeploymentStatus::Drained => 2,
-    });
-
-    for (deployment_id, deployment, services, status, active_inv) in enriched_deployments {
-        let mut row = vec![
-            Cell::new(render_deployment_url(&deployment)),
-            Cell::new(render_deployment_type(&deployment)),
-            render_deployment_status(status),
-            render_active_invocations(active_inv),
-            Cell::new(deployment_id),
-            Cell::new(match &deployment {
-                Deployment::Http { created_at, .. } => created_at,
-                Deployment::Lambda { created_at, .. } => created_at,
-            }),
-        ];
         if list_opts.extra {
-            row.push(render_services(&deployment_id, &services, &latest_services));
+            let active_inv = count_deployment_active_inv(&sql_client, &deployment_id).await?;
+
+            enriched_deployment.active_invocations = Some(active_inv);
+
+            enriched_deployment.status = calculate_deployment_status(
+                &deployment_id,
+                &enriched_deployment.services,
+                active_inv,
+                &latest_services,
+            )
+            .into();
         }
 
-        table.add_row(row);
+        enriched_deployments.push(enriched_deployment);
+    }
+
+    // Sort by active, draining, drained, then newest by creation time within the same status.
+    enriched_deployments.sort_unstable_by_key(|endriched_deployment| {
+        let order = match endriched_deployment.status {
+            Some(DeploymentStatus::Active) => 0,
+            Some(DeploymentStatus::Draining) => 1,
+            Some(DeploymentStatus::Drained) => 2,
+            None => 3,
+        };
+        (order, Reverse(endriched_deployment.deployment.created_at()))
+    });
+
+    for EnrichedDeployment {
+        deployment_id,
+        deployment,
+        services,
+        status,
+        active_invocations,
+    } in enriched_deployments
+    {
+        let mut row = DeploymentRow::default();
+        row.with_id(deployment_id)
+            .with_url(render_deployment_url(&deployment))
+            .with_type(render_deployment_type(&deployment))
+            .with_created_at(match &deployment {
+                Deployment::Http { created_at, .. } => created_at,
+                Deployment::Lambda { created_at, .. } => created_at,
+            })
+            .with_services(render_services(&deployment_id, &services, &latest_services));
+
+        if let Some(status) = status {
+            row.with_status(render_deployment_status(status));
+        }
+
+        if let Some(active_inv) = active_invocations {
+            row.with_active_invocations(render_active_invocations(active_inv));
+        }
+
+        table.add_row(row.into_row(list_opts.extra));
     }
 
     c_println!("{}", table);
@@ -171,4 +189,98 @@ fn render_services(
         }
     }
     Cell::new(out)
+}
+
+struct EnrichedDeployment {
+    deployment_id: DeploymentId,
+    deployment: Deployment,
+    services: Vec<ServiceNameRevPair>,
+    status: Option<DeploymentStatus>,
+    active_invocations: Option<i64>,
+}
+
+#[derive(Default)]
+struct DeploymentRow {
+    url: Option<Cell>,
+    deployment_type: Option<Cell>,
+    status: Option<Cell>,
+    active_invocations: Option<Cell>,
+    id: Option<Cell>,
+    created_at: Option<Cell>,
+    services: Option<Cell>,
+}
+
+impl DeploymentRow {
+    fn headers(extra: bool) -> Vec<&'static str> {
+        if extra {
+            vec![
+                "DEPLOYMENT",
+                "TYPE",
+                "STATUS",
+                "ACTIVE-INVOCATIONS",
+                "ID",
+                "CREATED-AT",
+                "SERVICES",
+            ]
+        } else {
+            vec!["DEPLOYMENT", "TYPE", "ID", "CREATED-AT"]
+        }
+    }
+
+    fn with_id<T: Into<Cell>>(&mut self, id: T) -> &mut Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    fn with_url<T: Into<Cell>>(&mut self, url: T) -> &mut Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    fn with_type<T: Into<Cell>>(&mut self, deployment_type: T) -> &mut Self {
+        self.deployment_type = Some(deployment_type.into());
+        self
+    }
+
+    fn with_status<T: Into<Cell>>(&mut self, status: T) -> &mut Self {
+        self.status = Some(status.into());
+        self
+    }
+
+    fn with_active_invocations<T: Into<Cell>>(&mut self, active_invocations: T) -> &mut Self {
+        self.active_invocations = Some(active_invocations.into());
+        self
+    }
+
+    fn with_created_at<T: Into<Cell>>(&mut self, created_at: T) -> &mut Self {
+        self.created_at = Some(created_at.into());
+        self
+    }
+
+    fn with_services<T: Into<Cell>>(&mut self, services: T) -> &mut Self {
+        self.services = Some(services.into());
+        self
+    }
+
+    fn into_row(self, extra: bool) -> Row {
+        if extra {
+            vec![
+                self.url.expect("is set"),
+                self.deployment_type.expect("is set"),
+                self.status.expect("is set"),
+                self.active_invocations.expect("is set"),
+                self.id.expect("is set"),
+                self.created_at.expect("is set"),
+                self.services.expect("is set"),
+            ]
+        } else {
+            vec![
+                self.url.expect("is set"),
+                self.deployment_type.expect("is set"),
+                self.id.expect("is set"),
+                self.created_at.expect("is set"),
+            ]
+        }
+        .into()
+    }
 }


### PR DESCRIPTION
[CLI] Add `--extra` flag for `deployment describe`

Summary:
This is useful on heavy systems to avoid running long and
heavy queries to compute the deployment status and number of
active invocations

Same for `deployment list`
