### PR TITLE
[PUT IN RELEASE NOTES] Set a default value of RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE in helm chart

### DIFF
--- a/charts/restate-helm/README.md
+++ b/charts/restate-helm/README.md
@@ -8,8 +8,26 @@ Helm chart for Restate as a single-node StatefulSet.
 helm install restate oci://ghcr.io/restatedev/restate-helm --namespace restate --create-namespace
 ```
 
+# Resources
+Restate's performance is strongly influenced by the CPU and memory available. You can vary the resources in your values file.
+The defaults are:
+
+```yaml
+resources:
+  limits:
+    cpu: 6
+    memory: 8Gi
+  requests:
+    cpu: 4
+    memory: 8Gi
+```
+
+The environment variable `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` should be set such that it is roughly 75% of the memory available.
+In the default helm values, this variable is set to `6Gi`.
+Under load, Restate will eventually use the entire RocksDB memory size offered to it.
+
 # Running a replicated cluster
-You can find example values for a 3-node replicated cluster in [replicated-values.yaml](./replicated-values.yaml). 
+You can find example values for a 3-node replicated cluster in [replicated-values.yaml](./replicated-values.yaml).
 Please ensure you use a version of that file (based on the git tag of the repo) which matches the version of the helm chart you are deploying.
 
 ```bash

--- a/charts/restate-helm/values.yaml
+++ b/charts/restate-helm/values.yaml
@@ -39,6 +39,10 @@ env:
     value: json
   - name: RESTATE_CLUSTER_NAME
     value: helm-single-node
+  - name: RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE
+    # This value should be around 75% of the container memory limit, which defaults to 8Gi below.
+    # If provisioning restate with a different memory limit, make sure to update this value
+    value: 6Gi
 
 service:
   type: ClusterIP
@@ -46,11 +50,12 @@ service:
 
 resources:
   limits:
-    cpu: 1
-    memory: 3Gi
+    cpu: 6
+    # note the comment above re 'RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE'
+    memory: 8Gi
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 4
+    memory: 8Gi
 
 storage:
   # If provided the volume will be mounted with the specified claim


### PR DESCRIPTION
Currently the default resources in the helm chart are really small, and more importantly, they are out of line with the default memory size.

My suggestion is that we increase the resources to match the default memory size of 6G - ie, 8G memory req/limit, 1:4 cpu to memory request ratio so 2 cpu - and also start specifying the memory size more explicitly so users can see that they need to override it.

This will be a breaking change for users that are not specifying their resources, and needs to be noted in the release notes for that reason. It is breaking in the sense that if you don't have enough capacity for the node any more, the replaced pod will not schedule. However this would be noticed immediately. In other cases it will still schedule, and performance will be improved, so there is only a cost impact, which I think is ok (the user can always specify the resources they want if needed).

However, it is NOT a breaking change for those who are specifying their resources but aren't specifying the rocks limit, which i think is probably very common. in those cases, the rocksdb memory size will stay 6G, but we will have the release notes and a logline encouraging them to consider changing it if it doesn't match their overrided resources.

Alternatives considered;
- We could add the memory size env to match the *current* default resources, and not change those resources. This would potentially reduce the memory from 6G for any users that have not explicitly overriden this env, which will likely be a 'silent' performance degradation
- We could just document that these should be kept in line, and hope users notice this in release notes etc. The logline in #3925 might help, but this still feels like quite the footgun.
- We could set some flag that instructs restate to automatically pick the memory limits to be 75% of the process limit. I'm inclined to avoid this kind of magic for the time being.