### PR TITLE
Support choosing random ip from headless initial addresses

### DIFF
--- a/crates/admin/src/rest_api/cluster_health.rs
+++ b/crates/admin/src/rest_api/cluster_health.rs
@@ -12,7 +12,7 @@ use axum::Json;
 use http::StatusCode;
 use okapi_operation::openapi;
 
-use restate_core::network::net_util::create_tonic_channel;
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::protobuf::node_ctl_svc::new_node_ctl_client;
 use restate_core::{Metadata, my_node_id};
 use restate_types::config::Configuration;
@@ -43,6 +43,7 @@ pub async fn cluster_health() -> Result<Json<ClusterHealthResponse>, GenericRest
     let mut node_ctl_svc_client = new_node_ctl_client(create_tonic_channel(
         node_config.address.clone(),
         &Configuration::pinned().networking,
+        DNSResolution::Gai,
     ));
     let cluster_health = node_ctl_svc_client
         .cluster_health(())

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -45,7 +45,7 @@ use tonic::Code;
 use tracing::{error, info, warn};
 use typed_builder::TypedBuilder;
 
-use restate_core::network::net_util::create_tonic_channel;
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::protobuf::node_ctl_svc::{
     ProvisionClusterRequest as ProtoProvisionClusterRequest, new_node_ctl_client,
 };
@@ -817,6 +817,7 @@ impl StartedNode {
         let mut metadata_server_client = new_metadata_server_client(create_tonic_channel(
             self.fabric_advertised_address.clone(),
             &self.config().networking,
+            DNSResolution::Gai,
         ));
 
         let Ok(response) = metadata_server_client
@@ -841,6 +842,7 @@ impl StartedNode {
         let channel = create_tonic_channel(
             self.advertised_address().clone(),
             &Configuration::default().networking,
+            DNSResolution::Gai,
         );
 
         let request = ProtoProvisionClusterRequest {
@@ -901,6 +903,7 @@ impl StartedNode {
         let mut client = new_metadata_server_client(create_tonic_channel(
             self.advertised_address().clone(),
             &self.config().networking,
+            DNSResolution::Gai,
         ));
 
         client.add_node(()).await?;
@@ -912,6 +915,7 @@ impl StartedNode {
         let mut client = new_metadata_server_client(create_tonic_channel(
             self.advertised_address().clone(),
             &self.config().networking,
+            DNSResolution::Gai,
         ));
 
         client
@@ -928,6 +932,7 @@ impl StartedNode {
         let mut client = new_metadata_server_client(create_tonic_channel(
             self.advertised_address().clone(),
             &self.config().networking,
+            DNSResolution::Gai,
         ));
         let response = client.status(()).await?.into_inner();
         Ok(response)

--- a/crates/metadata-server/src/raft/network/networking.rs
+++ b/crates/metadata-server/src/raft/network/networking.rs
@@ -166,7 +166,11 @@ where
             "metadata-store-network-connection-attempt",
             {
                 trace!(%target, "Try connecting to metadata store peer");
-                let channel = net_util::create_tonic_channel(address.clone(), networking_options);
+                let channel = net_util::create_tonic_channel(
+                    address.clone(),
+                    networking_options,
+                    net_util::DNSResolution::Gai,
+                );
 
                 async move {
                     let mut network_client = new_metadata_server_network_client(channel);

--- a/crates/metadata-server/src/raft/server/standby.rs
+++ b/crates/metadata-server/src/raft/server/standby.rs
@@ -19,7 +19,7 @@ use rand::prelude::IteratorRandom;
 use rand::rng;
 use tracing::{Span, debug, instrument, trace};
 
-use restate_core::network::net_util::create_tonic_channel;
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::{Metadata, MetadataWriter};
 use restate_metadata_providers::replicated::KnownLeader;
 use restate_time_util::DurationExt;
@@ -257,7 +257,11 @@ impl Standby {
                 .clone()
         };
 
-        let channel = create_tonic_channel(address, &Configuration::pinned().networking);
+        let channel = create_tonic_channel(
+            address,
+            &Configuration::pinned().networking,
+            DNSResolution::Gai,
+        );
 
         match new_metadata_server_network_client(channel)
             .join_cluster(network::grpc_svc::JoinClusterRequest {

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -24,7 +24,7 @@ use restate_metadata_store::protobuf::metadata_proxy_svc::{
     DeleteRequest, GetRequest, GetResponse, GetVersionResponse, PutRequest,
 };
 
-use restate_core::network::net_util::create_tonic_channel;
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::{NodeCtlSvc, NodeCtlSvcServer};
 use restate_core::protobuf::node_ctl_svc::{
     ClusterHealthResponse, EmbeddedMetadataClusterHealth, GetMetadataRequest, GetMetadataResponse,
@@ -212,6 +212,7 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
             let mut metadata_server_client = new_metadata_server_client(create_tonic_channel(
                 node_config.address.clone(),
                 &Configuration::pinned().networking,
+                DNSResolution::Gai,
             ));
 
             let response = match metadata_server_client.status(()).await {

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -21,7 +21,7 @@ use tonic::transport::Channel;
 use tracing::info;
 use url::Url;
 
-use restate_core::network::net_util::create_tonic_channel;
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::protobuf::cluster_ctrl_svc::{
     ClusterStateRequest, CreatePartitionSnapshotRequest,
     cluster_ctrl_svc_client::ClusterCtrlSvcClient, new_cluster_ctrl_client,
@@ -110,6 +110,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
     let mut client = new_cluster_ctrl_client(create_tonic_channel(
         cluster.nodes[0].advertised_address().clone(),
         &NetworkingOptions::default(),
+        DNSResolution::Gai,
     ));
 
     info!("Waiting until the partition processor has become the leader");

--- a/tools/restatectl/src/util.rs
+++ b/tools/restatectl/src/util.rs
@@ -19,7 +19,7 @@ use cling::{Collect, prelude::Parser};
 use tonic::transport::Channel;
 
 use restate_cli_util::CliContext;
-use restate_core::network::net_util::create_tonic_channel;
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_types::{
     logs::metadata::ProviderConfiguration,
     net::address::{AdvertisedAddress, GrpcPort, ListenerPort},
@@ -27,7 +27,7 @@ use restate_types::{
 
 pub fn grpc_channel<P: ListenerPort + GrpcPort>(address: AdvertisedAddress<P>) -> Channel {
     let ctx = CliContext::get();
-    create_tonic_channel(address, &ctx.network)
+    create_tonic_channel(address, &ctx.network, DNSResolution::Gai)
 }
 
 pub fn write_default_provider<W: fmt::Write>(


### PR DESCRIPTION
This change supports headless initial addresses for the metadata client. Previously if the dns name resolves to 5 ips, we would use whatever getaddrinfo returns first (typically this is either your own ip or another ip in the same zone), and we would also divide our conn timeout by 5. Which this change, we use our full conn timeout on a single randomly chosen ip of the 5. We only use this new code path in the initial addresses flow - the rest of the time, a tonic channel is intended for a single node and we have no reason to need to ensure we are using all the returned ips.