### PR TITLE
Support dynamic filters via remote scanner

### DIFF
--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -130,6 +130,11 @@ pub(crate) fn decode_record_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusio
 mod serde_tests {
     use datafusion::arrow::array::{Int32Array, RecordBatch};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::execution::TaskContext;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_plan::PhysicalExpr;
+    use datafusion::physical_plan::expressions::{BinaryExpr, Column, Literal};
+    use datafusion::scalar::ScalarValue;
     use std::sync::Arc;
 
     #[test]
@@ -166,5 +171,23 @@ mod serde_tests {
         assert_eq!(int32array.value(3), 3);
         assert_eq!(int32array.value(4), 4);
         assert_eq!(int32array.value(5), 5);
+    }
+
+    #[test]
+    pub fn round_trip_expr() {
+        let schema = Schema::new(vec![Field::new("status", DataType::LargeUtf8, false)]);
+
+        let physical_expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("status", 0)),
+            Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::LargeUtf8(Some(
+                "completed".into(),
+            )))),
+        ));
+
+        let buf = super::encode_expr(&physical_expr).expect("it to work");
+        let decoded = super::decode_expr(&TaskContext::default(), &schema, &buf).expect("to work");
+
+        assert_eq!(&physical_expr, &decoded);
     }
 }

--- a/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_expr_common::physical_expr::snapshot_generation;
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 use tracing::debug;
@@ -46,7 +47,10 @@ impl RemoteScanner {
         }
     }
 
-    async fn next_batch(&self) -> Result<RemoteQueryScannerNextResult, DataFusionError> {
+    async fn next_batch(
+        &self,
+        next_predicate: Option<RemoteQueryScannerPredicate>,
+    ) -> Result<RemoteQueryScannerNextResult, DataFusionError> {
         let Some(ref connection) = self.connection else {
             return Err(DataFusionError::Internal(
                 "connection used after forget()".to_string(),
@@ -67,6 +71,7 @@ impl RemoteScanner {
             .send_rpc(
                 RemoteQueryScannerNext {
                     scanner_id: self.scanner_id,
+                    next_predicate,
                 },
                 None,
             )
@@ -150,6 +155,9 @@ pub fn remote_scan_as_datafusion_stream(
     let tx = builder.tx();
 
     let task = async move {
+        // get a snapshot of the initial predicate
+        let mut predicate_generation = predicate.as_ref().map(snapshot_generation).unwrap_or(0);
+
         let initial_predicate = match &predicate {
             Some(predicate) => Some(RemoteQueryScannerPredicate {
                 serialized_physical_expression: encode_expr(predicate)?,
@@ -176,7 +184,9 @@ pub fn remote_scan_as_datafusion_stream(
         // loop while we have record_batch coming in
         //
         loop {
-            let batch = match remote_scanner.next_batch().await {
+            let next_predicate = next_predicate(&mut predicate_generation, predicate.as_ref())?;
+
+            let batch = match remote_scanner.next_batch(next_predicate).await {
                 Err(e) => {
                     return Err(e);
                 }
@@ -216,6 +226,30 @@ pub fn remote_scan_as_datafusion_stream(
 
     builder.spawn(task);
     builder.build()
+}
+
+fn next_predicate(
+    predicate_generation: &mut u64,
+    predicate: Option<&Arc<dyn PhysicalExpr>>,
+) -> Result<Option<RemoteQueryScannerPredicate>, DataFusionError> {
+    if *predicate_generation != 0 {
+        // generation 0 means the predicate is static (or we never had one)
+        let predicate = predicate.ok_or(DataFusionError::Internal(
+            "Missing predicate despite non-zero predicate generation".into(),
+        ))?;
+        let current_predicate_generation = snapshot_generation(predicate);
+
+        if current_predicate_generation != *predicate_generation {
+            *predicate_generation = current_predicate_generation;
+            Ok(Some(RemoteQueryScannerPredicate {
+                serialized_physical_expression: encode_expr(predicate)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 // ----- everything below is the client side implementation details -----

--- a/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
@@ -135,7 +135,10 @@ impl RemoteQueryScannerServer {
         // do that again here. If we do, we might end up dead-locking the map because we are holding a
         // reference into it (scanner).
         if let Err(mpsc::error::SendError(request)) =
-            scanner.send(super::scanner_task::NextRequest { reciprocal })
+            scanner.send(super::scanner_task::NextRequest {
+                reciprocal,
+                next_predicate: req.next_predicate,
+            })
         {
             tracing::info!(
                 "No such scanner {}. This could be an expired scanner due to a slow scan with no activity.",

--- a/crates/types/src/net/remote_query_scanner.rs
+++ b/crates/types/src/net/remote_query_scanner.rs
@@ -95,6 +95,9 @@ pub enum RemoteQueryScannerOpened {
 pub struct RemoteQueryScannerNext {
     #[bilrost(1)]
     pub scanner_id: ScannerId,
+    #[bilrost(tag(2))]
+    #[serde(default)]
+    pub next_predicate: Option<RemoteQueryScannerPredicate>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, bilrost::Message)]


### PR DESCRIPTION
Dynamic filters massively reduce the number of rows returned in topk operations like 'get the 50 most recent invocations'. They are not particularly helpful locally however, as we have to add a row to a record batch to be able to apply a filter, and at this point we have done 99% of the work of the scan. But remotely, they allow us to send less rows over the wire, which is valuable.

In handle_child_pushdown_result we track any dynamic filters and combine them with our initial filter. Then we are able to snapshot the dynamic filters and send them over the wire when they change, so on the remote side a stricter filter can be applied