### PR TITLE
Add support for state mutations when using vqueues 

### DIFF
--- a/crates/storage-api/src/vqueue_table/entry.rs
+++ b/crates/storage-api/src/vqueue_table/entry.rs
@@ -9,9 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use bytes::{Buf, BufMut};
-
 use restate_types::clock::UniqueTimestamp;
 use restate_types::identifiers::InvocationId;
+use restate_types::logs::Lsn;
+use restate_types::state_mut::ExternalStateMutation;
 use restate_types::vqueue::{
     EffectivePriority, NewEntryPriority, VQueueId, VQueueInstance, VQueueParent,
 };
@@ -71,6 +72,14 @@ impl From<InvocationId> for EntryId {
     #[inline]
     fn from(id: InvocationId) -> Self {
         Self::from_bytes(id.invocation_uuid().to_bytes())
+    }
+}
+
+impl From<Lsn> for EntryId {
+    #[inline]
+    fn from(lsn: Lsn) -> Self {
+        // big endian because we want messages with higher message indices to appear later
+        Self::from_bytes(u128::from(lsn.as_u64()).to_be_bytes())
     }
 }
 
@@ -184,4 +193,8 @@ pub trait EntryStateKind: Send {
 
 impl EntryStateKind for () {
     const KIND: EntryKind = EntryKind::Unknown;
+}
+
+impl EntryStateKind for ExternalStateMutation {
+    const KIND: EntryKind = EntryKind::StateMutation;
 }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -349,15 +349,27 @@ impl From<InvocationUuid> for opentelemetry::trace::SpanId {
 /// Services are isolated by key. This means that there cannot be two concurrent
 /// invocations for the same service instance (service name, key).
 #[derive(
-    Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Debug, serde::Serialize, serde::Deserialize,
+    Eq,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    bilrost::Message,
 )]
 pub struct ServiceId {
     // TODO rename this to KeyedServiceId. This type can be used only by keyed service types (virtual objects and workflows)
     /// Identifies the grpc service
+    #[bilrost(1)]
     pub service_name: ByteString,
     /// Identifies the service instance for the given service name
+    #[bilrost(2)]
     pub key: ByteString,
 
+    #[bilrost(3)]
     partition_key: PartitionKey,
 }
 

--- a/crates/types/src/state_mut.rs
+++ b/crates/types/src/state_mut.rs
@@ -22,12 +22,15 @@ use crate::identifiers::ServiceId;
 /// ExternalStateMutation
 ///
 /// represents an external request to mutate a user's state.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message)]
 pub struct ExternalStateMutation {
+    #[bilrost(1)]
     pub service_id: ServiceId,
+    #[bilrost(2)]
     pub version: Option<String>,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
+    #[bilrost(3)]
     pub state: HashMap<Bytes, Bytes>,
 }
 

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -242,6 +242,7 @@ where
                     }
 
                     // Acquire a global concurrency token
+                    // todo consider not requiring concurrency tokens for state mutations
                     if this
                         .concurrency_limiter
                         .poll_and_merge(cx, this.unconfirmed_capacity_permits)

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -668,6 +668,12 @@ impl LeaderState {
                     )
                     .map_err(Error::Invoker)?
             }
+            Action::VQConsumePermit { qid, item_hash } => {
+                let _ = self
+                    .scheduler
+                    .confirm_assignment(&qid, item_hash)
+                    .expect("scheduler should have a pending assignment");
+            }
         }
 
         Ok(())

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -43,6 +43,12 @@ pub enum Action {
         invocation_target: InvocationTarget,
         invoke_input_journal: InvokeInputJournal,
     },
+    /// Tells the scheduler to confirm the assignment for the given item hash and drops the
+    /// returned permit immediately to free up any held budget tokens.
+    VQConsumePermit {
+        qid: VQueueId,
+        item_hash: u64,
+    },
     Invoke {
         invocation_id: InvocationId,
         invocation_epoch: InvocationEpoch,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -873,6 +873,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             NewEntryPriority::default(),
             vqueue_table::EntryKind::Invocation,
             vqueue_table::EntryId::from(invocation_id),
+            None::<()>,
         )
         .await?;
 
@@ -1384,19 +1385,25 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteInboxTable
             + WriteFsmTable
             + ReadVirtualObjectStatusTable
-            + WriteVirtualObjectStatusTable,
+            + WriteVirtualObjectStatusTable
+            + WriteVQueueTable
+            + ReadVQueueTable,
     {
-        let service_status = self
-            .storage
-            .get_virtual_object_status(&mutation.service_id)
-            .await?;
+        if Configuration::pinned().common.experimental_enable_vqueues {
+            self.vqueue_enqueue_state_mutation(mutation).await?;
+        } else {
+            let service_status = self
+                .storage
+                .get_virtual_object_status(&mutation.service_id)
+                .await?;
 
-        match service_status {
-            VirtualObjectStatus::Locked(_) => {
-                self.enqueue_into_inbox(InboxEntry::StateMutation(mutation))
-                    .await?;
+            match service_status {
+                VirtualObjectStatus::Locked(_) => {
+                    self.enqueue_into_inbox(InboxEntry::StateMutation(mutation))
+                        .await?;
+                }
+                VirtualObjectStatus::Unlocked => Self::do_mutate_state(self, &mutation).await?,
             }
-            VirtualObjectStatus::Unlocked => Self::do_mutate_state(self, mutation).await?,
         }
 
         Ok(())
@@ -2772,7 +2779,9 @@ impl<S> StateMachineApplyContext<'_, S> {
             + ReadVirtualObjectStatusTable
             + WriteJournalTable
             + ReadVQueueTable
-            + WriteVQueueTable,
+            + WriteVQueueTable
+            + ReadStateTable
+            + WriteStateTable,
     {
         let qid = VQueueId::new(
             VQueueParent::from_raw(cards.parent),
@@ -2783,24 +2792,25 @@ impl<S> StateMachineApplyContext<'_, S> {
         let record_unique_ts = UniqueTimestamp::from_unix_millis(self.record_created_at).unwrap();
         for card in cards.decode_entry_cards() {
             let card = card?;
-            VQueues::new(
-                qid,
-                self.storage,
-                self.vqueues_cache,
-                self.is_leader.then_some(self.action_collector),
-            )
-            .attempt_to_run(record_unique_ts, &card)
-            .await?;
 
             match card.kind {
                 EntryKind::Unknown => {
                     panic!("Unknown card kind in inbox, cannot proceed");
                 }
                 EntryKind::StateMutation => {
-                    panic!("State mutations are not supported yet with vqueues");
-                    // self.mutate_state(state_mutation).await?;
+                    self.vqueue_mutate_state(qid, &card, record_unique_ts)
+                        .await?;
                 }
                 EntryKind::Invocation => {
+                    VQueues::new(
+                        qid,
+                        self.storage,
+                        self.vqueues_cache,
+                        self.is_leader.then_some(self.action_collector),
+                    )
+                    .attempt_to_run(record_unique_ts, &card)
+                    .await?;
+
                     let invocation_id = InvocationId::from_parts(
                         qid.partition_key,
                         InvocationUuid::from_slice(card.id.as_bytes()).unwrap(),
@@ -2998,7 +3008,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                         return Ok(());
                     }
                     InboxEntry::StateMutation(state_mutation) => {
-                        self.mutate_state(state_mutation).await?;
+                        self.mutate_state(&state_mutation).await?;
                     }
                 }
             }
@@ -4956,7 +4966,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         });
     }
 
-    async fn do_mutate_state(&mut self, state_mutation: ExternalStateMutation) -> Result<(), Error>
+    async fn do_mutate_state(&mut self, state_mutation: &ExternalStateMutation) -> Result<(), Error>
     where
         S: ReadStateTable + WriteStateTable,
     {
@@ -5002,7 +5012,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             .map_err(Error::Storage)
     }
 
-    async fn mutate_state(&mut self, state_mutation: ExternalStateMutation) -> StorageResult<()>
+    async fn mutate_state(&mut self, state_mutation: &ExternalStateMutation) -> StorageResult<()>
     where
         S: ReadStateTable + WriteStateTable,
     {
@@ -5016,7 +5026,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // are not contained in state
         let all_user_states: Vec<(Bytes, Bytes)> = self
             .storage
-            .get_all_user_states_for_service(&service_id)?
+            .get_all_user_states_for_service(service_id)?
             .try_collect()
             .await?;
 
@@ -5035,13 +5045,13 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         for (key, _) in &all_user_states {
             if !state.contains_key(key) {
-                self.storage.delete_user_state(&service_id, key)?;
+                self.storage.delete_user_state(service_id, key)?;
             }
         }
 
         // overwrite existing key value pairs
         for (key, value) in state {
-            self.storage.put_user_state(&service_id, key, value)?;
+            self.storage.put_user_state(service_id, key, value)?;
         }
 
         Ok(())
@@ -5214,6 +5224,97 @@ impl<S> StateMachineApplyContext<'_, S> {
         let partition_key = invocation_id.partition_key();
 
         VQueueId::new(parent, partition_key, instance)
+    }
+
+    async fn vqueue_enqueue_state_mutation(
+        &mut self,
+        state_mutation: ExternalStateMutation,
+    ) -> Result<(), Error>
+    where
+        S: WriteVQueueTable + ReadVQueueTable + WriteFsmTable,
+    {
+        let now = UniqueTimestamp::from_unix_millis(self.record_created_at).unwrap();
+        let visible_at = VisibleAt::Now;
+
+        let service_id = &state_mutation.service_id;
+        let parent = VQueueParent::default_singleton();
+
+        let qid = VQueueId::new(
+            parent,
+            service_id.partition_key(),
+            VQueueInstance::infer_from(service_id.key.as_bytes()),
+        );
+
+        let mut vqueue = VQueues::new(
+            qid,
+            self.storage,
+            self.vqueues_cache,
+            self.is_leader.then_some(self.action_collector),
+        );
+        vqueue
+            .enqueue_new(
+                now,
+                visible_at,
+                NewEntryPriority::UserDefault,
+                EntryKind::StateMutation,
+                // todo revisit entry id generation for state mutations
+                EntryId::from(self.record_lsn),
+                Some(state_mutation),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Apply the state mutation identified by the given qid and entry card.
+    async fn vqueue_mutate_state(
+        &mut self,
+        qid: VQueueId,
+        card: &EntryCard,
+        now: UniqueTimestamp,
+    ) -> Result<(), Error>
+    where
+        S: WriteVQueueTable + ReadVQueueTable + ReadStateTable + WriteStateTable,
+    {
+        if let Some(state_mutation) = self
+            .storage
+            .get_item(&qid, card.created_at, card.kind, &card.id)
+            .await?
+        {
+            let modified_card = {
+                let mut vqueue = VQueues::new(
+                    qid,
+                    self.storage,
+                    self.vqueues_cache,
+                    self.is_leader.then_some(self.action_collector),
+                );
+
+                vqueue.attempt_to_run(now, card).await?
+            };
+
+            // Temporary solution to consume the unconfirmed assignment held by the scheduler until
+            // this is done through `VQueues::attempt_to_run` or we manage the permits somewhere
+            // else.
+            if self.is_leader {
+                self.action_collector.push(Action::VQConsumePermit {
+                    qid,
+                    item_hash: card.unique_hash(),
+                });
+            }
+
+            self.mutate_state(&state_mutation).await?;
+
+            VQueues::new(
+                qid,
+                self.storage,
+                self.vqueues_cache,
+                self.is_leader.then_some(self.action_collector),
+            )
+            .end(now, Stage::Run, &modified_card)
+            .await?;
+        }
+
+        Ok(())
     }
 }
 

--- a/docs/dev/bilrost-migration-guidelines.md
+++ b/docs/dev/bilrost-migration-guidelines.md
@@ -21,7 +21,7 @@ To work around this I had to create my own custom `U128` which internally stores
 
 ## Enums
 
-`bilrost` makes a clear distinction between a `numberic` enum (represented as an integer value) , and `fat` enums. This was the most annoying thing to work with due to the following
+`bilrost` makes a clear distinction between a `numeric` enum (represented as an integer value) , and `fat` enums. This was the most annoying thing to work with due to the following
 
 ### Numeric (slim) Enums
 
@@ -61,8 +61,8 @@ enum MySlimEnum {
 
 #[derive(bilrost::Message)]
 struct MyStruct {
-		// This works because although the enum has NO empty state (0)
-		// the field here is optional
+    // This works because although the enum has NO empty state (0)
+    // the field here is optional
     slim: Option<MySlimEnum>,
 }
 ```
@@ -96,7 +96,7 @@ enum MySlimEnum {
 
 #[derive(bilrost::Message)]
 struct MyStruct {
-		// This will not compile! (required field but no empty state)
+    // This will not compile! (required field but no empty state)
     slim: MySlimEnum,
 }
 ```
@@ -113,9 +113,9 @@ This works completely different from above. It’s mainly because fat enums tran
 // Derives Oneof
 #[derive(bilrost::Oneof)]
 enum MyFatEnum {
-		// the only place where the empty state can appear
-		// and it's the only variant that is not associated with
-		// a value
+    // the only place where the empty state can appear
+    // and it's the only variant that is not associated with
+    // a value
     Unknown,
     // It will be clear why I am starting from 2 here later in this document
     // and not from 1


### PR DESCRIPTION
This commit integrates vqueues with external state mutations. The way it works is by
storing the external state mutation in the VQueue items table until it gets run
by the scheduler. When running the state mutation, we retrieve it from the VQueue items
table and apply the state mutation changes.

The external state mutation EntryId is currently derived from the internal inbox_seq_number
to generate unique EntryId's. In the future we might give external state mutations an explicit
id which could be used to derive the EntryId.

Currently, the DRR scheduler reserves a concurrency token for running state mutations.
We might want to relax this condition if we see that applying state mutations does not
need to be protected by the global concurrency limit.

This PR is based on #4069.