### PR TITLE
[Metadata] DynamoDB metadata store provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "faf26925f4a5b59eb76722b63c2892b1d70d06fa053c72e4a100ec308c1d47bc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.6"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -558,11 +558,11 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.27.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.8"
+version = "1.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+checksum = "9f2402da1a5e16868ba98725e5d73f26b8116eaa892e56f2cd0bf5eec7985f70"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -592,6 +592,28 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6034694d9f6b47ead8af47a1b79a85e185751d1171e9b983c4b3328bbff480c6"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -686,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.3"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+checksum = "c35452ec3f001e1f2f6db107b6373f1f48f05ec63ba2c5c9fa91f07dad32af11"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -709,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+checksum = "127fcfad33b7dfc531141fda7e1c402ac65f88aca5511a4d31e2e3d2cd01ce9c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -720,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.9"
+version = "0.60.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338a3642c399c0a5d157648426110e199ca7fd1c689cc395676b81aa563700c4"
+checksum = "e29a304f8319781a39808847efb39561351b1bb76e933da7aa90232673638658"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -731,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "445d5d720c99eed0b4aa674ed00d835d9b1427dd73e04adaf2f94c6b2d6f9fca"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -741,6 +763,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
+ "futures-util",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -752,41 +775,48 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f491388e741b7ca73b24130ff464c1478acc34d5b331b7dd0a2ee4643595a15"
+checksum = "623254723e8dfd535f566ee7b2381645f8981da086b5c4aa26c0c41582bb1d2c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2",
+ "h2 0.3.27",
+ "h2 0.4.12",
+ "http 0.2.12",
  "http 1.3.1",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.6.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tower 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.4"
+version = "0.61.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
+checksum = "2db31f727935fc63c6eeae8b37b438847639ec330a9161ece694efba257e0c54"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+checksum = "2d1881b1ea6d313f9890710d65c158bdab6fb08c91ea825f74c1c8c357baf4cc"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -803,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "0bbe9d018d646b96c7be063dd07987849862b0e6d07c778aad7d93d1be6c1ef0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -827,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
+checksum = "ec7204f9fd94749a7c53b26da1b961b4ac36bf070ef1e0b94bb09f79d4f6c193"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -844,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
+checksum = "25f535879a207fce0db74b679cfc3e91a3159c8144d717d55f5832aea9eef46e"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -879,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "d79fb68e3d7fe5d4833ea34dc87d2e97d26d3086cb3da660bb6b1f76d98680b6"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -931,7 +961,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1135,29 +1165,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.10.5",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.106",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
@@ -1166,10 +1173,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.106",
 ]
@@ -1397,10 +1406,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -1821,6 +1831,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3126,6 +3146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,9 +3511,28 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.11.4",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3588,15 +3633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "hostname"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,6 +3729,30 @@ checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -3700,7 +3760,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3714,19 +3774,35 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -3737,7 +3813,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3746,9 +3822,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3757,15 +3833,17 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.6.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4360,7 +4438,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "http-serde",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "lambda_runtime_api_client",
  "pin-project",
@@ -4386,7 +4464,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "tokio",
  "tower 0.4.13",
@@ -4400,12 +4478,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
@@ -4812,7 +4884,7 @@ dependencies = [
  "mlua_derive",
  "num-traits",
  "parking_lot",
- "rustc-hash 2.1.0",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -4850,7 +4922,7 @@ dependencies = [
  "bytes",
  "futures",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "prost 0.14.1",
  "restate-service-protocol-v4",
@@ -5194,7 +5266,7 @@ dependencies = [
  "http-body-util",
  "httparse",
  "humantime",
- "hyper",
+ "hyper 1.6.0",
  "itertools 0.14.0",
  "md-5",
  "parking_lot",
@@ -5203,7 +5275,7 @@ dependencies = [
  "rand 0.9.1",
  "reqwest",
  "ring",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5235,8 +5307,8 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-timeout",
  "hyper-util",
  "jsonwebtoken",
@@ -6217,8 +6289,8 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
- "rustls",
+ "rustc-hash",
+ "rustls 0.23.35",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
@@ -6235,8 +6307,8 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.1.0",
- "rustls",
+ "rustc-hash",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -6590,27 +6662,27 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.2",
  "tower-http",
@@ -6813,7 +6885,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "humantime",
- "hyper",
+ "hyper 1.6.0",
  "indicatif",
  "indoc",
  "itertools 0.14.0",
@@ -6830,7 +6902,7 @@ dependencies = [
  "restate-time-util",
  "restate-types",
  "restate-workspace-hack",
- "rustls",
+ "rustls 0.23.35",
  "serde",
  "serde_json",
  "serde_with",
@@ -6887,12 +6959,12 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "jsonwebtoken",
  "restate-workspace-hack",
- "rustls",
+ "rustls 0.23.35",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -6921,7 +6993,7 @@ dependencies = [
  "googletest",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "itertools 0.14.0",
  "metrics",
@@ -7062,7 +7134,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "humantime",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "metrics",
  "mockall",
@@ -7311,10 +7383,13 @@ version = "1.6.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
  "bilrost",
  "bytes",
  "bytestring",
  "ciborium",
+ "const_format",
  "derive_more",
  "etcd-client",
  "indexmap 2.11.4",
@@ -7652,7 +7727,7 @@ dependencies = [
  "restate-types",
  "restate-workspace-hack",
  "rlimit",
- "rustls",
+ "rustls 0.23.35",
  "schemars 0.8.22",
  "serde_json",
  "tempfile",
@@ -7685,19 +7760,19 @@ dependencies = [
  "bytestring",
  "futures",
  "googletest",
- "h2",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body-util",
  "http-serde",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "jsonwebtoken",
  "pem",
  "restate-types",
  "restate-workspace-hack",
  "ring",
- "rustls",
+ "rustls 0.23.35",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -8133,6 +8208,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-sigv4",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -8175,8 +8251,8 @@ dependencies = [
  "hdrhistogram",
  "hex",
  "hmac",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "idna",
  "indexmap 1.9.3",
@@ -8221,9 +8297,9 @@ dependencies = [
  "ring",
  "rustix 0.38.44",
  "rustix 1.0.7",
- "rustls",
+ "rustls 0.23.35",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.8",
  "schemars 0.8.22",
  "semver",
  "serde",
@@ -8236,8 +8312,7 @@ dependencies = [
  "syn 2.0.106",
  "sync_wrapper",
  "time",
- "time-macros",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
  "toml_datetime 0.6.11",
@@ -8302,7 +8377,7 @@ dependencies = [
  "restate-wal-protocol",
  "restate-workspace-hack",
  "rlimit",
- "rustls",
+ "rustls 0.23.35",
  "serde",
  "serde_json",
  "tempfile",
@@ -8390,7 +8465,7 @@ name = "rust-librocksdb-sys"
 version = "0.39.0+10.5.1"
 source = "git+https://github.com/restatedev/rust-rocksdb?rev=de8911652d398e9bfbb6bbc42a7b4f7296f6d101#de8911652d398e9bfbb6bbc42a7b4f7296f6d101"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -8418,12 +8493,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8468,18 +8537,42 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -8491,7 +8584,16 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -8505,18 +8607,29 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -8606,6 +8719,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8616,12 +8739,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -9225,6 +9361,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9540,11 +9697,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.35",
  "tokio",
 ]
 
@@ -9676,11 +9843,11 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -9706,20 +9873,20 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "socket2 0.6.0",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.5.2",
  "tower-layer",
@@ -10463,18 +10630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10532,8 +10687,8 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -10572,6 +10727,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10581,13 +10747,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ async-channel = "2.3.1"
 async-trait = "0.1.88"
 axum = { version = "0.8.4", default-features = false }
 aws-config = "1.8.0"
+aws-sdk-dynamodb = "1.97.0"
 aws-credential-types = "1.2.2"
 aws-smithy-async = { version = "1.2.5", default-features = false }
 aws-smithy-runtime-api = "1.7.4"

--- a/crates/metadata-providers/Cargo.toml
+++ b/crates/metadata-providers/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [features]
-default = []
+default = ["dynamodb"]
 etcd = ["etcd-client"]
 objstore = [
   "restate-core",
@@ -31,6 +31,7 @@ replicated = [
   "serde",
   "serde_json",
 ]
+dynamodb = ["aws-config", "aws-sdk-dynamodb"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
@@ -45,9 +46,12 @@ restate-object-store-util = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+aws-config = { workspace = true, optional = true }
+aws-sdk-dynamodb = { workspace = true, optional = true }
 bilrost = { workspace = true, optional = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
+const_format = "0.2.32"
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/metadata-providers/src/dynamodb.rs
+++ b/crates/metadata-providers/src/dynamodb.rs
@@ -1,0 +1,528 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_dynamodb::{
+    config::Credentials,
+    error::SdkError,
+    operation::{delete_item::DeleteItemError, put_item::PutItemError},
+    primitives::Blob,
+    types::{AttributeValue, ReturnConsumedCapacity, ReturnValue},
+};
+use bytestring::ByteString;
+
+use restate_metadata_store::{ProvisionedMetadataStore, ReadError, WriteError};
+use restate_types::{
+    Version,
+    config::DynamoDbOptions,
+    metadata::{Precondition, VersionedValue},
+};
+
+const KEY_FIELD: &str = "pk";
+const VERSION_FIELD: &str = "version";
+const DATA_FIELD: &str = "data";
+
+const CONDITION_DOES_NOT_EXIST: &str =
+    const_format::concatcp!("attribute_not_exists(", KEY_FIELD, ")");
+
+#[derive(Debug, thiserror::Error)]
+pub enum DynamoDbStoreCodecError {
+    #[error("Missing field {0}")]
+    MissingField(&'static str),
+    #[error("Field {0} has wrong type")]
+    InvalidType(&'static str),
+    #[error("Field {0} has an invalid format")]
+    InvalidFormat(&'static str),
+}
+
+impl From<DynamoDbStoreCodecError> for ReadError {
+    fn from(value: DynamoDbStoreCodecError) -> Self {
+        Self::Codec(value.into())
+    }
+}
+pub struct DynamoDbMetadataStore {
+    table: String,
+    key_prefix: Option<String>,
+    client: aws_sdk_dynamodb::Client,
+}
+
+impl DynamoDbMetadataStore {
+    pub async fn new(
+        table: impl Into<String>,
+        key_prefix: Option<String>,
+        dynamo_db_options: DynamoDbOptions,
+    ) -> anyhow::Result<Self> {
+        let cfg = aws_config::defaults(BehaviorVersion::latest());
+
+        let cfg = match (
+            dynamo_db_options.aws_profile,
+            dynamo_db_options.aws_access_key_id,
+        ) {
+            // loaded from env
+            (None, None) => cfg,
+            (Some(_), Some(_)) => anyhow::bail!(
+                "Either `aws-profile` or `aws-access-key-id` must be provided for dynamo-db metadata provider, but not both"
+            ),
+            (Some(profile), None) => cfg.profile_name(profile),
+            (None, Some(access_key_id)) => {
+                let secret_access_key =
+                    dynamo_db_options.aws_secret_access_key.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Missing aws-secret-access-key for dynamo-db metadata provider"
+                        )
+                    })?;
+
+                let cred = Credentials::new(
+                    access_key_id,
+                    secret_access_key,
+                    dynamo_db_options.aws_session_token,
+                    None,
+                    "config-file",
+                );
+                cfg.credentials_provider(cred)
+            }
+        };
+
+        let cfg = if let Some(region) = dynamo_db_options.aws_region {
+            cfg.region(Region::new(region))
+        } else {
+            cfg
+        };
+
+        let cfg = if let Some(url) = dynamo_db_options.aws_endpoint_url {
+            cfg.endpoint_url(url)
+        } else {
+            cfg
+        };
+
+        let sdk_cfg = cfg.load().await;
+
+        let client = aws_sdk_dynamodb::Client::new(&sdk_cfg);
+
+        Ok(Self {
+            table: table.into(),
+            key_prefix,
+            client,
+        })
+    }
+
+    #[cfg(test)]
+    pub async fn new_test_store(table: impl Into<String>, url: impl Into<String>) -> Self {
+        let cfg = aws_config::defaults(BehaviorVersion::latest())
+            .test_credentials()
+            .endpoint_url(url)
+            .region(Region::from_static("fake"))
+            .empty_test_environment()
+            .load()
+            .await;
+
+        Self {
+            table: table.into(),
+            key_prefix: None,
+            client: aws_sdk_dynamodb::Client::new(&cfg),
+        }
+    }
+
+    fn prefixed(&self, key: ByteString) -> String {
+        match &self.key_prefix {
+            Some(prefix) => {
+                let mut buf = String::with_capacity(prefix.len() + key.len());
+                buf.push_str(prefix);
+                buf.push_str(&key);
+                buf
+            }
+            None => key.to_string(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProvisionedMetadataStore for DynamoDbMetadataStore {
+    /// Gets the value and its current version for the given key. If key-value pair is not present,
+    /// then return [`None`].
+    async fn get(&self, key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+        let key = self.prefixed(key);
+        let result = self
+            .client
+            .get_item()
+            .table_name(&self.table)
+            .return_consumed_capacity(ReturnConsumedCapacity::None)
+            .consistent_read(true)
+            .key(KEY_FIELD, AttributeValue::S(key))
+            .send()
+            .await
+            .map_err(sdk_err_into_read_err)?;
+
+        let Some(mut item) = result.item else {
+            return Ok(None);
+        };
+
+        let AttributeValue::N(version_str) = item
+            .remove(VERSION_FIELD)
+            .ok_or(DynamoDbStoreCodecError::MissingField(VERSION_FIELD))?
+        else {
+            return Err(DynamoDbStoreCodecError::InvalidType(VERSION_FIELD).into());
+        };
+
+        let version: u32 = version_str
+            .parse()
+            .map_err(|_| DynamoDbStoreCodecError::InvalidFormat(VERSION_FIELD))?;
+
+        let AttributeValue::B(data) = item
+            .remove(DATA_FIELD)
+            .ok_or(DynamoDbStoreCodecError::MissingField(DATA_FIELD))?
+        else {
+            return Err(DynamoDbStoreCodecError::InvalidType(DATA_FIELD).into());
+        };
+
+        Ok(Some(VersionedValue {
+            version: version.into(),
+            value: data.into_inner().into(),
+        }))
+    }
+
+    /// Gets the current version for the given key. If key-value pair is not present, then return
+    /// [`None`].
+    async fn get_version(&self, key: ByteString) -> Result<Option<Version>, ReadError> {
+        let key = self.prefixed(key);
+        let result = self
+            .client
+            .get_item()
+            .table_name(&self.table)
+            .return_consumed_capacity(ReturnConsumedCapacity::None)
+            .attributes_to_get(VERSION_FIELD)
+            .consistent_read(true)
+            .key(KEY_FIELD, AttributeValue::S(key))
+            .send()
+            .await
+            .map_err(sdk_err_into_read_err)?;
+
+        let Some(mut item) = result.item else {
+            return Ok(None);
+        };
+
+        let AttributeValue::N(version_str) = item
+            .remove(VERSION_FIELD)
+            .ok_or(DynamoDbStoreCodecError::MissingField(VERSION_FIELD))?
+        else {
+            return Err(DynamoDbStoreCodecError::InvalidType(VERSION_FIELD).into());
+        };
+
+        let version: u32 = version_str
+            .parse()
+            .map_err(|_| DynamoDbStoreCodecError::InvalidFormat(VERSION_FIELD))?;
+
+        Ok(Some(version.into()))
+    }
+
+    /// Puts the versioned value under the given key following the provided precondition. If the
+    /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
+    async fn put(
+        &self,
+        key: ByteString,
+        value: VersionedValue,
+        precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        let key = self.prefixed(key);
+        let put = self
+            .client
+            .put_item()
+            .table_name(&self.table)
+            .return_consumed_capacity(ReturnConsumedCapacity::None)
+            .return_values(ReturnValue::None)
+            .item(KEY_FIELD, AttributeValue::S(key))
+            .item(
+                VERSION_FIELD,
+                AttributeValue::N(u32::from(value.version).to_string()),
+            )
+            .item(DATA_FIELD, AttributeValue::B(Blob::new(value.value)));
+
+        let put = match precondition {
+            Precondition::None => put,
+            Precondition::DoesNotExist => put.condition_expression(CONDITION_DOES_NOT_EXIST),
+            Precondition::MatchesVersion(version) => put
+                .condition_expression("version = :v")
+                .expression_attribute_values(
+                    ":v",
+                    AttributeValue::N(u32::from(version).to_string()),
+                ),
+        };
+
+        put.send().await.map(|_| ()).map_err(|err| match err {
+            SdkError::ServiceError(err) => match err.into_err() {
+                PutItemError::ConditionalCheckFailedException(exception) => {
+                    WriteError::FailedPrecondition(exception.to_string())
+                }
+                err => WriteError::terminal(err),
+            },
+            err => sdk_err_into_write_err(err),
+        })
+    }
+
+    /// Deletes the key-value pair for the given key following the provided precondition. If the
+    /// precondition is not met, then the operation returns a [`WriteError::PreconditionViolation`].
+    async fn delete(&self, key: ByteString, precondition: Precondition) -> Result<(), WriteError> {
+        let key = self.prefixed(key);
+        let delete = self
+            .client
+            .delete_item()
+            .table_name(&self.table)
+            .return_consumed_capacity(ReturnConsumedCapacity::None)
+            .return_values(ReturnValue::None)
+            .key(KEY_FIELD, AttributeValue::S(key));
+
+        let delete = match precondition {
+            Precondition::None => delete,
+            Precondition::DoesNotExist => delete.condition_expression(CONDITION_DOES_NOT_EXIST),
+            Precondition::MatchesVersion(version) => delete
+                .condition_expression("version = :v")
+                .expression_attribute_values(
+                    ":v",
+                    AttributeValue::N(u32::from(version).to_string()),
+                ),
+        };
+
+        delete.send().await.map(|_| ()).map_err(|err| match err {
+            SdkError::ServiceError(err) => match err.into_err() {
+                DeleteItemError::ConditionalCheckFailedException(exception) => {
+                    WriteError::FailedPrecondition(exception.to_string())
+                }
+                err => WriteError::terminal(err),
+            },
+            err => sdk_err_into_write_err(err),
+        })
+    }
+}
+
+fn sdk_err_into_read_err<E, R>(err: SdkError<E, R>) -> ReadError
+where
+    E: std::error::Error + Send + Sync + 'static,
+    R: std::fmt::Debug + Send + Sync + 'static,
+{
+    match err {
+        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) | SdkError::ResponseError(_) => {
+            ReadError::retryable(err)
+        }
+        err => ReadError::terminal(err),
+    }
+}
+
+fn sdk_err_into_write_err<E, R>(err: SdkError<E, R>) -> WriteError
+where
+    E: std::error::Error + Send + Sync + 'static,
+    R: std::fmt::Debug + Send + Sync + 'static,
+{
+    match err {
+        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) | SdkError::ResponseError(_) => {
+            WriteError::retryable(err)
+        }
+        err => WriteError::terminal(err),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+    use bytestring::ByteString;
+    use restate_metadata_store::{MetadataStore, WriteError};
+    use restate_types::{
+        Version,
+        metadata::{Precondition, VersionedValue},
+    };
+
+    // ## Running the tests
+    //
+    // The following tests requires that dynamodb to be running locally and listening on port 8000
+    //
+    // ```ignore
+    // # start dynamo db
+    // docker run -p 8000:8000 amazon/dynamodb-local
+    //
+    // # create the metadata table
+    //
+    // aws dynamodb create-table \
+    //     --endpoint-url http://localhost:8000 \
+    //     --table-name metadata \
+    //     --attribute-definitions \
+    //         AttributeName=pk,AttributeType=S
+    //     --key-schema \
+    //         AttributeName=pk,KeyType=HASH \
+    //     --billing-mode PAY_PER_REQUEST
+    // ```
+
+    use super::DynamoDbMetadataStore;
+
+    #[ignore = "requires running dynamodb on localhost:8000"]
+    #[tokio::test]
+    async fn test_put_does_not_exist() {
+        let client =
+            DynamoDbMetadataStore::new_test_store("metadata", "http://localhost:8000").await;
+
+        let key: ByteString = "put_does_not_exist".into();
+        // make sure key doesn't exist
+        client
+            .delete(key.clone(), Precondition::None)
+            .await
+            .unwrap();
+
+        let value = VersionedValue {
+            version: Version::MIN,
+            value: Bytes::new(),
+        };
+
+        client
+            .put(key.clone(), value, Precondition::DoesNotExist)
+            .await
+            .unwrap();
+
+        let result = client.get(key.clone()).await.unwrap();
+        assert!(matches!(result, Some(value) if value.version == Version::MIN));
+    }
+
+    #[ignore = "requires running dynamodb on localhost:8000"]
+    #[tokio::test]
+    async fn test_put_with_version() {
+        let client =
+            DynamoDbMetadataStore::new_test_store("metadata", "http://localhost:8000").await;
+
+        let key: ByteString = "put_with_version".into();
+        // make sure key doesn't exist
+        client
+            .delete(key.clone(), Precondition::None)
+            .await
+            .unwrap();
+
+        let value = VersionedValue {
+            version: 5.into(),
+            value: Bytes::new(),
+        };
+
+        client
+            .put(key.clone(), value, Precondition::DoesNotExist)
+            .await
+            .unwrap();
+
+        let result = client.get(key.clone()).await.unwrap();
+        assert!(result.is_some());
+        let value = result.unwrap();
+        assert_eq!(value.version, 5.into());
+
+        let value = VersionedValue {
+            version: 5.into(),
+            value: Bytes::new(),
+        };
+
+        let result = client
+            .put(key.clone(), value, Precondition::MatchesVersion(4.into()))
+            .await;
+
+        assert!(matches!(result, Err(WriteError::FailedPrecondition(_))));
+
+        let value = VersionedValue {
+            version: 6.into(),
+            value: Bytes::new(),
+        };
+
+        client
+            .put(key.clone(), value, Precondition::MatchesVersion(5.into()))
+            .await
+            .unwrap();
+
+        let result = client.get(key.clone()).await.unwrap();
+        assert!(result.is_some());
+        let value = result.unwrap();
+        assert_eq!(value.version, 6.into());
+
+        let version = client.get_version(key.clone()).await.unwrap();
+        assert!(matches!(version, Some(v) if v == Version::from(6)));
+    }
+
+    #[ignore = "requires running dynamodb on localhost:8000"]
+    #[tokio::test]
+    async fn test_put_force() {
+        let client =
+            DynamoDbMetadataStore::new_test_store("metadata", "http://localhost:8000").await;
+
+        let key: ByteString = "put_force".into();
+        // make sure key doesn't exist
+        client
+            .delete(key.clone(), Precondition::None)
+            .await
+            .unwrap();
+
+        let value = VersionedValue {
+            version: 3.into(),
+            value: Bytes::new(),
+        };
+
+        client
+            .put(key.clone(), value, Precondition::None)
+            .await
+            .unwrap();
+
+        let result = client.get(key.clone()).await.unwrap();
+        assert!(result.is_some());
+        let value = result.unwrap();
+        assert_eq!(value.version, 3.into());
+
+        let value = VersionedValue {
+            version: 5.into(),
+            value: Bytes::new(),
+        };
+
+        client
+            .put(key.clone(), value, Precondition::None)
+            .await
+            .unwrap();
+
+        let result = client.get(key.clone()).await.unwrap();
+        assert!(result.is_some());
+        let value = result.unwrap();
+        assert_eq!(value.version, 5.into());
+    }
+
+    #[ignore = "requires running dynamodb on localhost:8000"]
+    #[tokio::test]
+    async fn test_delete() {
+        let client =
+            DynamoDbMetadataStore::new_test_store("metadata", "http://localhost:8000").await;
+
+        let key: ByteString = "put_delete_me".into();
+        // make sure key doesn't exist
+        client
+            .delete(key.clone(), Precondition::None)
+            .await
+            .unwrap();
+
+        let value = VersionedValue {
+            version: Version::MIN,
+            value: Bytes::new(),
+        };
+
+        client
+            .put(key.clone(), value, Precondition::DoesNotExist)
+            .await
+            .unwrap();
+        let result = client.get(key.clone()).await.unwrap();
+
+        assert!(matches!(result, Some(value) if value.version == Version::MIN));
+
+        let result = client
+            .delete(key.clone(), Precondition::MatchesVersion(2.into()))
+            .await;
+        assert!(matches!(result, Err(WriteError::FailedPrecondition(_))));
+
+        let result = client
+            .delete(key.clone(), Precondition::MatchesVersion(Version::MIN))
+            .await;
+        assert!(result.is_ok());
+        assert!(client.get(key.clone()).await.unwrap().is_none());
+    }
+}

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -13,6 +13,7 @@ all-metadata-providers = [
     "restate-metadata-providers/replicated",
     "restate-metadata-providers/etcd",
     "restate-metadata-providers/objstore",
+    "restate-metadata-providers/dynamodb",
 ]
 
 memory-loglet = ["restate-bifrost/memory-loglet"]

--- a/crates/types/src/config/dynamodb_store.rs
+++ b/crates/types/src/config/dynamodb_store.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+#[serde_as]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(rename = "DynamoDbOptions", default))]
+#[serde(rename_all = "kebab-case")]
+#[builder(default)]
+pub struct DynamoDbOptions {
+    /// # AWS profile
+    ///
+    /// The AWS configuration profile to use for dynamo-db destinations. If you use
+    /// named profiles in your AWS configuration, you can replace all the other settings with
+    /// a single profile reference. See the [AWS documentation on profiles]
+    /// (https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html) for more.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_profile: Option<String>,
+
+    /// # AWS region
+    ///
+    /// AWS region to use with dynamo-db destinations. This may be inferred from the
+    /// environment, for example the current region when running in EC2. Because of the
+    /// request signing algorithm this must have a value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_region: Option<String>,
+
+    /// # AWS access key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_access_key_id: Option<String>,
+
+    /// # AWS secret key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_secret_access_key: Option<String>,
+
+    /// # AWS session token
+    ///
+    /// This is only needed with short-term STS session credentials.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_session_token: Option<String>,
+
+    /// # DynamoDB API endpoint URL override
+    ///
+    /// When you use Amazon DynamoDB, this is typically inferred from the region and there is no need to
+    /// set it. With other dynamo db (for example local test environment), you will have to provide an appropriate HTTP(S) endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_endpoint_url: Option<String>,
+}

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -17,6 +17,7 @@ mod bifrost;
 #[cfg(feature = "clap")]
 mod cli_option_overrides;
 mod common;
+mod dynamodb_store;
 mod gossip;
 mod http;
 mod ingress;
@@ -36,6 +37,7 @@ pub use bifrost::*;
 #[cfg(feature = "clap")]
 pub use cli_option_overrides::*;
 pub use common::*;
+pub use dynamodb_store::*;
 pub use gossip::*;
 pub use http::*;
 pub use ingress::*;

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -27,7 +27,8 @@ aws-runtime = { version = "1", default-features = false, features = ["event-stre
 aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sigv4 = { version = "1", features = ["http0-compat", "sign-eventstream"] }
 aws-smithy-http = { version = "0.62", default-features = false, features = ["event-stream"] }
-aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio"] }
+aws-smithy-http-client = { version = "1", default-features = false, features = ["legacy-rustls-ring", "rustls-aws-lc"] }
+aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio", "tls-rustls"] }
 aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "http-auth", "test-util"] }
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.8", features = ["http2"] }
@@ -104,7 +105,7 @@ regex-automata = { version = "0.4", default-features = false, features = ["dfa",
 regex-syntax = { version = "0.8" }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "http2", "json", "rustls-tls", "rustls-tls-native-roots", "stream"] }
 ring = { version = "0.17", features = ["std"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["logging", "prefer-post-quantum", "ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 schemars = { version = "0.8", features = ["bytes", "enumset", "preserve_order"] }
@@ -153,7 +154,8 @@ aws-runtime = { version = "1", default-features = false, features = ["event-stre
 aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sigv4 = { version = "1", features = ["http0-compat", "sign-eventstream"] }
 aws-smithy-http = { version = "0.62", default-features = false, features = ["event-stream"] }
-aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio"] }
+aws-smithy-http-client = { version = "1", default-features = false, features = ["legacy-rustls-ring", "rustls-aws-lc"] }
+aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio", "tls-rustls"] }
 aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "http-auth", "test-util"] }
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.8", features = ["http2"] }
@@ -234,7 +236,7 @@ regex-automata = { version = "0.4", default-features = false, features = ["dfa",
 regex-syntax = { version = "0.8" }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "http2", "json", "rustls-tls", "rustls-tls-native-roots", "stream"] }
 ring = { version = "0.17", features = ["std"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["logging", "prefer-post-quantum", "ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 schemars = { version = "0.8", features = ["bytes", "enumset", "preserve_order"] }
@@ -249,7 +251,6 @@ stable_deref_trait = { version = "1" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
-time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io-util", "net", "rt"] }
@@ -275,7 +276,6 @@ zstd-sys = { version = "2", features = ["experimental", "std"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
@@ -287,7 +287,6 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs",
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
@@ -299,7 +298,6 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs",
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
 num = { version = "0.4" }
@@ -310,7 +308,6 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs",
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 nix = { version = "0.29", features = ["fs", "signal"] }
 num = { version = "0.4" }


### PR DESCRIPTION
[Metadata] DynamoDB metadata store provider

Summary:
This PR adds support to dynamo-db metadata provider. It's up to the
user to make sure that the table exists and it has the correct key schema.

To create the table make sure to run the following command

```bash
aws dynamodb create-table --table-name metadata --attribute-definitions AttributeName=pk,AttributeType=S --key-schema AttributeName=pk,KeyType=HASH --billing-mode PAY_PER_REQUEST
```

Or for local development instance
```bash
aws dynamodb create-table --endpoint-url http://localhost:8000 --table-name metadata --attribute-definitions AttributeName=pk,AttributeType=S --key-schema AttributeName=pk,KeyType=HASH --billing-mode PAY_PER_REQUEST
```

> Choose the proper `billing-mode` and `table-name` for your setup

## Configuration
```toml
roles = [
    "http-ingress",
    "admin",
    "worker",
    "log-server",
]

[metadata-client]
type = "dynamo-db"
table = "metadata"
aws-profile = "fake"
#aws-access-key-id="fakeAccessKeyId"
#aws-secret-access-key="fakceSecretAccessKey"
#aws-endpoint-url ="http://localhost:8000"
```

You can either provide `aws-profile` or (`aws-access-key` and `aws-secret-access-key`)

> You must remove the `metadata-server` role from othe node `roles`
