### PR TITLE
[Restate UI] Update to v0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8362,8 +8362,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.18"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.18#d21a19ad391d015528aae40406958b4f0c14de20"
+version = "0.1.19"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.19#01aa424e2f6af96750803c14ba3d74bde8198713"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.18", tag = "v0.1.18" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.19", tag = "v0.1.19" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.19
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.19/ui-v0.1.19.zip