### PR TITLE
Harden helm charts against misconfiguration of different restate.name and restate.fullname

### DIFF
--- a/charts/restate-helm/templates/_helpers.tpl
+++ b/charts/restate-helm/templates/_helpers.tpl
@@ -14,7 +14,7 @@ app.kubernetes.io/version: {{ .Values.version | default .Chart.Version | quote }
 {{- end }}
 
 {{- define "restate.selectorLabels" -}}
-app: {{ include "restate.name" . }}
+app: {{ include "restate.fullname" . }}
 {{- end }}
 
 {{- define "restate.tag" -}}

--- a/charts/restate-helm/templates/service.yaml
+++ b/charts/restate-helm/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   # have to be able to talk to each other in order to become ready.
   publishNotReadyAddresses: true
   selector:
-    app: {{ include "restate.fullname" . }}
+    {{- include "restate.selectorLabels" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -42,4 +42,4 @@ spec:
     - port: 5122
       name: node
   selector:
-    app: {{ include "restate.fullname" . }}
+    {{- include "restate.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Harden helm charts against misconfiguration of different restate.name and restate.fullname