### PR TITLE
[Configuration] Adds support for rocksdb-disable-auto-compactions

### DIFF
--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -180,6 +180,8 @@ impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
             Some(global_cache),
         );
 
+        cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
+
         if cf_name == DATA_CF {
             cf_data_options(&mut cf_options, &block_options, config);
         } else if cf_name == METADATA_CF {
@@ -266,6 +268,7 @@ fn cf_metadata_options(
         DBCompressionType::None,
         DBCompressionType::Zstd,
     ]);
+
     opts.set_memtable_whole_key_filtering(true);
     opts.set_max_write_buffer_number(4);
     opts.set_max_successive_merges(10);

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -205,6 +205,8 @@ impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
             Some(global_cache),
         );
 
+        cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
+
         if cf_name == DATA_CF {
             cf_data_options(&mut cf_options, &block_options, config);
         } else if cf_name == METADATA_CF {

--- a/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
@@ -102,6 +102,8 @@ impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
             Some(global_cache),
         );
 
+        cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
+
         if cf_name == DATA_CF {
             cf_data_options(&mut cf_options, &block_options, config);
         } else if cf_name == METADATA_CF {

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -515,8 +515,9 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
         let mut cf_options =
             restate_rocksdb::configuration::create_default_cf_options(Some(write_buffer_manager));
 
+        let config = &Configuration::pinned().worker.storage.rocksdb;
         let block_options = restate_rocksdb::configuration::create_default_block_options(
-            &Configuration::pinned().worker.storage.rocksdb,
+            config,
             // use global block cache
             Some(global_cache),
         );
@@ -527,6 +528,8 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
             KeyKind::partial_merge,
         );
         cf_options.set_max_successive_merges(100);
+
+        cf_options.set_disable_auto_compactions(config.rocksdb_disable_auto_compactions());
 
         // Actually, we would love to use CappedPrefixExtractor but unfortunately it's neither exposed
         // in the C API nor the rust binding. That's okay and we can change it later.

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -68,6 +68,14 @@ pub struct RocksDbOptions {
     #[cfg_attr(feature = "schemars", schemars(with = "Option<NonZeroByteCount>"))]
     rocksdb_compaction_readahead_size: Option<NonZeroUsize>,
 
+    /// # RocksDB disable auto compactions
+    ///
+    /// Disables rocksdb automatic compactions. This can be useful in performance tuning
+    /// tests but should not be used in production to avoid write stall.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    rocksdb_disable_auto_compactions: Option<bool>,
+
     /// # RocksDB statistics level
     ///
     /// StatsLevel can be used to reduce statistics overhead by skipping certain
@@ -152,6 +160,9 @@ impl RocksDbOptions {
             self.rocksdb_compaction_readahead_size =
                 Some(common.rocksdb_compaction_readahead_size());
         }
+        if self.rocksdb_disable_auto_compactions.is_none() {
+            self.rocksdb_disable_auto_compactions = Some(common.rocksdb_disable_auto_compactions());
+        }
         if self.rocksdb_statistics_level.is_none() {
             self.rocksdb_statistics_level = Some(common.rocksdb_statistics_level());
         }
@@ -198,6 +209,10 @@ impl RocksDbOptions {
     pub fn rocksdb_compaction_readahead_size(&self) -> NonZeroUsize {
         self.rocksdb_compaction_readahead_size
             .unwrap_or(NonZeroUsize::new(2_000_000).unwrap())
+    }
+
+    pub fn rocksdb_disable_auto_compactions(&self) -> bool {
+        self.rocksdb_disable_auto_compactions.unwrap_or(false)
     }
 
     pub fn rocksdb_statistics_level(&self) -> StatisticsLevel {


### PR DESCRIPTION

This allows operators to disable automatic rocksdb compactions on per database basis (if rocksdb-disable-auto-compactions is true at the top level, it will be applied to all, unless overridden by the database-specific settings).

This is useful to use during testing and performance tuning.

Part of #4176
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4177).
* #4181
* #4180
* __->__ #4177