### PR TITLE
[VQueues] Fix for concurrency token leak when killing invocation

### DIFF
--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -163,6 +163,7 @@ impl VQueueMeta {
 
     #[inline]
     fn apply_update(&mut self, update: &Update) -> anyhow::Result<()> {
+        debug_assert!(self.length >= self.total_waiting());
         let now = update.ts;
         // Note to future authors: This match needs to continue to work even when
         // processing old/deprecated/removed actions. Therefore, removed actions should

--- a/crates/vqueues/src/scheduler.rs
+++ b/crates/vqueues/src/scheduler.rs
@@ -144,11 +144,10 @@ pub enum ThrottleScope {
 pub struct Entry<Item> {
     pub item: Item,
     pub stats: WaitStats,
-    pub permit: Permit,
 }
 impl<Item> Entry<Item> {
-    pub fn split(self) -> (Item, WaitStats, Permit) {
-        (self.item, self.stats, self.permit)
+    pub fn split(self) -> (Item, WaitStats) {
+        (self.item, self.stats)
     }
 }
 
@@ -403,6 +402,17 @@ impl<S: VQueueStore> SchedulerService<S> {
             drr_scheduler.as_mut().on_inbox_event(vqueues, event)?;
         }
         Ok(())
+    }
+
+    /// Return a run permit for a given item hash if it was assigned by the scheduler.
+    ///
+    /// The permit will not be returned if the unconfirmed assignment was rejected or removed.
+    pub fn pop_permit(&mut self, item_hash: u64) -> Option<Permit> {
+        if let State::Active(ref mut drr_scheduler) = self.state {
+            drr_scheduler.as_mut().pop_permit(item_hash)
+        } else {
+            None
+        }
     }
 
     pub async fn schedule_next(

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -22,7 +22,9 @@ use tokio::time::Instant;
 use tracing::{info, trace, warn};
 
 use restate_futures_util::concurrency::Concurrency;
+use restate_futures_util::concurrency::Permit;
 use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::VQueueEntry;
 use restate_storage_api::vqueue_table::VQueueStore;
 use restate_types::vqueue::VQueueId;
 
@@ -45,6 +47,8 @@ use super::vqueue_state::VQueueState;
 pub struct DRRScheduler<S: VQueueStore> {
     concurrency_limiter: Concurrency,
     global_throttling: Option<GlobalTokenBucket>,
+    /// Permits waiting for confirmation, rejection, or removal from the leader.
+    pending_permits: HashMap<u64, Permit>,
     // sorted by queue_id
     eligible: EligibilityTracker,
     /// Mapping of vqueue_id -> handle for active vqueues
@@ -107,6 +111,7 @@ impl<S: VQueueStore> DRRScheduler<S> {
             storage,
             limit_qid_per_poll,
             max_items_per_decision,
+            pending_permits: Default::default(),
         }
     }
 
@@ -177,11 +182,16 @@ impl<S: VQueueStore> DRRScheduler<S> {
                 }
                 Pop::Item {
                     action,
+                    permit,
                     entry,
                     updated_zt,
                 } => {
                     coop.made_progress();
                     items_collected += 1;
+                    if let Some(permit) = permit {
+                        this.pending_permits
+                            .insert(entry.item.unique_hash(), permit);
+                    }
                     decision.push(&qstate.qid, action, entry, updated_zt);
                     // We need to set the state so we check eligibility and setup
                     // necessary schedules when we poll the queue again.
@@ -218,6 +228,10 @@ impl<S: VQueueStore> DRRScheduler<S> {
             decision.report_metrics();
             Poll::Ready(Ok(decision))
         }
+    }
+
+    pub fn pop_permit(mut self: Pin<&mut Self>, item_hash: u64) -> Option<Permit> {
+        self.pending_permits.remove(&item_hash)
     }
 
     #[tracing::instrument(skip_all)]
@@ -266,6 +280,9 @@ impl<S: VQueueStore> DRRScheduler<S> {
                 let Some(qstate) = self.q.get_mut(*handle) else {
                     return Ok(());
                 };
+                // Note: do not remove the permit here, we depend on the leader to pop it
+                // when it actually runs the item (e.g on VQInvoke action) which doesn't
+                // necessarily need to happen before we see this inbox event.
                 if qstate.remove_from_unconfirmed_assignments(item_hash) {
                     counter!(VQUEUE_RUN_CONFIRMED).increment(1);
 
@@ -289,6 +306,7 @@ impl<S: VQueueStore> DRRScheduler<S> {
                 let config = vqueues.config_pool().find(&qid.parent);
                 let meta = vqueues.get_vqueue(&qid).unwrap();
 
+                self.pending_permits.remove(&item_hash);
                 if qstate.remove_from_unconfirmed_assignments(item_hash) {
                     counter!(VQUEUE_RUN_REJECTED).increment(1);
 
@@ -312,7 +330,15 @@ impl<S: VQueueStore> DRRScheduler<S> {
                 let config = vqueues.config_pool().find(&qid.parent);
                 let meta = vqueues.get_vqueue(&qid).unwrap();
 
-                qstate.notify_removed(item_hash);
+                // If we have been holding a concurrency permit for this item, we release it.
+                self.pending_permits.remove(&item_hash);
+
+                if qstate.notify_removed(item_hash) {
+                    // if removal invalidates the head, we remove the item from eligibility tracker
+                    // this way we ensure that if it's (possibly) eligible, it will be forced
+                    // to be polled again (in refresh_membership)
+                    self.eligible.remove(*handle);
+                }
 
                 if qstate.is_dormant(meta, config) {
                     // retire the vqueue state
@@ -705,10 +731,22 @@ mod tests {
             scheduler.get_status(&qids[0], cache.view()).unwrap().status,
             SchedulingStatus::BlockedOnCapacity,
         );
-        // dropping the permit should release the token, we should get another item
-        drop(result);
-        // Second poll should return Pending since we're at capacity
-        let result2 = poll_scheduler(pin!(&mut scheduler), &cache);
+        // Pop the permit from the scheduler to release the concurrency token.
+        // In production, the leader calls pop_permit() when it actually runs the item.
+        let item_hash = result
+            .into_iter()
+            .flat_map(|(_, a)| a.into_iter_per_action())
+            .flat_map(|(_, items)| items)
+            .next()
+            .unwrap()
+            .item
+            .unique_hash();
+        let mut scheduler = pin!(scheduler);
+        let permit = scheduler.as_mut().pop_permit(item_hash);
+        assert!(permit.is_some());
+        drop(permit);
+        // Now we should be able to get another item
+        let result2 = poll_scheduler(scheduler.as_mut(), &cache);
         let Poll::Ready(Ok(result2)) = result2 else {
             panic!("expected Poll::Ready(Ok(decision))");
         };
@@ -1104,8 +1142,23 @@ mod tests {
         assert!(matches!(status.is_paused, IsPaused::No));
         assert_eq!(status.tokens_used, 1);
 
-        drop(decision);
-        let result = poll_scheduler(pin!(&mut scheduler), &cache);
+        // Pop the permit from the scheduler to release the concurrency token.
+        // Only inbox items acquire permits, running items yield without permits.
+        // The inbox item from qid2 is the only one that acquired a permit.
+        let inbox_item_hash = decision
+            .into_iter()
+            .flat_map(|(_, a)| a.into_iter_per_action())
+            .flat_map(|(_, items)| items)
+            .find(|e| e.item.priority.is_new())
+            .unwrap()
+            .item
+            .unique_hash();
+        let mut scheduler = pin!(scheduler);
+        let permit = scheduler.as_mut().pop_permit(inbox_item_hash);
+        assert!(permit.is_some());
+        drop(permit);
+
+        let result = poll_scheduler(scheduler.as_mut(), &cache);
         let Poll::Ready(Ok(decision)) = result else {
             panic!("expected decision");
         };
@@ -1121,7 +1174,7 @@ mod tests {
             SchedulingStatus::Empty
         );
         assert!(matches!(
-            poll_scheduler(pin!(&mut scheduler), &cache),
+            poll_scheduler(scheduler.as_mut(), &cache),
             Poll::Pending
         ));
     }

--- a/crates/vqueues/src/scheduler/eligible.rs
+++ b/crates/vqueues/src/scheduler/eligible.rs
@@ -139,10 +139,12 @@ impl EligibilityTracker {
                 continue;
             };
 
-            let current_state = self
-                .states
-                .get_mut(handle)
-                .expect("eligible must have state");
+            let Some(current_state) = self.states.get_mut(handle) else {
+                // The vqueue is not eligible anymore. This can happen if the vqueue became dormant
+                // due to items being removed externally (killed, etc.)
+                self.ready_ring.pop_front();
+                continue;
+            };
 
             let meta = cache.get_vqueue(&qstate.qid).unwrap();
             match current_state {


### PR DESCRIPTION

Previously, concurrency permits were stored directly in Entry objects
and released when the Decision was dropped. This caused permit leaks
when items were killed/cancelled before being run, as the permits would
be lost without being properly returned to the pool.

This change moves permit storage to a pending_permits HashMap in the
scheduler. Permits are now explicitly retrieved via pop_permit() when
the leader actually runs an item, and properly released on rejection
or removal events.

Additionally, when an item removal invalidates the queue head, we now
remove the queue from the eligibility tracker state (even if it remains
in the ready ring) and force a membership refresh to recalculate its
eligibility. Previously this could cause a crash because the queue
state was not reset to NeedsPoll after head invalidation.

Changes:
- Move permit storage from Entry to DRRScheduler.pending_permits
- Add pop_permit() method to retrieve permits when running items
- Release permits on RunAttemptRejected and Removed events
- Reset eligibility state on head invalidation from item removal
- Handle missing eligibility state gracefully in next_eligible()
- Update tests to explicitly pop permits to simulate leader behavior
