### PR TITLE
Remove serde feature from restate-wal-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8352,8 +8352,6 @@ version = "1.6.0-dev"
 dependencies = [
  "bilrost",
  "bytes",
- "bytestring",
- "enum-map",
  "restate-invoker-api",
  "restate-storage-api",
  "restate-types",

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -62,7 +62,7 @@ restate-serde-util = { workspace = true }
 restate-storage-api = { workspace = true }
 restate-test-util = { workspace = true }
 restate-types = { workspace = true, features = ["test-util"] }
-restate-wal-protocol = { workspace = true, features = ["serde"] }
+restate-wal-protocol = { workspace = true }
 restate-invoker-api = { workspace = true }
 
 bytestring = { workspace = true }

--- a/crates/wal-protocol/Cargo.toml
+++ b/crates/wal-protocol/Cargo.toml
@@ -7,23 +7,17 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
-[features]
-default = ["serde"]
-serde = ["dep:serde", "dep:serde_with", "enum-map/serde", "bytestring/serde", "restate-invoker-api/serde"]
-
 [dependencies]
 restate-workspace-hack = { workspace = true }
 
-restate-invoker-api = { workspace = true }
+restate-invoker-api = { workspace = true, features = ["serde"] }
 restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 
 bytes = { workspace = true }
-bytestring = { workspace = true }
 bilrost = { workspace = true }
-enum-map = { workspace = true }
-serde = { workspace = true, optional = true }
-serde_with = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_with = { workspace = true }
 strum = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -22,8 +22,7 @@ use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version, Version
 
 /// Announcing a new leader. This message can be written by any component to make the specified
 /// partition processor the leader.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AnnounceLeader {
     /// Sender of the announce leader message.
     ///
@@ -39,36 +38,26 @@ pub struct AnnounceLeader {
     /// Optional only for backward compatibility
     ///
     /// *Since v1.6*
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch_version: Option<Version>,
     /// Current replica set configuration at the time of the announcement.
     /// This field is optional for backward compatibility with older versions.
     /// *Since v1.6*
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_config: Option<CurrentReplicaSetConfiguration>,
     /// Next replica set configuration.
     /// *Since v1.6*
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_config: Option<NextReplicaSetConfiguration>,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", serde_with::serde_as)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[serde_with::serde_as]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CurrentReplicaSetConfiguration {
     pub version: Version,
     pub replica_set: NodeSet,
     pub modified_at: MillisSinceEpoch,
-    #[cfg_attr(feature = "serde", serde_as(as = "serde_with::DisplayFromStr"))]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     pub replication: ReplicationProperty,
 }
 
@@ -97,8 +86,7 @@ impl CurrentReplicaSetConfiguration {
     }
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NextReplicaSetConfiguration {
     pub version: Version,
     pub replica_set: NodeSet,
@@ -149,8 +137,7 @@ fn new_replica_set_state(version: Version, node_set: &NodeSet) -> ReplicaSetStat
 /// Readers before v1.4.0 will crash when reading this command. For v1.4.0+, the barrier defines the
 /// minimum version of restate server that can progress after this command. It also updates the FSM
 /// in case command has been trimmed.
-#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message, serde::Serialize, serde::Deserialize)]
 pub struct VersionBarrier {
     /// The minimum version required (inclusive) to progress after this barrier.
     pub version: SemanticRestateVersion,
@@ -166,8 +153,7 @@ pub struct VersionBarrier {
 /// NOTE: The durability point is monotonically increasing.
 ///
 /// Since v1.4.2.
-#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PartitionDurability {
     pub partition_id: PartitionId,
     /// The partition has applied this LSN durably to the replica-set and/or has been
@@ -180,8 +166,7 @@ pub struct PartitionDurability {
 /// Consistently store schema across partition replicas.
 ///
 /// Since v1.6.0.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UpsertSchema {
     pub partition_key_range: Keys,
     pub schema: Schema,

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -31,14 +31,12 @@ pub mod timer;
 pub mod vqueues;
 
 /// The primary envelope for all messages in the system.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Envelope {
     pub header: Header,
     pub command: Command,
 }
 
-#[cfg(feature = "serde")]
 restate_types::flexbuffers_storage_encode_decode!(Envelope);
 
 impl Envelope {
@@ -48,16 +46,14 @@ impl Envelope {
 }
 
 /// Header is set on every message
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Header {
     pub source: Source,
     pub dest: Destination,
 }
 
 /// Identifies the source of a message
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Source {
     /// Message is sent from another partition processor
     Processor {
@@ -66,9 +62,9 @@ pub enum Source {
         /// v1.5 Marked as `Option`.
         /// v1.6 always set to `None`.
         /// Will be removed in v1.7.
-        #[cfg_attr(feature = "serde", serde(default))]
+        #[serde(default)]
         partition_id: Option<PartitionId>,
-        #[cfg_attr(feature = "serde", serde(default))]
+        #[serde(default)]
         partition_key: Option<PartitionKey>,
         /// The current epoch of the partition leader. Readers should observe this to decide which
         /// messages to accept. Readers should ignore messages coming from
@@ -79,7 +75,7 @@ pub enum Source {
         // still being set to Some(v) to maintain compatibility with v1.4.
         //
         // v1.6 field is removed. -- Kept here for reference only.
-        // #[cfg_attr(feature = "serde", serde(default))]
+        // #[serde(default)]
         // node_id: Option<PlainNodeId>,
 
         // From v1.1 this is always set, but maintained to support rollback to v1.0.
@@ -87,7 +83,7 @@ pub enum Source {
         // will be removed in v1.6. Commands that need the node-id of the sender should
         // include the node-id in the command payload itself (e.g. in the [`AnnounceLeader`])
         // v1.6 field is removed. -- Kept here for reference only.
-        // #[cfg_attr(feature = "serde", serde(default))]
+        // #[serde(default)]
         // generational_node_id: Option<GenerationalNodeId>,
     },
     /// Message is sent from an ingress node
@@ -99,7 +95,7 @@ pub enum Source {
         // Deprecated(v1.5): This field is set to Some(v) to maintain compatibility with v1.4.
         // but will be removed in v1.6.
         // v1.6 field is removed. -- Kept here for reference only.
-        // #[cfg_attr(feature = "serde", serde(default))]
+        // #[serde(default)]
         // node_id: Option<GenerationalNodeId>,
 
         // Last config version observed by sender. If this is a newer generation
@@ -108,7 +104,7 @@ pub enum Source {
         // Deprecated(v1.5): This field is set to Some(v) to maintain compatibility with v1.4.
         // but will be removed in v1.6.
         // v1.6 field is removed. -- Kept here for reference only.
-        // #[cfg_attr(feature = "serde", serde(default))]
+        // #[serde(default)]
         // nodes_config_version: Option<Version>,
     },
     /// Message is sent from some control plane component (controller, cli, etc.)
@@ -118,21 +114,26 @@ pub enum Source {
 }
 
 /// Identifies the intended destination of the message
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Destination {
     /// Message is sent to partition processor
     Processor {
         partition_key: PartitionKey,
-        #[cfg_attr(feature = "serde", serde(default))]
+        #[serde(default)]
         dedup: Option<DedupInformation>,
     },
 }
 
 /// State machine input commands
-#[derive(Debug, Clone, strum::EnumDiscriminants, strum::VariantNames)]
+#[derive(
+    Debug,
+    Clone,
+    strum::EnumDiscriminants,
+    strum::VariantNames,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[strum_discriminants(derive(strum::IntoStaticStr))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Command {
     /// Updates the `PARTITION_DURABILITY` FSM variable to the given value.
     /// See [`PartitionDurability`] for more details.

--- a/crates/wal-protocol/src/timer.rs
+++ b/crates/wal-protocol/src/timer.rs
@@ -16,8 +16,7 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TimerKeyValue {
     timer_key: TimerKey,
     value: Timer,


### PR DESCRIPTION
The serde feature was causing issues with serde_as proc-macro attribute not properly transforming field-level attributes when wrapped in cfg_attr. Since restate-types always has serde enabled and the serde feature was the default anyway, we simplify by removing the feature entirely.

Changes:
- Remove [features] section from wal-protocol/Cargo.toml
- Make serde and serde_with non-optional dependencies
- Remove unused bytestring and enum-map dependencies
- Remove all cfg_attr(feature = "serde", ...) wrappers from source files
- Fix serde_as attribute order (must come before derive)
- Update bifrost/Cargo.toml to not request serde feature