### PR TITLE
Handle Invoker unexpected crashes

### DIFF
--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -269,6 +269,8 @@ pub enum ProcessorError {
     ShutdownError(#[from] ShutdownError),
     #[error("log read stream has terminated")]
     LogReadStreamTerminated,
+    #[error("Invoker stopped unexpectedly")]
+    InvokerStoppedUnexpectedly,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
Handle Invoker unexpected crashes

Summary:
Gracefully handle invoker unexpected crashes by shutting down
the partition gracefully so it can be restarted cleanly

Fixes #4102
