### PR TITLE
Introduce KafkaCluster data-model:

### DIFF
--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -36,7 +36,7 @@ pub struct IngressOptions {
     /// the ingress will reply immediately with an appropriate status code. Default is unlimited.
     concurrent_api_requests_limit: Option<NonZeroUsize>,
 
-    kafka_clusters: Vec<KafkaClusterOptions>,
+    pub kafka_clusters: Vec<KafkaClusterOptions>,
 
     /// # Ingress endpoint
     ///

--- a/crates/types/src/schema/kafka.rs
+++ b/crates/types/src/schema/kafka.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/restate/blob/main/LICENSE
+
+use crate::config::KafkaClusterOptions;
+use crate::schema::Redaction;
+use crate::schema::subscriptions::Subscription;
+use crate::time::MillisSinceEpoch;
+use http::uri::Authority;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+
+/// # Kafka cluster name
+///
+/// Valid name to use as a kafka cluster identifier. MUST conform a valid hostname format.
+#[derive(Clone, serde_with::SerializeDisplay, serde_with::DeserializeFromStr)]
+#[cfg_attr(feature = "utoipa-schema", derive(::utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa-schema", schema(value_type = String, format = Hostname))]
+pub struct KafkaClusterName(String);
+
+impl KafkaClusterName {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Debug for KafkaClusterName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for KafkaClusterName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self, f)
+    }
+}
+
+impl FromStr for KafkaClusterName {
+    type Err = http::uri::InvalidUri;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // We validate with Uri authority directly, as it needs to be a valid authority string.
+        Authority::from_str(s).map(|a| KafkaClusterName(a.to_string()))
+    }
+}
+
+impl Deref for KafkaClusterName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct KafkaCluster {
+    pub name: KafkaClusterName,
+    pub properties: HashMap<String, String>,
+    pub created_at: MillisSinceEpoch,
+}
+
+impl KafkaCluster {
+    pub fn new(name: KafkaClusterName, properties: HashMap<String, String>) -> Self {
+        Self {
+            name,
+            properties,
+            created_at: MillisSinceEpoch::now(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn properties(&self) -> &HashMap<String, String> {
+        &self.properties
+    }
+
+    pub fn created_at(&self) -> MillisSinceEpoch {
+        self.created_at
+    }
+
+    pub(in crate::schema) fn properties_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.properties
+    }
+}
+
+pub trait KafkaClusterResolver {
+    fn get_kafka_cluster(
+        &self,
+        cluster_name: &str,
+        redact_secrets: Redaction,
+    ) -> Option<KafkaCluster>;
+
+    fn get_kafka_cluster_and_subscriptions(
+        &self,
+        cluster_name: &str,
+        redact_secrets: Redaction,
+    ) -> Option<(KafkaCluster, Vec<Subscription>)>;
+
+    fn list_kafka_clusters(&self, redact_secrets: Redaction) -> Vec<KafkaCluster>;
+}
+
+impl From<KafkaClusterOptions> for KafkaCluster {
+    fn from(
+        KafkaClusterOptions {
+            name,
+            brokers,
+            additional_options,
+        }: KafkaClusterOptions,
+    ) -> Self {
+        let mut properties = additional_options;
+        properties.insert("metadata.broker.list".to_string(), brokers.join(","));
+
+        Self {
+            name: KafkaClusterName(name),
+            properties,
+            created_at: MillisSinceEpoch::UNIX_EPOCH,
+        }
+    }
+}

--- a/crates/types/src/schema/metadata/mod.rs
+++ b/crates/types/src/schema/metadata/mod.rs
@@ -35,12 +35,15 @@ use crate::schema::invocation_target::{
     InputRules, InvocationAttemptOptions, InvocationTargetMetadata, InvocationTargetResolver,
     OnMaxAttempts, OutputRules,
 };
+use crate::schema::kafka::{KafkaCluster, KafkaClusterResolver};
 use crate::schema::metadata::openapi::ServiceOpenAPI;
 use crate::schema::service::{
     HandlerRetryPolicyMetadata, ServiceMetadataResolver, ServiceRetryPolicyMetadata,
 };
-use crate::schema::subscriptions::{ListSubscriptionFilter, Subscription, SubscriptionResolver};
-use crate::schema::{deployment, service};
+use crate::schema::subscriptions::{
+    ListSubscriptionFilter, Source, Subscription, SubscriptionResolver,
+};
+use crate::schema::{Redaction, deployment, service};
 use crate::service_protocol::ServiceProtocolVersion;
 use crate::time::MillisSinceEpoch;
 use crate::{Version, Versioned, identifiers};
@@ -58,6 +61,7 @@ pub struct Schema {
     deployments: HashMap<DeploymentId, Deployment>,
     active_service_revisions: HashMap<String, ActiveServiceRevision>,
     subscriptions: HashMap<SubscriptionId, Subscription>,
+    kafka_clusters: HashMap<String, KafkaCluster>,
 }
 
 impl Default for Schema {
@@ -67,6 +71,7 @@ impl Default for Schema {
             active_service_revisions: HashMap::default(),
             deployments: HashMap::default(),
             subscriptions: HashMap::default(),
+            kafka_clusters: HashMap::default(),
         }
     }
 }
@@ -850,11 +855,22 @@ impl ServiceMetadataResolver for Schema {
 }
 
 impl SubscriptionResolver for Schema {
-    fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription> {
-        self.subscriptions.get(&id).cloned()
+    fn get_subscription(
+        &self,
+        id: SubscriptionId,
+        redact_secrets: Redaction,
+    ) -> Option<Subscription> {
+        self.subscriptions
+            .get(&id)
+            .cloned()
+            .map(|sub| sub.redact(redact_secrets))
     }
 
-    fn list_subscriptions(&self, filters: &[ListSubscriptionFilter]) -> Vec<Subscription> {
+    fn list_subscriptions(
+        &self,
+        filters: &[ListSubscriptionFilter],
+        redact_secrets: Redaction,
+    ) -> Vec<Subscription> {
         self.subscriptions
             .values()
             .filter(|sub| {
@@ -866,8 +882,155 @@ impl SubscriptionResolver for Schema {
                 true
             })
             .cloned()
+            .map(|sub| sub.redact(redact_secrets))
             .collect()
     }
+}
+
+impl KafkaClusterResolver for Schema {
+    fn get_kafka_cluster(
+        &self,
+        cluster_name: &str,
+        redact_secrets: Redaction,
+    ) -> Option<KafkaCluster> {
+        self.kafka_clusters
+            .get(cluster_name)
+            .cloned()
+            .or_else(|| {
+                Configuration::pinned()
+                    .ingress
+                    .get_kafka_cluster(cluster_name)
+                    .cloned()
+                    .map(Into::into)
+            })
+            .map(|cluster| cluster.redact(redact_secrets))
+    }
+
+    fn get_kafka_cluster_and_subscriptions(
+        &self,
+        cluster_name: &str,
+        redact_secrets: Redaction,
+    ) -> Option<(KafkaCluster, Vec<Subscription>)> {
+        let cluster = KafkaClusterResolver::get_kafka_cluster(self, cluster_name, redact_secrets)?;
+
+        let subscriptions = self
+            .subscriptions
+            .values()
+            .filter(|sub| {
+                let Source::Kafka { cluster, .. } = sub.source();
+                cluster == cluster_name
+            })
+            .map(|sub| sub.clone().redact(redact_secrets))
+            .collect();
+        Some((cluster, subscriptions))
+    }
+
+    fn list_kafka_clusters(&self, redact_secrets: Redaction) -> Vec<KafkaCluster> {
+        self.kafka_clusters
+            .values()
+            .map(|cluster| cluster.clone().redact(redact_secrets))
+            .chain(
+                Configuration::pinned()
+                    .ingress
+                    .kafka_clusters
+                    .iter()
+                    .map(|cluster| KafkaCluster::from(cluster.clone()).redact(redact_secrets)),
+            )
+            .collect()
+    }
+}
+
+const REDACTION_VALUE: &str = "***";
+
+impl KafkaCluster {
+    fn redact(mut self, redact_secrets: Redaction) -> KafkaCluster {
+        match redact_secrets {
+            Redaction::Yes => {
+                let redacted_properties = self.properties_mut();
+                for (key, value) in redacted_properties.iter_mut() {
+                    if is_sensitive_kafka_property(key) {
+                        *value = REDACTION_VALUE.to_string();
+                    }
+                }
+            }
+            Redaction::No => {}
+        };
+        self
+    }
+}
+
+impl Subscription {
+    fn redact(mut self, redact_secrets: Redaction) -> Subscription {
+        match redact_secrets {
+            Redaction::Yes => {
+                let redacted_properties = self.metadata_mut();
+                for (key, value) in redacted_properties.iter_mut() {
+                    if is_sensitive_kafka_property(key) {
+                        *value = REDACTION_VALUE.to_string();
+                    }
+                }
+            }
+            Redaction::No => {}
+        };
+        self
+    }
+}
+
+/// Checks if a Kafka property key is sensitive and should be redacted
+/// Based on librdkafka CONFIGURATION.md
+fn is_sensitive_kafka_property(key: &str) -> bool {
+    let key_lower = key.to_lowercase();
+
+    // Redact anything with password, secret, passphrase, or token in the name
+    if key_lower.contains("password")
+        || key_lower.contains("secret")
+        || key_lower.contains("passphrase")
+    {
+        return true;
+    }
+
+    // Redact SASL credentials
+    if key_lower.contains("sasl.username") || key_lower.contains("sasl.password") {
+        return true;
+    }
+
+    // Redact SASL JAAS config (contains credentials)
+    if key_lower.contains("sasl.jaas.config") {
+        return true;
+    }
+
+    // Redact OAuth/OIDC configs (may contain credentials)
+    if key_lower.contains("sasl.oauthbearer.config") {
+        return true;
+    }
+
+    // Redact OAuth token endpoints (may contain secrets in URL params)
+    if key_lower.contains("token.endpoint.url") {
+        return true;
+    }
+
+    // Redact SSL/TLS private keys (PEM format or file locations)
+    if key_lower.contains("ssl.key.location")
+        || key_lower.contains("ssl.key.pem")
+        || key_lower.contains("ssl.key.password")
+    {
+        return true;
+    }
+
+    // Redact keystore and truststore locations (can reveal filesystem structure)
+    if key_lower.contains("keystore.location")
+        || key_lower.contains("truststore.location")
+        || key_lower.contains("keystore.password")
+    {
+        return true;
+    }
+
+    // Redact OAuth assertion private keys (JWT signing)
+    if key_lower.contains("sasl.oauthbearer.assertion.private.key") {
+        return true;
+    }
+
+    false
 }
 
 impl Configuration {

--- a/crates/types/src/schema/mod.rs
+++ b/crates/types/src/schema/mod.rs
@@ -26,9 +26,16 @@
 pub mod deployment;
 pub mod info;
 pub mod invocation_target;
+pub mod kafka;
 mod metadata;
 pub mod registry;
 pub mod service;
 pub mod subscriptions;
 
 pub use metadata::Schema;
+
+#[derive(Clone, Copy)]
+pub enum Redaction {
+    Yes,
+    No,
+}

--- a/crates/types/src/schema/subscriptions.rs
+++ b/crates/types/src/schema/subscriptions.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 
 use crate::identifiers::SubscriptionId;
 use crate::invocation::{VirtualObjectHandlerType, WorkflowHandlerType};
+use crate::schema::Redaction;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -151,9 +152,13 @@ impl ListSubscriptionFilter {
 }
 
 pub trait SubscriptionResolver {
-    fn get_subscription(&self, id: SubscriptionId) -> Option<Subscription>;
+    fn get_subscription(&self, id: SubscriptionId, redaction: Redaction) -> Option<Subscription>;
 
-    fn list_subscriptions(&self, filters: &[ListSubscriptionFilter]) -> Vec<Subscription>;
+    fn list_subscriptions(
+        &self,
+        filters: &[ListSubscriptionFilter],
+        redaction: Redaction,
+    ) -> Vec<Subscription>;
 }
 
 mod serde_hacks {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -54,6 +54,7 @@ use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
+use restate_types::schema::Redaction;
 use restate_types::schema::subscriptions::SubscriptionResolver;
 
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
@@ -261,7 +262,7 @@ where
                 version = metadata.wait_for_version(MetadataKind::Schema, next_version) => {
                     let _ = version?;
                     let schema = updateable_schema.live_load();
-                    let subscriptions = schema.list_subscriptions(&[]);
+                    let subscriptions = schema.list_subscriptions(&[], Redaction::No);
                     subscription_controller
                         .update_subscriptions(subscriptions)
                         .await?;


### PR DESCRIPTION
Introduce KafkaCluster data-model:

* New KafkaCluster entity in schema registry + KafkaClusterResolver to read the available kafka clusters
* Update Subscription validation logic to support the new KafkaCluster entity
* Add updater logic and schema registry logic
* Updater tests

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4235).
* #4179
* #4237
* #4236
* __->__ #4235