### PR TITLE
Add custom Record encoding with protocol version V3 compatibility

### DIFF
--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -18,6 +18,10 @@ enum ProtocolVersion {
   // V1 = 1;
   // [Native RPC] Released in >= v1.3.3
   V2 = 2;
+
+  // Release in v1.6. Support custom `Record`
+  // encoding that uses Bytes instead of PolyBytes
+  V3 = 3;
 }
 
 message NodeId {

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -28,7 +28,7 @@ mod tail;
 
 pub use loglet::*;
 pub use offset_watch::*;
-pub use record::Record;
+pub use record::{CustomRecordEncoding, Record};
 pub use record_cache::RecordCache;
 pub use tail::*;
 

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -25,7 +25,7 @@ pub use crate::protobuf::common::ProtocolVersion;
 pub use crate::protobuf::common::ServiceTag;
 
 pub static MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V2;
-pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V2;
+pub static CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V3;
 
 pub trait Service: Send + Unpin + 'static {
     const TAG: ServiceTag;


### PR DESCRIPTION
Add custom Record encoding with protocol version V3 compatibility

Summary
- Introduces a custom bilrost encoding (CustomRecordEncoding) for Record that uses Bytes instead of PolyBytes on the wire.
- Adds protocol version V3 to support the new encoding format
- Implements backward-compatible WireEncode/WireDecode for Store and Append messages to maintain compatibility with V2 nodes during rolling upgrades
- Adds an arena buffer to Appender for pre-encoding records before transmission via ensure_encoded()
