### PR TITLE
Fix cli queries re active invs on a deployment

### DIFF
--- a/cli/src/clients/datafusion_helpers/v2.rs
+++ b/cli/src/clients/datafusion_helpers/v2.rs
@@ -49,7 +49,7 @@ pub async fn count_deployment_active_inv(
         .run_count_agg_query(format!(
             "SELECT COUNT(1) AS inv_count
             FROM sys_invocation_status
-            WHERE pinned_deployment_id = '{deployment_id}'"
+            WHERE pinned_deployment_id = '{deployment_id}' AND status != 'completed'"
         ))
         .await?)
 }
@@ -64,7 +64,7 @@ pub async fn count_deployment_active_inv_by_method(
             target_handler_name as handler,
             COUNT(1) AS inv_count
             FROM sys_invocation_status
-            WHERE pinned_deployment_id = '{deployment_id}'
+            WHERE pinned_deployment_id = '{deployment_id} AND status != 'completed''
             GROUP BY pinned_deployment_id, target_service_name, target_handler_name"
     );
 


### PR DESCRIPTION
pinned_deployment_id used to not be set for completed invs. From 1.5 it started to be set, so we need to set an extra filter.