### PR TITLE
[12/N][VQueues] Weighted DRR scheduler with token-bucket throttling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8075,6 +8075,7 @@ dependencies = [
  "restate-workspace-hack",
  "serde",
  "smallvec",
+ "static_assertions",
  "strum 0.27.1",
  "thiserror 2.0.17",
 ]
@@ -8322,6 +8323,7 @@ dependencies = [
  "bilrost",
  "derive_more",
  "futures",
+ "gardal",
  "hashbrown 0.16.0",
  "metrics",
  "pin-project",
@@ -8331,6 +8333,7 @@ dependencies = [
  "restate-types",
  "restate-workspace-hack",
  "rust-rocksdb",
+ "slotmap",
  "smallvec",
  "strum 0.27.1",
  "thiserror 2.0.17",
@@ -8400,6 +8403,7 @@ dependencies = [
  "restate-bifrost",
  "restate-core",
  "restate-errors",
+ "restate-futures-util",
  "restate-ingress-http",
  "restate-ingress-kafka",
  "restate-invoker-api",
@@ -9417,6 +9421,15 @@ dependencies = [
  "term",
  "thread_local",
  "time",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/crates/invoker-api/src/capacity.rs
+++ b/crates/invoker-api/src/capacity.rs
@@ -15,12 +15,9 @@ use restate_types::config::ThrottlingOptions;
 
 pub type TokenBucket<C = gardal::TokioClock> = gardal::SharedTokenBucket<C>;
 
-/// Marker type used to identify invoker's capacity tokens
-pub struct InvokerToken;
-
 #[derive(Clone)]
 pub struct InvokerCapacity {
-    pub concurrency: Concurrency<InvokerToken>,
+    pub concurrency: Concurrency,
     pub invocation_token_bucket: Option<TokenBucket>,
     pub action_token_bucket: Option<TokenBucket>,
 }

--- a/crates/invoker-api/src/handle.rs
+++ b/crates/invoker-api/src/handle.rs
@@ -24,7 +24,6 @@ use restate_types::journal_v2::raw::RawNotification;
 
 use super::Effect;
 use super::JournalMetadata;
-use crate::capacity::InvokerToken;
 use crate::invocation_reader::JournalEntry;
 
 #[derive(Debug, Eq, PartialEq, Default)]
@@ -48,7 +47,7 @@ pub trait InvokerHandle<SR> {
         &mut self,
         partition: PartitionLeaderEpoch,
         qid: VQueueId,
-        permit: Permit<InvokerToken>,
+        permit: Permit,
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,
         journal: InvokeInputJournal,

--- a/crates/invoker-api/src/lib.rs
+++ b/crates/invoker-api/src/lib.rs
@@ -24,7 +24,6 @@ pub use status_handle::{InvocationErrorReport, InvocationStatusReport, StatusHan
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util {
     use super::*;
-    use crate::capacity::InvokerToken;
     use crate::invocation_reader::{
         EagerState, InvocationReader, InvocationReaderTransaction, JournalEntry,
     };
@@ -119,7 +118,7 @@ pub mod test_util {
             &mut self,
             _partition: PartitionLeaderEpoch,
             _qid: VQueueId,
-            _permit: Permit<InvokerToken>,
+            _permit: Permit,
             _invocation_id: InvocationId,
             _invocation_target: InvocationTarget,
             _journal: InvokeInputJournal,

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -10,7 +10,6 @@
 
 use restate_errors::NotRunningError;
 use restate_futures_util::concurrency::Permit;
-use restate_invoker_api::capacity::InvokerToken;
 use restate_invoker_api::{Effect, InvocationStatusReport, InvokeInputJournal, StatusHandle};
 use restate_types::identifiers::{InvocationId, PartitionKey, PartitionLeaderEpoch};
 use restate_types::invocation::{InvocationEpoch, InvocationTarget};
@@ -36,7 +35,7 @@ pub(crate) struct InvokeCommand {
 pub(crate) struct VQueueInvokeCommand {
     pub(super) qid: VQueueId,
     #[debug(skip)]
-    pub(super) permit: Permit<InvokerToken>,
+    pub(super) permit: Permit,
     pub(super) partition: PartitionLeaderEpoch,
     pub(super) invocation_id: InvocationId,
     pub(super) invocation_target: InvocationTarget,
@@ -134,7 +133,7 @@ impl<SR: Send> restate_invoker_api::InvokerHandle<SR> for InvokerHandle<SR> {
         &mut self,
         partition: PartitionLeaderEpoch,
         qid: VQueueId,
-        permit: Permit<InvokerToken>,
+        permit: Permit,
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,
         journal: InvokeInputJournal,

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -15,7 +15,6 @@ use tokio::sync::mpsc;
 use tokio::task::AbortHandle;
 
 use restate_futures_util::concurrency::Permit;
-use restate_invoker_api::capacity::InvokerToken;
 use restate_types::journal::Completion;
 use restate_types::journal_v2::raw::RawEntry;
 use restate_types::retries;
@@ -30,7 +29,7 @@ pub(super) struct InvocationStateMachine {
     #[allow(dead_code)]
     pub(super) qid: Option<VQueueId>,
     #[allow(dead_code)]
-    pub(super) _permit: Permit<InvokerToken>,
+    pub(super) _permit: Permit,
     pub(super) invocation_target: InvocationTarget,
     pub(super) invocation_epoch: InvocationEpoch,
     pub(super) last_transient_error_event: Option<TransientErrorEvent>,
@@ -182,7 +181,7 @@ struct RetryPolicyState {
 impl InvocationStateMachine {
     pub(super) fn create(
         qid: Option<VQueueId>,
-        permit: Permit<InvokerToken>,
+        permit: Permit,
         invocation_target: InvocationTarget,
         invocation_epoch: InvocationEpoch,
         retry_iter: retries::RetryIter<'static>,

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -29,6 +29,7 @@ prost-types = { workspace = true }
 rangemap = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
+static_assertions = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/storage-api/src/vqueue_table/mod.rs
+++ b/crates/storage-api/src/vqueue_table/mod.rs
@@ -79,6 +79,21 @@ impl PartialOrd<UniqueTimestamp> for VisibleAt {
     }
 }
 
+/// Some stats that are collected from the scheduler. Emitted along the item
+/// at decision time.
+#[derive(Debug, Clone, Default, bilrost::Message)]
+pub struct WaitStats {
+    /// Total milliseconds the item spent waiting on global invoker capacity
+    #[bilrost(1)]
+    pub blocked_on_global_capacity_ms: u32,
+    /// Total milliseconds the item was throttled on vqueue's "start" token bucket
+    #[bilrost(2)]
+    pub vqueue_start_throttling_ms: u32,
+    /// Total milliseconds the item was throttled on global "run" token bucket
+    #[bilrost(3)]
+    pub global_throttling_ms: u32,
+}
+
 mod bilrost_encoding {
     use super::*;
 

--- a/crates/types/src/clock/unique_timestamp.rs
+++ b/crates/types/src/clock/unique_timestamp.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::num::NonZeroU64;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use crate::time::MillisSinceEpoch;
 
@@ -61,7 +61,7 @@ static_assertions::const_assert_eq!(
 );
 
 impl UniqueTimestamp {
-    const MIN: UniqueTimestamp =
+    pub const MIN: UniqueTimestamp =
         UniqueTimestamp(NonZeroU64::new(RESTATE_EPOCH.as_u64() + 1).unwrap());
 
     pub fn try_from_raw(raw: u64) -> Result<Option<Self>, Error> {
@@ -112,6 +112,7 @@ impl UniqueTimestamp {
         Self::from_parts(self.physical_raw() + millis, self.logical_raw())
     }
 
+    /// Physical time is the raw number of milliseconds since restate's epoch.
     #[inline(always)]
     fn physical_raw(&self) -> u64 {
         // extract the physical time
@@ -129,6 +130,12 @@ impl UniqueTimestamp {
     /// or return 0 if the other timestamp is ahead.
     pub fn milliseconds_since(&self, other: Self) -> u64 {
         self.physical_raw().saturating_sub(other.physical_raw())
+    }
+
+    /// Returns the number of fractional seconds since RESTATE_EPOCH.
+    pub fn as_secs_f64(&self) -> f64 {
+        // NOTE: physical clock is in millis.
+        Duration::from_millis(self.physical_raw()).as_secs_f64()
     }
 }
 

--- a/crates/vqueues/Cargo.toml
+++ b/crates/vqueues/Cargo.toml
@@ -19,10 +19,12 @@ anyhow = { workspace = true }
 bilrost = { workspace = true, features = ["smallvec"] }
 derive_more = { workspace = true }
 futures = { workspace = true }
+gardal = { workspace = true }
 hashbrown = { version = "0.16"  }
 metrics = { workspace = true }
 pin-project = { workspace = true }
 rocksdb = { workspace = true }
+slotmap = { version = "1" }
 smallvec = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vqueues/src/cache.rs
+++ b/crates/vqueues/src/cache.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use hashbrown::{HashMap, hash_map};
-use tracing::debug;
+use tracing::{debug, trace};
 
 use restate_storage_api::StorageError;
 use restate_storage_api::vqueue_table::metadata::{VQueueMeta, VQueueMetaUpdates};
@@ -54,6 +54,14 @@ impl<'a> VQueuesMeta<'a> {
             .queues
             .iter()
             .filter(|(_, meta)| meta.is_active())
+    }
+
+    pub fn num_active(&self) -> usize {
+        self.inner
+            .queues
+            .values()
+            .filter(|meta| meta.is_active())
+            .count()
     }
 
     pub fn report(&self) {
@@ -171,5 +179,8 @@ impl VQueuesMetaMut {
             self.queues.len(),
             self.queues.allocation_size(),
         );
+        for (qid, meta) in self.queues.iter() {
+            trace!("[{qid:?}]: {meta:?}");
+        }
     }
 }

--- a/crates/vqueues/src/metric_definitions.rs
+++ b/crates/vqueues/src/metric_definitions.rs
@@ -14,10 +14,19 @@ pub const VQUEUE_ENQUEUE: &str = "restate.vqueue.scheduler.enqueue.total";
 pub const VQUEUE_SCHEDULER_DECISION: &str = "restate.vqueue.scheduler.decision.total";
 pub const VQUEUE_RUN_CONFIRMED: &str = "restate.vqueue.scheduler.run_confirmed.total";
 pub const VQUEUE_RUN_REJECTED: &str = "restate.vqueue.scheduler.run_rejected.total";
+pub const VQUEUE_INVOKER_CAPACITY_WAIT_MS: &str =
+    "restate.vqueue.scheduler.invoker_capacity_wait_ms.total";
+
+// Node-level scheduler throttling (affects resume/start)
+pub const VQUEUE_GLOBAL_THROTTLE_WAIT_MS: &str =
+    "restate.vqueue.scheduler.global_throttle_ms.total";
+// Per vqueue start throttling (affects starts only)
+pub const VQUEUE_LOCAL_THROTTLE_WAIT_MS: &str = "restate.vqueue.scheduler.vqueue_throttle_ms.total";
 
 pub const ACTION_YIELD: &str = "yield";
 pub const ACTION_RESUME: &str = "resume";
 pub const ACTION_RUN: &str = "run";
+pub const ACTION_START: &str = "start";
 
 pub fn describe_metrics() {
     describe_counter!(
@@ -43,9 +52,33 @@ pub fn describe_metrics() {
         Unit::Count,
         "Number of entries/invocations in vqueues where the run request was rejected"
     );
+
+    describe_counter!(
+        VQUEUE_INVOKER_CAPACITY_WAIT_MS,
+        Unit::Count,
+        "Cumulative number of seconds spent waiting for global invoker capacity"
+    );
+
+    describe_counter!(
+        VQUEUE_GLOBAL_THROTTLE_WAIT_MS,
+        Unit::Count,
+        "Cumulative number of seconds vqueues waited because of global start/resume throttling"
+    );
+
+    describe_counter!(
+        VQUEUE_LOCAL_THROTTLE_WAIT_MS,
+        Unit::Count,
+        "Cumulative number of seconds vqueues waited because of their self-imposed start throttling"
+    );
 }
 
-pub fn publish_scheduler_decision_metrics(num_run: usize, num_yield: usize, num_resume: usize) {
+pub fn publish_scheduler_decision_metrics(
+    num_start: u16,
+    num_run: u16,
+    num_yield: u16,
+    num_resume: u16,
+) {
+    counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_START).increment(num_start as u64);
     counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_RUN).increment(num_run as u64);
     counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_RESUME).increment(num_resume as u64);
     counter!(VQUEUE_SCHEDULER_DECISION, "action" => ACTION_YIELD).increment(num_yield as u64);

--- a/crates/vqueues/src/scheduler.rs
+++ b/crates/vqueues/src/scheduler.rs
@@ -19,7 +19,7 @@ use smallvec::SmallVec;
 
 use restate_futures_util::concurrency::{Concurrency, Permit};
 use restate_storage_api::StorageError;
-use restate_storage_api::vqueue_table::{ScanVQueueTable, VQueueStore};
+use restate_storage_api::vqueue_table::{ScanVQueueTable, VQueueEntry, VQueueStore, WaitStats};
 use restate_types::vqueue::VQueueId;
 
 use crate::VQueueEvent;
@@ -30,12 +30,38 @@ use self::drr::DRRScheduler;
 
 mod clock;
 mod drr;
+mod eligible;
+mod queue;
 mod vqueue_state;
 
-const INLINED_SIZE: usize = vqueue_state::QUANTUM as usize;
+const INLINED_SIZE: usize = 4;
 
-#[derive(Debug)]
+slotmap::new_key_type! { struct VQueueHandle; }
+
+// Token bucket used for throttling over all vqueues
+type GlobalTokenBucket<C = gardal::TokioClock> =
+    gardal::TokenBucket<gardal::PaddedAtomicSharedStorage, C>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThrottleScope {
+    Global,
+    VQueue,
+}
+
+pub struct Entry<Item> {
+    pub item: Item,
+    pub stats: WaitStats,
+    pub permit: Permit,
+}
+impl<Item> Entry<Item> {
+    pub fn split(self) -> (Item, WaitStats, Permit) {
+        (self.item, self.stats, self.permit)
+    }
+}
+
 pub struct Assignments<Item> {
+    latest_run_tb_zero_time: Option<f64>,
+
     // In the overwhelming majority of cases, we will have only one segment (inbox or running)
     // and in rare cases we may have both. If we (in the future) support sending the three actions
     // on the same scheduler's poll, we'll accept to allocated in those rare cases where the three actions
@@ -46,13 +72,14 @@ pub struct Assignments<Item> {
 impl<Item> Default for Assignments<Item> {
     fn default() -> Self {
         Self {
+            latest_run_tb_zero_time: None,
             segments: smallvec::smallvec![],
         }
     }
 }
 
 impl<Item> Assignments<Item> {
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (Action, &[Item])> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (Action, &[Entry<Item>])> {
         self.segments
             .iter()
             .map(|segment| (segment.action, segment.items.as_slice()))
@@ -60,49 +87,46 @@ impl<Item> Assignments<Item> {
 
     pub fn into_iter_per_action(
         self,
-    ) -> impl ExactSizeIterator<Item = (Action, impl ExactSizeIterator<Item = Item>)> {
+    ) -> impl ExactSizeIterator<Item = (Action, impl ExactSizeIterator<Item = Entry<Item>>)> {
         self.segments
             .into_iter()
             .map(|segment| (segment.action, segment.items.into_iter()))
     }
 
-    pub fn push(&mut self, action: Action, item: Item) {
+    pub fn push(&mut self, action: Action, entry: Entry<Item>) {
         // manipulate the last segment if the action is the same.
         if let Some(last_segment) = self.segments.last_mut()
             && last_segment.action == action
         {
-            last_segment.items.push(item);
+            last_segment.items.push(entry);
         } else {
             self.segments.push(AssignmentSegment {
                 action,
-                items: smallvec::smallvec![item],
+                items: smallvec::smallvec![entry],
             });
         }
     }
 
-    pub fn merge(&mut self, other: Self) {
-        self.segments.extend(other.segments);
+    /// Allows us to track the token bucket's zero time across scheduler runs.
+    pub fn set_latest_run_tb_zero_time(&mut self, zero_time: Option<f64>) {
+        self.latest_run_tb_zero_time = zero_time;
     }
 
     pub fn is_empty(&self) -> bool {
         self.segments.is_empty()
     }
+
+    pub fn updated_tb_zero_time(&self) -> Option<f64> {
+        self.latest_run_tb_zero_time
+    }
 }
 
-#[derive(Debug)]
 pub struct AssignmentSegment<Item> {
     pub action: Action,
-    pub items: SmallVec<[Item; INLINED_SIZE]>,
+    pub items: SmallVec<[Entry<Item>; INLINED_SIZE]>,
 }
 
 impl<Item> AssignmentSegment<Item> {
-    pub fn new(action: Action, item: Item) -> Self {
-        Self {
-            action,
-            items: smallvec::smallvec![item],
-        }
-    }
-
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
@@ -122,44 +146,89 @@ pub enum Action {
     Yield,
 }
 
-#[derive(derive_more::IntoIterator, Debug)]
-pub struct Decision<Item>(HashMap<VQueueId, Assignments<Item>>);
+#[derive(derive_more::IntoIterator, derive_more::Debug)]
+pub struct Decision<Item> {
+    #[into_iterator]
+    #[debug(skip)]
+    q: HashMap<VQueueId, Assignments<Item>>,
+    /// items running for the first time
+    num_start: u16,
+    /// running items previously started
+    num_run: u16,
+    /// running items that should continue to run
+    num_resume: u16,
+    /// Items in run queue that need to go back to waiting inbox
+    num_yield: u16,
+}
 
-impl<Item> Decision<Item> {
+impl<Item> Default for Decision<Item> {
+    fn default() -> Self {
+        Self {
+            q: HashMap::default(),
+            num_start: 0,
+            num_run: 0,
+            num_resume: 0,
+            num_yield: 0,
+        }
+    }
+}
+
+impl<Item: VQueueEntry> Decision<Item> {
+    pub fn push(
+        &mut self,
+        qid: &VQueueId,
+        action: Action,
+        entry: Entry<Item>,
+        updated_zt: Option<f64>,
+    ) {
+        let assignments = self.q.entry_ref(qid).or_default();
+        assignments.set_latest_run_tb_zero_time(updated_zt);
+        match action {
+            Action::ResumeAlreadyRunning => self.num_resume += 1,
+            Action::Yield => self.num_yield += 1,
+            Action::MoveToRunning if entry.item.priority().is_new() => self.num_start += 1,
+            Action::MoveToRunning => self.num_run += 1,
+        }
+        assignments.push(action, entry);
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.q.is_empty()
+    }
+
+    /// The number of vqueues in this decision
+    pub fn num_queues(&self) -> usize {
+        self.q.len()
+    }
+
+    /// Total number of items in all queues
+    pub fn total_items(&self) -> usize {
+        self.num_start as usize
+            + self.num_run as usize
+            + self.num_resume as usize
+            + self.num_yield as usize
     }
 
     pub fn report_metrics(&self) {
-        let mut num_run = 0;
-        let mut num_resume = 0;
-        let mut num_yield = 0;
-        for segment in self
-            .0
-            .values()
-            .flat_map(|assignments| &assignments.segments)
-        {
-            let count = segment.items.len();
-            match segment.action {
-                Action::ResumeAlreadyRunning => num_resume += count,
-                Action::MoveToRunning => num_run += count,
-                Action::Yield => num_yield += count,
-            }
-        }
-        publish_scheduler_decision_metrics(num_run, num_yield, num_resume);
+        publish_scheduler_decision_metrics(
+            self.num_start,
+            self.num_run,
+            self.num_yield,
+            self.num_resume,
+        );
     }
 }
 
-enum State<S: VQueueStore, Token> {
-    Active(Pin<Box<DRRScheduler<S, Token>>>),
+enum State<S: VQueueStore> {
+    Active(Pin<Box<DRRScheduler<S>>>),
     Disabled,
 }
 
-pub struct SchedulerService<S: VQueueStore, Token> {
-    state: State<S, Token>,
+pub struct SchedulerService<S: VQueueStore> {
+    state: State<S>,
 }
 
-impl<S, Token> SchedulerService<S, Token>
+impl<S> SchedulerService<S>
 where
     S: VQueueStore,
     S::Item: std::fmt::Debug,
@@ -169,12 +238,13 @@ where
         S: ScanVQueueTable,
     {
         Self {
-            state: State::<S, Token>::Disabled,
+            state: State::<S>::Disabled,
         }
     }
 
     pub async fn create(
-        concurrency: Concurrency<Token>,
+        concurrency: Concurrency,
+        global_throttling: Option<GlobalTokenBucket>,
         storage: S,
         vqueues_cache: &mut VQueuesMetaMut,
     ) -> Result<Self, StorageError>
@@ -195,7 +265,10 @@ where
             // Note that propose_many will error out if the number of commands is greater than the
             // channel's max capacity.
             NonZeroU16::new(25).unwrap(),
+            // currently constant but we can make it configurable if needed
+            NonZeroU16::new(1000).unwrap(),
             concurrency,
+            global_throttling,
             storage,
             vqueues_cache.view(),
         )));
@@ -230,15 +303,6 @@ where
             State::Disabled => Poll::Pending,
             State::Active(ref mut drr_scheduler) => {
                 drr_scheduler.as_mut().poll_schedule_next(cx, vqueues)
-            }
-        }
-    }
-
-    pub fn confirm_assignment(&mut self, qid: &VQueueId, item_hash: u64) -> Option<Permit<Token>> {
-        match self.state {
-            State::Disabled => None,
-            State::Active(ref mut drr_scheduler) => {
-                drr_scheduler.as_mut().confirm_assignment(qid, item_hash)
             }
         }
     }

--- a/crates/vqueues/src/scheduler/clock.rs
+++ b/crates/vqueues/src/scheduler/clock.rs
@@ -8,35 +8,33 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use restate_types::clock::UniqueTimestamp;
+use restate_types::time::MillisSinceEpoch;
+
+struct Datum {
+    ts_origin: UniqueTimestamp,
+    tokio_origin: tokio::time::Instant,
+}
+
+static DATUM: LazyLock<Datum> = LazyLock::new(|| Datum {
+    ts_origin: UniqueTimestamp::from_unix_millis(MillisSinceEpoch::now())
+        .expect("clock does not overflow"),
+    tokio_origin: tokio::time::Instant::now(),
+});
 
 /// A clock that tracks the physical clock of the scheduler that is synchronized
 /// with the UniqueTimestamp physical clock.
-pub struct SchedulerClock {
-    tokio_origin: tokio::time::Instant,
-    ts_origin: UniqueTimestamp,
-}
+#[derive(Debug, Copy, Clone, Default)]
+pub struct SchedulerClock;
 
 impl SchedulerClock {
-    /// `now` is the current physical clock that corresponds to `Instant::now()` at the time
-    /// of construction.
-    pub fn new(now: UniqueTimestamp) -> Self {
-        Self {
-            tokio_origin: tokio::time::Instant::now(),
-            ts_origin: now,
-        }
-    }
-
-    pub fn origin_instant(&self) -> tokio::time::Instant {
-        self.tokio_origin
-    }
-
     pub fn now_ts(&self) -> UniqueTimestamp {
-        let delta = self.tokio_origin.elapsed().as_millis() as u64;
-        self.ts_origin
-            .add_millis(delta)
+        DATUM
+            .ts_origin
+            .add_millis(DATUM.tokio_origin.elapsed().as_millis() as u64)
             .expect("clock doesn't overflow")
     }
 
@@ -44,7 +42,19 @@ impl SchedulerClock {
     ///
     /// Returns the clock datum/origin point if the input `ts` is in the past.
     pub fn ts_to_future_instant(&self, ts: UniqueTimestamp) -> tokio::time::Instant {
-        let delta = ts.milliseconds_since(self.ts_origin);
-        self.tokio_origin + Duration::from_millis(delta)
+        let delta = ts.milliseconds_since(DATUM.ts_origin);
+        DATUM.tokio_origin + Duration::from_millis(delta)
+    }
+}
+
+impl gardal::Clock for SchedulerClock {
+    fn now(&self) -> f64 {
+        // This calculates the new physical clock (ms since restate epoch)
+        // by offsetting the origin ts with the monotonic clock elapsed time since
+        // the clock was created.
+        //
+        // In a future change, this will be part of the global HLC clock that is updated
+        // via a background thread for coarse time updates.
+        self.now_ts().as_secs_f64()
     }
 }

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::VecDeque;
 use std::num::NonZeroU16;
 use std::pin::Pin;
 use std::task::Poll;
@@ -16,19 +15,16 @@ use std::task::Waker;
 use std::time::Duration;
 
 use hashbrown::HashMap;
-use hashbrown::hash_map;
 use metrics::counter;
 use pin_project::pin_project;
+use slotmap::SlotMap;
 use tokio::time::Instant;
-use tokio_util::time::DelayQueue;
+use tracing::warn;
 use tracing::{info, trace};
 
 use restate_futures_util::concurrency::Concurrency;
-use restate_futures_util::concurrency::Permit;
 use restate_storage_api::StorageError;
 use restate_storage_api::vqueue_table::VQueueStore;
-use restate_types::clock::UniqueTimestamp;
-use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueue::VQueueId;
 
 use crate::EventDetails;
@@ -37,105 +33,92 @@ use crate::VQueuesMeta;
 use crate::metric_definitions::VQUEUE_ENQUEUE;
 use crate::metric_definitions::VQUEUE_RUN_CONFIRMED;
 use crate::metric_definitions::VQUEUE_RUN_REJECTED;
-use crate::scheduler::Assignments;
-use crate::scheduler::vqueue_state::Eligibility;
+use crate::scheduler::eligible::EligibilityTracker;
+use crate::scheduler::vqueue_state::Pop;
 
 use super::Decision;
-use super::clock::SchedulerClock;
+use super::GlobalTokenBucket;
+use super::VQueueHandle;
 use super::vqueue_state::VQueueState;
 
-/// Capacity to maintain for N vqueues (N=100)
-const MIN_VQUEUES_CAPACITY: usize = 100;
-
 #[pin_project]
-pub struct DRRScheduler<S: VQueueStore, Token> {
-    /// Limits the number of queues picked per scheduler's poll
-    limit_qid_per_poll: NonZeroU16,
-    concurrency_limiter: Concurrency<Token>,
-    eligible: VecDeque<VQueueId>,
-    /// Mapping of vqueue_id -> vqueue_state for possibly eligible vqueues
-    q: HashMap<VQueueId, VQueueState<S>>,
-    unconfirmed_capacity_permits: Permit<Token>,
-    delayed_eligibility: DelayQueue<VQueueId>,
-    // Wraps to zero after 16::MAX.
-    global_sched_round: u16,
-    /// How many vqueues we need to still need to go visit before we start a new round
-    remaining_in_round: usize,
+pub struct DRRScheduler<S: VQueueStore> {
+    concurrency_limiter: Concurrency,
+    global_throttling: Option<GlobalTokenBucket>,
+    // sorted by queue_id
+    eligible: EligibilityTracker,
+    /// Mapping of vqueue_id -> handle for active vqueues
+    id_lookup: HashMap<VQueueId, VQueueHandle>,
+    q: SlotMap<VQueueHandle, VQueueState<S>>,
     /// Waker to be notified when scheduler is potentially able to scheduler more work
     waker: Waker,
-    datum: SchedulerClock,
     /// Time of the last memory reporting and memory compaction
     last_report: Instant,
+
+    /// Limits the number of queues picked per scheduler's poll
+    limit_qid_per_poll: NonZeroU16,
+    /// Limits the number of items included in a single decision across all queues
+    max_items_per_decision: NonZeroU16,
 
     // SAFETY NOTE: **must** Keep this at the end since it needs to outlive all readers.
     storage: S,
 }
 
-impl<S, Token> DRRScheduler<S, Token>
+impl<S> DRRScheduler<S>
 where
     S: VQueueStore,
     S::Item: std::fmt::Debug,
 {
     pub fn new(
         limit_qid_per_poll: NonZeroU16,
-        concurrency_limiter: Concurrency<Token>,
+        max_items_per_decision: NonZeroU16,
+        concurrency_limiter: Concurrency,
+        global_throttling: Option<GlobalTokenBucket>,
         storage: S,
         vqueues: VQueuesMeta<'_>,
     ) -> Self {
         let mut total_running = 0;
         let mut total_waiting = 0;
 
-        let q: HashMap<_, _> = vqueues
-            .iter_active_vqueues()
-            .map(|(qid, meta)| {
-                total_running += meta.num_running();
-                total_waiting += meta.total_waiting();
-                let vqueue = VQueueState::new(*qid, meta.num_running());
-                (*qid, vqueue)
-            })
-            .collect();
+        let num_active = vqueues.num_active();
+        let mut q = SlotMap::with_capacity_and_key(num_active);
+        let mut id_lookup = HashMap::with_capacity(num_active);
+        let mut eligible: EligibilityTracker = EligibilityTracker::with_capacity(num_active);
 
-        // We init all active vqueues as eligible first
-        let eligible = q.keys().copied().collect();
+        for (qid, meta) in vqueues.iter_active_vqueues() {
+            let config = vqueues.config_pool().find(&qid.parent);
+            total_running += meta.num_running();
+            total_waiting += meta.total_waiting();
+            let handle = q.insert_with_key(|handle| VQueueState::new(*qid, handle, meta, config));
+            id_lookup.insert(*qid, handle);
+            // We init all active vqueues as eligible first
+            eligible.insert_eligible(handle);
+        }
 
         info!(
             "Scheduler started. num_vqueues={}, total_running_items={total_running}, total_waiting_items={total_waiting}",
             q.len(),
         );
 
-        let datum = SchedulerClock::new(
-            UniqueTimestamp::from_unix_millis(MillisSinceEpoch::now())
-                .expect("clock does not overflow"),
-        );
-        // Makes sure we use the same clock datum for the internal timer wheel and for our
-        // own eligibility checks.
-        let start = datum.origin_instant();
-        let delayed_eligibility = DelayQueue::with_capacity(MIN_VQUEUES_CAPACITY);
-
         Self {
-            limit_qid_per_poll,
             concurrency_limiter,
+            global_throttling,
+            id_lookup,
             q,
             eligible,
-            global_sched_round: 0,
-            remaining_in_round: 0,
-            delayed_eligibility,
-            unconfirmed_capacity_permits: Permit::new_empty(),
             waker: Waker::noop().clone(),
-            datum,
-            last_report: start,
+            last_report: Instant::now(),
             storage,
+            limit_qid_per_poll,
+            max_items_per_decision,
         }
     }
 
     fn report(&mut self) {
         trace!(
-            "DRR scheduler report: eligible={}, queue_states_len={}, queue_states_mem={}bytes, unconfirmed_capacity_permits={:?}, global_sched_round={}",
+            "DRR scheduler report: eligible={}, queue_states_len={}",
             self.eligible.len(),
             self.q.len(),
-            self.q.allocation_size(),
-            self.unconfirmed_capacity_permits,
-            self.global_sched_round,
         );
     }
 
@@ -144,184 +127,100 @@ where
         cx: &mut std::task::Context<'_>,
         vqueues: VQueuesMeta<'_>,
     ) -> Poll<Result<Decision<S::Item>, StorageError>> {
-        enum Outcome {
-            ContinueRound,
-            Abort,
-        }
+        let mut decision = Decision::default();
+        let mut items_collected = 0;
+        let mut first_blocked = None;
 
-        if self.last_report.elapsed() >= Duration::from_secs(10) {
-            vqueues.report();
-            self.report();
-            // also report vqueues states
-            self.last_report = Instant::now();
-            // compact memory
-            self.q.shrink_to(MIN_VQUEUES_CAPACITY);
-            self.delayed_eligibility.compact();
-        }
-
-        let configs = vqueues.config_pool();
-        let mut decision: HashMap<VQueueId, Assignments<S::Item>> = HashMap::new();
-
-        'scheduler: loop {
-            if self.remaining_in_round == 0 {
-                // Pop all eligible vqueues that were delayed since we are starting a new round
-                // Once we hit pending, the waker will be registered.
-                let previous_round = self.global_sched_round;
-                while let Poll::Ready(Some(expired)) = self.delayed_eligibility.poll_expired(cx) {
-                    let Some(qstate) = self.q.get_mut(expired.get_ref()) else {
-                        // the vqueue is gone/empty, ignore.
-                        continue;
-                    };
-                    qstate.drop_scheduled_wake_up();
-                    qstate.deficit.set_last_round(previous_round);
-                    let vqueue_id = expired.into_inner();
-                    if !self.eligible.contains(&vqueue_id) {
-                        self.eligible.push_back(vqueue_id);
-                    }
-                }
-
-                if !self.eligible.is_empty() {
-                    // bump global scheduling round, reset remaining.
-                    self.remaining_in_round = self.eligible.len();
-                    self.global_sched_round = self.global_sched_round.wrapping_add(1);
-                } else {
-                    break 'scheduler;
-                }
+        loop {
+            self.eligible.poll_delayed(cx);
+            // bail if we exhausted coop budget.
+            let coop = match tokio::task::coop::poll_proceed(cx) {
+                Poll::Ready(coop) => coop,
+                Poll::Pending => break,
+            };
+            // stop when we have enough queues picked
+            if decision.num_queues() >= self.limit_qid_per_poll.get() as usize
+                || items_collected >= self.max_items_per_decision.get() as usize
+            {
+                trace!(
+                    "Reached limits of a single DRR decision. num_items={} qids_in_decision={}",
+                    decision.total_items(),
+                    decision.num_queues()
+                );
+                break;
             }
 
-            let now = self.datum.now_ts();
-            while self.remaining_in_round > 0 {
-                // bail if we exhausted coop budget.
-                let coop = match tokio::task::coop::poll_proceed(cx) {
-                    Poll::Ready(coop) => coop,
-                    Poll::Pending => break 'scheduler,
-                };
-                // stop when we have enough queues picked
-                if decision.len() >= self.limit_qid_per_poll.get() as usize {
-                    break 'scheduler;
-                }
+            let this = self.as_mut().project();
 
-                let this = self.as_mut().project();
-                let qid = this.eligible.front().copied().unwrap();
-                let Some(qstate) = this.q.get_mut(&qid) else {
-                    // the vqueue has been removed probably it's empty therefore, it's
-                    // safe to assume that it's not eligible.
-                    *this.remaining_in_round -= 1;
-                    this.eligible.pop_front();
+            let Some(handle) = this.eligible.next_eligible(this.storage, this.q, vqueues)? else {
+                trace!(
+                    "No more eligible vqueues, {:?}, states_len={}, states_capacity={}",
+                    this.eligible,
+                    this.q.len(),
+                    this.q.capacity()
+                );
+                break;
+            };
+
+            if first_blocked.is_some_and(|first| first == handle) {
+                // do not check the same vqueue twice for capacity in the same poll.
+                break;
+            }
+
+            let qstate = this.q.get_mut(handle).unwrap();
+
+            match qstate.pop_unchecked(
+                cx,
+                this.storage,
+                this.concurrency_limiter,
+                this.global_throttling.as_ref(),
+            )? {
+                Pop::DeficitExhausted => {
+                    this.eligible.rotate_one();
                     continue;
-                };
-
-                let meta = vqueues.get_vqueue(&qid).unwrap();
-                let config = configs.find(&qid.parent);
-
-                qstate.deficit.adjust(*this.global_sched_round);
-                let mut assignments = Assignments::default();
-                let outcome = 'single_vqueue: loop {
-                    // get concurrency token, but only if it's still eligible.
-                    qstate.poll_head(this.storage, meta)?;
-                    match qstate.check_eligibility(now, meta, config) {
-                        Eligibility::NotEligible => {
-                            // not eligible,
-                            *this.remaining_in_round -= 1;
-                            qstate.on_not_eligible(this.delayed_eligibility);
-                            this.eligible.pop_front();
-                            // check if the vqueue became inactive. This happens after
-                            // we drain the running set
-                            if !qstate.is_active(meta) {
-                                // remove it.
-                                this.q.remove(&qid);
-                            }
-                            break 'single_vqueue Outcome::ContinueRound;
-                        }
-                        Eligibility::EligibleAt(wake_up_at) => {
-                            *this.remaining_in_round -= 1;
-                            qstate.maybe_schedule_wakeup(
-                                this.datum.ts_to_future_instant(wake_up_at),
-                                this.delayed_eligibility,
-                            );
-                            this.eligible.pop_front();
-                            break 'single_vqueue Outcome::ContinueRound;
-                        }
-                        Eligibility::Eligible if !qstate.deficit.can_spend() => {
-                            // we'll get credit on the next round
-                            *this.remaining_in_round -= 1;
-                            this.eligible.rotate_left(1);
-                            break 'single_vqueue Outcome::ContinueRound;
-                        }
-                        Eligibility::Eligible => { /* fallthrough */ }
-                    }
-
-                    // Acquire a global concurrency token
-                    // todo consider not requiring concurrency tokens for state mutations
-                    if this
-                        .concurrency_limiter
-                        .poll_and_merge(cx, this.unconfirmed_capacity_permits)
-                        .is_pending()
-                    {
-                        // Waker will be notified when capacity is available.
-                        // will abort the entire scheduler loop after recording the accumulated
-                        // assignments.
-                        break 'single_vqueue Outcome::Abort;
-                    }
-
-                    // todo(asoli): We need to check if the decision requires a concurrency permit or not.
-                    // For instance, we currently still acquire a concurrency token on `yield`
-                    // which leaks invoker tokens. Additionally, in other scenarios, we might need
-                    // to acquire additional permits for other resources depending on the kind of
-                    // the item we are picking.
-
-                    // we have concurrency token, let's pick an item
-                    qstate.pop_unchecked(this.storage, &mut assignments)?;
-                    qstate.deficit.consume_one();
-                };
-
-                if !assignments.is_empty() {
-                    coop.made_progress();
-                    // merge into the overall decision
-                    match decision.entry(qid) {
-                        hash_map::Entry::Occupied(mut entry) => {
-                            entry.get_mut().merge(assignments);
-                        }
-                        hash_map::Entry::Vacant(entry) => {
-                            entry.insert(assignments);
-                        }
-                    }
                 }
-
-                // Depending on whether we stopped because we cannot acquire concurrency
-                // permit or because we exhausted the inbox/budget, we decide to bail out
-                // of the scheduler loop or not.
-                match outcome {
-                    // keep driving the scheduler loop
-                    Outcome::ContinueRound => {}
-                    Outcome::Abort => {
-                        break 'scheduler;
+                Pop::Item {
+                    action,
+                    entry,
+                    updated_zt,
+                } => {
+                    coop.made_progress();
+                    items_collected += 1;
+                    decision.push(&qstate.qid, action, entry, updated_zt);
+                    // We need to set the state so we check eligibility and setup
+                    // necessary schedules when we poll the queue again.
+                    this.eligible.front_needs_poll();
+                }
+                Pop::Throttle { delay, scope } => {
+                    this.eligible.front_throttled(delay, scope);
+                    continue;
+                }
+                Pop::BlockedOnCapacity => {
+                    if first_blocked.is_none() {
+                        first_blocked = Some(handle);
                     }
+                    this.eligible.front_blocked();
+                    // stay in ready ring
+                    this.eligible.rotate_one();
+                    continue;
                 }
             }
         }
 
         if decision.is_empty() {
+            if self.last_report.elapsed() >= Duration::from_secs(10) {
+                vqueues.report();
+                self.report();
+                // also report vqueues states
+                self.last_report = Instant::now();
+                self.eligible.compact_memory();
+            }
+
             self.waker.clone_from(cx.waker());
             Poll::Pending
         } else {
-            let decision = Decision(decision);
             decision.report_metrics();
             Poll::Ready(Ok(decision))
-        }
-    }
-
-    pub fn confirm_assignment(&mut self, qid: &VQueueId, item_hash: u64) -> Option<Permit<Token>> {
-        if let Some(qstate) = self.q.get_mut(qid)
-            && qstate.remove_from_unconfirmed_assignments(item_hash)
-        {
-            counter!(VQUEUE_RUN_CONFIRMED).increment(1);
-            debug_assert!(!self.unconfirmed_capacity_permits.is_empty());
-            Some(self.unconfirmed_capacity_permits.split(1).expect(
-                "trying to confirm a vqueue item after consuming all allotted concurrency tokens!",
-            ))
-        } else {
-            None
         }
     }
 
@@ -334,39 +233,52 @@ where
         let qid = event.qid;
         match event.details {
             EventDetails::Enqueued(ref item) => {
-                let qstate = self
-                    .q
-                    .entry_ref(&qid)
-                    .or_insert_with(|| VQueueState::new_empty(qid, self.global_sched_round));
-
                 let config = vqueues.config_pool().find(&qid.parent);
                 let meta = vqueues.get_vqueue(&qid).unwrap();
 
-                counter!(VQUEUE_ENQUEUE).increment(1);
-                if !qstate.notify_enqueued(item) {
-                    // no impact on eligibility, no need to spend more cycles.
-                    return Ok(());
-                }
+                let qstate = match self.id_lookup.get(&qid) {
+                    Some(handle) => match self.q.get_mut(*handle) {
+                        Some(qstate) => qstate,
+                        None => {
+                            let handle = self.q.insert_with_key(|handle| {
+                                VQueueState::new_empty(qid, handle, meta, config)
+                            });
+                            self.id_lookup.insert(qid, handle);
+                            self.q.get_mut(handle).unwrap()
+                        }
+                    },
+                    None => {
+                        let handle = self.q.insert_with_key(|handle| {
+                            VQueueState::new_empty(qid, handle, meta, config)
+                        });
+                        self.id_lookup.insert(qid, handle);
+                        self.q.get_mut(handle).unwrap()
+                    }
+                };
 
-                let now_ts = self.datum.now_ts();
-                match qstate.check_eligibility(now_ts, meta, config) {
-                    Eligibility::Eligible if !self.eligible.contains(&qid) => {
-                        // Make eligible immediately.
-                        qstate.deficit.set_last_round(self.global_sched_round);
-                        self.eligible.push_back(qid);
-                        self.wake_up();
-                    }
-                    Eligibility::EligibleAt(eligiblility_ts) if !self.eligible.contains(&qid) => {
-                        qstate.maybe_schedule_wakeup(
-                            self.datum.ts_to_future_instant(eligiblility_ts),
-                            &mut self.delayed_eligibility,
-                        );
-                    }
-                    _ => { /* do nothing */ }
+                counter!(VQUEUE_ENQUEUE).increment(1);
+                if qstate.notify_enqueued(item)
+                    && self.eligible.refresh_membership(qstate, meta, config)
+                {
+                    self.wake_up();
+                }
+            }
+            EventDetails::RunAttemptConfirmed { item_hash } => {
+                let Some(handle) = self.id_lookup.get(&qid) else {
+                    return Ok(());
+                };
+                let Some(qstate) = self.q.get_mut(*handle) else {
+                    return Ok(());
+                };
+                if qstate.remove_from_unconfirmed_assignments(item_hash) {
+                    counter!(VQUEUE_RUN_CONFIRMED).increment(1);
                 }
             }
             EventDetails::RunAttemptRejected { item_hash } => {
-                let Some(qstate) = self.q.get_mut(&qid) else {
+                let Some(handle) = self.id_lookup.get(&qid) else {
+                    return Ok(());
+                };
+                let Some(qstate) = self.q.get_mut(*handle) else {
                     return Ok(());
                 };
                 let config = vqueues.config_pool().find(&qid.parent);
@@ -374,59 +286,35 @@ where
 
                 if qstate.remove_from_unconfirmed_assignments(item_hash) {
                     counter!(VQUEUE_RUN_REJECTED).increment(1);
-                    // drop the already acquired permit
-                    let _ = self.unconfirmed_capacity_permits.split(1);
 
-                    if qstate
-                        .check_eligibility(self.datum.now_ts(), meta, config)
-                        .is_eligible()
-                    {
-                        if !self.eligible.contains(&qid) {
-                            self.eligible.push_back(qid);
-                            qstate.deficit.set_last_round(self.global_sched_round);
-                            self.wake_up();
-                        }
-                    } else if qstate.is_empty(meta) {
+                    if qstate.is_dormant(meta) {
                         // retire the vqueue state
-                        self.q.remove(&qid);
+                        self.q.remove(*handle);
+                        self.id_lookup.remove(&qid);
+                    } else if self.eligible.refresh_membership(qstate, meta, config) {
+                        self.wake_up();
                     }
                 }
             }
             EventDetails::Removed { item_hash } => {
-                let Some(qstate) = self.q.get_mut(&qid) else {
+                let Some(handle) = self.id_lookup.get(&qid) else {
+                    return Ok(());
+                };
+                let Some(qstate) = self.q.get_mut(*handle) else {
                     return Ok(());
                 };
                 let config = vqueues.config_pool().find(&qid.parent);
                 let meta = vqueues.get_vqueue(&qid).unwrap();
 
-                if qstate.remove_from_unconfirmed_assignments(item_hash) {
-                    // drop the already acquired permit
-                    let _ = self.unconfirmed_capacity_permits.split(1);
-                }
+                let _ = qstate.remove_from_unconfirmed_assignments(item_hash);
                 qstate.notify_removed(item_hash);
 
-                if qstate.is_empty(meta) {
+                if qstate.is_dormant(meta) {
                     // retire the vqueue state
-                    self.q.remove(&qid);
-                    return Ok(());
-                }
-
-                // perhaps we became eligible because this entry's removal released a concurrency
-                // token that we needed.
-                match qstate.check_eligibility(self.datum.now_ts(), meta, config) {
-                    Eligibility::Eligible if !self.eligible.contains(&qid) => {
-                        // Make eligible immediately.
-                        qstate.deficit.set_last_round(self.global_sched_round);
-                        self.eligible.push_back(qid);
-                        self.waker.wake_by_ref();
-                    }
-                    Eligibility::EligibleAt(eligiblility_ts) if !self.eligible.contains(&qid) => {
-                        qstate.maybe_schedule_wakeup(
-                            self.datum.ts_to_future_instant(eligiblility_ts),
-                            &mut self.delayed_eligibility,
-                        );
-                    }
-                    _ => { /* do nothing */ }
+                    self.q.remove(*handle);
+                    self.id_lookup.remove(&qid);
+                } else if self.eligible.refresh_membership(qstate, meta, config) {
+                    self.wake_up();
                 }
             }
         }

--- a/crates/vqueues/src/scheduler/eligible.rs
+++ b/crates/vqueues/src/scheduler/eligible.rs
@@ -1,0 +1,367 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cmp::Ordering;
+use std::collections::VecDeque;
+use std::task::Poll;
+use std::time::Duration;
+
+use slotmap::{SecondaryMap, SlotMap};
+use tokio_util::time::{DelayQueue, delay_queue};
+use tracing::trace;
+
+use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::VQueueStore;
+use restate_storage_api::vqueue_table::metadata::VQueueMeta;
+use restate_types::clock::UniqueTimestamp;
+
+use crate::VQueuesMeta;
+use crate::scheduler::vqueue_state::Eligibility;
+use crate::vqueue_config::VQueueConfig;
+
+use super::clock::SchedulerClock;
+use super::vqueue_state::VQueueState;
+use super::{ThrottleScope, VQueueHandle};
+
+#[derive(Debug, Copy, Clone)]
+struct WakeUp {
+    ts: UniqueTimestamp,
+    timer_key: delay_queue::Key,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum State {
+    /// Needs a `poll_eligibility` to update the state
+    NeedsPoll,
+    // Poll to pick next item. Next item is available now. It's in the ready ring.
+    Ready,
+    /// Can't dequeue items until wake_up point
+    Throttled {
+        wake_up: WakeUp,
+        #[allow(dead_code)]
+        scope: ThrottleScope,
+    },
+    /// Next item is scheduled (maybe this should be in head status?)
+    Scheduled {
+        wake_up: WakeUp,
+    },
+    BlockedOnCapacity,
+}
+
+#[derive(derive_more::Debug)]
+pub struct EligibilityTracker {
+    #[debug(skip)]
+    delayed_eligibility: DelayQueue<VQueueHandle>,
+    ready_ring: VecDeque<VQueueHandle>,
+    #[debug(skip)]
+    states: SecondaryMap<VQueueHandle, State>,
+}
+
+impl EligibilityTracker {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            delayed_eligibility: DelayQueue::with_capacity(capacity),
+            ready_ring: VecDeque::with_capacity(capacity),
+            states: SecondaryMap::with_capacity(capacity),
+        }
+    }
+
+    pub fn insert_eligible(&mut self, handle: VQueueHandle) {
+        self.states.insert(handle, State::NeedsPoll);
+        self.ready_ring.push_back(handle);
+    }
+
+    pub fn poll_delayed(&mut self, cx: &mut std::task::Context<'_>) {
+        while let Poll::Ready(Some(expired)) = self.delayed_eligibility.poll_expired(cx) {
+            let timer_key = expired.key();
+            let handle = expired.into_inner();
+            if let Some(state) = self.states.get_mut(handle) {
+                match state {
+                    State::Throttled { wake_up, .. } if wake_up.timer_key == timer_key => {
+                        debug_assert!(!self.ready_ring.contains(&handle));
+                        *state = State::NeedsPoll;
+                        self.ready_ring.push_back(handle);
+                    }
+                    State::Scheduled { wake_up } if wake_up.timer_key == timer_key => {
+                        *state = State::NeedsPoll;
+                        debug_assert!(!self.ready_ring.contains(&handle));
+                        self.ready_ring.push_back(handle);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    pub fn next_eligible<S>(
+        &mut self,
+        storage: &S,
+        vqueues: &mut SlotMap<VQueueHandle, VQueueState<S>>,
+        cache: VQueuesMeta<'_>,
+    ) -> Result<Option<VQueueHandle>, StorageError>
+    where
+        S: VQueueStore,
+        S::Item: std::fmt::Debug,
+    {
+        loop {
+            // what is my current status
+            let Some(handle) = self.ready_ring.front().copied() else {
+                return Ok(None);
+            };
+
+            let Some(qstate) = vqueues.get_mut(handle) else {
+                // the vqueue has been removed probably it's empty therefore, it's
+                // safe to assume that it's not eligible.
+                self.remove(handle);
+                self.ready_ring.pop_front();
+                continue;
+            };
+
+            let current_state = self
+                .states
+                .get_mut(handle)
+                .expect("eligible must have state");
+
+            let meta = cache.get_vqueue(&qstate.qid).unwrap();
+            match current_state {
+                State::NeedsPoll => {
+                    let config = cache.config_pool().find(&qstate.qid.parent);
+                    // update the state based on eligibility.
+                    match qstate.poll_eligibility(storage, SchedulerClock.now_ts(), meta, config)? {
+                        Eligibility::Eligible => {
+                            *current_state = State::Ready;
+                            return Ok(Some(handle));
+                        }
+                        Eligibility::EligibleAt(ts) => {
+                            let instant = SchedulerClock.ts_to_future_instant(ts);
+                            let timer_key = self.delayed_eligibility.insert_at(handle, instant);
+                            *current_state = State::Scheduled {
+                                wake_up: WakeUp { ts, timer_key },
+                            };
+                            self.ready_ring.pop_front();
+                            continue;
+                        }
+                        Eligibility::NotEligible => {
+                            self.ready_ring.pop_front();
+                            self.remove(handle);
+                            continue;
+                        }
+                    }
+                }
+                State::Ready | State::BlockedOnCapacity => {
+                    return Ok(Some(handle));
+                }
+                State::Throttled { .. } | State::Scheduled { .. } => {
+                    self.ready_ring.pop_front();
+                    continue;
+                }
+            }
+        }
+    }
+
+    fn remove(&mut self, handle: VQueueHandle) {
+        match self.states.remove(handle) {
+            // cancel scheduled wake ups
+            Some(State::Throttled { wake_up, .. }) => {
+                self.delayed_eligibility.remove(&wake_up.timer_key);
+            }
+            Some(State::Scheduled { wake_up }) => {
+                self.delayed_eligibility.remove(&wake_up.timer_key);
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns true if scheduler should be woken up
+    pub fn refresh_membership<S>(
+        &mut self,
+        vqueue: &VQueueState<S>,
+        meta: &VQueueMeta,
+        config: &VQueueConfig,
+    ) -> bool
+    where
+        S: VQueueStore,
+        S::Item: std::fmt::Debug,
+    {
+        let current_state = self.states.get(vqueue.handle).copied();
+        let eligibility = vqueue.check_eligibility(SchedulerClock.now_ts(), meta, config);
+
+        match (current_state, eligibility) {
+            // --
+            // Cases where we have NO state, we set the state and register membership in
+            // ready_ring accordingly.
+            // --
+            //
+            // should make it eligible, add to ready ring.
+            (None, Eligibility::Eligible) => {
+                self.states.insert(vqueue.handle, State::NeedsPoll);
+                self.ready_ring.push_back(vqueue.handle);
+                // should wake up
+                true
+            }
+            // add state, but not ready ring.
+            (None, Eligibility::EligibleAt(eligible_at)) => {
+                self.states.insert(
+                    vqueue.handle,
+                    State::Scheduled {
+                        wake_up: WakeUp {
+                            ts: eligible_at,
+                            timer_key: self.delayed_eligibility.insert_at(
+                                vqueue.handle,
+                                SchedulerClock.ts_to_future_instant(eligible_at),
+                            ),
+                        },
+                    },
+                );
+                false
+            }
+            // it wasn't ready, and it's also not ready now, do nothing.
+            (None, Eligibility::NotEligible) => false,
+            // --
+            // Cases where we have state, we deduce the action from the state and eligibility
+            // and issue a corrective action
+            // --
+            (
+                // needs poll will configure the state anyway.
+                Some(State::NeedsPoll),
+                _,
+            ) => false,
+            (
+                Some(State::Ready | State::BlockedOnCapacity | State::Throttled { .. }),
+                Eligibility::Eligible,
+            ) => {
+                // we are already good. Note that if we were throttled, we continue to be throttled
+                // as throttling is only determined by the pop() operation and not calculated from
+                // eligibility. Additionally, we only throttle after we become eligible anyway.
+                false
+            }
+            // we were scheduled, but became available (now)
+            (Some(State::Scheduled { wake_up }), Eligibility::Eligible) => {
+                self.delayed_eligibility.remove(&wake_up.timer_key);
+                self.ready_ring.push_back(vqueue.handle);
+                self.states.insert(vqueue.handle, State::NeedsPoll);
+                true
+            }
+
+            (
+                Some(State::Ready | State::BlockedOnCapacity),
+                Eligibility::EligibleAt(..) | Eligibility::NotEligible,
+            ) => {
+                // Switching to NeedsPoll to register the timer on the next poll
+                self.states.insert(vqueue.handle, State::NeedsPoll);
+                // no need to wake up because we were already ready
+                false
+            }
+            // We were scheduled as we should, but make sure that the time point is still the same
+            (Some(State::Scheduled { wake_up }), Eligibility::EligibleAt(eligible_at_ts)) => {
+                if eligible_at_ts.cmp_physical(&wake_up.ts) != Ordering::Equal {
+                    self.delayed_eligibility.reset_at(
+                        &wake_up.timer_key,
+                        SchedulerClock.ts_to_future_instant(eligible_at_ts),
+                    );
+                    self.states.insert(
+                        vqueue.handle,
+                        State::Scheduled {
+                            wake_up: WakeUp {
+                                ts: eligible_at_ts,
+                                timer_key: wake_up.timer_key,
+                            },
+                        },
+                    );
+                }
+                false
+            }
+
+            (Some(State::Throttled { wake_up, .. }), Eligibility::EligibleAt(eligible_at_ts)) => {
+                // We move away from throttled only if the new time point is _after_ the
+                // end of the throttling period.
+                if eligible_at_ts > wake_up.ts {
+                    // Reschedule the timer as the new eligibility is further in the future
+                    self.delayed_eligibility.reset_at(
+                        &wake_up.timer_key,
+                        SchedulerClock.ts_to_future_instant(eligible_at_ts),
+                    );
+                    self.states.insert(
+                        vqueue.handle,
+                        State::Scheduled {
+                            wake_up: WakeUp {
+                                ts: eligible_at_ts,
+                                timer_key: wake_up.timer_key,
+                            },
+                        },
+                    );
+                }
+                false
+            }
+
+            // If we were throttled/scheduled and we are confident that are no longer eligible,
+            // then we simply cancel the wake up timer
+            (
+                Some(State::Scheduled { wake_up } | State::Throttled { wake_up, .. }),
+                Eligibility::NotEligible,
+            ) => {
+                self.delayed_eligibility.remove(&wake_up.timer_key);
+                self.states.remove(vqueue.handle);
+                false
+            }
+        }
+    }
+
+    pub fn rotate_one(&mut self) {
+        self.ready_ring.rotate_left(1);
+    }
+
+    pub fn len(&self) -> usize {
+        self.ready_ring.len()
+    }
+
+    pub fn front_needs_poll(&mut self) {
+        if let Some(handle) = self.ready_ring.front()
+            && let Some(state) = self.states.get_mut(*handle)
+        {
+            *state = State::NeedsPoll;
+        }
+    }
+
+    pub fn front_blocked(&mut self) {
+        if let Some(handle) = self.ready_ring.front()
+            && let Some(state) = self.states.get_mut(*handle)
+        {
+            *state = State::BlockedOnCapacity;
+        }
+    }
+
+    pub fn front_throttled(&mut self, delay: Duration, scope: ThrottleScope) {
+        if let Some(handle) = self.ready_ring.front() {
+            let now = SchedulerClock.now_ts();
+            let wake_up_ts = now.add_millis(delay.as_millis() as u64).unwrap_or(now);
+
+            let old = self.states.insert(
+                *handle,
+                State::Throttled {
+                    scope,
+                    wake_up: WakeUp {
+                        ts: wake_up_ts,
+                        timer_key: self.delayed_eligibility.insert(*handle, delay),
+                    },
+                },
+            );
+            trace!("{handle:?} is being throttled for {delay:?} in throttling scope {scope:?}");
+            // cancel the previous timer
+            if let Some(State::Throttled { wake_up, .. } | State::Scheduled { wake_up }) = old {
+                self.delayed_eligibility.remove(&wake_up.timer_key);
+            }
+        }
+    }
+
+    pub fn compact_memory(&mut self) {
+        self.delayed_eligibility.compact();
+    }
+}

--- a/crates/vqueues/src/scheduler/queue.rs
+++ b/crates/vqueues/src/scheduler/queue.rs
@@ -1,0 +1,266 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use hashbrown::HashSet;
+
+use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::{VQueueCursor, VQueueEntry, VQueueStore};
+use restate_types::vqueue::VQueueId;
+
+#[derive(Debug)]
+enum Head<Item> {
+    /// We need a seek+read to know the head.
+    Unknown,
+    /// The current cursor's head
+    Known(Item),
+    /// We know that we've reached the end of the vqueue
+    Empty,
+}
+
+pub enum QueueItem<Item> {
+    Inbox(Item),
+    Running(Item),
+    None,
+}
+
+#[derive(derive_more::Debug)]
+pub(crate) enum Reader<S: VQueueStore> {
+    /// Reader was never opened and might need to scan running items
+    New { already_running: u32 },
+    #[debug("Running")]
+    Running {
+        remaining: u32,
+        reader: S::RunningReader,
+    },
+    #[debug("Inbox")]
+    Inbox(S::InboxReader),
+    // We can transition back to Reader::Inbox if new items have been added to the inbox
+    // but we should never return to `Running`.
+    #[debug("Closed")]
+    Closed,
+}
+
+pub(crate) struct Queue<S: VQueueStore> {
+    head: Head<S::Item>,
+    reader: Reader<S>,
+}
+
+impl<S: VQueueStore> Queue<S> {
+    /// Creates a new queue that must first go through the given number of running items
+    /// before it switches to reading the waiting inbox.
+    pub fn new(num_running: u32) -> Self {
+        Self {
+            head: Head::Unknown,
+            reader: Reader::New {
+                already_running: num_running,
+            },
+        }
+    }
+
+    /// Creates an empty queue
+    pub fn new_closed() -> Self {
+        Self {
+            head: Head::Empty,
+            reader: Reader::Closed,
+        }
+    }
+
+    /// If the queue is known to be empty (no more items to dequeue)
+    pub fn is_empty(&self) -> bool {
+        matches!(self.head, Head::Empty)
+    }
+
+    pub fn remove(&mut self, item_hash: u64) -> bool {
+        // Can this be the known head?
+        // Yes. Perhaps it expired/ended externally.
+        if let Head::Known(ref item) = self.head
+            && item.unique_hash() == item_hash
+        {
+            self.head = Head::Unknown;
+            // Ensure that next advance would re-seek to the newly added item
+            self.reader = Reader::Closed;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if the head was changed
+    pub fn enqueue(&mut self, item: &S::Item) -> bool {
+        match (&self.head, &self.reader) {
+            // we are only unknown if we are new and didn't read the running list yet,
+            // we might also be in a limbo state if advance() failed.
+            (_, Reader::New { .. } | Reader::Running { .. }) => { /* do nothing */ }
+            (Head::Unknown, _) => { /* do nothing */ }
+            (Head::Empty, _) => {
+                self.reader = Reader::Closed;
+                self.head = Head::Known(item.clone());
+                return true;
+            }
+            (Head::Known(current), Reader::Inbox(_) | Reader::Closed) => {
+                if item < current {
+                    self.head = Head::Known(item.clone());
+                    // Ensure that next advance would re-seek to the newly added item
+                    self.reader = Reader::Closed;
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Returns the head if known, or None if the queue needs advancing
+    pub fn head(&self) -> Option<QueueItem<&S::Item>> {
+        match (&self.head, &self.reader) {
+            (Head::Unknown, _) => None,
+            (_, Reader::New { .. }) => None,
+            (Head::Known(item), Reader::Running { .. }) => Some(QueueItem::Running(item)),
+            (Head::Known(item), Reader::Inbox(_) | Reader::Closed) => Some(QueueItem::Inbox(item)),
+            (Head::Empty, _) => Some(QueueItem::None),
+        }
+    }
+
+    pub fn advance_if_needed(
+        &mut self,
+        storage: &S,
+        skip: &HashSet<u64>,
+        qid: &VQueueId,
+    ) -> Result<QueueItem<&S::Item>, StorageError> {
+        // Keep advancing until the head is known
+        while matches!(self.head, Head::Unknown) {
+            self.advance(storage, skip, qid)?;
+        }
+
+        match (&self.head, &self.reader) {
+            (Head::Unknown, _) => unreachable!("head must be known"),
+            (_, Reader::New { .. }) => unreachable!("reader cannot be new after poll"),
+            (Head::Known(item), Reader::Running { .. }) => Ok(QueueItem::Running(item)),
+            (Head::Known(item), Reader::Inbox(_) | Reader::Closed) => Ok(QueueItem::Inbox(item)),
+            (Head::Empty, _) => Ok(QueueItem::None),
+        }
+    }
+
+    /// Advances the queue to the next item.
+    ///
+    /// The queue reader will skip over items in `skip` when reading the inbox stage. When reading
+    /// the running stage, the `skip` set is ignored.
+    pub fn advance(
+        &mut self,
+        storage: &S,
+        skip: &HashSet<u64>,
+        qid: &VQueueId,
+    ) -> Result<(), StorageError> {
+        loop {
+            match self.reader {
+                Reader::New { already_running } if already_running > 0 => {
+                    let mut reader = storage.new_run_reader(qid);
+                    reader.seek_to_first();
+                    let item = reader.peek()?;
+                    if let Some(item) = item {
+                        self.head = Head::Known(item);
+                        self.reader = Reader::Running {
+                            remaining: already_running,
+                            reader,
+                        };
+                        break;
+                    } else {
+                        assert!(
+                            already_running > 0,
+                            "vqueue {qid:?} has no running items but its metadata says that it has {already_running} running items",
+                        );
+                        // move to inbox reading
+                        self.head = Head::Unknown;
+                        self.reader = Reader::Closed;
+                    }
+                }
+                Reader::New { .. } => {
+                    // create new inbox reader
+                    self.reader = Reader::Closed;
+                }
+                Reader::Running {
+                    ref mut reader,
+                    ref mut remaining,
+                } => {
+                    reader.advance();
+                    *remaining = remaining.saturating_sub(1);
+                    let item = reader.peek()?;
+                    if let Some(item) = item {
+                        debug_assert!(*remaining > 0);
+                        self.head = Head::Known(item);
+                        break;
+                    } else {
+                        debug_assert_eq!(0, *remaining);
+                        // move to inbox reading
+                        self.head = Head::Unknown;
+                        self.reader = Reader::Closed;
+                    }
+                }
+                Reader::Inbox(ref mut reader) => {
+                    reader.advance();
+                    let item = reader.peek()?;
+                    if let Some(item) = item {
+                        if skip.contains(&item.unique_hash()) {
+                            continue;
+                        }
+                        self.head = Head::Known(item);
+                        break;
+                    } else {
+                        // we are done reading inbox
+                        self.head = Head::Empty;
+                        self.reader = Reader::Closed;
+                        break;
+                    }
+                }
+                Reader::Closed => {
+                    match self.head {
+                        Head::Unknown => {
+                            let mut reader = storage.new_inbox_reader(qid);
+                            reader.seek_to_first();
+                            let item = reader.peek()?;
+                            self.reader = Reader::Inbox(reader);
+                            if let Some(item) = item {
+                                if skip.contains(&item.unique_hash()) {
+                                    continue;
+                                }
+                                self.head = Head::Known(item);
+                                break;
+                            } else {
+                                self.head = Head::Empty;
+                                self.reader = Reader::Closed;
+                            }
+                        }
+                        Head::Known(ref item) => {
+                            // seek to known head first, then advance.
+                            let mut reader = storage.new_inbox_reader(qid);
+                            reader.seek_after(qid, item);
+                            let item = reader.peek()?;
+                            self.reader = Reader::Inbox(reader);
+                            if let Some(item) = item {
+                                if skip.contains(&item.unique_hash()) {
+                                    continue;
+                                }
+                                self.head = Head::Known(item);
+                                break;
+                            } else {
+                                self.head = Head::Empty;
+                                self.reader = Reader::Closed;
+                            }
+                        }
+                        Head::Empty => {
+                            // do nothing.
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/vqueues/src/scheduler/vqueue_state.rs
+++ b/crates/vqueues/src/scheduler/vqueue_state.rs
@@ -8,48 +8,50 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use hashbrown::HashSet;
-use tokio::time::Instant;
-use tokio_util::time::{DelayQueue, delay_queue};
-use tracing::{error, trace};
+use std::task::Poll;
+use std::time::Duration;
 
+use gardal::LocalTokenBucket;
+use hashbrown::HashSet;
+use metrics::counter;
+use tokio::time::Instant;
+use tracing::{debug, trace};
+
+use restate_futures_util::concurrency::{Concurrency, Permit};
 use restate_storage_api::StorageError;
 use restate_storage_api::vqueue_table::metadata::VQueueMeta;
-use restate_storage_api::vqueue_table::{VQueueCursor, VQueueEntry, VQueueStore, VisibleAt};
+use restate_storage_api::vqueue_table::{
+    EntryKind, VQueueEntry, VQueueStore, VisibleAt, WaitStats,
+};
 use restate_types::clock::UniqueTimestamp;
 use restate_types::vqueue::VQueueId;
 
-use super::Assignments;
+use crate::metric_definitions::{
+    VQUEUE_GLOBAL_THROTTLE_WAIT_MS, VQUEUE_INVOKER_CAPACITY_WAIT_MS, VQUEUE_LOCAL_THROTTLE_WAIT_MS,
+};
 use crate::scheduler::Action;
+use crate::scheduler::queue::QueueItem;
 use crate::vqueue_config::VQueueConfig;
 
-pub(super) const QUANTUM: i32 = 4;
+use super::clock::SchedulerClock;
+use super::queue::Queue;
+use super::{Entry, GlobalTokenBucket, ThrottleScope, VQueueHandle};
 
-#[derive(derive_more::Debug)]
-enum Reader<S: VQueueStore> {
-    /// Reader was never opened and might need to scan running items
-    New { already_running: u32 },
-    #[debug("Running")]
-    Running {
-        remaining: u32,
-        reader: S::RunningReader,
+const QUANTUM: i32 = 1;
+
+pub enum Pop<Item> {
+    DeficitExhausted,
+    Item {
+        action: Action,
+        entry: Entry<Item>,
+        updated_zt: Option<f64>,
     },
-    #[debug("Inbox")]
-    Inbox(S::InboxReader),
-    // We can transition back to Reader::Inbox if new items have been added to the inbox
-    // but we should never return to `Running`.
-    #[debug("Closed")]
-    Closed,
-}
-
-#[derive(Debug)]
-enum HeadStatus<Item> {
-    /// We need a seek+read to know the head.
-    Unknown,
-    /// The current cursor's head
-    Known(Item),
-    /// We know that we've reached the end of the vqueue
-    Empty,
+    Throttle {
+        delay: Duration,
+        /// the reason for throttling
+        scope: ThrottleScope,
+    },
+    BlockedOnCapacity,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::IsVariant)]
@@ -59,16 +61,83 @@ pub(super) enum Eligibility {
     NotEligible,
 }
 
+#[derive(Debug, Default)]
+struct Stats {
+    last_blocked_on_global_capacity: Option<tokio::time::Instant>,
+    blocked_on_global_capacity_micros: u32,
+    local_start_throttling_micros: u32,
+    global_throttling_micros: u32,
+}
+impl Stats {
+    fn reset(&mut self) {
+        self.last_blocked_on_global_capacity = None;
+        self.blocked_on_global_capacity_micros = 0;
+        self.local_start_throttling_micros = 0;
+        self.global_throttling_micros = 0;
+    }
+
+    fn finalize(&mut self) -> WaitStats {
+        // ensures that the last capacity-blocked segment is accounted for
+        self.record_global_capacity_delay(false);
+
+        let stats = WaitStats {
+            blocked_on_global_capacity_ms: self.blocked_on_global_capacity_micros / 1000,
+            vqueue_start_throttling_ms: self.local_start_throttling_micros / 1000,
+            global_throttling_ms: self.global_throttling_micros / 1000,
+        };
+        self.reset();
+
+        stats
+    }
+}
+
+impl Stats {
+    fn record_start_throttling_delay(&mut self, delay: &Duration) {
+        self.record_global_capacity_delay(false);
+        counter!(VQUEUE_LOCAL_THROTTLE_WAIT_MS).increment(delay.as_millis() as u64);
+        self.local_start_throttling_micros = self
+            .local_start_throttling_micros
+            .saturating_add(delay.as_micros().try_into().unwrap_or(u32::MAX))
+    }
+
+    fn record_global_throttling_delay(&mut self, delay: &Duration) {
+        self.record_global_capacity_delay(false);
+        counter!(VQUEUE_GLOBAL_THROTTLE_WAIT_MS).increment(delay.as_millis() as u64);
+        self.global_throttling_micros = self
+            .global_throttling_micros
+            .saturating_add(delay.as_micros().try_into().unwrap_or(u32::MAX))
+    }
+
+    fn record_global_capacity_delay(&mut self, is_now_blocked: bool) {
+        let last = self.last_blocked_on_global_capacity.take();
+        self.last_blocked_on_global_capacity = if is_now_blocked {
+            Some(Instant::now())
+        } else {
+            None
+        };
+        if let Some(last) = last {
+            let delay = last.elapsed();
+            counter!(VQUEUE_INVOKER_CAPACITY_WAIT_MS).increment(delay.as_millis() as u64);
+            self.blocked_on_global_capacity_micros = self
+                .blocked_on_global_capacity_micros
+                .saturating_add(delay.as_micros().try_into().unwrap_or(u32::MAX))
+        }
+    }
+}
+
 #[derive(derive_more::Debug)]
 pub struct VQueueState<S: VQueueStore> {
-    qid: VQueueId,
-    #[debug(skip)]
-    reader: Reader<S>,
+    pub handle: VQueueHandle,
+    pub qid: VQueueId,
     // contains hashes (unique_hash)
+    deficit: i32,
+    #[debug(skip)]
+    // Run token bucket is used to throttle the rate of "start" attempts of this
+    // vqueue.
+    start_tb: Option<LocalTokenBucket<SchedulerClock>>,
     unconfirmed_assignments: HashSet<u64>,
-    pub(super) deficit: Deficit,
-    head: HeadStatus<S::Item>,
-    wake_up_after: Option<WakeUp>,
+    queue: Queue<S>,
+    head_stats: Stats,
 }
 
 impl<S> VQueueState<S>
@@ -76,228 +145,203 @@ where
     S: VQueueStore,
     S::Item: std::fmt::Debug,
 {
-    pub fn new(qid: VQueueId, already_running: u32) -> Self {
+    pub fn new(
+        qid: VQueueId,
+        handle: VQueueHandle,
+        meta: &VQueueMeta,
+        config: &VQueueConfig,
+    ) -> Self {
+        let start_tb = config.start_rate_limit().map(|limit| {
+            LocalTokenBucket::with_zero_time(*limit, SchedulerClock, meta.start_tb_zero_time())
+        });
+
         Self {
             qid,
-            reader: Reader::New { already_running },
+            handle,
+            start_tb,
             unconfirmed_assignments: HashSet::new(),
-            deficit: Deficit::new(0),
-            head: HeadStatus::Unknown,
-            wake_up_after: None,
+            queue: Queue::new(meta.num_running()),
+            deficit: QUANTUM,
+            head_stats: Stats::default(),
         }
     }
 
-    pub fn new_empty(qid: VQueueId, current_round: u16) -> Self {
+    pub fn new_empty(
+        qid: VQueueId,
+        handle: VQueueHandle,
+        meta: &VQueueMeta,
+        config: &VQueueConfig,
+    ) -> Self {
+        let start_tb = config.start_rate_limit().map(|limit| {
+            LocalTokenBucket::with_zero_time(*limit, SchedulerClock, meta.start_tb_zero_time())
+        });
         Self {
             qid,
-            reader: Reader::Closed,
+            handle,
+            start_tb,
             unconfirmed_assignments: HashSet::new(),
-            deficit: Deficit::new(current_round),
-            head: HeadStatus::Empty,
-            wake_up_after: None,
+            queue: Queue::new_closed(),
+            deficit: 0,
+            head_stats: Stats::default(),
         }
     }
 
-    pub fn is_active(&self, meta: &VQueueMeta) -> bool {
-        match self.reader {
-            Reader::New { already_running } if already_running > 0 => true,
-            Reader::Running { remaining, .. } if remaining > 0 => true,
-            _ => {
-                !self.unconfirmed_assignments.is_empty()
-                    || (self.num_waiting(meta) > 0 && !meta.is_paused())
-            }
-        }
-    }
-
-    /// Pops the head, unchecked.
-    ///
-    /// This must be used after `poll_head()` of the queue.
-    ///
-    /// Panics if the queue's head is unknown or empty.
     pub fn pop_unchecked(
         &mut self,
+        cx: &mut std::task::Context<'_>,
         storage: &S,
-        assignments: &mut Assignments<S::Item>,
-    ) -> Result<(), StorageError> {
-        match self.head {
-            HeadStatus::Unknown => {
-                panic!("poll_head must be called before pop_unchecked");
+        concurrency_limiter: &mut Concurrency,
+        global_throttling: Option<&GlobalTokenBucket>,
+    ) -> Result<Pop<S::Item>, StorageError> {
+        let (inbox_head, is_running) = match self.queue.head() {
+            Some(QueueItem::Inbox(item)) => (item, false),
+            Some(QueueItem::Running(item)) => (item, true),
+            Some(QueueItem::None) | None => {
+                unreachable!("cannot pop from empty queue or attempted to pop before polling")
             }
-            HeadStatus::Empty => {
-                panic!("vqueue is empty");
-            }
-            HeadStatus::Known(ref item) => {
-                if matches!(self.reader, Reader::Running { .. }) {
-                    // switch between these to change the behavior as needed
-                    // Action::ResumeAlreadyRunning;
-                    assignments.push(Action::Yield, item.clone());
-                    self.advance(storage)?;
-                } else {
-                    self.unconfirmed_assignments.insert(item.unique_hash());
-                    assignments.push(Action::MoveToRunning, item.clone());
-                    self.advance(storage)?;
-                }
-                // Unnecessary but left to be defensive against a lingering
-                // wake_up_after preventing later scheduling from happening.
-                self.wake_up_after = None;
-            }
+        };
+
+        let item_weight = inbox_head.weight().get() as i32;
+        if self.deficit < item_weight {
+            // give credit.
+            self.deficit += QUANTUM;
+            return Ok(Pop::DeficitExhausted);
+        } else {
+            self.deficit -= item_weight;
         }
 
-        Ok(())
-    }
-
-    pub fn poll_head(&mut self, storage: &S, meta: &VQueueMeta) -> Result<(), StorageError> {
-        // Keep advancing until the head is known
-        while matches!(self.head, HeadStatus::Unknown) && self.is_active(meta) {
-            self.advance(storage)?;
+        if is_running {
+            // switch between these to change the behavior as needed
+            // Action::ResumeAlreadyRunning;
+            // Note that resumption requires acquiring concurrency permits similar to
+            // MoveToRunning. This is currently not implemented since (at the moment) we
+            // only support yielding.
+            let result = Pop::Item {
+                action: Action::Yield,
+                entry: Entry {
+                    item: inbox_head.clone(),
+                    stats: self.head_stats.finalize(),
+                    permit: Permit::new_empty(),
+                },
+                updated_zt: None,
+            };
+            self.queue
+                .advance(storage, &self.unconfirmed_assignments, &self.qid)?;
+            return Ok(result);
         }
 
-        Ok(())
-    }
-
-    fn advance(&mut self, storage: &S) -> Result<(), StorageError> {
-        loop {
-            match self.reader {
-                Reader::New { already_running } if already_running > 0 => {
-                    let mut reader = storage.new_run_reader(&self.qid);
-                    reader.seek_to_first();
-                    let item = reader.peek()?;
-                    if let Some(item) = item {
-                        self.head = HeadStatus::Known(item);
-                        self.reader = Reader::Running {
-                            remaining: already_running,
-                            reader,
-                        };
-                        break;
-                    } else {
-                        error!(
-                            "vqueue {:?} has no running items but its metadata says that it has {already_running} running items",
-                            self.qid
-                        );
-                        debug_assert!(already_running > 0);
-                        // move to inbox reading
-                        self.head = HeadStatus::Unknown;
-                        self.reader = Reader::Closed;
-                    }
-                }
-                Reader::New { .. } => {
-                    // create new inbox reader
-                    self.reader = Reader::Closed;
-                }
-                Reader::Running {
-                    ref mut reader,
-                    ref mut remaining,
-                } => {
-                    reader.advance();
-                    *remaining = remaining.saturating_sub(1);
-                    let item = reader.peek()?;
-                    if let Some(item) = item {
-                        debug_assert!(*remaining > 0);
-                        self.head = HeadStatus::Known(item);
-                        break;
-                    } else {
-                        debug_assert_eq!(0, *remaining);
-                        // move to inbox reading
-                        self.head = HeadStatus::Unknown;
-                        self.reader = Reader::Closed;
-                    }
-                }
-                Reader::Inbox(ref mut reader) => {
-                    reader.advance();
-                    let item = reader.peek()?;
-                    if let Some(item) = item {
-                        if self.unconfirmed_assignments.contains(&item.unique_hash()) {
-                            trace!("skipping over an unconfirmed assignment (inbox)");
-                            continue;
-                        }
-                        self.head = HeadStatus::Known(item);
-                        break;
-                    } else {
-                        // we are done reading inbox
-                        self.head = HeadStatus::Empty;
-                        self.reader = Reader::Closed;
-                        break;
-                    }
-                }
-                Reader::Closed => {
-                    match self.head {
-                        HeadStatus::Unknown => {
-                            let mut reader = storage.new_inbox_reader(&self.qid);
-                            reader.seek_to_first();
-                            let item = reader.peek()?;
-                            self.reader = Reader::Inbox(reader);
-                            if let Some(item) = item {
-                                if self.unconfirmed_assignments.contains(&item.unique_hash()) {
-                                    trace!(
-                                        "[HeadStatus=unknown] skipping over an unconfirmed assignment (inbox)"
-                                    );
-                                    continue;
-                                }
-                                self.head = HeadStatus::Known(item);
-                                break;
-                            } else {
-                                self.head = HeadStatus::Empty;
-                                self.reader = Reader::Closed;
-                            }
-                        }
-                        HeadStatus::Known(ref item) => {
-                            // seek to known head first, then advance.
-                            let mut reader = storage.new_inbox_reader(&self.qid);
-                            reader.seek_after(&self.qid, item);
-                            let item = reader.peek()?;
-                            self.reader = Reader::Inbox(reader);
-                            if let Some(item) = item {
-                                if self.unconfirmed_assignments.contains(&item.unique_hash()) {
-                                    continue;
-                                }
-                                self.head = HeadStatus::Known(item);
-                                break;
-                            } else {
-                                self.head = HeadStatus::Empty;
-                                self.reader = Reader::Closed;
-                            }
-                        }
-                        HeadStatus::Empty => {
-                            // do nothing.
-                            return Ok(());
-                        }
-                    }
-                }
+        let has_tb_token = if inbox_head.priority().is_new()
+            && let Some(ref start_tb) = self.start_tb
+        {
+            // Checking for VQueue starts throttling
+            if let Err(rate_limited) = start_tb.try_consume_one() {
+                let delay = rate_limited.earliest_retry_after();
+                self.head_stats.record_start_throttling_delay(&delay);
+                trace!(
+                    "[vqueue] Need to throttle start from vqueue {:?} for {delay:?}",
+                    self.qid,
+                );
+                return Ok(Pop::Throttle {
+                    delay,
+                    scope: ThrottleScope::VQueue,
+                });
             }
+            true
+        } else {
+            // no throttling or the item has already been started before
+            false
+        };
+
+        let permit = match inbox_head.kind() {
+            EntryKind::Invocation => {
+                let Poll::Ready(permit) = concurrency_limiter.poll_acquire(cx) else {
+                    // Waker will be notified when capacity is available.
+                    // if we have start tokens, we should return them.
+                    if has_tb_token && let Some(ref start_tb) = self.start_tb {
+                        start_tb.add_tokens(1.0);
+                    }
+                    self.head_stats.record_global_capacity_delay(true);
+                    trace!("vqueue {:?} is blocked on global capacity", self.qid);
+                    return Ok(Pop::BlockedOnCapacity);
+                };
+                permit
+            }
+            EntryKind::StateMutation | EntryKind::Unknown => Permit::new_empty(),
+        };
+
+        if let Some(global_throttling) = global_throttling
+            && let Err(rate_limited) = global_throttling.try_consume_one()
+        {
+            let delay = rate_limited.earliest_retry_after();
+            self.head_stats.record_global_throttling_delay(&delay);
+
+            trace!(
+                "[global] Need to throttle start from vqueue {:?} for {delay:?}",
+                self.qid,
+            );
+            // return the start token to the vqueue if we have one.
+            if has_tb_token && let Some(ref start_tb) = self.start_tb {
+                start_tb.add_tokens(1.0);
+            }
+            // NOTE: the concurrency limiter's permit will be dropped here.
+            return Ok(Pop::Throttle {
+                delay,
+                scope: ThrottleScope::Global,
+            });
         }
-        Ok(())
+
+        self.unconfirmed_assignments
+            .insert(inbox_head.unique_hash());
+        let result = Pop::Item {
+            action: Action::MoveToRunning,
+            entry: Entry {
+                item: inbox_head.clone(),
+                stats: self.head_stats.finalize(),
+                permit,
+            },
+            updated_zt: self
+                .start_tb
+                .as_ref()
+                .map(|start_tb| start_tb.get_zero_time()),
+        };
+
+        self.queue
+            .advance(storage, &self.unconfirmed_assignments, &self.qid)?;
+
+        Ok(result)
     }
 
-    pub fn is_empty(&self, meta: &VQueueMeta) -> bool {
-        (matches!(self.head, HeadStatus::Empty) || meta.total_waiting() == 0)
+    pub fn is_dormant(&self, meta: &VQueueMeta) -> bool {
+        (self.queue.is_empty() || meta.total_waiting() == 0)
             && self.unconfirmed_assignments.is_empty()
     }
 
-    pub fn check_eligibility(
+    pub fn poll_eligibility(
         &mut self,
+        storage: &S,
+        now: UniqueTimestamp,
+        meta: &VQueueMeta,
+        config: &VQueueConfig,
+    ) -> Result<Eligibility, StorageError> {
+        self.queue
+            .advance_if_needed(storage, &self.unconfirmed_assignments, &self.qid)?;
+
+        Ok(self.check_eligibility(now, meta, config))
+    }
+
+    pub fn check_eligibility(
+        &self,
         now: UniqueTimestamp,
         meta: &VQueueMeta,
         config: &VQueueConfig,
     ) -> Eligibility {
-        if !self.is_active(meta) {
-            return Eligibility::NotEligible;
-        }
-
-        let inbox_head = match self.head {
-            HeadStatus::Unknown if self.has_available_tokens(meta, config) => {
-                return Eligibility::Eligible;
-            }
-            HeadStatus::Unknown => {
-                return Eligibility::NotEligible;
-            }
-            HeadStatus::Known(_) if matches!(self.reader, Reader::Running { .. }) => {
-                // Running entries are always eligible to run
-                return Eligibility::Eligible;
-            }
-            HeadStatus::Known(ref item) => item,
-            HeadStatus::Empty => {
-                return Eligibility::NotEligible;
-            }
+        let inbox_head = match self.queue.head() {
+            Some(QueueItem::Running(_)) => return Eligibility::Eligible,
+            Some(QueueItem::Inbox(item)) => item,
+            Some(QueueItem::None) => return Eligibility::NotEligible,
+            // needs polling, so we lean on the side of saying we are eligible to force the queue
+            // to being polled.
+            None => return Eligibility::Eligible,
         };
 
         // Only applies to inboxed items.
@@ -307,18 +351,11 @@ where
             return Eligibility::EligibleAt(ts);
         }
 
-        // todo: this is where more checks for eligibility should happen
         if inbox_head.is_token_held() || self.has_available_tokens(meta, config) {
             Eligibility::Eligible
         } else {
             Eligibility::NotEligible
         }
-    }
-
-    pub fn num_waiting(&self, meta: &VQueueMeta) -> u32 {
-        // ready are items we can ship.
-        meta.total_waiting()
-            .saturating_sub(self.unconfirmed_assignments.len() as u32)
     }
 
     pub fn has_available_tokens(&self, meta: &VQueueMeta, config: &VQueueConfig) -> bool {
@@ -328,137 +365,24 @@ where
             .is_none_or(|limit| tokens_used < limit.get())
     }
 
-    pub fn notify_removed(&mut self, item_hash: u64) -> bool {
-        // Can this be the known head?
-        // Yes. Perhaps it expired/ended externally.
-        if let HeadStatus::Known(ref item) = self.head
-            && item.unique_hash() == item_hash
-        {
-            trace!("Removing from inbox, it was the previous head!");
-            self.head = HeadStatus::Unknown;
-            // Ensure that next advance would re-seek to the newly added item
-            self.reader = Reader::Closed;
-            return true;
+    pub fn notify_removed(&mut self, item_hash: u64) {
+        self.remove_from_unconfirmed_assignments(item_hash);
+        if self.queue.remove(item_hash) {
+            self.head_stats.reset();
         }
-        false
     }
 
     pub fn remove_from_unconfirmed_assignments(&mut self, item_hash: u64) -> bool {
         self.unconfirmed_assignments.remove(&item_hash)
     }
 
-    /// Returns true if there was a change that could affect eligibility
+    /// Returns true if the head was changed
     pub fn notify_enqueued(&mut self, item: &S::Item) -> bool {
-        match (&self.head, &self.reader) {
-            // we are only unknown if we are new and didn't read the running list yet,
-            // we might also be in a limbo state if advance() failed.
-            (_, Reader::New { .. } | Reader::Running { .. }) => { /* do nothing */ }
-            (HeadStatus::Unknown, _) => { /* do nothing */ }
-            (HeadStatus::Empty, _) => {
-                self.reader = Reader::Closed;
-                self.head = HeadStatus::Known(item.clone());
-                return true;
-            }
-            (HeadStatus::Known(current), Reader::Inbox(_) | Reader::Closed) => {
-                if item < current {
-                    self.head = HeadStatus::Known(item.clone());
-                    // Ensure that next advance would re-seek to the newly added item
-                    self.reader = Reader::Closed;
-                    return true;
-                }
-            }
+        if self.queue.enqueue(item) {
+            self.head_stats.reset();
+            true
+        } else {
+            false
         }
-        false
-    }
-
-    pub fn maybe_schedule_wakeup(
-        &mut self,
-        wake_up_at: Instant,
-        delay_queue: &mut DelayQueue<VQueueId>,
-    ) {
-        match &self.wake_up_after {
-            // Need to be eligible sooner than what's already scheduled
-            Some(wake_up) if wake_up.ts > wake_up_at => {
-                let timer_key = wake_up.timer_key;
-
-                delay_queue.reset_at(&timer_key, wake_up_at);
-                self.wake_up_after = Some(WakeUp {
-                    ts: wake_up_at,
-                    timer_key,
-                });
-            }
-            Some(_) => {
-                // We are already scheduled for this timestamp or sooner.
-            }
-            None => {
-                let timer_key = delay_queue.insert_at(self.qid, wake_up_at);
-                self.wake_up_after = Some(WakeUp {
-                    ts: wake_up_at,
-                    timer_key,
-                });
-            }
-        }
-    }
-
-    /// It's the caller's responsibility to ensure that the timer is removed from
-    /// the delay queue before calling this method.
-    pub fn drop_scheduled_wake_up(&mut self) {
-        self.wake_up_after = None;
-    }
-
-    pub fn on_not_eligible(&mut self, delay_queue: &mut DelayQueue<VQueueId>) {
-        self.deficit.reset();
-        if let Some(previous_wake_up) = self.wake_up_after.take() {
-            delay_queue.remove(&previous_wake_up.timer_key);
-        }
-    }
-}
-
-#[derive(Debug)]
-struct WakeUp {
-    ts: Instant,
-    timer_key: delay_queue::Key,
-}
-
-#[derive(Debug)]
-pub(crate) struct Deficit {
-    deficit: i32,
-    last_round: u16,
-}
-
-impl Deficit {
-    /// How much do we cost each queue item
-    const COST_PER_ITEM: i32 = 1;
-
-    pub const fn new(last_round: u16) -> Self {
-        Self {
-            deficit: 0,
-            last_round,
-        }
-    }
-
-    pub fn can_spend(&self) -> bool {
-        self.deficit >= Self::COST_PER_ITEM
-    }
-
-    pub const fn adjust(&mut self, current_round: u16) {
-        // a trick to avoid branching at u16 boundaries.
-        // This will return 1 (as expected) if:
-        // - current_round = 0, and last_round = u16::MAX
-        // - current_round = u16::MAX, and last_round = u16::MAX - 1;
-        self.deficit += current_round.wrapping_sub(self.last_round) as i32 * QUANTUM;
-        self.last_round = current_round;
-    }
-
-    pub const fn set_last_round(&mut self, last_round: u16) {
-        self.last_round = last_round;
-    }
-
-    pub const fn consume_one(&mut self) {
-        self.deficit -= Self::COST_PER_ITEM;
-    }
-
-    pub const fn reset(&mut self) {
-        self.deficit = 0;
     }
 }

--- a/crates/vqueues/src/vqueue_config.rs
+++ b/crates/vqueues/src/vqueue_config.rs
@@ -12,9 +12,9 @@
 
 use std::num::NonZeroU32;
 
+use gardal::Limit;
 use hashbrown::HashMap;
 
-use restate_types::rate::Rate;
 use restate_types::vqueue::VQueueParent;
 
 static UNLIMITED: VQueueConfig = const { VQueueConfig::new() };
@@ -23,7 +23,7 @@ static SINGLETON: VQueueConfig = const {
         is_paused: false,
         concurrency: Some(NonZeroU32::new(1).unwrap()),
         capacity: None,
-        rate_limit: None,
+        start_rate_limit: None,
     }
 };
 
@@ -64,9 +64,9 @@ impl ConfigPool {
     }
 
     #[inline]
-    pub fn rate_limit(&self, parent: &VQueueParent) -> Option<Rate> {
+    pub fn start_rate_limit(&self, parent: &VQueueParent) -> Option<&Limit> {
         let parent = self.vqueues.get(parent)?;
-        parent.rate_limit()
+        parent.start_rate_limit()
     }
 
     #[inline]
@@ -83,7 +83,7 @@ pub struct VQueueConfig {
     is_paused: bool,
     concurrency: Option<NonZeroU32>,
     capacity: Option<NonZeroU32>,
-    rate_limit: Option<Rate>,
+    start_rate_limit: Option<Limit>,
 }
 
 impl VQueueConfig {
@@ -91,7 +91,7 @@ impl VQueueConfig {
         Self {
             concurrency: None,
             capacity: None,
-            rate_limit: None,
+            start_rate_limit: None,
             is_paused: false,
         }
     }
@@ -107,8 +107,8 @@ impl VQueueConfig {
     }
 
     #[inline]
-    pub const fn rate_limit(&self) -> Option<Rate> {
-        self.rate_limit
+    pub const fn start_rate_limit(&self) -> Option<&Limit> {
+        self.start_rate_limit.as_ref()
     }
 
     #[inline]

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use bytes::Bytes;
+
 use restate_storage_api::deduplication_table::DedupInformation;
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey};
 use restate_types::invocation::{
@@ -194,8 +196,10 @@ pub enum Command {
     // ----------------------------------
     /// A command to attempt a run an entry in the vqueue (invocation, or otherwise)
     /// *Since v1.6.0
-    VQWaitingToRunning(vqueues::Cards),
-    VQYieldRunning(vqueues::Cards),
+    /// payload is vqueues::VQWaitingToRunning (bilrost encoded)
+    VQWaitingToRunning(Bytes),
+    /// payload is vqueues::VQYieldRunning (bilrost encoded)
+    VQYieldRunning(Bytes),
 }
 
 impl Command {

--- a/crates/wal-protocol/src/vqueues.rs
+++ b/crates/wal-protocol/src/vqueues.rs
@@ -8,51 +8,87 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::{Bytes, BytesMut};
+use bilrost::OwnedMessage;
+use bytes::{Buf, Bytes};
 
 use restate_storage_api::StorageError;
-use restate_storage_api::vqueue_table::EntryCard;
+use restate_storage_api::vqueue_table::{EntryCard, WaitStats};
 use restate_types::vqueue::VQueueId;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Cards {
-    // todo(asoli): please remove me before usage in any released version.
-    // we should not need this field if we pass the partition-key from the envelope's
-    // header at rsm replay time.
-    pub partition_key: u64,
-    // doing so to avoid the need to implement serde for qid/entry-card types.
-    pub parent: u32,
-    pub instance: u32,
-    // encoded entry cards
-    pub entry_cards: Vec<Bytes>,
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct VQWaitingToRunning {
+    #[bilrost(1)]
+    pub assignment: Assignment,
+    #[bilrost(2)]
+    pub meta_updates: MetaUpdates,
 }
 
-impl Cards {
-    pub fn new(
-        qid: &VQueueId,
-        cards: impl IntoIterator<Item = EntryCard> + ExactSizeIterator,
-    ) -> Self {
-        let mut buf = BytesMut::with_capacity(EntryCard::serialized_length() * cards.len());
-        let entry_cards = cards
-            .into_iter()
-            .map(|card| {
-                card.encode(&mut buf);
-                buf.split().freeze()
-            })
-            .collect();
+impl VQWaitingToRunning {
+    pub fn encode_to_bytes(&self) -> Bytes {
+        bilrost::Message::encode_length_delimited_to_bytes(self)
+    }
 
+    pub fn decode<B: Buf>(buf: B) -> Result<Self, StorageError> {
+        Ok(Self::decode_length_delimited(buf)?)
+    }
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct VQYieldRunning {
+    #[bilrost(1)]
+    pub assignment: Assignment,
+}
+
+impl VQYieldRunning {
+    pub fn encode_to_bytes(&self) -> Bytes {
+        bilrost::Message::encode_length_delimited_to_bytes(self)
+    }
+
+    pub fn decode<B: Buf>(buf: B) -> Result<Self, StorageError> {
+        Ok(Self::decode_length_delimited(buf)?)
+    }
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct Assignment {
+    // todo: We should not need this field if we pass the partition-key from the envelope's
+    // header at rsm replay time.
+    #[bilrost(1)]
+    pub partition_key: u64,
+    // doing so to avoid the need to implement serde for qid/entry-card types.
+    #[bilrost(2)]
+    pub parent: u32,
+    #[bilrost(3)]
+    pub instance: u32,
+    // encoded entry cards
+    #[bilrost(4)]
+    pub entries: Vec<Entry>,
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct Entry {
+    #[bilrost(1)]
+    pub card: EntryCard,
+    #[bilrost(2)]
+    pub stats: WaitStats,
+}
+
+impl Assignment {
+    pub fn with_capacity(qid: &VQueueId, capacity: usize) -> Self {
         Self {
             partition_key: qid.partition_key,
             parent: qid.parent.as_u32(),
             instance: qid.instance.as_u32(),
-            entry_cards,
+            entries: Vec::with_capacity(capacity),
         }
     }
 
-    pub fn decode_entry_cards(&self) -> impl Iterator<Item = Result<EntryCard, StorageError>> + '_ {
-        self.entry_cards
-            .iter()
-            .map(|buf| EntryCard::decode(&mut buf.as_ref()))
+    pub fn push(&mut self, item: EntryCard, stats: WaitStats) {
+        self.entries.push(Entry { card: item, stats });
     }
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct MetaUpdates {
+    pub updated_token_bucket_zero_time: Option<f64>,
 }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -25,6 +25,7 @@ restate-workspace-hack = { workspace = true }
 restate-bifrost = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
+restate-futures-util = { workspace = true }
 restate-ingress-http = { workspace = true }
 restate-ingress-kafka = { workspace = true }
 restate-invoker-api = { workspace = true }

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -27,7 +27,7 @@ use tracing::{debug, trace};
 use restate_bifrost::CommitToken;
 use restate_core::network::{Oneshot, Reciprocal};
 use restate_core::{Metadata, MetadataKind, TaskCenter, TaskHandle, TaskId};
-use restate_invoker_api::capacity::InvokerToken;
+use restate_futures_util::concurrency::Permit;
 use restate_partition_store::{PartitionDb, PartitionStore};
 use restate_storage_api::vqueue_table::EntryCard;
 use restate_types::identifiers::{
@@ -43,10 +43,10 @@ use restate_types::time::MillisSinceEpoch;
 use restate_types::{SemanticRestateVersion, Version, Versioned};
 use restate_vqueues::VQueueEvent;
 use restate_vqueues::{SchedulerService, VQueuesMeta, scheduler};
-use restate_wal_protocol::Command;
 use restate_wal_protocol::control::UpsertSchema;
 use restate_wal_protocol::timer::TimerKeyValue;
-use restate_wal_protocol::vqueues::Cards;
+use restate_wal_protocol::vqueues::Assignment;
+use restate_wal_protocol::{Command, vqueues};
 
 use crate::metric_definitions::{PARTITION_HANDLE_LEADER_ACTIONS, USAGE_LEADER_ACTION_COUNT};
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
@@ -75,8 +75,9 @@ pub struct LeaderState {
     // returns a [`Error:TaskFailed`] error.
     shuffle_task_handle: Option<TaskHandle<anyhow::Result<()>>>,
     pub timer_service: Pin<Box<TimerService>>,
-    scheduler: SchedulerService<PartitionDb, InvokerToken>,
+    scheduler: SchedulerService<PartitionDb>,
     self_proposer: SelfProposer,
+    unconfirmed_scheduler_assignments: HashMap<u64, Permit>,
 
     awaiting_rpc_actions: HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
     awaiting_rpc_self_propose: FuturesUnordered<SelfAppendFuture>,
@@ -101,7 +102,7 @@ impl LeaderState {
         trimmer_task_id: TaskId,
         shuffle_hint_tx: HintSender,
         timer_service: TimerService,
-        scheduler: SchedulerService<PartitionDb, InvokerToken>,
+        scheduler: SchedulerService<PartitionDb>,
         self_proposer: SelfProposer,
         invoker_rx: InvokerStream,
         shuffle_rx: tokio::sync::mpsc::Receiver<shuffle::OutboxTruncation>,
@@ -120,6 +121,7 @@ impl LeaderState {
             }),
             timer_service: Box::pin(timer_service),
             scheduler,
+            unconfirmed_scheduler_assignments: Default::default(),
             self_proposer,
             awaiting_rpc_actions: Default::default(),
             awaiting_rpc_self_propose: Default::default(),
@@ -287,34 +289,63 @@ impl LeaderState {
         for effect in action_effects {
             match effect {
                 ActionEffect::Scheduler(decisions) => {
-                    let commands: Vec<_> = decisions?.into_iter().flat_map(|(qid, decision)| {
-                        decision.into_iter_per_action().map(move |(action, items)| {
-                            let cards = Cards::new(&qid, items);
+                    let decisions = decisions?;
+                    // `queues * 2` because we assume a worst case of two actions per queue
+                    // (yields/resume, and starts) each action generates its own command.
+                    let mut commands = Vec::with_capacity(decisions.num_queues() * 2);
+                    for (qid, decision) in decisions.into_iter() {
+                        let updated_token_bucket_zero_time = decision.updated_tb_zero_time();
+                        for (action, items) in decision.into_iter_per_action() {
+                            let mut assignment = Assignment::with_capacity(&qid, items.len());
+                            for entry in items.into_iter() {
+                                let (item, stats, permit) = entry.split();
+                                if !permit.is_empty() {
+                                    self.unconfirmed_scheduler_assignments
+                                        .insert(item.unique_hash(), permit);
+                                }
+                                assignment.push(item, stats);
+                            }
                             match action {
                                 scheduler::Action::MoveToRunning => {
-                                    (qid.partition_key, Command::VQWaitingToRunning(cards))
+                                    let command = vqueues::VQWaitingToRunning {
+                                        assignment,
+                                        meta_updates: vqueues::MetaUpdates {
+                                            updated_token_bucket_zero_time,
+                                        },
+                                    }
+                                    .encode_to_bytes();
+                                    commands.push((
+                                        qid.partition_key,
+                                        Command::VQWaitingToRunning(command),
+                                    ));
                                 }
                                 scheduler::Action::Yield => {
-                                    (qid.partition_key, Command::VQYieldRunning(cards))
+                                    let command =
+                                        vqueues::VQYieldRunning { assignment }.encode_to_bytes();
+                                    commands.push((
+                                        qid.partition_key,
+                                        Command::VQYieldRunning(command),
+                                    ));
                                 }
                                 scheduler::Action::ResumeAlreadyRunning => {
-                                        todo!(
-                                            "Unsupported: We don't support directly resuming at the moment"
-                                        )
-                                        // invoker_tx
-                                        //     .run(
-                                        //         self.partition_id,
-                                        //         self.leader_epoch,
-                                        //         inv_id,
-                                        //         // todo: fix/remove
-                                        //         SharedString::from_borrowed(""),
-                                        //         SharedString::from_borrowed(""),
-                                        //     )
-                                        //     .map_err(Error::Invoker)?;
-                                    }
+                                    todo!(
+                                        "Unsupported: We don't support directly resuming at the moment"
+                                    )
+                                    // invoker_tx
+                                    //     .run(
+                                    //         self.partition_id,
+                                    //         self.leader_epoch,
+                                    //         inv_id,
+                                    //         // todo: fix/remove
+                                    //         SharedString::from_borrowed(""),
+                                    //         SharedString::from_borrowed(""),
+                                    //     )
+                                    //     .map_err(Error::Invoker)?;
                                 }
-                            })
-                    }).collect();
+                            }
+                        }
+                    }
+
                     self.self_proposer
                         .propose_many(commands.into_iter())
                         .await?;
@@ -655,8 +686,10 @@ impl LeaderState {
                 invocation_target,
                 invoke_input_journal,
             } => {
-                let permit = self.scheduler.confirm_assignment(&qid, item_hash);
-                let permit = permit.expect("invoke invocations assigned by scheduler");
+                let permit = self
+                    .unconfirmed_scheduler_assignments
+                    .remove(&item_hash)
+                    .expect("invoke invocations assigned by scheduler");
                 invoker_tx
                     .vqueue_invoke(
                         partition_leader_epoch,
@@ -667,12 +700,6 @@ impl LeaderState {
                         invoke_input_journal,
                     )
                     .map_err(Error::Invoker)?
-            }
-            Action::VQConsumePermit { qid, item_hash } => {
-                let _ = self
-                    .scheduler
-                    .confirm_assignment(&qid, item_hash)
-                    .expect("scheduler should have a pending assignment");
             }
         }
 

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -378,6 +378,7 @@ where
             let scheduler_service = if config.common.experimental_enable_vqueues {
                 SchedulerService::create(
                     self.invoker_capacity.concurrency.clone(),
+                    self.invoker_capacity.invocation_token_bucket.clone(),
                     partition_store.partition_db().clone(),
                     vqueues_cache,
                 )

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -43,12 +43,6 @@ pub enum Action {
         invocation_target: InvocationTarget,
         invoke_input_journal: InvokeInputJournal,
     },
-    /// Tells the scheduler to confirm the assignment for the given item hash and drops the
-    /// returned permit immediately to free up any held budget tokens.
-    VQConsumePermit {
-        qid: VQueueId,
-        item_hash: u64,
-    },
     Invoke {
         invocation_id: InvocationId,
         invocation_epoch: InvocationEpoch,


### PR DESCRIPTION

- Introduce weighted Deficit Round-Robin (DRR) scheduling to favor resumptions over new starts.
- Add per-vqueue and global token-bucket throttling with observable wait-time metrics.
- Use slotmap arena allocator for efficient vqueue handle management in the scheduler.
- Collect and emit WaitStats (blocked on capacity, vqueue throttle, global throttle) per scheduled item.
- Simplify Concurrency/Permit by removing marker types for cleaner invoker APIs.

Note: the `Concurrency` abstraction will need to be replaced with a a compound Permit that encodes the global and per-vqueue capacity requirements.
This is not done in this changeset, but the type parameter removal is a step in that direction.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4080).
* #4090
* #4089
* #4087
* __->__ #4080