### PR TITLE
[Restate UI] Update to v0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8117,8 +8117,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.12"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.12#d69d5357b191bfbc1b5a7d7459352c3b4bc49563"
+version = "0.1.13"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.13#49bff0a253f49af70f7deb66e83e2928c992d5d0"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.12", tag = "v0.1.12" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.13", tag = "v0.1.13" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.13
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.13/ui-v0.1.13.zip