### PR TITLE
[Restate UI] Update to v0.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,8 +8331,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.23"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.23#9c5ab65c0068048f9ceceb30b840fc57d3f8aaf0"
+version = "0.1.24"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.24#601669e61ef307943e555effb56610f7ed237a28"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.23", tag = "v0.1.23" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.24", tag = "v0.1.24" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.24
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.24/ui-v0.1.24.zip