### PR TITLE
Maintain rest api V2 compatibility support

### DIFF
--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -278,7 +278,7 @@ where
 /// Updates an existing deployment configuration, such as the endpoint address or invocation headers.
 /// By default, service schemas are not re-discovered. Set `overwrite: true` to trigger re-discovery.
 #[utoipa::path(
-    patch,
+    method(put, patch),
     path = "/deployments/{deployment}",
     operation_id = "update_deployment",
     tag = "deployment",


### PR DESCRIPTION
Maintain rest api V2 compatibility support

Summary:
In RestAPI V2 update_deployment uses `PUT`, not `PATCH`.

https://github.com/restatedev/restate/blob/release-1.5/crates/admin/src/rest_api/mod.rs#L60
