### PR TITLE
[Logs] Forward compatibility support for HLC timestamps in Logs chain metadata

### DIFF
--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -44,7 +44,7 @@ use restate_types::logs::metadata::{
     LogletParams, Logs, LogsConfiguration, ProviderConfiguration, ProviderKind,
     ReplicatedLogletConfig, SealMetadata, SegmentIndex,
 };
-use restate_types::logs::{LogId, LogletId, Lsn};
+use restate_types::logs::{self, LogId, LogletId, Lsn};
 use restate_types::net::node::NodeState;
 use restate_types::net::partition_processor_manager::{CreateSnapshotRequest, Snapshot};
 use restate_types::nodes_config::{NodesConfiguration, StorageState};
@@ -614,7 +614,7 @@ async fn update_cluster_configuration(
                 ));
             }
 
-            let mut builder = logs.as_ref().clone().into_builder();
+            let mut builder = logs.as_ref().clone().try_into_builder()?;
 
             builder.set_configuration(LogsConfiguration {
                 default_provider: default_provider.clone(),
@@ -685,7 +685,9 @@ enum ClusterConfigurationUpdateError {
     #[error("changing default provider kind to {0} is not supported. Choose 'replicated' instead")]
     ChooseReplicatedLoglet(ProviderKind),
     #[error(transparent)]
-    BuildError(#[from] partition_table::BuilderError),
+    PartitionTableBuilderError(#[from] partition_table::BuilderError),
+    #[error(transparent)]
+    LogsBuilderError(#[from] logs::builder::BuilderError),
     #[error("missing partition table; cluster seems to be not provisioned")]
     MissingPartitionTable,
     #[error("changing the number of partitions is not yet supported by Restate")]

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -1014,7 +1014,7 @@ mod tests {
         let metadata = Metadata::current();
         let old_version = metadata.logs_version();
 
-        let mut builder = metadata.logs_ref().clone().into_builder();
+        let mut builder = metadata.logs_ref().clone().try_into_builder().unwrap();
         let mut chain_builder = builder.chain(LOG_ID).unwrap();
         assert_eq!(2, chain_builder.num_segments());
         let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);

--- a/crates/bifrost/src/error.rs
+++ b/crates/bifrost/src/error.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use restate_core::{ShutdownError, SyncError};
 use restate_metadata_store::ReadWriteError;
+use restate_types::clock;
 use restate_types::errors::MaybeRetryableError;
 use restate_types::logs::builder::BuilderError;
 use restate_types::logs::metadata::SegmentIndex;
@@ -83,6 +84,8 @@ pub enum AdminError {
     },
     #[error("loglet params could not be deserialized: {0}")]
     ParamsSerde(#[from] Arc<serde_json::Error>),
+    #[error("logs HLC clock error: {0}")]
+    LogsHlcClock(clock::Error),
 }
 
 impl From<OperationError> for Error {
@@ -103,6 +106,7 @@ impl From<BuilderError> for AdminError {
             }
             BuilderError::ParamsSerde(error) => AdminError::ParamsSerde(Arc::new(error)),
             BuilderError::SegmentConflict(lsn) => AdminError::SegmentConflict(lsn),
+            BuilderError::HlcClock(err) => AdminError::LogsHlcClock(err),
         }
     }
 }

--- a/crates/bifrost/src/log_chain_writer.rs
+++ b/crates/bifrost/src/log_chain_writer.rs
@@ -237,7 +237,8 @@ impl LogChainWriter {
                 .read_modify_write(|logs: Option<Arc<Logs>>| {
                     let mut builder =
                         Arc::unwrap_or_clone(logs.ok_or(Error::LogsMetadataNotProvisioned)?)
-                            .into_builder();
+                            .try_into_builder()
+                            .map_err(|err| Error::Other(format!("LogsBuilder error: {err}")))?;
 
                     for cmd in &mut buffer {
                         match cmd.op {

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -979,7 +979,11 @@ mod tests {
         // perform manual reconfiguration (can be replaced with bifrost reconfiguration API
         // when it's implemented)
         let old_version = metadata.logs_version();
-        let mut builder = metadata.logs_ref().clone().into_builder();
+        let mut builder = metadata
+            .logs_ref()
+            .clone()
+            .try_into_builder()
+            .expect("can create builder");
         let mut chain_builder = builder.chain(LOG_ID).unwrap();
         assert_eq!(2, chain_builder.num_segments());
         let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);
@@ -1306,7 +1310,11 @@ mod tests {
         let metadata = Metadata::current();
         // prepare a chain that starts from Lsn 10 (we expect trim from OLDEST -> 9)
         let old_version = metadata.logs_version();
-        let mut builder = metadata.logs_ref().clone().into_builder();
+        let mut builder = metadata
+            .logs_ref()
+            .clone()
+            .try_into_builder()
+            .expect("can create builder");
         let mut chain_builder = builder.chain(LOG_ID).unwrap();
         assert_eq!(1, chain_builder.num_segments());
         let new_segment_params = new_single_node_loglet_params(ProviderKind::Local);

--- a/crates/clock/src/unique_timestamp.rs
+++ b/crates/clock/src/unique_timestamp.rs
@@ -12,6 +12,8 @@ use std::fmt::{Debug, Formatter};
 use std::num::NonZeroU64;
 use std::time::SystemTime;
 
+use serde::{Deserialize, Serialize};
+
 use crate::RESTATE_EPOCH;
 use crate::time::MillisSinceEpoch;
 
@@ -28,7 +30,7 @@ pub(super) const LC_BITS: u8 = 22;
 /// A mask to extract the logical clock counter (LSB 22 bits)
 pub(super) const LC_MAX: u64 = (1 << LC_BITS) - 1;
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     #[error("HLC timestamp outside the valid range")]
     TimestampExceedsMax,
@@ -65,7 +67,7 @@ pub enum Error {
 /// the valid input range `0..=u64::MAX-1` to `1..=u64::MAX`. This assumes that
 /// `u64::MAX` is not a valid value and will never be used (see [`PHY_TIME_MAX`]
 /// for the upper bound of the physical time).
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct UniqueTimestamp(NonZeroU64);
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -40,11 +40,12 @@ use restate_metadata_store::{ReadWriteError, WriteError, retry_on_retryable_erro
 use restate_partition_store::PartitionStoreManager;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::{CommonOptions, Configuration};
+use restate_types::errors::IntoMaybeRetryable;
 use restate_types::health::NodeStatus;
 use restate_types::live::Live;
 use restate_types::live::LiveLoadExt;
-use restate_types::logs::RecordCache;
 use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfiguration, ProviderKind};
+use restate_types::logs::{self, RecordCache};
 use restate_types::metadata::{GlobalMetadata, Precondition};
 use restate_types::net::listener::AddressBook;
 use restate_types::nodes_config::{ClusterFingerprint, NodeConfig, NodesConfiguration, Role};
@@ -750,27 +751,38 @@ async fn write_initial_logs_dont_fail_if_it_exists(
             None => Ok(initial_value.clone()),
             Some(current_value) => {
                 if current_value.configuration() == initial_value.configuration() {
-                    Err(ReadModifyWriteError::FailedOperation(AlreadyInitialized))
+                    Err(WriteInitialLogsError::AlreadyInitialized)
                 } else if current_value.version() == Version::MIN && current_value.num_logs() == 0 {
-                    let builder = initial_value.clone().into_builder();
+                    let builder = initial_value.clone().try_into_builder()?;
                     // make sure version is incremented to MIN + 1
                     Ok(builder.build())
                 } else {
-                    Err(ReadModifyWriteError::FailedOperation(AlreadyInitialized))
+                    Err(WriteInitialLogsError::AlreadyInitialized)
                 }
             }
         })
         .await;
 
     match value {
-        Ok(_) | Err(ReadModifyWriteError::FailedOperation(_)) => Ok(()),
+        Ok(_) => Ok(()),
+        Err(ReadModifyWriteError::FailedOperation(WriteInitialLogsError::AlreadyInitialized)) => {
+            Ok(())
+        }
+        Err(ReadModifyWriteError::FailedOperation(WriteInitialLogsError::BuilderError(err))) => {
+            Err(ReadWriteError::Other(Box::new(err.into_terminal())))
+        }
         Err(ReadModifyWriteError::ReadWrite(err)) => Err(err),
     }
 }
 
-#[derive(Debug)]
-struct AlreadyInitialized;
+#[derive(Debug, thiserror::Error)]
+enum WriteInitialLogsError {
+    #[error("Logs already initialized")]
+    AlreadyInitialized,
 
+    #[error(transparent)]
+    BuilderError(#[from] logs::builder::BuilderError),
+}
 /// Update the logs configuration metadata on single nodes, if it is still using the local loglet
 /// when the configured provider is replicated (default in 1.4.0+). This migrates older nodes
 /// provisioned with default config from versions <1.4.0 to use the replicated loglet. Does not
@@ -805,7 +817,7 @@ async fn migrate_logs_configuration_to_replicated_if_needed(
             .global_metadata()
             .read_modify_write(|current: Option<Arc<Logs>>| {
                 let logs = current.expect("logs are initialized");
-                let mut builder = logs.as_ref().clone().into_builder();
+                let mut builder = logs.as_ref().clone().try_into_builder()?;
 
                 // Why not ProviderConfiguration::from_configuration(config)? Using the default
                 // replicated loglet provider configuration is a safer alternative as there might be

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -23,7 +23,7 @@ multi-db = []
 restate-workspace-hack = { workspace = true }
 
 restate-base64-util = { workspace = true }
-restate-clock = { workspace = true, features = ["prost-types", "jiff"] }
+restate-clock = { workspace = true, features = ["prost-types", "jiff", "hlc"] }
 restate-encoding = { workspace = true }
 restate-errors = { workspace = true }
 restate-serde-util = { workspace = true }

--- a/crates/types/src/logs/metadata.rs
+++ b/crates/types/src/logs/metadata.rs
@@ -18,14 +18,17 @@ use ahash::{HashMap, HashMapExt};
 use anyhow::Context;
 use bytestring::ByteString;
 use enum_map::Enum;
-use restate_encoding::BilrostNewType;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 use smallvec::SmallVec;
 
+use restate_clock::UniqueTimestamp;
+use restate_encoding::BilrostNewType;
+
 use super::LogletId;
 use super::builder::LogsBuilder;
 use crate::config::Configuration;
+use crate::logs::builder::BuilderError;
 use crate::logs::{LogId, Lsn, SequenceNumber};
 use crate::metadata::GlobalMetadata;
 use crate::net::metadata::{MetadataContainer, MetadataKind};
@@ -337,6 +340,8 @@ pub struct Logs {
     #[debug(skip)]
     pub(super) lookup_index: LookupIndex,
     pub(super) config: LogsConfiguration,
+    // The last modification time.
+    pub(super) modified_at: Option<UniqueTimestamp>,
 }
 
 impl Default for Logs {
@@ -346,6 +351,7 @@ impl Default for Logs {
             logs: Default::default(),
             lookup_index: Default::default(),
             config: LogsConfiguration::default(),
+            modified_at: None,
         }
     }
 }
@@ -366,6 +372,7 @@ impl From<Logs> for LogsSerde {
             version: value.version,
             logs: value.logs.into_iter().collect(),
             config: Some(value.config),
+            modified_at: value.modified_at,
         }
     }
 }
@@ -410,6 +417,7 @@ impl TryFrom<LogsSerde> for Logs {
             logs,
             lookup_index,
             config: config.unwrap_or_default(),
+            modified_at: value.modified_at,
         })
     }
 }
@@ -424,6 +432,8 @@ struct LogsSerde {
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     logs: Vec<(LogId, Chain)>,
     config: Option<LogsConfiguration>,
+    #[serde(default)]
+    modified_at: Option<UniqueTimestamp>,
 }
 
 /// Seal metadata is json-serialized and stored as loglet params of the seal marker segment.
@@ -436,6 +446,7 @@ pub struct SealMetadata {
     pub sealed_at: MillisSinceEpoch,
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub context: std::collections::HashMap<String, String>,
+    pub tail_ts: Option<UniqueTimestamp>,
 }
 
 impl SealMetadata {
@@ -475,6 +486,7 @@ impl Default for SealMetadata {
             permanent_seal: false,
             sealed_at: MillisSinceEpoch::now(),
             context: Default::default(),
+            tail_ts: None,
         }
     }
 }
@@ -528,6 +540,8 @@ pub struct LogletConfig {
     // loglet chains already.
     #[serde(default)]
     index: SegmentIndex,
+    #[serde(default)]
+    pub created_at: Option<UniqueTimestamp>,
 }
 
 impl LogletConfig {
@@ -537,6 +551,7 @@ impl LogletConfig {
             kind: InternalKind::InMemory,
             params: LogletParams(ByteString::default()),
             index: 0.into(),
+            created_at: None,
         }
     }
 }
@@ -691,6 +706,7 @@ impl LogletConfig {
             kind: InternalKind::from(kind),
             params,
             index,
+            created_at: None,
         }
     }
 
@@ -702,6 +718,7 @@ impl LogletConfig {
             kind: InternalKind::Sealed,
             params: LogletParams::try_from(metadata)?,
             index,
+            created_at: None,
         })
     }
 
@@ -742,8 +759,8 @@ impl Logs {
         self.logs.get(log_id)
     }
 
-    pub fn into_builder(self) -> LogsBuilder {
-        self.into()
+    pub fn try_into_builder(self) -> Result<LogsBuilder, BuilderError> {
+        self.try_into()
     }
 
     pub fn configuration(&self) -> &LogsConfiguration {

--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -15,6 +15,7 @@ use log::render_loglet_params;
 
 use restate_cli_util::_comfy_table::{Cell, Color, Table};
 use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::{Tense, duration_to_human_rough};
 use restate_cli_util::{CliContext, c_println};
 use restate_core::protobuf::cluster_ctrl_svc::{DescribeLogRequest, new_cluster_ctrl_client};
 use restate_types::Versioned;
@@ -131,6 +132,7 @@ async fn describe_log(
         "REPLICATION",
         "SEQUENCER",
         "EFF-NODESET",
+        "CREATED-AT",
     ];
     if opts.extra {
         header_row.push("PARAMS");
@@ -170,6 +172,21 @@ async fn describe_log(
         let is_tail_segment = [Position::Last, Position::Only].contains(&position)
             && segment.index() == chain.tail_index();
 
+        let created_at = match segment.config.created_at {
+            None => Cell::new("--"),
+            Some(created_at) => {
+                match chrono::DateTime::from_timestamp_millis(
+                    created_at.to_unix_millis().as_u64() as i64
+                ) {
+                    Some(tz) => Cell::new(duration_to_human_rough(
+                        chrono::Local::now().signed_duration_since(tz),
+                        Tense::Past,
+                    )),
+                    None => Cell::new("--"),
+                }
+            }
+        };
+
         match segment.config.kind {
             InternalKind::Replicated => {
                 let params = log::deserialize_replicated_log_params(&segment);
@@ -186,6 +203,7 @@ async fn describe_log(
                     render_loglet_params(&params, |p| {
                         render_effective_nodeset(is_tail_segment, p, nodes_configuration)
                     }),
+                    created_at,
                 ];
                 if opts.extra {
                     segment_row.push(Cell::new(
@@ -207,6 +225,7 @@ async fn describe_log(
                     Cell::new(""),
                     Cell::new(""),
                     Cell::new(""),
+                    created_at,
                 ];
                 if opts.extra {
                     row.push(Cell::new(segment.config.params.to_string()))


### PR DESCRIPTION
[Logs] Forward compatibility support for HLC timestamps in Logs chain metadata

Summary:
- Add `modified_at` to Logs and `created_at` to each segment
- Modified at time is used to update the Builder HLC clock. This will
  guarantee that next generated timestamps are globally unique for the logs
  metadata.
- Once HLC clock is updated it is used to stamp new added segments
- On build the Logs updated_at is updated with latest unique timestamp.

What's next:
On Seal and AppendSegment the inserted segment will hold an HLC timesstamp
that is greater than the last record on the previous segement. This will require
that seal, or append to carry hlc information from find_tail.

Fixes #4148
