### PR TITLE
[cli] Add WorkOS identity provider support for Restate Cloud login

### DIFF
--- a/cli/src/clients/cloud/client.rs
+++ b/cli/src/clients/cloud/client.rs
@@ -114,7 +114,7 @@ impl CloudClient {
 
         Ok(Self {
             inner: raw_client,
-            base_url: env.config.cloud.api_base_url.clone(),
+            base_url: env.config.cloud.api_base_url(),
             access_token,
             request_timeout: CliContext::get().request_timeout(),
         })

--- a/cli/src/commands/cloud/config_discovery.rs
+++ b/cli/src/commands/cloud/config_discovery.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use tracing::debug;
+use url::Url;
+
+#[derive(Debug, Deserialize)]
+pub struct DiscoveredAuthConfig {
+    pub provider: String,
+    pub client_id: String,
+    pub login_base_url: Option<Url>,
+}
+
+pub async fn fetch_auth_config(discovery_url: &Url) -> Result<DiscoveredAuthConfig> {
+    debug!(%discovery_url, "Fetching authentication config");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("Failed to build HTTP client for config discovery")?;
+
+    let response = client
+        .get(discovery_url.clone())
+        .send()
+        .await
+        .with_context(|| {
+            format!("Failed to discover authentication configuration at {discovery_url}")
+        })?;
+
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "Auth config discovery returned non-success status {} from {discovery_url}",
+            response.status()
+        );
+    }
+
+    response
+        .json::<DiscoveredAuthConfig>()
+        .await
+        .with_context(|| format!("Failed to parse auth config from {discovery_url}"))
+}

--- a/cli/src/commands/cloud/mod.rs
+++ b/cli/src/commands/cloud/mod.rs
@@ -8,22 +8,37 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod config_discovery;
 mod environments;
 mod login;
 
 use base64::Engine;
 use cling::prelude::*;
 use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
 use url::Url;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+pub enum IdentityProvider {
+    Cognito {
+        client_id: String,
+        login_base_url: Url,
+    },
+    WorkOS {
+        client_id: String,
+    },
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct CloudConfig {
     #[serde(flatten)]
     pub environment_info: Option<EnvironmentInfo>, // Set on a profile on login
-    pub api_base_url: Url,
-    pub login_base_url: Url,
-    pub client_id: String,
-    pub redirect_ports: Vec<u16>,
+    pub api_base_url: Option<Url>,
+    // Optional manual overrides
+    pub provider: Option<String>,
+    pub client_id: Option<String>,
+    pub login_base_url: Option<Url>,
+    pub redirect_ports: Option<Vec<u16>>,
     #[serde(flatten)]
     pub credentials: Option<Credentials>, // Set globally on login
 }
@@ -39,15 +54,127 @@ pub struct Credentials {
     access_token: String,
 }
 
-impl Default for CloudConfig {
-    fn default() -> Self {
-        Self {
-            environment_info: None,
-            api_base_url: Url::parse("https://api.us.restate.cloud").unwrap(),
-            login_base_url: Url::parse("https://auth.restate.cloud").unwrap(),
-            client_id: "5q3dsdnrr5r400jvibd8d3k66l".into(),
-            redirect_ports: vec![33912, 44643, 47576, 54788, 61844],
-            credentials: None,
+pub const DEFAULT_REDIRECT_PORTS: &[u16] = &[33912, 44643, 47576, 54788, 61844];
+pub const DEFAULT_API_BASE_URL: &str = "https://api.us.restate.cloud";
+
+// Legacy fallback defaults (used when discovery fails)
+const LEGACY_CLIENT_ID: &str = "5q3dsdnrr5r400jvibd8d3k66l";
+const LEGACY_LOGIN_BASE_URL: &str = "https://auth.restate.cloud";
+
+impl CloudConfig {
+    pub fn redirect_ports(&self) -> &[u16] {
+        self.redirect_ports
+            .as_deref()
+            .unwrap_or(DEFAULT_REDIRECT_PORTS)
+    }
+
+    pub fn api_base_url(&self) -> Url {
+        self.api_base_url
+            .clone()
+            .unwrap_or_else(|| Url::parse(DEFAULT_API_BASE_URL).expect("default API URL is valid"))
+    }
+
+    pub async fn resolve_identity_provider(&self) -> anyhow::Result<IdentityProvider> {
+        if let Some(provider) = &self.provider {
+            return self.resolve_explicit_provider(provider);
+        }
+
+        let discovery_url = self
+            .api_base_url()
+            .join(".auth-config")
+            .expect("valid auth-config path");
+
+        match config_discovery::fetch_auth_config(&discovery_url).await {
+            Ok(config) => {
+                debug!(
+                    "Discovered auth config: provider={}, client_id={}",
+                    config.provider, config.client_id
+                );
+                self.resolve_discovered_provider(&config)
+            }
+            Err(e) => {
+                warn!("Auth config discovery failed, using legacy defaults: {}", e);
+                Ok(self.resolve_legacy_provider())
+            }
+        }
+    }
+
+    fn resolve_explicit_provider(&self, provider: &str) -> anyhow::Result<IdentityProvider> {
+        let client_id = self.client_id.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("Explicit provider config requires client_id to be set")
+        })?;
+
+        match provider {
+            "cognito" => {
+                let login_base_url = self.login_base_url.clone().ok_or_else(|| {
+                    anyhow::anyhow!("Cognito provider requires login_base_url to be set")
+                })?;
+                debug!(
+                    "Using explicit Cognito provider: client_id={}, login_base_url={}",
+                    client_id, login_base_url
+                );
+                Ok(IdentityProvider::Cognito {
+                    client_id: client_id.to_string(),
+                    login_base_url,
+                })
+            }
+            "workos" => {
+                debug!("Using explicit WorkOS provider: client_id={}", client_id);
+                Ok(IdentityProvider::WorkOS {
+                    client_id: client_id.to_string(),
+                })
+            }
+            other => {
+                anyhow::bail!(
+                    "Unknown identity provider: {other}. Expected 'cognito' or 'workos'."
+                );
+            }
+        }
+    }
+
+    fn resolve_discovered_provider(
+        &self,
+        config: &config_discovery::DiscoveredAuthConfig,
+    ) -> anyhow::Result<IdentityProvider> {
+        match config.provider.as_str() {
+            "cognito" => {
+                let login_base_url = config.login_base_url.clone().ok_or_else(|| {
+                    anyhow::anyhow!("Discovered Cognito provider missing login_base_url")
+                })?;
+                debug!(
+                    "Using discovered Cognito provider: client_id={}, login_base_url={}",
+                    config.client_id, login_base_url
+                );
+                Ok(IdentityProvider::Cognito {
+                    client_id: config.client_id.clone(),
+                    login_base_url,
+                })
+            }
+            "workos" => {
+                debug!(
+                    "Using discovered WorkOS provider: client_id={}",
+                    config.client_id
+                );
+                Ok(IdentityProvider::WorkOS {
+                    client_id: config.client_id.clone(),
+                })
+            }
+            other => {
+                anyhow::bail!(
+                    "Unknown identity provider from discovery: {other}. Expected 'cognito' or 'workos'."
+                );
+            }
+        }
+    }
+
+    fn resolve_legacy_provider(&self) -> IdentityProvider {
+        debug!(
+            "Using legacy Cognito provider: client_id={}, login_base_url={}",
+            LEGACY_CLIENT_ID, LEGACY_LOGIN_BASE_URL
+        );
+        IdentityProvider::Cognito {
+            client_id: LEGACY_CLIENT_ID.to_string(),
+            login_base_url: Url::parse(LEGACY_LOGIN_BASE_URL).expect("valid legacy login URL"),
         }
     }
 }


### PR DESCRIPTION
This prepares the Restate CLI for the WorkOS identity provider set to replace Cognito in Restate Cloud.

With this change `restate cloud login` will try to fetch https://api.us.restate.dev/.auth-config to discover the defaults Cloud login client id and URL. We also support local overrides in CLI config (e.g. `~/.config/restate/config.toml`) for early opt-in / testing. In typical usage users will only hit this ~once a day and we only add a trivial amount of latency to the login flow which involves multiple web requests anyway. This change allows us to change the defaults remotely without forcing a version update on all Cloud customers.

We can continue to support Cognito and WorkOS side by side in Cloud for as long as we like; when we feel the time is right to retire Cognito, we will update auth.restate.dev to point to a static web page that instructs customers with legacy v1.5 CLI installations to upgrade to the latest version which will enable WorkOS for them.

To opt into the WorkOS identity provider early, add the following CLI config:

```toml
[global.cloud]
provider = "workos"
client_id = "client_01K8ZW3DSQK9D7PW0DT4DBRVSC"
```

Restate Cloud engineers can set both the API endpoint and switch identity provider defaults with a single line of config:

```toml
[global.cloud]
api_base_url = "https://..."
```