### PR TITLE
[forward compatibility] Add binary_version to nodes configuration

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/test_util.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/test_util.rs
@@ -11,7 +11,7 @@
 use restate_types::nodes_config::{
     LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState,
 };
-use restate_types::{GenerationalNodeId, PlainNodeId};
+use restate_types::{GenerationalNodeId, PlainNodeId, RestateVersion};
 
 pub fn generate_logserver_node(
     id: impl Into<PlainNodeId>,
@@ -25,6 +25,7 @@ pub fn generate_logserver_node(
         .address(format!("unix:/tmp/my_socket-{id}").parse().unwrap())
         .roles(Role::LogServer.into())
         .log_server_config(LogServerConfig { storage_state })
+        .binary_version(RestateVersion::current())
         .build()
 }
 

--- a/crates/core/src/metadata/manager.rs
+++ b/crates/core/src/metadata/manager.rs
@@ -340,7 +340,7 @@ mod tests {
     use restate_test_util::assert_eq;
     use restate_types::net::address::AdvertisedAddress;
     use restate_types::nodes_config::{NodeConfig, Role};
-    use restate_types::{GenerationalNodeId, Version};
+    use restate_types::{GenerationalNodeId, RestateVersion, Version};
 
     use crate::metadata::spawn_metadata_manager;
     use crate::{TaskCenter, TaskCenterBuilder};
@@ -509,6 +509,7 @@ mod tests {
             .current_generation(node_id)
             .address(address)
             .roles(roles)
+            .binary_version(RestateVersion::current())
             .build();
         nodes_config.upsert_node(my_node);
         nodes_config

--- a/crates/core/src/network/connection_manager.rs
+++ b/crates/core/src/network/connection_manager.rs
@@ -647,6 +647,7 @@ mod tests {
     use tokio_stream::wrappers::ReceiverStream;
 
     use restate_test_util::assert_eq;
+    use restate_types::RestateVersion;
     use restate_types::Version;
     use restate_types::config::NetworkingOptions;
     use restate_types::net::address::AdvertisedAddress;
@@ -841,6 +842,7 @@ mod tests {
             .current_generation(node_id)
             .address(AdvertisedAddress::default())
             .roles(Role::Worker.into())
+            .binary_version(RestateVersion::current())
             .build();
         nodes_config.upsert_node(node_config);
 

--- a/crates/core/src/test_env.rs
+++ b/crates/core/src/test_env.rs
@@ -24,7 +24,7 @@ use restate_types::net::address::AdvertisedAddress;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
 use restate_types::partition_table::PartitionTable;
-use restate_types::{GenerationalNodeId, Version};
+use restate_types::{GenerationalNodeId, RestateVersion, Version};
 
 use crate::network::protobuf::network::Message;
 use crate::network::{
@@ -245,6 +245,7 @@ pub fn create_mock_nodes_config(node_id: u32, generation: u32) -> NodesConfigura
         .current_generation(node_id)
         .address(address)
         .roles(roles)
+        .binary_version(RestateVersion::current())
         .build();
     nodes_config.upsert_node(my_node);
     nodes_config

--- a/crates/metadata-server/src/lib.rs
+++ b/crates/metadata-server/src/lib.rs
@@ -22,7 +22,6 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use prost::Message;
 use raft_proto::eraftpb::Snapshot;
-use restate_types::net::listener::AddressBook;
 use tokio::sync::{mpsc, oneshot, watch};
 use tonic::Status;
 use ulid::Ulid;
@@ -39,13 +38,14 @@ use restate_types::errors::{ConversionError, GenericError, MaybeRetryableError};
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
 use restate_types::metadata::{Precondition, VersionedValue};
+use restate_types::net::listener::AddressBook;
 use restate_types::nodes_config::{
     ClusterFingerprint, MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
     Role,
 };
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
-use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+use restate_types::{GenerationalNodeId, PlainNodeId, RestateVersion, Version};
 
 use crate::raft::RaftMetadataServer;
 
@@ -660,6 +660,7 @@ fn nodes_configuration_for_metadata_cluster_seed(
             .address(advertised_address)
             .roles(configuration.common.roles)
             .metadata_server_config(metadata_server_config)
+            .binary_version(RestateVersion::current())
             .build();
 
         nodes_configuration.upsert_node(node_config);

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -11,7 +11,6 @@
 use crate::cluster_marker::mark_cluster_as_provisioned;
 use restate_core::{MetadataWriter, ShutdownError, TaskCenter, cancellation_token};
 use restate_metadata_store::{MetadataStoreClient, ReadWriteError};
-use restate_types::PlainNodeId;
 use restate_types::config::Configuration;
 use restate_types::errors::MaybeRetryableError;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
@@ -19,6 +18,7 @@ use restate_types::nodes_config::{
     MetadataServerConfig, MetadataServerState, NodeConfig, NodesConfiguration,
 };
 use restate_types::retries::RetryPolicy;
+use restate_types::{PlainNodeId, RestateVersion};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{Level, debug, enabled, info, trace, warn};
@@ -272,6 +272,7 @@ impl<'a> NodeInit<'a> {
                         node_config.roles = common.roles;
                         node_config.address = my_advertised_address.clone();
                         node_config.current_generation.bump_generation();
+                        node_config.binary_version = Some(RestateVersion::current());
 
                         node_config
                     } else {
@@ -304,6 +305,7 @@ impl<'a> NodeInit<'a> {
                             .metadata_server_config(MetadataServerConfig {
                                 metadata_server_state,
                             })
+                            .binary_version(RestateVersion::current())
                             .build()
                     };
 
@@ -329,7 +331,7 @@ mod tests {
     use restate_types::config::{Configuration, set_current_config};
     use restate_types::net::listener::AddressBook;
     use restate_types::nodes_config::{ClusterFingerprint, NodeConfig, NodesConfiguration};
-    use restate_types::{GenerationalNodeId, PlainNodeId, Version};
+    use restate_types::{GenerationalNodeId, PlainNodeId, RestateVersion, Version};
 
     use crate::init::NodeInit;
 
@@ -356,6 +358,7 @@ mod tests {
                     .advertised_address(&address_book),
             )
             .roles(EnumSet::default())
+            .binary_version(RestateVersion::current())
             .build();
         let mut nodes_configuration =
             NodesConfiguration::new(Version::MIN, cluster_name, ClusterFingerprint::generate());

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -54,7 +54,7 @@ use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::{
     AdminStatus, IngressStatus, LogServerStatus, NodeRpcStatus, WorkerStatus,
 };
-use restate_types::{GenerationalNodeId, Version, Versioned};
+use restate_types::{GenerationalNodeId, RestateVersion, Version, Versioned};
 
 use self::failure_detector::FailureDetector;
 use crate::cluster_marker::ClusterValidationError;
@@ -693,6 +693,7 @@ fn create_initial_nodes_configuration(common_opts: &CommonOptions) -> NodesConfi
         .location(common_opts.location().clone())
         .address(my_advertised_address)
         .roles(common_opts.roles)
+        .binary_version(RestateVersion::current())
         .build();
     initial_nodes_configuration.upsert_node(node_config);
     initial_nodes_configuration

--- a/crates/types/src/replication/balanced_spread_selector.rs
+++ b/crates/types/src/replication/balanced_spread_selector.rs
@@ -570,7 +570,7 @@ mod tests {
     use crate::nodes_config::{NodeConfig, NodesConfiguration, Role, WorkerConfig, WorkerState};
     use crate::partitions::worker_candidate_filter;
     use crate::replication::{NodeSet, ReplicationProperty};
-    use crate::{GenerationalNodeId, PlainNodeId};
+    use crate::{GenerationalNodeId, PlainNodeId, RestateVersion};
 
     fn generate_node(
         id: impl Into<PlainNodeId>,
@@ -586,6 +586,7 @@ mod tests {
             .address(format!("unix:/tmp/my_socket-{id}").parse().unwrap())
             .roles(role.into())
             .worker_config(WorkerConfig { worker_state })
+            .binary_version(RestateVersion::current())
             .build()
     }
 

--- a/crates/types/src/replication/checker.rs
+++ b/crates/types/src/replication/checker.rs
@@ -784,7 +784,7 @@ mod tests {
     use crate::nodes_config::{
         LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState,
     };
-    use crate::{GenerationalNodeId, PlainNodeId};
+    use crate::{GenerationalNodeId, PlainNodeId, RestateVersion};
 
     fn generate_logserver_node(
         id: impl Into<PlainNodeId>,
@@ -799,6 +799,7 @@ mod tests {
             .address(format!("unix:/tmp/my_socket-{id}").parse().unwrap())
             .roles(Role::LogServer.into())
             .log_server_config(LogServerConfig { storage_state })
+            .binary_version(RestateVersion::current())
             .build()
     }
 

--- a/crates/types/src/replication/nodeset_selector.rs
+++ b/crates/types/src/replication/nodeset_selector.rs
@@ -595,7 +595,7 @@ pub mod tests {
         LogServerConfig, NodeConfig, NodesConfiguration, Role, StorageState,
     };
     use crate::replication::{NodeSet, ReplicationProperty};
-    use crate::{GenerationalNodeId, PlainNodeId};
+    use crate::{GenerationalNodeId, PlainNodeId, RestateVersion};
 
     use super::*;
 
@@ -631,6 +631,7 @@ pub mod tests {
             .address(format!("unix:/tmp/my_socket-{id}").parse().unwrap())
             .roles(role.into())
             .log_server_config(LogServerConfig { storage_state })
+            .binary_version(RestateVersion::current())
             .build()
     }
 

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1516,7 +1516,7 @@ mod tests {
     use restate_types::partitions::state::{
         MemberState, PartitionReplicaSetStates, ReplicaSetState,
     };
-    use restate_types::{GenerationalNodeId, Version};
+    use restate_types::{GenerationalNodeId, RestateVersion, Version};
     use std::num::NonZeroUsize;
     use std::time::Duration;
     use test_log::test;
@@ -1534,6 +1534,7 @@ mod tests {
             .current_generation(node_id)
             .address(AdvertisedAddress::default())
             .roles(Role::Worker | Role::Admin)
+            .binary_version(RestateVersion::current())
             .build();
         nodes_config.upsert_node(node_config);
 


### PR DESCRIPTION

Forward compatibility prep work to add modified_at to the nodes configuration and to allow nodes to advertise their own binary version when they join.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4289).
* #4291
* #4290
* __->__ #4289