### PR TITLE
[Restate UI] Update to v0.1.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8332,8 +8332,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.27"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.27#8e47cb0c2c43ce2742d1b90f6f7925cf2c19eadd"
+version = "0.1.28"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.28#155f6f74edad761201dc42d8570fa44f37d71128"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.27", tag = "v0.1.27" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.28", tag = "v0.1.28" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.28
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.28/ui-v0.1.28.zip