### PR TITLE
Switch to bilrost as default encoding for objstore version repository

### DIFF
--- a/crates/metadata-providers/src/objstore/version_repository.rs
+++ b/crates/metadata-providers/src/objstore/version_repository.rs
@@ -55,10 +55,9 @@ pub enum EncodingError {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum ValueEncoding {
-    #[default]
     Cbor,
-    // TODO: Switch default to bilrost in v1.6.0
-    // Bilrost V1
+    // default since version v1.6
+    #[default]
     Bilrost,
 }
 


### PR DESCRIPTION
Switch to bilrost as default encoding for objstore version repository

Summary:
Fixes #4021
