### PR TITLE
[10/N][VQueue] Basic scheduler metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8323,6 +8323,7 @@ dependencies = [
  "derive_more",
  "futures",
  "hashbrown 0.16.0",
+ "metrics",
  "pin-project",
  "restate-futures-util",
  "restate-rocksdb",

--- a/crates/vqueues/Cargo.toml
+++ b/crates/vqueues/Cargo.toml
@@ -20,6 +20,7 @@ bilrost = { workspace = true, features = ["smallvec"] }
 derive_more = { workspace = true }
 futures = { workspace = true }
 hashbrown = { version = "0.16"  }
+metrics = { workspace = true }
 pin-project = { workspace = true }
 rocksdb = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -9,10 +9,12 @@
 // by the Apache License, Version 2.0.
 
 mod cache;
+mod metric_definitions;
 pub mod scheduler;
 mod vqueue_config;
 
 pub use cache::{VQueuesMeta, VQueuesMetaMut};
+pub use metric_definitions::describe_metrics;
 pub use scheduler::SchedulerService;
 
 use restate_storage_api::StorageError;

--- a/crates/vqueues/src/metric_definitions.rs
+++ b/crates/vqueues/src/metric_definitions.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics::{Unit, counter, describe_counter};
+
+pub const VQUEUE_ENQUEUE: &str = "restate.vqueue.scheduler.enqueue.total";
+pub const VQUEUE_SCHEDULER_DECISION: &str = "restate.vqueue.scheduler.decision.total";
+pub const VQUEUE_RUN_CONFIRMED: &str = "restate.vqueue.scheduler.run_confirmed.total";
+pub const VQUEUE_RUN_REJECTED: &str = "restate.vqueue.scheduler.run_rejected.total";
+
+pub const ACTION_YIELD: &str = "yield";
+pub const ACTION_RESUME: &str = "resume";
+pub const ACTION_RUN: &str = "run";
+
+pub fn describe_metrics() {
+    describe_counter!(
+        VQUEUE_ENQUEUE,
+        Unit::Count,
+        "Number of entries/invocations in vqueues added to the waiting inbox"
+    );
+
+    describe_counter!(
+        VQUEUE_SCHEDULER_DECISION,
+        Unit::Count,
+        "Number of entries in vqueues scheduler, broken down by decision"
+    );
+
+    describe_counter!(
+        VQUEUE_RUN_CONFIRMED,
+        Unit::Count,
+        "Number of entries/invocations in vqueues where the run request was confirmed"
+    );
+
+    describe_counter!(
+        VQUEUE_RUN_REJECTED,
+        Unit::Count,
+        "Number of entries/invocations in vqueues where the run request was rejected"
+    );
+}
+
+pub fn publish_scheduler_decision_metrics(num_run: usize, num_yield: usize, num_resume: usize) {
+    counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_RUN).increment(num_run as u64);
+    counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_RESUME).increment(num_resume as u64);
+    counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_YIELD).increment(num_yield as u64);
+}

--- a/crates/vqueues/src/scheduler.rs
+++ b/crates/vqueues/src/scheduler.rs
@@ -23,6 +23,7 @@ use restate_storage_api::vqueue_table::{ScanVQueueTable, VQueueStore};
 use restate_types::vqueue::VQueueId;
 
 use crate::VQueueEvent;
+use crate::metric_definitions::publish_scheduler_decision_metrics;
 use crate::{VQueuesMeta, VQueuesMetaMut};
 
 use self::drr::DRRScheduler;
@@ -127,6 +128,25 @@ pub struct Decision<Item>(HashMap<VQueueId, Assignments<Item>>);
 impl<Item> Decision<Item> {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    pub fn report_metrics(&self) {
+        let mut num_run = 0;
+        let mut num_resume = 0;
+        let mut num_yield = 0;
+        for segment in self
+            .0
+            .values()
+            .flat_map(|assignments| &assignments.segments)
+        {
+            let count = segment.items.len();
+            match segment.action {
+                Action::ResumeAlreadyRunning => num_resume += count,
+                Action::MoveToRunning => num_run += count,
+                Action::Yield => num_yield += count,
+            }
+        }
+        publish_scheduler_decision_metrics(num_run, num_yield, num_resume);
     }
 }
 

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use hashbrown::HashMap;
 use hashbrown::hash_map;
+use metrics::counter;
 use pin_project::pin_project;
 use tokio::time::Instant;
 use tokio_util::time::DelayQueue;
@@ -33,6 +34,9 @@ use restate_types::vqueue::VQueueId;
 use crate::EventDetails;
 use crate::VQueueEvent;
 use crate::VQueuesMeta;
+use crate::metric_definitions::VQUEUE_ENQUEUE;
+use crate::metric_definitions::VQUEUE_RUN_CONFIRMED;
+use crate::metric_definitions::VQUEUE_RUN_REJECTED;
 use crate::scheduler::Assignments;
 use crate::scheduler::vqueue_state::Eligibility;
 
@@ -62,6 +66,7 @@ pub struct DRRScheduler<S: VQueueStore, Token> {
     datum: SchedulerClock,
     /// Time of the last memory reporting and memory compaction
     last_report: Instant,
+
     // SAFETY NOTE: **must** Keep this at the end since it needs to outlive all readers.
     storage: S,
 }
@@ -253,6 +258,7 @@ where
                         // assignments.
                         break 'single_vqueue Outcome::Abort;
                     }
+
                     // we have concurrency token, let's pick an item
                     qstate.pop_unchecked(this.storage, &mut assignments)?;
                     qstate.deficit.consume_one();
@@ -288,7 +294,9 @@ where
             self.waker.clone_from(cx.waker());
             Poll::Pending
         } else {
-            Poll::Ready(Ok(Decision(decision)))
+            let decision = Decision(decision);
+            decision.report_metrics();
+            Poll::Ready(Ok(decision))
         }
     }
 
@@ -296,6 +304,7 @@ where
         if let Some(qstate) = self.q.get_mut(qid)
             && qstate.remove_from_unconfirmed_assignments(item_hash)
         {
+            counter!(VQUEUE_RUN_CONFIRMED).increment(1);
             debug_assert!(!self.unconfirmed_capacity_permits.is_empty());
             Some(self.unconfirmed_capacity_permits.split(1).expect(
                 "trying to confirm a vqueue item after consuming all allotted concurrency tokens!",
@@ -322,6 +331,7 @@ where
                 let config = vqueues.config_pool().find(&qid.parent);
                 let meta = vqueues.get_vqueue(&qid).unwrap();
 
+                counter!(VQUEUE_ENQUEUE).increment(1);
                 if !qstate.notify_enqueued(item) {
                     // no impact on eligibility, no need to spend more cycles.
                     return Ok(());
@@ -352,6 +362,7 @@ where
                 let meta = vqueues.get_vqueue(&qid).unwrap();
 
                 if qstate.remove_from_unconfirmed_assignments(item_hash) {
+                    counter!(VQUEUE_RUN_REJECTED).increment(1);
                     // drop the already acquired permit
                     let _ = self.unconfirmed_capacity_permits.split(1);
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -110,6 +110,7 @@ impl Worker {
         metadata_writer: MetadataWriter,
     ) -> Result<Self, BuildError> {
         metric_definitions::describe_metrics();
+        restate_vqueues::describe_metrics();
         health_status.update(WorkerStatus::StartingUp);
 
         let partition_routing =


### PR DESCRIPTION

Introduces a small set of cumulative metrics from the vqueue scheduler to help visualize:
- The rate of items in scheduler decisions broken down by action
- The enqueue rate (in waiting inbox)
- Counters for confirmed/rejected items (confirmed items is low signal and we can remove it)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4060).
* #4080
* #4066
* __->__ #4060