### PR TITLE
[Restate UI] Update to v0.1.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8271,8 +8271,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.13"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.13#49bff0a253f49af70f7deb66e83e2928c992d5d0"
+version = "0.1.15"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.15#6726ed3b427dcea5fa21b9a2fa8b289987764eb2"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -29,7 +29,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.13", tag = "v0.1.13" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.15", tag = "v0.1.15" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.15
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.15/ui-v0.1.15.zip