### PR TITLE
Fix building rdkafka without curl-static enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6620,7 +6620,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.38.0"
-source = "git+https://github.com/restatedev/rust-rdkafka.git?rev=22895f8c22471309e1615b0686cd31be5966d575#22895f8c22471309e1615b0686cd31be5966d575"
+source = "git+https://github.com/restatedev/rust-rdkafka.git?rev=e92cad90eff797a0dc29fa524cabb89b602ae234#e92cad90eff797a0dc29fa524cabb89b602ae234"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -6637,7 +6637,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.9.0+2.12.1"
-source = "git+https://github.com/restatedev/rust-rdkafka.git?rev=22895f8c22471309e1615b0686cd31be5966d575#22895f8c22471309e1615b0686cd31be5966d575"
+source = "git+https://github.com/restatedev/rust-rdkafka.git?rev=e92cad90eff797a0dc29fa524cabb89b602ae234#e92cad90eff797a0dc29fa524cabb89b602ae234"
 dependencies = [
  "cmake",
  "curl-sys",

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -37,8 +37,9 @@ opentelemetry_sdk = { workspace = true }
 parking_lot = { workspace = true }
 # Use https://github.com/restatedev/rust-rdkafka/tree/fix-build-script which is based on
 # https://github.com/fede1024/rust-rdkafka/pull/803. The PR bumps librdkafka to 2.12.1 and enables WITH_CURL for
-# librdkafka if the feature curl-static is enabled. The additional fixes in fix-build-script fix the musl build.
-rdkafka = { version = "0.38", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", features = ["libz-static", "cmake-build", "ssl-vendored"] }
+# librdkafka if the feature curl-static is enabled. Additionally, it cherry-picks https://github.com/confluentinc/librdkafka/pull/5182
+# which prevents pulling in curl if it is not activated. The additional fixes in fix-build-script fix the musl build.
+rdkafka = { version = "0.38", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["libz-static", "cmake-build", "ssl-vendored"] }
 schemars = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -103,8 +103,8 @@ quanta = { version = "0.12" }
 quote = { version = "1" }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
-rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
-rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
@@ -239,8 +239,8 @@ quanta = { version = "0.12" }
 quote = { version = "1" }
 rand = { version = "0.8", features = ["small_rng"] }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
-rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
-rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "22895f8c22471309e1615b0686cd31be5966d575", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }


### PR DESCRIPTION
Because of bumping to librdkafka 2.12.1, there is a regression where building w/o curl-static fails because of a wrong compiler directive. This commit chooses a forked rust-rdkafka which uses a forked librdkafka which cherry-picked a fix for it.