### PR TITLE
[Restate UI] Update to v0.1.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8366,8 +8366,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.31"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.31#6e8a6582b81e56e6eeb01c877a7630a84e1b163c"
+version = "0.1.33"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.33#82753f12a3bb89a8a8875e06c54dca041f6778b4"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.31", tag = "v0.1.31" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.33", tag = "v0.1.33" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.33
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.33/ui-v0.1.33.zip