### PR TITLE
Add vqueue items table

### DIFF
--- a/crates/partition-store/src/keys.rs
+++ b/crates/partition-store/src/keys.rs
@@ -57,6 +57,8 @@ pub enum KeyKind {
     VQueueMeta,
     // Resources' canonical key(s)
     VQueueEntryState,
+    // Items stored in vqueues (e.g. state mutations, invocations, etc.)
+    VQueueItems,
 }
 
 impl KeyKind {
@@ -108,6 +110,7 @@ impl KeyKind {
             KeyKind::VQueueMeta => b"qm",
             // Queue Entry State (canonical state of vqueue entries)
             KeyKind::VQueueEntryState => b"qe",
+            KeyKind::VQueueItems => b"qI",
         }
     }
 
@@ -142,6 +145,7 @@ impl KeyKind {
             b"qi" => Some(KeyKind::VQueueInbox),
             b"qm" => Some(KeyKind::VQueueMeta),
             b"qe" => Some(KeyKind::VQueueEntryState),
+            b"qI" => Some(KeyKind::VQueueItems),
             _ => None,
         }
     }

--- a/crates/partition-store/src/vqueue_table/items.rs
+++ b/crates/partition-store/src/vqueue_table/items.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_storage_api::vqueue_table::{EntryId, EntryKind};
+use restate_types::clock::UniqueTimestamp;
+use restate_types::identifiers::PartitionKey;
+use restate_types::vqueue::{VQueueInstance, VQueueParent};
+
+use crate::TableKind::VQueue;
+use crate::keys::{KeyKind, define_table_key};
+
+// Vqueue items are stored under the qid they belong to and their creation timestamp to maintain
+// the order in which they were inserted into the vqueue.
+// 'qI' | PKEY | VQUEUE_PARENT | VQUEUE_INSTANCE | CREATED_AT | ENTRY_KIND | ENTRY_ID
+define_table_key!(
+    VQueue,
+    KeyKind::VQueueItems,
+    ItemsKey (
+        partition_key: PartitionKey,
+        parent: VQueueParent,
+        instance: VQueueInstance,
+        created_at: UniqueTimestamp,
+        kind: EntryKind,
+        id: EntryId,
+    )
+);
+
+static_assertions::const_assert_eq!(ItemsKey::serialized_length_fixed(), 43);
+
+impl ItemsKey {
+    pub const fn serialized_length_fixed() -> usize {
+        KeyKind::SERIALIZED_LENGTH
+            + size_of::<PartitionKey>()
+            + size_of::<VQueueParent>()
+            + size_of::<VQueueInstance>()
+            + size_of::<UniqueTimestamp>()
+            + size_of::<EntryKind>()
+            + size_of::<EntryId>()
+    }
+}


### PR DESCRIPTION
The vqueue items table is intended to store the payload of a vqueue item (e.g. the invocation or the state mutation). The item is stored when it is being enqueued into the vqueue and removed once the vqueue item ends. The payload can be accessed by the tuple (qid, created_at, kind, entry_id). The creation timestamp is part of the key in order to establish the insertion order into the given vqueue.