### PR TITLE
[RELEASE NOTES + DOCS] CLI tunnel feature should use all tunnel servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2149,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datafusion"
@@ -2966,6 +2978,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3648,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.1",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.1",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4143,6 +4213,18 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.10",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
 ]
 
 [[package]]
@@ -4914,6 +4996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mnemonic"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b8f3a258db515d5e91a904ce4ae3f73e091149b90cadbdb93d210bee07f63b"
+
+[[package]]
 name = "mock-service-endpoint"
 version = "1.6.0-dev"
 dependencies = [
@@ -5378,6 +5466,10 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -6696,6 +6788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
+
+[[package]]
 name = "restate-admin"
 version = "1.6.0-dev"
 dependencies = [
@@ -6883,6 +6981,7 @@ dependencies = [
  "dirs",
  "figment",
  "futures",
+ "hickory-resolver",
  "http 1.3.1",
  "humantime",
  "hyper 1.6.0",
@@ -6890,9 +6989,11 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "json-patch",
+ "mnemonic",
  "mock-service-endpoint",
  "octocrab",
  "open",
+ "rand 0.9.1",
  "reqwest",
  "restate-admin-rest-model",
  "restate-cli-util",
@@ -8257,6 +8358,7 @@ dependencies = [
  "idna",
  "indexmap 1.9.3",
  "indexmap 2.11.4",
+ "ipnet",
  "itertools 0.13.0",
  "itertools 0.14.0",
  "lexical-parse-float",
@@ -8276,9 +8378,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "phf_shared",
+ "portable-atomic",
  "pprof",
  "proc-macro2",
  "prost 0.13.4",
@@ -10630,6 +10734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11021,6 +11131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,6 +56,7 @@ dialoguer = { workspace = true }
 dirs = { version = "5.0" }
 figment = { version = "0.10.8", features = ["env", "toml"] }
 futures = { workspace = true }
+hickory-resolver = "0.25.2"
 http = { workspace = true }
 hyper = { workspace = true }
 humantime = { workspace = true }
@@ -63,8 +64,10 @@ indicatif = "0.17.7"
 indoc = { version = "2.0.4" }
 itertools = { workspace = true }
 json-patch = "2.0.0"
+mnemonic = "1.1.1"
 octocrab = { version = "0.44.0", features = ["stream"] }
 open = "5.1.2"
+rand = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls-tls", "stream", "http2"] }
 rustls = { workspace = true, features = ["aws-lc-rs"]}
 serde = { workspace = true }

--- a/cli/src/clients/cloud/schema.json
+++ b/cli/src/clients/cloud/schema.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "Restate Cloud API",
     "version": "v1"
@@ -17,7 +17,293 @@
   ],
   "definitions": {
     "GetUserIdentityRequest": {
-      "type": "object"
+      "type": "object",
+      "properties": {}
+    },
+    "ListAccountsRequest": {
+      "type": "object",
+      "properties": {}
+    },
+    "GetUserLimitsRequest": {
+      "type": "object",
+      "properties": {}
+    },
+    "CreateAccountRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "DeleteAccountRequest": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "accountId"
+      ]
+    },
+    "UpdateAccountRequest": {
+      "type": "object",
+      "properties": {
+        "accountId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "accountId"
+      ]
+    },
+    "AccountId": {
+      "description": "Unique account identifier",
+      "example": "acc_1b2DE3f40",
+      "type": "string"
+    },
+    "DescribeAccountRequest": {
+      "type": "object",
+      "properties": {}
+    },
+    "CreateStripePortalSessionRequest": {
+      "type": "object",
+      "properties": {
+        "returnUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "CreateEnvironmentRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "tierId": {
+          "type": "string",
+          "enum": [
+            "FREE",
+            "STARTER",
+            "BUSINESS",
+            "PREMIUM"
+          ]
+        },
+        "payment": {
+          "type": "object",
+          "properties": {
+            "successUrl": {
+              "type": "string"
+            },
+            "cancelUrl": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "successUrl",
+            "cancelUrl"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "UpdateEnvironmentTierRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        },
+        "tierId": {
+          "type": "string",
+          "enum": [
+            "FREE",
+            "STARTER",
+            "BUSINESS",
+            "PREMIUM"
+          ]
+        },
+        "payment": {
+          "type": "object",
+          "properties": {
+            "successUrl": {
+              "type": "string"
+            },
+            "cancelUrl": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "successUrl",
+            "cancelUrl"
+          ]
+        }
+      },
+      "required": [
+        "environmentId",
+        "tierId"
+      ]
+    },
+    "GetAccountLimitsRequest": {
+      "type": "object",
+      "properties": {}
+    },
+    "ListEnvironmentsRequest": {
+      "type": "object",
+      "properties": {}
+    },
+    "DescribeEnvironmentRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId"
+      ]
+    },
+    "DestroyEnvironmentRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId"
+      ]
+    },
+    "CreateApiKeyRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        },
+        "roleId": {
+          "$ref": "#/components/schemas/RoleId"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId",
+        "roleId"
+      ]
+    },
+    "RoleId": {
+      "description": "A role identifier specifying a particular level of access for a principal.",
+      "example": "rst:role::FullAccess",
+      "type": "string",
+      "enum": [
+        "rst:role::FullAccess",
+        "rst:role::IngressAccess",
+        "rst:role::AdminAccess",
+        "rst:role::CompleteAwakeableAccess",
+        "rst:role::TunnelAccess"
+      ]
+    },
+    "ListApiKeysRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId"
+      ]
+    },
+    "DescribeApiKeyRequest": {
+      "type": "object",
+      "properties": {
+        "keyId": {
+          "type": "string"
+        },
+        "environmentId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "keyId",
+        "environmentId"
+      ]
+    },
+    "DeleteApiKeyRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        },
+        "keyId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId",
+        "keyId"
+      ]
+    },
+    "GetEnvironmentLogsRequest": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        },
+        "start": {
+          "type": "number",
+          "minimum": 1700000000,
+          "maximum": 2000000000
+        },
+        "end": {
+          "type": "number",
+          "minimum": 1700000000,
+          "maximum": 2000000000
+        }
+      },
+      "required": [
+        "environmentId",
+        "start",
+        "end"
+      ]
+    },
+    "ListAccountSecondaryOwnersRequest": {
+      "type": "object",
+      "properties": {}
+    },
+    "AddAccountSecondaryOwnerRequest": {
+      "type": "object",
+      "properties": {
+        "secondaryOwnerUserId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "secondaryOwnerUserId"
+      ]
+    },
+    "RemoveAccountSecondaryOwnerRequest": {
+      "type": "object",
+      "properties": {
+        "secondaryOwnerUserId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "secondaryOwnerUserId"
+      ]
     },
     "GetUserIdentityResponse": {
       "type": "object",
@@ -28,7 +314,8 @@
       },
       "required": [
         "userId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "ClientError": {
       "type": "object",
@@ -43,7 +330,8 @@
       "required": [
         "code",
         "message"
-      ]
+      ],
+      "additionalProperties": false
     },
     "UnauthorizedError": {
       "type": "object",
@@ -58,7 +346,8 @@
       "required": [
         "code",
         "message"
-      ]
+      ],
+      "additionalProperties": false
     },
     "ServerInternalError": {
       "type": "object",
@@ -73,10 +362,8 @@
       "required": [
         "code",
         "message"
-      ]
-    },
-    "ListAccountsRequest": {
-      "type": "object"
+      ],
+      "additionalProperties": false
     },
     "ListAccountsResponse": {
       "type": "object",
@@ -103,24 +390,40 @@
             "required": [
               "accountId",
               "name"
-            ]
+            ],
+            "additionalProperties": false
           }
         }
       },
       "required": [
         "accounts"
-      ]
+      ],
+      "additionalProperties": false
     },
-    "CreateAccountRequest": {
+    "GetUserLimitsResponse": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
+        "accounts": {
+          "type": "object",
+          "properties": {
+            "usage": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "usage",
+            "limit"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
-        "name"
-      ]
+        "accounts"
+      ],
+      "additionalProperties": false
     },
     "CreateAccountResponse": {
       "type": "object",
@@ -135,18 +438,8 @@
       "required": [
         "accountId",
         "name"
-      ]
-    },
-    "DeleteAccountRequest": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "accountId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "DeleteAccountResponse": {
       "type": "object",
@@ -162,28 +455,16 @@
               },
               "required": [
                 "ok"
-              ]
+              ],
+              "additionalProperties": false
             },
             {
               "type": "string"
             }
           ]
         }
-      }
-    },
-    "UpdateAccountRequest": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        }
       },
-      "required": [
-        "accountId"
-      ]
+      "additionalProperties": false
     },
     "UpdateAccountResponse": {
       "type": "object",
@@ -205,26 +486,87 @@
       "required": [
         "accountId",
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
-    "AccountId": {
-      "type": "string",
-      "description": "Unique account identifier",
-      "example": "acc_1b2DE3f40"
-    },
-    "CreateEnvironmentRequest": {
+    "DescribeAccountResponse": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "environmentId": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tierId": {
+                "type": "string",
+                "enum": [
+                  "FREE",
+                  "STARTER",
+                  "BUSINESS",
+                  "PREMIUM"
+                ]
+              }
+            },
+            "required": [
+              "environmentId",
+              "region",
+              "name",
+              "tierId"
+            ],
+            "additionalProperties": false
+          }
         },
-        "region": {
+        "subscription": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "AWAITING_PAYMENT",
+                "ACTIVE",
+                "INACTIVE"
+              ]
+            },
+            "currentPeriodStart": {
+              "type": "number"
+            },
+            "currentPeriodEnd": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "status",
+            "currentPeriodStart",
+            "currentPeriodEnd"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "environments"
+      ],
+      "additionalProperties": false
+    },
+    "CreateStripePortalSessionResponse": {
+      "type": "object",
+      "properties": {
+        "url": {
           "type": "string"
         }
       },
       "required": [
-        "name"
-      ]
+        "url"
+      ],
+      "additionalProperties": false
     },
     "CreateEnvironmentResponse": {
       "type": "object",
@@ -234,15 +576,50 @@
         },
         "name": {
           "type": "string"
+        },
+        "checkoutUrl": {
+          "type": "string"
         }
       },
       "required": [
         "environmentId",
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
-    "ListEnvironmentsRequest": {
-      "type": "object"
+    "UpdateEnvironmentTierResponse": {
+      "type": "object",
+      "properties": {
+        "checkoutUrl": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "GetAccountLimitsResponse": {
+      "type": "object",
+      "properties": {
+        "freeEnvironments": {
+          "type": "object",
+          "properties": {
+            "usage": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "usage",
+            "limit"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "freeEnvironments"
+      ],
+      "additionalProperties": false
     },
     "ListEnvironmentsResponse": {
       "type": "object",
@@ -260,30 +637,31 @@
               },
               "name": {
                 "type": "string"
+              },
+              "tierId": {
+                "type": "string",
+                "enum": [
+                  "FREE",
+                  "STARTER",
+                  "BUSINESS",
+                  "PREMIUM"
+                ]
               }
             },
             "required": [
               "environmentId",
               "region",
-              "name"
-            ]
+              "name",
+              "tierId"
+            ],
+            "additionalProperties": false
           }
         }
       },
       "required": [
         "environments"
-      ]
-    },
-    "DescribeEnvironmentRequest": {
-      "type": "object",
-      "properties": {
-        "environmentId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "environmentId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "DescribeEnvironmentResponse": {
       "type": "object",
@@ -324,7 +702,8 @@
             "required": [
               "keyId",
               "environmentId"
-            ]
+            ],
+            "additionalProperties": false
           }
         },
         "ingressBaseUrl": {
@@ -336,8 +715,20 @@
         "tunnelBaseUrl": {
           "type": "string"
         },
+        "tunnelSrv": {
+          "type": "string"
+        },
         "proxyBaseUrl": {
           "type": "string"
+        },
+        "tierId": {
+          "type": "string",
+          "enum": [
+            "FREE",
+            "STARTER",
+            "BUSINESS",
+            "PREMIUM"
+          ]
         }
       },
       "required": [
@@ -350,19 +741,11 @@
         "ingressBaseUrl",
         "adminBaseUrl",
         "tunnelBaseUrl",
-        "proxyBaseUrl"
-      ]
-    },
-    "DestroyEnvironmentRequest": {
-      "type": "object",
-      "properties": {
-        "environmentId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "environmentId"
-      ]
+        "tunnelSrv",
+        "proxyBaseUrl",
+        "tierId"
+      ],
+      "additionalProperties": false
     },
     "DestroyEnvironmentResponse": {
       "type": "object",
@@ -378,43 +761,16 @@
               },
               "required": [
                 "ok"
-              ]
+              ],
+              "additionalProperties": false
             },
             {
               "type": "string"
             }
           ]
         }
-      }
-    },
-    "CreateApiKeyRequest": {
-      "type": "object",
-      "properties": {
-        "environmentId": {
-          "type": "string"
-        },
-        "roleId": {
-          "$ref": "#/components/schemas/RoleId"
-        },
-        "description": {
-          "type": "string"
-        }
       },
-      "required": [
-        "environmentId",
-        "roleId"
-      ]
-    },
-    "RoleId": {
-      "type": "string",
-      "enum": [
-        "rst:role::FullAccess",
-        "rst:role::IngressAccess",
-        "rst:role::AdminAccess",
-        "rst:role::CompleteAwakeableAccess"
-      ],
-      "description": "A role identifier specifying a particular level of access for a principal.",
-      "example": "rst:role::FullAccess"
+      "additionalProperties": false
     },
     "CreateApiKeyResponse": {
       "type": "object",
@@ -449,18 +805,8 @@
         "accountId",
         "apiKey",
         "state"
-      ]
-    },
-    "ListApiKeysRequest": {
-      "type": "object",
-      "properties": {
-        "environmentId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "environmentId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "ListApiKeysResponse": {
       "type": "object",
@@ -480,28 +826,15 @@
             "required": [
               "keyId",
               "environmentId"
-            ]
+            ],
+            "additionalProperties": false
           }
         }
       },
       "required": [
         "apiKeys"
-      ]
-    },
-    "DescribeApiKeyRequest": {
-      "type": "object",
-      "properties": {
-        "keyId": {
-          "type": "string"
-        },
-        "environmentId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "keyId",
-        "environmentId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "DescribeApiKeyResponse": {
       "type": "object",
@@ -535,22 +868,8 @@
         "environmentId",
         "accountId",
         "state"
-      ]
-    },
-    "DeleteApiKeyRequest": {
-      "type": "object",
-      "properties": {
-        "environmentId": {
-          "type": "string"
-        },
-        "keyId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "environmentId",
-        "keyId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "DeleteApiKeyResponse": {
       "type": "object",
@@ -566,37 +885,16 @@
               },
               "required": [
                 "ok"
-              ]
+              ],
+              "additionalProperties": false
             },
             {
               "type": "string"
             }
           ]
         }
-      }
-    },
-    "GetEnvironmentLogsRequest": {
-      "type": "object",
-      "properties": {
-        "environmentId": {
-          "type": "string"
-        },
-        "start": {
-          "type": "number",
-          "minimum": 1700000000,
-          "maximum": 2000000000
-        },
-        "end": {
-          "type": "number",
-          "minimum": 1700000000,
-          "maximum": 2000000000
-        }
       },
-      "required": [
-        "environmentId",
-        "start",
-        "end"
-      ]
+      "additionalProperties": false
     },
     "GetEnvironmentLogsResponse": {
       "type": "object",
@@ -616,16 +914,15 @@
             "required": [
               "unixNanos",
               "line"
-            ]
+            ],
+            "additionalProperties": false
           }
         }
       },
       "required": [
         "lines"
-      ]
-    },
-    "ListAccountSecondaryOwnersRequest": {
-      "type": "object"
+      ],
+      "additionalProperties": false
     },
     "ListAccountSecondaryOwnersResponse": {
       "type": "object",
@@ -635,22 +932,31 @@
           "items": {
             "type": "string"
           }
+        },
+        "secondaryOwners": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "userId": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "userId"
+            ],
+            "additionalProperties": false
+          }
         }
       },
       "required": [
-        "secondaryOwnersUserIds"
-      ]
-    },
-    "AddAccountSecondaryOwnerRequest": {
-      "type": "object",
-      "properties": {
-        "secondaryOwnerUserId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "secondaryOwnerUserId"
-      ]
+        "secondaryOwnersUserIds",
+        "secondaryOwners"
+      ],
+      "additionalProperties": false
     },
     "AddAccountSecondaryOwnerResponse": {
       "type": "object",
@@ -664,18 +970,8 @@
       },
       "required": [
         "secondaryOwnersUserIds"
-      ]
-    },
-    "RemoveAccountSecondaryOwnerRequest": {
-      "type": "object",
-      "properties": {
-        "secondaryOwnerUserId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "secondaryOwnerUserId"
-      ]
+      ],
+      "additionalProperties": false
     },
     "RemoveAccountSecondaryOwnerResponse": {
       "type": "object",
@@ -689,7 +985,8 @@
       },
       "required": [
         "secondaryOwnersUserIds"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/cli/src/commands/cloud/environments/configure.rs
+++ b/cli/src/commands/cloud/environments/configure.rs
@@ -250,8 +250,6 @@ fn write_environment(
     let cloud = profile_block["cloud"].or_insert(table());
     cloud["account_id"] = value(account_id);
     cloud["environment_id"] = value(&environment.environment_id);
-    cloud["tunnel_base_url"] = value(&environment.tunnel_base_url);
-    cloud["proxy_base_url"] = value(&environment.proxy_base_url);
 
     Ok(())
 }

--- a/cli/src/commands/cloud/mod.rs
+++ b/cli/src/commands/cloud/mod.rs
@@ -22,8 +22,6 @@ pub struct CloudConfig {
     pub environment_info: Option<EnvironmentInfo>, // Set on a profile on login
     pub api_base_url: Url,
     pub login_base_url: Url,
-    pub tunnel_base_url: Url,
-    pub proxy_base_url: Url,
     pub client_id: String,
     pub redirect_ports: Vec<u16>,
     #[serde(flatten)]
@@ -47,9 +45,6 @@ impl Default for CloudConfig {
             environment_info: None,
             api_base_url: Url::parse("https://api.us.restate.cloud").unwrap(),
             login_base_url: Url::parse("https://auth.restate.cloud").unwrap(),
-            tunnel_base_url: Url::parse("https://tunnel.us.restate.cloud:19080").unwrap(),
-            // no port as this is inserted as needed
-            proxy_base_url: Url::parse("https://tunnel.us.restate.cloud").unwrap(),
             client_id: "5q3dsdnrr5r400jvibd8d3k66l".into(),
             redirect_ports: vec![33912, 44643, 47576, 54788, 61844],
             credentials: None,

--- a/crates/cloud-tunnel-client/src/lib.rs
+++ b/crates/cloud-tunnel-client/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod client;
 mod request_identity;
+pub mod util;

--- a/crates/cloud-tunnel-client/src/util.rs
+++ b/crates/cloud-tunnel-client/src/util.rs
@@ -1,0 +1,154 @@
+use std::str::FromStr;
+
+use bytes::{BufMut, BytesMut};
+use http::Uri;
+
+pub fn parse_tunnel_destination(
+    path_and_query: &http::uri::PathAndQuery,
+) -> Result<Uri, &'static str> {
+    let path = path_and_query
+        .path()
+        .strip_prefix('/')
+        .ok_or("no leading /")?;
+    let (scheme, path) = path.split_once("/").ok_or("no host")?;
+    let scheme = http::uri::Scheme::from_str(scheme)
+        .ok()
+        .ok_or("invalid scheme")?;
+    let (host, path) = path.split_once("/").ok_or("no port")?;
+
+    let (port, path) = match path.split_once("/") {
+        Some((port, path)) => (port, path),
+        None => (path, ""),
+    };
+
+    let mut authority = BytesMut::with_capacity(host.len() + 1 + port.len());
+    authority.put(host.as_bytes());
+    authority.put(&b":"[..]);
+    authority.put(port.as_bytes());
+
+    let authority = http::uri::Authority::from_maybe_shared(authority.freeze())
+        .ok()
+        .ok_or("invalid authority")?;
+
+    let path_and_query = if let Some(query) = path_and_query.query() {
+        let mut path_and_query = BytesMut::with_capacity(1 + path.len() + 1 + query.len());
+        path_and_query.put(&b"/"[..]);
+        path_and_query.put(path.as_bytes());
+        path_and_query.put(&b"?"[..]);
+        path_and_query.put(query.as_bytes());
+
+        http::uri::PathAndQuery::from_maybe_shared(path_and_query.freeze())
+    } else {
+        let mut path_and_query = BytesMut::with_capacity(1 + path.len());
+        path_and_query.put(&b"/"[..]);
+        path_and_query.put(path.as_bytes());
+
+        http::uri::PathAndQuery::from_maybe_shared(path_and_query.freeze())
+    };
+    let path_and_query = path_and_query.ok().ok_or("invalid path")?;
+
+    Uri::builder()
+        .scheme(scheme)
+        .authority(authority)
+        .path_and_query(path_and_query)
+        .build()
+        .ok()
+        .ok_or("invalid uri")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::uri::PathAndQuery;
+
+    #[test]
+    fn test_parse_tunnel_destination_valid_http() {
+        let path_and_query =
+            PathAndQuery::from_static("/http/example.com/8080/api/v1/users?id=123");
+        let result = parse_tunnel_destination(&path_and_query).unwrap();
+
+        assert_eq!(result.scheme_str(), Some("http"));
+        assert_eq!(result.authority().unwrap().as_str(), "example.com:8080");
+        assert_eq!(
+            result.path_and_query().unwrap().as_str(),
+            "/api/v1/users?id=123"
+        );
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_valid_https() {
+        let path_and_query = PathAndQuery::from_static("/https/api.example.com/443/v2/data");
+        let result = parse_tunnel_destination(&path_and_query).unwrap();
+
+        assert_eq!(result.scheme_str(), Some("https"));
+        assert_eq!(result.authority().unwrap().as_str(), "api.example.com:443");
+        assert_eq!(result.path_and_query().unwrap().as_str(), "/v2/data");
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_root_path() {
+        let path_and_query = PathAndQuery::from_static("/http/localhost/3000");
+        let result = parse_tunnel_destination(&path_and_query).unwrap();
+
+        assert_eq!(result.scheme_str(), Some("http"));
+        assert_eq!(result.authority().unwrap().as_str(), "localhost:3000");
+        assert_eq!(result.path_and_query().unwrap().as_str(), "/");
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_with_query_no_path() {
+        let path_and_query = PathAndQuery::from_static("/https/example.com/443?query=value");
+        let result = parse_tunnel_destination(&path_and_query).unwrap();
+
+        assert_eq!(result.scheme_str(), Some("https"));
+        assert_eq!(result.authority().unwrap().as_str(), "example.com:443");
+        assert_eq!(result.path_and_query().unwrap().as_str(), "/?query=value");
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_missing_leading_slash() {
+        let path_and_query = PathAndQuery::from_static("http/example.com/8080/api");
+        let result = parse_tunnel_destination(&path_and_query);
+
+        assert_eq!(result, Err("no leading /"));
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_no_host() {
+        let path_and_query = PathAndQuery::from_static("/http");
+        let result = parse_tunnel_destination(&path_and_query);
+
+        assert_eq!(result, Err("no host"));
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_invalid_scheme() {
+        let path_and_query = PathAndQuery::from_static("/!/example.com/8080/api");
+        let result = parse_tunnel_destination(&path_and_query);
+
+        assert_eq!(result, Err("invalid scheme"));
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_no_port() {
+        let path_and_query = PathAndQuery::from_static("/http/example.com");
+        let result = parse_tunnel_destination(&path_and_query);
+
+        assert_eq!(result, Err("no port"));
+    }
+
+    #[test]
+    fn test_parse_tunnel_destination_complex_path() {
+        let path_and_query = PathAndQuery::from_static(
+            "/https/api.service.com/443/v1/users/123/posts?limit=10&offset=20",
+        );
+        let result = parse_tunnel_destination(&path_and_query).unwrap();
+
+        assert_eq!(result.scheme_str(), Some("https"));
+        assert_eq!(result.authority().unwrap().as_str(), "api.service.com:443");
+        assert_eq!(
+            result.path_and_query().unwrap().as_str(),
+            "/v1/users/123/posts?limit=10&offset=20"
+        );
+    }
+}

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -73,6 +73,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 idna = { version = "1" }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["serde-1"] }
 indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["serde"] }
+ipnet = { version = "2" }
 itertools-582f2526e08bb6a0 = { package = "itertools", version = "0.14" }
 lexical-parse-float = { version = "1", features = ["format"] }
 lexical-parse-integer = { version = "1", default-features = false, features = ["format", "std"] }
@@ -88,9 +89,11 @@ num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
+once_cell = { version = "1", features = ["critical-section"] }
 opentelemetry = { version = "0.31" }
 opentelemetry_sdk = { version = "0.31", features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio"] }
 phf_shared = { version = "0.11" }
+portable-atomic = { version = "1" }
 pprof = { version = "0.15", features = ["criterion", "flamegraph", "frame-pointer"] }
 proc-macro2 = { version = "1" }
 prost-582f2526e08bb6a0 = { package = "prost", version = "0.14" }
@@ -202,6 +205,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 idna = { version = "1" }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["serde-1"] }
 indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["serde"] }
+ipnet = { version = "2" }
 itertools-582f2526e08bb6a0 = { package = "itertools", version = "0.14" }
 itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13" }
 lexical-parse-float = { version = "1", features = ["format"] }
@@ -218,9 +222,11 @@ num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
+once_cell = { version = "1", features = ["critical-section"] }
 opentelemetry = { version = "0.31" }
 opentelemetry_sdk = { version = "0.31", features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio"] }
 phf_shared = { version = "0.11" }
+portable-atomic = { version = "1" }
 pprof = { version = "0.15", features = ["criterion", "flamegraph", "frame-pointer"] }
 proc-macro2 = { version = "1" }
 prost-582f2526e08bb6a0 = { package = "prost", version = "0.14" }


### PR DESCRIPTION
Currently the CLI tunnel is a bit of a special case. It talks to only a single tunnel server eg :19082, which it is assigned randomly after first hitting 19080, and it then asks users to register a tunnel url that has a particular port, like tunnel://foo:9082 which means their restate env will hit the same tunnel server. This means that on the infra side, we have to maintain the ability for restate to hit a particular tunnel server using a port and a dns name, and this is potentially cross zone, which is not desirable. Instead, the cli should talk to all the tunnel servers (as discovered from the srv record eg `tunnel.us.restate.cloud`, and the restate environment should talk to its zone local tunnel servers to try and find a connection. This behaviour matches the standalone tunnel client that people run in their clusters. In the CLI we have a slightly simplified client however, as we do not handle tunnel draining mechanism and we don't handle the srv record changing.

In addition, the tunnel:// urls that map to a single local port are confusing. Instead we move to a generic local proxy approach, where you can register any url, providing `--tunnel-name` to specify that it should go through the tunnel for your environment. This will unify CLI + standalone tunnels, so that users don't have to build the tunnel url themselves.

eg:
```
restate cloud env tunnel --tunnel-name foo
restate dp register --tunnel-name foo http://localhost:9080
# you can even proxy to external urls
restate dp register --tunnel-name foo https://my-worker.workers.dev
```

Summary of changes:
- We have to generate tunnel names client side, as we need to reach out to all tunnel servers simultaneously so it is tricky to let the server generate it
- Resolve srv and connect to all tunnel servers
- Generic forward proxy based on incoming url, matching standalone tunnel client
- Change register command to accept normal urls + --tunnel-name
- Get proxy base url at registration time from describe environment response, not local config so that we have more flexibility eg for byoc clusters