### PR TITLE
Enable Azure and GCS object-store protocols for partition snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5118,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc4f07659e11cd45a341cd24d71e683e3be65d9ff1f8150061678fe60437496"
+checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5130,6 +5130,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
+ "httparse",
  "humantime",
  "hyper",
  "itertools 0.14.0",
@@ -5140,6 +5141,7 @@ dependencies = [
  "rand 0.9.1",
  "reqwest",
  "ring",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ metrics-util = { version = "0.20.0" }
 moka = "0.12.5"
 mockall = { version = "0.13.1" }
 num-traits = { version = "0.2.17" }
-object_store = { version = "0.12.2", features = ["aws"] }
+object_store = { version = "0.12.4", features = ["aws", "azure", "gcp"] }
 opentelemetry = { version = "0.30" }
 opentelemetry-contrib = { version = "0.22" }
 opentelemetry-http = { version = "0.30" }

--- a/crates/object-store-util/Cargo.toml
+++ b/crates/object-store-util/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+test-util = []
+
 [dependencies]
 restate-workspace-hack = { workspace = true }
 

--- a/crates/object-store-util/src/lib.rs
+++ b/crates/object-store-util/src/lib.rs
@@ -13,65 +13,47 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use aws_config::default_provider::region::DefaultRegionChain;
 use aws_config::{BehaviorVersion, Region};
 use aws_smithy_runtime_api::client::identity::ResolveCachedIdentity;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
 use futures::FutureExt;
 use object_store::aws::{AmazonS3Builder, S3ConditionalPut};
-use object_store::{BackoffConfig, ObjectStore, RetryConfig};
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::{BackoffConfig, ObjectStore, ObjectStoreScheme, RetryConfig};
 use tracing::debug;
 use url::Url;
 
 use restate_types::retries::RetryPolicy;
 
 pub async fn create_object_store_client(
-    destination: Url,
+    url: Url,
     options: &restate_types::config::ObjectStoreOptions,
     retry_policy: &RetryPolicy,
 ) -> anyhow::Result<Arc<dyn ObjectStore>> {
-    // We use the AWS SDK configuration and credentials provider so that the conventional AWS
-    // environment variables and config files work as expected. The object_store crate has its
-    // own configuration mechanism which doesn't support many of the AWS conventions. This
-    // differs quite a lot from the Lambda invoker which uses the AWS SDK, and that would be a
-    // very surprising inconsistency for customers. This mechanism allows us to infer the region
-    // and securely obtain session credentials without any hard-coded configuration.
-    let object_store: Arc<dyn ObjectStore> = if destination.scheme() == "s3" {
-        let builder = match &options.aws_profile {
-            Some(profile) => {
-                debug!(profile, "Using AWS profile for object store access");
+    // We do not use the top-level convenience method object_store::parse_url() as the
+    // store-specific builders' from_env() provide a more ergonomic setup mechanism that allows us
+    // to avoid having too many provider-specific config keys, while still supporting them when it
+    // makes sense to do so.
+    let object_store: Arc<dyn ObjectStore> = match ObjectStoreScheme::parse(&url)?.0 {
+        ObjectStoreScheme::AmazonS3 => {
+            // We use the AWS SDK configuration and credentials provider so that the conventional
+            // AWS environment variables and config files work as expected. The object_store crate
+            // has its own configuration mechanism which doesn't support many of the AWS
+            // conventions. This differs quite a lot from the Lambda invoker which uses the AWS SDK,
+            // and that would be a very surprising inconsistency for customers. This mechanism
+            // allows us to infer the region and securely obtain session credentials without any
+            // hard-coded configuration.
+            let builder = match &options.aws_profile {
+                Some(profile) => {
+                    debug!(profile, "Using AWS profile for object store access");
 
-                let sdk_config = aws_config::defaults(BehaviorVersion::latest())
-                    .profile_name(profile)
-                    .load()
-                    .await;
-
-                let region = options
-                    .aws_region
-                    .clone()
-                    .map(Region::new)
-                    .or_else(|| sdk_config.region().cloned())
-                    .context("Unable to determine AWS region")?;
-
-                debug!(?region, ?profile, "Using AWS SDK credentials provider");
-
-                let builder = AmazonS3Builder::new()
-                    .with_region(region.to_string())
-                    .with_credentials(Arc::new(AwsSdkCredentialsProvider::new(&sdk_config)?));
-
-                if let Some(endpoint_url) = sdk_config.endpoint_url() {
-                    debug!(endpoint_url, "Using custom AWS endpoint override");
-                    // we'll override this with the explicit endpoint URL from Restate config, if any, later on
-                    builder.with_endpoint(endpoint_url)
-                } else {
-                    builder
-                }
-            }
-
-            None => {
-                if options.aws_access_key_id.is_none() {
-                    let sdk_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+                    let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+                        .profile_name(profile)
+                        .load()
+                        .await;
 
                     let region = options
                         .aws_region
@@ -80,92 +62,131 @@ pub async fn create_object_store_client(
                         .or_else(|| sdk_config.region().cloned())
                         .context("Unable to determine AWS region")?;
 
-                    debug!(?region, "Using AWS SDK credentials provider");
+                    debug!(?region, ?profile, "Using AWS SDK credentials provider");
 
-                    AmazonS3Builder::new()
+                    let builder = AmazonS3Builder::new()
                         .with_region(region.to_string())
-                        .with_credentials(Arc::new(AwsSdkCredentialsProvider::new(&sdk_config)?))
-                } else {
-                    let region = if let Some(region) = options.aws_region.as_ref() {
-                        Region::new(region.clone())
+                        .with_credentials(Arc::new(AwsSdkCredentialsProvider::new(&sdk_config)?));
+
+                    if let Some(endpoint_url) = sdk_config.endpoint_url() {
+                        debug!(endpoint_url, "Using custom AWS endpoint override");
+                        // we'll override this with the explicit endpoint URL from Restate config, if any, later on
+                        builder.with_endpoint(endpoint_url)
                     } else {
-                        DefaultRegionChain::builder()
-                            .build()
-                            .region()
-                            .await
-                            .context("Unable to determine AWS region")?
-                    };
-
-                    AmazonS3Builder::new().with_region(region.to_string())
+                        builder
+                    }
                 }
-            }
-        };
 
-        let builder = if let Some(region) = &options.aws_region {
-            builder.with_region(region)
-        } else {
-            builder
-        };
-        let env_allow_http_fallback = std::env::var("AWS_ALLOW_HTTP")
-            .ok()
-            .map(|s| s.trim().eq_ignore_ascii_case("true"));
-        let allow_insecure_http = options.aws_allow_http.or(env_allow_http_fallback);
-        let builder = if let Some(allow_http) = allow_insecure_http {
-            builder.with_allow_http(allow_http)
-        } else {
-            builder
-        };
-        let env_endpoint_url_fallback = std::env::var("AWS_ENDPOINT_URL_S3")
-            .ok()
-            .or_else(|| std::env::var("AWS_ENDPOINT_URL").ok());
-        let s3_endpoint = options
-            .aws_endpoint_url
-            .as_ref()
-            .or(env_endpoint_url_fallback.as_ref());
-        if !allow_insecure_http.unwrap_or_default()
-            && s3_endpoint.is_some_and(|endpoint| {
-                Url::parse(endpoint).is_ok_and(|url| url.scheme().eq_ignore_ascii_case("http"))
-            })
-        {
-            anyhow::bail!(
-                "Misconfiguration detected: an HTTP endpoint URL \"{}\" override is set for object \
+                None => {
+                    if options.aws_access_key_id.is_none() {
+                        let sdk_config =
+                            aws_config::defaults(BehaviorVersion::latest()).load().await;
+
+                        let region = options
+                            .aws_region
+                            .clone()
+                            .map(Region::new)
+                            .or_else(|| sdk_config.region().cloned())
+                            .context("Unable to determine AWS region")?;
+
+                        debug!(?region, "Using AWS SDK credentials provider");
+
+                        AmazonS3Builder::new()
+                            .with_region(region.to_string())
+                            .with_credentials(Arc::new(AwsSdkCredentialsProvider::new(
+                                &sdk_config,
+                            )?))
+                    } else {
+                        let region = if let Some(region) = options.aws_region.as_ref() {
+                            Region::new(region.clone())
+                        } else {
+                            DefaultRegionChain::builder()
+                                .build()
+                                .region()
+                                .await
+                                .context("Unable to determine AWS region")?
+                        };
+
+                        AmazonS3Builder::new().with_region(region.to_string())
+                    }
+                }
+            };
+
+            let builder = if let Some(region) = &options.aws_region {
+                builder.with_region(region)
+            } else {
+                builder
+            };
+            let env_allow_http_fallback = std::env::var("AWS_ALLOW_HTTP")
+                .ok()
+                .map(|s| s.trim().eq_ignore_ascii_case("true"));
+            let allow_insecure_http = options.aws_allow_http.or(env_allow_http_fallback);
+            let builder = if let Some(allow_http) = allow_insecure_http {
+                builder.with_allow_http(allow_http)
+            } else {
+                builder
+            };
+            let env_endpoint_url_fallback = std::env::var("AWS_ENDPOINT_URL_S3")
+                .ok()
+                .or_else(|| std::env::var("AWS_ENDPOINT_URL").ok());
+            let s3_endpoint = options
+                .aws_endpoint_url
+                .as_ref()
+                .or(env_endpoint_url_fallback.as_ref());
+            if !allow_insecure_http.unwrap_or_default()
+                && s3_endpoint.is_some_and(|endpoint| {
+                    Url::parse(endpoint).is_ok_and(|url| url.scheme().eq_ignore_ascii_case("http"))
+                })
+            {
+                anyhow::bail!(
+                    "Misconfiguration detected: an HTTP endpoint URL \"{}\" override is set for object \
                 store destination \"{}\", but plain HTTP is not allowed. Please set 'aws-allow-http' \
                 to `true` to enable this destination",
-                s3_endpoint.expect("is some"),
-                destination
-            );
+                    s3_endpoint.expect("is some"),
+                    url
+                );
+            }
+            let builder = if let Some(endpoint_url) = s3_endpoint {
+                builder.with_endpoint(endpoint_url)
+            } else {
+                builder
+            };
+            let builder = if let Some(access_key_id) = &options.aws_access_key_id {
+                builder.with_access_key_id(access_key_id)
+            } else {
+                builder
+            };
+            let builder = if let Some(secret_access_key) = &options.aws_secret_access_key {
+                builder.with_secret_access_key(secret_access_key)
+            } else {
+                builder
+            };
+            let builder = if let Some(token) = &options.aws_session_token {
+                builder.with_token(token)
+            } else {
+                builder
+            };
+
+            let builder = builder
+                .with_url(url)
+                .with_conditional_put(S3ConditionalPut::ETagMatch)
+                .with_retry(from_retry_policy(retry_policy));
+
+            Arc::new(builder.build()?)
         }
-        let builder = if let Some(endpoint_url) = s3_endpoint {
-            builder.with_endpoint(endpoint_url)
-        } else {
-            builder
-        };
-        let builder = if let Some(access_key_id) = &options.aws_access_key_id {
-            builder.with_access_key_id(access_key_id)
-        } else {
-            builder
-        };
-        let builder = if let Some(secret_access_key) = &options.aws_secret_access_key {
-            builder.with_secret_access_key(secret_access_key)
-        } else {
-            builder
-        };
-        let builder = if let Some(token) = &options.aws_session_token {
-            builder.with_token(token)
-        } else {
-            builder
-        };
-
-        let builder = builder
-            .with_url(destination)
-            .with_conditional_put(S3ConditionalPut::ETagMatch)
-            .with_retry(from_retry_policy(retry_policy));
-
-        Arc::new(builder.build()?)
-    } else {
-        // Since we only compile object_store with AWS support, the only other possibility is a file:// URL
-        object_store::parse_url(&destination)?.0.into()
+        ObjectStoreScheme::MicrosoftAzure => {
+            Arc::new(MicrosoftAzureBuilder::from_env().with_url(url).build()?)
+        }
+        ObjectStoreScheme::GoogleCloudStorage => Arc::new(
+            GoogleCloudStorageBuilder::from_env()
+                .with_url(url)
+                .build()?,
+        ),
+        #[cfg(any(test, feature = "test-util"))]
+        ObjectStoreScheme::Local => object_store::parse_url(&url)?.0.into(),
+        _ => bail!("Unsupported protocol: {url}"),
     };
+
     Ok(object_store)
 }
 

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -54,6 +54,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }
+restate-object-store-util = { workspace = true, features = ["test-util"] }
 restate-rocksdb = { workspace = true, features = ["test-util"] }
 restate-test-util = { workspace = true }
 restate-types = { workspace = true, features = ["test-util"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -86,7 +86,7 @@ nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
-object_store = { version = "0.12", features = ["aws"] }
+object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
 opentelemetry_sdk = { version = "0.30", features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio"] }
 phf_shared = { version = "0.11" }
 pprof = { version = "0.15", features = ["criterion", "flamegraph", "frame-pointer"] }
@@ -215,7 +215,7 @@ nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
-object_store = { version = "0.12", features = ["aws"] }
+object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
 opentelemetry_sdk = { version = "0.30", features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio"] }
 phf_shared = { version = "0.11" }
 pprof = { version = "0.15", features = ["criterion", "flamegraph", "frame-pointer"] }


### PR DESCRIPTION
This change enables native Azure and GCS access for snapshots. The new protocols are unavailable for use use as a metadata store backend, and S3 remains the only supported provider when metadata client type is "object-store" pending further validation.

The change also removes the undocumented file:// protocol support which suffers from not supporting conditional updates. There isn't really a good reason to ever use this in a real cluster.

Most of the change is whitespace due to the move to a match statement, consider ignoring it for review.

---

A very brief note on usage - we might add specific config keys in the future based on user feedback.

### Google Cloud Storage

GCS credentials can currently only be configured via environment variables. For more information, see https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html#method.from_env.

GCS environment credentials should work without additional configuration when running in e.g. GCP. Alternatively, create a service credential key and make it available to Restate with:

`export GOOGLE_SERVICE_ACCOUNT_PATH=.../gcs-creds.json`

Restate configuration:

```toml
[worker.snapshots]
destination = "gs://restate-bucket/path"
```

To provide the config values via the environment to a Docker container, we can achieve the same effect via:

```sh
export GOOGLE_SERVICE_ACCOUNT_KEY=$(cat gcs-key.json) RESTATE_WORKER__SNAPSHOTS__DESTINATION=gs://restate-snapshots-jhb/c4/snapshots docker run --net=host -e GOOGLE_SERVICE_ACCOUNT_KEY -e RESTATE_WORKER__SNAPSHOTS__DESTINATION ghcr.io/restatedev/restate:main
```

### Azure Blob Storage

Azure credentials can currently only be configured via environment variables. For more information, see https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html#method.from_env.

Example use with Azurite emulator:

```
export AZURE_USE_EMULATOR=1 \
    AZURE_STORAGE_ACCOUNT_NAME=devstoreaccount1 \
    AZURE_STORAGE_ACCESS_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw== \
    AZURE_ENDPOINT=http://127.0.0.1:10000/devstoreaccount1 \
    AZURE_ALLOW_HTTP=true
```

Restate configuration:

```toml
[worker.snapshots]
destination = "az://restate-bucket/path"
```