### PR TITLE
Add batch invocation operations for UI 

### DIFF
--- a/crates/admin-rest-model/src/invocations.rs
+++ b/crates/admin-rest-model/src/invocations.rs
@@ -8,8 +8,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::identifiers::InvocationId;
+use restate_types::identifiers::{DeploymentId, InvocationId};
+use restate_types::invocation::client as invocation_client;
 use serde::{Deserialize, Serialize};
+
+/// Specifies which deployment to use when resuming or restarting an invocation.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub enum PatchDeploymentId {
+    /// Keep the currently pinned deployment
+    #[default]
+    #[serde(alias = "keep")]
+    Keep,
+    /// Use the latest deployment
+    #[serde(alias = "latest")]
+    Latest,
+    /// Use a specific deployment ID
+    #[serde(untagged)]
+    Id(String),
+}
+
+impl PatchDeploymentId {
+    /// Convert to the internal client representation.
+    /// Returns an error string if the deployment ID cannot be parsed.
+    pub fn into_client(self) -> Result<invocation_client::PatchDeploymentId, String> {
+        Ok(match self {
+            PatchDeploymentId::Keep => invocation_client::PatchDeploymentId::KeepPinned,
+            PatchDeploymentId::Latest => invocation_client::PatchDeploymentId::PinToLatest,
+            PatchDeploymentId::Id(dp_id) => invocation_client::PatchDeploymentId::PinTo {
+                id: dp_id.parse::<DeploymentId>().map_err(|e| e.to_string())?,
+            },
+        })
+    }
+}
 
 /// The invocation was restarted as new.
 #[derive(Debug, Serialize, Deserialize)]
@@ -17,4 +48,81 @@ use serde::{Deserialize, Serialize};
 pub struct RestartAsNewInvocationResponse {
     /// The invocation id of the new invocation.
     pub new_invocation_id: InvocationId,
+}
+
+// --- Batch operation types ---
+
+/// Maximum number of invocations in a single batch operation
+pub const BATCH_OPERATION_MAX_SIZE: usize = 1000;
+
+/// Request body for batch invocation operations
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct BatchInvocationRequest {
+    /// List of invocation IDs to operate on
+    pub invocation_ids: Vec<InvocationId>,
+}
+
+/// Request body for batch resume operations (with optional deployment)
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct BatchResumeRequest {
+    /// List of invocation IDs to resume
+    pub invocation_ids: Vec<InvocationId>,
+    /// Deployment ID to use when resuming (applies to all invocations).
+    /// Use "Keep" to keep the pinned deployment, "Latest" for latest, or a specific deployment ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<PatchDeploymentId>,
+}
+
+/// Request body for batch restart-as-new operations
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct BatchRestartAsNewRequest {
+    /// List of invocation IDs to restart
+    pub invocation_ids: Vec<InvocationId>,
+    /// Deployment ID to use (applies to all invocations).
+    /// Use "Keep" to keep the pinned deployment, "Latest" for latest, or a specific deployment ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment: Option<PatchDeploymentId>,
+}
+
+/// Information about a failed invocation operation
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct FailedInvocationOperation {
+    /// The invocation ID that failed
+    pub invocation_id: InvocationId,
+    /// Error message describing the failure
+    pub error: String,
+}
+
+/// Result of a batch invocation operation
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct BatchOperationResult {
+    /// Invocations that were successfully processed
+    pub succeeded: Vec<InvocationId>,
+    /// Invocations that failed with error details
+    pub failed: Vec<FailedInvocationOperation>,
+}
+
+/// Successful restart-as-new operation result
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct RestartedInvocation {
+    /// The original invocation ID
+    pub old_invocation_id: InvocationId,
+    /// The new invocation ID
+    pub new_invocation_id: InvocationId,
+}
+
+/// Result of batch restart-as-new operations
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+pub struct BatchRestartAsNewResult {
+    /// Successfully restarted invocations with their new IDs
+    pub succeeded: Vec<RestartedInvocation>,
+    /// Invocations that failed with error details
+    pub failed: Vec<FailedInvocationOperation>,
 }

--- a/crates/admin/src/rest_api/error.rs
+++ b/crates/admin/src/rest_api/error.rs
@@ -127,6 +127,16 @@ pub(crate) struct InvalidFieldError(pub(crate) &'static str, pub(crate) String);
 impl_meta_api_error!(InvalidFieldError: BAD_REQUEST);
 
 #[derive(Debug, thiserror::Error)]
+#[error("The query parameter '{0}' is invalid. Reason: {1}")]
+pub(crate) struct InvalidQueryParameterError(pub(crate) &'static str, pub(crate) String);
+impl_meta_api_error!(InvalidQueryParameterError: BAD_REQUEST);
+
+#[derive(Debug, thiserror::Error)]
+#[error("Batch size {0} exceeds maximum allowed size of {1}")]
+pub(crate) struct BatchTooLargeError(pub(crate) usize, pub(crate) usize);
+impl_meta_api_error!(BatchTooLargeError: BAD_REQUEST "The batch size exceeds the maximum allowed.");
+
+#[derive(Debug, thiserror::Error)]
 #[error("The requested invocation '{0}' does not exist")]
 pub(crate) struct InvocationNotFoundError(pub(crate) String);
 impl_meta_api_error!(InvocationNotFoundError: NOT_FOUND);

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -126,6 +126,35 @@ where
             "/deployments/{deployment}",
             axum::routing::put(deployments::update_deployment),
         )
+        // Internal batch operation routes (for UI only, not documented in OpenAPI)
+        .route(
+            "/internal/invocations_batch_operations/kill",
+            axum::routing::post(invocations::batch_kill_invocations),
+        )
+        .route(
+            "/internal/invocations_batch_operations/cancel",
+            axum::routing::post(invocations::batch_cancel_invocations),
+        )
+        .route(
+            "/internal/invocations_batch_operations/purge",
+            axum::routing::post(invocations::batch_purge_invocations),
+        )
+        .route(
+            "/internal/invocations_batch_operations/purge-journal",
+            axum::routing::post(invocations::batch_purge_journal),
+        )
+        .route(
+            "/internal/invocations_batch_operations/restart-as-new",
+            axum::routing::post(invocations::batch_restart_as_new_invocations),
+        )
+        .route(
+            "/internal/invocations_batch_operations/resume",
+            axum::routing::post(invocations::batch_resume_invocations),
+        )
+        .route(
+            "/internal/invocations_batch_operations/pause",
+            axum::routing::post(invocations::batch_pause_invocations),
+        )
         .route(
             "/openapi",
             axum::routing::get(|| async move { axum::Json(api) }),


### PR DESCRIPTION
Add internal REST endpoints for batch invocation operations to support
efficient batch operations from the UI. These endpoints are hidden from
the OpenAPI specification as they are intended for internal UI use only.

New endpoints (POST, under /internal/invocations_batch_operations/):
- /kill - Kill multiple invocations
- /cancel - Cancel multiple invocations
- /purge - Purge multiple completed invocations
- /purge-journal - Purge journals for multiple completed invocations
- /restart-as-new - Restart multiple invocations as new
- /resume - Resume multiple paused/suspended invocations
- /pause - Pause multiple running invocations

Key features:
- All operations execute in parallel using futures::join_all
- Operations don't fail fast - all results are collected and returned
- Returns succeeded/failed lists with error details for failures
- Batch size limited to 1000 invocations per request
- For restart-as-new and resume, deployment ID applies to all invocations

New types in admin-rest-model:
- PatchDeploymentId enum with into_client() conversion method
- BatchInvocationRequest, BatchResumeRequest, BatchRestartAsNewRequest
- BatchOperationResult, BatchRestartAsNewResult
- FailedInvocationOperation, RestartedInvocation

Closes https://github.com/restatedev/restate/issues/4138