### PR TITLE
Remove support for FlexBuffers serialization of NodeStateResponse

### DIFF
--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -47,7 +47,7 @@ pub(crate) fn append_partition_row(
     }
 
     row.fmt_replay_status(state.replay_status);
-    if let Some(lsn) = state.last_persisted_log_lsn {
+    if let Some(lsn) = state.durable_lsn {
         row.durable_log_lsn(lsn.into());
     }
 

--- a/crates/types/benches/network_serialization.rs
+++ b/crates/types/benches/network_serialization.rs
@@ -43,7 +43,7 @@ pub fn gen_partition_processor_status() -> PartitionProcessorStatus {
         target_tail_lsn: lsn(),
         last_applied_log_lsn: lsn(),
         last_archived_log_lsn: lsn(),
-        last_persisted_log_lsn: lsn(),
+        durable_lsn: lsn(),
         ..Default::default()
     }
 }
@@ -57,25 +57,6 @@ pub fn gen_node_state_response() -> NodeStateResponse {
         ),
         uptime: Duration::from_secs(rand::random_range(500..1000)),
     }
-}
-
-pub fn flexbuffer_serialization(c: &mut Criterion) {
-    let message = gen_node_state_response();
-
-    let serialized = flexbuffers::to_vec(&message).expect("serializes");
-    println!("Flexbuffers Message Size: {}", serialized.len());
-
-    c.bench_function("flexbuffers-serialize", |b| {
-        b.iter(|| black_box(flexbuffers::to_vec(&message)));
-    });
-
-    c.bench_function("flexbuffers-deserialize", |b| {
-        b.iter(|| {
-            black_box(
-                flexbuffers::from_slice::<NodeStateResponse>(&serialized).expect("deserializes"),
-            )
-        });
-    });
 }
 
 pub fn bilrost_serialization(c: &mut Criterion) {
@@ -99,7 +80,7 @@ pub fn bilrost_serialization(c: &mut Criterion) {
 criterion_group!(
     name=benches;
     config=Criterion::default();
-    targets=flexbuffer_serialization, bilrost_serialization
+    targets=bilrost_serialization
 );
 
 criterion_main!(benches);

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -68,7 +68,7 @@ message PartitionProcessorStatus {
   optional google.protobuf.Timestamp last_record_applied_at = 7;
   uint64 num_skipped_records = 8;
   ReplayStatus replay_status = 9;
-  optional restate.common.Lsn last_persisted_log_lsn = 10;
+  optional restate.common.Lsn durable_lsn = 10;
   optional restate.common.Lsn last_archived_log_lsn = 12;
   // Set if replay_status is CATCHING_UP
   optional restate.common.Lsn target_tail_lsn = 11;

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -177,7 +177,7 @@ pub enum ReplayStatus {
     CatchingUp = 2,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, IntoProst, bilrost::Message, NetSerde)]
+#[derive(Debug, Clone, IntoProst, bilrost::Message, NetSerde)]
 #[prost(target = "crate::protobuf::cluster::PartitionProcessorStatus")]
 pub struct PartitionProcessorStatus {
     #[prost(required)]
@@ -199,10 +199,8 @@ pub struct PartitionProcessorStatus {
     pub num_skipped_records: u64,
     #[bilrost(9)]
     pub replay_status: ReplayStatus,
-    /// Also known as Durable LSN. Old name kept for compatibility with V1 networking clients.
-    // todo: rename in 1.5 (or as soon as we no longer support interop with V1 cluster controllers)
     #[bilrost(10)]
-    pub last_persisted_log_lsn: Option<Lsn>,
+    pub durable_lsn: Option<Lsn>,
     #[bilrost(11)]
     pub last_archived_log_lsn: Option<Lsn>,
     // Set if replay_status is CatchingUp
@@ -222,7 +220,7 @@ impl Default for PartitionProcessorStatus {
             last_record_applied_at: None,
             num_skipped_records: 0,
             replay_status: ReplayStatus::Starting,
-            last_persisted_log_lsn: None,
+            durable_lsn: None,
             last_archived_log_lsn: None,
             target_tail_lsn: None,
         }

--- a/crates/types/src/net/node.rs
+++ b/crates/types/src/net/node.rs
@@ -12,7 +12,6 @@ use std::{collections::BTreeMap, time::Duration};
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
 use restate_encoding::{BilrostNewType, NetSerde};
 
@@ -56,18 +55,13 @@ bilrost_wire_codec!(ClusterStateReply);
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, bilrost::Message, NetSerde)]
 pub struct GetNodeState {}
 
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, bilrost::Message, NetSerde)]
+#[derive(Debug, Clone, bilrost::Message, NetSerde)]
 pub struct NodeStateResponse {
     /// Partition processor status per partition. Is set to None if this node is not a `Worker` node
-    #[serde_as(as = "Option<serde_with::Seq<(_, _)>>")]
     #[bilrost(1)]
     pub partition_processor_state: Option<BTreeMap<PartitionId, PartitionProcessorStatus>>,
 
-    /// node uptime.
-    // serde(default) is required for backward compatibility when updating the cluster,
-    // ensuring that older nodes can still interact with newer nodes that recognize this attribute.
-    #[serde(default)]
+    /// Node uptime
     #[bilrost(2)]
     pub uptime: Duration,
 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -341,7 +341,7 @@ where
         let durable_lsn = durable_lsn_watch
             .borrow_and_update()
             .unwrap_or(Lsn::INVALID);
-        self.status.last_persisted_log_lsn = Some(durable_lsn);
+        self.status.durable_lsn = Some(durable_lsn);
         self.replica_set_states
             .note_durable_lsn(partition_id, my_node, durable_lsn);
 
@@ -478,7 +478,7 @@ where
                         let durable_lsn = durable_lsn_watch
                                 .borrow_and_update()
                                 .unwrap_or(Lsn::INVALID);
-                        self.status.last_persisted_log_lsn = Some(durable_lsn);
+                        self.status.durable_lsn = Some(durable_lsn);
                         self.replica_set_states.note_durable_lsn(
                             partition_id,
                             my_node,

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -191,7 +191,7 @@ pub async fn list_partitions(
                 Cell::new(
                     processor
                         .status
-                        .last_persisted_log_lsn
+                        .durable_lsn
                         .map(|x| x.to_string())
                         .unwrap_or("-".to_owned()),
                 ),


### PR DESCRIPTION
Can we safely do this now? I noticed an `raft_metadata_cluster_smoke_test` initially which went away on retry.