### PR TITLE
Introduce kafka-oidc feature and enable it by default for restate-server builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,11 @@ on:
         required: false
         default: false
         type: boolean
+      features:
+        description: "features to enable in the build"
+        required: false
+        default: ""
+        type: string
       pushToDockerHub:
         description: "push image to DockerHub"
         required: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl-sys"
+version = "0.4.84+curl-8.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +2953,18 @@ name = "downcast-rs"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
+
+[[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
 
 [[package]]
 name = "dunce"
@@ -3909,7 +3936,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4508,6 +4535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "krb5-src"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04b2f0dfefd7b54af22d22768dc3ab1ed5e55e6d5ff6af3f619069aa17c0ba4"
+dependencies = [
+ "duct",
+]
+
+[[package]]
 name = "lambda_runtime"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4639,7 +4675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5309,7 +5345,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -5497,9 +5533,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]
@@ -5629,6 +5665,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6593,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.38.0"
-source = "git+https://github.com/fede1024/rust-rdkafka.git?rev=47d86d71e340896491b65521594bbf081186201e#47d86d71e340896491b65521594bbf081186201e"
+source = "git+https://github.com/restatedev/rust-rdkafka.git?rev=22895f8c22471309e1615b0686cd31be5966d575#22895f8c22471309e1615b0686cd31be5966d575"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -6609,15 +6655,17 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.9.0+2.10.0"
-source = "git+https://github.com/fede1024/rust-rdkafka.git?rev=47d86d71e340896491b65521594bbf081186201e#47d86d71e340896491b65521594bbf081186201e"
+version = "4.9.0+2.12.1"
+source = "git+https://github.com/restatedev/rust-rdkafka.git?rev=22895f8c22471309e1615b0686cd31be5966d575#22895f8c22471309e1615b0686cd31be5966d575"
 dependencies = [
  "cmake",
+ "curl-sys",
  "libc",
  "libz-sys",
  "num_enum 0.7.4",
  "openssl-sys",
  "pkg-config",
+ "sasl2-sys",
 ]
 
 [[package]]
@@ -8399,6 +8447,8 @@ dependencies = [
  "quote",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "rdkafka",
+ "rdkafka-sys",
  "regex",
  "regex-automata",
  "regex-syntax",
@@ -8768,6 +8818,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sasl2-sys"
+version = "0.1.22+2.1.28"
+source = "git+https://github.com/restatedev/rust-sasl?rev=d3e87c54e87327ddbd226881d7546ab7696bf683#d3e87c54e87327ddbd226881d7546ab7696bf683"
+dependencies = [
+ "autotools",
+ "cc",
+ "duct",
+ "krb5-src",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9070,6 +9133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10766,7 +10839,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,12 @@ zstd = { version = "0.13" }
 [patch.crates-io.restate-workspace-hack]
 path = "workspace-hack"
 
+[patch.crates-io]
+# Cross compilation fixes: Use autotools to detect cross compilation tool chain.
+# The fixes are based on rust-sasl v0.1.22.
+# Todo: Upstream changes and get rid of patch
+sasl2-sys = { git = "https://github.com/restatedev/rust-sasl", rev = "d3e87c54e87327ddbd226881d7546ab7696bf683" }
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -10,6 +10,10 @@ publish = false
 [features]
 default = []
 options_schema = ["dep:schemars"]
+# support for OIDC based authentication via the Kafka consumer, building with rdkafka/curl-static does not work as it
+# fails with "SSL certificate OpenSSL verify result: unable to get local issuer certificate (20) (-1)" when trying to
+# obtain the OIDC token.
+oidc = ["rdkafka/curl-static", "rdkafka/gssapi-vendored"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
@@ -31,8 +35,10 @@ metrics = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 parking_lot = { workspace = true }
-# 0.38 was not released yet at the time of writing, so when this happens, remove the pin.
-rdkafka = { version = "0.38", git = "https://github.com/fede1024/rust-rdkafka.git", rev = "47d86d71e340896491b65521594bbf081186201e", features = ["libz-static", "cmake-build", "ssl-vendored"] }
+# Use https://github.com/restatedev/rust-rdkafka/tree/fix-build-script which is based on
+# https://github.com/fede1024/rust-rdkafka/pull/803. The PR bumps librdkafka to 2.12.1 and enables WITH_CURL for
+# librdkafka if the feature curl-static is enabled. The additional fixes in fix-build-script fix the musl build.
+rdkafka = { version = "0.38", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", features = ["libz-static", "cmake-build", "ssl-vendored"] }
 schemars = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -120,6 +120,8 @@ impl Service {
         task_orchestrator: &mut TaskOrchestrator,
     ) -> anyhow::Result<()> {
         let mut client_config = rdkafka::ClientConfig::new();
+        // enabling probing for the ca certificates if the user does not specify anything else
+        client_config.set("https.ca.location", "probe");
 
         let Source::Kafka { cluster, topic, .. } = subscription.source();
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -22,6 +22,7 @@ options_schema = [
     "restate-admin/options_schema",
     "restate-worker/options_schema"
 ]
+kafka-oidc = ["restate-worker/kafka-oidc"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -17,6 +17,7 @@ options_schema = [
   "restate-storage-query-datafusion/options_schema",
   "restate-timer/options_schema",
 ]
+kafka-oidc = ["restate-ingress-kafka/oidc"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -174,7 +174,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/apache/arrow-rs.git",
     "https://github.com/tikv/raft-rs.git",
-    "https://github.com/fede1024/rust-rdkafka.git",
 ]
 
 [sources.allow-org]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,11 @@
 
 ARG UPLOAD_DEBUGINFO=false
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.5 AS planner
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.7 AS planner
 COPY . .
 RUN just chef-prepare
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.5 AS base
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.7 AS base
 COPY --from=planner /restate/recipe.json recipe.json
 COPY justfile justfile
 
@@ -31,6 +31,18 @@ ARG TARGETARCH
 
 ENV RUSTC_WRAPPER=/usr/bin/sccache
 ENV SCCACHE_DIR=/var/cache/sccache
+
+# todo only enable those env variables when cross compiling
+# todo remove once https://github.com/MaterializeInc/rust-krb5-src/pull/30 has been merged and released
+# Set krb5 cross-compilation env variables (because we cannot run cross compiled tests)
+ENV krb5_cv_attr_constructor_destructor=yes
+ENV ac_cv_func_regcomp=yes
+ENV ac_cv_printf_positional=yes
+
+# todo only enable this env variable when cross compiling
+# todo remove once https://github.com/MaterializeInc/rust-sasl/pull/55 has been merged and released
+# Set sasl2-sys cross-compilation env variables (because we cannot run cross compiled tests)
+ENV ac_cv_gssapi_supports_spnego=yes
 
 # Overrides the behaviour of the release profile re including debug symbols, which in our repo is not to include them.
 # Should be set to 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html

--- a/docker/debug.Dockerfile
+++ b/docker/debug.Dockerfile
@@ -8,11 +8,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.5 AS planner
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.7 AS planner
 COPY . .
 RUN just chef-prepare
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.5 AS base
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.14.7 AS base
 COPY --from=planner /restate/recipe.json recipe.json
 COPY justfile justfile
 
@@ -29,6 +29,18 @@ ARG TARGETARCH
 
 ENV RUSTC_WRAPPER=/usr/bin/sccache
 ENV SCCACHE_DIR=/var/cache/sccache
+
+# todo only enable those env variables when cross compiling
+# todo remove once https://github.com/MaterializeInc/rust-krb5-src/pull/30 has been merged and released
+# Set krb5 cross-compilation env variables (because we cannot run cross compiled tests)
+ENV krb5_cv_attr_constructor_destructor=yes
+ENV ac_cv_func_regcomp=yes
+ENV ac_cv_printf_positional=yes
+
+# todo only enable this env variable when cross compiling
+# todo remove once https://github.com/MaterializeInc/rust-sasl/pull/55 has been merged and released
+# Set sasl2-sys cross-compilation env variables (because we cannot run cross compiled tests)
+ENV ac_cv_gssapi_supports_spnego=yes
 
 # Avoids feature unification by building the three binaries individually
 ARG BUILD_INDIVIDUALLY=false

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,7 +15,8 @@ build = "build.rs"
 dist = true
 
 [features]
-default = ["no-trace-logging"]
+# kafka-oidc should work on all targets, so let's enable it by default
+default = ["no-trace-logging", "kafka-oidc"]
 console = [
     "tokio/full",
     "tokio/tracing",
@@ -31,6 +32,7 @@ options_schema = [
 memory-loglet = ["restate-node/memory-loglet"]
 no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
 metadata-api = ["restate-admin/metadata-api"]
+kafka-oidc = ["restate-node/kafka-oidc"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -103,6 +103,8 @@ quanta = { version = "0.12" }
 quote = { version = "1" }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
+rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
@@ -237,6 +239,8 @@ quanta = { version = "0.12" }
 quote = { version = "1" }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
+rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }


### PR DESCRIPTION
To use the Kafka ingress with OIDC authentication, we need to enable the gssapi-vendored
and curl-static features on our rdkafka dependency. To make things properly work with cross
compilation, we need to patch rust-sasl and rdkafka and bump librdkafka to v2.12.1. The latter
allows us to compile with curl-static which saves us the hassle to dynamically link against
libraries from a different target architecture.