### PR TITLE
Change default RocksDB memory budget to 2GiB with 85% for memtables

### DIFF
--- a/charts/restate-helm/README.md
+++ b/charts/restate-helm/README.md
@@ -22,8 +22,8 @@ resources:
     memory: 8Gi
 ```
 
-The environment variable `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` should be set such that it is roughly 75% of the memory available.
-In the default helm values, this variable is set to `6Gi`.
+The environment variable `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` should be set under 50% of the memory available.
+In the default helm values, this variable is set to `3Gi`.
 Under load, Restate will eventually use the entire RocksDB memory size offered to it.
 
 # Running a replicated cluster

--- a/charts/restate-helm/values.yaml
+++ b/charts/restate-helm/values.yaml
@@ -40,9 +40,9 @@ env:
   - name: RESTATE_CLUSTER_NAME
     value: helm-single-node
   - name: RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE
-    # This value should be around 75% of the container memory limit, which defaults to 8Gi below.
+    # This value should less than 50% of the container memory limit, which defaults to 8Gi below.
     # If provisioning restate with a different memory limit, make sure to update this value
-    value: 6Gi
+    value: 3Gi
 
 service:
   type: ClusterIP

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -475,21 +475,15 @@ fn check_memory_limit(opts: &CommonOptions) {
     if let Some(process_memory_size) = opts.process_total_memory_size() {
         let memory_ratio =
             opts.rocksdb_total_memory_size.get() as f64 / process_memory_size.get() as f64;
-        if memory_ratio < 0.5 {
-            warn!(
-                "'rocksdb-total-memory-size' parameter is set to {}, less than half the process memory limit of {}. Roughly 75% of process memory should be given to RocksDB",
-                ByteCount::from(opts.rocksdb_total_memory_size),
-                ByteCount::from(process_memory_size),
-            )
-        } else if memory_ratio > 1.0 {
+        if memory_ratio > 1.0 {
             error!(
-                "'rocksdb-total-memory-size' parameter is set to {}, more than the process memory limit of {}. This guarantees an OOM under load; roughly 75% of process memory should be given to RocksDB",
+                "'rocksdb-total-memory-size' parameter is set to {}, more than the process memory limit of {}. This guarantees an OOM under load; keep it under 50% of process memory",
                 ByteCount::from(opts.rocksdb_total_memory_size),
                 ByteCount::from(process_memory_size),
             )
         } else if memory_ratio > 0.9 {
             error!(
-                "'rocksdb-total-memory-size' parameter is set to {}, more than 90% of the process memory limit of {}. This risks an OOM under load; roughly 75% of process memory should be given to RocksDB",
+                "'rocksdb-total-memory-size' parameter is set to {}, more than 90% of the process memory limit of {}. This risks an OOM under load; keep it under 50% of process memory",
                 ByteCount::from(opts.rocksdb_total_memory_size),
                 ByteCount::from(process_memory_size),
             )

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -701,8 +701,8 @@ impl Default for CommonOptions {
             storage_high_priority_bg_threads: None,
             storage_low_priority_bg_threads: None,
             process_total_memory_size: None,
-            rocksdb_total_memory_size: NonZeroUsize::new(6 * 1024 * 1024 * 1024).unwrap(), // 6GiB
-            rocksdb_total_memtables_ratio: 0.5, // (50% of rocksdb-total-memory-size)
+            rocksdb_total_memory_size: NonZeroUsize::new(2 * 1024 * 1024 * 1024).unwrap(), // 2GiB
+            rocksdb_total_memtables_ratio: 0.85, // (85% of rocksdb-total-memory-size)
             rocksdb_bg_threads: None,
             rocksdb_high_priority_bg_threads: NonZeroU32::new(2).unwrap(),
             rocksdb_perf_level: PerfStatsLevel::EnableCount,

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -99,7 +99,7 @@ impl LogServerOptions {
         self.rocksdb.apply_common(&common.rocksdb);
         if self.rocksdb_memory_budget.is_none() {
             self.rocksdb_memory_budget = Some(
-                // 1MB minimum
+                // 1MiB minimum
                 NonZeroUsize::new(
                     (common.rocksdb_safe_total_memtables_size() as f64
                         * self.rocksdb_memory_ratio as f64)
@@ -141,7 +141,7 @@ impl LogServerOptions {
         self.rocksdb_memory_budget
             .unwrap_or_else(|| {
                 warn!("LogServer's rocksdb_memory_budget is not set, defaulting to 1MB");
-                // 1MB minimum
+                // 1MiB minimum
                 NonZeroUsize::new(1024 * 1024).unwrap()
             })
             .get()

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -77,7 +77,7 @@ impl MetadataServerOptions {
 
         if self.rocksdb_memory_budget.is_none() {
             self.rocksdb_memory_budget = Some(
-                // 1MB minimum
+                // 1MiB minimum
                 NonZeroUsize::new(
                     (common.rocksdb_safe_total_memtables_size() as f64
                         * self.rocksdb_memory_ratio as f64)
@@ -93,7 +93,7 @@ impl MetadataServerOptions {
         self.rocksdb_memory_budget
             .unwrap_or_else(|| {
                 warn!("metadata-server rocksdb_memory_budget is not set, defaulting to 1MB");
-                // 1MB minimum
+                // 1MiB minimum
                 NonZeroUsize::new(1024 * 1024).unwrap()
             })
             .get()

--- a/release-notes/unreleased/3927-helm-rocksdb-memory-default.md
+++ b/release-notes/unreleased/3927-helm-rocksdb-memory-default.md
@@ -12,7 +12,7 @@ The Restate Helm chart default resource limits have been significantly increased
 | Memory request | 1Gi | **8Gi** |
 | CPU limit | 1 | **6** |
 | CPU request | 500m | **4** |
-| `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` | (not set) | **6Gi** |
+| `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` | (not set) | **3Gi** |
 
 ### Why This Matters
 
@@ -21,7 +21,7 @@ The Restate Helm chart default resource limits have been significantly increased
 - Clusters with limited available resources
 - Existing deployments that were running with the previous lower defaults
 
-**Performance improvement**: The new defaults are sized for production workloads and ensure RocksDB has adequate memory (75% of container limit) for optimal performance.
+**Performance improvement**: The new defaults are sized for production workloads and ensure RocksDB has adequate memory (<50% of container limit) for optimal performance.
 
 ### Impact on Users
 
@@ -36,7 +36,7 @@ The Restate Helm chart default resource limits have been significantly increased
 
 **Custom configurations**:
 - If you already specified custom `resources` in your values file, your settings will continue to be used
-- If you provision Restate with a different container memory limit, update `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` to ~75% of that limit
+- If you provision Restate with a different container memory limit, update `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` to be within ~20-50% of that limit
 
 ### Migration Guidance
 
@@ -51,7 +51,7 @@ If you need to maintain the previous resource limits (e.g., for development clus
 ```yaml
 env:
   - name: RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE
-    value: "2Gi"  # ~75% of 3Gi memory limit
+    value: "1Gi"  # ~<50% of 3Gi memory limit
 
 resources:
   limits:

--- a/release-notes/unreleased/rocksdb-memory-defaults.md
+++ b/release-notes/unreleased/rocksdb-memory-defaults.md
@@ -1,0 +1,35 @@
+# Release Notes: RocksDB memory defaults changed
+
+## Behavioral Change
+
+### What Changed
+The default RocksDB memory configuration has been changed:
+- **`rocksdb-total-memory-size`**: Changed from **6GiB** to **2GiB**
+- **`rocksdb-total-memtables-ratio`**: Changed from **0.5 (50%)** to **0.85 (85%)**
+
+This means the default block cache size is now approximately 300MiB (15% of 2GiB) compared to the previous 3GiB (50% of 6GiB).
+
+### Why This Matters
+These changes address two goals:
+
+1. **Reduced memory confusion**: The previous 6GiB default caused Restate's memory footprint to appear to grow continuously as the block cache filled up, leading to user confusion about memory "ballooning." The lower default provides more predictable memory behavior out of the box.
+
+2. **Performance-optimized allocation**: Memtables have a much larger impact on write performance than block cache does on read performance in typical workloads. By allocating 85% of RocksDB memory to memtables, the new defaults prioritize the more performance-critical component.
+
+Thanks to the variety of performance improvements in v1.6, Restate now delivers better performance with less memory than before.
+
+### Impact on Users
+- **New deployments**: Will use the new memory-efficient defaults automatically
+- **Existing deployments**: Will adopt new defaults on upgrade, resulting in lower memory usage
+- **Custom configurations**: Any explicitly configured `rocksdb-total-memory-size` or `rocksdb-total-memtables-ratio` values will continue to work as before
+
+### Migration Guidance
+The new defaults should work well for most workloads. However, if you have a read-heavy workload that benefits from a larger block cache, or if you were relying on the previous memory allocation, you can restore the old behavior:
+
+```toml
+[common]
+rocksdb-total-memory-size = "6GiB"
+rocksdb-total-memtables-ratio = 0.5
+```
+
+For systems with more available memory that want to maximize performance, consider tuning these values based on your specific workload characteristics and available RAM.


### PR DESCRIPTION

Reduce the default rocksdb-total-memory-size from 6GiB to 2GiB and increase
rocksdb-total-memtables-ratio from 0.5 to 0.85. This reduces memory confusion
from block cache growth while maintaining excellent performance, as memtables
have a larger impact on performance than block cache in typical workloads.

Thanks to the performance improvements in v1.6, we can achieve better
performance with less memory.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4264).
* #4268
* __->__ #4264