### PR TITLE
[Ingestion] `ingestion-client` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,6 +7331,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-ingestion-client"
+version = "1.6.0-dev"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "dashmap",
+ "futures",
+ "googletest",
+ "pin-project",
+ "restate-core",
+ "restate-types",
+ "restate-workspace-hack",
+ "test-log",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "restate-ingress-http"
 version = "1.6.0-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ restate-utoipa = { path = "crates/utoipa" }
 restate-vqueues = { path = "crates/vqueues" }
 restate-wal-protocol = { path = "crates/wal-protocol" }
 restate-worker = { path = "crates/worker" }
+restate-ingestion-client = { path = "crates/ingestion-client" }
 
 # this workspace-hack package is overridden by a patch below to use workspace-hack subdir when building in this repo
 # outside this repo, the crates.io restate-workspace-hack (an empty package) will be used instead

--- a/crates/ingestion-client/Cargo.toml
+++ b/crates/ingestion-client/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "restate-ingestion-client"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+arc-swap = { workspace = true }
+dashmap = { workspace = true }
+futures = { workspace = true }
+pin-project = { workspace = true }
+thiserror = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+restate-core = { workspace = true }
+restate-types = { workspace = true }
+restate-workspace-hack = { workspace = true }
+
+[dev-dependencies]
+bytes = { workspace = true }
+googletest = { workspace = true }
+test-log = { workspace = true }
+
+restate-core = { workspace = true, features = ["test-util"] }

--- a/crates/ingestion-client/src/chunks_size.rs
+++ b/crates/ingestion-client/src/chunks_size.rs
@@ -1,0 +1,144 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use tokio_stream::adapters::Fuse;
+use tokio_stream::{Stream, StreamExt};
+
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+#[must_use = "streams do nothing unless polled"]
+#[derive(Debug)]
+#[pin_project::pin_project]
+pub struct ChunksSize<F, S: Stream> {
+    #[pin]
+    stream: Fuse<S>,
+    items: Vec<S::Item>,
+    size: usize,
+    cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+    size_fn: F,
+}
+
+impl<F, S: Stream> ChunksSize<F, S>
+where
+    F: Fn(&S::Item) -> usize,
+{
+    pub fn new(stream: S, max_size: usize, size_fn: F) -> Self {
+        ChunksSize {
+            stream: stream.fuse(),
+            items: Vec::default(),
+            size: 0,
+            cap: max_size,
+            size_fn,
+        }
+    }
+
+    /// Drains the buffered items, returning them without waiting for the timeout or capacity limit.
+    pub fn into_remainder(self) -> Vec<S::Item> {
+        self.items
+    }
+}
+
+impl<F, S: Stream> Stream for ChunksSize<F, S>
+where
+    F: Fn(&S::Item) -> usize,
+{
+    type Item = Vec<S::Item>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.as_mut().project();
+        loop {
+            match me.stream.as_mut().poll_next(cx) {
+                Poll::Pending if me.items.is_empty() => return Poll::Pending,
+                Poll::Pending => {
+                    *me.size = 0;
+                    return Poll::Ready(Some(std::mem::take(me.items)));
+                }
+                Poll::Ready(Some(item)) => {
+                    let item_size = (me.size_fn)(&item);
+
+                    if *me.size + item_size <= *me.cap {
+                        *me.size += item_size;
+                        me.items.push(item);
+                    } else if me.items.is_empty() {
+                        *me.size = 0;
+                        return Poll::Ready(Some(vec![item]));
+                    } else {
+                        let items = std::mem::replace(me.items, vec![item]);
+                        *me.size = item_size;
+                        return Poll::Ready(Some(items));
+                    }
+                }
+                Poll::Ready(None) => {
+                    // Returning Some here is only correct because we fuse the inner stream.
+                    let last = if me.items.is_empty() {
+                        None
+                    } else {
+                        Some(std::mem::take(me.items))
+                    };
+
+                    return Poll::Ready(last);
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let chunk_len = if self.items.is_empty() { 0 } else { 1 };
+        let (lower, upper) = self.stream.size_hint();
+        let lower = (lower / self.cap).saturating_add(chunk_len);
+        let upper = upper.and_then(|x| x.checked_add(chunk_len));
+        (lower, upper)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::task::Poll;
+
+    use futures::{StreamExt, stream::poll_fn};
+    use tokio_stream::iter;
+
+    use super::ChunksSize;
+
+    #[tokio::test]
+    async fn splits_into_size_bound_chunks() {
+        let stream = iter([2usize, 2, 3, 1]);
+        let chunks: Vec<Vec<usize>> = ChunksSize::new(stream, 5, |item| *item).collect().await;
+
+        assert_eq!(chunks, vec![vec![2, 2], vec![3, 1]]);
+    }
+
+    #[tokio::test]
+    async fn emits_item_larger_than_cap_as_its_own_chunk() {
+        let stream = iter([10usize, 2]);
+        let chunks: Vec<Vec<usize>> = ChunksSize::new(stream, 5, |item| *item).collect().await;
+
+        assert_eq!(chunks, vec![vec![10], vec![2]]);
+    }
+
+    #[tokio::test]
+    async fn flushes_buffer_when_inner_stream_is_pending() {
+        let mut state = 0;
+        let stream = poll_fn(move |_| {
+            state += 1;
+            match state {
+                1 => Poll::Ready(Some(1usize)),
+                2 => Poll::Pending,
+                3 => Poll::Ready(Some(2usize)),
+                _ => Poll::Ready(None),
+            }
+        });
+
+        let chunks: Vec<Vec<usize>> = ChunksSize::new(stream, 10, |item| *item).collect().await;
+
+        assert_eq!(chunks, vec![vec![1], vec![2]]);
+    }
+}

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -1,0 +1,444 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{marker::PhantomData, num::NonZeroUsize, sync::Arc, task::Poll};
+
+use futures::{FutureExt, future::BoxFuture, ready};
+use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
+
+use restate_core::{
+    network::{Networking, TransportConnect},
+    partitions::PartitionRouting,
+};
+use restate_types::{
+    identifiers::PartitionKey,
+    live::Live,
+    logs::{HasRecordKeys, Keys},
+    net::ingest::IngestRecord,
+    partitions::{FindPartition, PartitionTable, PartitionTableError},
+    storage::StorageEncode,
+};
+
+use crate::{
+    RecordCommit, SessionOptions,
+    session::{SessionHandle, SessionManager},
+};
+
+/// Errors that can be observed when interacting with the ingestion facade.
+#[derive(Debug, thiserror::Error)]
+pub enum IngestionError {
+    #[error("Ingestion closed")]
+    Closed,
+    #[error(transparent)]
+    PartitionTableError(#[from] PartitionTableError),
+}
+
+/// High-level ingestion entry point that allocates permits and hands out session handles per partition.
+/// [`IngestionClient`] can be cloned and shared across different routines. All users will share the same budget
+/// and underlying partition sessions.
+#[derive(Clone)]
+pub struct IngestionClient<T, V> {
+    manager: SessionManager<T>,
+    partition_table: Live<PartitionTable>,
+    // memory budget for inflight invocations.
+    permits: Arc<Semaphore>,
+    memory_budget: NonZeroUsize,
+    _phantom: PhantomData<V>,
+}
+
+impl<T, V> IngestionClient<T, V> {
+    /// Builds a new ingestion facade with the provided networking stack, partition metadata, and
+    /// budget (in bytes) for inflight records.
+    pub fn new(
+        networking: Networking<T>,
+        partition_table: Live<PartitionTable>,
+        partition_routing: PartitionRouting,
+        memory_budget: NonZeroUsize,
+        opts: Option<SessionOptions>,
+    ) -> Self {
+        Self {
+            manager: SessionManager::new(networking, partition_routing, opts),
+            partition_table,
+            permits: Arc::new(Semaphore::new(memory_budget.get())),
+            memory_budget,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, V> IngestionClient<T, V>
+where
+    T: TransportConnect,
+    V: StorageEncode,
+{
+    pub fn partition_routing(&self) -> &PartitionRouting {
+        self.manager.partition_routing()
+    }
+
+    pub fn partition_table(&self) -> &Live<PartitionTable> {
+        &self.partition_table
+    }
+
+    pub fn networking(&self) -> &Networking<T> {
+        self.manager.networking()
+    }
+
+    /// Ingest a record with `partition_key`.
+    #[must_use]
+    pub fn ingest(
+        &self,
+        partition_key: PartitionKey,
+        record: impl Into<InputRecord<V>>,
+    ) -> IngestFuture {
+        let record = record.into().into_record();
+
+        let budget = record.estimate_size().min(self.memory_budget.get());
+
+        let partition_id = match self
+            .partition_table
+            .pinned()
+            .find_partition_id(partition_key)
+        {
+            Ok(partition_id) => partition_id,
+            Err(err) => return IngestFuture::error(err.into()),
+        };
+
+        let handle = self.manager.get(partition_id);
+
+        let acquire = self.permits.clone().acquire_many_owned(budget as u32);
+
+        IngestFuture::awaiting_permits(record, handle, acquire)
+    }
+
+    /// Once closed, calls to ingest will return [`IngestionError::Closed`].
+    /// Inflight records might still get committed.
+    pub fn close(&self) {
+        self.permits.close();
+        self.manager.close();
+    }
+}
+
+/// Future returned by [`IngestionClient::ingest`]
+#[pin_project::pin_project(project=IngestFutureStateProj)]
+enum IngestFutureState {
+    Error {
+        err: Option<IngestionError>,
+    },
+    AwaitingPermit {
+        record: Option<IngestRecord>,
+        handle: SessionHandle,
+        acquire: BoxFuture<'static, Result<OwnedSemaphorePermit, AcquireError>>,
+    },
+    Done,
+}
+
+#[pin_project::pin_project]
+pub struct IngestFuture {
+    #[pin]
+    state: IngestFutureState,
+}
+
+impl IngestFuture {
+    /// create a "ready" ingestion future that will resolve to error
+    fn error(err: IngestionError) -> Self {
+        IngestFuture {
+            state: IngestFutureState::Error { err: Some(err) },
+        }
+    }
+
+    /// create a pending ingestion future that will eventually resolve to
+    /// [`RecordCommit`] or error
+    fn awaiting_permits<F>(record: IngestRecord, handle: SessionHandle, acquire: F) -> Self
+    where
+        F: Future<Output = Result<OwnedSemaphorePermit, AcquireError>> + Send + 'static,
+    {
+        Self {
+            state: IngestFutureState::AwaitingPermit {
+                record: Some(record),
+                handle,
+                acquire: acquire.boxed(),
+            },
+        }
+    }
+}
+
+impl Future for IngestFuture {
+    type Output = Result<RecordCommit, IngestionError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let mut this = self.project();
+        let result = match this.state.as_mut().project() {
+            IngestFutureStateProj::Error { err } => Poll::Ready(Err(err.take().unwrap())),
+            IngestFutureStateProj::AwaitingPermit {
+                record,
+                handle,
+                acquire,
+            } => {
+                let output = match ready!(acquire.as_mut().poll(cx)) {
+                    Ok(permit) => {
+                        let record = record.take().unwrap();
+                        handle
+                            .ingest(permit, record)
+                            .map_err(|_| IngestionError::Closed)
+                    }
+                    Err(_) => Err(IngestionError::Closed),
+                };
+
+                Poll::Ready(output)
+            }
+            IngestFutureStateProj::Done => {
+                panic!("polled IngestFuture after completion");
+            }
+        };
+
+        this.state.set(IngestFutureState::Done);
+        result
+    }
+}
+
+pub struct InputRecord<T> {
+    keys: Keys,
+    record: T,
+}
+
+impl<T> InputRecord<T>
+where
+    T: StorageEncode,
+{
+    fn into_record(self) -> IngestRecord {
+        IngestRecord::from_parts(self.keys, self.record)
+    }
+}
+
+impl<T> From<T> for InputRecord<T>
+where
+    T: HasRecordKeys + StorageEncode,
+{
+    fn from(value: T) -> Self {
+        InputRecord {
+            keys: value.record_keys(),
+            record: value,
+        }
+    }
+}
+
+impl InputRecord<String> {
+    #[cfg(test)]
+    fn from_str(s: impl Into<String>) -> Self {
+        InputRecord {
+            keys: Keys::None,
+            record: s.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{num::NonZeroUsize, time::Duration};
+
+    use futures::{FutureExt, StreamExt};
+    use googletest::prelude::*;
+    use test_log::test;
+
+    use restate_core::{
+        Metadata, TaskCenter, TestCoreEnvBuilder,
+        network::{
+            BackPressureMode, FailingConnector, Incoming, Rpc, ServiceMessage, ServiceStream,
+        },
+        partitions::PartitionRouting,
+    };
+    use restate_types::{
+        Version,
+        identifiers::{LeaderEpoch, PartitionId},
+        net::{
+            self, RpcRequest,
+            ingest::{ReceivedIngestRequest, ResponseStatus},
+            partition_processor::PartitionLeaderService,
+        },
+        partitions::{
+            PartitionTable,
+            state::{LeadershipState, PartitionReplicaSetStates},
+        },
+    };
+
+    use crate::{CancelledError, IngestionClient, SessionOptions, client::InputRecord};
+
+    async fn init_env(
+        batch_size: usize,
+    ) -> (
+        ServiceStream<PartitionLeaderService>,
+        IngestionClient<FailingConnector, String>,
+    ) {
+        let mut builder = TestCoreEnvBuilder::with_incoming_only_connector()
+            .add_mock_nodes_config()
+            .set_partition_table(PartitionTable::with_equally_sized_partitions(
+                Version::MIN,
+                4,
+            ));
+
+        let partition_replica_set_states = PartitionReplicaSetStates::default();
+        for i in 0..4 {
+            partition_replica_set_states.note_observed_leader(
+                i.into(),
+                LeadershipState {
+                    current_leader: builder.my_node_id,
+                    current_leader_epoch: LeaderEpoch::INITIAL,
+                },
+            );
+        }
+
+        let svc = builder
+            .router_builder
+            .register_service::<net::partition_processor::PartitionLeaderService>(
+                10,
+                BackPressureMode::PushBack,
+            );
+
+        let incoming = svc.start();
+
+        let env = builder.build().await;
+        let client = IngestionClient::new(
+            env.networking,
+            env.metadata.updateable_partition_table(),
+            PartitionRouting::new(partition_replica_set_states, TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(), // 10MB
+            SessionOptions {
+                batch_size,
+                ..Default::default()
+            }
+            .into(),
+        );
+
+        (incoming, client)
+    }
+
+    async fn must_next(
+        recv: &mut ServiceStream<PartitionLeaderService>,
+    ) -> Incoming<Rpc<ReceivedIngestRequest>> {
+        let Some(ServiceMessage::Rpc(msg)) = recv.next().await else {
+            panic!("stream closed");
+        };
+
+        assert_eq!(msg.msg_type(), ReceivedIngestRequest::TYPE);
+        msg.into_typed()
+    }
+
+    #[test(restate_core::test)]
+    async fn test_client_single_record() {
+        let (mut incoming, client) = init_env(10).await;
+
+        let commit = client
+            .ingest(0, InputRecord::from_str("hello world"))
+            .await
+            .unwrap();
+
+        let msg = must_next(&mut incoming).await;
+        let (rx, body) = msg.split();
+        assert_that!(
+            body.records,
+            all!(
+                len(eq(1)),
+                contains(eq(InputRecord::from_str("hello world").into_record()))
+            )
+        );
+
+        rx.send(ResponseStatus::Ack.into());
+
+        commit.await.expect("to resolve");
+    }
+
+    #[test(restate_core::test)]
+    async fn test_client_single_record_retry() {
+        let (mut incoming, client) = init_env(10).await;
+
+        let mut commit = client
+            .ingest(0, InputRecord::from_str("hello world"))
+            .await
+            .unwrap();
+
+        let msg = must_next(&mut incoming).await;
+        let (rx, _) = msg.split();
+        rx.send(ResponseStatus::NotLeader { of: 0.into() }.into());
+
+        assert!((&mut commit).now_or_never().is_none());
+
+        // ingestion will retry automatically so we must receive another message
+        let msg = must_next(&mut incoming).await;
+        let (rx, body) = msg.split();
+        assert_that!(
+            body.records,
+            all!(
+                len(eq(1)),
+                contains(eq(InputRecord::from_str("hello world").into_record()))
+            )
+        );
+        // lets acknowledge it this time
+        rx.send(ResponseStatus::Ack.into());
+
+        commit.await.expect("to resolve");
+    }
+
+    #[test(restate_core::test)]
+    async fn test_client_close() {
+        let (_, client) = init_env(10).await;
+
+        let commit = client
+            .ingest(0, InputRecord::from_str("hello world"))
+            .await
+            .unwrap();
+
+        client.close();
+
+        assert!(matches!(commit.await, Err(CancelledError)));
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn test_client_dispatch() {
+        let (mut incoming, client) = init_env(10).await;
+
+        let pt = Metadata::with_current(|p| p.partition_table_snapshot());
+
+        for p in 0..4 {
+            let partition_id = PartitionId::from(p);
+            let partition = pt.get(&partition_id).unwrap();
+            client
+                .ingest(
+                    *partition.key_range.start(),
+                    InputRecord::from_str(format!("partition {p}")),
+                )
+                .await
+                .unwrap();
+        }
+
+        tokio::time::advance(Duration::from_millis(10)).await; // batch timeout
+
+        // what happens is that we still get 4 different messages because each targets
+        // a single partition.
+        let mut received = vec![];
+        for _ in 0..4 {
+            let msg = must_next(&mut incoming).await;
+            received.push(msg.sort_code());
+        }
+
+        assert_that!(
+            received,
+            all!(
+                len(eq(4)), //4 messages for 4 partitions
+                contains(eq(Some(0))),
+                contains(eq(Some(1))),
+                contains(eq(Some(2))),
+                contains(eq(Some(3))),
+            )
+        );
+    }
+}

--- a/crates/ingestion-client/src/lib.rs
+++ b/crates/ingestion-client/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod chunks_size;
+mod client;
+mod session;
+
+pub use client::{IngestFuture, IngestionClient, IngestionError};
+pub use session::{CancelledError, RecordCommit, SessionClosed, SessionOptions};

--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -1,0 +1,535 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{collections::VecDeque, sync::Arc, time::Duration};
+
+use dashmap::DashMap;
+use futures::{FutureExt, StreamExt, future::OptionFuture, ready};
+use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, trace};
+
+use restate_core::{
+    TaskCenter, TaskKind,
+    network::{
+        ConnectError, Connection, ConnectionClosed, NetworkSender, Networking, ReplyRx, Swimlane,
+        TransportConnect,
+    },
+    partitions::PartitionRouting,
+};
+use restate_types::{
+    identifiers::PartitionId,
+    net::ingest::{IngestRecord, IngestRequest, IngestResponse, ResponseStatus},
+    retries::RetryPolicy,
+};
+
+use crate::chunks_size::ChunksSize;
+
+/// Error returned when attempting to use a session that has already been closed.
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+#[error("Partition session is closed")]
+pub struct SessionClosed;
+
+/// Commitment failures that can be observed when waiting on [`RecordCommit`].
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("commit cancelled")]
+pub struct CancelledError;
+
+/// Future that is resolved to the commit result
+/// A [`CommitError::Cancelled`] might be returned
+/// if [`IngestionClient`] is closed while record is in
+/// flight. This does not guarantee that the record
+/// was not processed or committed.
+#[pin_project::pin_project]
+pub struct RecordCommit<V = ()> {
+    v: Option<V>,
+    #[pin]
+    rx: oneshot::Receiver<Result<(), CancelledError>>,
+}
+
+impl<V> Future for RecordCommit<V>
+where
+    V: Send + 'static,
+{
+    type Output = Result<V, CancelledError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let mut this = self.project();
+        match ready!(this.rx.poll_unpin(cx)) {
+            Ok(result) => std::task::Poll::Ready(result.map(|_| {
+                this.v
+                    .take()
+                    .expect("future should not be polled after completion")
+            })),
+            Err(_) => std::task::Poll::Ready(Err(CancelledError)),
+        }
+    }
+}
+
+impl RecordCommit {
+    fn new(permit: OwnedSemaphorePermit) -> (Self, RecordCommitResolver) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self { v: Some(()), rx },
+            RecordCommitResolver {
+                tx,
+                _permit: permit,
+            },
+        )
+    }
+}
+
+impl<V> RecordCommit<V> {
+    pub fn map<F, T>(self, f: F) -> RecordCommit<T>
+    where
+        F: FnOnce(V) -> T,
+    {
+        let RecordCommit { v, rx } = self;
+        RecordCommit { v: v.map(f), rx }
+    }
+}
+
+struct RecordCommitResolver {
+    tx: oneshot::Sender<Result<(), CancelledError>>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl RecordCommitResolver {
+    /// Resolve the [`RecordCommit`] to committed.
+    pub fn committed(self) {
+        let _ = self.tx.send(Ok(()));
+    }
+
+    /// explicitly cancel the RecordCommit
+    /// If resolver is dropped, the RecordCommit
+    /// will resolve to [`CommitError::Cancelled`]
+    #[allow(dead_code)]
+    pub fn cancelled(self) {
+        let _ = self.tx.send(Err(CancelledError));
+    }
+}
+
+struct IngestionBatch {
+    records: Arc<[IngestRecord]>,
+    resolvers: Vec<RecordCommitResolver>,
+
+    reply_rx: Option<ReplyRx<IngestResponse>>,
+}
+
+impl IngestionBatch {
+    fn new(batch: impl IntoIterator<Item = (RecordCommitResolver, IngestRecord)>) -> Self {
+        let (resolvers, records): (Vec<_>, Vec<_>) = batch.into_iter().unzip();
+        let records: Arc<[IngestRecord]> = Arc::from(records);
+
+        Self {
+            records,
+            resolvers,
+            reply_rx: None,
+        }
+    }
+
+    /// Marks every tracked record in the batch as committed.
+    fn committed(self) {
+        for resolver in self.resolvers {
+            resolver.committed();
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.records.len()
+    }
+}
+
+/// Tunable parameters for batching and networking behaviour of partition sessions.
+#[derive(Debug, Clone)]
+pub struct SessionOptions {
+    /// Maximum batch size in `bytes`
+    pub batch_size: usize,
+    /// Connection retry policy
+    /// Retry policy must be infinite (retries forever)
+    /// If not, the retry will fallback to 2 seconds intervals
+    pub connection_retry_policy: RetryPolicy,
+    /// Connection swimlane
+    pub swimlane: Swimlane,
+}
+
+impl Default for SessionOptions {
+    fn default() -> Self {
+        Self {
+            // The default batch size of 50KB is to avoid
+            // overwhelming the PP on the hot path.
+            batch_size: 50 * 1024, // 50 KB
+            swimlane: Swimlane::IngressData,
+            connection_retry_policy: RetryPolicy::exponential(
+                Duration::from_millis(10),
+                2.0,
+                None,
+                Some(Duration::from_secs(1)),
+            ),
+        }
+    }
+}
+
+/// Cloneable sender that enqueues records for a specific partition session.
+#[derive(Clone)]
+pub struct SessionHandle {
+    tx: mpsc::UnboundedSender<(RecordCommitResolver, IngestRecord)>,
+}
+
+impl SessionHandle {
+    /// Enqueues an ingest request along with the owned permit and returns a future tracking commit outcome.
+    pub fn ingest(
+        &self,
+        permit: OwnedSemaphorePermit,
+        record: IngestRecord,
+    ) -> Result<RecordCommit, SessionClosed> {
+        let (commit, resolver) = RecordCommit::new(permit);
+        self.tx
+            .send((resolver, record))
+            .map_err(|_| SessionClosed)?;
+
+        Ok(commit)
+    }
+}
+
+enum SessionState {
+    Connecting,
+    Connected { connection: Connection },
+    Shutdown,
+}
+
+/// Background task that drives the lifecycle of a single partition connection.
+pub struct PartitionSession<T> {
+    partition: PartitionId,
+    partition_routing: PartitionRouting,
+    networking: Networking<T>,
+    opts: SessionOptions,
+    rx: UnboundedReceiverStream<(RecordCommitResolver, IngestRecord)>,
+    tx: mpsc::UnboundedSender<(RecordCommitResolver, IngestRecord)>,
+    inflight: VecDeque<IngestionBatch>,
+}
+
+impl<T> PartitionSession<T> {
+    fn new(
+        networking: Networking<T>,
+        partition_routing: PartitionRouting,
+        partition: PartitionId,
+        opts: SessionOptions,
+    ) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rx = UnboundedReceiverStream::new(rx);
+
+        Self {
+            partition,
+            partition_routing,
+            networking,
+            opts,
+            inflight: Default::default(),
+            rx,
+            tx,
+        }
+    }
+
+    /// Returns a handle that can be used by callers to enqueue new records.
+    pub fn handle(&self) -> SessionHandle {
+        SessionHandle {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+impl<T> PartitionSession<T>
+where
+    T: TransportConnect,
+{
+    /// Runs the session state machine until shut down, reacting to cancellation and connection errors.
+    pub async fn start(self, cancellation: CancellationToken) {
+        debug!(
+            partition_id = %self.partition,
+            "Starting ingestion partition session",
+        );
+
+        cancellation.run_until_cancelled(self.run_inner()).await;
+    }
+
+    /// Runs the session state machine until shut down, reacting to cancellation and connection errors.
+    async fn run_inner(mut self) {
+        let mut state = SessionState::Connecting;
+        debug!(
+            partition_id = %self.partition,
+            "Starting ingestion partition session",
+        );
+
+        loop {
+            state = match state {
+                SessionState::Connecting => {
+                    let mut retry = self.opts.connection_retry_policy.iter();
+                    loop {
+                        match self.connect().await {
+                            Some(state) => break state,
+                            None => {
+                                // retry
+                                // this assumes that retry policy is infinite. If it's not it falls back
+                                // to a fixed 2 seconds sleep between retries
+                                tokio::time::sleep(retry.next().unwrap_or(Duration::from_secs(2)))
+                                    .await;
+                            }
+                        }
+                    }
+                }
+                SessionState::Connected { connection } => self.connected(connection).await,
+                SessionState::Shutdown => {
+                    self.rx.close();
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn connect(&self) -> Option<SessionState> {
+        let node_id = self
+            .partition_routing
+            .get_node_by_partition(self.partition)?;
+
+        let result = self
+            .networking
+            .get_connection(node_id, self.opts.swimlane)
+            .await;
+
+        match result {
+            Ok(connection) => {
+                debug!("Connection established to node {node_id}");
+                Some(SessionState::Connected { connection })
+            }
+            Err(ConnectError::Shutdown(_)) => Some(SessionState::Shutdown),
+            Err(err) => {
+                debug!("Failed to connect to node {node_id}: {err}");
+                None
+            }
+        }
+    }
+
+    /// Re-sends all inflight batches after a connection is restored.
+    async fn replay(&mut self, connection: &Connection) -> Result<(), ConnectionClosed> {
+        // todo(azmy): to avoid all the inflight batches again and waste traffic
+        //  maybe test the connection first by sending an empty batch and wait for response
+        //  before proceeding?
+
+        let total = self.inflight.iter().fold(0, |v, i| v + i.len());
+        trace!(
+            partition = %self.partition,
+            batches = self.inflight.len(),
+            records = total,
+            "Replaying inflight records after connection was restored"
+        );
+
+        for batch in self.inflight.iter_mut() {
+            let Some(permit) = connection.reserve().await else {
+                return Err(ConnectionClosed);
+            };
+
+            // resend batch
+            let reply_rx = permit
+                .send_rpc(
+                    IngestRequest::from(Arc::clone(&batch.records)),
+                    Some(self.partition.into()),
+                )
+                .expect("encoding version to match");
+            batch.reply_rx = Some(reply_rx);
+        }
+
+        Ok(())
+    }
+
+    async fn connected(&mut self, connection: Connection) -> SessionState {
+        if self.replay(&connection).await.is_err() {
+            return SessionState::Connecting;
+        }
+
+        let mut chunked = ChunksSize::new(&mut self.rx, self.opts.batch_size, |(_, item)| {
+            item.estimate_size()
+        });
+
+        let state = loop {
+            let head: OptionFuture<_> = self
+                .inflight
+                .front_mut()
+                .and_then(|batch| batch.reply_rx.as_mut())
+                .into();
+
+            tokio::select! {
+                _ = connection.closed() => {
+                    break SessionState::Connecting;
+                }
+                Some(batch) = chunked.next() => {
+                    let batch = IngestionBatch::new(batch);
+                    let records = Arc::clone(&batch.records);
+
+                    self.inflight.push_back(batch);
+
+                    let Some(permit) = connection.reserve().await else {
+                        break SessionState::Connecting;
+                    };
+
+                    trace!("Sending ingest batch, len: {}", records.len());
+                    let reply_rx = permit
+                        .send_rpc(IngestRequest::from(records), Some(self.partition.into()))
+                        .expect("encoding version to match");
+
+                    self.inflight.back_mut().expect("to exist").reply_rx = Some(reply_rx);
+                }
+                Some(result) = head => {
+                    match result.map(|r|r.status) {
+                        Ok(ResponseStatus::Ack) => {
+                            let batch = self.inflight.pop_front().expect("not empty");
+                            batch.committed();
+                        }
+                        Ok(response) => {
+                            // Handle any other response code as a connection loss
+                            // and retry all inflight batches.
+                            debug!("Ingestion response from {}: {:?}", connection.peer(), response);
+                            break SessionState::Connecting;
+                        }
+                        Err(err) => {
+                            // we can assume that for any error
+                            // we need to retry all the inflight batches.
+                            // special case for load shedding we could
+                            // throttle the stream a little bit then
+                            // speed up over a period of time.
+
+                            debug!("Ingestion error from {}: {}", connection.peer(),  err);
+                            break SessionState::Connecting;
+                        }
+                    }
+                }
+            }
+        };
+
+        // state == Connecting
+        assert!(matches!(state, SessionState::Connecting));
+
+        // don't lose the buffered batch
+        let remainder = chunked.into_remainder();
+        if !remainder.is_empty() {
+            self.inflight.push_back(IngestionBatch::new(remainder));
+        }
+
+        state
+    }
+}
+
+struct SessionManagerInner<T> {
+    networking: Networking<T>,
+    partition_routing: PartitionRouting,
+    opts: SessionOptions,
+    // Since ingestion sessions are started on demand
+    // we make sure we decouple the session cancellation
+    // from the initiating task. Hence the session manager
+    // keep it's own cancellation token that is passed to
+    // all the sessions.
+    cancellation: CancellationToken,
+    handles: DashMap<PartitionId, SessionHandle>,
+}
+
+impl<T> SessionManagerInner<T>
+where
+    T: TransportConnect,
+{
+    /// Gets or start a new session to partition with given partition id.
+    /// It guarantees that only one session is started per partition id.
+    pub fn get(&self, id: PartitionId) -> SessionHandle {
+        self.handles
+            .entry(id)
+            .or_insert_with(|| {
+                let session = PartitionSession::new(
+                    self.networking.clone(),
+                    self.partition_routing.clone(),
+                    id,
+                    self.opts.clone(),
+                );
+
+                let handle = session.handle();
+
+                let cancellation = self.cancellation.child_token();
+                let _ = TaskCenter::spawn(
+                    TaskKind::Background,
+                    "ingestion-partition-session",
+                    async move {
+                        session.start(cancellation).await;
+                        Ok(())
+                    },
+                );
+
+                handle
+            })
+            .value()
+            .clone()
+    }
+}
+
+impl<T> Drop for SessionManagerInner<T> {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+    }
+}
+
+/// Manager that owns all partition sessions and caches their handles.
+#[derive(Clone)]
+pub struct SessionManager<T> {
+    inner: Arc<SessionManagerInner<T>>,
+}
+
+impl<T> SessionManager<T> {
+    /// Creates a new session manager with optional overrides for session behaviour.
+    pub fn new(
+        networking: Networking<T>,
+        partition_routing: PartitionRouting,
+        opts: Option<SessionOptions>,
+    ) -> Self {
+        let inner = SessionManagerInner {
+            networking,
+            partition_routing,
+            opts: opts.unwrap_or_default(),
+            handles: Default::default(),
+            cancellation: CancellationToken::new(),
+        };
+
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub fn partition_routing(&self) -> &PartitionRouting {
+        &self.inner.partition_routing
+    }
+
+    pub fn networking(&self) -> &Networking<T> {
+        &self.inner.networking
+    }
+}
+
+impl<T> SessionManager<T>
+where
+    T: TransportConnect,
+{
+    /// Returns a handle to the session for the given partition, creating it if needed.
+    pub fn get(&self, id: PartitionId) -> SessionHandle {
+        self.inner.get(id)
+    }
+
+    /// Signals all sessions to shut down and prevents new work from being scheduled.
+    pub fn close(&self) {
+        self.inner.cancellation.cancel();
+    }
+}

--- a/crates/types/src/net/ingest.rs
+++ b/crates/types/src/net/ingest.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use bytes::{Bytes, BytesMut};
+use metrics::Key;
+
+use crate::identifiers::PartitionId;
+use crate::logs::{HasRecordKeys, Keys};
+use crate::net::partition_processor::PartitionLeaderService;
+use crate::net::{RpcRequest, bilrost_wire_codec, default_wire_codec, define_rpc};
+use crate::storage::{StorageCodec, StorageEncode};
+
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IngestRecord {
+    pub keys: Keys,
+    pub record: Bytes,
+}
+
+impl IngestRecord {
+    pub fn estimate_size(&self) -> usize {
+        size_of::<Key>() + self.record.len()
+    }
+
+    pub fn from_parts<T>(keys: Keys, record: T) -> Self
+    where
+        T: StorageEncode,
+    {
+        let mut buf = BytesMut::new();
+        StorageCodec::encode(&record, &mut buf).expect("encode to pass");
+
+        Self {
+            keys,
+            record: buf.freeze(),
+        }
+    }
+}
+
+impl HasRecordKeys for IngestRecord {
+    fn record_keys(&self) -> Keys {
+        self.keys.clone()
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct IngestRequest {
+    pub records: Arc<[IngestRecord]>,
+}
+
+impl IngestRequest {
+    pub fn estimate_size(&self) -> usize {
+        self.records
+            .iter()
+            .fold(0, |size, item| size + item.estimate_size())
+    }
+}
+
+impl From<Arc<[IngestRecord]>> for IngestRequest {
+    fn from(records: Arc<[IngestRecord]>) -> Self {
+        Self { records }
+    }
+}
+
+// todo(azmy): Use bilrost (depends on the payload)
+default_wire_codec!(IngestRequest);
+
+#[derive(Debug, Clone, bilrost::Oneof, bilrost::Message)]
+pub enum ResponseStatus {
+    Unknown,
+    #[bilrost(tag = 1, message)]
+    Ack,
+    #[bilrost(tag = 2, message)]
+    NotLeader {
+        of: PartitionId,
+    },
+    #[bilrost(tag = 3, message)]
+    Internal {
+        msg: String,
+    },
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct IngestResponse {
+    #[bilrost(1)]
+    pub status: ResponseStatus,
+}
+
+impl From<ResponseStatus> for IngestResponse {
+    fn from(status: ResponseStatus) -> Self {
+        Self { status }
+    }
+}
+
+bilrost_wire_codec!(IngestResponse);
+
+define_rpc! {
+    @request=IngestRequest,
+    @response=IngestResponse,
+    @service=PartitionLeaderService,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ReceivedIngestRequest {
+    pub records: Vec<IngestRecord>,
+}
+
+default_wire_codec!(ReceivedIngestRequest);
+
+/// The [`ReceivedIngestRequest`] uses the same TYPE
+/// as [`IngestRequest`] to be able to directly decode
+/// received RPC messages to this type.
+impl RpcRequest for ReceivedIngestRequest {
+    const TYPE: &str = stringify!(IngestRequest);
+    type Response = IngestResponse;
+    type Service = PartitionLeaderService;
+}

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -11,6 +11,7 @@
 pub mod address;
 pub mod codec;
 pub mod connect_opts;
+pub mod ingest;
 pub mod listener;
 pub mod log_server;
 pub mod metadata;


### PR DESCRIPTION
[Ingestion] `ingestion-client` crate

- `ingestion-client` implements the runtime layer that receives WAL envelopes, fans it out to the correct partition, and tracks completion. It exposes:
  - `IngestionClient`, enforces inflight budgets, and resolves partition IDs before sending work downstream.
  - The session subsystem that batches `IngestRecords`, retries connections, and reports commit status to callers.
- `ingestion-client` only ingests records and notify the caller once the record is "committed" to bifrost by the PP. This makes it useful to implement kafka ingress and other external ingestion

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3976).
* #4024
* #3987
* #3980
* #3975
* #3974
* #3968
* __->__ #3976