### PR TITLE
Pin dev-tools in release binary build workflow

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -72,8 +72,8 @@ host = "aarch64-apple-darwin"
 
 [dist.github-custom-runners.aarch64-unknown-linux-musl]
 runner = "warp-ubuntu-latest-arm64-32x"
-container = { image = "ghcr.io/restatedev/dev-tools", host = "aarch64-unknown-linux-musl" }
+container = { image = "ghcr.io/restatedev/dev-tools:1.16.1", host = "aarch64-unknown-linux-musl" }
 
 [dist.github-custom-runners.x86_64-unknown-linux-musl ]
 runner = "warp-ubuntu-latest-x64-32x"
-container = { image = "ghcr.io/restatedev/dev-tools", host = "x86_64-unknown-linux-musl" }
+container = { image = "ghcr.io/restatedev/dev-tools:1.16.1", host = "x86_64-unknown-linux-musl" }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@
 
 ARG UPLOAD_DEBUGINFO=false
 
+# NB this version is also pinned in dist-workspace.toml for release binary builds
 FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.16.1 AS planner
 COPY . .
 RUN just chef-prepare


### PR DESCRIPTION
Currently the release workflow uses latest implicitly, its better if we give a particular tag, to match the dockerfile