### PR TITLE
[16/N][VQueues] Introduce introspection API for scheduler status

### DIFF
--- a/crates/storage-api/src/vqueue_table/store.rs
+++ b/crates/storage-api/src/vqueue_table/store.rs
@@ -25,7 +25,7 @@ pub trait VQueueStore {
     fn new_inbox_reader(&self, qid: &VQueueId) -> Self::InboxReader;
 }
 
-pub trait VQueueEntry: PartialOrd + PartialEq + Eq + Clone {
+pub trait VQueueEntry: PartialOrd + PartialEq + Eq + Clone + std::fmt::Debug {
     fn unique_hash(&self) -> u64;
     fn priority(&self) -> EffectivePriority;
     fn visible_at(&self) -> VisibleAt;

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -15,7 +15,7 @@ mod vqueue_config;
 
 pub use cache::{VQueuesMeta, VQueuesMetaMut};
 pub use metric_definitions::describe_metrics;
-pub use scheduler::SchedulerService;
+pub use scheduler::{SchedulerService, SchedulingStatus, ThrottleScope, VQueueSchedulerStatus};
 
 use restate_storage_api::StorageError;
 use restate_storage_api::vqueue_table::metadata::VQueueMetaUpdates;

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -19,8 +19,7 @@ use metrics::counter;
 use pin_project::pin_project;
 use slotmap::SlotMap;
 use tokio::time::Instant;
-use tracing::warn;
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 use restate_futures_util::concurrency::Concurrency;
 use restate_storage_api::StorageError;
@@ -39,6 +38,7 @@ use crate::scheduler::vqueue_state::Pop;
 use super::Decision;
 use super::GlobalTokenBucket;
 use super::VQueueHandle;
+use super::VQueueSchedulerStatus;
 use super::vqueue_state::VQueueState;
 
 #[pin_project]
@@ -64,11 +64,7 @@ pub struct DRRScheduler<S: VQueueStore> {
     storage: S,
 }
 
-impl<S> DRRScheduler<S>
-where
-    S: VQueueStore,
-    S::Item: std::fmt::Debug,
-{
+impl<S: VQueueStore> DRRScheduler<S> {
     pub fn new(
         limit_qid_per_poll: NonZeroU16,
         max_items_per_decision: NonZeroU16,
@@ -321,6 +317,55 @@ where
             }
         }
         Ok(())
+    }
+
+    pub fn iter_status(
+        &self,
+        cache: VQueuesMeta<'_>,
+    ) -> impl Iterator<Item = (VQueueId, VQueueSchedulerStatus)> {
+        self.q.iter().map(move |(_handle, qstate)| {
+            let Some(meta) = cache.get_vqueue(&qstate.qid) else {
+                return (qstate.qid, VQueueSchedulerStatus::default());
+            };
+
+            let config = cache.config_pool().find(&qstate.qid.parent);
+            let status = VQueueSchedulerStatus {
+                is_paused: qstate.is_paused(meta, config),
+                wait_stats: qstate.get_head_wait_stats(),
+                remaining_running: qstate.num_remaining_in_running_stage(),
+                waiting_inbox: qstate.num_waiting_inbox(meta),
+                tokens_used: qstate.num_tokens_used(meta),
+                status: self.eligible.get_status(qstate, meta, config),
+            };
+
+            (qstate.qid, status)
+        })
+    }
+
+    pub fn get_status(
+        &self,
+        qid: &VQueueId,
+        cache: VQueuesMeta<'_>,
+    ) -> Option<VQueueSchedulerStatus> {
+        let qstate = self
+            .id_lookup
+            .get(qid)
+            .and_then(|handle| self.q.get(*handle))?;
+
+        let Some(meta) = cache.get_vqueue(qid) else {
+            return Some(VQueueSchedulerStatus::default());
+        };
+
+        let config = cache.config_pool().find(&qstate.qid.parent);
+
+        Some(VQueueSchedulerStatus {
+            is_paused: qstate.is_paused(meta, config),
+            wait_stats: qstate.get_head_wait_stats(),
+            remaining_running: qstate.num_remaining_in_running_stage(),
+            waiting_inbox: qstate.num_waiting_inbox(meta),
+            tokens_used: qstate.num_tokens_used(meta),
+            status: self.eligible.get_status(qstate, meta, config),
+        })
     }
 
     fn wake_up(&mut self) {

--- a/crates/vqueues/src/scheduler/queue.rs
+++ b/crates/vqueues/src/scheduler/queue.rs
@@ -270,6 +270,15 @@ impl<S: VQueueStore> Queue<S> {
         }
         Ok(())
     }
+
+    pub(crate) fn remaining_in_running_stage(&self) -> u32 {
+        match self.reader {
+            Reader::New { already_running } => already_running,
+            Reader::Running { remaining, .. } => remaining,
+            Reader::Inbox(..) => 0,
+            Reader::Closed => 0,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/vqueues/src/scheduler/vqueue_state.rs
+++ b/crates/vqueues/src/scheduler/vqueue_state.rs
@@ -35,11 +35,11 @@ use crate::vqueue_config::VQueueConfig;
 
 use super::clock::SchedulerClock;
 use super::queue::Queue;
-use super::{Entry, GlobalTokenBucket, ThrottleScope, VQueueHandle};
+use super::{Entry, GlobalTokenBucket, IsPaused, ThrottleScope, VQueueHandle};
 
 const QUANTUM: i32 = 1;
 
-pub enum Pop<Item> {
+pub(super) enum Pop<Item> {
     DeficitExhausted,
     Item {
         action: Action,
@@ -59,6 +59,30 @@ pub(super) enum Eligibility {
     Eligible,
     EligibleAt(UniqueTimestamp),
     NotEligible,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DetailedEligibility {
+    EligibleRunning,
+    EligibleInbox,
+    Scheduled(UniqueTimestamp),
+    Empty,
+    WaitingConcurrencyTokens,
+}
+
+impl DetailedEligibility {
+    #[inline(always)]
+    pub fn as_compact(&self) -> Eligibility {
+        match self {
+            DetailedEligibility::EligibleRunning | DetailedEligibility::EligibleInbox => {
+                Eligibility::Eligible
+            }
+            DetailedEligibility::Scheduled(ts) => Eligibility::EligibleAt(*ts),
+            DetailedEligibility::Empty | DetailedEligibility::WaitingConcurrencyTokens => {
+                Eligibility::NotEligible
+            }
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -88,6 +112,23 @@ impl Stats {
         self.reset();
 
         stats
+    }
+
+    pub fn snapshot(&self) -> WaitStats {
+        let blocked_on_global_capacity_micros =
+            if let Some(last) = self.last_blocked_on_global_capacity {
+                let delay = last.elapsed();
+                self.blocked_on_global_capacity_micros
+                    .saturating_add(delay.as_micros().try_into().unwrap_or(u32::MAX))
+            } else {
+                self.blocked_on_global_capacity_micros
+            };
+
+        WaitStats {
+            blocked_on_global_capacity_ms: blocked_on_global_capacity_micros / 1000,
+            vqueue_start_throttling_ms: self.local_start_throttling_micros / 1000,
+            global_throttling_ms: self.global_throttling_micros / 1000,
+        }
     }
 }
 
@@ -141,11 +182,7 @@ pub struct VQueueState<S: VQueueStore> {
     head_stats: Stats,
 }
 
-impl<S> VQueueState<S>
-where
-    S: VQueueStore,
-    S::Item: std::fmt::Debug,
-{
+impl<S: VQueueStore> VQueueState<S> {
     pub fn new(
         qid: VQueueId,
         handle: VQueueHandle,
@@ -323,11 +360,21 @@ where
         now: UniqueTimestamp,
         meta: &VQueueMeta,
         config: &VQueueConfig,
-    ) -> Result<Eligibility, StorageError> {
+    ) -> Result<DetailedEligibility, StorageError> {
         self.queue
             .advance_if_needed(storage, &self.unconfirmed_assignments, &self.qid)?;
 
         Ok(self.check_eligibility(now, meta, config))
+    }
+
+    pub fn is_paused(&self, meta: &VQueueMeta, config: &VQueueConfig) -> IsPaused {
+        if meta.is_paused() {
+            IsPaused::Directly
+        } else if config.is_paused() {
+            IsPaused::ViaParent
+        } else {
+            IsPaused::No
+        }
     }
 
     pub fn check_eligibility(
@@ -335,35 +382,30 @@ where
         now: UniqueTimestamp,
         meta: &VQueueMeta,
         config: &VQueueConfig,
-    ) -> Eligibility {
+    ) -> DetailedEligibility {
         let inbox_head = match self.queue.head() {
-            Some(QueueItem::Running(_)) => return Eligibility::Eligible,
+            Some(QueueItem::Running(_)) => return DetailedEligibility::EligibleRunning,
             Some(QueueItem::Inbox(item)) => item,
-            Some(QueueItem::None) => return Eligibility::NotEligible,
-            // needs polling, so we lean on the side of saying we are eligible to force the queue
-            // to being polled.
-            None => return Eligibility::Eligible,
+            Some(QueueItem::None) => return DetailedEligibility::Empty,
+            None if self.queue.remaining_in_running_stage() > 0 => {
+                return DetailedEligibility::EligibleRunning;
+            }
+            None if meta.total_waiting() > 0 => return DetailedEligibility::EligibleInbox,
+            None => return DetailedEligibility::Empty,
         };
 
         // Only applies to inboxed items.
         if let VisibleAt::At(ts) = inbox_head.visible_at()
             && ts > now
         {
-            return Eligibility::EligibleAt(ts);
+            return DetailedEligibility::Scheduled(ts);
         }
 
         if inbox_head.is_token_held() || self.has_available_tokens(meta, config) {
-            Eligibility::Eligible
+            DetailedEligibility::EligibleInbox
         } else {
-            Eligibility::NotEligible
+            DetailedEligibility::WaitingConcurrencyTokens
         }
-    }
-
-    pub fn has_available_tokens(&self, meta: &VQueueMeta, config: &VQueueConfig) -> bool {
-        let tokens_used = meta.tokens_used() + self.unconfirmed_assignments.len() as u32;
-        config
-            .concurrency()
-            .is_none_or(|limit| tokens_used < limit.get())
     }
 
     pub fn notify_removed(&mut self, item_hash: u64) {
@@ -385,5 +427,29 @@ where
         } else {
             false
         }
+    }
+
+    pub fn get_head_wait_stats(&self) -> WaitStats {
+        self.head_stats.snapshot()
+    }
+
+    /// How many items left in the running stage
+    pub fn num_remaining_in_running_stage(&self) -> u32 {
+        self.queue.remaining_in_running_stage()
+    }
+
+    pub fn num_waiting_inbox(&self, meta: &VQueueMeta) -> u32 {
+        meta.total_waiting()
+            .saturating_sub(self.unconfirmed_assignments.len() as u32)
+    }
+
+    pub fn num_tokens_used(&self, meta: &VQueueMeta) -> u32 {
+        meta.tokens_used() + self.unconfirmed_assignments.len() as u32
+    }
+
+    fn has_available_tokens(&self, meta: &VQueueMeta, config: &VQueueConfig) -> bool {
+        config
+            .concurrency()
+            .is_none_or(|limit| self.num_tokens_used(meta) < limit.get())
     }
 }


### PR DESCRIPTION

Adds some public types and methods to inspect the scheduler status of vqueues, most notably:

- `VQueueSchedulerStatus`: A view into a vqueue's scheduling state including
  pause status, wait statistics, running/waiting counts, and token usage

New methods on `SchedulerService`:
- `get_status()`: Get scheduling status for a specific vqueue
- `iter_status()`: Iterate over all tracked vqueues' status

This API enables external introspection of scheduler decisions for debugging
and monitoring purposes. The intention is to plumb this into datafusion.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4095).
* #4104
* #4101
* __->__ #4095