### PR TITLE
[Restate UI] Update to v0.1.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8332,8 +8332,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.28"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.28#155f6f74edad761201dc42d8570fa44f37d71128"
+version = "0.1.29"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.29#c2f9fe2840d18e73ff7f184f99cec18ba4939b2e"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.28", tag = "v0.1.28" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.29", tag = "v0.1.29" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.29
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.29/ui-v0.1.29.zip