### PR TITLE
[telemetry] Cover partition stop/start events with metrics

### DIFF
--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -12,12 +12,34 @@
 /// the metrics' sink.
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
+pub const TYPE_LABEL: &str = "type";
 pub const PARTITION_LABEL: &str = "partition";
+pub const REASON_LABEL: &str = "reason";
 
+// contains `reason' label and `partition`labels:
+// - `version_barrier` indicates that the partition processor manager was unable to start
+//                     the partition processor because the version of the running restate-server
+//                     is not compatible with the version of the data in the partition store.
+// - `snapshot-unavailable` indicates that the partition processor manager was unable to start
+//                     the partition processor because the snapshot repository is not available or
+//                     not configured.
 pub const PARTITION_BLOCKED_FLARE: &str = "restate.partition.blocked_flare";
+pub const FLARE_REASON_VERSION_BARRIER: &str = "version_barrier";
+pub const FLARE_REASON_SNAPSHOT_UNAVAILABLE: &str = "snapshot-unavailable";
 
 pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command_duration.seconds";
 pub const PARTITION_HANDLE_LEADER_ACTIONS: &str = "restate.partition.handle_leader_action.total";
+
+pub const PARTITION_START: &str = "restate.partition.start.total";
+// contains 'type' label
+pub const PARTITION_STOP: &str = "restate.partition.stop.total";
+// types of partition stop
+pub const NORMAL_STOP: &str = "normal";
+pub const STARTUP_ERROR_STOP: &str = "startup-error";
+pub const GAP_STOP: &str = "log-gap-detected";
+pub const ERROR_STOP: &str = "error";
+
+pub const SNAPSHOT_AGE: &str = "restate.partition.snapshot_age.seconds";
 
 pub const USAGE_LEADER_ACTION_COUNT: &str = "restate.usage.leader_action_count.total";
 
@@ -53,6 +75,18 @@ pub(crate) fn describe_metrics() {
         PARTITION_HANDLE_LEADER_ACTIONS,
         Unit::Count,
         "Number of actions the leader has performed"
+    );
+
+    describe_counter!(
+        PARTITION_START,
+        Unit::Count,
+        "Number of partition processor starts on this node"
+    );
+
+    describe_counter!(
+        PARTITION_STOP,
+        Unit::Count,
+        "Number of partition processor stops on this node"
     );
 
     describe_counter!(
@@ -101,6 +135,12 @@ pub(crate) fn describe_metrics() {
         PARTITION_APPLIED_LSN_LAG,
         Unit::Count,
         "Number of records between last applied lsn and the log tail"
+    );
+
+    describe_gauge!(
+        SNAPSHOT_AGE,
+        Unit::Seconds,
+        "The age of the latest partition snapshot in seconds"
     );
 
     describe_histogram!(

--- a/monitoring/grafana/restate-internals.json
+++ b/monitoring/grafana/restate-internals.json
@@ -2370,12 +2370,423 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total partition starts/stops and stop reasons. Error stops are highlighted in red.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total starts"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total stops"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*error.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 30
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*log-gap.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 45
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(restate_partition_start_total{cluster_name=\"$cluster\", node_name=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "total starts",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(restate_partition_stop_total{cluster_name=\"$cluster\", node_name=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "total stops",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (type) (rate(restate_partition_stop_total{cluster_name=\"$cluster\", node_name=~\"$node\"}[$__rate_interval])) > 0",
+          "legendFormat": "stop:{{type}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Partition Starts/Stops",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Partitions with frequent restarts. High values indicate unstable partitions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 45
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (partition) (rate(restate_partition_start_total{cluster_name=\"$cluster\", node_name=~\"$node\"}[$__rate_interval]))) > 0",
+          "legendFormat": "p{{partition}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Frequently Restarting Partitions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Maximum snapshot age per partition (across all nodes). High values indicate snapshots may be stale.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 45
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max by (partition) (restate_partition_snapshot_age_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", partition=~\"$partition\"})",
+          "legendFormat": "p{{partition}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Snapshot Age",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Partitions that are blocked and cannot start due to version mismatch or missing snapshots.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 45
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "restate_partition_blocked_flare{cluster_name=\"$cluster\", node_name=~\"$node\", partition=~\"$partition\"}",
+          "legendFormat": "{{node_name}}/p{{partition}} ({{reason}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Partitions",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 52
       },
       "id": 40,
       "panels": [],
@@ -2429,7 +2840,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 46
+        "y": 53
       },
       "id": 41,
       "options": {
@@ -2515,7 +2926,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 46
+        "y": 53
       },
       "id": 42,
       "options": {
@@ -2634,7 +3045,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 46
+        "y": 53
       },
       "id": 43,
       "options": {
@@ -2787,7 +3198,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 53
+        "y": 60
       },
       "id": 44,
       "options": {
@@ -2907,7 +3318,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 53
+        "y": 60
       },
       "id": 45,
       "options": {
@@ -3042,7 +3453,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 53
+        "y": 60
       },
       "id": 46,
       "options": {
@@ -3221,7 +3632,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 60
+        "y": 67
       },
       "id": 47,
       "options": {
@@ -3339,7 +3750,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 60
+        "y": 67
       },
       "id": 48,
       "options": {
@@ -3458,7 +3869,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 60
+        "y": 67
       },
       "id": 49,
       "options": {
@@ -3505,7 +3916,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 74
       },
       "id": 50,
       "panels": [],
@@ -3590,7 +4001,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 75
       },
       "id": 51,
       "options": {
@@ -3676,7 +4087,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 68
+        "y": 75
       },
       "id": 52,
       "options": {
@@ -3763,7 +4174,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 68
+        "y": 75
       },
       "id": 53,
       "options": {

--- a/monitoring/grafana/restate-overview.json
+++ b/monitoring/grafana/restate-overview.json
@@ -377,6 +377,84 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Partitions that are blocked and cannot start. Non-zero indicates partitions requiring manual intervention (version mismatch or missing snapshots).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "green",
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(restate_partition_blocked_flare{cluster_name=\"$cluster\", node_name=~\"$node\"}) or vector(0)",
+          "legendFormat": "Blocked",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Partitions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Distribution of node states",
       "fieldConfig": {
         "defaults": {
@@ -461,8 +539,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 12,
+        "w": 4,
+        "x": 15,
         "y": 1
       },
       "id": 14,
@@ -542,8 +620,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 7,
-        "x": 17,
+        "w": 5,
+        "x": 19,
         "y": 1
       },
       "id": 15,


### PR DESCRIPTION

Add new Prometheus metrics to track partition processor lifecycle events:

- `restate.partition.start.total`: Counter for partition processor starts
- `restate.partition.stop.total`: Counter for partition stops with `type` label
  (normal, startup-error, error, log-gap-detected)
- `restate.partition.snapshot_age.seconds`: Gauge for snapshot age
- `restate.partition.blocked_flare`: Gauge indicating blocked partitions that
  require manual intervention (version mismatch or missing snapshots)

Updated Grafana dashboards:
- Overview: Added "Blocked Partitions" stat panel in health row (red when non-zero)
- Internals: Added new row with 4 panels in Partition Processor section:
  - Partition Starts/Stops (with error stops highlighted in red)
  - Frequently Restarting Partitions (identifies unstable partitions)
  - Snapshot Age (max per partition across nodes)
  - Blocked Partitions (detailed view with reason labels)
