### PR TITLE
[Restate UI] Update to v0.1.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,8 +8331,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.24"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.24#601669e61ef307943e555effb56610f7ed237a28"
+version = "0.1.25"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.25#1a16ef7feddad9a1e3912bc37e3703e9a8f5dde0"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.24", tag = "v0.1.24" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.25", tag = "v0.1.25" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.25
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.25/ui-v0.1.25.zip