### PR TITLE
[Bifrost] Improve error reporting on append failures

### DIFF
--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -17,6 +17,7 @@ use bytes::Bytes;
 use futures::FutureExt;
 use tokio::sync::oneshot;
 
+use restate_time_util::DurationExt;
 use restate_types::net::address::AdvertisedAddress;
 use restate_types::net::address::FabricPort;
 use restate_types::net::metadata::MetadataKind;
@@ -176,7 +177,7 @@ pub enum RpcError {
     Send(#[from] MessageSendError),
     #[error(transparent)]
     Receive(#[from] RpcReplyError),
-    #[error("timed out")]
+    #[error("timed out after {}", .0.friendly())]
     Timeout(Duration),
 }
 


### PR DESCRIPTION

When an append wave fails, we'll now report the last error message from each node that failed. Additionally, when a connection is lost due to receive error
(e.g. decoding error), we'll report a warning message with the status code returned from tonic. Closes #4131.

Bonus: the append wave failure includes the estimated number of bytes in the payload.

Example messages from log:
```
2026-01-05T14:43:21.134839Z WARN restate_bifrost::providers::replicated_loglet::sequencer::appender
  Append wave failed, retrying with a new wave after 5.394872401s. Status is [N1(ERROR(attempts=63, last_err='connection closed')), N2(ERROR(attempts=63, last_err='connection closed')), N4(ERROR(attempts=63, last_err='connection closed'))]
    wave: 63
    loglet_id: 14_5
    first_offset: 2
    to_offset: 5
    length: 4
    estimated_bytes: 40002500
    otel.name: "replicated_loglet::sequencer::appender: run"
on rs:worker-8


2026-01-05T14:44:07.852911Z WARN restate_core::network::grpc::svc_handler
  Error while receiving network message from peer, connection will be dropped
    err: status: 'Internal error', self: "h2 protocol error: error reading a body from connection"
on rs:worker-3
  in restate_core::network::io::reactor::network-reactor
    peer: N1:3
    task_id: 4076
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4134).
* #4135
* __->__ #4134