### PR TITLE
[CLI] Various improvements to batch cancel/kill and co

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7108,6 +7108,7 @@ dependencies = [
  "restate-admin-rest-model",
  "restate-cli-util",
  "restate-cloud-tunnel-client",
+ "restate-futures-util",
  "restate-lite",
  "restate-serde-util",
  "restate-time-util",
@@ -7302,6 +7303,7 @@ name = "restate-futures-util"
 version = "1.6.0-dev"
 dependencies = [
  "anyhow",
+ "async-channel",
  "futures",
  "pin-project",
  "pin-project-lite",
@@ -8480,6 +8482,7 @@ dependencies = [
  "comfy-table",
  "criterion",
  "crossbeam-epoch",
+ "crossbeam-utils",
  "digest",
  "either",
  "enum-map",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,6 +31,7 @@ restate-cli-util = { workspace = true }
 restate-cloud-tunnel-client = { workspace = true }
 restate-serde-util = { workspace = true }
 restate-time-util = { workspace = true }
+restate-futures-util = { workspace = true }
 restate-types = { workspace = true }
 restate-lite = { workspace = true, optional = true }
 mock-service-endpoint = { workspace = true, optional = true }

--- a/cli/src/clients/datafusion_helpers/mod.rs
+++ b/cli/src/clients/datafusion_helpers/mod.rs
@@ -23,7 +23,6 @@ pub struct ServiceHandlerUsage {
 pub struct SimpleInvocation {
     pub id: String,
     pub target: String,
-    pub status: InvocationState,
 }
 
 #[derive(

--- a/cli/src/clients/datafusion_helpers/v2.rs
+++ b/cli/src/clients/datafusion_helpers/v2.rs
@@ -37,7 +37,7 @@ pub async fn find_active_invocations_simple(
     client: &DataFusionHttpClient,
     filter: &str,
 ) -> Result<Vec<SimpleInvocation>> {
-    let query = format!("SELECT id, target, status FROM sys_invocation WHERE {filter}");
+    let query = format!("SELECT id, target FROM sys_invocation_status WHERE {filter}");
     Ok(client.run_json_query::<SimpleInvocation>(query).await?)
 }
 

--- a/cli/src/clients/mod.rs
+++ b/cli/src/clients/mod.rs
@@ -19,29 +19,6 @@ mod errors;
 pub use self::admin_client::AdminClient;
 pub use self::admin_client::Error as MetasClientError;
 pub use self::admin_client::{MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION};
-pub use self::admin_interface::AdminClientInterface;
 pub use self::admin_interface::Deployment;
+pub use self::admin_interface::{AdminClientInterface, batch_execute};
 pub use self::datafusion_http_client::DataFusionHttpClient;
-
-use futures::StreamExt;
-use futures::stream::FuturesUnordered;
-
-pub(crate) async fn collect_and_split_futures<Fut, Ok, Err>(
-    iter: impl IntoIterator<Item = Fut>,
-) -> (Vec<Ok>, Vec<Err>)
-where
-    Fut: Future<Output = Result<Ok, Err>> + Send,
-    Ok: Send,
-    Err: Send,
-{
-    iter.into_iter()
-        .collect::<FuturesUnordered<_>>()
-        .fold((vec![], vec![]), |(mut done, mut failed), result| async {
-            match result {
-                Ok(ok) => done.push(ok),
-                Err(err) => failed.push(err),
-            }
-            (done, failed)
-        })
-        .await
-}

--- a/cli/src/commands/invocations/cancel.rs
+++ b/cli/src/commands/invocations/cancel.rs
@@ -7,19 +7,24 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+
 use anyhow::{Result, anyhow, bail};
 use cling::prelude::*;
 use comfy_table::{Cell, Color, Table};
-use futures::TryFutureExt;
 use restate_cli_util::ui::console::{Styled, StyledTable, confirm_or_exit};
 use restate_cli_util::ui::stylesheet::Style;
-use restate_cli_util::{c_error, c_indent_table, c_println, c_success, c_warn};
+use restate_cli_util::{c_indent_table, c_println, c_success, c_warn};
 
 use crate::cli_env::CliEnv;
-use crate::clients::datafusion_helpers::{InvocationState, find_active_invocations_simple};
-use crate::clients::{self, AdminClientInterface, collect_and_split_futures};
-use crate::commands::invocations::create_query_filter;
+use crate::clients::batch_execute;
+use crate::clients::datafusion_helpers::find_active_invocations_simple;
+use crate::clients::{self, AdminClientInterface};
+use crate::commands::invocations::{
+    DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT, DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    create_query_filter,
+};
 use crate::ui::invocations::render_simple_invocation_list;
+use crate::ui::with_progress;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_cancel")]
@@ -38,6 +43,9 @@ pub struct Cancel {
     /// Ungracefully kill the invocation and its children
     #[clap(long)]
     pub(super) kill: bool,
+    /// Limit the number of fetched invocations
+    #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]
+    pub(super) limit: usize,
 }
 
 pub async fn run_cancel(State(env): State<CliEnv>, opts: &Cancel) -> Result<()> {
@@ -45,11 +53,16 @@ pub async fn run_cancel(State(env): State<CliEnv>, opts: &Cancel) -> Result<()> 
     let sql_client = clients::DataFusionHttpClient::from(client.clone());
 
     let filter = format!(
-        "{} AND status != 'completed'",
-        create_query_filter(&opts.query)
+        "{} AND status != 'completed' LIMIT {}",
+        create_query_filter(&opts.query),
+        opts.limit
     );
 
-    let invocations = find_active_invocations_simple(&sql_client, &filter).await?;
+    let invocations = with_progress(
+        "Reading invocations...",
+        find_active_invocations_simple(&sql_client, &filter),
+    )
+    .await?;
     if invocations.is_empty() {
         bail!(
             "No invocations found for query {}! Note that the cancel command only works on non-completed invocations. \
@@ -58,19 +71,10 @@ pub async fn run_cancel(State(env): State<CliEnv>, opts: &Cancel) -> Result<()> 
         );
     };
 
-    render_simple_invocation_list(&invocations);
-
-    if invocations
-        .iter()
-        .all(|inv| matches!(inv.status, InvocationState::Completed))
-    {
-        // Should only happen with explicit invocation ids, as we filter the completed state out otherwise
-        c_error!(
-            "The invocations matching your query are completed; cancel/kill has no effect on them. \
-            If you want to remove a completed invocation, consider using the purge command instead.",
-        );
-        return Ok(());
-    }
+    render_simple_invocation_list(
+        &invocations,
+        DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    );
 
     // Get the invocation and confirm
     let prompt = format!(
@@ -86,28 +90,18 @@ pub async fn run_cancel(State(env): State<CliEnv>, opts: &Cancel) -> Result<()> 
     if opts.kill {
         // Kill invocations
         let (killed, failed_to_kill) =
-            collect_and_split_futures(invocations.into_iter().map(|invocation| invocation.id).map(
-                |invocation_id| async {
-                    client
-                        .kill_invocation(&invocation_id)
-                        .map_err(anyhow::Error::from)
-                        .await
-                        .map(|_| invocation_id.clone())
-                        .map_err(|e| (invocation_id, e))
-                },
-            ))
+            batch_execute(client, invocations, |client, invocation| async move {
+                client
+                    .kill_invocation(&invocation.id)
+                    .await
+                    .map_err(anyhow::Error::from)
+            })
             .await;
+        let succeeded_count = killed.len();
+        let failed_count = failed_to_kill.len();
 
         c_println!();
-        c_success!("Killed invocations:");
-
-        // Print success
-        let mut invocations_table = Table::new_styled();
-        invocations_table.set_styled_header(vec!["KILLED INVOCATIONS"]);
-        for id in killed {
-            invocations_table.add_row(vec![Cell::new(&id)]);
-        }
-        c_indent_table!(0, invocations_table);
+        c_success!("Killed {} invocations", succeeded_count);
 
         // Print failed ones, if any
         if !failed_to_kill.is_empty() {
@@ -115,39 +109,35 @@ pub async fn run_cancel(State(env): State<CliEnv>, opts: &Cancel) -> Result<()> 
             c_warn!("Failed to kill:");
             let mut failed_to_kill_table = Table::new_styled();
             failed_to_kill_table.set_styled_header(vec!["ID", "REASON"]);
-            for (id, reason) in failed_to_kill {
-                failed_to_kill_table
-                    .add_row(vec![Cell::new(&id), Cell::new(reason).fg(Color::DarkRed)]);
+            for (inv, reason) in failed_to_kill {
+                failed_to_kill_table.add_row(vec![
+                    Cell::new(&inv.id),
+                    Cell::new(reason).fg(Color::DarkRed),
+                ]);
             }
             c_indent_table!(0, failed_to_kill_table);
 
-            return Err(anyhow!("Failed to kill some invocations"));
+            return Err(anyhow!(
+                "Failed to kill {} invocations out of {}",
+                failed_count,
+                failed_count + succeeded_count
+            ));
         }
     } else {
         // Cancel invocations
         let (cancelled, failed_to_cancel) =
-            collect_and_split_futures(invocations.into_iter().map(|invocation| invocation.id).map(
-                |invocation_id| async {
-                    client
-                        .cancel_invocation(&invocation_id)
-                        .map_err(anyhow::Error::from)
-                        .await
-                        .map(|_| invocation_id.clone())
-                        .map_err(|e| (invocation_id, e))
-                },
-            ))
+            batch_execute(client, invocations, |client, invocation| async move {
+                client
+                    .cancel_invocation(&invocation.id)
+                    .await
+                    .map_err(anyhow::Error::from)
+            })
             .await;
+        let succeeded_count = cancelled.len();
+        let failed_count = failed_to_cancel.len();
 
         c_println!();
-        c_success!("Cancelled invocations:");
-
-        // Print success
-        let mut invocations_table = Table::new_styled();
-        invocations_table.set_styled_header(vec!["CANCELLED INVOCATIONS"]);
-        for id in cancelled {
-            invocations_table.add_row(vec![Cell::new(&id)]);
-        }
-        c_indent_table!(0, invocations_table);
+        c_success!("Cancelled {} invocations", succeeded_count);
 
         // Print failed ones, if any
         if !failed_to_cancel.is_empty() {
@@ -155,13 +145,19 @@ pub async fn run_cancel(State(env): State<CliEnv>, opts: &Cancel) -> Result<()> 
             c_warn!("Failed to cancel:");
             let mut failed_to_cancel_table = Table::new_styled();
             failed_to_cancel_table.set_styled_header(vec!["ID", "REASON"]);
-            for (id, reason) in failed_to_cancel {
-                failed_to_cancel_table
-                    .add_row(vec![Cell::new(&id), Cell::new(reason).fg(Color::DarkRed)]);
+            for (inv, reason) in failed_to_cancel {
+                failed_to_cancel_table.add_row(vec![
+                    Cell::new(&inv.id),
+                    Cell::new(reason).fg(Color::DarkRed),
+                ]);
             }
             c_indent_table!(0, failed_to_cancel_table);
 
-            return Err(anyhow!("Failed to cancel some invocations"));
+            return Err(anyhow!(
+                "Failed to cancel {} invocations out of {}",
+                failed_count,
+                failed_count + succeeded_count
+            ));
         }
     }
 

--- a/cli/src/commands/invocations/kill.rs
+++ b/cli/src/commands/invocations/kill.rs
@@ -7,6 +7,9 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+
+use super::DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT;
+
 use anyhow::Result;
 use cling::prelude::*;
 
@@ -27,6 +30,9 @@ pub struct Kill {
     /// * `workflowName/key`
     /// * `workflowName/key/handler`
     query: String,
+    /// Limit the number of fetched invocations
+    #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]
+    limit: usize,
 }
 
 pub async fn run_kill(state: State<CliEnv>, opts: &Kill) -> Result<()> {
@@ -35,6 +41,7 @@ pub async fn run_kill(state: State<CliEnv>, opts: &Kill) -> Result<()> {
         &Cancel {
             query: opts.query.clone(),
             kill: true,
+            limit: opts.limit,
         },
     )
     .await

--- a/cli/src/commands/invocations/mod.rs
+++ b/cli/src/commands/invocations/mod.rs
@@ -20,6 +20,10 @@ mod resume;
 use cling::prelude::*;
 use restate_types::identifiers::InvocationId;
 
+const DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT: usize = 500;
+const DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT: usize =
+    DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT;
+
 #[derive(Run, Subcommand, Clone)]
 pub enum Invocations {
     /// List invocations

--- a/cli/src/commands/invocations/purge.rs
+++ b/cli/src/commands/invocations/purge.rs
@@ -10,14 +10,16 @@
 
 use crate::cli_env::CliEnv;
 use crate::clients::datafusion_helpers::find_active_invocations_simple;
-use crate::clients::{self, AdminClientInterface, collect_and_split_futures};
+use crate::clients::{self, AdminClientInterface, batch_execute};
+use crate::commands::invocations::{
+    DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT, DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    create_query_filter,
+};
 use crate::ui::invocations::render_simple_invocation_list;
 
-use crate::commands::invocations::create_query_filter;
 use anyhow::{Result, anyhow, bail};
 use cling::prelude::*;
 use comfy_table::{Cell, Color, Table};
-use futures::TryFutureExt;
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_cli_util::{c_indent_table, c_println, c_success, c_warn};
 
@@ -36,6 +38,9 @@ pub struct Purge {
     /// * `workflowName/key`
     /// * `workflowName/key/handler`
     query: String,
+    /// Limit the number of fetched invocations
+    #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]
+    limit: usize,
 }
 
 pub async fn run_purge(State(env): State<CliEnv>, opts: &Purge) -> Result<()> {
@@ -43,8 +48,9 @@ pub async fn run_purge(State(env): State<CliEnv>, opts: &Purge) -> Result<()> {
     let sql_client = clients::DataFusionHttpClient::from(client.clone());
 
     let filter = format!(
-        "{} AND status = 'completed'",
-        create_query_filter(&opts.query)
+        "{} AND status = 'completed' LIMIT {}",
+        create_query_filter(&opts.query),
+        opts.limit
     );
 
     let invocations = find_active_invocations_simple(&sql_client, &filter).await?;
@@ -56,35 +62,28 @@ pub async fn run_purge(State(env): State<CliEnv>, opts: &Purge) -> Result<()> {
         );
     };
 
-    render_simple_invocation_list(&invocations);
+    render_simple_invocation_list(
+        &invocations,
+        DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    );
 
     // Get the invocation and confirm
     confirm_or_exit("Are you sure you want to purge these invocations?")?;
 
     // Purge invocations
     let (purged, failed_to_purge) =
-        collect_and_split_futures(invocations.into_iter().map(|invocation| invocation.id).map(
-            |invocation_id| async {
-                client
-                    .purge_invocation(&invocation_id)
-                    .map_err(anyhow::Error::from)
-                    .await
-                    .map(|_| invocation_id.clone())
-                    .map_err(|e| (invocation_id, e))
-            },
-        ))
+        batch_execute(client, invocations, |client, invocation| async move {
+            client
+                .purge_invocation(&invocation.id)
+                .await
+                .map_err(anyhow::Error::from)
+        })
         .await;
+    let succeeded_count = purged.len();
+    let failed_count = failed_to_purge.len();
 
     c_println!();
-    c_success!("Purged invocations:");
-
-    // Print new ids
-    let mut invocations_table = Table::new_styled();
-    invocations_table.set_styled_header(vec!["PURGED INVOCATIONS"]);
-    for id in purged {
-        invocations_table.add_row(vec![Cell::new(&id)]);
-    }
-    c_indent_table!(0, invocations_table);
+    c_success!("Paused {} invocations", succeeded_count);
 
     // Print failed ones, if any
     if !failed_to_purge.is_empty() {
@@ -92,13 +91,19 @@ pub async fn run_purge(State(env): State<CliEnv>, opts: &Purge) -> Result<()> {
         c_warn!("Failed to purge:");
         let mut failed_to_purge_table = Table::new_styled();
         failed_to_purge_table.set_styled_header(vec!["ID", "REASON"]);
-        for (id, reason) in failed_to_purge {
-            failed_to_purge_table
-                .add_row(vec![Cell::new(&id), Cell::new(reason).fg(Color::DarkRed)]);
+        for (inv, reason) in failed_to_purge {
+            failed_to_purge_table.add_row(vec![
+                Cell::new(&inv.id),
+                Cell::new(reason).fg(Color::DarkRed),
+            ]);
         }
         c_indent_table!(0, failed_to_purge_table);
 
-        return Err(anyhow!("Failed to purge some invocations"));
+        return Err(anyhow!(
+            "Failed to purge {} invocations out of {}",
+            failed_count,
+            failed_count + succeeded_count
+        ));
     }
 
     Ok(())

--- a/cli/src/commands/invocations/restart_as_new.rs
+++ b/cli/src/commands/invocations/restart_as_new.rs
@@ -10,14 +10,16 @@
 
 use crate::cli_env::CliEnv;
 use crate::clients::datafusion_helpers::find_active_invocations_simple;
-use crate::clients::{self, AdminClientInterface, collect_and_split_futures};
+use crate::clients::{self, AdminClientInterface, batch_execute};
 use crate::ui::invocations::render_simple_invocation_list;
 
-use crate::commands::invocations::create_query_filter;
+use crate::commands::invocations::{
+    DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT, DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    create_query_filter,
+};
 use anyhow::{Result, anyhow, bail};
 use cling::prelude::*;
 use comfy_table::{Attribute, Cell, Color, Table};
-use futures::TryFutureExt;
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_cli_util::{c_indent_table, c_println, c_success, c_warn};
 
@@ -33,6 +35,9 @@ pub struct RestartAsNew {
     /// * `virtualObjectName/key`
     /// * `virtualObjectName/key/handler`
     query: String,
+    /// Limit the number of fetched invocations
+    #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]
+    limit: usize,
 }
 
 pub async fn run_restart_as_new(State(env): State<CliEnv>, opts: &RestartAsNew) -> Result<()> {
@@ -40,8 +45,9 @@ pub async fn run_restart_as_new(State(env): State<CliEnv>, opts: &RestartAsNew) 
     let sql_client = clients::DataFusionHttpClient::from(client.clone());
 
     let filter = format!(
-        "{} AND status = 'completed'",
-        create_query_filter(&opts.query)
+        "{} AND status = 'completed' LIMIT {}",
+        create_query_filter(&opts.query),
+        opts.limit
     );
 
     let invocations = find_active_invocations_simple(&sql_client, &filter).await?;
@@ -52,35 +58,37 @@ pub async fn run_restart_as_new(State(env): State<CliEnv>, opts: &RestartAsNew) 
         );
     };
 
-    render_simple_invocation_list(&invocations);
+    render_simple_invocation_list(
+        &invocations,
+        DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    );
 
     // Get the invocation and confirm
     confirm_or_exit("Are you sure you want to restart these invocations?")?;
 
     // Restart invocations
     let (restarted, failed_to_restart) =
-        collect_and_split_futures(invocations.into_iter().map(|invocation| invocation.id).map(
-            |invocation_id| async {
-                client
-                    .restart_invocation(&invocation_id)
-                    .map_err(anyhow::Error::from)
-                    .and_then(|e| async { e.into_body().map_err(anyhow::Error::from).await })
-                    .await
-                    .map(|response| (invocation_id.clone(), response.new_invocation_id))
-                    .map_err(|e| (invocation_id, e))
-            },
-        ))
+        batch_execute(client, invocations, |client, invocation| async move {
+            let envelope = client
+                .restart_invocation(&invocation.id)
+                .await
+                .map_err(anyhow::Error::from)?;
+            let response = envelope.into_body().await.map_err(anyhow::Error::from)?;
+            Ok(response.new_invocation_id)
+        })
         .await;
+    let succeeded_count = restarted.len();
+    let failed_count = failed_to_restart.len();
 
     c_println!();
-    c_success!("Restarted invocations:");
+    c_success!("Restarted {} invocations:", succeeded_count);
 
     // Print success
     let mut invocations_table = Table::new_styled();
     invocations_table.set_styled_header(vec!["OLD ID", "NEW ID"]);
-    for (old_id, restart_as_new_response) in restarted {
+    for (old_inv, restart_as_new_response) in restarted {
         invocations_table.add_row(vec![
-            Cell::new(&old_id),
+            Cell::new(&old_inv.id),
             Cell::new(restart_as_new_response).add_attribute(Attribute::Bold),
         ]);
     }
@@ -92,13 +100,19 @@ pub async fn run_restart_as_new(State(env): State<CliEnv>, opts: &RestartAsNew) 
         c_warn!("Failed to restart:");
         let mut failed_to_restart_table = Table::new_styled();
         failed_to_restart_table.set_styled_header(vec!["ID", "REASON"]);
-        for (id, reason) in failed_to_restart {
-            failed_to_restart_table
-                .add_row(vec![Cell::new(&id), Cell::new(reason).fg(Color::DarkRed)]);
+        for (inv, reason) in failed_to_restart {
+            failed_to_restart_table.add_row(vec![
+                Cell::new(&inv.id),
+                Cell::new(reason).fg(Color::DarkRed),
+            ]);
         }
         c_indent_table!(0, failed_to_restart_table);
 
-        return Err(anyhow!("Failed to restart some invocations"));
+        return Err(anyhow!(
+            "Failed to restart {} invocations out of {}",
+            failed_count,
+            failed_count + succeeded_count
+        ));
     }
 
     Ok(())

--- a/cli/src/commands/invocations/resume.rs
+++ b/cli/src/commands/invocations/resume.rs
@@ -10,14 +10,16 @@
 
 use crate::cli_env::CliEnv;
 use crate::clients::datafusion_helpers::find_active_invocations_simple;
-use crate::clients::{self, AdminClientInterface, collect_and_split_futures};
+use crate::clients::{self, AdminClientInterface, batch_execute};
 use crate::ui::invocations::render_simple_invocation_list;
 
-use crate::commands::invocations::create_query_filter;
+use crate::commands::invocations::{
+    DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT, DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    create_query_filter,
+};
 use anyhow::{Result, anyhow, bail};
 use cling::prelude::*;
 use comfy_table::{Cell, Color, Table};
-use futures::TryFutureExt;
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_cli_util::{c_indent_table, c_println, c_success, c_warn};
 
@@ -39,6 +41,9 @@ pub struct Resume {
     /// When provided and the invocation is either running, or no deployment is pinned, this operation will fail.
     #[clap(long)]
     deployment: Option<String>,
+    /// Limit the number of fetched invocations
+    #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]
+    limit: usize,
 }
 
 pub async fn run_resume(State(env): State<CliEnv>, opts: &Resume) -> Result<()> {
@@ -47,8 +52,9 @@ pub async fn run_resume(State(env): State<CliEnv>, opts: &Resume) -> Result<()> 
 
     // Filter only by invoked/suspended/paused, this command has no effect on non-completed invocations
     let filter = format!(
-        "{} AND status IN ('paused', 'running', 'backing-off', 'suspended', 'ready')",
-        create_query_filter(&opts.query)
+        "{} AND status IN ('paused', 'invoked', 'suspended') LIMIT {}",
+        create_query_filter(&opts.query),
+        opts.limit
     );
 
     let invocations = find_active_invocations_simple(&sql_client, &filter).await?;
@@ -59,51 +65,54 @@ pub async fn run_resume(State(env): State<CliEnv>, opts: &Resume) -> Result<()> 
         );
     };
 
-    render_simple_invocation_list(&invocations);
+    render_simple_invocation_list(
+        &invocations,
+        DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    );
 
     // Get the invocation and confirm
     confirm_or_exit("Are you sure you want to resume these invocations?")?;
 
     // Resume invocations
-    let deployment = opts.deployment.as_deref();
-    let (resumed, failed_to_resume) =
-        collect_and_split_futures(invocations.into_iter().map(|invocation| invocation.id).map(
-            |invocation_id| async {
-                client
-                    .resume_invocation(&invocation_id, deployment)
-                    .map_err(anyhow::Error::from)
-                    .await
-                    .map(|_| invocation_id.clone())
-                    .map_err(|e| (invocation_id, e))
-            },
-        ))
-        .await;
+    let deployment = opts.deployment.clone();
+    let (resumed, failed_to_resume) = batch_execute(
+        client,
+        invocations
+            .into_iter()
+            .map(|i| (i, deployment.clone()))
+            .collect(),
+        |client, (invocation, deployment)| async move {
+            client
+                .resume_invocation(&invocation.id, deployment.as_deref())
+                .await
+                .map_err(anyhow::Error::from)
+        },
+    )
+    .await;
+    let succeeded_count = resumed.len();
+    let failed_count = failed_to_resume.len();
 
     c_println!();
-    c_success!("Resumed invocations:");
-
-    // Print new ids
-    let mut invocations_table = Table::new_styled();
-    invocations_table.set_styled_header(vec!["RESUMED INVOCATIONS"]);
-    for id in resumed {
-        invocations_table.add_row(vec![Cell::new(&id)]);
-    }
-    c_indent_table!(0, invocations_table);
+    c_success!("Resumed {} invocations", succeeded_count);
 
     // Print failed ones, if any
     if !failed_to_resume.is_empty() {
         c_warn!("Failed to resume:");
         let mut failed_to_restart_table = Table::new_styled();
         failed_to_restart_table.set_styled_header(vec!["ID", "REASON"]);
-        for (id, reason) in failed_to_resume {
-            failed_to_restart_table
-                .add_row(vec![Cell::new(&id), Cell::new(reason).fg(Color::DarkRed)]);
+        for ((inv, _), reason) in failed_to_resume {
+            failed_to_restart_table.add_row(vec![
+                Cell::new(&inv.id),
+                Cell::new(reason).fg(Color::DarkRed),
+            ]);
         }
         c_indent_table!(0, failed_to_restart_table);
 
-        return Err(anyhow!("Failed to resume some invocations"));
-    } else {
-        c_success!("Request was sent successfully");
+        return Err(anyhow!(
+            "Failed to resume {} invocations out of {}",
+            failed_count,
+            failed_count + succeeded_count
+        ));
     }
 
     Ok(())

--- a/cli/src/ui/invocations.rs
+++ b/cli/src/ui/invocations.rs
@@ -254,18 +254,20 @@ pub fn add_invocation_to_kv_table(table: &mut Table, invocation: &Invocation) {
     }
 }
 
-pub fn render_simple_invocation_list(invocations: &[SimpleInvocation]) {
+pub fn render_simple_invocation_list(invocations: &[SimpleInvocation], limit: usize) {
     let mut invocations_table = Table::new_styled();
-    invocations_table.set_styled_header(vec!["ID", "TARGET", "STATUS"]);
+    invocations_table.set_styled_header(vec!["ID", "TARGET"]);
 
-    for inv in invocations {
+    for inv in invocations.iter().take(limit) {
         invocations_table.add_row(vec![
             Cell::new(&inv.id).add_attribute(Attribute::Bold),
             Cell::new(&inv.target),
-            Cell::new(invocation_status(inv.status)),
         ]);
     }
     c_indent_table!(0, invocations_table);
+    if invocations.len() > limit {
+        c_println!("And other {} invocations...", invocations.len() - limit)
+    }
     c_println!();
 }
 

--- a/cli/src/ui/mod.rs
+++ b/cli/src/ui/mod.rs
@@ -8,7 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use indicatif::ProgressBar;
+
 pub mod datetime;
 pub mod deployments;
 pub mod invocations;
 pub mod service_handlers;
+
+pub async fn with_progress<T>(msg: &'static str, f: impl Future<Output = T>) -> T {
+    let progress = ProgressBar::new_spinner();
+    progress
+        .set_style(indicatif::ProgressStyle::with_template("{spinner} [{elapsed}] {msg}").unwrap());
+    progress.enable_steady_tick(std::time::Duration::from_millis(120));
+
+    progress.set_message(msg);
+    let result = f.await;
+    progress.finish_and_clear();
+    result
+}

--- a/crates/futures-util/Cargo.toml
+++ b/crates/futures-util/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 restate-workspace-hack = { workspace = true }
 
 anyhow = { workspace = true }
+async-channel = { workspace = true }
 futures = { workspace = true }
 pin-project = { workspace = true }
 pin-project-lite = { workspace = true }

--- a/crates/futures-util/src/lib.rs
+++ b/crates/futures-util/src/lib.rs
@@ -12,3 +12,4 @@ pub mod command;
 pub mod concurrency;
 pub mod overdue;
 pub mod pipe;
+pub mod streams;

--- a/crates/futures-util/src/streams.rs
+++ b/crates/futures-util/src/streams.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_channel::Receiver;
+use futures::Stream;
+use std::ops::Fn;
+use std::pin::pin;
+
+pub trait StreamExt
+where
+    Self: Stream,
+{
+    fn concurrent_map_unordered<T, Ctx, Fun, Fut>(
+        self,
+        concurrency_limit: usize,
+        ctx: Ctx,
+        fun: Fun,
+    ) -> Receiver<T>
+    where
+        T: Send + 'static,
+        Ctx: Send + Clone + 'static,
+        Fun: Fn(Ctx, Self::Item) -> Fut + Copy + Send + 'static,
+        Fut: Future<Output = T> + Send,
+        Self: Sized + Send + 'static,
+        <Self as Stream>::Item: Send + 'static,
+    {
+        let (in_tx, in_rx) = async_channel::bounded(concurrency_limit);
+        let (out_tx, out_rx) = async_channel::unbounded();
+
+        for _worker in 0..concurrency_limit {
+            let rx = in_rx.clone();
+            let tx = out_tx.clone();
+            let ctx = ctx.clone();
+            tokio::spawn(async move {
+                while let Ok(item) = rx.recv().await {
+                    let res = fun(ctx.clone(), item).await;
+                    tx.send(res).await.unwrap();
+                }
+            });
+        }
+
+        tokio::spawn(async move {
+            let mut this = pin!(self);
+            while let Some(item) = futures::StreamExt::next(&mut this).await {
+                in_tx.send(item).await.unwrap();
+            }
+            in_tx.close();
+        });
+
+        out_rx
+    }
+}
+
+impl<S> StreamExt for S where S: Stream {}

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -45,6 +45,7 @@ clap_builder = { version = "4", default-features = false, features = ["color", "
 comfy-table = { version = "7" }
 criterion = { version = "0.5", features = ["async_tokio"] }
 crossbeam-epoch = { version = "0.9" }
+crossbeam-utils = { version = "0.8" }
 digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }
@@ -175,6 +176,7 @@ clap_builder = { version = "4", default-features = false, features = ["color", "
 comfy-table = { version = "7" }
 criterion = { version = "0.5", features = ["async_tokio"] }
 crossbeam-epoch = { version = "0.9" }
+crossbeam-utils = { version = "0.8" }
 digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }


### PR DESCRIPTION
[CLI] Various improvements to batch cancel/kill and co

Summary:

Assorted improvements to cancel/kill:

* Use the limited concurrency map to execute concurrently the admin api commands. Limiting concurrency to 500 seems to be the way to not make it fail :shrug: There's also the mistery of 1011...
* Don't print twice the invocations we're going to kill, there's no need. Just print the failed ones, if any. Same for pause/resume, etc.
* Limit the amount of output too. This is a problem when killing 2milion invocations...
* Add progress bar when reading the invocations
* Add another progress bar when cancelling them
* Add a limit to the batch cancel/kill and co. Mitigates #3857
* Introduce a utility for running concurrent `map` on a stream, limiting the concurrency.

Based on #3943 
