### PR TITLE
[Tooling] Bootstrapping restate-doctor for raw storage debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7232,6 +7232,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-doctor"
+version = "1.6.0-dev"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "clap_complete",
+ "cling",
+ "comfy-table",
+ "crossterm",
+ "ctrlc",
+ "restate-cli-util",
+ "restate-partition-store",
+ "restate-rocksdb",
+ "restate-serde-util",
+ "restate-storage-api",
+ "restate-types",
+ "restate-workspace-hack",
+ "rlimit",
+ "rust-rocksdb",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+ "vergen",
+]
+
+[[package]]
 name = "restate-encoding"
 version = "1.6.0-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "benchmarks",
     "tools/bifrost-benchpress",
     "tools/mock-service-endpoint",
+    "tools/restate-doctor",
     "tools/restatectl",
     "tools/service-protocol-wireshark-dissector",
     "tools/xtask",
@@ -21,6 +22,7 @@ default-members = [
     "crates/core/derive",
     "crates/codederror/derive",
     "server",
+    "tools/restate-doctor",
     "tools/restatectl",
 ]
 resolver = "2"

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -16,6 +16,9 @@ mod reader;
 mod running_reader;
 mod waiting_reader;
 
+pub use entry::EntryStateKey;
+pub use inbox::{ActiveKey, InboxKey};
+pub use items::ItemsKey;
 pub use metadata::*;
 
 use anyhow::Context;
@@ -34,10 +37,8 @@ use restate_types::clock::UniqueTimestamp;
 use restate_types::identifiers::PartitionKey;
 use restate_types::vqueue::{EffectivePriority, VQueueId, VQueueInstance, VQueueParent};
 
-use self::entry::{EntryStateHeader, EntryStateKey, OwnedEntryState, OwnedHeader};
-use self::inbox::{ActiveKey, InboxKey};
+use self::entry::{EntryStateHeader, OwnedEntryState, OwnedHeader};
 use crate::keys::{KeyCodec, KeyKind, TableKey};
-use crate::vqueue_table::items::ItemsKey;
 use crate::{PartitionDb, PartitionStoreTransaction, Result, StorageAccess};
 
 impl KeyCodec for VQueueParent {

--- a/tools/restate-doctor/Cargo.toml
+++ b/tools/restate-doctor/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "restate-doctor"
+version.workspace = true
+authors.workspace = true
+description = "Restate diagnostic and analysis tools for partition-store and log-store"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+build = "build.rs"
+
+[features]
+default = ["no-trace-logging"]
+no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+# Restate crates
+restate-cli-util = { workspace = true }
+restate-partition-store = { workspace = true }
+restate-rocksdb = { workspace = true }
+restate-serde-util = { workspace = true }
+restate-storage-api = { workspace = true }
+restate-types = { workspace = true }
+
+anyhow = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive", "env", "wrap_help", "color", "std", "suggestions", "usage"] }
+clap_complete = { workspace = true }
+cling = { workspace = true }
+comfy-table = { workspace = true }
+crossterm = { workspace = true }
+ctrlc = { version = "3.4" }
+rlimit = { workspace = true }
+rocksdb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+ulid = { workspace = true }
+
+[build-dependencies]
+vergen = { workspace = true, default-features = false, features = [
+    "build",
+    "git",
+    "gitcl",
+    "cargo",
+] }
+
+[[bin]]
+name = "restate-doctor"
+path = "src/main.rs"

--- a/tools/restate-doctor/build.rs
+++ b/tools/restate-doctor/build.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    EmitBuilder::builder()
+        .all_build()
+        .all_cargo()
+        .git_sha(true)
+        .git_commit_date()
+        .git_dirty(true)
+        .emit()?;
+    Ok(())
+}

--- a/tools/restate-doctor/src/app.rs
+++ b/tools/restate-doctor/src/app.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use cling::prelude::*;
+
+use restate_cli_util::{CliContext, CommonOpts};
+
+use crate::commands::completions::Completions;
+use crate::commands::id;
+
+/// Restate Doctor - Diagnostic tools Restate storage
+///
+/// https://docs.restate.dev
+#[derive(Run, Parser, Clone)]
+#[command(author, version = crate::build_info::version(), about, infer_subcommands = true)]
+#[cling(run = "init")]
+pub struct CliApp {
+    #[clap(flatten)]
+    pub common_opts: CommonOpts,
+    #[clap(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(Run, Subcommand, Clone)]
+pub enum Command {
+    /// ID analysis and decoding commands
+    #[clap(subcommand)]
+    Id(id::IdCommand),
+    /// Generate or install shell completions
+    #[clap(subcommand)]
+    Completions(Completions),
+}
+
+fn init(common_opts: &CommonOpts) {
+    // Initialize CLI context (handles colors, logging, etc.)
+    CliContext::new(common_opts.clone()).set_as_global();
+}

--- a/tools/restate-doctor/src/build_info.rs
+++ b/tools/restate-doctor/src/build_info.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub fn version() -> &'static str {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (",
+        env!("VERGEN_GIT_SHA"),
+        " ",
+        env!("VERGEN_CARGO_TARGET_TRIPLE"),
+        ")",
+        env!("VERGEN_BUILD_DATE")
+    )
+}

--- a/tools/restate-doctor/src/commands/completions.rs
+++ b/tools/restate-doctor/src/commands/completions.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::CliApp;
+use restate_cli_util::{completion_commands, completions::CompletionProvider};
+
+// Use the completion_commands macro to generate standard completion structures
+completion_commands!(CliApp);
+impl CompletionProvider for CliApp {}

--- a/tools/restate-doctor/src/commands/id.rs
+++ b/tools/restate-doctor/src/commands/id.rs
@@ -1,0 +1,283 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! ID decoding commands for analyzing Restate resource identifiers
+
+use std::str::FromStr;
+
+use cling::prelude::*;
+use ulid::Ulid;
+
+use comfy_table::Table;
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::{c_println, c_title};
+use restate_types::identifiers::{
+    AwakeableIdentifier, DeploymentId, ExternalSignalIdentifier, InvocationId, SnapshotId,
+    SubscriptionId, TimestampAwareId, WithPartitionKey,
+};
+use restate_types::time::MillisSinceEpoch;
+
+use crate::util::colorize_id::{colorize_id, id_color_legend};
+use crate::util::hex_encode;
+
+/// ID analysis commands
+#[derive(Run, Subcommand, Clone)]
+pub enum IdCommand {
+    /// Decode a Restate resource ID and display its components
+    Decode(Decode),
+}
+
+/// Decode a resource ID
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_decode")]
+pub struct Decode {
+    /// The ID to decode (e.g., inv_1fBuS9KMPNrt0zQBGdilypucn1EeT7AO5j)
+    pub id: String,
+}
+
+pub async fn run_decode(cmd: &Decode) -> anyhow::Result<()> {
+    let input = cmd.id.trim();
+
+    // Try to detect the resource type from the prefix
+    if let Some(prefix) = input.split('_').next() {
+        match prefix {
+            "inv" => return decode_invocation_id(input),
+            "dp" => return decode_deployment_id(input),
+            "sub" => return decode_subscription_id(input),
+            "prom" => return decode_awakeable_id(input),
+            "sign" => return decode_signal_id(input),
+            "snap" => return decode_snapshot_id(input),
+            _ => {}
+        }
+    }
+
+    // No recognized prefix - try as raw ULID
+    decode_raw_ulid(input)
+}
+
+/// Print the common header table with resource type, colorized input, and legend
+fn print_header(resource_type: &str, input: &str) {
+    let mut table = Table::new_styled();
+    table.add_kv_row("Resource Type:", resource_type);
+    table.add_kv_row("Input:", colorize_id(input));
+    table.add_kv_row("ID colors:", id_color_legend());
+    c_println!("{table}");
+}
+
+/// Print the raw bytes section for any byte-serializable ID
+fn print_raw_bytes(bytes: &[u8]) {
+    c_title!("📦", "Raw Bytes");
+    let mut table = Table::new_styled();
+    table.add_kv_row("Total Length:", format!("{} bytes", bytes.len()));
+    table.add_kv_row("Hex:", hex_encode(bytes));
+    c_println!("{table}");
+}
+
+/// Try to print ULID timestamp info if the value looks like a valid ULID timestamp.
+/// Returns true if a timestamp was printed.
+fn print_ulid_timestamp_if_valid(uuid_u128: u128) -> bool {
+    if let Some(ts) = try_extract_ulid_timestamp(uuid_u128) {
+        c_title!("🕐", "ULID Timestamp (if random invocation)");
+        let mut table = Table::new_styled();
+        table.add_kv_row("Timestamp:", format_timestamp(ts));
+        c_println!("{table}");
+        true
+    } else {
+        false
+    }
+}
+
+/// Decode a ULID-based ID that implements TimestampAwareId (Deployment, Subscription, Snapshot)
+fn decode_timestamp_id<T>(input: &str, resource_type: &str) -> anyhow::Result<()>
+where
+    T: FromStr + TimestampAwareId + IdWithBytes,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    let id = T::from_str(input)?;
+
+    print_header(resource_type, input);
+
+    c_title!("🔍", "Decoded Components");
+    let mut components = Table::new_styled();
+    components.add_kv_row("Created At:", format_timestamp(id.timestamp()));
+    c_println!("{components}");
+
+    print_raw_bytes(&id.to_bytes());
+
+    Ok(())
+}
+
+trait IdWithBytes {
+    fn to_bytes(&self) -> [u8; 16];
+}
+
+impl IdWithBytes for DeploymentId {
+    fn to_bytes(&self) -> [u8; 16] {
+        DeploymentId::to_bytes(self)
+    }
+}
+
+impl IdWithBytes for SubscriptionId {
+    fn to_bytes(&self) -> [u8; 16] {
+        SubscriptionId::to_bytes(self)
+    }
+}
+
+impl IdWithBytes for SnapshotId {
+    fn to_bytes(&self) -> [u8; 16] {
+        SnapshotId::to_bytes(self)
+    }
+}
+
+fn decode_invocation_id(input: &str) -> anyhow::Result<()> {
+    let id = InvocationId::from_str(input)?;
+
+    print_header("Invocation", input);
+
+    c_title!("🔍", "Decoded Components");
+    let mut components = Table::new_styled();
+    components.add_kv_row("Partition Key:", id.partition_key());
+    components.add_kv_row("Invocation UUID:", id.invocation_uuid());
+    c_println!("{components}");
+
+    // The InvocationUuid could be a ULID (random invocation) or a hash (deterministic)
+    let uuid_u128: u128 = id.invocation_uuid().into();
+    if !print_ulid_timestamp_if_valid(uuid_u128) {
+        c_println!("Note: UUID appears to be a hash (deterministic invocation), not a ULID");
+    }
+
+    print_raw_bytes(&id.to_bytes());
+
+    Ok(())
+}
+
+fn decode_deployment_id(input: &str) -> anyhow::Result<()> {
+    decode_timestamp_id::<DeploymentId>(input, "Deployment")
+}
+
+fn decode_subscription_id(input: &str) -> anyhow::Result<()> {
+    decode_timestamp_id::<SubscriptionId>(input, "Subscription")
+}
+
+fn decode_snapshot_id(input: &str) -> anyhow::Result<()> {
+    decode_timestamp_id::<SnapshotId>(input, "Snapshot")
+}
+
+/// Decode IDs that contain an embedded InvocationId (Awakeable, Signal)
+fn decode_invocation_based_id<T, F, E>(
+    input: &str,
+    resource_type: &str,
+    extra_fields: F,
+) -> anyhow::Result<()>
+where
+    T: FromStr<Err = E>,
+    E: std::error::Error + Send + Sync + 'static,
+    F: FnOnce(T, &mut Table) -> InvocationId,
+{
+    let id = T::from_str(input)?;
+
+    print_header(resource_type, input);
+
+    c_title!("🔍", "Decoded Components");
+    let mut components = Table::new_styled();
+    let invocation_id = extra_fields(id, &mut components);
+    c_println!("{components}");
+
+    // Try to extract timestamp from invocation UUID
+    let uuid_u128: u128 = invocation_id.invocation_uuid().into();
+    print_ulid_timestamp_if_valid(uuid_u128);
+
+    Ok(())
+}
+
+fn decode_awakeable_id(input: &str) -> anyhow::Result<()> {
+    decode_invocation_based_id::<AwakeableIdentifier, _, _>(
+        input,
+        "Awakeable (Promise)",
+        |id, table| {
+            let (invocation_id, entry_index) = id.into_inner();
+            table.add_kv_row("Invocation ID:", invocation_id);
+            table.add_kv_row("  Partition Key:", invocation_id.partition_key());
+            table.add_kv_row("  UUID:", invocation_id.invocation_uuid());
+            table.add_kv_row("Entry Index:", entry_index);
+            invocation_id
+        },
+    )
+}
+
+fn decode_signal_id(input: &str) -> anyhow::Result<()> {
+    decode_invocation_based_id::<ExternalSignalIdentifier, _, _>(input, "Signal", |id, table| {
+        let (invocation_id, signal_id) = id.into_inner();
+        table.add_kv_row("Invocation ID:", invocation_id);
+        table.add_kv_row("  Partition Key:", invocation_id.partition_key());
+        table.add_kv_row("  UUID:", invocation_id.invocation_uuid());
+        table.add_kv_row("Signal ID:", format!("{signal_id:?}"));
+        invocation_id
+    })
+}
+
+fn decode_raw_ulid(input: &str) -> anyhow::Result<()> {
+    let id = Ulid::from_string(input).map_err(|_| {
+        anyhow::anyhow!(
+            "Unrecognized ID format: '{input}'\n\n\
+             Expected formats:\n  \
+               - inv_1...  (Invocation ID)\n  \
+               - dp_1...   (Deployment ID)\n  \
+               - sub_1...  (Subscription ID)\n  \
+               - prom_1... (Awakeable/Promise ID)\n  \
+               - sign_1... (Signal ID)\n  \
+               - snap_1... (Snapshot ID)\n  \
+               - Raw ULID (26 character Crockford base32)"
+        )
+    })?;
+
+    print_header("Raw ULID (unknown resource type)", input);
+
+    c_title!("🔍", "Decoded Components");
+    let mut components = Table::new_styled();
+    components.add_kv_row(
+        "Timestamp:",
+        format_timestamp(MillisSinceEpoch::new(id.timestamp_ms())),
+    );
+    components.add_kv_row("Random:", id.random());
+    c_println!("{components}");
+
+    c_title!("📦", "Raw Bytes");
+    let bytes = id.to_bytes();
+    let mut raw = Table::new_styled();
+    raw.add_kv_row("Total Length:", format!("{} bytes", bytes.len()));
+    raw.add_kv_row("Hex:", hex_encode(&bytes));
+    raw.add_kv_row("u128:", u128::from(id));
+    c_println!("{raw}");
+
+    Ok(())
+}
+
+/// Try to extract a ULID timestamp from a u128 value.
+/// Returns None if the timestamp seems unreasonable (likely a hash, not a ULID).
+fn try_extract_ulid_timestamp(value: u128) -> Option<MillisSinceEpoch> {
+    // ULID structure: 48 bits timestamp + 80 bits random
+    let timestamp_ms = (value >> 80) as u64;
+
+    // Sanity check: timestamp should be reasonable (between year 2000 and 2100)
+    const MIN_REASONABLE_TS: u64 = 946_684_800_000; // Year 2000
+    const MAX_REASONABLE_TS: u64 = 4_102_444_800_000; // Year 2100
+
+    if (MIN_REASONABLE_TS..=MAX_REASONABLE_TS).contains(&timestamp_ms) {
+        Some(MillisSinceEpoch::new(timestamp_ms))
+    } else {
+        None
+    }
+}
+
+/// Format a MillisSinceEpoch timestamp as a human-readable string using jiff
+fn format_timestamp(ts: MillisSinceEpoch) -> String {
+    format!("{} ({} ms)", ts.into_timestamp(), ts.as_u64())
+}

--- a/tools/restate-doctor/src/commands/mod.rs
+++ b/tools/restate-doctor/src/commands/mod.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod completions;
+pub mod id;

--- a/tools/restate-doctor/src/lib.rs
+++ b/tools/restate-doctor/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod app;
+mod build_info;
+mod commands;
+mod util;
+
+pub use app::CliApp;

--- a/tools/restate-doctor/src/main.rs
+++ b/tools/restate-doctor/src/main.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::Write;
+
+use cling::prelude::*;
+use crossterm::execute;
+
+use restate_doctor::CliApp;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> ClingFinished<CliApp> {
+    // Increase file descriptor limit to handle large RocksDB databases with many SST files
+    if rlimit::increase_nofile_limit(u64::MAX).is_err() {
+        eprintln!("Warning: Failed to increase the number of open file descriptors limit.");
+    }
+
+    let _ = ctrlc::set_handler(move || {
+        // Showing cursor again if it was hidden.
+        let mut stdout = std::io::stdout();
+        let _ = execute!(
+            stdout,
+            crossterm::terminal::LeaveAlternateScreen,
+            crossterm::cursor::Show,
+            crossterm::style::ResetColor
+        );
+
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr);
+        let _ = writeln!(stderr, "Ctrl-C pressed, aborting...");
+
+        std::process::exit(1);
+    });
+
+    Cling::parse_and_run().await
+}

--- a/tools/restate-doctor/src/output.rs
+++ b/tools/restate-doctor/src/output.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+use std::str::FromStr;
+
+// Re-export cli-util macros and helpers
+pub use restate_cli_util::ui::console::StyledTable;
+pub use restate_cli_util::{_comfy_table as comfy_table, c_println, c_title};
+
+/// Output format for command results
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+}
+
+impl FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "human" | "text" | "table" => Ok(OutputFormat::Human),
+            "json" => Ok(OutputFormat::Json),
+            _ => Err(format!(
+                "Unknown output format: {s}. Use 'human' or 'json'."
+            )),
+        }
+    }
+}
+
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputFormat::Human => write!(f, "human"),
+            OutputFormat::Json => write!(f, "json"),
+        }
+    }
+}

--- a/tools/restate-doctor/src/util/colorize_id.rs
+++ b/tools/restate-doctor/src/util/colorize_id.rs
@@ -1,0 +1,352 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Colorized display for Restate resource IDs.
+//!
+//! This module provides utilities to display ID strings with color-coding
+//! to help visualize the ID structure. Each part of the ID is colored
+//! differently to make it easier to understand the encoding layout.
+
+use std::fmt::Write;
+
+use crossterm::style::{Color, Stylize};
+use restate_cli_util::CliContext;
+
+/// Color scheme for different ID segments.
+#[derive(Debug, Clone, Copy)]
+pub enum IdSegment {
+    /// Resource type prefix (inv, dp, sub, prom, sign, snap)
+    Prefix,
+    /// Separator character (_)
+    Separator,
+    /// Version character (1)
+    Version,
+    /// Partition key (base62 encoded, 11 chars for u64)
+    PartitionKey,
+    /// UUID/ULID component (base62 encoded, 22 chars for u128)
+    Uuid,
+    /// Base64 payload (for awakeable/signal IDs)
+    Base64Payload,
+}
+
+impl IdSegment {
+    fn color(self) -> Color {
+        match self {
+            IdSegment::Prefix => Color::Cyan,
+            IdSegment::Separator => Color::DarkGrey,
+            IdSegment::Version => Color::DarkGrey,
+            IdSegment::PartitionKey => Color::Yellow,
+            IdSegment::Uuid => Color::Green,
+            IdSegment::Base64Payload => Color::Magenta,
+        }
+    }
+}
+
+/// A segment of the ID string with its semantic meaning
+struct Segment {
+    kind: IdSegment,
+    start: usize,
+    len: usize,
+}
+
+/// ID format types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdFormat {
+    /// inv_1<partition_key><uuid> - 11 chars partition key + 22 chars uuid
+    Invocation,
+    /// dp_1<uuid>, sub_1<uuid>, snap_1<uuid> - 22 chars uuid
+    UlidBased,
+    /// prom_1<base64>, sign_1<base64> - base64 encoded payload
+    Base64Based,
+    /// Raw ULID (26 chars Crockford base32)
+    RawUlid,
+    /// Unknown format
+    Unknown,
+}
+
+impl IdFormat {
+    /// Detect the ID format from the prefix
+    pub fn detect(id: &str) -> Self {
+        if let Some(prefix) = id.split('_').next() {
+            match prefix {
+                "inv" => IdFormat::Invocation,
+                "dp" | "sub" | "snap" => IdFormat::UlidBased,
+                "prom" | "sign" => IdFormat::Base64Based,
+                _ => {
+                    // Check if it's a raw ULID (26 chars, no underscore)
+                    if !id.contains('_') && id.len() == 26 {
+                        IdFormat::RawUlid
+                    } else {
+                        IdFormat::Unknown
+                    }
+                }
+            }
+        } else if !id.contains('_') && id.len() == 26 {
+            IdFormat::RawUlid
+        } else {
+            IdFormat::Unknown
+        }
+    }
+}
+
+/// Build segments for an ID string based on its format
+fn build_segments(id: &str, format: IdFormat) -> Vec<Segment> {
+    let mut segments = Vec::new();
+
+    match format {
+        IdFormat::Invocation => {
+            // Format: inv_1<partition_key:11><uuid:22>
+            // Total after prefix: 1 + 11 + 22 = 34 chars
+            if let Some(sep_pos) = id.find('_') {
+                // Prefix
+                segments.push(Segment {
+                    kind: IdSegment::Prefix,
+                    start: 0,
+                    len: sep_pos,
+                });
+                // Separator
+                segments.push(Segment {
+                    kind: IdSegment::Separator,
+                    start: sep_pos,
+                    len: 1,
+                });
+                // Version (1 char)
+                let version_start = sep_pos + 1;
+                if version_start < id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::Version,
+                        start: version_start,
+                        len: 1,
+                    });
+                }
+                // Partition key (11 chars for base62 u64)
+                let pk_start = version_start + 1;
+                if pk_start + 11 <= id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::PartitionKey,
+                        start: pk_start,
+                        len: 11,
+                    });
+                }
+                // UUID (22 chars for base62 u128)
+                let uuid_start = pk_start + 11;
+                if uuid_start < id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::Uuid,
+                        start: uuid_start,
+                        len: id.len() - uuid_start,
+                    });
+                }
+            }
+        }
+        IdFormat::UlidBased => {
+            // Format: <prefix>_1<uuid:22>
+            if let Some(sep_pos) = id.find('_') {
+                // Prefix
+                segments.push(Segment {
+                    kind: IdSegment::Prefix,
+                    start: 0,
+                    len: sep_pos,
+                });
+                // Separator
+                segments.push(Segment {
+                    kind: IdSegment::Separator,
+                    start: sep_pos,
+                    len: 1,
+                });
+                // Version (1 char)
+                let version_start = sep_pos + 1;
+                if version_start < id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::Version,
+                        start: version_start,
+                        len: 1,
+                    });
+                }
+                // UUID (rest is base62 u128)
+                let uuid_start = version_start + 1;
+                if uuid_start < id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::Uuid,
+                        start: uuid_start,
+                        len: id.len() - uuid_start,
+                    });
+                }
+            }
+        }
+        IdFormat::Base64Based => {
+            // Format: <prefix>_1<base64_payload>
+            if let Some(sep_pos) = id.find('_') {
+                // Prefix
+                segments.push(Segment {
+                    kind: IdSegment::Prefix,
+                    start: 0,
+                    len: sep_pos,
+                });
+                // Separator
+                segments.push(Segment {
+                    kind: IdSegment::Separator,
+                    start: sep_pos,
+                    len: 1,
+                });
+                // Version (1 char)
+                let version_start = sep_pos + 1;
+                if version_start < id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::Version,
+                        start: version_start,
+                        len: 1,
+                    });
+                }
+                // Base64 payload (rest)
+                let payload_start = version_start + 1;
+                if payload_start < id.len() {
+                    segments.push(Segment {
+                        kind: IdSegment::Base64Payload,
+                        start: payload_start,
+                        len: id.len() - payload_start,
+                    });
+                }
+            }
+        }
+        IdFormat::RawUlid => {
+            // Entire string is the ULID
+            segments.push(Segment {
+                kind: IdSegment::Uuid,
+                start: 0,
+                len: id.len(),
+            });
+        }
+        IdFormat::Unknown => {
+            // No colorization for unknown formats
+        }
+    }
+
+    segments
+}
+
+/// Format an ID string with colorized components for terminal display.
+///
+/// Each segment of the ID is colored differently to help visualize
+/// the ID structure:
+/// - Cyan: Resource type prefix (inv, dp, sub, etc.)
+/// - Grey: Separator (_) and version (1)
+/// - Yellow: Partition key (for invocation IDs)
+/// - Green: UUID/ULID component
+/// - Magenta: Base64 payload (for awakeable/signal IDs)
+pub fn colorize_id(id: &str) -> String {
+    let colors_enabled = CliContext::get().colors_enabled();
+    let format = IdFormat::detect(id);
+    let segments = build_segments(id, format);
+
+    if !colors_enabled || segments.is_empty() {
+        return id.to_string();
+    }
+
+    let mut result = String::with_capacity(id.len() * 2); // Extra capacity for ANSI codes
+    let mut pos = 0;
+
+    for seg in &segments {
+        // Fill gap with uncolored text (shouldn't happen normally)
+        if pos < seg.start {
+            result.push_str(&id[pos..seg.start]);
+            pos = seg.start;
+        }
+
+        // Write colored segment
+        let end = (seg.start + seg.len).min(id.len());
+        if pos < end {
+            let part = &id[pos..end];
+            let colored = part.with(seg.kind.color());
+            let _ = write!(result, "{}", colored);
+            pos = end;
+        }
+    }
+
+    // Handle any remaining characters
+    if pos < id.len() {
+        result.push_str(&id[pos..]);
+    }
+
+    result
+}
+
+/// Generate a legend for the ID colors
+pub fn id_color_legend() -> String {
+    let colors_enabled = CliContext::get().colors_enabled();
+    if !colors_enabled {
+        return String::from("[colors disabled]");
+    }
+
+    format!(
+        "{} {} {} {}",
+        "prefix".with(IdSegment::Prefix.color()),
+        "partition".with(IdSegment::PartitionKey.color()),
+        "uuid".with(IdSegment::Uuid.color()),
+        "payload".with(IdSegment::Base64Payload.color()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_format() {
+        assert_eq!(
+            IdFormat::detect("inv_1fBuS9KMPNrt0zQBGdilypucn1EeT7AO5j"),
+            IdFormat::Invocation
+        );
+        assert_eq!(
+            IdFormat::detect("dp_11nGQpCRmau6ypL82KH2TnP"),
+            IdFormat::UlidBased
+        );
+        assert_eq!(
+            IdFormat::detect("sub_11nGQpCRmau6ypL82KH2TnP"),
+            IdFormat::UlidBased
+        );
+        assert_eq!(
+            IdFormat::detect("snap_11nGQpCRmau6ypL82KH2TnP"),
+            IdFormat::UlidBased
+        );
+        assert_eq!(IdFormat::detect("prom_1abc123"), IdFormat::Base64Based);
+        assert_eq!(IdFormat::detect("sign_1abc123"), IdFormat::Base64Based);
+        assert_eq!(
+            IdFormat::detect("01HZJ49VHPQ14ZM6YGG5NJD2RN"),
+            IdFormat::RawUlid
+        );
+        assert_eq!(IdFormat::detect("invalid"), IdFormat::Unknown);
+    }
+
+    #[test]
+    fn test_build_segments_invocation() {
+        let id = "inv_1fBuS9KMPNrt0zQBGdilypucn1EeT7AO5j";
+        let segments = build_segments(id, IdFormat::Invocation);
+
+        assert_eq!(segments.len(), 5);
+        assert_eq!(segments[0].len, 3); // "inv"
+        assert_eq!(segments[1].len, 1); // "_"
+        assert_eq!(segments[2].len, 1); // "1"
+        assert_eq!(segments[3].len, 11); // partition key
+        assert_eq!(segments[4].len, 22); // uuid
+    }
+
+    #[test]
+    fn test_build_segments_ulid_based() {
+        let id = "dp_11nGQpCRmau6ypL82KH2TnP";
+        let segments = build_segments(id, IdFormat::UlidBased);
+
+        assert_eq!(segments.len(), 4);
+        assert_eq!(segments[0].len, 2); // "dp"
+        assert_eq!(segments[1].len, 1); // "_"
+        assert_eq!(segments[2].len, 1); // "1"
+        assert_eq!(segments[3].len, 22); // uuid
+    }
+}

--- a/tools/restate-doctor/src/util/mod.rs
+++ b/tools/restate-doctor/src/util/mod.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod colorize_id;
+
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
+/// Encode bytes as lowercase hex string
+pub fn hex_encode(bytes: &[u8]) -> String {
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        result.push(HEX_CHARS[(b >> 4) as usize] as char);
+        result.push(HEX_CHARS[(b & 0xf) as usize] as char);
+    }
+    result
+}


### PR DESCRIPTION

Introduces a new tool used for low-level debugging of restate server data.

The first command is `restate-doctor id decode <id>` which decodes restate identifiers. See comments for a screenshot.

This is still work in progress and is highly experimental.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4208).
* #4226
* #4225
* #4214
* __->__ #4208