### PR TITLE
Bump metrics-exporter-prometheus dependency to 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "hyper-util",
@@ -7711,6 +7711,7 @@ dependencies = [
  "futures",
  "googletest",
  "http 1.4.0",
+ "indexmap 2.12.0",
  "itertools 0.14.0",
  "jemalloc_pprof",
  "metrics",
@@ -8151,6 +8152,7 @@ dependencies = [
  "console-subscriber",
  "criterion",
  "http 1.4.0",
+ "indexmap 2.12.0",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ jsonptr = "0.7.1"
 jsonschema = { version = "0.38.1", default-features = false }
 jsonwebtoken = { version = "10.2.0", features = ["aws_lc_rs"] }
 metrics = { version = "0.24" }
-metrics-exporter-prometheus = { version = "0.17", default-features = false, features = [
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false, features = [
     "async-runtime",
 ] }
 metrics-util = { version = "0.20.1" }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -59,6 +59,7 @@ derive_more = { workspace = true }
 enumset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }

--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -208,10 +208,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
     );
 
     for db in &all_dbs {
-        labels.push(format!(
-            "db=\"{}\"",
-            formatting::sanitize_label_value(db.name())
-        ));
+        labels.insert("db".to_owned(), formatting::sanitize_label_value(db.name()));
 
         // Tickers (Counters)
         for ticker in ROCKSDB_TICKERS {
@@ -274,8 +271,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
         // Properties (Gauges)
         // For properties, we need to get them for each column family.
         for cf in &db.cfs() {
-            let sanitized_cf_name = formatting::sanitize_label_value(cf);
-            labels.push(format!("cf=\"{sanitized_cf_name}\""));
+            labels.insert("cf".to_owned(), formatting::sanitize_label_value(cf));
             for (property, unit) in ROCKSDB_CF_PROPERTIES {
                 format_rocksdb_property_for_prometheus(
                     &mut out,
@@ -288,9 +284,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
                         .unwrap_or_default(),
                 );
             }
-            labels.pop();
         }
-        labels.pop();
     }
     out
 }

--- a/crates/tracing-instrumentation/Cargo.toml
+++ b/crates/tracing-instrumentation/Cargo.toml
@@ -27,6 +27,7 @@ restate-types = { workspace = true }
 
 console-subscriber = { version = "0.5.0", features = ["parking_lot"], optional = true }
 http = { workspace = true }
+indexmap = { workspace = true }
 metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
 metrics-util = { workspace = true, optional = true }

--- a/crates/tracing-instrumentation/src/prometheus_metrics.rs
+++ b/crates/tracing-instrumentation/src/prometheus_metrics.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use indexmap::IndexMap;
 use metrics_exporter_prometheus::formatting;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use tokio::task::AbortHandle;
@@ -20,7 +21,7 @@ use restate_types::config::CommonOptions;
 pub struct Prometheus {
     handle: Option<PrometheusHandle>,
     upkeep_task: Option<AbortHandle>,
-    global_labels: Vec<String>,
+    global_labels: IndexMap<String, String>,
 }
 
 impl Prometheus {
@@ -34,7 +35,7 @@ impl Prometheus {
             return Self {
                 handle: None,
                 upkeep_task: None,
-                global_labels: vec![],
+                global_labels: IndexMap::default(),
             };
         }
         let builder = PrometheusBuilder::default()
@@ -53,16 +54,16 @@ impl Prometheus {
         Self {
             handle: Some(prometheus_handle),
             upkeep_task: None,
-            global_labels: vec![
-                format!(
-                    "cluster_name=\"{}\"",
-                    formatting::sanitize_label_value(opts.cluster_name())
+            global_labels: IndexMap::from([
+                (
+                    "cluster_name".to_owned(),
+                    formatting::sanitize_label_value(opts.cluster_name()),
                 ),
-                format!(
-                    "node_name=\"{}\"",
-                    formatting::sanitize_label_value(opts.node_name())
+                (
+                    "node_name".to_owned(),
+                    formatting::sanitize_label_value(opts.node_name()),
                 ),
-            ],
+            ]),
         }
     }
 
@@ -70,7 +71,7 @@ impl Prometheus {
         self.handle.as_ref()
     }
 
-    pub fn global_labels(&self) -> &Vec<String> {
+    pub fn global_labels(&self) -> &IndexMap<String, String> {
         &self.global_labels
     }
 


### PR DESCRIPTION
This commit uses the new APIs of the metrics-exporter-prometheues dependency
which was bumped to 0.18.1.

This PR is based on #4126.