### PR TITLE
Unify message_size_limit configuration across gRPC services

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -39,6 +39,7 @@ use restate_types::logs::metadata::{Logs, SegmentIndex};
 use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata::{GlobalMetadata, Precondition};
 use restate_types::metadata_store::keys::{NODES_CONFIG_KEY, partition_processor_epoch_key};
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 use restate_types::net::partition_processor_manager::Snapshot;
 use restate_types::nodes_config::{NodesConfiguration, Role};
 use restate_types::partitions::PartitionTable;
@@ -80,7 +81,7 @@ impl ClusterCtrlSvcHandler {
 
     pub fn into_server(self, config: &NetworkingOptions) -> ClusterCtrlSvcServer<Self> {
         let server = ClusterCtrlSvcServer::new(self)
-            .max_decoding_message_size(config.max_message_size.as_usize())
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/core/src/network/grpc/mod.rs
+++ b/crates/core/src/network/grpc/mod.rs
@@ -11,13 +11,10 @@
 mod connector;
 mod svc_handler;
 
-pub use connector::GrpcConnector;
-pub use svc_handler::CoreNodeSvcHandler;
 use tonic::codec::CompressionEncoding;
 
-/// The maximum size for a grpc message for core networking service.
-/// This impacts the buffer limit for prost codec.
-pub const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+pub use connector::GrpcConnector;
+pub use svc_handler::CoreNodeSvcHandler;
 
 /// Default send compression for grpc clients
 pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;

--- a/crates/core/src/network/grpc/svc_handler.rs
+++ b/crates/core/src/network/grpc/svc_handler.rs
@@ -15,6 +15,7 @@ use tonic::{Request, Response, Status, Streaming};
 use tracing::warn;
 
 use restate_types::config::NetworkingOptions;
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 
 use crate::network::ConnectionManager;
 use crate::network::protobuf::core_node_svc::core_node_svc_server::{
@@ -22,8 +23,6 @@ use crate::network::protobuf::core_node_svc::core_node_svc_server::{
 };
 use crate::network::protobuf::core_node_svc::{RpcRequest, RpcResponse};
 use crate::network::protobuf::network::Message;
-
-use super::MAX_MESSAGE_SIZE;
 
 pub struct CoreNodeSvcHandler {
     connections: ConnectionManager,
@@ -36,7 +35,7 @@ impl CoreNodeSvcHandler {
 
     pub fn into_server(self, config: &NetworkingOptions) -> CoreNodeSvcServer<Self> {
         let server = CoreNodeSvcServer::new(self)
-            .max_decoding_message_size(MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -22,7 +22,7 @@ pub mod cluster_ctrl_svc {
         connection_options: &O,
     ) -> cluster_ctrl_svc_client::ClusterCtrlSvcClient<tonic::transport::Channel> {
         cluster_ctrl_svc_client::ClusterCtrlSvcClient::new(channel)
-            .max_decoding_message_size(connection_options.max_message_size())
+            .max_decoding_message_size(connection_options.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
             .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
@@ -68,7 +68,7 @@ pub mod node_ctl_svc {
         connection_options: &O,
     ) -> NodeCtlSvcClient<Channel> {
         node_ctl_svc_client::NodeCtlSvcClient::new(channel)
-            .max_decoding_message_size(connection_options.max_message_size())
+            .max_decoding_message_size(connection_options.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -16,6 +16,7 @@ use super::Notification;
 use std::collections::HashSet;
 use std::convert::Infallible;
 use std::iter::Empty;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 use std::time::{Duration, Instant};
@@ -145,8 +146,8 @@ pub(super) struct InvocationTask<IR, EE, DMR> {
     inactivity_timeout: Duration,
     abort_timeout: Duration,
     disable_eager_state: bool,
-    message_size_warning: usize,
-    message_size_limit: Option<usize>,
+    message_size_warning: NonZeroUsize,
+    message_size_limit: NonZeroUsize,
     retry_count_since_last_stored_entry: u32,
 
     // Invoker tx/rx
@@ -207,8 +208,8 @@ where
         default_inactivity_timeout: Duration,
         default_abort_timeout: Duration,
         disable_eager_state: bool,
-        message_size_warning: usize,
-        message_size_limit: Option<usize>,
+        message_size_warning: NonZeroUsize,
+        message_size_limit: NonZeroUsize,
         retry_count_since_last_stored_entry: u32,
         invocation_reader: IR,
         entry_enricher: EE,

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
@@ -1152,8 +1153,8 @@ impl<S> DecoderStream<S> {
     fn new(
         inner: S,
         service_protocol_version: ServiceProtocolVersion,
-        message_size_warning: usize,
-        message_size_limit: Option<usize>,
+        message_size_warning: NonZeroUsize,
+        message_size_limit: NonZeroUsize,
     ) -> Self {
         Self {
             inner,

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -146,7 +146,7 @@ where
                     opts.inactivity_timeout.into(),
                     opts.abort_timeout.into(),
                     opts.disable_eager_state,
-                    opts.message_size_warning.get(),
+                    opts.message_size_warning.as_non_zero_usize(),
                     opts.message_size_limit(),
                     retry_count_since_last_stored_entry,
                     storage_reader,
@@ -1881,7 +1881,7 @@ mod tests {
             .inactivity_timeout(FriendlyDuration::ZERO)
             .abort_timeout(FriendlyDuration::ZERO)
             .disable_eager_state(false)
-            .message_size_warning(NonZeroUsize::new(1024).unwrap())
+            .message_size_warning(NonZeroUsize::new(1024).unwrap().into())
             .message_size_limit(None)
             .build()
             .unwrap();
@@ -1951,7 +1951,7 @@ mod tests {
             .inactivity_timeout(FriendlyDuration::ZERO)
             .abort_timeout(FriendlyDuration::ZERO)
             .disable_eager_state(false)
-            .message_size_warning(NonZeroUsize::new(1024).unwrap())
+            .message_size_warning(NonZeroUsize::new(1024).unwrap().into())
             .message_size_limit(None)
             .build()
             .unwrap();
@@ -2066,7 +2066,7 @@ mod tests {
             .inactivity_timeout(FriendlyDuration::ZERO)
             .abort_timeout(FriendlyDuration::ZERO)
             .disable_eager_state(false)
-            .message_size_warning(NonZeroUsize::new(1024).unwrap())
+            .message_size_warning(NonZeroUsize::new(1024).unwrap().into())
             .message_size_limit(None)
             .build()
             .unwrap();
@@ -2143,7 +2143,7 @@ mod tests {
             .inactivity_timeout(FriendlyDuration::ZERO)
             .abort_timeout(FriendlyDuration::ZERO)
             .disable_eager_state(false)
-            .message_size_warning(NonZeroUsize::new(1024).unwrap())
+            .message_size_warning(NonZeroUsize::new(1024).unwrap().into())
             .message_size_limit(None)
             .build()
             .unwrap();

--- a/crates/log-server-grpc/src/lib.rs
+++ b/crates/log-server-grpc/src/lib.rs
@@ -15,21 +15,18 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 
 /// Creates a new ClusterCtrlSvcClient with appropriate configuration
 #[cfg(feature = "grpc-client")]
-pub fn new_log_server_client(
+pub fn new_log_server_client<O: restate_types::net::connect_opts::GrpcConnectionOptions>(
     channel: tonic::transport::Channel,
+    connection_options: &O,
 ) -> log_server_svc_client::LogServerSvcClient<tonic::transport::Channel> {
-    /// The maximum size for a grpc message for core networking service.
-    /// This impacts the buffer limit for prost codec.
-    pub const MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
-
     use tonic::codec::CompressionEncoding;
     /// Default send compression for grpc clients
     pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
     log_server_svc_client::LogServerSvcClient::new(channel)
-        .max_decoding_message_size(MAX_MESSAGE_SIZE)
+        .max_decoding_message_size(connection_options.message_size_limit().get())
         // note: the order of those calls defines the priority
-        .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
-        .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip)
         .send_compressed(DEFAULT_GRPC_COMPRESSION)
 }

--- a/crates/log-server/src/grpc_svc_handler.rs
+++ b/crates/log-server/src/grpc_svc_handler.rs
@@ -12,9 +12,9 @@ use async_trait::async_trait;
 use tonic::codec::CompressionEncoding;
 use tonic::{Request, Response, Status};
 
-use restate_core::network::grpc::MAX_MESSAGE_SIZE;
 use restate_types::config::NetworkingOptions;
 use restate_types::logs::{LogletId, LogletOffset, SequenceNumber};
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 use restate_types::net::log_server::{GetDigest, LogServerResponseHeader, LogletInfo};
 
 use crate::logstore::LogStore;
@@ -42,7 +42,7 @@ where
 
     pub fn into_server(self, config: &NetworkingOptions) -> LogServerSvcServer<Self> {
         let server = LogServerSvcServer::new(self)
-            .max_decoding_message_size(MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/log-server/src/protobuf.rs
+++ b/crates/log-server/src/protobuf.rs
@@ -15,12 +15,13 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 
 /// Creates a new ClusterCtrlSvcClient with appropriate configuration
 #[cfg(feature = "clients")]
-pub fn new_log_server_client(
+pub fn new_log_server_client<O: restate_types::net::connect_opts::GrpcConnectionOptions>(
     channel: tonic::transport::Channel,
+    connection_options: &O,
 ) -> log_server_svc_client::LogServerSvcClient<tonic::transport::Channel> {
-    use restate_core::network::grpc::{DEFAULT_GRPC_COMPRESSION, MAX_MESSAGE_SIZE};
+    use restate_core::network::grpc::DEFAULT_GRPC_COMPRESSION;
     log_server_svc_client::LogServerSvcClient::new(channel)
-        .max_decoding_message_size(MAX_MESSAGE_SIZE)
+        .max_decoding_message_size(connection_options.message_size_limit().get())
         // note: the order of those calls defines the priority
         .accept_compressed(tonic::codec::CompressionEncoding::Zstd)
         .accept_compressed(tonic::codec::CompressionEncoding::Gzip)

--- a/crates/metadata-server-grpc/src/grpc.rs
+++ b/crates/metadata-server-grpc/src/grpc.rs
@@ -28,7 +28,7 @@ where
     pub const DEFAULT_GRPC_COMPRESSION: CompressionEncoding = CompressionEncoding::Zstd;
 
     metadata_server_svc_client::MetadataServerSvcClient::new(channel)
-        .max_decoding_message_size(connection_options.max_message_size())
+        .max_decoding_message_size(connection_options.message_size_limit().get())
         // note: the order of those calls defines the priority
         .accept_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Gzip)

--- a/crates/metadata-server/src/grpc/handler.rs
+++ b/crates/metadata-server/src/grpc/handler.rs
@@ -30,6 +30,7 @@ use restate_types::config::{Configuration, NetworkingOptions};
 use restate_types::errors::ConversionError;
 use restate_types::metadata::Precondition;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::storage::StorageCodec;
 
@@ -71,7 +72,7 @@ impl MetadataServerHandler {
 
     pub fn into_server(self, config: &NetworkingOptions) -> MetadataServerSvcServer<Self> {
         let server = MetadataServerSvcServer::new(self)
-            .max_decoding_message_size(config.max_message_size.as_usize())
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/metadata-server/src/raft/network/handler.rs
+++ b/crates/metadata-server/src/raft/network/handler.rs
@@ -19,6 +19,7 @@ use tonic::{Request, Response, Status, Streaming};
 
 use restate_types::PlainNodeId;
 use restate_types::config::NetworkingOptions;
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 
 use super::MetadataServerNetworkSvcServer;
 use crate::raft::network::connection_manager::ConnectionError;
@@ -46,7 +47,7 @@ impl<M> MetadataServerNetworkHandler<M> {
 
     pub fn into_server(self, config: &NetworkingOptions) -> MetadataServerNetworkSvcServer<Self> {
         let server = MetadataServerNetworkSvcServer::new(self)
-            .max_decoding_message_size(config.max_message_size.as_usize())
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);

--- a/crates/metadata-store/src/metadata_store.rs
+++ b/crates/metadata-store/src/metadata_store.rs
@@ -514,7 +514,7 @@ impl MetadataStoreClient {
         value: &VersionedValue,
     ) -> Result<(), MetadataSizeHardLimitError> {
         let config = &Configuration::pinned().common.metadata_client;
-        let grp_msg_size_limit = config.max_message_size() as f64;
+        let grp_msg_size_limit = config.message_size_limit().get() as f64;
 
         let soft_limit = (grp_msg_size_limit * METADATA_SIZE_SOFT_LIMIT) as usize;
         let hard_limit = (grp_msg_size_limit * METADATA_SIZE_HARD_LIMIT) as usize;

--- a/crates/metadata-store/src/protobuf.rs
+++ b/crates/metadata-store/src/protobuf.rs
@@ -42,7 +42,7 @@ pub mod metadata_proxy_svc {
             options: &O,
         ) -> MetadataProxySvcClient<Channel> {
             MetadataProxySvcClient::new(connection_options)
-                .max_decoding_message_size(options.max_message_size())
+                .max_decoding_message_size(options.message_size_limit().get())
                 // note: the order of those calls defines the priority
                 .accept_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Gzip)

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -23,6 +23,7 @@ use restate_metadata_store::protobuf::metadata_proxy_svc::metadata_proxy_svc_ser
 use restate_metadata_store::protobuf::metadata_proxy_svc::{
     DeleteRequest, GetRequest, GetResponse, GetVersionResponse, PutRequest,
 };
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 
 use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::{NodeCtlSvc, NodeCtlSvcServer};
@@ -56,7 +57,7 @@ impl NodeCtlSvcHandler {
 
     pub fn into_server(self, config: &NetworkingOptions) -> NodeCtlSvcServer<Self> {
         let server = NodeCtlSvcServer::new(self)
-            .max_decoding_message_size(config.max_message_size.as_usize())
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);
@@ -273,8 +274,8 @@ impl MetadataProxySvcHandler {
 
     pub fn into_server(self, config: &NetworkingOptions) -> MetadataProxySvcServer<Self> {
         let server = MetadataProxySvcServer::new(self)
+            .max_decoding_message_size(config.message_size_limit().get())
             // note: the order of those calls defines the priority
-            .max_decoding_message_size(config.max_message_size.as_usize())
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip);
         if config.disable_compression {

--- a/crates/serde-util/src/byte_count.rs
+++ b/crates/serde-util/src/byte_count.rs
@@ -73,17 +73,17 @@ impl schemars::JsonSchema for ByteCount<false> {
 }
 
 impl ByteCount<true> {
-    pub fn new(value: u64) -> Self {
+    pub const fn new(value: u64) -> Self {
         Self(value)
     }
 }
 
 impl ByteCount<false> {
-    pub fn new(value: NonZeroUsize) -> Self {
-        Self(usize::from(value) as u64)
+    pub const fn new(value: NonZeroUsize) -> Self {
+        Self(value.get() as u64)
     }
 
-    pub fn as_non_zero_usize(&self) -> NonZeroUsize {
+    pub const fn as_non_zero_usize(&self) -> NonZeroUsize {
         NonZeroUsize::new(self.0 as usize).expect("ByteCount is not zero")
     }
 }
@@ -95,11 +95,11 @@ impl<const CAN_BE_ZERO: bool> Display for ByteCount<CAN_BE_ZERO> {
 }
 
 impl<const CAN_BE_ZERO: bool> ByteCount<CAN_BE_ZERO> {
-    pub fn as_u64(&self) -> u64 {
+    pub const fn as_u64(&self) -> u64 {
         self.0
     }
 
-    pub fn as_usize(&self) -> usize {
+    pub const fn as_usize(&self) -> usize {
         self.0 as usize
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -194,6 +194,7 @@ impl Configuration {
             .common
             .set_derived_values(&config.networking)
             .unwrap();
+        config.worker.set_derived_values(&config.networking);
         config.admin.set_derived_values(&config.common);
         config.ingress.set_derived_values(&config.common);
         config
@@ -206,6 +207,7 @@ impl Configuration {
             .common
             .set_derived_values(&config.networking)
             .unwrap();
+        config.worker.set_derived_values(&config.networking);
         config.admin.set_derived_values(&config.common);
         config.ingress.set_derived_values(&config.common);
         config

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -81,6 +81,7 @@ impl ConfigLoader {
         config.common.set_derived_values(&config.networking)?;
         config.admin.set_derived_values(&config.common);
         config.ingress.set_derived_values(&config.common);
+        config.worker.set_derived_values(&config.networking);
 
         if self.metadata_migration_mode {
             // In metadata migration mode we keep only Admin and MetadataServer roles that were

--- a/crates/types/src/net/connect_opts.rs
+++ b/crates/types/src/net/connect_opts.rs
@@ -8,14 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::config::{MetadataClientOptions, NetworkingOptions};
 
+/// Overhead added to user-facing max_message_size.
+///
+/// This accounts for message wrapping (headers, envelopes, encoding overhead)
+/// when messages are transmitted over the internal message fabric.
+pub const MESSAGE_SIZE_OVERHEAD: usize = 1024 * 1024; // 1 MiB
+
 pub trait GrpcConnectionOptions {
-    /// Gets the maximum message size for grpc servers and clients.
-    fn max_message_size(&self) -> usize;
+    /// The maximum message size for tonic gRPC configuration.
+    /// Implementations should add [`MESSAGE_SIZE_OVERHEAD`] to account for message
+    /// wrapping when transmitted over the internal network.
+    fn message_size_limit(&self) -> NonZeroUsize;
 }
 /// Helper trait to extract common client connection options from different configuration types.
 pub trait CommonClientConnectionOptions: GrpcConnectionOptions {
@@ -27,8 +36,8 @@ pub trait CommonClientConnectionOptions: GrpcConnectionOptions {
 }
 
 impl<T: GrpcConnectionOptions> GrpcConnectionOptions for &T {
-    fn max_message_size(&self) -> usize {
-        (*self).max_message_size()
+    fn message_size_limit(&self) -> NonZeroUsize {
+        (*self).message_size_limit()
     }
 }
 
@@ -61,8 +70,8 @@ impl<T> GrpcConnectionOptions for Arc<T>
 where
     T: GrpcConnectionOptions,
 {
-    fn max_message_size(&self) -> usize {
-        (**self).max_message_size()
+    fn message_size_limit(&self) -> NonZeroUsize {
+        (**self).message_size_limit()
     }
 }
 
@@ -92,8 +101,11 @@ where
 }
 
 impl GrpcConnectionOptions for NetworkingOptions {
-    fn max_message_size(&self) -> usize {
-        self.max_message_size.as_usize()
+    #[inline]
+    fn message_size_limit(&self) -> NonZeroUsize {
+        self.message_size_limit
+            .as_non_zero_usize()
+            .saturating_add(MESSAGE_SIZE_OVERHEAD)
     }
 }
 
@@ -120,8 +132,8 @@ impl CommonClientConnectionOptions for NetworkingOptions {
 }
 
 impl GrpcConnectionOptions for MetadataClientOptions {
-    fn max_message_size(&self) -> usize {
-        Self::max_message_size(self)
+    fn message_size_limit(&self) -> NonZeroUsize {
+        Self::message_size_limit(self).saturating_add(MESSAGE_SIZE_OVERHEAD)
     }
 }
 

--- a/lite/src/lib.rs
+++ b/lite/src/lib.rs
@@ -201,6 +201,7 @@ impl Restate {
         config.common.set_derived_values(&config.networking)?;
         config.ingress.set_derived_values(&config.common);
         config.admin.set_derived_values(&config.common);
+        config.worker.set_derived_values(&config.networking);
         let config = config.apply_cascading_values();
         config.validate()?;
 

--- a/tools/mock-service-endpoint/src/handler.rs
+++ b/tools/mock-service-endpoint/src/handler.rs
@@ -10,6 +10,7 @@
 
 use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use async_stream::{stream, try_stream};
@@ -83,7 +84,11 @@ pub async fn serve(
     };
 
     let req_body = BodyStream::new(req_body);
-    let mut decoder = Decoder::new(ServiceProtocolVersion::V5, usize::MAX, None);
+    let mut decoder = Decoder::new(
+        ServiceProtocolVersion::V5,
+        NonZeroUsize::MAX,
+        NonZeroUsize::MAX,
+    );
     let mut encoder = Encoder::new(ServiceProtocolVersion::V5);
 
     let incoming = stream! {

--- a/tools/restatectl/src/commands/replicated_loglet/digest.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/digest.rs
@@ -14,8 +14,8 @@ use cling::prelude::*;
 use tracing::{info, warn};
 
 use restate_cli_util::_comfy_table::{Cell, Color, Table};
-use restate_cli_util::c_println;
 use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::{CliContext, c_println};
 use restate_log_server_grpc::{GetDigestRequest, GetLogletInfoRequest, new_log_server_client};
 use restate_types::PlainNodeId;
 use restate_types::logs::TailOffsetWatch;
@@ -83,7 +83,7 @@ async fn get_digest(connection: &ConnectionInfo, opts: &DigestOpts) -> anyhow::R
     // get loglet info
     let mut loglet_infos: HashMap<PlainNodeId, _> = HashMap::default();
     for (node_id, channel) in nodeset_channels.iter() {
-        let mut client = new_log_server_client(channel.clone());
+        let mut client = new_log_server_client(channel.clone(), &CliContext::get().network);
         let Ok(Some(loglet_info)) = client
             .get_loglet_info(GetLogletInfoRequest {
                 loglet_id: opts.loglet_id.into(),
@@ -131,7 +131,7 @@ async fn get_digest(connection: &ConnectionInfo, opts: &DigestOpts) -> anyhow::R
             from_offset,
             to_offset,
         };
-        let mut client = new_log_server_client(channel.clone());
+        let mut client = new_log_server_client(channel.clone(), &CliContext::get().network);
         let digest = match client.get_digest(req).await {
             Ok(response) => response.into_inner().digest.expect("always set by servers"),
             Err(err) => {

--- a/tools/restatectl/src/commands/replicated_loglet/info.rs
+++ b/tools/restatectl/src/commands/replicated_loglet/info.rs
@@ -14,9 +14,9 @@ use cling::prelude::*;
 use tracing::warn;
 
 use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
-use restate_cli_util::c_println;
 use restate_cli_util::ui::console::{Styled, StyledTable};
 use restate_cli_util::ui::stylesheet::Style;
+use restate_cli_util::{CliContext, c_println};
 use restate_log_server_grpc::{GetLogletInfoRequest, new_log_server_client};
 use restate_types::PlainNodeId;
 use restate_types::logs::LogletId;
@@ -124,7 +124,10 @@ async fn get_info(connection: &ConnectionInfo, opts: &InfoOpts) -> anyhow::Resul
             );
             continue;
         }
-        let mut client = new_log_server_client(grpc_channel(node.address.clone()));
+        let mut client = new_log_server_client(
+            grpc_channel(node.address.clone()),
+            &CliContext::get().network,
+        );
         let Ok(Some(loglet_info)) = client
             .get_loglet_info(GetLogletInfoRequest {
                 loglet_id: opts.loglet_id.into(),

--- a/tools/service-protocol-wireshark-dissector/src/lib.rs
+++ b/tools/service-protocol-wireshark-dissector/src/lib.rs
@@ -14,6 +14,7 @@ use mlua::{Table, Value};
 use restate_service_protocol_v4::message_codec::{Decoder, Message, MessageType};
 use restate_time_util::DurationExt;
 use restate_types::service_protocol::ServiceProtocolVersion;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 #[derive(Debug, thiserror::Error)]
@@ -32,7 +33,11 @@ fn decode_packages(lua: &Lua, buf_lua: Value) -> LuaResult<Table> {
     // We should store it somewhere, but right now wireshark doesn't support conversations in lua api
     // so we just keep it simple and assume all messages are self contained within the same http data frame
     // https://ask.wireshark.org/question/11650/lua-wireshark-dissector-combine-data-from-2-udp-packets
-    let mut dec = Decoder::new(ServiceProtocolVersion::V4, usize::MAX, None);
+    let mut dec = Decoder::new(
+        ServiceProtocolVersion::V4,
+        NonZeroUsize::MAX,
+        NonZeroUsize::MAX,
+    );
 
     // Convert the buffer and push it to the decoder
     let buf = match buf_lua {


### PR DESCRIPTION

This change consolidates the max message size configuration for all gRPC
servers and clients to use the configurable and cascading value for `message-size-limit` from
NetworkingOptions via the GrpcConnectionOptions trait. The value can be overridden for metadata client
and invoker independently if needed. Additionally, the internal max message size is a little more than
the configured value to allow for the overhead of our messaging and other fields outside of what the
user sets. For instance, the user can think of the message-size-limit as the maximum value they can
set in their virtual object state or the maximum size of a ctx.run() block without considering the
overhead of the gRPC serialization and the additional metadata that is added by us.

This change is part of #4130

Key changes:
- Introduced DEFAULT_MESSAGE_SIZE_LIMIT constant (32 MiB) in
  `restate_types::config` as a single source of truth
- Updated all gRPC servers and clients to use config.message_size_limit() instead of hardcoded constants
- Updated CLI tools to use the same default via the shared constant
- Improved (and exposed) documentation for message-size-limit configuration
- Invoker now clamps the message-size-limit to the networking.message-size-limit value and uses it as default value if unset

Configuration changes:
- `networking.max-message-size` renamed to `networking.message-size-limit`
- `networking.message-size-limit` default changed from 10 MiB to 32 MiB
- `common.metadata-client.max-message-size` renamed to `common.metadata-client.message-size-limit`
- `common.metadata-client.message-size-limit` now defaults to `networking.message-size-limit` if unset,
  and is clamped to the networking limit if set higher
- `worker.invoker.message-size-limit` now defaults to `networking.message-size-limit` if unset,
  and is clamped to the networking limit if set higher

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4137).
* #4139
* __->__ #4137
* #4135