### PR TITLE
Handle decoding errors for RPC

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/network.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/network.rs
@@ -92,7 +92,9 @@ impl<T: TransportConnect> SequencerDataRpcHandler<T> {
     )]
     async fn handle_append(&mut self, incoming: Incoming<Rpc<Append>>) {
         let peer_logs_version = incoming.metadata_version().get(MetadataKind::Logs);
-        let (reciprocal, append) = incoming.split();
+        let Some((reciprocal, append)) = incoming.split() else {
+            return;
+        };
 
         let loglet = match get_loglet(&self.provider, peer_logs_version, &append.header).await {
             Ok(loglet) => loglet,
@@ -149,7 +151,9 @@ impl<T: TransportConnect> SequencerInfoRpcHandler<T> {
     #[instrument(level = "debug", skip_all)]
     async fn handle_get_sequencer_state(&mut self, incoming: Incoming<Rpc<GetSequencerState>>) {
         let peer_logs_version = incoming.metadata_version().get(MetadataKind::Logs);
-        let (reciprocal, msg) = incoming.split();
+        let Some((reciprocal, msg)) = incoming.split() else {
+            return;
+        };
 
         let loglet = match get_loglet(&self.provider, peer_logs_version, &msg.header).await {
             Ok(loglet) => loglet,

--- a/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/remote_sequencer.rs
@@ -540,7 +540,9 @@ mod test {
         async fn on_rpc(&mut self, message: Incoming<RawSvcRpc<Self::Service>>) {
             if message.msg_type() == Append::TYPE {
                 let msg = message.into_typed::<Append>();
-                let (reciprocal, msg) = msg.split();
+                let Some((reciprocal, msg)) = msg.split() else {
+                    return;
+                };
                 let last_offset = self
                     .offset
                     .fetch_add(msg.payloads.len() as u32, Ordering::Relaxed);

--- a/crates/core/protobuf/restate/network.proto
+++ b/crates/core/protobuf/restate/network.proto
@@ -197,6 +197,9 @@ message WatchUpdate {
     // Message type was unrecognized by the receiver
     // Request has not been processed
     MESSAGE_UNRECOGNIZED = 7;
+    // Message type was recognized but payload was invalid or failed to decode
+    // Request has not been processed 
+    INVALID_PAYLOAD = 8;
   }
 
   enum End {
@@ -256,6 +259,9 @@ message RpcReply {
     // Message type was unrecognized by the receiver
     // Request has not been processed
     MESSAGE_UNRECOGNIZED = 7;
+    // Message type was recognized but payload was invalid or failed to decode
+    // Request has not been processed 
+    INVALID_PAYLOAD = 8;
   }
 
   // correlates the reply to the original request

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -213,7 +213,10 @@ impl MetadataManager {
     fn handle_network_message(&mut self, msg: ServiceMessage<MetadataManagerService>) {
         match msg {
             ServiceMessage::Rpc(msg) if msg.msg_type() == GetMetadataRequest::TYPE => {
-                let (reciprocal, request) = msg.into_typed::<GetMetadataRequest>().split();
+                let Some((reciprocal, request)) = msg.into_typed::<GetMetadataRequest>().split()
+                else {
+                    return;
+                };
                 self.send_metadata(reciprocal, request.metadata_kind, request.min_version);
             }
             msg => {

--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -68,6 +68,9 @@ pub enum Verdict {
     /// returns gives the caller the guarantee that it's safe to retry the request
     /// without causing any duplication.
     LoadShedding,
+    /// Message type was recognized but payload failed
+    /// to decode.
+    InvalidPayload,
 }
 
 impl From<Verdict> for rpc_reply::Status {
@@ -76,6 +79,7 @@ impl From<Verdict> for rpc_reply::Status {
             Verdict::MessageUnrecognized => Self::MessageUnrecognized,
             Verdict::SortCodeNotFound => Self::SortCodeNotFound,
             Verdict::LoadShedding => Self::LoadShedding,
+            Verdict::InvalidPayload => Self::InvalidPayload,
         }
     }
 }
@@ -86,6 +90,7 @@ impl From<Verdict> for watch_update::Start {
             Verdict::MessageUnrecognized => Self::MessageUnrecognized,
             Verdict::SortCodeNotFound => Self::SortCodeNotFound,
             Verdict::LoadShedding => Self::LoadShedding,
+            Verdict::InvalidPayload => Self::InvalidPayload,
         }
     }
 }

--- a/crates/core/src/network/incoming.rs
+++ b/crates/core/src/network/incoming.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 use bytes::Bytes;
 use opentelemetry::Context;
 use tokio::sync::{oneshot, watch};
-use tracing::Span;
+use tracing::{Span, error};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use restate_types::GenerationalNodeId;
@@ -521,20 +521,29 @@ impl<M: RpcRequest + WireDecode> Incoming<Rpc<M>> {
     /// Consumes the message and returns a tuple of a reciprocal (reply port) and the decoded body
     /// of the message.
     ///
-    /// **Panics** if message decoding failed
-    pub fn split(self) -> (Reciprocal<Oneshot<M::Response>>, M) {
-        let body = M::decode(self.inner.payload, self.protocol_version);
-        (
-            Reciprocal {
-                protocol_version: self.protocol_version,
-                reply_port: Oneshot {
-                    inner: self.inner.reply_port,
-                    _phantom: PhantomData,
-                },
+    /// Returns None if message decoding fails. And returns an InvalidPayload error back
+    /// to the caller.
+    pub fn split(self) -> Option<(Reciprocal<Oneshot<M::Response>>, M)> {
+        let reciprocal = Reciprocal {
+            protocol_version: self.protocol_version,
+            reply_port: Oneshot {
+                inner: self.inner.reply_port,
                 _phantom: PhantomData,
             },
-            body,
-        )
+            _phantom: PhantomData,
+        };
+
+        match M::try_decode(self.inner.payload, self.protocol_version) {
+            Ok(body) => Some((reciprocal, body)),
+            Err(err) => {
+                error!(
+                    "Failed to decode RPC message (this indicates a Restate server mismatch): {}",
+                    err.into()
+                );
+                reciprocal.fail(Verdict::InvalidPayload);
+                None
+            }
+        }
     }
 
     /// Consumes the message and returns a tuple of a reciprocal (reply port) and drops the body

--- a/crates/core/src/network/types.rs
+++ b/crates/core/src/network/types.rs
@@ -201,6 +201,8 @@ pub enum RpcReplyError {
     ServiceStopped,
     #[error("the requested rpc service didn't recognize this message")]
     MessageUnrecognized,
+    #[error("the requested rpc service couldn't decode this message")]
+    InvalidPayload,
     #[error("peer dropped the request due to back-pressure")]
     LoadShedding,
     #[error(
@@ -220,6 +222,7 @@ impl RpcReplyError {
             | Self::LoadShedding
             | Self::ServiceStopped
             | Self::MessageUnrecognized
+            | Self::InvalidPayload
             | Self::ServiceNotReady
             | Self::SortCodeNotFound => false,
         }
@@ -239,6 +242,7 @@ impl From<i32> for RpcReplyError {
             Ok(rpc_reply::Status::ServiceStopped) => Self::ServiceStopped,
             Ok(rpc_reply::Status::ServiceNotReady) => Self::ServiceNotReady,
             Ok(rpc_reply::Status::MessageUnrecognized) => Self::MessageUnrecognized,
+            Ok(rpc_reply::Status::InvalidPayload) => Self::InvalidPayload,
             Err(err) => err,
         }
     }

--- a/crates/core/src/worker_api/partition_processor_rpc_client.rs
+++ b/crates/core/src/worker_api/partition_processor_rpc_client.rs
@@ -135,6 +135,7 @@ impl From<RpcReplyError> for RpcErrorKind {
             // todo: perhaps this should be an explicit error
             e @ RpcReplyError::ConnectionClosed(_) => Self::Internal(e.to_string()),
             e @ RpcReplyError::MessageUnrecognized => Self::Internal(e.to_string()),
+            e @ RpcReplyError::InvalidPayload => Self::Internal(e.to_string()),
             RpcReplyError::ServiceNotFound | RpcReplyError::SortCodeNotFound => Self::NotLeader,
             RpcReplyError::LoadShedding => Self::Busy,
             RpcReplyError::ServiceNotReady => Self::Busy,

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -365,7 +365,7 @@ mod test {
             .unwrap();
 
         let msg = must_next(&mut incoming).await;
-        let (rx, body) = msg.split();
+        let (rx, body) = msg.split().expect("split should succeed");
         assert_that!(
             body.records,
             all!(
@@ -392,14 +392,14 @@ mod test {
             .unwrap();
 
         let msg = must_next(&mut incoming).await;
-        let (rx, _) = msg.split();
+        let (rx, _) = msg.split().expect("split should succeed");
         rx.send(ResponseStatus::NotLeader { of: 0.into() }.into());
 
         assert!((&mut commit).now_or_never().is_none());
 
         // ingestion will retry automatically so we must receive another message
         let msg = must_next(&mut incoming).await;
-        let (rx, body) = msg.split();
+        let (rx, body) = msg.split().expect("split should succeed");
         assert_that!(
             body.records,
             all!(

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -188,7 +188,9 @@ impl<S: LogStore> LogletWorker<S> {
                 msg.follow_from_sender_for(&span);
                 let peer = msg.peer();
 
-                let (reciprocal, msg) = msg.split();
+                let Some((reciprocal, msg)) = msg.split() else {
+                    return;
+                };
                 let first_offset = msg.first_offset;
                 // this message might be telling us about a higher `known_global_tail`
                 self.loglet_state
@@ -270,7 +272,9 @@ impl<S: LogStore> LogletWorker<S> {
             ServiceMessage::Rpc(msg) if msg.msg_type() == GetLogletInfo::TYPE => {
                 let msg = msg.into_typed::<GetLogletInfo>();
                 let peer = msg.peer();
-                let (reciprocal, msg) = msg.split();
+                let Some((reciprocal, msg)) = msg.split() else {
+                    return;
+                };
                 self.loglet_state
                     .notify_known_global_tail(msg.header.known_global_tail);
                 // drop response if connection is lost/congested
@@ -288,7 +292,9 @@ impl<S: LogStore> LogletWorker<S> {
             // SEAL
             ServiceMessage::Rpc(msg) if msg.msg_type() == Seal::TYPE => {
                 let message = msg.into_typed::<Seal>();
-                let (reciprocal, msg) = message.split();
+                let Some((reciprocal, msg)) = message.split() else {
+                    return;
+                };
                 // this message might be telling us about a higher `known_global_tail`
                 self.loglet_state
                     .notify_known_global_tail(msg.header.known_global_tail);
@@ -413,7 +419,9 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_wait_for_tail(&mut self, msg: Incoming<Rpc<WaitForTail>>) {
-        let (reciprocal, msg) = msg.split();
+        let Some((reciprocal, msg)) = msg.split() else {
+            return;
+        };
         self.loglet_state
             .notify_known_global_tail(msg.header.known_global_tail);
 
@@ -458,7 +466,9 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_get_records(&mut self, msg: Incoming<Rpc<GetRecords>>) {
-        let (reciprocal, msg) = msg.split();
+        let Some((reciprocal, msg)) = msg.split() else {
+            return;
+        };
         self.loglet_state
             .notify_known_global_tail(msg.header.known_global_tail);
 
@@ -491,7 +501,9 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_get_digest(&mut self, msg: Incoming<Rpc<GetDigest>>) {
-        let (reciprocal, msg) = msg.split();
+        let Some((reciprocal, msg)) = msg.split() else {
+            return;
+        };
         self.loglet_state
             .notify_known_global_tail(msg.header.known_global_tail);
 
@@ -520,7 +532,9 @@ impl<S: LogStore> LogletWorker<S> {
     }
 
     fn process_trim(&mut self, msg: Incoming<Rpc<Trim>>) {
-        let (reciprocal, mut msg) = msg.split();
+        let Some((reciprocal, mut msg)) = msg.split() else {
+            return;
+        };
         self.loglet_state
             .notify_known_global_tail(msg.header.known_global_tail);
         // When trimming, we eagerly update the in-memory view of the trim-point _before_ we

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -741,7 +741,9 @@ where
             ServiceMessage::Rpc(msg) if msg.msg_type() == PartitionProcessorRpcRequest::TYPE => {
                 let msg = msg.into_typed::<PartitionProcessorRpcRequest>();
                 // note: split() decodes the payload
-                let (response_tx, body) = msg.split();
+                let Some((response_tx, body)) = msg.split() else {
+                    return;
+                };
                 self.on_pp_rpc_request(response_tx, body, partition_store, schemas)
                     .await;
             }
@@ -801,7 +803,9 @@ where
         partition_store: &mut PartitionStore,
         msg: Incoming<Rpc<DedupSequenceNrQueryRequest>>,
     ) {
-        let (tx, body) = msg.split();
+        let Some((tx, body)) = msg.split() else {
+            return;
+        };
         let producer_id = match body.producer_id {
             ingest::ProducerId::Unknown => {
                 tx.send(DedupSequenceNrQueryResponse {
@@ -846,7 +850,9 @@ where
     }
 
     async fn on_pp_ingest_request(&mut self, msg: Incoming<Rpc<ReceivedIngestRequest>>) {
-        let (reciprocal, request) = msg.split();
+        let Some((reciprocal, request)) = msg.split() else {
+            return;
+        };
         histogram!(
             PARTITION_INGESTION_REQUEST_LEN, PARTITION_LABEL => self.partition_id_str.clone()
         )

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -896,7 +896,9 @@ mod ingestion_client_tests {
         'out: while let Some(ServiceMessage::Rpc(incoming)) = stream.next().await {
             assert_eq!(incoming.msg_type(), ReceivedIngestRequest::TYPE);
             let incoming = incoming.into_typed::<ReceivedIngestRequest>();
-            let (r, body) = incoming.split();
+            let Some((r, body)) = incoming.split() else {
+                continue;
+            };
             r.send(ResponseStatus::Ack.into());
             for mut record in body.records {
                 let envelope = StorageCodec::decode::<Envelope, _>(&mut record.record)

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1228,7 +1228,9 @@ where
 
     fn handle_create_snapshot_request(&mut self, request: Incoming<Rpc<CreateSnapshotRequest>>) {
         let (sender, rx) = oneshot::channel();
-        let (reciprocal, body) = request.split();
+        let Some((reciprocal, body)) = request.split() else {
+            return;
+        };
         self.on_create_snapshot(body.partition_id, body.min_target_lsn, sender);
         tokio::spawn(async move {
             let Ok(result) = rx.await else {


### PR DESCRIPTION
Handle decoding errors for RPC

Summary:
This makes sure doing an rpc.split() will not panic if the message docoding fails
which can happen in a mixed cluster and a serde RPC message.
