### PR TITLE
[Restate UI] Update to v0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8042,8 +8042,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.11"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.11#a31311715229e95367aaf1c746444d84395cb0ce"
+version = "0.1.12"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.12#d69d5357b191bfbc1b5a7d7459352c3b4bc49563"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.11", tag = "v0.1.11" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.12", tag = "v0.1.12" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.12
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.12/ui-v0.1.12.zip