### PR TITLE
Upgrade gardal to alpha.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "gardal"
-version = "0.0.1-alpha.7"
+version = "0.0.1-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29896fff51cce710a632bea22ca5b174ec76634c4459687949a26046d09d3e7"
+checksum = "aee8cfaab5bff357684bf9396842bdc2985f9fc25ce9a56ec1bce7ccb8c6318b"
 dependencies = [
  "futures",
  "likely_stable",
@@ -4011,7 +4011,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4739,7 +4739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10959,7 +10959,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ flexbuffers = { version = "25.2.10" }
 futures = "0.3.25"
 futures-sink = "0.3.25"
 futures-util = "0.3.25"
-gardal = "0.0.1-alpha.7"
+gardal = { version = "0.0.1-alpha.9" }
 googletest = { version = "0.10", features = ["anyhow"] }
 hostname = { version = "0.4.0" }
 http = "1.3.1"

--- a/crates/invoker-api/src/capacity.rs
+++ b/crates/invoker-api/src/capacity.rs
@@ -13,8 +13,7 @@ use std::num::NonZeroUsize;
 use restate_futures_util::concurrency::Concurrency;
 use restate_types::config::ThrottlingOptions;
 
-pub type TokenBucket<C = gardal::TokioClock> =
-    gardal::TokenBucket<gardal::PaddedAtomicSharedStorage, C>;
+pub type TokenBucket<C = gardal::TokioClock> = gardal::SharedTokenBucket<C>;
 
 /// Marker type used to identify invoker's capacity tokens
 pub struct InvokerToken;
@@ -43,18 +42,10 @@ impl InvokerCapacity {
         Self {
             concurrency: Concurrency::new(concurrency),
             invocation_token_bucket: invocation_throttling.map(|opts| {
-                let limit = gardal::Limit::from(opts.clone());
-                let capacity = limit.burst();
-                let bucket = TokenBucket::from_parts(limit, gardal::TokioClock::default());
-                bucket.add_tokens(capacity.get());
-                bucket
+                TokenBucket::new(gardal::Limit::from(opts.clone()), gardal::TokioClock)
             }),
             action_token_bucket: action_throttling.map(|opts| {
-                let limit = gardal::Limit::from(opts.clone());
-                let capacity = limit.burst();
-                let bucket = TokenBucket::from_parts(limit, gardal::TokioClock::default());
-                bucket.add_tokens(capacity.get());
-                bucket
+                TokenBucket::new(gardal::Limit::from(opts.clone()), gardal::TokioClock)
             }),
         }
     }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -56,7 +56,7 @@ futures-executor = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-gardal = { version = "0.0.1-alpha.7", features = ["async"] }
+gardal = { version = "0.0.1-alpha.9", features = ["async"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std", "wasm_js"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 half = { version = "2", default-features = false, features = ["num-traits"] }
@@ -187,7 +187,7 @@ futures-executor = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-gardal = { version = "0.0.1-alpha.7", features = ["async"] }
+gardal = { version = "0.0.1-alpha.9", features = ["async"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std", "wasm_js"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 half = { version = "2", default-features = false, features = ["num-traits"] }


### PR DESCRIPTION

Gardal is now at alpha.9, it includes a few fixes, improvements, and most importantly. By default the bucket will be prefilled if constructed with new().
