### PR TITLE
Bump rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8667,8 +8667,8 @@ dependencies = [
 
 [[package]]
 name = "rust-librocksdb-sys"
-version = "0.39.0+10.5.1"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=de8911652d398e9bfbb6bbc42a7b4f7296f6d101#de8911652d398e9bfbb6bbc42a7b4f7296f6d101"
+version = "0.40.0+10.7.5"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=060a890466468930638f0056fe5e284865c99702#060a890466468930638f0056fe5e284865c99702"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -8683,8 +8683,8 @@ dependencies = [
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.43.1"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=de8911652d398e9bfbb6bbc42a7b4f7296f6d101#de8911652d398e9bfbb6bbc42a7b4f7296f6d101"
+version = "0.44.3"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=060a890466468930638f0056fe5e284865c99702#060a890466468930638f0056fe5e284865c99702"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,10 +207,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.2" }
-rocksdb = { version = "0.43.0", package = "rust-rocksdb", features = [
+rocksdb = { version = "0.44.3", package = "rust-rocksdb", features = [
     "multi-threaded-cf",
     "jemalloc",
-], git = "https://github.com/restatedev/rust-rocksdb", rev = "de8911652d398e9bfbb6bbc42a7b4f7296f6d101" }
+], git = "https://github.com/restatedev/rust-rocksdb", rev = "060a890466468930638f0056fe5e284865c99702" }
 rstest = "0.26.1"
 rustls = { version = "0.23.35", default-features = false, features = ["ring"] }
 schemars = { version = "1.2", features = ["bytes1"] }

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -282,7 +282,7 @@ impl PartitionCell {
 
         let mut import_metadata = ExportImportFilesMetaData::default();
         import_metadata.set_db_comparator_name(snapshot.db_comparator_name.as_str());
-        import_metadata.set_files(&snapshot.files);
+        import_metadata.set_files(&snapshot.files)?;
 
         info!(
             snapshot_applied_lsn = %snapshot.min_applied_lsn,


### PR DESCRIPTION
This commit bumps rust-rocksdb and thereby Rocksdb. The rust-rocksdb
fork is based on zaidoon/rust-rocksdb v0.44.2 and Rocksdb is based on
10.7.5.

This PR is based on #4127.