### PR TITLE
Change default memory budget of query engine to 1 GiB

### DIFF
--- a/crates/types/src/config/query_engine.rs
+++ b/crates/types/src/config/query_engine.rs
@@ -56,7 +56,7 @@ impl Default for QueryEngineOptions {
     fn default() -> Self {
         #[allow(deprecated)]
         Self {
-            memory_size: NonZeroUsize::new(4 * 1024 * 1024 * 1024).unwrap(), // 4GiB
+            memory_size: NonZeroUsize::new(1024 * 1024 * 1024).unwrap(), // 1GiB
             tmp_dir: None,
             query_parallelism: None,
             datafusion_options: HashMap::new(),


### PR DESCRIPTION

We used to have 4 GiB as default budget, that was needed due to inefficient queries by the UI in the past. Since then, we have optimized the internals and we now stream the underlying iterators in most cases. Changing this value to reduce the max memory usage of the "default" restate configuration.


The documentation https://github.com/restatedev/docs-restate/pull/127 will reflect this change as well.
