### PR TITLE
Fix Prometheus metric naming to include proper unit suffixes

### DIFF
--- a/crates/node/src/network_server/prometheus_helpers.rs
+++ b/crates/node/src/network_server/prometheus_helpers.rs
@@ -62,7 +62,7 @@ pub fn format_rocksdb_stat_ticker_for_prometheus(
     formatting::write_metric_line::<&str, u64>(
         out,
         &sanitized_name,
-        None,
+        Some("total"),
         &LabelSet::from_key_and_global(&Key::from_static_name("non-existent"), labels),
         None,
         db.get_ticker_count(ticker),
@@ -98,7 +98,7 @@ pub fn format_rocksdb_property_for_prometheus(
         &LabelSet::from_key_and_global(&Key::from_static_name("non-existent"), labels),
         None,
         property_value,
-        None,
+        Some(unit.normalized_unit()),
     );
     let _ = writeln!(out);
 }
@@ -137,7 +137,7 @@ pub fn format_rocksdb_histogram_for_prometheus(
         &labels,
         Some(("quantile", "0.5")),
         unit.normalize_value(data.median()),
-        None,
+        Some(unit.normalized_unit()),
     );
     formatting::write_metric_line::<&str, f64>(
         out,
@@ -146,7 +146,7 @@ pub fn format_rocksdb_histogram_for_prometheus(
         &labels,
         Some(("quantile", "0.95")),
         unit.normalize_value(data.p95()),
-        None,
+        Some(unit.normalized_unit()),
     );
     formatting::write_metric_line::<&str, f64>(
         out,
@@ -155,7 +155,7 @@ pub fn format_rocksdb_histogram_for_prometheus(
         &labels,
         Some(("quantile", "0.99")),
         unit.normalize_value(data.p99()),
-        None,
+        Some(unit.normalized_unit()),
     );
     formatting::write_metric_line::<&str, f64>(
         out,
@@ -164,7 +164,7 @@ pub fn format_rocksdb_histogram_for_prometheus(
         &labels,
         Some(("quantile", "1.0")),
         unit.normalize_value(data.max()),
-        None,
+        Some(unit.normalized_unit()),
     );
     formatting::write_metric_line::<&str, f64>(
         out,
@@ -173,7 +173,7 @@ pub fn format_rocksdb_histogram_for_prometheus(
         &labels,
         None,
         unit.normalize_value(data.sum() as f64),
-        None,
+        Some(unit.normalized_unit()),
     );
     formatting::write_metric_line::<&str, u64>(
         out,
@@ -182,7 +182,7 @@ pub fn format_rocksdb_histogram_for_prometheus(
         &labels,
         None,
         data.count(),
-        None,
+        Some(unit.normalized_unit()),
     );
     let _ = writeln!(out);
 }

--- a/release-notes/unreleased/metrics-naming-fixes.md
+++ b/release-notes/unreleased/metrics-naming-fixes.md
@@ -1,0 +1,61 @@
+# Release Notes: Prometheus Metrics Naming Convention Fixes
+
+## Breaking Change
+
+### What Changed
+
+Several Prometheus metric names have been corrected to follow proper naming conventions:
+
+1. **RocksDB gauge metrics no longer have incorrect `_count` suffix**:
+   - `restate_rocksdb_actual_delayed_write_rate_count` → `restate_rocksdb_actual_delayed_write_rate`
+   - `restate_rocksdb_background_errors_count` → `restate_rocksdb_background_errors`
+   - `restate_rocksdb_compaction_pending_count` → `restate_rocksdb_compaction_pending`
+   - `restate_rocksdb_estimate_num_keys_count` → `restate_rocksdb_estimate_num_keys`
+   - `restate_rocksdb_is_write_stopped_count` → `restate_rocksdb_is_write_stopped`
+   - `restate_rocksdb_mem_table_flush_pending_count` → `restate_rocksdb_mem_table_flush_pending`
+   - `restate_rocksdb_min_log_number_to_keep_count` → `restate_rocksdb_min_log_number_to_keep`
+   - `restate_rocksdb_num_deletes_active_mem_table_count` → `restate_rocksdb_num_deletes_active_mem_table`
+   - `restate_rocksdb_num_deletes_imm_mem_tables_count` → `restate_rocksdb_num_deletes_imm_mem_tables`
+   - `restate_rocksdb_num_entries_active_mem_table_count` → `restate_rocksdb_num_entries_active_mem_table`
+   - `restate_rocksdb_num_entries_imm_mem_tables_count` → `restate_rocksdb_num_entries_imm_mem_tables`
+   - `restate_rocksdb_num_files_at_level{0-6}_count` → `restate_rocksdb_num_files_at_level{0-6}`
+   - `restate_rocksdb_num_immutable_mem_table_count` → `restate_rocksdb_num_immutable_mem_table`
+   - `restate_rocksdb_num_live_versions_count` → `restate_rocksdb_num_live_versions`
+   - `restate_rocksdb_num_running_compactions_count` → `restate_rocksdb_num_running_compactions`
+   - `restate_rocksdb_num_running_flushes_count` → `restate_rocksdb_num_running_flushes`
+
+2. **Fixed duplicate `_bytes` suffix**:
+   - `restate_rocksdb_estimate_pending_compaction_bytes_bytes` → `restate_rocksdb_estimate_pending_compaction_bytes`
+
+3. **Fixed duplicate `_count` suffix on summary metrics**:
+   - `restate_rocksdb_num_sst_read_per_level_count` → `restate_rocksdb_num_sst_read_per_level`
+   - `restate_rocksdb_read_num_merge_operands_count` → `restate_rocksdb_read_num_merge_operands`
+
+### Why This Matters
+
+The previous metric names violated Prometheus naming conventions:
+- The `_count` suffix should only be used for the count component of summary/histogram metrics, not for gauges that measure quantities
+- Having `_bytes_bytes` or `_count_count` suffixes was incorrect and confusing
+
+The new names follow [Prometheus best practices for metric naming](https://prometheus.io/docs/practices/naming/).
+
+### Impact on Users
+
+- **Prometheus/Grafana dashboards**: Any dashboards, alerts, or recording rules that reference the old metric names will need to be updated
+- **Monitoring integrations**: External monitoring systems querying these metrics will need updates
+
+### Migration Guidance
+
+Update any Prometheus queries, Grafana dashboards, or alerting rules to use the new metric names. For example:
+
+```promql
+# Old query
+sum(restate_rocksdb_background_errors_count)
+
+# New query
+sum(restate_rocksdb_background_errors)
+```
+
+If you have many dashboards to update, you can use find-and-replace to remove the `_count` suffix from RocksDB gauge metrics:
+- Replace `_count{` with `{` for affected metrics
+- Replace `_bytes_bytes` with `_bytes` for `estimate_pending_compaction_bytes`


### PR DESCRIPTION
Pass the unit parameter to write_metric_line() calls in the RocksDB metrics formatting functions. This ensures that:

- Gauge metrics get proper unit suffixes (_bytes, _seconds) instead of incorrect _count suffixes
- Histogram/summary metrics include unit suffixes on all components
- Duplicate suffixes like _bytes_bytes are avoided

This is a breaking change for users with existing dashboards or alerts that reference the old metric names.

See release-notes/unreleased/metrics-naming-fixes.md for migration guidance.