### PR TITLE
Tag invoker metrics with partition ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7079,6 +7079,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "codederror",
+ "dashmap",
  "futures",
  "gardal",
  "googletest",

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 gardal = { workspace = true , features = ["async"]}
 http = { workspace = true }

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -52,7 +52,7 @@ use restate_types::service_protocol::ServiceProtocolVersion;
 use crate::TokenBucket;
 use crate::error::InvokerError;
 use crate::invocation_task::service_protocol_runner::ServiceProtocolRunner;
-use crate::metric_definitions::INVOKER_TASK_DURATION;
+use crate::metric_definitions::{ID_LOOKUP, INVOKER_TASK_DURATION};
 
 // Clippy false positive, might be caused by Bytes contained within HeaderValue.
 // https://github.com/rust-lang/rust/issues/40543#issuecomment-1212981256
@@ -271,7 +271,8 @@ where
         };
 
         self.send_invoker_tx(inner);
-        histogram!(INVOKER_TASK_DURATION).record(start.elapsed());
+        histogram!(INVOKER_TASK_DURATION, "partition_id" => ID_LOOKUP.get(self.partition.0))
+            .record(start.elapsed());
     }
 
     async fn select_protocol_version_and_run(

--- a/crates/invoker-impl/src/quota.rs
+++ b/crates/invoker-impl/src/quota.rs
@@ -10,51 +10,89 @@
 
 use metrics::gauge;
 
-use crate::metric_definitions::{INVOKER_AVAILABLE_SLOTS, INVOKER_CONCURRENCY_LIMIT};
+use crate::{
+    InvokerId,
+    metric_definitions::{ID_LOOKUP, INVOKER_AVAILABLE_SLOTS, INVOKER_CONCURRENCY_LIMIT},
+};
 
 #[derive(Debug)]
-pub(super) enum InvokerConcurrencyQuota {
+enum InvokerConcurrencyQuotaInner {
     Unlimited,
     Limited { available_slots: usize },
 }
 
+#[derive(Debug)]
+pub(super) struct InvokerConcurrencyQuota {
+    inner: InvokerConcurrencyQuotaInner,
+    invoker_id: InvokerId,
+}
+
 impl InvokerConcurrencyQuota {
-    pub(super) fn new(quota: Option<usize>) -> Self {
-        match quota {
+    pub(super) fn new(invoker_id: impl Into<InvokerId>, quota: Option<usize>) -> Self {
+        let invoker_id = invoker_id.into();
+        let inner = match quota {
             Some(available_slots) => {
-                gauge!(INVOKER_CONCURRENCY_LIMIT).set(available_slots as f64);
-                gauge!(INVOKER_AVAILABLE_SLOTS).set(available_slots as f64);
-                Self::Limited { available_slots }
+                gauge!(INVOKER_CONCURRENCY_LIMIT, "invoker_id" => ID_LOOKUP.get(invoker_id))
+                    .set(available_slots as f64);
+                gauge!(INVOKER_AVAILABLE_SLOTS, "invoker_id" => ID_LOOKUP.get(invoker_id))
+                    .set(available_slots as f64);
+                InvokerConcurrencyQuotaInner::Limited { available_slots }
             }
             None => {
-                gauge!(INVOKER_CONCURRENCY_LIMIT).set(f64::INFINITY);
-                gauge!(INVOKER_AVAILABLE_SLOTS).set(f64::INFINITY);
-                Self::Unlimited
+                gauge!(INVOKER_CONCURRENCY_LIMIT, "invoker_id" => ID_LOOKUP.get(invoker_id))
+                    .set(f64::INFINITY);
+                gauge!(INVOKER_AVAILABLE_SLOTS, "invoker_id" => ID_LOOKUP.get(invoker_id))
+                    .set(f64::INFINITY);
+                InvokerConcurrencyQuotaInner::Unlimited
             }
-        }
+        };
+
+        Self { inner, invoker_id }
     }
 
     pub(super) fn is_slot_available(&self) -> bool {
-        match self {
-            Self::Unlimited => true,
-            Self::Limited { available_slots } => *available_slots > 0,
+        match &self.inner {
+            InvokerConcurrencyQuotaInner::Unlimited => true,
+            InvokerConcurrencyQuotaInner::Limited { available_slots } => *available_slots > 0,
         }
     }
 
     pub(super) fn unreserve_slot(&mut self) {
-        gauge!(INVOKER_AVAILABLE_SLOTS).increment(1);
-        match self {
-            Self::Unlimited => {}
-            Self::Limited { available_slots } => *available_slots += 1,
+        match &mut self.inner {
+            InvokerConcurrencyQuotaInner::Unlimited => {}
+            InvokerConcurrencyQuotaInner::Limited { available_slots } => {
+                *available_slots += 1;
+                gauge!(
+                    INVOKER_AVAILABLE_SLOTS,
+                    "invoker_id" =>
+                    ID_LOOKUP.get(self.invoker_id)
+                )
+                .set(*available_slots as f64);
+            }
         }
     }
 
     pub(super) fn reserve_slot(&mut self) {
         assert!(self.is_slot_available());
-        gauge!(INVOKER_AVAILABLE_SLOTS).decrement(1);
-        match self {
-            Self::Unlimited => {}
-            Self::Limited { available_slots } => *available_slots -= 1,
+        match &mut self.inner {
+            InvokerConcurrencyQuotaInner::Unlimited => {}
+            InvokerConcurrencyQuotaInner::Limited { available_slots } => {
+                *available_slots -= 1;
+                gauge!(
+                    INVOKER_AVAILABLE_SLOTS,
+                    "invoker_id" =>
+                    ID_LOOKUP.get(self.invoker_id)
+                )
+                .set(*available_slots as f64);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn available_slots(&self) -> usize {
+        match self.inner {
+            InvokerConcurrencyQuotaInner::Unlimited => usize::MAX,
+            InvokerConcurrencyQuotaInner::Limited { available_slots } => available_slots,
         }
     }
 }

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -109,6 +109,7 @@ impl SpawnPartitionProcessorTask {
             EntryEnricher<Schema, ProtobufRawEntryCodec>,
             Schema,
         > = InvokerService::from_options(
+            partition.partition_id,
             &config.common.service_client,
             &config.worker.invoker,
             EntryEnricher::new(schema.clone()),


### PR DESCRIPTION
Tag invoker metrics with partition ids

- add partition_id labels to the enqueue counter, task lifecycle counters, and duration histogram
- back the labels with a IdLookup (prefilled vec + dashmap fallback) to avoid per-record string allocation
- use a new `invoker-id` to report invoker specific metrics (available concurrency slots) which also
  fixes the issue(s) with available slots metrics

Fixes: #3879
Fixes: #3880
