### PR TITLE
[Invoker] Fixes remove invocation with epoch

### DIFF
--- a/crates/invoker-api/src/handle.rs
+++ b/crates/invoker-api/src/handle.rs
@@ -96,12 +96,15 @@ pub trait InvokerHandle<SR> {
         partition: PartitionLeaderEpoch,
     ) -> Result<(), NotRunningError>;
 
+    /// Aborts an invocation for the given `invocation_id` and `invocation_epoch`.
+    /// When `invocation_epoch` is `None`, abort any epoch for that invocation.
+    ///
     /// *Note*: When aborting an invocation, and restarting it, the `invocation_epoch` MUST be bumped.
     fn abort_invocation(
         &mut self,
         partition_leader_epoch: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        invocation_epoch: InvocationEpoch,
+        invocation_epoch: Option<InvocationEpoch>,
     ) -> Result<(), NotRunningError>;
 
     fn register_partition(

--- a/crates/invoker-api/src/lib.rs
+++ b/crates/invoker-api/src/lib.rs
@@ -167,7 +167,7 @@ pub mod test_util {
             &mut self,
             _partition_leader_epoch: PartitionLeaderEpoch,
             _invocation_id: InvocationId,
-            _invocation_epoch: InvocationEpoch,
+            _invocation_epoch: Option<InvocationEpoch>,
         ) -> Result<(), NotRunningError> {
             Ok(())
         }

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -72,7 +72,7 @@ pub(crate) enum InputCommand<SR> {
     Abort {
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        invocation_epoch: InvocationEpoch,
+        invocation_epoch: Option<InvocationEpoch>,
     },
 
     /// Retry now specific invocation id
@@ -213,7 +213,7 @@ impl<SR: Send> restate_invoker_api::InvokerHandle<SR> for InvokerHandle<SR> {
         &mut self,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        invocation_epoch: InvocationEpoch,
+        invocation_epoch: Option<InvocationEpoch>,
     ) -> Result<(), NotRunningError> {
         self.input
             .send(InputCommand::Abort {

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1067,7 +1067,7 @@ where
     ) {
         if let Some((sender, _, ism)) = self
             .invocation_state_machine_manager
-            .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
+            .remove_invocation_with_epoch(partition, &invocation_id, Some(invocation_epoch))
         {
             debug_assert_eq!(invocation_epoch, ism.invocation_epoch);
             counter!(INVOKER_INVOCATION_TASKS, "status" => TASK_OP_COMPLETED, "partition_id" => ID_LOOKUP.get(partition.0)).increment(1);
@@ -1110,7 +1110,7 @@ where
     ) {
         if let Some((sender, _, ism)) = self
             .invocation_state_machine_manager
-            .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
+            .remove_invocation_with_epoch(partition, &invocation_id, Some(invocation_epoch))
         {
             debug_assert_eq!(invocation_epoch, ism.invocation_epoch);
             counter!(INVOKER_INVOCATION_TASKS, "status" => TASK_OP_SUSPENDED, "partition_id" => ID_LOOKUP.get(partition.0)).increment(1);
@@ -1175,7 +1175,7 @@ where
     ) {
         if let Some((sender, _, ism)) = self
             .invocation_state_machine_manager
-            .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
+            .remove_invocation_with_epoch(partition, &invocation_id, Some(invocation_epoch))
         {
             debug_assert_eq!(invocation_epoch, ism.invocation_epoch);
             counter!(INVOKER_INVOCATION_TASKS, "status" => TASK_OP_SUSPENDED, "partition_id" => ID_LOOKUP.get(partition.0))
@@ -1241,7 +1241,7 @@ where
     ) {
         if let Some((_, _, ism)) = self
             .invocation_state_machine_manager
-            .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
+            .remove_invocation_with_epoch(partition, &invocation_id, Some(invocation_epoch))
         {
             debug_assert_eq!(invocation_epoch, ism.invocation_epoch);
             self.handle_error_event(partition, invocation_id, error, ism)
@@ -1257,7 +1257,7 @@ where
         skip_all,
         fields(
             restate.invocation.id = %invocation_id,
-            restate.invocation.epoch = %invocation_epoch,
+            restate.invocation.epoch = ?invocation_epoch,
             restate.invoker.partition_leader_epoch = ?partition,
         )
     )]
@@ -1265,7 +1265,7 @@ where
         &mut self,
         partition: PartitionLeaderEpoch,
         invocation_id: InvocationId,
-        invocation_epoch: InvocationEpoch,
+        invocation_epoch: Option<InvocationEpoch>,
     ) {
         if let Some((_, _, mut ism)) = self
             .invocation_state_machine_manager
@@ -1323,7 +1323,7 @@ where
     ) {
         if let Some((sender, _, mut ism)) = self
             .invocation_state_machine_manager
-            .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
+            .remove_invocation_with_epoch(partition, &invocation_id, Some(invocation_epoch))
         {
             if ism.notify_pause() {
                 // If returns true, we need to pause now
@@ -1640,7 +1640,7 @@ where
     {
         if let Some((_, storage_reader, mut ism)) = self
             .invocation_state_machine_manager
-            .remove_invocation_with_epoch(partition, &invocation_id, invocation_epoch)
+            .remove_invocation_with_epoch(partition, &invocation_id, Some(invocation_epoch))
         {
             f(&mut ism);
             if ism.is_ready_to_retry() {
@@ -2195,7 +2195,7 @@ mod tests {
         assert_eq!(service_inner.quota.available_slots(), 1);
 
         // Abort the invocation
-        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, 0);
+        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, Some(0));
 
         // Check the quota
         assert_eq!(service_inner.quota.available_slots(), 2);
@@ -2242,7 +2242,7 @@ mod tests {
         );
 
         // Now abort 0, this should have no effect
-        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, 0);
+        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, Some(0));
         assert_eq!(
             service_inner
                 .invocation_state_machine_manager
@@ -2273,7 +2273,7 @@ mod tests {
         );
 
         // Now abort 1, this should have effect
-        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, 1);
+        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, Some(1));
         assert!(
             service_inner
                 .invocation_state_machine_manager
@@ -2382,7 +2382,7 @@ mod tests {
         );
 
         // Now abort 0, this should have no effect
-        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, 0);
+        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, Some(0));
         assert_eq!(
             service_inner
                 .invocation_state_machine_manager
@@ -2394,7 +2394,7 @@ mod tests {
         );
 
         // Now abort 1, this should have effect
-        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, 1);
+        service_inner.handle_abort_invocation(MOCK_PARTITION, invocation_id, Some(1));
         assert!(
             service_inner
                 .invocation_state_machine_manager

--- a/crates/invoker-impl/src/state_machine_manager.rs
+++ b/crates/invoker-impl/src/state_machine_manager.rs
@@ -107,16 +107,19 @@ where
         })
     }
 
+    /// Removes invocation with invocation_id and invocation_epoch.
+    /// When `invocation_epoch` is `None`, removes any epoch for that invocation.
     #[inline]
     pub(super) fn remove_invocation_with_epoch(
         &mut self,
         partition: PartitionLeaderEpoch,
         invocation_id: &InvocationId,
-        invocation_epoch: InvocationEpoch,
+        invocation_epoch: Option<InvocationEpoch>,
     ) -> Option<(&mpsc::Sender<Box<Effect>>, &IR, InvocationStateMachine)> {
         self.resolve_partition(partition).and_then(|p| {
             if let Some(ism) = p.invocation_state_machines.get(invocation_id)
-                && ism.invocation_epoch == invocation_epoch
+                && invocation_epoch
+                    .is_none_or(|invocation_epoch| invocation_epoch == ism.invocation_epoch)
             {
                 return Some((
                     &p.output_tx,

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -81,7 +81,7 @@ pub enum Action {
     },
     AbortInvocation {
         invocation_id: InvocationId,
-        invocation_epoch: InvocationEpoch,
+        invocation_epoch: Option<InvocationEpoch>,
     },
     IngressResponse {
         request_id: PartitionProcessorRpcRequestId,

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -25,9 +25,7 @@ use restate_storage_api::timer_table::WriteTimerTable;
 use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::client::CancelInvocationResponse;
-use restate_types::invocation::{
-    InvocationEpoch, InvocationMutationResponseSink, TerminationFlavor,
-};
+use restate_types::invocation::{InvocationMutationResponseSink, TerminationFlavor};
 use restate_types::journal_v2::CANCEL_SIGNAL;
 use tracing::{debug, trace};
 
@@ -107,7 +105,7 @@ where
                 // This can happen because the invoke/resume and the abort invoker messages end up in different queues,
                 // and the abort message can overtake the invoke/resume.
                 // Consequently the invoker might have not received the abort and the user tried to send it again.
-                ctx.send_abort_invocation_to_invoker(self.invocation_id, InvocationEpoch::MAX);
+                ctx.do_send_abort_invocation_to_invoker(self.invocation_id, None);
                 ctx.reply_to_cancel(self.response_sink, CancelInvocationResponse::NotFound);
             }
         };

--- a/crates/worker/src/partition/state_machine/tests/invocation_epoch_awareness.rs
+++ b/crates/worker/src/partition/state_machine/tests/invocation_epoch_awareness.rs
@@ -53,7 +53,7 @@ async fn fence_old_calls_and_completions() {
         actions,
         contains(pat!(Action::AbortInvocation {
             invocation_id: eq(invocation_id),
-            invocation_epoch: eq(0),
+            invocation_epoch: eq(Some(0)),
         }))
     );
     assert_that!(
@@ -118,7 +118,7 @@ async fn fence_old_calls_and_completions() {
         actions,
         contains(pat!(Action::AbortInvocation {
             invocation_id: eq(invocation_id),
-            invocation_epoch: eq(0),
+            invocation_epoch: eq(Some(0)),
         }))
     );
     assert_that!(
@@ -208,7 +208,7 @@ async fn fence_old_sleep_and_completions() {
         actions,
         contains(pat!(Action::AbortInvocation {
             invocation_id: eq(invocation_id),
-            invocation_epoch: eq(0),
+            invocation_epoch: eq(Some(0)),
         }))
     );
     assert_that!(
@@ -268,7 +268,7 @@ async fn fence_old_sleep_and_completions() {
         all![
             contains(pat!(Action::AbortInvocation {
                 invocation_id: eq(invocation_id),
-                invocation_epoch: eq(0),
+                invocation_epoch: eq(Some(0)),
             })),
             not(contains(pat!(Action::RegisterTimer {
                 timer_value: eq(TimerKeyValue::complete_journal_entry(


### PR DESCRIPTION
[Invoker] Fixes remove invocation with epoch

Summary:
Fixes how the invoker handle invocation abort, by also allowing
a wildcard epoch removal.

The PP sends InvocationEpoch::MAX to signal a "matches any" invocation epoch
but was not handled properly by the invoker.

Quick fix was fix how the `InvocationEpoch::MAX` is handled, but I think
using an Option<InvocationEpoch> is clearer and less error-prone

Fixes #4085
