### PR TITLE
Introduce leases for snapshot coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8421,6 +8421,7 @@ dependencies = [
  "restate-errors",
  "restate-limiter",
  "restate-memory",
+ "restate-metadata-server",
  "restate-object-store-util",
  "restate-rocksdb",
  "restate-service-protocol-v4",
@@ -8445,6 +8446,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "url",
 ]
 

--- a/crates/clock/src/mock_clock.rs
+++ b/crates/clock/src/mock_clock.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use crate::time::MillisSinceEpoch;
 use crate::{Clock, RESTATE_EPOCH, WallClock};
@@ -47,6 +48,13 @@ impl MockClock {
 
     pub fn advance_ms(&self, ms: u64) {
         self.storage.fetch_add(ms, Ordering::SeqCst);
+    }
+
+    pub fn advance(&self, duration: Duration) {
+        self.storage.fetch_add(
+            u64::try_from(duration.as_millis()).expect("fits in u64"),
+            Ordering::SeqCst,
+        );
     }
 
     pub fn refresh_from_wall_clock(&self) {

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -22,7 +22,7 @@ options_schema = [
     "restate-worker/options_schema"
 ]
 kafka-oidc = ["restate-worker/kafka-oidc"]
-test-util = ["restate-worker/test-util"]
+test-util = ["restate-partition-store/test-util", "restate-worker/test-util"]
 # Enables heap flamegraph generation via /debug/heap/flamegraph endpoint.
 # This feature requires debug symbols and adds the symbolize/flamegraph features to jemalloc_pprof.
 heap-flamegraph = ["jemalloc_pprof/flamegraph"]

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -19,6 +19,7 @@ restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-limiter = { workspace = true, features = ["rule-book"] }
 restate-memory = { workspace = true }
+restate-metadata-server = { workspace = true }
 restate-object-store-util = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-storage-api = { workspace = true }
@@ -57,10 +58,13 @@ tokio = { workspace = true, features = ["fs"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
+ulid = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+restate-clock = { workspace = true, features = ["test-util"] }
 restate-core = { workspace = true, features = ["test-util"] }
+restate-metadata-server = { workspace = true, features = ["test-util"] }
 restate-object-store-util = { workspace = true, features = ["test-util"] }
 restate-rocksdb = { workspace = true, features = ["test-util"] }
 restate-test-util = { workspace = true }

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod leases;
 mod metadata;
 mod repository;
 mod snapshot_task;
@@ -17,8 +18,16 @@ use std::sync::Arc;
 
 use crate::{PartitionDb, PartitionStore, SnapshotError, SnapshotErrorKind};
 
+#[cfg(any(test, feature = "test-util"))]
+pub use self::leases::NoOpLeaseManager;
+pub use self::leases::{
+    LEASE_DURATION, LEASE_RENEWAL_INTERVAL, LEASE_SAFETY_MARGIN, LeaseError, SnapshotLeaseGuard,
+    SnapshotLeaseManager, SnapshotLeaseValue,
+};
 pub use self::metadata::*;
-pub use self::repository::{PartitionSnapshotStatus, SnapshotReference, SnapshotRepository};
+pub use self::repository::{
+    LeaseProvider, PartitionSnapshotStatus, SnapshotReference, SnapshotRepository,
+};
 pub use self::snapshot_task::*;
 
 use tokio::sync::Semaphore;
@@ -36,7 +45,7 @@ pub struct Snapshots {
 
 impl Snapshots {
     pub async fn create(config: &Configuration) -> anyhow::Result<Self> {
-        let repository = SnapshotRepository::new_from_config(
+        let repository = SnapshotRepository::new_read_only_from_config(
             &config.worker.snapshots,
             config.worker.storage.snapshots_staging_dir(),
         )

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -1,0 +1,1231 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use bytestring::ByteString;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, instrument, warn};
+use ulid::Ulid;
+
+use restate_clock::{Clock, WallClock};
+use restate_core::task_center::TaskHandle;
+use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind};
+use restate_metadata_server::{MetadataStoreClient, ReadError, WriteError};
+use restate_types::Version;
+use restate_types::config::Configuration;
+use restate_types::identifiers::PartitionId;
+use restate_types::metadata::Precondition;
+use restate_types::retries::RetryPolicy;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, Versioned, flexbuffers_storage_encode_decode};
+
+/// Duration for which a snapshot operation lease is valid (5 minutes).
+///
+/// Note: callers get at most `LEASE_DURATION - LEASE_SAFETY_MARGIN` of useful work time
+/// per acquire before they should refresh or stop, because operations must complete before
+/// `expires_at - LEASE_SAFETY_MARGIN`.
+///
+/// Clock skew assumption: Nodes in the cluster should have clocks synchronized within
+/// `LEASE_SAFETY_MARGIN` (1 minute). Larger clock skew could cause a node to believe a lease has
+/// expired while the holder still considers it valid, leading to concurrent operations. NTP
+/// synchronization typically provides sub-second accuracy, well within this tolerance.
+///
+/// The downside of making this longer is that this is the maximum time during which a zombie lease
+/// whose owner has died can lock out other potential acquirers from making progress.
+pub const LEASE_DURATION: Duration = Duration::from_mins(5);
+
+/// Minimum remaining lease time required to continue operations (1 minute). Lease-covered
+/// operations should aim to complete before `expires_at - LEASE_SAFETY_MARGIN`.
+pub const LEASE_SAFETY_MARGIN: Duration = Duration::from_mins(1);
+
+/// Interval at which lease renewal should occur (2 minutes). This should be well before lease
+/// expiry to ensure smooth operations, but ideally long enough that most operations complete before
+/// we have to renew.
+pub const LEASE_RENEWAL_INTERVAL: Duration = Duration::from_mins(2);
+
+/// Outcome of `SnapshotLeaseGuard::start_renewal_task`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenewalTaskStart {
+    /// A new renewal task was spawned by this call.
+    Started,
+    /// A renewal task was already running for this guard; no new task was spawned.
+    AlreadyRunning,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LeaseError {
+    #[error("Lease held by {holder} (lease_id: {lease_id}), expires at: {expires_at}")]
+    Held {
+        holder: GenerationalNodeId,
+        lease_id: Ulid,
+        expires_at: jiff::Timestamp,
+    },
+    #[error("Lease expired or taken over by another node")]
+    Expired,
+    #[error("Snapshot repository is read-only (no lease provider configured)")]
+    Unavailable,
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
+    #[error(transparent)]
+    MetadataRead(#[from] ReadError),
+    #[error(transparent)]
+    MetadataWrite(#[from] WriteError),
+}
+
+impl LeaseError {
+    fn retryable(&self) -> bool {
+        match self {
+            LeaseError::Held { .. }
+            | LeaseError::Expired
+            | LeaseError::Unavailable
+            | LeaseError::Shutdown(_) => false,
+            LeaseError::MetadataRead(ReadError::Other(err)) => err.retryable(),
+            LeaseError::MetadataRead(ReadError::Codec(_)) => false,
+            LeaseError::MetadataWrite(WriteError::FailedPrecondition(_)) => false,
+            LeaseError::MetadataWrite(WriteError::Other(err)) => err.retryable(),
+            LeaseError::MetadataWrite(WriteError::Codec(_)) => false,
+        }
+    }
+}
+
+fn lease_key(partition_id: PartitionId) -> ByteString {
+    ByteString::from(format!("snapshot_lease_{}", partition_id))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SnapshotLeaseValue {
+    pub holder: GenerationalNodeId,
+    pub lease_id: Ulid,
+    pub expires_at: MillisSinceEpoch,
+    version: Version,
+}
+
+impl SnapshotLeaseValue {
+    fn new(holder: GenerationalNodeId, clock: &impl Clock) -> Self {
+        let expires_at = clock.recent() + LEASE_DURATION;
+        Self {
+            holder,
+            lease_id: Ulid::new(),
+            expires_at,
+            version: Version::MIN,
+        }
+    }
+
+    /// Constructs a marker value used by the Drop path to release a lease via a
+    /// versioned CAS. The caller must pass the version they expect the metadata
+    /// store slot to currently hold; the resulting record will carry
+    /// `version.next()` once `put` returns Ok.
+    fn expired(holder: GenerationalNodeId, lease_id: Ulid, current_version: Version) -> Self {
+        Self {
+            holder,
+            lease_id,
+            expires_at: MillisSinceEpoch::UNIX_EPOCH,
+            version: current_version.next(),
+        }
+    }
+
+    /// Returns true at and after `expires_at`. Used by acquirers to decide
+    /// whether an existing slot is up for takeover. The current holder's
+    /// `is_valid` returns false `LEASE_SAFETY_MARGIN` earlier so that operations
+    /// drain before any other node can take over.
+    fn is_expired(&self, clock: &impl Clock) -> bool {
+        clock.recent() >= self.expires_at
+    }
+
+    fn with_version(mut self, version: Version) -> Self {
+        self.version = version;
+        self
+    }
+}
+
+impl Versioned for SnapshotLeaseValue {
+    fn version(&self) -> Version {
+        self.version
+    }
+}
+
+flexbuffers_storage_encode_decode!(SnapshotLeaseValue);
+
+/// Metadata-backed RAII lease which automatically releases when dropped
+pub enum SnapshotLeaseGuard<C: Clock + Clone + Send + Sync + 'static = WallClock> {
+    /// Metadata store-backed lease
+    Lease(inner::MetadataBackedLeaseGuard<C>),
+    /// No-op lease for testing
+    #[cfg(any(test, feature = "test-util"))]
+    NoOp(inner::NoOpLeaseGuard),
+}
+
+impl<C: Clock + Clone + Send + Sync + 'static> std::fmt::Display for SnapshotLeaseGuard<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Lease(g) => write!(f, "{}", g.lease_id),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => write!(f, "noop"),
+        }
+    }
+}
+
+impl<C: Clock + Clone + Send + Sync + 'static> SnapshotLeaseGuard<C> {
+    /// Check if lease is still valid within the safety margin.
+    pub fn is_valid(&self) -> bool {
+        match self {
+            Self::Lease(g) => g.is_valid(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(g) => g.is_valid(),
+        }
+    }
+
+    /// Cancellation token representing lease validity.
+    ///
+    /// Use this to abort long-running lease-guarded operations:
+    /// ```ignore
+    /// tokio::select! {
+    ///     _ = lease_guard.lease_lost().cancelled() => { /* abort work */ }
+    ///     result = do_work() => { /* handle result */ }
+    /// }
+    /// ```
+    pub fn lease_lost(&self) -> CancellationToken {
+        match self {
+            Self::Lease(g) => g.lease_lost.clone(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(g) => g.lease_lost.clone(),
+        }
+    }
+
+    /// Remaining time within the lease (accounting for the safety margin). The returned values are
+    /// not monotonic - refreshing the lease will extend the remaining time. Use `run_under_lease`
+    /// for a convenient wrapper that monitors lease expiry automatically.
+    fn remaining_operation_time(&self) -> Duration {
+        match self {
+            Self::Lease(g) => g.duration_until_deadline(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(g) => g.duration_until_deadline(),
+        }
+    }
+
+    /// Run a future under this lease, aborting if the lease is lost or deadline reached.
+    ///
+    /// This method is conservative about operation deadlines - it respects the shifting deadline
+    /// that can be extended by background lease renewal. If the deadline expires without renewal,
+    /// the work is aborted.
+    pub async fn run_under_lease<F, T>(&self, work: F) -> Option<T>
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let lease_lost = self.lease_lost();
+        tokio::pin!(work);
+
+        loop {
+            let time_until_deadline = self.remaining_operation_time();
+
+            if time_until_deadline.is_zero() && !self.is_valid() {
+                warn!(lease = %self, "Snapshot lease lost (deadline expired), task was canceled");
+                return None;
+            }
+
+            tokio::select! {
+                biased;
+                _ = lease_lost.cancelled() => {
+                    warn!(lease = %self, "Snapshot lease lost (lease_lost cancelled), task was canceled");
+                    return None;
+                }
+                // Deadline sleep BEFORE work for strict enforcement
+                _ = tokio::time::sleep(time_until_deadline), if !time_until_deadline.is_zero() => {
+                    if self.is_valid() {
+                        // background renewal has extended deadline
+                        continue;
+                    }
+                    warn!(lease = %self, "Snapshot lease lost (deadline reached), task was canceled");
+                    return None;
+                }
+                result = &mut work => {
+                    return Some(result);
+                }
+            }
+        }
+    }
+
+    /// Start a background task that renews the lease at a fixed renewal interval.
+    /// The task holds a weak reference to the lease and stops when the guard is dropped.
+    /// The guard ensures that at most one renewal task is spawned per guard. Subsequent calls
+    /// after the first successful start return `Ok(RenewalTaskStart::AlreadyRunning)`.
+    pub fn start_renewal_task(self: &Arc<Self>) -> Result<RenewalTaskStart, ShutdownError> {
+        match self.as_ref() {
+            Self::Lease(g) => g.start_renewal_task(Arc::downgrade(self)),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => Ok(RenewalTaskStart::Started),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn test_renew(&self) -> Result<(), LeaseError> {
+        match self {
+            Self::Lease(g) => g.renew().await,
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_mark_released(&self) {
+        match self {
+            Self::Lease(g) => g.test_mark_released(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => {}
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn operation_deadline(&self) -> MillisSinceEpoch {
+        match self {
+            Self::Lease(g) => g.operation_deadline(),
+            Self::NoOp(g) => g.operation_deadline(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl SnapshotLeaseGuard {
+    pub fn noop() -> Self {
+        Self::NoOp(inner::NoOpLeaseGuard::new(MillisSinceEpoch::MAX))
+    }
+}
+
+mod inner {
+    use std::ops::Add;
+
+    use super::*;
+
+    pub struct MetadataBackedLeaseGuard<C: Clock + Clone + Send + Sync + 'static = WallClock> {
+        pub(super) partition_id: PartitionId,
+        pub(super) lease_id: Ulid,
+        holder: GenerationalNodeId,
+        expires_at: AtomicU64,
+        metadata_store_client: MetadataStoreClient,
+        version: Mutex<Version>,
+        renewal_task: Mutex<Option<TaskHandle<()>>>,
+        pub(super) lease_lost: CancellationToken,
+        clock: C,
+    }
+
+    impl<C: Clock + Clone + Send + Sync + 'static> MetadataBackedLeaseGuard<C> {
+        pub(super) fn new(
+            partition_id: PartitionId,
+            lease: SnapshotLeaseValue,
+            metadata_store_client: MetadataStoreClient,
+            version: Version,
+            clock: C,
+        ) -> Self {
+            Self {
+                partition_id,
+                lease_id: lease.lease_id,
+                holder: lease.holder,
+                expires_at: AtomicU64::new(lease.expires_at.as_u64()),
+                metadata_store_client,
+                version: Mutex::new(version),
+                renewal_task: Mutex::new(None),
+                lease_lost: CancellationToken::new(),
+                clock,
+            }
+        }
+
+        fn expires_at(&self) -> MillisSinceEpoch {
+            MillisSinceEpoch::new(self.expires_at.load(Ordering::Acquire))
+        }
+
+        /// Returns true while the current time is strictly before
+        /// `expires_at - LEASE_SAFETY_MARGIN` - i.e. the lease holder still has
+        /// useful work time before they must stop and let the lease expire.
+        ///
+        /// Acquirers, by contrast, use [`SnapshotLeaseValue::is_expired`] which
+        /// triggers takeover only at the true `expires_at`. The
+        /// `LEASE_SAFETY_MARGIN` gap between the two predicates is intentional:
+        /// it gives the current holder time to drain its operation while
+        /// preventing a different node from believing the lease is up for grabs.
+        pub(super) fn is_valid(&self) -> bool {
+            self.clock.recent() + LEASE_SAFETY_MARGIN < self.expires_at()
+        }
+
+        #[instrument(
+            level = "debug",
+            skip_all,
+            fields(partition_id = %self.partition_id, lease_id = %self.lease_id),
+            err,
+        )]
+        pub(super) async fn renew(&self) -> Result<(), LeaseError> {
+            if self.lease_lost.is_cancelled() {
+                debug!(
+                    partition_id = %self.partition_id,
+                    lease_id = %self.lease_id,
+                    "Lease renewal skipped - lease already marked as lost"
+                );
+                return Err(LeaseError::Expired);
+            }
+
+            let key = lease_key(self.partition_id);
+            let current_version = *self.version.lock();
+
+            let stored: Option<SnapshotLeaseValue> =
+                self.metadata_store_client.get(key.clone()).await?;
+            let stored_lease = stored.ok_or(LeaseError::Expired)?;
+
+            if stored_lease.lease_id != self.lease_id {
+                warn!(
+                    partition_id = %self.partition_id,
+                    expected_lease_id = %self.lease_id,
+                    actual_lease_id = %stored_lease.lease_id,
+                    actual_holder = %stored_lease.holder,
+                    "Lease was taken over by another node during renewal"
+                );
+                return Err(LeaseError::Expired);
+            }
+
+            let new_expiration = self.clock.recent().add(LEASE_DURATION);
+            let renewed_lease = SnapshotLeaseValue {
+                holder: self.holder,
+                lease_id: self.lease_id,
+                expires_at: new_expiration,
+                version: current_version.next(),
+            };
+
+            self.metadata_store_client
+                .put(
+                    key,
+                    &renewed_lease,
+                    Precondition::MatchesVersion(current_version),
+                )
+                .await?;
+
+            self.expires_at
+                .store(new_expiration.as_u64(), Ordering::Release);
+            *self.version.lock() = current_version.next();
+
+            debug!(partition_id = %self.partition_id, "Snapshot lease renewed");
+            Ok(())
+        }
+
+        pub(super) fn start_renewal_task(
+            &self,
+            guard: Weak<SnapshotLeaseGuard<C>>,
+        ) -> Result<RenewalTaskStart, ShutdownError> {
+            let mut renewal_task = self.renewal_task.lock();
+            if renewal_task.is_some() {
+                return Ok(RenewalTaskStart::AlreadyRunning);
+            }
+
+            let lease_lost = self.lease_lost.clone();
+            let partition_id = self.partition_id;
+
+            let retry_policy: RetryPolicy = Configuration::pinned()
+                .common
+                .network_error_retry_policy
+                .clone();
+
+            let handle = TaskCenter::current().spawn_unmanaged_child(
+                TaskKind::Disposable,
+                "snapshot-lease-renewal",
+                async move {
+                    loop {
+                        tokio::select! {
+                            _ = lease_lost.cancelled() => break,
+                            _ = tokio::time::sleep(LEASE_RENEWAL_INTERVAL) => {
+                                let Some(guard) = guard.upgrade() else {
+                                    debug!(%partition_id, "Lease guard dropped, stopping renewal");
+                                    break;
+                                };
+                                match guard.as_ref() {
+                                    SnapshotLeaseGuard::Lease(g) => {
+                                        // Retry transient metadata-store errors while the lease
+                                        // is still valid. A single network blip should not cost
+                                        // us the lease - acquire uses the same policy.
+                                        let result = retry_policy
+                                            .clone()
+                                            .retry_if(
+                                                || async { g.renew().await },
+                                                |e: &LeaseError| {
+                                                    e.retryable() && g.is_valid()
+                                                },
+                                            )
+                                            .await;
+                                        if let Err(e) = result {
+                                            warn!(%partition_id, error = %e, "Lease renewal failed");
+                                            g.lease_lost.cancel();
+                                            break;
+                                        }
+                                    }
+                                    #[cfg(any(test, feature = "test-util"))]
+                                    SnapshotLeaseGuard::NoOp(_) => {}
+                                }
+                            }
+                        }
+                    }
+                },
+            )?;
+            *renewal_task = Some(handle);
+            Ok(RenewalTaskStart::Started)
+        }
+
+        fn spawn_release_task(&mut self) {
+            let client = self.metadata_store_client.clone();
+            let partition_id = self.partition_id;
+            let version = *self.version.lock();
+            let lease_id = self.lease_id;
+            let holder = self.holder;
+
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let key = lease_key(partition_id);
+                    let expired = SnapshotLeaseValue::expired(holder, lease_id, version);
+
+                    match client
+                        .put(key, &expired, Precondition::MatchesVersion(version))
+                        .await
+                    {
+                        Ok(()) => {
+                            debug!(%partition_id, %lease_id, "Lease released via Drop");
+                        }
+                        Err(WriteError::FailedPrecondition(_)) => {
+                            debug!(
+                                %partition_id,
+                                %lease_id,
+                                %holder,
+                                "Lease release via Drop failed: version mismatch (lease was likely taken over)"
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                %partition_id,
+                                %lease_id,
+                                %holder,
+                                %err,
+                                "Lease release via Drop failed"
+                            );
+                        }
+                    }
+                });
+                debug!(
+                    partition_id = %partition_id,
+                    "Snapshot lease dropped, spawned async release"
+                );
+            } else {
+                warn!(
+                    partition_id = %partition_id,
+                    "Snapshot lease dropped without release - no runtime available"
+                );
+            }
+        }
+
+        #[cfg(test)]
+        pub(super) fn test_mark_released(&self) {
+            self.lease_lost.cancel();
+        }
+
+        #[cfg(test)]
+        pub(super) fn operation_deadline(&self) -> MillisSinceEpoch {
+            self.expires_at() - LEASE_SAFETY_MARGIN
+        }
+
+        pub(super) fn duration_until_deadline(&self) -> Duration {
+            let now = self.clock.recent();
+            let deadline = self.expires_at() - LEASE_SAFETY_MARGIN;
+            deadline.duration_since(now)
+        }
+    }
+
+    impl<C: Clock + Clone + Send + Sync + 'static> Drop for MetadataBackedLeaseGuard<C> {
+        fn drop(&mut self) {
+            self.lease_lost.cancel();
+            self.spawn_release_task();
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub struct NoOpLeaseGuard {
+        expires_at: MillisSinceEpoch,
+        /// Cancelled on drop to match MetadataBackedLeaseGuard behavior.
+        pub(super) lease_lost: CancellationToken,
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    impl NoOpLeaseGuard {
+        pub(super) fn new(expires_at: MillisSinceEpoch) -> Self {
+            Self {
+                expires_at,
+                lease_lost: CancellationToken::new(),
+            }
+        }
+
+        pub(super) fn is_valid(&self) -> bool {
+            WallClock.recent() + LEASE_SAFETY_MARGIN < self.expires_at
+        }
+
+        #[cfg(test)]
+        pub(super) fn operation_deadline(&self) -> MillisSinceEpoch {
+            self.expires_at - LEASE_SAFETY_MARGIN
+        }
+
+        pub(super) fn duration_until_deadline(&self) -> Duration {
+            let deadline = self.expires_at - LEASE_SAFETY_MARGIN;
+            deadline.duration_since(WallClock.recent())
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    impl Drop for NoOpLeaseGuard {
+        fn drop(&mut self) {
+            self.lease_lost.cancel();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SnapshotLeaseManager<C: Clock + Clone + Send + Sync + 'static = WallClock> {
+    metadata_store_client: MetadataStoreClient,
+    /// Node id to use for leases. If None, fetched from Metadata at acquire time.
+    node_id: Option<GenerationalNodeId>,
+    clock: C,
+}
+
+impl SnapshotLeaseManager<WallClock> {
+    pub fn new(metadata_store_client: MetadataStoreClient) -> Self {
+        Self {
+            metadata_store_client,
+            node_id: None,
+            clock: WallClock,
+        }
+    }
+}
+
+impl<C: Clock + Clone + Send + Sync + 'static> SnapshotLeaseManager<C> {
+    #[cfg(test)]
+    pub fn new_with_clock(
+        metadata_store_client: MetadataStoreClient,
+        node_id: GenerationalNodeId,
+        clock: C,
+    ) -> Self {
+        Self {
+            metadata_store_client,
+            node_id: Some(node_id),
+            clock,
+        }
+    }
+
+    /// Acquire a lease for the given partition.
+    ///
+    /// Returns error if another valid lease exists or if the metadata store is unavailable.
+    /// Transient metadata store failures are retried with exponential backoff.
+    pub async fn acquire(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard<C>, LeaseError> {
+        let retry_policy: RetryPolicy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+
+        retry_policy
+            .retry_if(|| self.try_acquire(partition_id), LeaseError::retryable)
+            .await
+    }
+
+    #[instrument(level = "debug", skip_all, fields(%partition_id))]
+    async fn try_acquire(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard<C>, LeaseError> {
+        let my_node_id = self
+            .node_id
+            .unwrap_or_else(|| Metadata::with_current(|m| m.my_node_id()));
+        let key = lease_key(partition_id);
+
+        let new_lease = SnapshotLeaseValue::new(my_node_id, &self.clock);
+        let new_lease_id = new_lease.lease_id;
+
+        let existing: Option<SnapshotLeaseValue> =
+            self.metadata_store_client.get(key.clone()).await?;
+
+        match existing {
+            None => {
+                let written_version = Version::MIN;
+                let lease_to_write = new_lease.with_version(written_version);
+                self.metadata_store_client
+                    .put(key.clone(), &lease_to_write, Precondition::DoesNotExist)
+                    .await?;
+
+                debug!(lease_id = %new_lease_id, "Acquired snapshot lease (new)");
+
+                Ok(SnapshotLeaseGuard::Lease(
+                    inner::MetadataBackedLeaseGuard::new(
+                        partition_id,
+                        lease_to_write,
+                        self.metadata_store_client.clone(),
+                        written_version,
+                        self.clock.clone(),
+                    ),
+                ))
+            }
+            Some(existing_lease) => {
+                if existing_lease.is_expired(&self.clock) {
+                    let written_version = existing_lease.version.next();
+                    let lease_to_write = new_lease.with_version(written_version);
+                    self.metadata_store_client
+                        .put(
+                            key,
+                            &lease_to_write,
+                            Precondition::MatchesVersion(existing_lease.version),
+                        )
+                        .await?;
+
+                    debug!(
+                        lease_id = %new_lease_id,
+                        previous_holder = %existing_lease.holder,
+                        "Acquired snapshot lease (expired takeover)"
+                    );
+
+                    Ok(SnapshotLeaseGuard::Lease(
+                        inner::MetadataBackedLeaseGuard::new(
+                            partition_id,
+                            lease_to_write,
+                            self.metadata_store_client.clone(),
+                            written_version,
+                            self.clock.clone(),
+                        ),
+                    ))
+                } else {
+                    Err(LeaseError::Held {
+                        holder: existing_lease.holder,
+                        lease_id: existing_lease.lease_id,
+                        expires_at: existing_lease.expires_at.into_timestamp(),
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+#[derive(Clone, Default)]
+pub struct NoOpLeaseManager;
+
+#[cfg(any(test, feature = "test-util"))]
+impl NoOpLeaseManager {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn acquire(
+        &self,
+        _partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard, LeaseError> {
+        let expires_at =
+            MillisSinceEpoch::new(WallClock.recent().as_u64() + 365 * 24 * 60 * 60 * 1000);
+        Ok(SnapshotLeaseGuard::NoOp(inner::NoOpLeaseGuard::new(
+            expires_at,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use restate_clock::MockClock;
+    use restate_core::TestCoreEnv;
+    use restate_test_util::let_assert;
+    use restate_types::GenerationalNodeId;
+    use restate_types::identifiers::PartitionId;
+
+    use super::*;
+
+    #[restate_core::test]
+    async fn lease_acquire_no_existing() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock.clone(),
+        );
+
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        assert!(guard.is_valid());
+        assert_eq!(
+            guard.operation_deadline(),
+            clock.recent() + LEASE_DURATION - LEASE_SAFETY_MARGIN
+        );
+
+        // validity window spans (time acquired + lease duration - safety margin)
+        clock.advance(LEASE_DURATION - LEASE_SAFETY_MARGIN - Duration::from_millis(1));
+        assert!(guard.is_valid());
+
+        clock.advance_ms(1);
+        assert!(!guard.is_valid());
+    }
+
+    #[restate_core::test]
+    async fn lease_acquire_expired_takeover() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+        let _guard = n2_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("initial acquire should succeed");
+
+        clock.advance(LEASE_DURATION + Duration::from_millis(100));
+
+        let n1_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n1,
+            clock.clone(),
+        );
+        let guard = n1_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("takeover should succeed");
+        assert!(guard.is_valid());
+    }
+
+    #[restate_core::test]
+    async fn lease_acquire_held_by_other_node() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+        let _guard = n2_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("initial acquire should succeed");
+
+        let expected_expiry = clock.recent() + LEASE_DURATION;
+        clock.advance_ms(500);
+
+        let n1_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n1,
+            clock.clone(),
+        );
+        let result = n1_manager.acquire(PartitionId::MIN).await;
+
+        let_assert!(
+            Err(LeaseError::Held {
+                holder,
+                expires_at,
+                ..
+            }) = result
+        );
+        assert_eq!(holder, n2);
+        assert_eq!(expected_expiry.into_timestamp(), expires_at);
+    }
+
+    #[restate_core::test]
+    async fn lease_renewal_extends_expiry() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock.clone(),
+        );
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        let initial_deadline = guard.operation_deadline();
+
+        clock.advance(Duration::from_mins(2));
+        guard.test_renew().await.expect("renewal should succeed");
+
+        assert_eq!(
+            guard.operation_deadline(),
+            initial_deadline + Duration::from_mins(2)
+        );
+    }
+
+    #[restate_core::test]
+    async fn lease_renewal_fails_when_taken_over() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        let n1_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n1,
+            clock.clone(),
+        );
+        let guard = n1_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        clock.advance(LEASE_DURATION + Duration::from_millis(1000));
+
+        // another node takes over
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+        let _n2_guard = n2_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("takeover should succeed");
+
+        // original lease can no longer be renewed
+        let result = guard.test_renew().await;
+        assert!(matches!(result, Err(LeaseError::Expired)));
+    }
+
+    #[restate_core::test]
+    async fn lease_acquire_concurrent_race() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            MockClock::new(),
+        );
+
+        for _ in 0..100 {
+            let (result1, result2) = tokio::join!(
+                manager.acquire(PartitionId::MIN),
+                manager.acquire(PartitionId::MIN)
+            );
+
+            // exactly one should succeed
+            let (guard, err) = match (result1, result2) {
+                (Ok(g), Err(e)) | (Err(e), Ok(g)) => (g, e),
+                (Ok(_), Ok(_)) => panic!("Both acquires succeeded"),
+                (Err(e1), Err(e2)) => panic!("Both acquires failed: {e1:?}, {e2:?}"),
+            };
+            assert!(guard.is_valid());
+            assert!(matches!(
+                err,
+                LeaseError::Held { .. }
+                    | LeaseError::MetadataWrite(WriteError::FailedPrecondition(_))
+            ));
+
+            drop(guard);
+            // allow async release task to complete
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[restate_core::test]
+    async fn lease_renewal_fails_when_released() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            MockClock::new(),
+        );
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        guard.test_mark_released();
+
+        let result = guard.test_renew().await;
+        assert!(matches!(result, Err(LeaseError::Expired)));
+    }
+
+    #[restate_core::test(start_paused = true)]
+    async fn lease_start_renewal_lifecycle() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = Arc::new(
+            manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed"),
+        );
+
+        assert!(guard.is_valid());
+
+        assert_eq!(
+            guard.start_renewal_task().expect("starts renewal task"),
+            RenewalTaskStart::Started,
+        );
+        assert_eq!(
+            guard
+                .start_renewal_task()
+                .expect("second call must succeed"),
+            RenewalTaskStart::AlreadyRunning,
+        );
+
+        let initial_deadline = guard.operation_deadline();
+
+        // Sleep past the renewal interval - the renewal task will wake and extend the deadline
+        tokio::time::sleep(LEASE_RENEWAL_INTERVAL + Duration::from_secs(1)).await;
+
+        let expected_deadline = initial_deadline + LEASE_RENEWAL_INTERVAL;
+
+        assert_eq!(
+            guard.operation_deadline(),
+            expected_deadline,
+            "Lease should have been renewed, extending the operation deadline"
+        );
+
+        assert!(guard.is_valid());
+        drop(guard); // cancel renewal task
+
+        for _ in 0..10 {
+            match manager.acquire(PartitionId::MIN).await {
+                Ok(_) => return,
+                Err(LeaseError::Held { .. }) => tokio::task::yield_now().await,
+                Err(e) => panic!("Unexpected error during acquire: {:?}", e),
+            }
+        }
+        panic!("Should be able to re-acquire after drop");
+    }
+
+    #[restate_core::test]
+    async fn lease_release_on_drop() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        {
+            let n1_manager = SnapshotLeaseManager::new_with_clock(
+                env.metadata_store_client.clone(),
+                n1,
+                clock.clone(),
+            );
+            // immediately dropped
+            let _lease = n1_manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed");
+        }
+
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+
+        let mut acquired = false;
+        for _ in 0..10 {
+            match n2_manager.acquire(PartitionId::MIN).await {
+                Ok(_) => {
+                    acquired = true;
+                    break;
+                }
+                Err(LeaseError::Held { .. }) => {
+                    // release task might not have completed yet
+                    tokio::task::yield_now().await;
+                }
+                Err(e) => panic!("Unexpected error during acquire: {:?}", e),
+            }
+        }
+
+        assert!(
+            acquired,
+            "other node should be able to acquire after release (within timeout)"
+        );
+    }
+
+    #[restate_core::test]
+    async fn lease_lost_on_drop_and_run_under_lease() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            MockClock::new(),
+        );
+
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        let lease_lost = guard.lease_lost();
+        assert!(!lease_lost.is_cancelled());
+
+        let result = guard.run_under_lease(async { 42 }).await;
+        assert_eq!(result, Some(42));
+
+        guard.test_mark_released();
+        assert!(lease_lost.is_cancelled());
+
+        let result = guard.run_under_lease(async { 42 }).await;
+        assert_eq!(result, None);
+    }
+
+    #[restate_core::test(start_paused = true)]
+    async fn run_under_lease_respects_deadline_with_renewal() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = Arc::new(
+            manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed"),
+        );
+        assert_eq!(
+            guard.start_renewal_task().expect("should start renewal"),
+            RenewalTaskStart::Started,
+        );
+        let initial_deadline = guard.operation_deadline();
+
+        // the mock work future sleeps slightly longer than the renewal interval
+        // renewal task's sleep future fires first, extending the deadline
+        let result = guard
+            .run_under_lease(async {
+                tokio::time::sleep(LEASE_RENEWAL_INTERVAL + Duration::from_secs(1)).await;
+                42
+            })
+            .await;
+
+        assert!(
+            guard.operation_deadline() > initial_deadline,
+            "Deadline should have been extended by renewal"
+        );
+        assert_eq!(result, Some(42), "Work should complete with lease renewal");
+    }
+
+    #[restate_core::test(start_paused = true)]
+    async fn run_under_lease_aborts_at_deadline_without_renewal() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        // no lease renewal task started
+
+        let result = guard
+            .run_under_lease(async {
+                tokio::time::sleep(LEASE_DURATION).await;
+                42
+            })
+            .await;
+
+        assert_eq!(result, None, "Work should be aborted at deadline");
+    }
+
+    /// If the lease is lost mid-operation (renewal failure, takeover by another node, etc.),
+    /// `run_under_lease` must abort the in-flight work and return `None` instead of letting
+    /// it finish under an invalid lease.
+    #[restate_core::test(start_paused = true)]
+    async fn run_under_lease_aborts_when_lease_lost_mid_operation() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = Arc::new(
+            manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed"),
+        );
+
+        let lease_lost = guard.lease_lost();
+        let cancel_guard = guard.clone();
+
+        // Cancel the lease shortly into the work, simulating renewal-task failure.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            cancel_guard.test_mark_released();
+        });
+
+        let result = guard
+            .run_under_lease(async {
+                // Work that would otherwise complete well within the lease duration.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                42
+            })
+            .await;
+
+        assert!(lease_lost.is_cancelled());
+        assert_eq!(
+            result, None,
+            "Work must be aborted once the lease is signalled lost"
+        );
+    }
+
+    /// Handy for paused tokio tests, this clock reflects `tokio::time::advance()` calls eliminating
+    /// the need to manipulate two time sources.
+    #[derive(Clone)]
+    struct TokioClock {
+        initial_instant: tokio::time::Instant,
+    }
+
+    impl TokioClock {
+        fn new() -> Self {
+            Self {
+                initial_instant: tokio::time::Instant::now(),
+            }
+        }
+
+        /// Fixed base time for deterministic tests (well after RESTATE_EPOCH)
+        const BASE_TIME: MillisSinceEpoch = MillisSinceEpoch::new(1_700_000_000_000);
+    }
+
+    impl Clock for TokioClock {
+        fn recent(&self) -> MillisSinceEpoch {
+            let elapsed = tokio::time::Instant::now().duration_since(self.initial_instant);
+            Self::BASE_TIME + elapsed
+        }
+
+        fn now(&self) -> MillisSinceEpoch {
+            self.recent()
+        }
+    }
+}

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -31,6 +31,7 @@ use url::Url;
 
 use restate_clock::WallClock;
 use restate_core::Metadata;
+use restate_metadata_server::MetadataStoreClient;
 use restate_object_store_util::create_object_store_client;
 use restate_types::config::SnapshotsOptions;
 use restate_types::identifiers::{PartitionId, SnapshotId};
@@ -38,9 +39,32 @@ use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::ClusterFingerprint;
 use restate_types::time::MillisSinceEpoch;
 
+#[cfg(any(test, feature = "test-util"))]
+use super::leases::NoOpLeaseManager;
+use super::leases::{LeaseError, SnapshotLeaseGuard, SnapshotLeaseManager};
 use super::{
     LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotDir, SnapshotFormatVersion,
 };
+
+#[derive(Clone)]
+pub enum LeaseProvider {
+    Real(SnapshotLeaseManager),
+    #[cfg(any(test, feature = "test-util"))]
+    NoOp(NoOpLeaseManager),
+}
+
+impl LeaseProvider {
+    pub async fn acquire(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard, super::leases::LeaseError> {
+        match self {
+            Self::Real(m) => m.acquire(partition_id).await,
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(m) => m.acquire(partition_id).await,
+        }
+    }
+}
 
 /// Provides read and write access to the long-term partition snapshot storage destination.
 ///
@@ -63,6 +87,7 @@ pub struct SnapshotRepository {
     prefix: ObjectPath,
     staging_dir: PathBuf,
     num_retained: std::num::NonZeroU8,
+    lease_provider: Option<LeaseProvider>,
     #[cfg(any(test, feature = "test-util"))]
     enable_cleanup: bool,
 }
@@ -302,10 +327,27 @@ impl UniqueSnapshotKey {
 }
 
 impl SnapshotRepository {
-    /// Creates an instance of the repository if a snapshots destination is configured.
+    /// Creates a writable repository with a default metadata-backed lease manager
     pub async fn new_from_config(
         snapshots_options: &SnapshotsOptions,
         staging_dir: PathBuf,
+        metadata_store_client: MetadataStoreClient,
+    ) -> anyhow::Result<Option<SnapshotRepository>> {
+        Self::new_internal(snapshots_options, staging_dir, Some(metadata_store_client)).await
+    }
+
+    /// Creates a repository without a lease manager; can not be used to upload snapshots
+    pub async fn new_read_only_from_config(
+        snapshots_options: &SnapshotsOptions,
+        staging_dir: PathBuf,
+    ) -> anyhow::Result<Option<SnapshotRepository>> {
+        Self::new_internal(snapshots_options, staging_dir, None).await
+    }
+
+    async fn new_internal(
+        snapshots_options: &SnapshotsOptions,
+        staging_dir: PathBuf,
+        metadata_store_client: Option<MetadataStoreClient>,
     ) -> anyhow::Result<Option<SnapshotRepository>> {
         let mut destination = if let Some(ref destination) = snapshots_options.destination {
             Url::parse(destination).context("Failed parsing snapshot repository URL")?
@@ -332,6 +374,9 @@ impl SnapshotRepository {
         // See https://github.com/restatedev/restate/issues/4838.
         Self::sweep_staging_dir(&staging_dir).await;
 
+        let lease_provider = metadata_store_client
+            .map(|client| LeaseProvider::Real(SnapshotLeaseManager::new(client)));
+
         Ok(Some(SnapshotRepository {
             object_store,
             destination,
@@ -340,7 +385,41 @@ impl SnapshotRepository {
             num_retained: snapshots_options.num_retained,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: snapshots_options.enable_cleanup,
+            lease_provider,
         }))
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn new_from_config_with_stub_leases(
+        snapshots_options: &SnapshotsOptions,
+        staging_dir: PathBuf,
+    ) -> anyhow::Result<Option<SnapshotRepository>> {
+        Ok(Self::new_internal(snapshots_options, staging_dir, None)
+            .await?
+            .map(|mut repository| {
+                repository.lease_provider = Some(LeaseProvider::NoOp(NoOpLeaseManager::new()));
+                repository
+            }))
+    }
+
+    /// Acquire a lease for snapshot operations on this partition
+    ///
+    /// On success, returns a guard with background renewal already started. The guard should be
+    /// held for the duration of snapshot operations and passed to `put`.
+    ///
+    /// Returns `LeaseError::Unavailable` if the repository was created without a lease provider.
+    pub async fn acquire_lease(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<Arc<SnapshotLeaseGuard>, LeaseError> {
+        let provider = self
+            .lease_provider
+            .as_ref()
+            .ok_or(LeaseError::Unavailable)?;
+        let guard = provider.acquire(partition_id).await?;
+        let guard = Arc::new(guard);
+        guard.start_renewal_task()?;
+        Ok(guard)
     }
 
     /// Removes any entries left over in the snapshot staging directory by a previous run.
@@ -367,10 +446,11 @@ impl SnapshotRepository {
     /// Write a partition snapshot to the snapshot repository
     ///
     /// Returns the latest snapshot status on successful upload. Depending on retention settings,
-    /// the archived LSN may be earlier than that of the snapshot which was just uploaded.
-    /// Uploads a local snapshot to the repository. Takes ownership of the local snapshot
-    /// directory via [`SnapshotDir`] and removes it once the upload completes (success or
-    /// failure), so callers cannot leak it.
+    /// the archived LSN may be earlier than that of the snapshot which was just uploaded. This
+    /// operation requires a valid lease obtained by calling `acquire_lease`.
+    ///
+    /// Takes ownership of the local snapshot directory via [`SnapshotDir`] and removes it once
+    /// the upload completes (success or failure), so callers cannot leak it.
     #[instrument(
         level = "error",
         err,
@@ -381,6 +461,7 @@ impl SnapshotRepository {
         &self,
         snapshot: &PartitionSnapshotMetadata,
         local_snapshot: SnapshotDir,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) -> anyhow::Result<PartitionSnapshotStatus> {
         use crate::metric_definitions::{
             SNAPSHOT_UPLOAD_DURATION, SNAPSHOT_UPLOAD_FAILED, SNAPSHOT_UPLOAD_SUCCESS,
@@ -390,7 +471,7 @@ impl SnapshotRepository {
 
         let start = tokio::time::Instant::now();
         let put_result = self
-            .put_snapshot_inner(snapshot, local_snapshot.path())
+            .put_snapshot_inner(snapshot, local_snapshot.path(), lease_guard)
             .await;
 
         // We own the local snapshot directory; remove it asynchronously (it may hold large SST
@@ -426,6 +507,7 @@ impl SnapshotRepository {
         &self,
         snapshot: &PartitionSnapshotMetadata,
         local_snapshot_path: &Path,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) -> Result<PartitionSnapshotStatus, PutSnapshotError> {
         let snapshot_prefix = self.base_prefix(snapshot);
         debug!(
@@ -439,39 +521,10 @@ impl SnapshotRepository {
             .await?;
 
         let latest_path = self.latest_snapshot_pointer_path(snapshot.partition_id);
-
         let maybe_stored = self
             .get_latest_snapshot_metadata_for_update(&latest_path)
             .await
             .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
-
-        if let Some((latest_stored, _)) = &maybe_stored
-            && latest_stored.min_applied_lsn >= snapshot.min_applied_lsn
-        {
-            info!(
-                repository_latest_lsn = ?latest_stored.min_applied_lsn,
-                new_snapshot_lsn = ?snapshot.min_applied_lsn,
-                "The newly uploaded snapshot is no newer than the already-stored latest snapshot, \
-                will not update latest pointer"
-            );
-
-            let snapshot_ref = SnapshotReference::from_metadata(snapshot);
-            let partition_id = snapshot.partition_id;
-            let repository = self.clone();
-            let _ = restate_core::TaskCenter::spawn_unmanaged_child(
-                restate_core::TaskKind::Disposable,
-                "snapshot-cleanup-superseded",
-                async move {
-                    repository
-                        .delete_snapshot_files(partition_id, &snapshot_ref)
-                        .await;
-                    Ok::<(), anyhow::Error>(())
-                },
-            );
-
-            return PartitionSnapshotStatus::try_from(latest_stored)
-                .map_err(|e| PutSnapshotError::from(e, progress.clone()));
-        }
 
         let (new_latest, evicted_snapshots) = self
             .build_latest_v2(snapshot, maybe_stored.as_ref().map(|(l, _)| l))
@@ -482,9 +535,20 @@ impl SnapshotRepository {
                 .map_err(|e| PutSnapshotError::from(e, progress.clone()))?,
         );
 
-        let conditions =
-            self.conditional_put_options(maybe_stored.as_ref().map(|(_, version)| version));
+        // Uploads can outlive a lease duration, so re-check immediately before publishing rather
+        // than trusting the lease we held when the upload started. This narrows, but cannot close,
+        // the window: the lease may still lapse between here and the CAS landing. The
+        // descending-LSN sort in build_latest_v2 is what makes that residual race harmless.
+        if !lease_guard.is_valid() {
+            return Err(PutSnapshotError::from(
+                anyhow::anyhow!(
+                    "lease lost before publishing the snapshot pointer; abandoning snapshot"
+                ),
+                progress.clone(),
+            ));
+        }
 
+        let conditions = self.conditional_put_options(maybe_stored.map(|(_, v)| v));
         let put_result = self
             .object_store
             .put_opts(&latest_path, latest_payload, conditions)
@@ -503,7 +567,7 @@ impl SnapshotRepository {
         let enable_cleanup = self.enable_cleanup;
 
         if !evicted_snapshots.is_empty() && enable_cleanup {
-            self.spawn_cleanup_task(snapshot.partition_id, evicted_snapshots);
+            self.spawn_cleanup_task(snapshot.partition_id, evicted_snapshots, lease_guard);
         }
 
         PartitionSnapshotStatus::try_from(&new_latest)
@@ -571,8 +635,19 @@ impl SnapshotRepository {
             .map(|l| l.effective_retained_snapshots())
             .unwrap_or_default();
 
-        // List will be in correct descending order if we insert the newest snapshot first
-        retained_snapshots.insert(0, new_snapshot_ref.clone());
+        retained_snapshots.push(new_snapshot_ref.clone());
+
+        // Eviction below is positional, and both pruning and restore rely on descending-LSN order.
+        // The snapshot lease normally makes us the only writer, so the new snapshot would already
+        // be the newest - but a holder that lost its lease mid-upload can still win the pointer
+        // CAS below. Sorting keeps the invariant a property of this function rather than of the
+        // lease, so a late writer can no longer displace a newer snapshot from the head of the
+        // list and get it evicted.
+        retained_snapshots.sort_by(|a, b| {
+            b.min_applied_lsn
+                .cmp(&a.min_applied_lsn)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
 
         let evicted_snapshots = retained_snapshots
             .split_off((self.num_retained.get() as usize).min(retained_snapshots.len()));
@@ -594,10 +669,28 @@ impl SnapshotRepository {
         Ok((latest, evicted_snapshots))
     }
 
+    fn conditional_put_options(&self, version: Option<UpdateVersion>) -> PutOptions {
+        // The object_store file provider supports create-if-not-exists but not update-version on
+        // put. The file:// protocol is only be enabled in test because of this.
+        let use_conditional_update = !matches!(self.destination.scheme(), "file");
+
+        let mode = match (use_conditional_update, version) {
+            (true, Some(v)) if v.e_tag.is_some() || v.version.is_some() => PutMode::Update(v),
+            (false, _) => PutMode::Overwrite,
+            _ => PutMode::Create,
+        };
+
+        PutOptions {
+            mode,
+            ..PutOptions::default()
+        }
+    }
+
     fn spawn_cleanup_task(
         &self,
         partition_id: PartitionId,
         cleanup_snapshots: Vec<SnapshotReference>,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) {
         let repository = self.clone();
         let task_name = format!("snapshot-cleanup-{}", partition_id);
@@ -607,23 +700,72 @@ impl SnapshotRepository {
             task_name,
             async move {
                 repository
-                    .cleanup_pending_deletions(partition_id, cleanup_snapshots)
+                    .cleanup_evicted_snapshots(partition_id, cleanup_snapshots, lease_guard)
                     .await;
                 Ok::<(), anyhow::Error>(())
             },
         );
     }
 
-    async fn cleanup_pending_deletions(
+    #[instrument(level = "debug", skip_all, fields(%partition_id))]
+    async fn cleanup_evicted_snapshots(
         &self,
         partition_id: PartitionId,
-        cleanup_snapshots: Vec<SnapshotReference>,
+        evicted_snapshots: Vec<SnapshotReference>,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) {
-        for snapshot_ref in &cleanup_snapshots {
+        if !lease_guard.is_valid() {
+            debug!("Lease expired before cleanup, aborting");
+            return;
+        }
+
+        let result = lease_guard
+            .run_under_lease(self.cleanup_evicted_snapshots_inner(
+                partition_id,
+                evicted_snapshots,
+                &lease_guard,
+            ))
+            .await;
+
+        match result {
+            Some(Ok(())) => {
+                debug!("Cleanup completed successfully");
+            }
+            Some(Err(e)) => {
+                debug!(error = %e, "Cleanup failed");
+            }
+            None => {
+                warn!("Cleanup aborted due to lease loss");
+            }
+        }
+        // lease_guard dropped
+    }
+
+    async fn cleanup_evicted_snapshots_inner(
+        &self,
+        partition_id: PartitionId,
+        evicted_snapshots: Vec<SnapshotReference>,
+        lease_guard: &Arc<SnapshotLeaseGuard>,
+    ) -> anyhow::Result<()> {
+        if !lease_guard.is_valid() {
+            anyhow::bail!("Lease expired before cleanup could start");
+        }
+
+        for snapshot_ref in &evicted_snapshots {
+            if !lease_guard.is_valid() {
+                debug!(
+                    %partition_id,
+                    "Lease approaching deadline, aborting remaining cleanup"
+                );
+                break;
+            }
+
             // Errors are logged inside delete_snapshot_files; if cleanup fails,
             // these snapshots become orphans to be cleaned by future scan-sweep.
             self.delete_snapshot_files(partition_id, snapshot_ref).await;
         }
+
+        Ok(())
     }
 
     /// Best-effort deletion of snapshot files. Errors are logged but not propagated.
@@ -959,16 +1101,7 @@ impl SnapshotRepository {
                     e_tag: result.meta.e_tag.clone(),
                     version: result.meta.version.clone(),
                 };
-                let latest: LatestSnapshot = serde_json::from_slice(
-                    &result.bytes().await?,
-                )
-                    .inspect_err(|e| {
-                        debug!(
-                        repository_latest_lsn = "unknown",
-                        "Failed to parse stored latest snapshot pointer, refusing to overwrite: {}",
-                        e
-                    )
-                    })
+                let latest: LatestSnapshot = serde_json::from_slice(&result.bytes().await?)
                     .map_err(|e| anyhow!("Failed to parse latest snapshot metadata: {}", e))?;
 
                 Metadata::with_current(|m| {
@@ -1011,25 +1144,6 @@ impl SnapshotRepository {
         filename: &str,
     ) -> ObjectPath {
         self.base_prefix(snapshot_metadata).join(filename)
-    }
-
-    fn conditional_put_options(&self, version: Option<&UpdateVersion>) -> PutOptions {
-        // The object_store file provider supports create-if-not-exists but not update-version on
-        // put. The file:// protocol is only be enabled in test because of this.
-        let use_conditional_update = !matches!(self.destination.scheme(), "file");
-
-        let mode = match (use_conditional_update, version) {
-            (true, Some(v)) if v.e_tag.is_some() || v.version.is_some() => {
-                PutMode::Update(v.clone())
-            }
-            (false, _) => PutMode::Overwrite,
-            _ => PutMode::Create,
-        };
-
-        PutOptions {
-            mode,
-            ..PutOptions::default()
-        }
     }
 }
 
@@ -1142,6 +1256,7 @@ async fn abort_tasks<T: 'static>(mut join_set: JoinSet<T>) {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
     use ahash::HashSet;
@@ -1164,6 +1279,7 @@ mod tests {
     use restate_types::retries::RetryPolicy;
     use restate_types::sharding::KeyRange;
 
+    use crate::snapshots::SnapshotLeaseGuard;
     use crate::snapshots::repository::{LatestSnapshotVersion, SnapshotUploadProgress};
 
     use super::{LatestSnapshot, SnapshotReference, SnapshotRepository, UniqueSnapshotKey};
@@ -1171,7 +1287,7 @@ mod tests {
 
     #[restate_core::test]
     async fn overwrite_unparsable_latest() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshot_source = TempDir::new()?;
         let source_dir = snapshot_source.path().to_path_buf();
@@ -1197,9 +1313,13 @@ mod tests {
             ),
             ..SnapshotsOptions::default()
         };
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         // Write invalid JSON to latest.json
         let latest_path = destination_dir
@@ -1213,7 +1333,11 @@ mod tests {
 
         assert!(
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await
                 .is_err()
         );
@@ -1242,7 +1366,7 @@ mod tests {
     }
 
     async fn test_put_snapshot(destination: String) -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshot_source = TempDir::new()?;
         let source_dir = snapshot_source.path().to_path_buf();
@@ -1282,12 +1406,20 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         repository
-            .put(&snapshot1, SnapshotDir::new(source_dir.clone()))
+            .put(
+                &snapshot1,
+                SnapshotDir::new(source_dir.clone()),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
             .await?;
 
         let partition_prefix =
@@ -1333,7 +1465,11 @@ mod tests {
         snapshot2.min_applied_lsn = snapshot1.min_applied_lsn.next();
 
         repository
-            .put(&snapshot2, SnapshotDir::new(source_dir))
+            .put(
+                &snapshot2,
+                SnapshotDir::new(source_dir),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
             .await?;
 
         let latest = object_store
@@ -1378,6 +1514,87 @@ mod tests {
         Ok((snapshot, snapshot_dir))
     }
 
+    /// A snapshot published by a writer that lost its lease mid-upload can reach the pointer CAS
+    /// after a newer snapshot was already published. Eviction is positional, so the retained list
+    /// must be ordered by LSN rather than by arrival, or the late writer displaces - and then
+    /// evicts - the newest snapshot.
+    #[restate_core::test]
+    async fn build_latest_v2_orders_by_lsn_not_arrival() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let repository = mock_repository(1);
+
+        let newest = SnapshotReference {
+            snapshot_id: SnapshotId::new(),
+            min_applied_lsn: Lsn::new(100),
+            created_at: Timestamp::now(),
+            path: "lsn_00000000000000000100-snap_1".to_owned(),
+        };
+        let current = mock_latest_snapshot(&newest);
+
+        let mut late = mock_snapshot_metadata("/data.sst".to_owned(), "/".to_owned(), 0);
+        late.min_applied_lsn = Lsn::new(50);
+        let (latest, evicted) = repository.build_latest_v2(&late, Some(&current))?;
+
+        assert_eq!(
+            latest
+                .retained_snapshots
+                .iter()
+                .map(|s| s.min_applied_lsn)
+                .collect::<Vec<_>>(),
+            vec![Lsn::new(100)],
+            "the newest snapshot must stay at the head of the retained list"
+        );
+        assert_eq!(
+            evicted
+                .iter()
+                .map(|s| s.min_applied_lsn)
+                .collect::<Vec<_>>(),
+            vec![Lsn::new(50)],
+            "the late, lower-LSN snapshot is the one that gets evicted"
+        );
+
+        // The ordinary case - a genuinely newer snapshot - still takes the head position.
+        let mut newer = mock_snapshot_metadata("/data.sst".to_owned(), "/".to_owned(), 0);
+        newer.min_applied_lsn = Lsn::new(150);
+        let (latest, evicted) = repository.build_latest_v2(&newer, Some(&current))?;
+        assert_eq!(latest.retained_snapshots[0].min_applied_lsn, Lsn::new(150));
+        assert_eq!(evicted[0].min_applied_lsn, Lsn::new(100));
+
+        Ok(())
+    }
+
+    fn mock_repository(num_retained: u8) -> SnapshotRepository {
+        SnapshotRepository {
+            object_store: Arc::new(object_store::memory::InMemory::new()),
+            destination: Url::parse("memory:///").unwrap(),
+            prefix: ObjectPath::default(),
+            staging_dir: PathBuf::new(),
+            num_retained: std::num::NonZeroU8::new(num_retained).unwrap(),
+            lease_provider: None,
+            enable_cleanup: false,
+        }
+    }
+
+    fn mock_latest_snapshot(reference: &SnapshotReference) -> LatestSnapshot {
+        LatestSnapshot {
+            version: LatestSnapshotVersion::V2,
+            partition_id: PartitionId::MIN,
+            log_id: Some(LogId::MIN),
+            cluster_name: Metadata::with_current(|m| {
+                m.nodes_config_ref().cluster_name().to_string()
+            }),
+            cluster_fingerprint: Metadata::with_current(|m| {
+                m.nodes_config_ref().cluster_fingerprint()
+            }),
+            node_name: "node".to_string(),
+            created_at: reference.created_at,
+            snapshot_id: reference.snapshot_id,
+            min_applied_lsn: reference.min_applied_lsn,
+            path: reference.path.clone(),
+            retained_snapshots: vec![reference.clone()],
+        }
+    }
+
     fn mock_snapshot_metadata(
         file_name: String,
         directory: String,
@@ -1417,7 +1634,7 @@ mod tests {
 
     #[restate_core::test]
     async fn snapshot_retention_v2() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1430,9 +1647,13 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         for i in 1..=4 {
             let snapshot_source = TempDir::new()?;
@@ -1451,7 +1672,11 @@ mod tests {
             snapshot.min_applied_lsn = Lsn::new(i * 1000);
 
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1480,7 +1705,7 @@ mod tests {
 
     #[restate_core::test]
     async fn get_snapshot_candidates_returns_retained_descending() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1491,9 +1716,13 @@ mod tests {
             num_retained: std::num::NonZeroU8::new(3).unwrap(),
             ..SnapshotsOptions::default()
         };
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         // No snapshots yet -> no candidates.
         assert!(
@@ -1508,7 +1737,11 @@ mod tests {
             let (snapshot, source_dir) =
                 mock_snapshot(format!("snapshot-data-{i}").as_bytes(), Lsn::new(i * 1000)).await?;
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1527,7 +1760,7 @@ mod tests {
 
     #[restate_core::test]
     async fn download_snapshot_falls_back_to_older_when_latest_fails() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1538,9 +1771,13 @@ mod tests {
             num_retained: std::num::NonZeroU8::new(3).unwrap(),
             ..SnapshotsOptions::default()
         };
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         // `SnapshotRepository` is cheaply cloneable and shares the underlying object store, so the
         // `Snapshots` wrapper observes snapshots we `put` through `repository` below.
@@ -1559,9 +1796,21 @@ mod tests {
 
         // Older snapshot A (LSN 2000) then latest B (LSN 3000).
         let (snapshot_a, dir_a) = mock_snapshot(b"snapshot-A", Lsn::new(2000)).await?;
-        repository.put(&snapshot_a, SnapshotDir::new(dir_a)).await?;
+        repository
+            .put(
+                &snapshot_a,
+                SnapshotDir::new(dir_a),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
+            .await?;
         let (snapshot_b, dir_b) = mock_snapshot(b"snapshot-B", Lsn::new(3000)).await?;
-        repository.put(&snapshot_b, SnapshotDir::new(dir_b)).await?;
+        repository
+            .put(
+                &snapshot_b,
+                SnapshotDir::new(dir_b),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
+            .await?;
 
         // Happy path: the latest snapshot is restored.
         let restored = snapshots
@@ -1614,7 +1863,7 @@ mod tests {
 
     #[restate_core::test]
     async fn v1_to_v2_migration() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1648,9 +1897,13 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         let mut progress =
             SnapshotUploadProgress::with_snapshot_path(repository.base_prefix(&snapshot));
@@ -1697,7 +1950,11 @@ mod tests {
         snapshot_v2.min_applied_lsn = Lsn::new(2000);
 
         repository
-            .put(&snapshot_v2, SnapshotDir::new(source_dir_2))
+            .put(
+                &snapshot_v2,
+                SnapshotDir::new(source_dir_2),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
             .await?;
 
         let latest_data = object_store.get(&latest_path).await?;
@@ -1710,7 +1967,7 @@ mod tests {
 
     #[restate_core::test]
     async fn archived_lsn_v2() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1723,9 +1980,13 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         for i in 1..=3 {
             let snapshot_source = TempDir::new()?;
@@ -1744,7 +2005,11 @@ mod tests {
             snapshot.min_applied_lsn = Lsn::new(i * 1000);
 
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1762,6 +2027,7 @@ mod tests {
 
     #[restate_core::test]
     async fn cleanup() -> anyhow::Result<()> {
+        // Required for mock_snapshot's use of Metadata::with_current
         let _env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
@@ -1776,9 +2042,12 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config_with_stub_leases(
+            &opts,
+            TempDir::new().unwrap().keep(),
+        )
+        .await?
+        .unwrap();
 
         let mut all_snapshot_paths = Vec::new();
         for i in 1..=5 {
@@ -1786,7 +2055,11 @@ mod tests {
                 mock_snapshot(format!("data-{}", i).as_bytes(), Lsn::new(100 * i)).await?;
             all_snapshot_paths.push(SnapshotReference::from_metadata(&snapshot).path);
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1963,6 +2236,32 @@ mod tests {
         assert_eq!(kept, dir);
         assert!(dir.exists(), "into_path() must leave the directory intact");
 
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn acquire_lease_read_only_repository_returns_unavailable() -> anyhow::Result<()> {
+        use crate::snapshots::LeaseError;
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+
+        let opts = SnapshotsOptions {
+            destination: Some(destination),
+            ..SnapshotsOptions::default()
+        };
+
+        let repository =
+            SnapshotRepository::new_read_only_from_config(&opts, TempDir::new().unwrap().keep())
+                .await?
+                .unwrap();
+
+        let result = repository.acquire_lease(PartitionId::MIN).await;
+        assert!(
+            matches!(result, Err(LeaseError::Unavailable)),
+            "expected Err(LeaseError::Unavailable) from a read-only repository"
+        );
         Ok(())
     }
 }

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -21,8 +21,8 @@ use restate_types::logs::Lsn;
 use restate_types::nodes_config::ClusterFingerprint;
 
 use super::{
-    LocalPartitionSnapshot, PartitionSnapshotMetadata, PartitionSnapshotStatus, SnapshotError,
-    SnapshotErrorKind, SnapshotFormatVersion, SnapshotRepository,
+    LeaseError, LocalPartitionSnapshot, PartitionSnapshotMetadata, PartitionSnapshotStatus,
+    SnapshotError, SnapshotErrorKind, SnapshotFormatVersion, SnapshotRepository,
 };
 use crate::PartitionStoreManager;
 
@@ -74,6 +74,28 @@ impl SnapshotPartitionTask {
     }
 
     async fn create_snapshot_inner(&self) -> Result<PartitionSnapshotStatus, SnapshotError> {
+        // Acquire lease BEFORE export to avoid dedup/delete races with cleanup while uploading SSTs.
+        // Also eliminates the possibility of concurrent snapshots for the same partition at close LSNs.
+        let lease_guard = self
+            .snapshot_repository
+            .acquire_lease(self.partition_id)
+            .await
+            .map_err(|e| {
+                let kind = if matches!(e, LeaseError::Unavailable) {
+                    warn!(
+                        "Create snapshot unavailable due to read-only repository; \
+                        this indicates an internal misconfiguration bug"
+                    );
+                    SnapshotErrorKind::RepositoryNotConfigured
+                } else {
+                    SnapshotErrorKind::RepositoryIo(anyhow::Error::new(e))
+                };
+                SnapshotError {
+                    partition_id: self.partition_id,
+                    kind,
+                }
+            })?;
+
         let snapshot = self
             .partition_store_manager
             .export_partition(
@@ -89,7 +111,7 @@ impl SnapshotPartitionTask {
         let status = self
             .snapshot_repository
             // `put` takes ownership of the snapshot directory and removes it after upload.
-            .put(&metadata, snapshot.base_dir)
+            .put(&metadata, snapshot.base_dir, lease_guard)
             .await
             .map_err(|e| SnapshotError {
                 partition_id: self.partition_id,

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -179,6 +179,7 @@ where
             SnapshotRepository::new_from_config(
                 snapshots_options,
                 config.worker.storage.snapshots_staging_dir(),
+                metadata_store_client.clone(),
             )
             .await
             .map_err(BuildError::SnapshotRepository)?,

--- a/tools/restate-doctor/src/commands/snapshot/mod.rs
+++ b/tools/restate-doctor/src/commands/snapshot/mod.rs
@@ -190,6 +190,12 @@ impl MetadataStore for OfflineMetadataStore {
 }
 
 pub async fn run_snapshot(args: &SnapshotArgs) -> anyhow::Result<()> {
+    // Boxed because this future holds the partition store manager, the snapshot repository and the
+    // query engine at once, which makes it too large to keep on the caller's stack.
+    Box::pin(run_snapshot_inner(args)).await
+}
+
+async fn run_snapshot_inner(args: &SnapshotArgs) -> anyhow::Result<()> {
     let repository_url =
         Url::parse(&args.repository).context("failed to parse the snapshot repository URL")?;
     let object_store_options = args.object_store_options();
@@ -307,7 +313,7 @@ async fn run(
     let manager = PartitionStoreManager::create(true)
         .await
         .context("failed to create the partition store manager")?;
-    let snapshot_repository = SnapshotRepository::new_from_config(
+    let snapshot_repository = SnapshotRepository::new_read_only_from_config(
         &config.worker.snapshots,
         config.worker.storage.snapshots_staging_dir(),
     )


### PR DESCRIPTION
Introduce a metadata-backed leases implementation to enable cluster-wide snapshot operation serialization. This change is a precursor to incremental snapshot support.

Leases now span from exporting the partition store checkpoint (which prevents racing snapshots so we no longer have the possibility of uploading a superseded snapshot) up to cleanup completion (which ensures that a single task can exclusively update retained/evicted snapshot referenced files).

## Related PRs (earliest to latest)

1. https://github.com/restatedev/restate/pull/3942
2. https://github.com/restatedev/restate/pull/4204 ⬅️ **you are here**
3. https://github.com/restatedev/restate/pull/4198
4. https://github.com/restatedev/restate/pull/4212
5. https://github.com/restatedev/restate/pull/4222