### PR TITLE
Integrate vqueues with suspending invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4159,7 +4159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -8212,6 +8212,7 @@ dependencies = [
  "restate-types",
  "restate-utoipa",
  "restate-workspace-hack",
+ "rustc-hash",
  "schemars 0.8.22",
  "semver",
  "serde",
@@ -8431,6 +8432,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "hdrhistogram",
  "hex",
  "hmac",
@@ -8684,9 +8686,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -77,6 +77,7 @@ prost-types = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 regress = { version = "0.10" }
+rustc-hash = "2.1.1"
 schemars = { workspace = true, optional = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["rc"] }

--- a/crates/worker/src/partition/state_machine/entries/mod.rs
+++ b/crates/worker/src/partition/state_machine/entries/mod.rs
@@ -40,6 +40,7 @@ use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
 use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
 use restate_storage_api::timer_table::WriteTimerTable;
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::journal_v2::raw::RawEntry;
 use restate_types::journal_v2::{
@@ -116,7 +117,9 @@ where
         + ReadPromiseTable
         + WritePromiseTable
         + ReadStateTable
-        + WriteStateTable,
+        + WriteStateTable
+        + WriteVQueueTable
+        + ReadVQueueTable,
 {
     async fn apply(mut self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         if !matches!(self.invocation_status, InvocationStatus::Invoked(_))

--- a/crates/worker/src/partition/state_machine/entries/notification.rs
+++ b/crates/worker/src/partition/state_machine/entries/notification.rs
@@ -12,6 +12,7 @@ use tracing::trace;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_storage_api::invocation_status_table::{InFlightInvocationMetadata, InvocationStatus};
 use restate_storage_api::journal_table_v2::ReadJournalTable;
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_tracing_instrumentation as instrumentation;
 use restate_types::identifiers::InvocationId;
 use restate_types::journal_v2::raw::RawNotification;
@@ -115,7 +116,7 @@ impl<'e> ApplyNotificationCommand<'e> {
 impl<'e, 'ctx: 'e, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for ApplyNotificationCommand<'e>
 where
-    S: ReadJournalTable,
+    S: ReadJournalTable + WriteVQueueTable + ReadVQueueTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         if ctx.is_leader {

--- a/crates/worker/src/partition/state_machine/lifecycle/manual_resume.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/manual_resume.rs
@@ -13,6 +13,7 @@ use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyCo
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
 };
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::identifiers::{DeploymentId, InvocationId};
 use restate_types::invocation::InvocationMutationResponseSink;
 use restate_types::invocation::client::ResumeInvocationResponse;
@@ -27,7 +28,7 @@ pub struct OnManualResumeCommand {
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for OnManualResumeCommand
 where
-    S: ReadInvocationStatusTable + WriteInvocationStatusTable,
+    S: ReadInvocationStatusTable + WriteInvocationStatusTable + WriteVQueueTable + ReadVQueueTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let OnManualResumeCommand {

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_get_invocation_output_response.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_get_invocation_output_response.rs
@@ -21,6 +21,7 @@ use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
 use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
 use restate_storage_api::timer_table::WriteTimerTable;
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::invocation::GetInvocationOutputResponse;
 use restate_types::journal_v2::GetInvocationOutputCompletion;
 
@@ -41,7 +42,9 @@ where
         + WritePromiseTable
         + ReadStateTable
         + WriteStateTable
-        + WriteOutboxTable,
+        + WriteOutboxTable
+        + WriteVQueueTable
+        + ReadVQueueTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let invocation_status = ctx.get_invocation_status(&self.0.target.caller_id).await?;

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_invocation_response.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_invocation_response.rs
@@ -21,6 +21,7 @@ use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
 use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
 use restate_storage_api::timer_table::WriteTimerTable;
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::errors::NOT_READY_INVOCATION_ERROR;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{InvocationEpoch, ResponseResult};
@@ -55,7 +56,9 @@ where
         + WritePromiseTable
         + ReadStateTable
         + WriteStateTable
-        + WriteOutboxTable,
+        + WriteOutboxTable
+        + WriteVQueueTable
+        + ReadVQueueTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let OnNotifyInvocationResponse {

--- a/crates/worker/src/partition/state_machine/lifecycle/notify_sleep_completion.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/notify_sleep_completion.rs
@@ -21,6 +21,7 @@ use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
 use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
 use restate_storage_api::timer_table::WriteTimerTable;
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::InvocationEpoch;
 use restate_types::journal_v2::{CompletionId, SleepCompletion};
@@ -47,7 +48,9 @@ where
         + WritePromiseTable
         + ReadStateTable
         + WriteStateTable
-        + WriteOutboxTable,
+        + WriteOutboxTable
+        + WriteVQueueTable
+        + ReadVQueueTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let OnNotifySleepCompletionCommand {

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -64,6 +64,7 @@ getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-f
 half = { version = "2", default-features = false, features = ["num-traits"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hdrhistogram = { version = "7" }
 hex = { version = "0.4" }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
@@ -198,6 +199,7 @@ getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-f
 half = { version = "2", default-features = false, features = ["num-traits"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hdrhistogram = { version = "7" }
 hex = { version = "0.4" }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }


### PR DESCRIPTION
This commit wires up the vqueues with how the partition processor state machine handles suspending invocations. On suspension we call VQueues::park and on resumptions we call VQueues::wake_up.