### PR TITLE
Make NodesConfiguration::ClusterFingerprint non-optional

### DIFF
--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -302,8 +302,7 @@ impl ConnectionManager {
         // check cluster fingerprint if it's set on the hello message *and* our nodes config has it
         // set as well.
         if let Ok(incoming_fingerprint) = ClusterFingerprint::try_from(hello.cluster_fingerprint)
-            && let Some(cluster_fingerprint) = nodes_config.cluster_fingerprint()
-            && incoming_fingerprint != cluster_fingerprint
+            && incoming_fingerprint != nodes_config.cluster_fingerprint()
         {
             return Err(HandshakeError::Failed("cluster fingerprint mismatch".to_owned()).into());
         }
@@ -716,10 +715,7 @@ mod tests {
             max_protocol_version: ProtocolVersion::Unknown.into(),
             my_node_id: Some(my_node_id.into()),
             cluster_name: metadata.nodes_config_ref().cluster_name().to_owned(),
-            cluster_fingerprint: metadata
-                .nodes_config_ref()
-                .cluster_fingerprint()
-                .map_or(0, ClusterFingerprint::to_u64),
+            cluster_fingerprint: metadata.nodes_config_ref().cluster_fingerprint().to_u64(),
             direction: ConnectionDirection::Bidirectional.into(),
             swimlane: Swimlane::default().into(),
         };
@@ -745,10 +741,7 @@ mod tests {
             max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
             my_node_id: Some(my_node_id.into()),
             cluster_name: "Random-cluster".to_owned(),
-            cluster_fingerprint: metadata
-                .nodes_config_ref()
-                .cluster_fingerprint()
-                .map_or(0, ClusterFingerprint::to_u64),
+            cluster_fingerprint: metadata.nodes_config_ref().cluster_fingerprint().to_u64(),
             direction: ConnectionDirection::Bidirectional.into(),
             swimlane: Swimlane::default().into(),
         };
@@ -813,7 +806,7 @@ mod tests {
         let hello = Hello::new(
             Some(my_node_id),
             metadata.nodes_config_ref().cluster_name().to_owned(),
-            None,
+            metadata.nodes_config_ref().cluster_fingerprint(),
             ConnectionDirection::Bidirectional,
             Swimlane::default(),
         );

--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -47,7 +47,7 @@ pub mod network {
         pub fn new(
             my_node_id: Option<GenerationalNodeId>,
             cluster_name: String,
-            cluster_fingerprint: Option<ClusterFingerprint>,
+            cluster_fingerprint: ClusterFingerprint,
             direction: ConnectionDirection,
             swimlane: Swimlane,
         ) -> Self {
@@ -57,7 +57,7 @@ pub mod network {
                 max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
                 my_node_id: my_node_id.map(Into::into),
                 cluster_name,
-                cluster_fingerprint: cluster_fingerprint.map_or(0, ClusterFingerprint::to_u64),
+                cluster_fingerprint: cluster_fingerprint.to_u64(),
                 swimlane: swimlane.into(),
             }
         }

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -16,7 +16,7 @@ use restate_types::config::Configuration;
 use restate_types::errors::MaybeRetryableError;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{
-    ClusterFingerprint, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
+    MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
 };
 use restate_types::retries::RetryPolicy;
 use std::sync::Arc;
@@ -308,11 +308,6 @@ impl<'a> NodeInit<'a> {
                     };
 
                     nodes_config.upsert_node(my_node_config);
-                    // generate a new cluster fingerprint if the old configuration didn't have one.
-                    // This is an automatic migration step for clusters created before v1.5.0.
-                    if nodes_config.cluster_fingerprint().is_none() {
-                        nodes_config.set_cluster_fingerprint(ClusterFingerprint::generate());
-                    }
 
                     nodes_config.increment_version();
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -487,8 +487,7 @@ impl Node {
             location = %my_node_config.location,
             nodes_config_version = %metadata.nodes_config_version(),
             cluster_name = %nodes_config.cluster_name(),
-            cluster_fingerprint = %nodes_config.cluster_fingerprint().map(|f|
-                f.to_string()).unwrap_or_default(),
+            cluster_fingerprint = %nodes_config.cluster_fingerprint().to_string(),
             %partition_table_version,
             %logs_version,
             "My Node ID is {}", my_node_config.current_generation,

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -80,7 +80,7 @@ impl PartitionSnapshotMetadata {
     pub fn validate(
         &self,
         cluster_name: &str,
-        cluster_fingerprint: Option<ClusterFingerprint>,
+        cluster_fingerprint: ClusterFingerprint,
     ) -> anyhow::Result<()> {
         if cluster_name != self.cluster_name {
             anyhow::bail!(
@@ -92,8 +92,7 @@ impl PartitionSnapshotMetadata {
         // If the snapshot doesn't have a fingerprint on it, we'll ignore the
         // check. Eventually all new snapshots will have a fingerprint and this
         // check will be kept for very old snapshots only.
-        if let Some(cluster_fingerprint) = cluster_fingerprint
-            && let Some(snapshot_cluster_fingerprint) = self.cluster_fingerprint
+        if let Some(snapshot_cluster_fingerprint) = self.cluster_fingerprint
             && snapshot_cluster_fingerprint != cluster_fingerprint
         {
             // If nodes_config and snapshot both contain a fingerprint, they must match.

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -34,7 +34,7 @@ pub struct SnapshotPartitionTask {
     pub snapshot_base_path: PathBuf,
     pub partition_store_manager: Arc<PartitionStoreManager>,
     pub cluster_name: String,
-    pub cluster_fingerprint: Option<ClusterFingerprint>,
+    pub cluster_fingerprint: ClusterFingerprint,
     pub node_name: String,
     pub snapshot_repository: SnapshotRepository,
 }
@@ -106,7 +106,7 @@ impl SnapshotPartitionTask {
         PartitionSnapshotMetadata {
             version: SnapshotFormatVersion::V1,
             cluster_name: self.cluster_name.clone(),
-            cluster_fingerprint: self.cluster_fingerprint,
+            cluster_fingerprint: Some(self.cluster_fingerprint),
             node_name: self.node_name.clone(),
             partition_id: self.partition_id,
             created_at: humantime::Timestamp::from(created_at),


### PR DESCRIPTION
We started writing the ClusterFingerprint in v1.5 so that by now we can assume that every NodesConfiguration has a ClusterFingerprint set. Hence, this commit makes the field non-optional. Additionally, it makes some of the checks more strict.

This fixes #4022.