### PR TITLE
Bump object_store dependency to 0.13.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,7 +2129,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.4",
  "parking_lot",
  "rand 0.9.2",
  "regex",
@@ -2161,7 +2161,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.4",
  "parking_lot",
  "tokio",
 ]
@@ -2186,7 +2186,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.4",
  "tokio",
 ]
 
@@ -2205,7 +2205,7 @@ dependencies = [
  "indexmap 2.12.0",
  "libc",
  "log",
- "object_store",
+ "object_store 0.12.4",
  "paste",
  "recursive",
  "sqlparser",
@@ -2247,7 +2247,7 @@ dependencies = [
  "glob",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.4",
  "rand 0.9.2",
  "tokio",
  "url",
@@ -2273,7 +2273,7 @@ dependencies = [
  "datafusion-session",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.12.4",
  "tokio",
 ]
 
@@ -2295,7 +2295,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.12.4",
  "regex",
  "tokio",
 ]
@@ -2318,7 +2318,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.12.4",
  "tokio",
 ]
 
@@ -2341,7 +2341,7 @@ dependencies = [
  "datafusion-expr",
  "futures",
  "log",
- "object_store",
+ "object_store 0.12.4",
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
@@ -2681,7 +2681,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-proto-common",
- "object_store",
+ "object_store 0.12.4",
  "prost 0.14.1",
 ]
 
@@ -5417,6 +5417,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
 dependencies = [
  "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d180d5469872facb82dec7e233ff850d615330ea3044a7813550b22ffa4f05ce"
+dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -5435,7 +5459,7 @@ dependencies = [
  "rand 0.9.2",
  "reqwest",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -7604,7 +7628,7 @@ dependencies = [
  "derive_more",
  "etcd-client",
  "indexmap 2.12.0",
- "object_store",
+ "object_store 0.13.0",
  "parking_lot",
  "rand 0.9.2",
  "restate-core",
@@ -7779,7 +7803,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "futures",
- "object_store",
+ "object_store 0.13.0",
  "restate-types",
  "restate-workspace-hack",
  "tracing",
@@ -7804,7 +7828,7 @@ dependencies = [
  "googletest",
  "humantime",
  "num-bigint",
- "object_store",
+ "object_store 0.13.0",
  "parking_lot",
  "paste",
  "prost 0.14.1",
@@ -8791,15 +8815,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ metrics-util = { version = "0.20.1" }
 moka = "0.12.12"
 mockall = { version = "0.14.0" }
 num-traits = { version = "0.2.19" }
-object_store = { version = "0.12.4", features = ["aws", "azure", "gcp"] }
+object_store = { version = "0.13.0", features = ["aws", "azure", "gcp"] }
 octocrab = { version = "0.44.1" }
 opentelemetry = { version = "0.31" }
 opentelemetry-contrib = { version = "0.23" }

--- a/crates/metadata-providers/src/objstore/object_store_version_repository.rs
+++ b/crates/metadata-providers/src/objstore/object_store_version_repository.rs
@@ -14,7 +14,9 @@ use anyhow::Context;
 use bytes::Bytes;
 use bytestring::ByteString;
 use object_store::path::{Path, PathPart};
-use object_store::{Attribute, Error, ObjectStore, PutMode, PutOptions, PutPayload, UpdateVersion};
+use object_store::{
+    Attribute, Error, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+};
 use tracing::{debug, info, instrument};
 use url::Url;
 

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -16,7 +16,9 @@ use std::time::{Duration, SystemTime};
 use anyhow::{Context, anyhow, bail};
 use bytes::BytesMut;
 use object_store::path::Path as ObjectPath;
-use object_store::{MultipartUpload, ObjectStore, PutMode, PutOptions, PutPayload, UpdateVersion};
+use object_store::{
+    MultipartUpload, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+};
 use restate_core::Metadata;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -786,7 +788,7 @@ async fn abort_tasks<T: 'static>(mut join_set: JoinSet<T>) {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreExt;
     use object_store::path::Path as ObjectPath;
     use std::sync::Arc;
     use std::time::SystemTime;

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@ ignore = [
     { id = "RUSTSEC-2024-0436", reason = "crate is unmaintained. We need to migrate to a different crate than `paste`" },
     { id = "RUSTSEC-2024-0437", reason = "protobuf-rs stackoverflow in deep nested messages, not fixed yet" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash is not maintained anymore, currently used only by raft-rs" },
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is no longer maintained. It is currently pulled in by the object-store dependency. Remove once object-store has released a version that no longer depends on rustls-pemfile."},
 ]
 
 


### PR DESCRIPTION
By bumping the dependency we are no longer affected by RUSTSEC-2025-0134.

This PR is based on #4121.