### PR TITLE
[Restate UI] Update to v0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8368,8 +8368,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.20"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.20#8a8325a275e37c0528772eafc7bc446697dedec3"
+version = "0.1.21"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.21#c819cdb00f32d4c6c158da6d230c8ee08b075008"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -37,7 +37,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.20", tag = "v0.1.20" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.21", tag = "v0.1.21" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.21
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.21/ui-v0.1.21.zip