### PR TITLE
Apply filters + coalesce while scanning

### DIFF
--- a/crates/storage-query-datafusion/src/scanner_task.rs
+++ b/crates/storage-query-datafusion/src/scanner_task.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use anyhow::Context;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::prelude::SessionContext;
 use tokio::sync::mpsc;
@@ -50,7 +51,7 @@ pub(crate) struct ScannerTask {
     scanners: Weak<ScannerMap>,
     ctx: Arc<TaskContext>,
     schema: SchemaRef,
-    predicate: Option<Arc<dyn PhysicalExpr>>,
+    dynamic_filter: Option<Arc<DynamicFilterPhysicalExpr>>,
 }
 
 impl ScannerTask {
@@ -75,11 +76,17 @@ impl ScannerTask {
 
         let schema = Arc::new(schema);
 
+        let dynamic_filter = predicate
+            .as_ref()
+            .map(|pred| Arc::new(DynamicFilterPhysicalExpr::new(Vec::new(), Arc::clone(pred))));
+
         let stream = scanner.scan_partition(
             request.partition_id,
             request.range.clone(),
             schema.clone(),
-            predicate.clone(),
+            dynamic_filter
+                .as_ref()
+                .map(|filter| filter.clone() as Arc<dyn PhysicalExpr>),
             usize::try_from(request.batch_size).expect("batch_size to fit in a usize"),
             request
                 .limit
@@ -95,7 +102,7 @@ impl ScannerTask {
             scanners: Arc::downgrade(scanners),
             ctx: SessionContext::new().task_ctx(),
             schema,
-            predicate,
+            dynamic_filter,
         };
 
         scanners.insert(scanner_id, tx);
@@ -146,68 +153,49 @@ impl ScannerTask {
                     &self.schema,
                     &next_predicate.serialized_physical_expression,
                 ) {
-                    // for now, we are not updating the predicate being passed to ScanPartition,
-                    // so we rely on the filtering below to apply dynamic filters
-                    Ok(next_predicate) => self.predicate = Some(next_predicate),
+                    Ok(next_predicate) => {
+                        if let Some(dynamic_filter) = &self.dynamic_filter
+                            && let Err(e) = dynamic_filter.update(next_predicate)
+                        {
+                            warn!("Failed to update dynamic filter: {e}");
+                        }
+                    }
                     Err(e) => {
                         warn!("Failed to decode next predicate: {e}")
                     }
                 }
             }
 
-            let record_batch = loop {
-                // connection/request has been closed, don't bother with driving the stream.
-                // The scanner will be dropped because we want to make sure that we don't get supurious
-                // next messages from the client after.
-                if request.reciprocal.is_closed() {
+            // connection/request has been closed, don't bother with driving the stream.
+            // The scanner will be dropped because we want to make sure that we don't get spurious
+            // next messages from the client after.
+            if request.reciprocal.is_closed() {
+                return;
+            }
+
+            // The filtering is now done by FilterCoalesceStream inside scan_partition,
+            // so we just need to get the next batch from the stream.
+            let record_batch = match self.stream.next().await {
+                Some(Ok(record_batch)) => record_batch,
+                Some(Err(e)) => {
+                    warn!("Error while scanning {}: {e}", self.scanner_id);
+                    request
+                        .reciprocal
+                        .send(RemoteQueryScannerNextResult::Failure(ScannerFailure {
+                            scanner_id: self.scanner_id,
+                            message: e.to_string(),
+                        }));
                     return;
                 }
-
-                let record_batch = match self.stream.next().await {
-                    Some(Ok(record_batch)) => record_batch,
-                    Some(Err(e)) => break Err(e),
-                    None => {
-                        request
-                            .reciprocal
-                            .send(RemoteQueryScannerNextResult::NoMoreRecords(self.scanner_id));
-                        return;
-                    }
-                };
-
-                let Some(predicate) = &self.predicate else {
-                    break Ok(record_batch);
-                };
-
-                let filtered_batch = predicate
-                    .evaluate(&record_batch)
-                    .and_then(|v| v.into_array(record_batch.num_rows()))
-                    .and_then(|array| {
-                        match datafusion::common::cast::as_boolean_array(&array) {
-                            // Apply filter array to record batch
-                            Ok(filter_array) => {
-                                Ok(datafusion::arrow::compute::filter_record_batch(
-                                    &record_batch,
-                                    filter_array,
-                                )?)
-                            }
-                            Err(_) => {
-                                datafusion::common::internal_err!(
-                                    "Cannot create filter_array from non-boolean predicates"
-                                )
-                            }
-                        }
-                    });
-
-                match filtered_batch {
-                    Ok(filtered_batch) if filtered_batch.num_rows() == 0 => continue,
-                    Ok(filtered_batch) => break Ok(filtered_batch),
-                    Err(err) => break Err(err),
+                None => {
+                    request
+                        .reciprocal
+                        .send(RemoteQueryScannerNextResult::NoMoreRecords(self.scanner_id));
+                    return;
                 }
             };
 
-            match record_batch
-                .and_then(|record_batch| encode_record_batch(&self.stream.schema(), record_batch))
-            {
+            match encode_record_batch(&self.stream.schema(), record_batch) {
                 Ok(record_batch) => {
                     request
                         .reciprocal
@@ -217,15 +205,14 @@ impl ScannerTask {
                         }))
                 }
                 Err(e) => {
-                    warn!("Error while scanning {}: {e}", self.scanner_id);
-
+                    warn!("Error while encoding batch {}: {e}", self.scanner_id);
                     request
                         .reciprocal
                         .send(RemoteQueryScannerNextResult::Failure(ScannerFailure {
                             scanner_id: self.scanner_id,
                             message: e.to_string(),
                         }));
-                    break;
+                    return;
                 }
             }
         }

--- a/crates/storage-query-datafusion/src/table_util.rs
+++ b/crates/storage-query-datafusion/src/table_util.rs
@@ -8,12 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::mem::ManuallyDrop;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+use datafusion::arrow::compute::filter_record_batch;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::cast::as_boolean_array;
 use datafusion::physical_expr::expressions::col;
 use datafusion::physical_expr::{PhysicalExpr, PhysicalSortExpr};
-use std::mem::ManuallyDrop;
-use std::sync::Arc;
+use datafusion::physical_plan::coalesce::{LimitedBatchCoalescer, PushBatchStatus};
 use tokio::sync::mpsc::Sender;
 
 #[macro_export]
@@ -65,42 +70,133 @@ pub(crate) trait Builder {
 pub(crate) struct BatchSender<B: Builder> {
     builder: ManuallyDrop<B>,
     tx: Sender<datafusion::error::Result<RecordBatch>>,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    coalescer: LimitedBatchCoalescer,
+    batch_size: usize,
+    limit_reached: bool,
 }
 
 impl<B: Builder> BatchSender<B> {
     pub(crate) fn new(
         projection: SchemaRef,
         tx: Sender<datafusion::error::Result<RecordBatch>>,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        batch_size: usize,
+        limit: Option<usize>,
     ) -> Self {
-        let builder = B::new(projection);
+        let builder = B::new(projection.clone());
+        let coalescer = LimitedBatchCoalescer::new(projection, batch_size, limit);
         Self {
             builder: ManuallyDrop::new(builder),
             tx,
+            predicate,
+            coalescer,
+            batch_size,
+            limit_reached: false,
         }
-    }
-
-    pub(crate) fn send(
-        &mut self,
-    ) -> Result<(), tokio::sync::mpsc::error::SendError<datafusion::error::Result<RecordBatch>>>
-    {
-        self.tx.blocking_send(self.builder.finish_and_new())
     }
 
     pub(crate) fn builder_mut(&mut self) -> &mut B {
         &mut self.builder
     }
 
-    pub(crate) fn num_rows(&self) -> usize {
-        self.builder.num_rows()
+    pub(crate) fn send_if_needed(&mut self) -> ControlFlow<()> {
+        if self.limit_reached {
+            ControlFlow::Break(())
+            // TOOD; this check could be based on selectivity metrics
+            // ie, we could finish the batch when we predict that post-filter it will be big enough to send
+        } else if self.builder.num_rows() >= self.batch_size {
+            let batch = match self.builder.finish_and_new() {
+                Ok(batch) => batch,
+                Err(e) => {
+                    let _ = self.tx.blocking_send(Err(e));
+                    return ControlFlow::Break(());
+                }
+            };
+
+            self.filter_coalesce_send(batch, false)
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+
+    fn filter_coalesce_send(&mut self, batch: RecordBatch, last: bool) -> ControlFlow<()> {
+        // Apply predicate filter
+        let filtered = match self.apply_filter(batch) {
+            Ok(batch) => batch,
+            Err(e) => {
+                let _ = self.tx.blocking_send(Err(e));
+                return ControlFlow::Break(());
+            }
+        };
+
+        match self.coalescer.push_batch(filtered) {
+            Ok(PushBatchStatus::Continue) => {}
+            Ok(PushBatchStatus::LimitReached) => {
+                self.limit_reached = true;
+            }
+            Err(e) => {
+                let _ = self.tx.blocking_send(Err(e));
+                return ControlFlow::Break(());
+            }
+        }
+
+        if last || self.limit_reached {
+            if let Err(e) = self.coalescer.finish() {
+                let _ = self.tx.blocking_send(Err(e));
+                return ControlFlow::Break(());
+            }
+            let _ = self.send_completed_batches();
+            ControlFlow::Break(())
+        } else {
+            self.send_completed_batches()
+        }
+    }
+
+    fn apply_filter(&self, batch: RecordBatch) -> datafusion::common::Result<RecordBatch> {
+        let Some(predicate) = &self.predicate else {
+            return Ok(batch);
+        };
+
+        let filter_result = predicate.evaluate(&batch)?;
+        let filter_array = filter_result.into_array(batch.num_rows())?;
+        let filter_array = as_boolean_array(&filter_array).map_err(|_| {
+            datafusion::error::DataFusionError::Internal(
+                "Cannot create filter_array from non-boolean predicates".into(),
+            )
+        })?;
+
+        Ok(filter_record_batch(&batch, filter_array)?)
+    }
+
+    fn send_completed_batches(&mut self) -> ControlFlow<()> {
+        while let Some(batch) = self.coalescer.next_completed_batch() {
+            if self.tx.blocking_send(Ok(batch)).is_err() {
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
     }
 }
 
 impl<B: Builder> Drop for BatchSender<B> {
     fn drop(&mut self) {
-        // Safety: self.builder is exclusively taken at drop time, and never accessed again.
+        // Safety: self.builder is exclusively taken here and never accessed again.
         let builder = unsafe { ManuallyDrop::take(&mut self.builder) };
-        if !builder.empty() {
-            let _ = self.tx.blocking_send(builder.finish());
+
+        if self.limit_reached {
+            // Already finished and sent when limit was reached
+            return;
         }
+
+        let batch = match builder.finish() {
+            Ok(batch) => batch,
+            Err(e) => {
+                let _ = self.tx.blocking_send(Err(e));
+                return;
+            }
+        };
+
+        let _ = self.filter_coalesce_send(batch, true);
     }
 }


### PR DESCRIPTION
Currently we filter only in the remote scanner server, and we do not coalesce there (so we send very small batches when there are tight filters)
With this pr, we will filter+coalesce both remotely and locally. The advantage of doing so locally is that we can filter before we even send the batch out of the io thread. That can end up meaning far fewer batches sent, which means less scheduling overhead, and less work further on in the plan. 

The filters that we are evaluating can change due to dynamic filter pushdown. In the remote scanner case, we use a single DynamicFilterPhysicalExpr, which is basically just a mutex, to wrap the entire filter, as it may change later if a `next_predicate` comes in. In the local scanner case, some parts of the filter may indeed be a DynamicFilterPhysicalExpr but others may not be

Currently we are not advertising in the table provider that we can support pushdown exactly, so there will still be FilterExec higher up the plan. However, we are indeed applying them exactly - equivalent to a FilterExec itself - so the higher up one is redundant. This was already a problem with the remote scanner and fixing it is non trivial as it requires keeping track of projection + filter columns separately - if we claim to support a filter exactly, fields needed just for the filter will drop out of the schema. The optimisation benefit is quite minimal so perhaps leave this for now.

I see a 20% speedup when filters are highly selective. Something to note is that `select id FROM sys_invocation_status ORDER BY created_at DESC LIMIT 100` is *not* very selective because the data on disk is roughly in ascending time order. Once wonders if we should iterate backwards!