### PR TITLE
[RocksDB] Add support for periodic compactions

### DIFF
--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -182,6 +182,9 @@ impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
         );
 
         cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
+        if let Some(compaction_period) = config.rocksdb.rocksdb_periodic_compaction_seconds() {
+            cf_options.set_periodic_compaction_seconds(compaction_period);
+        }
 
         if cf_name == DATA_CF {
             cf_data_options(&mut cf_options, &block_options, config);

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -207,6 +207,9 @@ impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
         );
 
         cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
+        if let Some(compaction_period) = config.rocksdb.rocksdb_periodic_compaction_seconds() {
+            cf_options.set_periodic_compaction_seconds(compaction_period);
+        }
 
         if cf_name == DATA_CF {
             cf_data_options(&mut cf_options, &block_options, config);

--- a/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
@@ -104,6 +104,9 @@ impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
         );
 
         cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
+        if let Some(compaction_period) = config.rocksdb.rocksdb_periodic_compaction_seconds() {
+            cf_options.set_periodic_compaction_seconds(compaction_period);
+        }
 
         if cf_name == DATA_CF {
             cf_data_options(&mut cf_options, &block_options, config);

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -531,6 +531,9 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
         cf_options.set_max_successive_merges(100);
 
         cf_options.set_disable_auto_compactions(config.rocksdb_disable_auto_compactions());
+        if let Some(compaction_period) = config.rocksdb_periodic_compaction_seconds() {
+            cf_options.set_periodic_compaction_seconds(compaction_period);
+        }
 
         // Actually, we would love to use CappedPrefixExtractor but unfortunately it's neither exposed
         // in the C API nor the rust binding. That's okay and we can change it later.


### PR DESCRIPTION

Add a new configuration option `rocksdb_periodic_compaction` that allows
users to specify a period after which data must go through at least one
compaction operation. This is useful for ensuring that old data eventually
gets compacted even when write rates are low.

Compaction is triggered based on the table file age. For example, if a table file (SST) was created
2 hours ago, it will be eligible for compaction if periodic compaction is set to 2 hours.

Related to #4177

The new option is propagated to all RocksDB-based stores:
- Local loglet (Bifrost)
- Log server
- Metadata server (Raft storage)
- Partition store

The configuration accepts a duration value and defaults to unset
(RocksDB's automatic behavior). Setting to 0 disables periodic compactions.

Note 1: that rocksdb default behavior in our case is (disabled) because we don't use compaction filter. I didn't want to explicitly name it as (disabled) because we _might_ want to add a compaction filter in the future and have a value for this option. That said, if we didn't use rocksdb's default in the latter case (30 days), we might as well change this to a concrete value.

In all cases, we want this option to be "unset" for users who don't want to mess with it.

Note 2: The option is hidden since it's an advanced feature. We might consider exposing it in future releases.
