### PR TITLE
[Restate UI] Update to v0.1.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8367,8 +8367,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.36"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.36#d031d31b9ed28d41d0b76cb9c92a6910aa39bb7e"
+version = "0.1.37"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.37#72ed47ac354117803948d3a08116544ae0647469"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.36", tag = "v0.1.36" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.37", tag = "v0.1.37" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.37
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.37/ui-v0.1.37.zip