### PR TITLE
[Restate UI] Update to v0.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8324,8 +8324,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.21"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.21#c819cdb00f32d4c6c158da6d230c8ee08b075008"
+version = "0.1.22"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.22#55ac98b139c5dd022e4d7ab338dbe5daa4789542"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.21", tag = "v0.1.21" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.22", tag = "v0.1.22" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.22
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.22/ui-v0.1.22.zip