### PR TITLE
Support migrating to another metadata store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6872,6 +6872,7 @@ dependencies = [
  "restate-bifrost",
  "restate-core",
  "restate-errors",
+ "restate-metadata-providers",
  "restate-metadata-store",
  "restate-service-client",
  "restate-service-protocol",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -14,6 +14,12 @@ serve-web-ui = ["restate-web-ui", "mime_guess"]
 storage-query = []
 metadata-api = []
 restate-web-ui = ["dep:restate-web-ui"]
+all-metadata-providers = [
+    "restate-metadata-providers/replicated",
+    "restate-metadata-providers/etcd",
+    "restate-metadata-providers/objstore",
+    "restate-metadata-providers/dynamodb",
+]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
@@ -23,6 +29,7 @@ restate-bifrost = { workspace = true, features = ["local-loglet", "replicated-lo
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-metadata-store = { workspace = true }
+restate-metadata-providers = { workspace = true }
 restate-service-client = { workspace = true }
 restate-service-protocol = { workspace = true, features = ["discovery"] }
 restate-storage-query-datafusion = { workspace = true }

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -41,6 +41,8 @@ service ClusterCtrlSvc {
       returns (SetClusterConfigurationResponse);
 
   rpc Query(QueryRequest) returns (stream QueryResponse);
+
+  rpc MigrateMetadata(MigrateMetadataRequest) returns (MigrateMetadataResponse);
 }
 
 message SetClusterConfigurationResponse {}
@@ -183,3 +185,12 @@ message QueryResponse {
   // arrow encoded record batch
   bytes encoded = 1;
 }
+
+message MigrateMetadataRequest {
+  // force override target metadata store
+  bool force_override = 1;
+  // target MetadataClientOptions in json format
+  bytes target_client_config = 2;
+}
+
+message MigrateMetadataResponse {}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,7 +46,7 @@ restate-rocksdb = { workspace = true }
 restate-service-client = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio", "prometheus"] }
 restate-types = { workspace = true, features = ["clap"] }
-restate-admin = { workspace = true }
+restate-admin = { workspace = true, features = ["all-metadata-providers"] }
 
 clap = { workspace = true, features = ["derive", "env", "color", "help", "wrap_help", "usage", "suggestions", "error-context", "std"] }
 codederror = { workspace = true }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -83,6 +83,12 @@ struct RestateArguments {
 
     #[clap(flatten)]
     opts_overrides: CommonOptionCliOverride,
+
+    #[clap(long)]
+    /// Run in metadata migration mode. This limits the node roles so you
+    /// can run one-off metadata migrations without starting workers/ingress/log servers.
+    /// Required to run `restatectl metadata migrate`
+    metadata_migration_mode: bool,
 }
 
 const EXIT_CODE_FAILURE: i32 = 1;
@@ -116,6 +122,7 @@ fn main() {
         .load_env(true)
         .path(config_path.clone())
         .cli_override(cli_args.opts_overrides.clone())
+        .metadata_migration_mode(cli_args.metadata_migration_mode)
         .build()
         .unwrap();
 
@@ -183,6 +190,11 @@ fn main() {
                 );
                 let _ = writeln!(&mut stdout, "{:^40}", "https://restate.dev/");
                 let _ = writeln!(&mut stdout);
+            }
+
+            if cli_args.metadata_migration_mode {
+                warn!("Metadata migration mode enabled.");
+                warn!("Only use this mode to move metadata from the current store to a new store with `restatectl metadata migrate`; invocation processing is disabled while it is active.");
             }
 
             // Attempts to bind on all configured ports as early as possible so we can detect


### PR DESCRIPTION
Support migrating to another metadata store

Summary:
In this PR we add support to migrate to a new metadata store

Includes:
- Introduce `--metadata-migration-mode`. For the migration to pass, all nodes must be started with this mode set. This mode makes sure the cluster metadata
becomes immutable during the migration process. This of course implies a downtime.
- Introduce the Admi API to do the migration. The migration process first
  - Sanity check of the cluster state, makes sure all alive nodes are running with proper migration mode
  - Creates a client instance of the target store
  - Copies all well know metadata keys from current to target store

Fixes https://github.com/restatedev/internal/issues/76

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4062).
* #4065
* __->__ #4062