### PR TITLE
Forward PartitionConfiguration through AnnounceLeader and persist in FSM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8359,6 +8359,7 @@ dependencies = [
  "restate-types",
  "restate-workspace-hack",
  "serde",
+ "serde_with",
  "strum",
  "tracing",
 ]

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -10,7 +10,7 @@
 
 use restate_storage_api::Result;
 use restate_storage_api::fsm_table::{
-    PartitionDurability, ReadFsmTable, SequenceNumber, WriteFsmTable,
+    CachedEpochMetadata, PartitionDurability, ReadFsmTable, SequenceNumber, WriteFsmTable,
 };
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_types::SemanticRestateVersion;
@@ -53,6 +53,10 @@ pub(crate) mod fsm_variable {
     pub(crate) const STORAGE_VERSION: u64 = 5;
 
     pub(crate) const SERVICES_SCHEMA_METADATA: u64 = 6;
+
+    /// Stores the current and next partition configuration from the latest AnnounceLeader.
+    /// *Since v1.6*
+    pub(crate) const PARTITION_CONFIG_STATE: u64 = 7;
 }
 
 fn get<T: PartitionStoreProtobufValue, S: StorageAccess>(
@@ -158,6 +162,11 @@ impl ReadFsmTable for PartitionStore {
         let key = create_key(self.partition_id(), fsm_variable::SERVICES_SCHEMA_METADATA);
         self.get_value_storage_codec(key)
     }
+
+    async fn get_partition_config_state(&mut self) -> Result<Option<CachedEpochMetadata>> {
+        let key = create_key(self.partition_id(), fsm_variable::PARTITION_CONFIG_STATE);
+        self.get_value_storage_codec(key)
+    }
 }
 
 impl WriteFsmTable for PartitionStoreTransaction<'_> {
@@ -209,5 +218,10 @@ impl WriteFsmTable for PartitionStoreTransaction<'_> {
     fn put_schema(&mut self, schema: &Schema) -> Result<()> {
         let key = create_key(self.partition_id(), fsm_variable::SERVICES_SCHEMA_METADATA);
         self.put_kv_storage_codec(key, schema)
+    }
+
+    fn put_partition_config_state(&mut self, state: &CachedEpochMetadata) -> Result<()> {
+        let key = create_key(self.partition_id(), fsm_variable::PARTITION_CONFIG_STATE);
+        self.put_kv_storage_codec(key, state)
     }
 }

--- a/crates/storage-api/src/fsm_table/mod.rs
+++ b/crates/storage-api/src/fsm_table/mod.rs
@@ -10,11 +10,20 @@
 
 use std::future::Future;
 
-use restate_types::SemanticRestateVersion;
+use bytes::BytesMut;
+
+use restate_types::identifiers::LeaderEpoch;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
+use restate_types::partitions::state::ReplicaSetState;
+use restate_types::replication::ReplicationProperty;
 use restate_types::schema::Schema;
+use restate_types::storage::{
+    StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError, decode,
+    encode,
+};
 use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version};
 
 use crate::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
@@ -35,6 +44,10 @@ pub trait ReadFsmTable {
     ) -> impl Future<Output = Result<Option<PartitionDurability>>> + Send + '_;
 
     fn get_schema(&mut self) -> impl Future<Output = Result<Option<Schema>>> + Send + '_;
+
+    fn get_partition_config_state(
+        &mut self,
+    ) -> impl Future<Output = Result<Option<CachedEpochMetadata>>> + Send + '_;
 }
 
 pub trait WriteFsmTable {
@@ -49,6 +62,8 @@ pub trait WriteFsmTable {
     fn put_partition_durability(&mut self, durability: &PartitionDurability) -> Result<()>;
 
     fn put_schema(&mut self, schema: &Schema) -> Result<()>;
+
+    fn put_partition_config_state(&mut self, state: &CachedEpochMetadata) -> Result<()>;
 }
 
 #[derive(Debug, Clone, Copy, derive_more::From, derive_more::Into)]
@@ -82,4 +97,74 @@ impl PartialOrd for PartitionDurability {
 
 impl PartitionStoreProtobufValue for PartitionDurability {
     type ProtobufType = crate::protobuf_types::v1::PartitionDurability;
+}
+
+/// Stores the current and next replica set state from the latest AnnounceLeader.
+/// *Since v1.6*
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct CachedEpochMetadata {
+    #[bilrost(tag(1))]
+    pub version: Version,
+    #[bilrost(tag(2))]
+    pub leader_node_id: GenerationalNodeId,
+    #[bilrost(tag(3))]
+    pub leader_epoch: LeaderEpoch,
+    /// The current replica set state at the time of the announcement.
+    #[bilrost(tag(4))]
+    pub current: CurrentReplicaSetState,
+    /// The next replica set state
+    #[bilrost(tag(5))]
+    pub next: Option<NextReplicaSetState>,
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct CurrentReplicaSetState {
+    #[bilrost(tag(1))]
+    pub replica_set: ReplicaSetState,
+    #[bilrost(tag(2))]
+    pub modified_at: MillisSinceEpoch,
+    #[bilrost(tag(3))]
+    pub replication: ReplicationProperty,
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct NextReplicaSetState {
+    #[bilrost(tag(1))]
+    pub replica_set: ReplicaSetState,
+}
+
+impl From<ReplicaSetState> for NextReplicaSetState {
+    fn from(value: ReplicaSetState) -> Self {
+        Self { replica_set: value }
+    }
+}
+
+impl From<NextReplicaSetState> for ReplicaSetState {
+    fn from(value: NextReplicaSetState) -> Self {
+        value.replica_set
+    }
+}
+
+impl StorageEncode for CachedEpochMetadata {
+    fn default_codec(&self) -> StorageCodecKind {
+        StorageCodecKind::Bilrost
+    }
+
+    fn encode(&self, buf: &mut BytesMut) -> Result<(), StorageEncodeError> {
+        encode::encode_bilrost(self, buf)
+    }
+}
+
+impl StorageDecode for CachedEpochMetadata {
+    fn decode<B: bytes::Buf>(
+        buf: &mut B,
+        kind: StorageCodecKind,
+    ) -> Result<Self, StorageDecodeError>
+    where
+        Self: Sized,
+    {
+        assert_eq!(kind, StorageCodecKind::Bilrost);
+
+        decode::decode_bilrost(buf)
+    }
 }

--- a/crates/types/src/locality/location_scope.rs
+++ b/crates/types/src/locality/location_scope.rs
@@ -25,6 +25,7 @@
     strum::EnumString,
     serde::Serialize,
     serde::Deserialize,
+    bilrost::Enumeration,
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(ascii_case_insensitive)]
@@ -34,12 +35,12 @@ pub enum LocationScope {
     Node = 0,
 
     // Actual scopes representing the location of a node
-    Zone,
-    Region,
+    Zone = 1,
+    Region = 2,
 
     // Special; Includes all lower-level scopes.
     #[strum(disabled)]
-    Root,
+    Root = 3,
 }
 
 impl LocationScope {

--- a/crates/types/src/partitions/configuration.rs
+++ b/crates/types/src/partitions/configuration.rs
@@ -10,12 +10,11 @@
 
 use ahash::HashMap;
 
-use crate::logs::{Lsn, SequenceNumber};
 use crate::replication::{NodeSet, ReplicationProperty};
 use crate::time::MillisSinceEpoch;
 use crate::{Version, Versioned};
 
-use super::state::{MemberState, ReplicaSetState};
+use super::state::ReplicaSetState;
 
 /// The Partition configuration contains information about which nodes run partition processors for
 /// the given partition.
@@ -58,21 +57,15 @@ impl PartitionConfiguration {
     }
 
     pub fn to_replica_set_state(&self) -> ReplicaSetState {
-        ReplicaSetState {
-            version: self.version,
-            members: self
-                .replica_set
-                .iter()
-                .map(|node_id| MemberState {
-                    node_id: *node_id,
-                    durable_lsn: Lsn::INVALID,
-                })
-                .collect(),
-        }
+        ReplicaSetState::from_partition_configuration(self)
     }
 
     pub fn replica_set(&self) -> &NodeSet {
         &self.replica_set
+    }
+
+    pub fn into_replica_set(self) -> NodeSet {
+        self.replica_set
     }
 
     pub fn replication(&self) -> &ReplicationProperty {

--- a/crates/types/src/replication/replication_property.rs
+++ b/crates/types/src/replication/replication_property.rs
@@ -35,8 +35,10 @@ static REPLICATION_PROPERTY_EXTRACTOR: LazyLock<Regex> = LazyLock::new(|| {
 pub struct ReplicationPropertyError(String);
 
 /// The replication policy for appends
-#[derive(serde::Serialize, serde::Deserialize, Clone, Eq, PartialEq)]
-pub struct ReplicationProperty(BTreeMap<LocationScope, u8>);
+#[derive(serde::Serialize, serde::Deserialize, Clone, Eq, PartialEq, bilrost::Message)]
+pub struct ReplicationProperty(
+    #[bilrost(tag(0), encoding(map<general, varint>))] BTreeMap<LocationScope, u8>,
+);
 
 impl ReplicationProperty {
     pub fn new(replication_factor: NonZeroU8) -> Self {

--- a/crates/types/src/storage/encode.rs
+++ b/crates/types/src/storage/encode.rs
@@ -59,6 +59,20 @@ fn encode_serde_as_json<T: Serialize>(
 }
 
 /// Utility method to encode a [`bilrost::Message`] type
-pub fn encode_bilrost<T: bilrost::Message>(value: &T) -> Bytes {
+// todo(azmy): Contiguous encoding is supposedly faster for complex
+// and nested types. Confirm this claim by running benchmarks.
+// (is it still beneficial to encode_contiguous if we still have to
+// copy the bytes over to the buffer)
+pub fn encode_bilrost_contiguous<T: bilrost::Message>(value: &T) -> Bytes {
     value.encode_contiguous().into_vec().into()
+}
+
+/// Utility method to encode a [`bilrost::Message`] type
+pub fn encode_bilrost<T: bilrost::Message>(
+    value: &T,
+    buf: &mut BytesMut,
+) -> Result<(), StorageEncodeError> {
+    value
+        .encode(buf)
+        .map_err(|err| StorageEncodeError::EncodeValue(err.into()))
 }

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde"]
+serde = ["dep:serde", "dep:serde_with", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
@@ -23,6 +23,7 @@ bytestring = { workspace = true }
 bilrost = { workspace = true }
 enum-map = { workspace = true }
 serde = { workspace = true, optional = true }
+serde_with = { workspace = true, optional = true }
 strum = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -10,15 +10,19 @@
 
 use std::ops::RangeInclusive;
 
+use restate_storage_api::fsm_table::{CurrentReplicaSetState, NextReplicaSetState};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
-use restate_types::logs::{Keys, Lsn};
+use restate_types::logs::{Keys, Lsn, SequenceNumber};
+use restate_types::partitions::PartitionConfiguration;
+use restate_types::partitions::state::{MemberState, ReplicaSetState};
+use restate_types::replication::{NodeSet, ReplicationProperty};
 use restate_types::schema::Schema;
 use restate_types::time::MillisSinceEpoch;
-use restate_types::{GenerationalNodeId, SemanticRestateVersion};
+use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version, Versioned};
 
 /// Announcing a new leader. This message can be written by any component to make the specified
 /// partition processor the leader.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnnounceLeader {
     /// Sender of the announce leader message.
@@ -28,8 +32,117 @@ pub struct AnnounceLeader {
     pub node_id: GenerationalNodeId,
     pub leader_epoch: LeaderEpoch,
     pub partition_key_range: RangeInclusive<PartitionKey>,
+
+    /// Associated epoch metadata version
+    ///
+    /// This value **MUST** be set in version v1.6
+    /// Optional only for backward compatibility
+    ///
+    /// *Since v1.6*
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub epoch_version: Option<Version>,
+    /// Current replica set configuration at the time of the announcement.
+    /// This field is optional for backward compatibility with older versions.
+    /// *Since v1.6*
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub current_config: Option<CurrentReplicaSetConfiguration>,
+    /// Next replica set configuration.
+    /// *Since v1.6*
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub next_config: Option<NextReplicaSetConfiguration>,
 }
 
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", serde_with::serde_as)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CurrentReplicaSetConfiguration {
+    pub version: Version,
+    pub replica_set: NodeSet,
+    pub modified_at: MillisSinceEpoch,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub replication: ReplicationProperty,
+}
+
+impl From<PartitionConfiguration> for CurrentReplicaSetConfiguration {
+    fn from(value: PartitionConfiguration) -> Self {
+        Self {
+            version: value.version(),
+            modified_at: value.modified_at(),
+            replication: value.replication().clone(),
+            replica_set: value.into_replica_set(),
+        }
+    }
+}
+
+impl CurrentReplicaSetConfiguration {
+    pub fn to_replica_set_state(&self) -> ReplicaSetState {
+        new_replica_set_state(self.version, &self.replica_set)
+    }
+
+    pub fn to_current_replica_set_state(&self) -> CurrentReplicaSetState {
+        CurrentReplicaSetState {
+            replica_set: new_replica_set_state(self.version, &self.replica_set),
+            modified_at: self.modified_at,
+            replication: self.replication.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NextReplicaSetConfiguration {
+    pub version: Version,
+    pub replica_set: NodeSet,
+}
+
+impl From<PartitionConfiguration> for NextReplicaSetConfiguration {
+    fn from(value: PartitionConfiguration) -> Self {
+        Self {
+            version: value.version(),
+            replica_set: value.into_replica_set(),
+        }
+    }
+}
+
+impl NextReplicaSetConfiguration {
+    pub fn new(replica_set: &ReplicaSetState) -> Self {
+        Self {
+            version: replica_set.version,
+            replica_set: replica_set.members.iter().map(|m| m.node_id).collect(),
+        }
+    }
+
+    pub fn to_replica_set_state(&self) -> ReplicaSetState {
+        new_replica_set_state(self.version, &self.replica_set)
+    }
+
+    pub fn to_next_replica_set_state(&self) -> NextReplicaSetState {
+        NextReplicaSetState {
+            replica_set: new_replica_set_state(self.version, &self.replica_set),
+        }
+    }
+}
+
+fn new_replica_set_state(version: Version, node_set: &NodeSet) -> ReplicaSetState {
+    let members = node_set
+        .iter()
+        .map(|node_id| MemberState {
+            node_id: *node_id,
+            durable_lsn: Lsn::INVALID,
+        })
+        .collect();
+
+    ReplicaSetState { version, members }
+}
 /// A version barrier to fence off state machine changes that require a certain minimum
 /// version of restate server.
 ///

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -23,7 +23,7 @@ use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStat
 use restate_types::identifiers::{LeaderEpoch, PartitionKey};
 use restate_types::net::partition_processor::PartitionLeaderService;
 
-use crate::partition::TargetLeaderState;
+use crate::partition::{LeadershipInfo, TargetLeaderState};
 
 pub type LeaderEpochToken = Ulid;
 
@@ -186,9 +186,10 @@ impl ProcessorState {
 
     pub fn on_leader_epoch_obtained(
         &mut self,
-        leader_epoch: LeaderEpoch,
+        leadership_info: Box<LeadershipInfo>,
         leader_epoch_token: LeaderEpochToken,
     ) {
+        let leader_epoch = leadership_info.leader_epoch;
         match self {
             ProcessorState::Starting { .. } => {
                 debug!(
@@ -215,7 +216,7 @@ impl ProcessorState {
                             processor
                                 .as_ref()
                                 .expect("must be some")
-                                .run_for_leader(leader_epoch);
+                                .run_for_leader(leadership_info);
                             debug!(%leader_epoch, "Instruct partition processor to run as leader.");
                             *leader_state = LeaderState::Leader(leader_epoch);
                         } else {
@@ -376,7 +377,7 @@ impl StartedProcessor {
 
     pub fn step_down(&self) {
         self.control_tx.send_if_modified(|target_state| {
-            if *target_state != TargetLeaderState::Follower {
+            if !matches!(*target_state, TargetLeaderState::Follower) {
                 *target_state = TargetLeaderState::Follower;
                 true
             } else {
@@ -385,10 +386,17 @@ impl StartedProcessor {
         });
     }
 
-    pub fn run_for_leader(&self, leader_epoch: LeaderEpoch) {
+    pub fn run_for_leader(&self, leadership_info: Box<LeadershipInfo>) {
         self.control_tx.send_if_modified(|target_state| {
-            if *target_state != TargetLeaderState::Leader(leader_epoch) {
-                *target_state = TargetLeaderState::Leader(leader_epoch);
+            // Compare by leader_epoch only for equality check
+            let should_update = match target_state {
+                TargetLeaderState::Leader(info) => {
+                    info.leader_epoch != leadership_info.leader_epoch
+                }
+                TargetLeaderState::Follower => true,
+            };
+            if should_update {
+                *target_state = TargetLeaderState::Leader(leadership_info);
                 true
             } else {
                 false


### PR DESCRIPTION
Forward PartitionConfiguration through AnnounceLeader and persist in FSM

# Summary

- Thread current and next `PartitionConfiguration` from `obtain_next_epoch()` through to `AnnounceLeader` message
- Persist `PartitionConfiguration` state in the FSM when applying `AnnounceLeader` commands
- Load persisted configuration state on partition processor startup

This implements forward compatibility for ReplicaSet storage by ensuring partition configuration information is available after restarts.

## Test plan

- [x] All existing tests pass (139 tests in restate-worker)
- [x] cargo check, fmt, clippy pass

Fixes #4150
