### PR TITLE
Deprecate localhost:9070/cluster-health endpoint

### DIFF
--- a/crates/admin/src/rest_api/cluster_health.rs
+++ b/crates/admin/src/rest_api/cluster_health.rs
@@ -11,21 +11,24 @@
 use axum::Json;
 use http::StatusCode;
 use okapi_operation::openapi;
-use restate_core::protobuf::node_ctl_svc::new_node_ctl_client;
 
-use crate::rest_api::error::GenericRestError;
 use restate_core::network::net_util::create_tonic_channel;
+use restate_core::protobuf::node_ctl_svc::new_node_ctl_client;
 use restate_core::{Metadata, my_node_id};
 use restate_types::config::Configuration;
 use restate_types::{NodeId, PlainNodeId};
+
+use crate::rest_api::error::GenericRestError;
 
 /// Cluster state endpoint
 #[openapi(
     summary = "Cluster health",
     description = "Get the cluster health.",
     operation_id = "cluster_health",
-    tags = "cluster_health"
+    tags = "cluster_health",
+    deprecated = true
 )]
+// todo: Remove in v1.7.0 as it should no longer be actively used
 pub async fn cluster_health() -> Result<Json<ClusterHealthResponse>, GenericRestError> {
     let nodes_configuration = Metadata::with_current(|m| m.nodes_config_ref());
     let node_config = nodes_configuration

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -141,6 +141,7 @@ where
         )
         .route("/health", get(openapi_handler!(health::health)))
         .route("/version", get(openapi_handler!(version::version)))
+        // The cluster_health endpoint is deprecated in the OpenAPI spec in preparation for removing it
         .route(
             "/cluster-health",
             get(openapi_handler!(cluster_health::cluster_health)),

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -26,6 +26,7 @@ service NodeCtlSvc {
   rpc ProvisionCluster(ProvisionClusterRequest)
       returns (ProvisionClusterResponse);
 
+  // todo: Remove in v1.7.0 once the REST endpoint /cluster-health is removed
   // Returns the cluster health from the point of view of this node.
   rpc ClusterHealth(google.protobuf.Empty) returns (ClusterHealthResponse);
 }


### PR DESCRIPTION
The /cluster-health endpoint should not have been publicly exposed. It is no longer used by Restate. Hence, this commit deprecates this endpoint by removing it from the OpenAPI spec as a first step. In v1.7.0, we can then remove this endpoint. The release notes of v1.6.0 should mention the deprecation of this endpoint so that users can stop using it.

This fixes #3898.