### PR TITLE
Introduces restate-clock crate with cached wall clock management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6996,6 +6996,7 @@ dependencies = [
  "pprof",
  "rand 0.9.1",
  "reqwest",
+ "restate-clock",
  "restate-core",
  "restate-node",
  "restate-rocksdb",
@@ -7160,6 +7161,21 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "restate-clock"
+version = "1.6.0-dev"
+dependencies = [
+ "bilrost",
+ "bytes",
+ "criterion",
+ "jiff",
+ "prost-types 0.14.1",
+ "restate-encoding",
+ "restate-workspace-hack",
+ "schemars 0.8.22",
+ "serde",
 ]
 
 [[package]]
@@ -7505,6 +7521,7 @@ dependencies = [
  "reqwest",
  "restate-admin",
  "restate-bifrost",
+ "restate-clock",
  "restate-core",
  "restate-errors",
  "restate-metadata-server",
@@ -7540,6 +7557,7 @@ dependencies = [
  "rand 0.9.1",
  "regex",
  "reqwest",
+ "restate-clock",
  "restate-core",
  "restate-metadata-providers",
  "restate-metadata-server-grpc",
@@ -7950,6 +7968,7 @@ dependencies = [
  "reqwest",
  "restate-admin",
  "restate-bifrost",
+ "restate-clock",
  "restate-core",
  "restate-errors",
  "restate-local-cluster-runner",
@@ -8289,6 +8308,7 @@ dependencies = [
  "regex",
  "regress",
  "restate-base64-util",
+ "restate-clock",
  "restate-encoding",
  "restate-errors",
  "restate-serde-util",
@@ -8504,6 +8524,8 @@ dependencies = [
  "criterion",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "darling 0.20.10",
+ "darling_core 0.20.10",
  "digest",
  "either",
  "enum-map",
@@ -8641,6 +8663,7 @@ dependencies = [
  "rand 0.9.1",
  "restate-bifrost",
  "restate-cli-util",
+ "restate-clock",
  "restate-core",
  "restate-futures-util",
  "restate-local-cluster-runner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ restate-admin-rest-model = { path = "crates/admin-rest-model" }
 restate-base64-util = { path = "crates/base64-util" }
 restate-bifrost = { path = "crates/bifrost" }
 restate-cli-util = { path = "crates/cli-util" }
+restate-clock = { path = "crates/clock" }
 restate-cloud-tunnel-client = { path = "crates/cloud-tunnel-client" }
 restate-core = { path = "crates/core" }
 restate-core-derive = { path = "crates/core/derive" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -16,6 +16,7 @@ no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"
 restate-workspace-hack = { workspace = true }
 
 mock-service-endpoint = { workspace = true }
+restate-clock = { workspace = true }
 restate-core = { workspace = true, features = ["test-util"] }
 restate-node = { workspace = true, features = ["memory-loglet"] }
 restate-rocksdb = { workspace = true }

--- a/benchmarks/benches/throughput_parallel.rs
+++ b/benchmarks/benches/throughput_parallel.rs
@@ -30,6 +30,7 @@ fn throughput_benchmark(criterion: &mut Criterion) {
         .with(fmt::layer())
         .with(EnvFilter::from_default_env())
         .init();
+    let _clock = restate_clock::ClockUpkeep::start();
 
     let config = restate_benchmarks::restate_configuration();
     let tc = restate_benchmarks::spawn_restate(config);

--- a/benchmarks/benches/throughput_sequential.rs
+++ b/benchmarks/benches/throughput_sequential.rs
@@ -26,6 +26,7 @@ fn throughput_benchmark(criterion: &mut Criterion) {
         .with(fmt::layer())
         .with(EnvFilter::from_default_env())
         .init();
+    let _clock = restate_clock::ClockUpkeep::start();
 
     let config = restate_benchmarks::restate_configuration();
     let tc = restate_benchmarks::spawn_restate(config);

--- a/crates/clock/Cargo.toml
+++ b/crates/clock/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "restate-clock"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+test-util = []
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+restate-encoding = { workspace = true }
+
+bilrost = { workspace = true }
+bytes = { workspace = true }
+jiff = { workspace = true, optional = true }
+prost-types = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "wall_clock"
+harness = false

--- a/crates/clock/benches/wall_clock.rs
+++ b/crates/clock/benches/wall_clock.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::{Duration, SystemTime};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use restate_clock::Clock;
+use restate_clock::time::MillisSinceEpoch;
+use restate_clock::{ClockUpkeep, WallClock};
+
+pub fn wall_clock_single_threaded(c: &mut Criterion) {
+    // Start the ClockUpkeep thread before benchmarking
+    let _upkeep = ClockUpkeep::start().expect("failed to start clock upkeep thread");
+
+    let mut group = c.benchmark_group("single-threaded");
+
+    group
+        .measurement_time(Duration::from_secs(5))
+        .sample_size(1000)
+        .bench_function(BenchmarkId::new("cached", "WallClock.recent"), |b| {
+            b.iter(|| std::hint::black_box(WallClock.recent()));
+        })
+        .bench_function(BenchmarkId::new("uncached", "SystemTime::now"), |b| {
+            b.iter(|| std::hint::black_box(MillisSinceEpoch::from(SystemTime::now())));
+        });
+
+    group.finish();
+}
+
+pub fn wall_clock_multi_threaded(c: &mut Criterion) {
+    // Start the ClockUpkeep thread before benchmarking
+    let _upkeep = ClockUpkeep::start().expect("failed to start clock upkeep thread");
+
+    let num_threads = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(4);
+
+    let mut group = c.benchmark_group("multi-threaded");
+
+    group
+        .measurement_time(Duration::from_secs(5))
+        .sample_size(1000)
+        .bench_function(BenchmarkId::new("cached", "WallClock.recent"), |b| {
+            b.iter_custom(|iters| {
+                let mut children = Vec::with_capacity(num_threads);
+                let start = std::time::Instant::now();
+                for _i in 0..num_threads {
+                    children.push(std::thread::spawn(move || {
+                        for _i in 0..iters {
+                            std::hint::black_box(WallClock.recent());
+                        }
+                    }));
+                }
+                for child in children {
+                    child.join().unwrap()
+                }
+                start.elapsed()
+            });
+        })
+        .bench_function(BenchmarkId::new("uncached", "SystemTime::now"), |b| {
+            b.iter_custom(|iters| {
+                let mut children = Vec::with_capacity(num_threads);
+                let start = std::time::Instant::now();
+                for _i in 0..num_threads {
+                    children.push(std::thread::spawn(move || {
+                        for _i in 0..iters {
+                            std::hint::black_box(MillisSinceEpoch::from(SystemTime::now()));
+                        }
+                    }));
+                }
+                for child in children {
+                    child.join().unwrap()
+                }
+                start.elapsed()
+            });
+        });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = wall_clock_single_threaded, wall_clock_multi_threaded
+);
+
+criterion_main!(benches);

--- a/crates/clock/src/lib.rs
+++ b/crates/clock/src/lib.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#[cfg(feature = "test-util")]
+mod mock_clock;
+pub mod time;
+mod upkeep;
+mod wall_clock;
+
+#[cfg(feature = "test-util")]
+pub use mock_clock::MockClock;
+pub use upkeep::ClockUpkeep;
+pub use wall_clock::WallClock;
+
+/// A trait for accessing physical/wall clock timestamps.
+///
+/// This trait provides two methods for reading the current time, offering a trade-off
+/// between precision and performance:
+///
+/// - [`recent()`](Clock::recent): Returns a cached timestamp with ~100x better performance
+///   but potentially up to ~1ms stale (refreshed every 500μs by [`ClockUpkeep`]).
+/// - [`now()`](Clock::now): Returns a precise timestamp via a `SystemTime::now()` syscall/vDSO.
+pub trait Clock {
+    /// Returns a cached unix timestamp that may be up to ~1ms stale.
+    ///
+    /// This method reads from an atomic variable updated every 500μs by the
+    /// [`ClockUpkeep`] background thread, avoiding syscall/vDSO overhead.
+    ///
+    /// # Performance
+    ///
+    /// ~100x faster than [`now()`](Clock::now) due to atomic read vs syscall/vDSO.
+    ///
+    /// # Requirements
+    ///
+    /// The [`ClockUpkeep`] thread must be running for this to return valid timestamps.
+    /// If called before upkeep starts, returns `MillisSinceEpoch(0)`.
+    fn recent(&self) -> crate::time::MillisSinceEpoch;
+
+    /// Returns the current unix timestamp in milliseconds via `SystemTime::now()`.
+    ///
+    /// This method always makes a syscall/vDSO to get the precise current time.
+    /// For hot paths where ~1ms staleness is acceptable, prefer [`recent()`](Clock::recent).
+    fn now(&self) -> crate::time::MillisSinceEpoch;
+}
+
+impl<T: Clock> Clock for &T {
+    #[inline]
+    fn now(&self) -> crate::time::MillisSinceEpoch {
+        T::now(self)
+    }
+
+    #[inline]
+    fn recent(&self) -> crate::time::MillisSinceEpoch {
+        T::recent(self)
+    }
+}
+
+/// An anchor point for restate physical clock used in HLC timestamps.
+///
+/// RESTATE_EPOCH -> (2022-01-01 00:00:00 GMT)
+const RESTATE_EPOCH: crate::time::MillisSinceEpoch =
+    crate::time::MillisSinceEpoch::new(1_640_995_200_000);

--- a/crates/clock/src/mock_clock.rs
+++ b/crates/clock/src/mock_clock.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::time::MillisSinceEpoch;
+use crate::{Clock, RESTATE_EPOCH, WallClock};
+
+#[derive(Clone)]
+pub struct MockClock {
+    storage: Arc<AtomicU64>,
+}
+
+impl Default for MockClock {
+    fn default() -> Self {
+        let clock = Self {
+            storage: Arc::new(AtomicU64::default()),
+        };
+        clock.refresh_from_wall_clock();
+        clock
+    }
+}
+
+impl MockClock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_timestamp(timestamp: MillisSinceEpoch) -> Self {
+        assert!(
+            timestamp > RESTATE_EPOCH,
+            "Restate requires a wall clock set after Sat Jan 01 2022 00:00:00 GMT+0000"
+        );
+
+        Self {
+            storage: Arc::new(AtomicU64::new(timestamp.as_u64())),
+        }
+    }
+
+    pub fn advance_ms(&self, ms: u64) {
+        self.storage.fetch_add(ms, Ordering::SeqCst);
+    }
+
+    pub fn refresh_from_wall_clock(&self) {
+        self.set(WallClock.now());
+    }
+
+    pub fn set(&self, timestamp: MillisSinceEpoch) {
+        assert!(
+            timestamp > RESTATE_EPOCH,
+            "Restate requires a wall clock set after Sat Jan 01 2022 00:00:00 GMT+0000"
+        );
+        self.storage.store(timestamp.as_u64(), Ordering::SeqCst);
+    }
+}
+
+impl Clock for MockClock {
+    fn now(&self) -> MillisSinceEpoch {
+        MillisSinceEpoch::new(self.storage.load(Ordering::SeqCst))
+    }
+
+    fn recent(&self) -> MillisSinceEpoch {
+        MillisSinceEpoch::new(self.storage.load(Ordering::SeqCst))
+    }
+}

--- a/crates/clock/src/time.rs
+++ b/crates/clock/src/time.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, SystemTime};
 
 use restate_encoding::{BilrostNewType, NetSerde};
 
+use crate::WallClock;
+
 /// Milliseconds since the unix epoch
 #[derive(
     Debug,
@@ -27,7 +29,6 @@ use restate_encoding::{BilrostNewType, NetSerde};
     Hash,
     serde::Serialize,
     serde::Deserialize,
-    derive_more::Into,
     BilrostNewType,
     NetSerde,
 )]
@@ -36,22 +37,53 @@ use restate_encoding::{BilrostNewType, NetSerde};
 pub struct MillisSinceEpoch(u64);
 
 impl MillisSinceEpoch {
-    pub const UNIX_EPOCH: MillisSinceEpoch = MillisSinceEpoch::new(0);
-    pub const MAX: MillisSinceEpoch = MillisSinceEpoch::new(u64::MAX);
+    pub const UNIX_EPOCH: Self = Self::new(0);
+    pub const MAX: Self = Self::new(u64::MAX);
 
     pub const fn new(millis_since_epoch: u64) -> Self {
-        MillisSinceEpoch(millis_since_epoch)
+        Self(millis_since_epoch)
     }
 
+    /// Returns the current unix timestamp in milliseconds.
+    ///
+    /// This method uses the cached [`WallClock::recent_ms()`] timestamp when available,
+    /// providing ~100x better performance than a direct `SystemTime::now()` syscall.
+    /// The cached value is refreshed every 500μs by [`ClockUpkeep`](crate::ClockUpkeep),
+    /// so it may be up to ~1ms stale.
+    ///
+    /// # Fallback Behavior
+    ///
+    /// If [`ClockUpkeep`](crate::ClockUpkeep) has not been started (e.g., in tests or
+    /// standalone tools), this falls back to `SystemTime::now()`. The fallback path
+    /// is marked `#[cold]` to hint to the compiler that it's not the expected hot path.
+    ///
+    /// # Usage
+    ///
+    /// For production server binaries, ensure [`ClockUpkeep::start()`](crate::ClockUpkeep::start)
+    /// is called early in initialization to enable the fast path.
     pub fn now() -> Self {
-        SystemTime::now().into()
+        let recent = WallClock::recent_ms();
+        if recent.0 > 0 {
+            recent
+        } else {
+            // In tests or binaries where the upkeep thread is not running, we don't
+            // care about the performance of this call, so we can always call now()
+            // but we keep it non-inlined to hint to the compiler that it's unlikely
+            // the case.
+            Self::from_system_now()
+        }
     }
 
-    pub fn after(duration: Duration) -> MillisSinceEpoch {
-        SystemTime::now()
-            .checked_add(duration)
-            .map(|time| time.into())
-            .unwrap_or(Self::MAX)
+    // a hint to the compiler that this is unlikely to be called in the hot path.
+    #[cold]
+    #[inline(never)]
+    fn from_system_now() -> Self {
+        WallClock::now_ms()
+    }
+
+    #[inline]
+    pub fn after(duration: Duration) -> Self {
+        Self::now() + duration
     }
 
     pub const fn as_u64(&self) -> u64 {
@@ -61,6 +93,7 @@ impl MillisSinceEpoch {
     /// Note, this doesn't fail if the timestamp is higher than Timestamp::MAX instead
     /// it returns the default value (now). There are no practical cases where this can happen
     /// so it's decided to do this for API convenience.
+    #[cfg(feature = "jiff")]
     pub fn into_timestamp(self) -> jiff::Timestamp {
         jiff::Timestamp::from_millisecond(self.0 as i64).unwrap_or_default()
     }
@@ -76,6 +109,13 @@ impl MillisSinceEpoch {
     /// If the earlier timestamp is later than this timestamp, this will return zero.
     pub fn saturating_sub_ms(&self, earlier: Self) -> u64 {
         self.0.saturating_sub(earlier.0)
+    }
+}
+
+impl From<MillisSinceEpoch> for u64 {
+    #[inline]
+    fn from(value: MillisSinceEpoch) -> Self {
+        value.0
     }
 }
 
@@ -119,6 +159,7 @@ impl From<SystemTime> for MillisSinceEpoch {
     }
 }
 
+#[cfg(feature = "prost-types")]
 /// # Panics
 /// If timestamp is out of range (e.g. older than UNIX_EPOCH) this conversion will panic.
 impl From<prost_types::Timestamp> for MillisSinceEpoch {
@@ -129,6 +170,7 @@ impl From<prost_types::Timestamp> for MillisSinceEpoch {
     }
 }
 
+#[cfg(feature = "prost-types")]
 impl From<MillisSinceEpoch> for prost_types::Timestamp {
     fn from(value: MillisSinceEpoch) -> Self {
         // safest approach is to convert into SystemTime first, then calculate distance to
@@ -173,7 +215,24 @@ pub struct NanosSinceEpoch(u64);
 
 impl NanosSinceEpoch {
     pub fn now() -> Self {
-        SystemTime::now().into()
+        let recent_us = WallClock::recent_us();
+        if recent_us > 0 {
+            // the input is in microseconds, so we scale it to nanoseconds
+            Self(recent_us * 1_000)
+        } else {
+            // In tests or binaries where the upkeep thread is not running, we don't
+            // care about the performance of this call, so we can always call now()
+            // but we keep is non-inlined to hint to the compiler that it's unlikely
+            // the case.
+            Self::from_system_now()
+        }
+    }
+
+    // a hint to the compiler that this is unlikely to be called in the hot path.
+    #[cold]
+    #[inline(never)]
+    fn from_system_now() -> Self {
+        Self(WallClock::now_us() * 1_000)
     }
 
     pub fn as_u64(&self) -> u64 {
@@ -214,6 +273,7 @@ impl From<SystemTime> for NanosSinceEpoch {
     }
 }
 
+#[cfg(feature = "prost-types")]
 /// # Panics
 /// If timestamp is out of range (e.g. older than UNIX_EPOCH) this conversion will panic.
 impl From<prost_types::Timestamp> for NanosSinceEpoch {

--- a/crates/clock/src/upkeep.rs
+++ b/crates/clock/src/upkeep.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use crate::{Clock, RESTATE_EPOCH, WallClock};
+
+/// Defines the frequency of updating the cached wall clock.
+const UPKEEP_INTERVAL: Duration = const { Duration::from_micros(500) };
+
+pub struct ClockUpkeep {
+    running: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ClockUpkeep {
+    /// Starts the clock upkeep thread, periodically updating the global physical clock and
+    /// the coarse monotonic clock.
+    ///
+    /// The returned handle is a drop guard for the upkeep thread if it is successfully spawned.
+    /// Dropping the handle will stop the thread, so the handle must be held.
+    ///
+    /// # Important
+    ///
+    /// This function must be called as early as possible during server/binary initialization, before
+    /// any code attempts to read from [`WallClock::recent_ms()`](crate::WallClock::recent_ms).
+    ///
+    /// The server's `main()` function is responsible for starting the upkeep thread before
+    /// any other initialization occurs.
+    ///
+    /// # Errors
+    ///
+    /// If there was an issue spawning the thread.
+    pub fn start() -> Result<Self, std::io::Error> {
+        // perform an immediate update
+        WallClock::update_recent();
+
+        let unix_millis = WallClock.now();
+        assert!(
+            unix_millis > RESTATE_EPOCH,
+            "Restate requires a wall clock set after Sat Jan 01 2022 00:00:00 GMT+0000. Detected wall clock timestamp is {unix_millis}"
+        );
+
+        let running = Arc::new(AtomicBool::new(true));
+        let handle: std::thread::JoinHandle<()> = std::thread::Builder::new()
+            .name("rs-clock".to_owned())
+            .spawn({
+                let running = running.clone();
+                move || {
+                    while running.load(Ordering::Relaxed) {
+                        std::thread::sleep(UPKEEP_INTERVAL);
+                        WallClock::update_recent();
+                    }
+                }
+            })?;
+        Ok(Self {
+            handle: Some(handle),
+            running,
+        })
+    }
+}
+
+impl Drop for ClockUpkeep {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+
+        if let Some(handle) = self.handle.take() {
+            let _result = handle
+                .join()
+                .map_err(|_| std::io::Error::other("failed to stop rs-clock thread"));
+        }
+    }
+}

--- a/crates/clock/src/wall_clock.rs
+++ b/crates/clock/src/wall_clock.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::SystemTime;
+
+use crate::time::MillisSinceEpoch;
+
+use super::Clock;
+
+/// The cached timestamp of the most recent updated unix timestamp.
+///
+/// # Important
+///
+/// This requires the clock upkeep thread ([`ClockUpkeep`](crate::ClockUpkeep)) to
+/// be running. If `WallClock::recent_ms()` is called before the upkeep thread is started,
+/// it will return `MillisSinceEpoch(0)`.
+///
+/// The server's `main()` function starts the upkeep thread as early as possible to remove
+/// the possibility where this could occur.
+static RECENT_UNIX_TIMESTAMP_US: AtomicU64 = const { AtomicU64::new(0) };
+
+/// Production implementation of [`Clock`] backed by system time.
+///
+/// `WallClock` provides different ways to read the current time:
+///
+/// - [`now_ms()`](WallClock::now_ms): Precise timestamp (in milliseconds) via `SystemTime::now()` syscall/vDSO.
+/// - [`now_us()`](WallClock::now_us): Precise timestamp (in microseconds) via `SystemTime::now()` syscall/vDSO.
+/// - [`recent_ms()`](WallClock::recent_ms): Cached timestamp (in milliseconds) from an atomic variable, ~100x faster.
+/// - [`recent_us()`](WallClock::recent_us): Cached timestamp (in microseconds) from an atomic variable, ~100x faster.
+///
+/// # Cached Time
+///
+/// The cached timestamp is stored in a global atomic and refreshed every 500μs by
+/// [`ClockUpkeep`](crate::ClockUpkeep). This provides sub-nanosecond read performance
+/// at the cost of up to ~1ms staleness.
+///
+/// # Example
+///
+/// ```ignore
+/// use restate_clock::{Clock, ClockUpkeep, WallClock};
+///
+/// // Start the upkeep thread (required for `recent_ms()` to work)
+/// let _upkeep = ClockUpkeep::start().expect("failed to start clock upkeep");
+///
+/// // Fast path: read cached timestamp (~100x faster)
+/// let cached = WallClock::recent_ms();
+///
+/// // Precise path: syscall/vDSO to get exact time
+/// let precise = WallClock::now_ms();
+///
+/// // Can also use via the Clock trait
+/// let clock = WallClock;
+/// let timestamp = clock.recent();
+/// ```
+///
+/// # Thread Safety
+///
+/// `WallClock` is `Copy`, `Clone`, and can be safely shared across threads. The cached
+/// timestamp uses relaxed atomic ordering, which is sufficient since absolute precision
+/// is not required for the cached value.
+#[derive(Default, Copy, Clone)]
+pub struct WallClock;
+
+impl WallClock {
+    /// Updates the cached recent timestamp.
+    ///
+    /// This is intended to be called exclusively from the [`ClockUpkeep`](crate::ClockUpkeep)
+    /// background thread every 500μs.
+    pub(crate) fn update_recent() {
+        RECENT_UNIX_TIMESTAMP_US.store(Self::now_us(), Ordering::Relaxed);
+    }
+
+    /// Returns the current unix timestamp in milliseconds via `SystemTime::now()`.
+    ///
+    /// This method always makes a syscall/vDSO. For hot paths where ~1ms staleness is
+    /// acceptable, prefer [`recent_ms()`](WallClock::recent_ms).
+    #[inline]
+    pub fn now_ms() -> MillisSinceEpoch {
+        MillisSinceEpoch::new(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("duration since Unix epoch should be well-defined")
+                .as_millis() as u64,
+        )
+    }
+
+    /// Returns the current unix timestamp in microseconds via `SystemTime::now()`.
+    ///
+    /// This method always makes a syscall/vDSO. For hot paths where ~1ms staleness is
+    /// acceptable, prefer [`recent_us()`](WallClock::recent_us).
+    #[inline]
+    pub fn now_us() -> u64 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("duration since Unix epoch should be well-defined")
+            .as_micros() as u64
+    }
+
+    /// Returns a cached unix timestamp (in milliseconds) that may be up to ~1ms stale.
+    ///
+    /// This method reads from a global atomic variable updated every 500μs by
+    /// [`ClockUpkeep`](crate::ClockUpkeep), providing ~100x better performance than
+    /// [`now_ms()`](WallClock::now_ms).
+    ///
+    /// # Requirements
+    ///
+    /// [`ClockUpkeep`](crate::ClockUpkeep) must be running for this to return valid
+    /// timestamps. Returns `MillisSinceEpoch(0)` if called before upkeep starts.
+    #[inline]
+    pub fn recent_ms() -> MillisSinceEpoch {
+        MillisSinceEpoch::new(RECENT_UNIX_TIMESTAMP_US.load(Ordering::Relaxed) / 1_000)
+    }
+
+    /// Returns a cached unix timestamp (in microseconds) that may be up to ~1ms stale.
+    ///
+    /// This method reads from a global atomic variable updated every 500μs by
+    /// [`ClockUpkeep`](crate::ClockUpkeep), providing ~100x better performance than
+    /// [`now_us()`](WallClock::now_us).
+    ///
+    /// # Requirements
+    ///
+    /// [`ClockUpkeep`](crate::ClockUpkeep) must be running for this to return valid
+    /// timestamps. Returns `MillisSinceEpoch(0)` if called before upkeep starts.
+    #[inline]
+    pub fn recent_us() -> u64 {
+        RECENT_UNIX_TIMESTAMP_US.load(Ordering::Relaxed)
+    }
+}
+
+impl Clock for WallClock {
+    #[inline]
+    fn now(&self) -> MillisSinceEpoch {
+        WallClock::now_ms()
+    }
+
+    #[inline]
+    fn recent(&self) -> MillisSinceEpoch {
+        WallClock::recent_ms()
+    }
+}

--- a/crates/local-cluster-runner/Cargo.toml
+++ b/crates/local-cluster-runner/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
+restate-clock = { workspace = true }
 restate-metadata-store = { workspace = true }
 restate-metadata-providers = { workspace = true, features = ["replicated"] }
 restate-metadata-server-grpc = { workspace = true, features = ["grpc-client"] }

--- a/crates/local-cluster-runner/src/cluster/mod.rs
+++ b/crates/local-cluster-runner/src/cluster/mod.rs
@@ -84,6 +84,7 @@ pub enum ClusterStartError {
 
 impl Cluster {
     pub async fn start(self) -> Result<StartedCluster, ClusterStartError> {
+        let clock_guard = restate_clock::ClockUpkeep::start().expect("to start the clock upkeep");
         let Self {
             cluster_name,
             base_dir,
@@ -131,6 +132,7 @@ impl Cluster {
         }
 
         Ok(StartedCluster {
+            clock_guard,
             cluster_name,
             base_dir,
             nodes: started_nodes,
@@ -139,6 +141,8 @@ impl Cluster {
 }
 
 pub struct StartedCluster {
+    #[allow(dead_code)]
+    clock_guard: restate_clock::ClockUpkeep,
     cluster_name: String,
     base_dir: MaybeTempDir,
     pub nodes: Vec<StartedNode>,

--- a/crates/local-cluster-runner/src/main.rs
+++ b/crates/local-cluster-runner/src/main.rs
@@ -30,6 +30,7 @@ async fn main() {
     tracing_subscriber::fmt().init();
 
     let arguments = Arguments::parse();
+    let _upkeep = restate_clock::ClockUpkeep::start().expect("to start the clock upkeep");
 
     let cluster_file = match arguments.cluster_file {
         None => {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 
 [features]
 default = []
-schemars = ["dep:schemars", "restate-serde-util/schema", "restate-time-util/schema"]
+schemars = ["dep:schemars", "restate-serde-util/schema", "restate-time-util/schema", "restate-clock/schemars"]
 unsafe-mutable-config = []
 # Enables the tokio console subscriber and exposes its configuration
 console = []
-test-util = ["unsafe-mutable-config", "dep:tempfile", "dep:restate-test-util"]
+test-util = ["unsafe-mutable-config", "dep:tempfile", "dep:restate-test-util", "restate-clock/test-util"]
 # Runs every partition in a separate rocksdb database
 # Note: this is currently backwards-incompatible with the production builds.
 multi-db = []
@@ -22,6 +22,7 @@ multi-db = []
 restate-workspace-hack = { workspace = true }
 
 restate-base64-util = { workspace = true }
+restate-clock = { workspace = true, features = ["prost-types"] }
 restate-encoding = { workspace = true }
 restate-errors = { workspace = true }
 restate-serde-util = { workspace = true }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -55,7 +55,6 @@ pub mod service_discovery;
 pub mod service_protocol;
 pub mod state_mut;
 pub mod storage;
-pub mod time;
 pub mod timer;
 pub mod vqueue;
 
@@ -64,6 +63,8 @@ pub use node_id::*;
 pub use restate_version::*;
 pub use version::*;
 
+// Re-export of the old time module by delegating to the restate-clock crate.
+pub use restate_clock::time;
 // Re-export metrics' SharedString (Space-efficient Cow + RefCounted variant)
 pub type SharedString = metrics::SharedString;
 

--- a/lite/Cargo.toml
+++ b/lite/Cargo.toml
@@ -21,7 +21,9 @@ no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"
 [dependencies]
 restate-workspace-hack = { workspace = true }
 
+restate-admin = { workspace = true }
 restate-bifrost = { workspace = true }
+restate-clock = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-metadata-server = { workspace = true }
@@ -29,7 +31,6 @@ restate-node = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-service-client = { workspace = true }
 restate-types = { workspace = true }
-restate-admin = { workspace = true }
 
 anyhow = { workspace = true }
 http = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,7 +38,9 @@ taskdump = ["restate-core/taskdump"]
 [dependencies]
 restate-workspace-hack = { workspace = true }
 
+restate-admin = { workspace = true, features = ["all-metadata-providers"] }
 restate-bifrost = { workspace = true }
+restate-clock = { workspace = true }
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-metadata-server = { workspace = true }
@@ -47,7 +49,6 @@ restate-rocksdb = { workspace = true }
 restate-service-client = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio", "prometheus"] }
 restate-types = { workspace = true, features = ["clap"] }
-restate-admin = { workspace = true, features = ["all-metadata-providers"] }
 
 clap = { workspace = true, features = ["derive", "env", "color", "help", "wrap_help", "usage", "suggestions", "error-context", "std"] }
 codederror = { workspace = true }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,6 +21,7 @@ use rustls::crypto::aws_lc_rs;
 use tracing::error;
 use tracing::{info, trace, warn};
 
+use restate_clock::ClockUpkeep;
 use restate_core::TaskCenter;
 use restate_core::TaskCenterBuilder;
 use restate_core::TaskCenterFutureExt;
@@ -94,6 +95,11 @@ struct RestateArguments {
 const EXIT_CODE_FAILURE: i32 = 1;
 
 fn main() {
+    // Start the global clock upkeep thread
+    let Ok(_clock) = ClockUpkeep::start() else {
+        eprintln!("Failed to start restate internal clock thread!");
+        std::process::exit(EXIT_CODE_FAILURE);
+    };
     // We need to install a crypto provider explicitly because we depend on crates that activate the
     // ring as well aws_lc_rs rustls features. Unfortunately, these features are not additive. See
     // https://github.com/rustls/rustls/issues/1877. We can remove this line of code once all our

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -31,6 +31,7 @@ dump-local-log = [
 restate-workspace-hack = { workspace = true }
 
 restate-cli-util = { workspace = true }
+restate-clock = { workspace = true, features = ["jiff"] }
 restate-core = { workspace = true }
 restate-futures-util = { workspace = true }
 restate-log-server-grpc = { workspace = true, features = ["grpc-client"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -177,6 +177,8 @@ comfy-table = { version = "7" }
 criterion = { version = "0.5", features = ["async_tokio"] }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
+darling = { version = "0.20" }
+darling_core = { version = "0.20", default-features = false, features = ["suggestions"] }
 digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }


### PR DESCRIPTION

Introduce a dedicated clock abstraction crate that provides:

- `Clock` trait for abstracting physical/wall clock access
- `WallClock` providing both precise (`now_ms()`) and coarse-grained cached (`recent_ms()`)
  timestamp access, where `recent_ms()` reads from an atomic instead of making syscalls
- `ClockUpkeep` background thread that refreshes the cached timestamp every 500μs
- `MockClock` for testing (under `test-util` feature)
- `MillisSinceEpoch` and `NanosSinceEpoch` has also been updated to used the cached wall clock if it's available,
  this comes at a minor precision impact when calculating bifrost latency but the gain is worth it. For high-precision
  latency measurement, a dedicated canary message can be added to bifrost. This is to avoid the
  cost of the clock calls in the very hot paths (bifrost append path, etc.).


The cached wall clock improves performance in hot paths by avoiding repeated
`SystemTime::now()` syscalls. Benchmarks show 60-100x speedup:

  Single-threaded: ~395 ps (cached) vs ~25 ns (uncached) → ~62x faster
  Multi-threaded:  ~476 ps (cached) vs ~50 ns (uncached) → ~105x faster

All server binaries now start the clock upkeep thread early in initialization.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4104).
* #4114
* #4109
* #4105
* #4108
* #4107
* #4106
* __->__ #4104