### PR TITLE
Rebase rust-rdkafka fork onto latest v0.39 rdkafka release

### DIFF
--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -36,11 +36,10 @@ metrics = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 parking_lot = { workspace = true }
-# Use https://github.com/restatedev/rust-rdkafka/tree/fix-build-script which is based on
-# https://github.com/fede1024/rust-rdkafka/pull/803. The PR bumps librdkafka to 2.12.1 and enables WITH_CURL for
-# librdkafka if the feature curl-static is enabled. Additionally, it cherry-picks https://github.com/confluentinc/librdkafka/pull/5182
-# which prevents pulling in curl if it is not activated. The additional fixes in fix-build-script fix the musl build.
-rdkafka = { version = "0.38", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["libz-static", "cmake-build", "ssl-vendored"] }
+# Use https://github.com/restatedev/rust-rdkafka/tree/v0.39-with-curl which is based on
+# https://github.com/fede1024/rust-rdkafka/releases/tag/v0.39.0 and cherry-picks https://github.com/confluentinc/librdkafka/pull/5182
+# to prevent pulling in curl if it is not activated.
+rdkafka = { version = "0.39", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "5374d5a96d622f4223cae0e00740a6be23482c3a", features = ["libz-static", "cmake-build", "ssl-vendored"] }
 schemars = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }


### PR DESCRIPTION
This commit uses the latest rust-rdkafka fork which is based on v0.39 and only cherry picks https://github.com/confluentinc/librdkafka/pull/5182 on top of the used librdkafka version.