### PR TITLE
Fix metadata server shutdown panic

### DIFF
--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -138,25 +138,19 @@ enum JoinError {
 
 #[async_trait::async_trait]
 pub trait MetadataServerBoxed {
-    async fn run_boxed(
-        self: Box<Self>,
-        metadata_writer: Option<MetadataWriter>,
-    ) -> anyhow::Result<()>;
+    async fn run_boxed(self: Box<Self>, metadata_writer: MetadataWriter) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
 impl<T: MetadataServer> MetadataServerBoxed for T {
-    async fn run_boxed(
-        self: Box<Self>,
-        metadata_writer: Option<MetadataWriter>,
-    ) -> anyhow::Result<()> {
+    async fn run_boxed(self: Box<Self>, metadata_writer: MetadataWriter) -> anyhow::Result<()> {
         (*self).run(metadata_writer).await
     }
 }
 
 #[async_trait::async_trait]
 pub trait MetadataServer: MetadataServerBoxed + Send {
-    async fn run(self, metadata_writer: Option<MetadataWriter>) -> anyhow::Result<()>;
+    async fn run(self, metadata_writer: MetadataWriter) -> anyhow::Result<()>;
 
     fn boxed(self) -> BoxedMetadataServer
     where
@@ -168,7 +162,7 @@ pub trait MetadataServer: MetadataServerBoxed + Send {
 
 #[async_trait::async_trait]
 impl<T: MetadataServer + ?Sized> MetadataServer for Box<T> {
-    async fn run(self, metadata_writer: Option<MetadataWriter>) -> anyhow::Result<()> {
+    async fn run(self, metadata_writer: MetadataWriter) -> anyhow::Result<()> {
         self.run_boxed(metadata_writer).await
     }
 }

--- a/crates/metadata-server/src/raft/server.rs
+++ b/crates/metadata-server/src/raft/server.rs
@@ -181,7 +181,7 @@ impl RaftMetadataServer {
         })
     }
 
-    pub async fn run(mut self, metadata_writer: Option<MetadataWriter>) -> Result<(), Error> {
+    pub async fn run(mut self, metadata_writer: MetadataWriter) -> Result<(), Error> {
         let mut shutdown = std::pin::pin!(cancellation_watcher());
         let health_status = self.health_status.take().expect("to be present");
 
@@ -204,7 +204,7 @@ impl RaftMetadataServer {
     async fn run_inner(
         &mut self,
         health_status: &HealthStatus<MetadataServerStatus>,
-        metadata_writer: Option<MetadataWriter>,
+        metadata_writer: MetadataWriter,
     ) -> Result<Never, Error> {
         self.initialize(health_status, metadata_writer).await?;
 
@@ -238,7 +238,7 @@ impl RaftMetadataServer {
     async fn initialize(
         &mut self,
         health_status: &HealthStatus<MetadataServerStatus>,
-        metadata_writer: Option<MetadataWriter>,
+        metadata_writer: MetadataWriter,
     ) -> Result<(), Error> {
         let RaftMetadataServerState::Uninitialized(uninitialized) =
             self.inner.as_mut().expect("inner state should be set")
@@ -332,7 +332,7 @@ impl RaftMetadataServerState {
 
 #[async_trait::async_trait]
 impl MetadataServer for RaftMetadataServer {
-    async fn run(self, metadata_writer: Option<MetadataWriter>) -> anyhow::Result<()> {
+    async fn run(self, metadata_writer: MetadataWriter) -> anyhow::Result<()> {
         self.run(metadata_writer).await.map_err(Into::into)
     }
 }

--- a/crates/metadata-server/src/raft/server/uninitialized.rs
+++ b/crates/metadata-server/src/raft/server/uninitialized.rs
@@ -87,19 +87,17 @@ impl Uninitialized {
     pub async fn initialize(
         &mut self,
         health_status: &HealthStatus<MetadataServerStatus>,
-        mut metadata_writer: Option<MetadataWriter>,
+        metadata_writer: MetadataWriter,
     ) -> Result<RaftServerState, Error> {
-        if let Some(metadata_writer) = metadata_writer.as_mut() {
-            // Try to read a persisted nodes configuration in order to learn about the addresses of our
-            // potential peers and the metadata store states.
-            if let Some(nodes_configuration) = self.storage.get_nodes_configuration()? {
-                metadata_writer
-                    .update(Arc::new(nodes_configuration))
-                    .await?;
-            }
+        // Try to read a persisted nodes configuration in order to learn about the addresses of our
+        // potential peers and the metadata store states.
+        if let Some(nodes_configuration) = self.storage.get_nodes_configuration()? {
+            metadata_writer
+                .update(Arc::new(nodes_configuration))
+                .await?;
         }
 
-        self.metadata_writer = metadata_writer;
+        self.metadata_writer = Some(metadata_writer);
 
         // Check whether we are already provisioned based on the StorageMarker
         if self.storage.get_marker()?.is_none() {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -405,7 +405,7 @@ impl Node {
             TaskCenter::spawn(
                 TaskKind::MetadataServer,
                 "metadata-server",
-                metadata_server.run(Some(metadata_writer.clone())),
+                metadata_server.run(metadata_writer.clone()),
             )?;
         }
 


### PR DESCRIPTION
The problem was that with f30b398ceb4d45812d07d7120d7dd3675eed0598, we took the `inner` state across an await point. Hence, when the outer `tokio::select` loop decided to shut down, there was a possibility that `inner` was unset. This PR reverts f30b398ceb4d45812d07d7120d7dd3675eed0598 and only removes the optionality of the passed in `MetadataWriter`.