### PR TITLE
Removes max_encoding_message_size from all grpc servers and clients

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -81,7 +81,6 @@ impl ClusterCtrlSvcHandler {
     pub fn into_server(self, config: &NetworkingOptions) -> ClusterCtrlSvcServer<Self> {
         let server = ClusterCtrlSvcServer::new(self)
             .max_decoding_message_size(config.max_message_size.as_usize())
-            .max_encoding_message_size(config.max_message_size.as_usize())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/core/src/network/grpc/connector.rs
+++ b/crates/core/src/network/grpc/connector.rs
@@ -56,7 +56,6 @@ impl TransportConnect for GrpcConnector {
 
         // Establish the connection
         let client = CoreNodeSvcClient::new(channel)
-            .max_encoding_message_size(MAX_MESSAGE_SIZE)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -37,7 +37,6 @@ impl CoreNodeSvcHandler {
     pub fn into_server(self, config: &NetworkingOptions) -> CoreNodeSvcServer<Self> {
         let server = CoreNodeSvcServer::new(self)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
-            .max_encoding_message_size(MAX_MESSAGE_SIZE)
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -22,7 +22,6 @@ pub mod cluster_ctrl_svc {
         connection_options: &O,
     ) -> cluster_ctrl_svc_client::ClusterCtrlSvcClient<tonic::transport::Channel> {
         cluster_ctrl_svc_client::ClusterCtrlSvcClient::new(channel)
-            .max_encoding_message_size(connection_options.max_message_size())
             .max_decoding_message_size(connection_options.max_message_size())
             // note: the order of those calls defines the priority
             .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
@@ -69,7 +68,6 @@ pub mod node_ctl_svc {
         connection_options: &O,
     ) -> NodeCtlSvcClient<Channel> {
         node_ctl_svc_client::NodeCtlSvcClient::new(channel)
-            .max_encoding_message_size(connection_options.max_message_size())
             .max_decoding_message_size(connection_options.max_message_size())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)

--- a/crates/log-server-grpc/src/lib.rs
+++ b/crates/log-server-grpc/src/lib.rs
@@ -28,7 +28,6 @@ pub fn new_log_server_client(
 
     log_server_svc_client::LogServerSvcClient::new(channel)
         .max_decoding_message_size(MAX_MESSAGE_SIZE)
-        .max_encoding_message_size(MAX_MESSAGE_SIZE)
         // note: the order of those calls defines the priority
         .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
         .accept_compressed(tonic::codec::CompressionEncoding::Gzip)

--- a/crates/log-server/src/grpc_svc_handler.rs
+++ b/crates/log-server/src/grpc_svc_handler.rs
@@ -43,7 +43,6 @@ where
     pub fn into_server(self, config: &NetworkingOptions) -> LogServerSvcServer<Self> {
         let server = LogServerSvcServer::new(self)
             .max_decoding_message_size(MAX_MESSAGE_SIZE)
-            .max_encoding_message_size(MAX_MESSAGE_SIZE)
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/log-server/src/protobuf.rs
+++ b/crates/log-server/src/protobuf.rs
@@ -21,7 +21,6 @@ pub fn new_log_server_client(
     use restate_core::network::grpc::{DEFAULT_GRPC_COMPRESSION, MAX_MESSAGE_SIZE};
     log_server_svc_client::LogServerSvcClient::new(channel)
         .max_decoding_message_size(MAX_MESSAGE_SIZE)
-        .max_encoding_message_size(MAX_MESSAGE_SIZE)
         // note: the order of those calls defines the priority
         .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
         .accept_compressed(tonic::codec::CompressionEncoding::Gzip)

--- a/crates/metadata-server-grpc/src/grpc.rs
+++ b/crates/metadata-server-grpc/src/grpc.rs
@@ -29,7 +29,6 @@ where
 
     metadata_server_svc_client::MetadataServerSvcClient::new(channel)
         .max_decoding_message_size(connection_options.max_message_size())
-        .max_encoding_message_size(connection_options.max_message_size())
         // note: the order of those calls defines the priority
         .accept_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Gzip)

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -72,7 +72,6 @@ impl MetadataServerHandler {
     pub fn into_server(self, config: &NetworkingOptions) -> MetadataServerSvcServer<Self> {
         let server = MetadataServerSvcServer::new(self)
             .max_decoding_message_size(config.max_message_size.as_usize())
-            .max_encoding_message_size(config.max_message_size.as_usize())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/metadata-server/src/raft/network/handler.rs
+++ b/crates/metadata-server/src/raft/network/handler.rs
@@ -47,7 +47,6 @@ impl<M> MetadataServerNetworkHandler<M> {
     pub fn into_server(self, config: &NetworkingOptions) -> MetadataServerNetworkSvcServer<Self> {
         let server = MetadataServerNetworkSvcServer::new(self)
             .max_decoding_message_size(config.max_message_size.as_usize())
-            .max_encoding_message_size(config.max_message_size.as_usize())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/metadata-store/src/protobuf.rs
+++ b/crates/metadata-store/src/protobuf.rs
@@ -42,7 +42,6 @@ pub mod metadata_proxy_svc {
             options: &O,
         ) -> MetadataProxySvcClient<Channel> {
             MetadataProxySvcClient::new(connection_options)
-                .max_encoding_message_size(options.max_message_size())
                 .max_decoding_message_size(options.max_message_size())
                 // note: the order of those calls defines the priority
                 .accept_compressed(CompressionEncoding::Zstd)

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -57,7 +57,6 @@ impl NodeCtlSvcHandler {
     pub fn into_server(self, config: &NetworkingOptions) -> NodeCtlSvcServer<Self> {
         let server = NodeCtlSvcServer::new(self)
             .max_decoding_message_size(config.max_message_size.as_usize())
-            .max_encoding_message_size(config.max_message_size.as_usize())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);
@@ -276,7 +275,6 @@ impl MetadataProxySvcHandler {
         let server = MetadataProxySvcServer::new(self)
             // note: the order of those calls defines the priority
             .max_decoding_message_size(config.max_message_size.as_usize())
-            .max_encoding_message_size(config.max_message_size.as_usize())
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);
         if config.disable_compression {


### PR DESCRIPTION

This change is part of #4130

1. Errors in the send path caused by encoding limits cannot be surfaced in logs or handled properly - connections are silently dropped. We
   leave the encoding limit as unlimited (the default) and will add explicit checks in key parts of the send path in a subsequent PR.
2. Setting a high decode limit does not add overhead since tonic does not preallocate this value per decoder. It only uses it as a check to limit uncompressed buffer sizes. Decode failures due to limits are correctly surfaced in logs.

Therefore, we are opting to have an unlimited encoding limit on the grpc layer since failures are obsecure and we'll
selectively add explicit checks in the important parts of the send path in a subsequent PR.

The decode size limit is still set so practically, the impact of this change is improved logging when the limit is hit.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4135).
* #4139
* #4137
* __->__ #4135