### PR TITLE
Add support for time-based snapshot intervals

### DIFF
--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -26,7 +26,7 @@ use restate_types::partitions::Partition;
 use crate::SnapshotError;
 use crate::memory::MemoryController;
 use crate::partition_db::{AllDataCf, PartitionCell, PartitionDb, RocksConfigurator};
-use crate::snapshots::{LocalPartitionSnapshot, Snapshots};
+use crate::snapshots::{ArchivedLsn, LocalPartitionSnapshot, Snapshots};
 use crate::{BuildError, OpenError, PartitionStore, SnapshotErrorKind};
 
 const PARTITION_CF_PREFIX: &str = "data-";
@@ -183,7 +183,10 @@ impl PartitionStoreManager {
         self.snapshots.is_repository_configured()
     }
 
-    pub async fn refresh_latest_archived_lsn(&self, partition_id: PartitionId) -> Option<Lsn> {
+    pub async fn refresh_latest_archived_lsn(
+        &self,
+        partition_id: PartitionId,
+    ) -> Option<ArchivedLsn> {
         let db = self.get_partition_db(partition_id).await?;
         self.snapshots.refresh_latest_archived_lsn(db).await
     }

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -24,6 +24,7 @@ use super::{
     SnapshotFormatVersion, SnapshotRepository,
 };
 use crate::PartitionStoreManager;
+use crate::snapshots::ArchivedLsn;
 
 /// Creates a partition store snapshot along with Restate snapshot metadata.
 pub struct SnapshotPartitionTask {
@@ -91,7 +92,7 @@ impl SnapshotPartitionTask {
             .get_partition_db(self.partition_id)
             .await
         {
-            db.note_archived_lsn(metadata.min_applied_lsn);
+            db.note_archived_lsn(ArchivedLsn::from(&metadata));
         }
 
         Ok(metadata)

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -126,7 +126,8 @@ impl Worker {
             SubscriptionControllerHandle::new(ingress_kafka.create_command_sender());
 
         let snapshots_options = &config.worker.snapshots;
-        if snapshots_options.snapshot_interval_num_records.is_some()
+        if (snapshots_options.snapshot_interval.is_some()
+            || snapshots_options.snapshot_interval_num_records.is_some())
             && snapshots_options.destination.is_none()
         {
             return Err(BuildError::SnapshotRepository(anyhow::anyhow!(


### PR DESCRIPTION
This change adds a basic time interval configuration option for triggering automated snapshots. When both time and record-based intervals are set, the logic for the trigger condition is an "and" between the two, so the record interval becomes a minimum requirement for time-based snapshotting.

Time interval-based snapshotting will get a lot more useful with incremental snapshot support, but this is already a big improvement as it allows operators to configure snapshots in slightly more intuitive terms of elapsed time.

The time interval is measured from the created-at timestamp of the published snapshot, which is based on the wall clock time of the producing node. Clock drift error is assumed to be relatively negligible compared to typical snapshotting intervals. A small amount of jitter is added to each partition's snapshot age check to spread snapshot uploads out over time.

## Configuration examples

### Periodic + minimum number of records

```toml
[worker.snapshots]
destination = "s3://bucket/cluster-name"
snapshot-interval-num-records = 10000
snapshot-interval = "30 min"
```

Translates into: "snapshot every 30 minutes, as long as the applied LSN has advanced by least 10,000 records since the last snapshot".

### Periodic (unconditional)

```toml
[worker.snapshots]
destination = "s3://bucket/cluster-name"
snapshot-interval = "24 hours"
```

Translates into: "snapshot once every 24 hours even if zero new changes are committed".