### PR TITLE
[Restate UI] Update to v0.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8361,8 +8361,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.16"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.16#97129d72303cfa42524fa906a4b3c4169c5bac82"
+version = "0.1.17"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.17#18eb60e8cf34c422131a951f771406ec37b45bf7"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.16", tag = "v0.1.16" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.17", tag = "v0.1.17" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.17
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.17/ui-v0.1.17.zip