### PR TITLE
fix(cli): misplaced quote in query

### DIFF
--- a/cli/src/clients/datafusion_helpers/v2.rs
+++ b/cli/src/clients/datafusion_helpers/v2.rs
@@ -64,7 +64,7 @@ pub async fn count_deployment_active_inv_by_method(
             target_handler_name as handler,
             COUNT(1) AS inv_count
             FROM sys_invocation_status
-            WHERE pinned_deployment_id = '{deployment_id} AND status != 'completed''
+            WHERE pinned_deployment_id = '{deployment_id}' AND status != 'completed'
             GROUP BY pinned_deployment_id, target_service_name, target_handler_name"
     );
 


### PR DESCRIPTION
A small fix to address a quote being incorrectly placed.

When running `restate deployments describe [deployment id]`, the command isn't failing. So there might be some safeguard somewhere, potentially returning a default response or count of `0` and preventing the command to fail - but potentially showing improper results. **Haven't check but it might be worth verifying if this behavior of not failing is the expected one?**

If i run that same query via `restate sql` command though, it clearly fails.