### PR TITLE
Update `crazy-max/ghaction-setup-docker` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,9 @@ jobs:
     needs: docker
     steps:
       - name: Set up Docker containerd snapshotter
-        uses: crazy-max/ghaction-setup-docker@v3
+        uses: docker/setup-docker-action@v4
         with:
+          version: "v28.5.2"
           set-host: true
           daemon-config: |
             {


### PR DESCRIPTION
Update `crazy-max/ghaction-setup-docker` to v4

Summary:
Also fix docker to version 28.5.2 since 29 is broken (iptables issues)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/3977).
* #3975
* #3974
* #3968
* #3976
* __->__ #3977