### PR TITLE
Reduce CPU overhead of rs-clock thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7130,6 +7130,7 @@ dependencies = [
  "bytes",
  "criterion",
  "jiff",
+ "libc",
  "prost-types",
  "restate-clock",
  "restate-encoding",

--- a/crates/clock/Cargo.toml
+++ b/crates/clock/Cargo.toml
@@ -17,6 +17,7 @@ restate-workspace-hack = { workspace = true }
 restate-encoding = { workspace = true }
 
 bilrost = { workspace = true }
+libc = { version = "0.2" }
 bytes = { workspace = true }
 jiff = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }

--- a/crates/clock/src/lib.rs
+++ b/crates/clock/src/lib.rs
@@ -35,12 +35,12 @@ pub use wall_clock::WallClock;
 /// between precision and performance:
 ///
 /// - [`recent()`](Clock::recent): Returns a cached timestamp with ~100x better performance
-///   but potentially up to ~1ms stale (refreshed every 500μs by [`ClockUpkeep`]).
+///   but potentially up to ~2ms stale (refreshed every 1ms by [`ClockUpkeep`]).
 /// - [`now()`](Clock::now): Returns a precise timestamp via a `SystemTime::now()` syscall/vDSO.
 pub trait Clock {
-    /// Returns a cached unix timestamp that may be up to ~1ms stale.
+    /// Returns a cached unix timestamp that may be up to ~2ms stale.
     ///
-    /// This method reads from an atomic variable updated every 500μs by the
+    /// This method reads from an atomic variable updated every 1ms by the
     /// [`ClockUpkeep`] background thread, avoiding syscall/vDSO overhead.
     ///
     /// # Performance

--- a/crates/clock/src/time.rs
+++ b/crates/clock/src/time.rs
@@ -89,8 +89,8 @@ impl MillisSinceEpoch {
     ///
     /// This method uses the cached [`WallClock::recent_ms()`] timestamp when available,
     /// providing ~100x better performance than a direct `SystemTime::now()` syscall.
-    /// The cached value is refreshed every 500μs by [`ClockUpkeep`](crate::ClockUpkeep),
-    /// so it may be up to ~1ms stale.
+    /// The cached value is refreshed every 1ms by [`ClockUpkeep`](crate::ClockUpkeep),
+    /// so it may be up to ~2ms stale.
     ///
     /// # Fallback Behavior
     ///

--- a/crates/clock/src/wall_clock.rs
+++ b/crates/clock/src/wall_clock.rs
@@ -39,7 +39,7 @@ static RECENT_UNIX_TIMESTAMP_US: AtomicU64 = const { AtomicU64::new(0) };
 ///
 /// # Cached Time
 ///
-/// The cached timestamp is stored in a global atomic and refreshed every 500μs by
+/// The cached timestamp is stored in a global atomic and refreshed every 1ms by
 /// [`ClockUpkeep`](crate::ClockUpkeep). This provides sub-nanosecond read performance
 /// at the cost of up to ~1ms staleness.
 ///
@@ -74,7 +74,7 @@ impl WallClock {
     /// Updates the cached recent timestamp.
     ///
     /// This is intended to be called exclusively from the [`ClockUpkeep`](crate::ClockUpkeep)
-    /// background thread every 500μs.
+    /// background thread every 1ms.
     pub(crate) fn update_recent() {
         RECENT_UNIX_TIMESTAMP_US.store(Self::now_us(), Ordering::Relaxed);
     }
@@ -107,7 +107,7 @@ impl WallClock {
 
     /// Returns a cached unix timestamp (in milliseconds) that may be up to ~1ms stale.
     ///
-    /// This method reads from a global atomic variable updated every 500μs by
+    /// This method reads from a global atomic variable updated every 1ms by
     /// [`ClockUpkeep`](crate::ClockUpkeep), providing ~100x better performance than
     /// [`now_ms()`](WallClock::now_ms).
     ///
@@ -122,7 +122,7 @@ impl WallClock {
 
     /// Returns a cached unix timestamp (in microseconds) that may be up to ~1ms stale.
     ///
-    /// This method reads from a global atomic variable updated every 500μs by
+    /// This method reads from a global atomic variable updated every 1ms by
     /// [`ClockUpkeep`](crate::ClockUpkeep), providing ~100x better performance than
     /// [`now_us()`](WallClock::now_us).
     ///


### PR DESCRIPTION

- Sets the update frequency to 1KHz.
- Use timer slack of 500us on Linux to coalesce timer with other wakeups.

With this change, in my test I see consistent CPU overhead of <0.7% of a single core. This is down from ~2% before.

Fixes #4244
