### PR TITLE
[Restate UI] Update to v0.1.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,8 +8364,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.33"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.33#82753f12a3bb89a8a8875e06c54dca041f6778b4"
+version = "0.1.35"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.35#faa19db9ba32a48ac1a882e471e087728abfcfcd"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.33", tag = "v0.1.33" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.35", tag = "v0.1.35" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.35
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.35/ui-v0.1.35.zip