### PR TITLE
Fix `restate dp register` help message

### DIFF
--- a/cli/src/commands/deployments/register.rs
+++ b/cli/src/commands/deployments/register.rs
@@ -383,12 +383,10 @@ async fn register_v3_admin_api(
             ❯ To overwrite this deployment during development, use:
                 restate deployment register {} --force
 
-            ❯ To modify connection parameters, use:
-                restate deployment edit {}"
+            ❯ To modify connection parameters, use the UI"
             },
             Styled(Style::Info, &dry_run_result.id),
             discover_opts.deployment.cli_parameter_display(),
-            dry_run_result.id
         );
         return Ok(());
     }


### PR DESCRIPTION
Fix `restate dp register` help message

Summary:
Seems there is no `edit` command.

Related to #4265
