### PR TITLE
Fix memory leak in batch sender

### DIFF
--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -97,9 +97,9 @@ impl<B: Builder> BatchSender<B> {
 
 impl<B: Builder> Drop for BatchSender<B> {
     fn drop(&mut self) {
-        if !self.builder.empty() {
-            // Safety: self.builder is exclusively taken at drop time, and never accessed again.
-            let builder = unsafe { ManuallyDrop::take(&mut self.builder) };
+        // Safety: self.builder is exclusively taken at drop time, and never accessed again.
+        let builder = unsafe { ManuallyDrop::take(&mut self.builder) };
+        if !builder.empty() {
             let _ = self.tx.blocking_send(builder.finish());
         }
     }


### PR DESCRIPTION
Currently we only drop the builder if it is not empty. But the builder still has some initial capacity even if a row was never added, and we are letting that memory leak. If someone does lots of queries that return zero rows, it will eventually accumulate - I am observing this in a Cloud environment.