### PR TITLE
[Restate UI] Update to v0.1.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8327,8 +8327,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.22"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.22#55ac98b139c5dd022e4d7ab338dbe5daa4789542"
+version = "0.1.23"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.23#9c5ab65c0068048f9ceceb30b840fc57d3f8aaf0"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.22", tag = "v0.1.22" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.23", tag = "v0.1.23" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.23
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.23/ui-v0.1.23.zip