### PR TITLE
Revert non-optional ClusterFingerprint to support v1.5 upgrades

### DIFF
--- a/crates/core/src/network/protobuf.rs
+++ b/crates/core/src/network/protobuf.rs
@@ -47,7 +47,7 @@ pub mod network {
         pub fn new(
             my_node_id: Option<GenerationalNodeId>,
             cluster_name: String,
-            cluster_fingerprint: ClusterFingerprint,
+            cluster_fingerprint: Option<ClusterFingerprint>,
             direction: ConnectionDirection,
             swimlane: Swimlane,
         ) -> Self {
@@ -57,7 +57,7 @@ pub mod network {
                 max_protocol_version: CURRENT_PROTOCOL_VERSION.into(),
                 my_node_id: my_node_id.map(Into::into),
                 cluster_name,
-                cluster_fingerprint: cluster_fingerprint.to_u64(),
+                cluster_fingerprint: cluster_fingerprint.map_or(0, |f| f.to_u64()),
                 swimlane: swimlane.into(),
             }
         }

--- a/crates/metadata-providers/src/replicated.rs
+++ b/crates/metadata-providers/src/replicated.rs
@@ -211,7 +211,7 @@ fn cluster_identity() -> (String, Option<ClusterFingerprint>) {
     let cluster_fingerprint = TaskCenter::try_with_current(|handle| {
         handle
             .metadata()
-            .and_then(|m| m.nodes_config_ref().try_cluster_fingerprint())
+            .and_then(|m| m.nodes_config_ref().cluster_fingerprint())
     })
     .flatten();
 

--- a/crates/metadata-server/src/raft/server/standby.rs
+++ b/crates/metadata-server/src/raft/server/standby.rs
@@ -121,7 +121,7 @@ impl Standby {
                         // nodes_config might still be uninitialized if we haven't joined a cluster yet.
                         // Once nodes store the last seen nodes configuration, we can assume that the
                         // nodes configuration is valid when starting the metadata server in standby.
-                        if let Some(my_cluster_fingerprint) = nodes_config.try_cluster_fingerprint() && my_cluster_fingerprint != incoming_fingerprint {
+                        if let Some(my_cluster_fingerprint) = nodes_config.cluster_fingerprint() && my_cluster_fingerprint != incoming_fingerprint {
                             request.fail(RequestError::ClusterIdentityMismatch(format!("cluster fingerprint mismatch: expected {}, got {}", my_cluster_fingerprint, incoming_fingerprint)));
                             continue;
                         }
@@ -292,7 +292,7 @@ impl Standby {
             .join_cluster(network::grpc_svc::JoinClusterRequest {
                 node_id: u32::from(member_id.node_id),
                 created_at_millis: member_id.created_at_millis,
-                cluster_fingerprint: nodes_config.cluster_fingerprint().to_u64(),
+                cluster_fingerprint: nodes_config.cluster_fingerprint().map_or(0, |f| f.to_u64()),
                 cluster_name: Some(nodes_config.cluster_name().to_owned()),
             })
             .await

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -508,7 +508,7 @@ impl Node {
             location = %my_node_config.location,
             nodes_config_version = %metadata.nodes_config_version(),
             cluster_name = %nodes_config.cluster_name(),
-            cluster_fingerprint = %nodes_config.cluster_fingerprint().to_string(),
+            cluster_fingerprint = ?nodes_config.cluster_fingerprint(),
             %partition_table_version,
             %logs_version,
             "My Node ID is {}", my_node_config.current_generation,

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -80,7 +80,7 @@ impl PartitionSnapshotMetadata {
     pub fn validate(
         &self,
         cluster_name: &str,
-        cluster_fingerprint: ClusterFingerprint,
+        cluster_fingerprint: Option<ClusterFingerprint>,
     ) -> anyhow::Result<()> {
         if cluster_name != self.cluster_name {
             anyhow::bail!(
@@ -89,15 +89,16 @@ impl PartitionSnapshotMetadata {
             );
         }
 
-        // If the snapshot doesn't have a fingerprint on it, we'll ignore the
-        // check. Eventually all new snapshots will have a fingerprint and this
-        // check will be kept for very old snapshots only.
-        if let Some(snapshot_cluster_fingerprint) = self.cluster_fingerprint
-            && snapshot_cluster_fingerprint != cluster_fingerprint
+        // If either the snapshot or the nodes config doesn't have a fingerprint, skip the check.
+        // Eventually all new snapshots will have a fingerprint and this check will be kept for
+        // very old snapshots only.
+        if let (Some(snapshot_cluster_fingerprint), Some(expected_fingerprint)) =
+            (self.cluster_fingerprint, cluster_fingerprint)
+            && snapshot_cluster_fingerprint != expected_fingerprint
         {
             // If nodes_config and snapshot both contain a fingerprint, they must match.
             anyhow::bail!(
-                "Snapshot {} does not match the cluster fingerprint. Expected: '{cluster_fingerprint}' {cluster_fingerprint:?}, got: '{snapshot_cluster_fingerprint}' {snapshot_cluster_fingerprint:?}",
+                "Snapshot {} does not match the cluster fingerprint. Expected: '{expected_fingerprint}' {expected_fingerprint:?}, got: '{snapshot_cluster_fingerprint}' {snapshot_cluster_fingerprint:?}",
                 self.snapshot_id,
             );
         }

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -34,7 +34,7 @@ pub struct SnapshotPartitionTask {
     pub snapshot_base_path: PathBuf,
     pub partition_store_manager: Arc<PartitionStoreManager>,
     pub cluster_name: String,
-    pub cluster_fingerprint: ClusterFingerprint,
+    pub cluster_fingerprint: Option<ClusterFingerprint>,
     pub node_name: String,
     pub snapshot_repository: SnapshotRepository,
 }
@@ -114,7 +114,7 @@ impl SnapshotPartitionTask {
         PartitionSnapshotMetadata {
             version: SnapshotFormatVersion::V1,
             cluster_name: self.cluster_name.clone(),
-            cluster_fingerprint: Some(self.cluster_fingerprint),
+            cluster_fingerprint: self.cluster_fingerprint,
             node_name: self.node_name.clone(),
             partition_id: self.partition_id,
             created_at: created_at.into_timestamp(),


### PR DESCRIPTION
This partially reverts commit df6cd8deb366f44c02ac86c85b4c9eb994c5e9ab which made NodesConfiguration::cluster_fingerprint() panic if the fingerprint is missing.

Restate v1.5 might restore a persisted NodesConfiguration that was written by a MetadataServer running a version < v1.5, which doesn't have a cluster fingerprint. This would cause a panic on startup.

Changes:
- NodesConfiguration::cluster_fingerprint() now returns Option<ClusterFingerprint>
- Removed try_cluster_fingerprint() as it's now redundant
- Updated validate_update() to handle optional fingerprints gracefully
- ConnectionManager in metadata-server now looks up fingerprint from Metadata dynamically instead of storing it statically
- All validation logic updated to only compare fingerprints when both sides have one (backward compatibility)

This fixes https://github.com/restatedev/restate/issues/4286.