### PR TITLE
Add linearizability workload to raft chaos test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7927,6 +7927,7 @@ name = "restate-server"
 version = "1.6.1-dev"
 dependencies = [
  "anyhow",
+ "bytes",
  "bytestring",
  "clap",
  "codederror",
@@ -7937,6 +7938,7 @@ dependencies = [
  "http-body-util",
  "mock-service-endpoint",
  "octocrab",
+ "parking_lot",
  "rand 0.9.2",
  "regex",
  "reqwest",
@@ -7958,7 +7960,9 @@ dependencies = [
  "rlimit",
  "rustls 0.23.35",
  "schemars 1.2.0",
+ "serde",
  "serde_json",
+ "spectroscope",
  "tempfile",
  "test-log",
  "tikv-jemallocator",
@@ -9443,6 +9447,15 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spectroscope"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bffc0a17fcd309e3315d2b305eb83b125df54969eeaa8a44a97af158c485ce5"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -80,6 +80,7 @@ restate-types = { workspace = true, features = ["test-util"] }
 mock-service-endpoint = { workspace = true }
 
 anyhow = { workspace = true }
+bytes = { workspace = true }
 bytestring = { workspace = true}
 googletest = { workspace = true }
 tempfile = { workspace = true }
@@ -90,6 +91,10 @@ rand = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+spectroscope = "0.1.0"
+tokio-util = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/server/tests/raft_metadata_cluster.rs
+++ b/server/tests/raft_metadata_cluster.rs
@@ -8,14 +8,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeSet;
+use std::convert::Infallible;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
 use anyhow::anyhow;
 use bytestring::ByteString;
 use enumset::enum_set;
 use futures_util::never::Never;
 use googletest::prelude::err;
 use googletest::{IntoTestResult, assert_that, pat};
+use parking_lot::Mutex;
 use rand::Rng;
 use rand::seq::IndexedMutRandom;
+use serde::{Deserialize, Serialize};
+use spectroscope::{History, Op, SetFullChecker, Validity};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
 use restate_core::{TaskCenter, TaskKind, cancellation_token};
 use restate_local_cluster_runner::cluster::{Cluster, StartedCluster};
 use restate_local_cluster_runner::node::{BinarySource, HealthCheck, NodeSpec, TerminationSignal};
@@ -28,13 +42,7 @@ use restate_types::config::{
 use restate_types::metadata::Precondition;
 use restate_types::nodes_config::Role;
 use restate_types::retries::RetryPolicy;
-use restate_types::{PlainNodeId, Versioned};
-use std::convert::Infallible;
-use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::time::{Duration, Instant};
-use tokio::sync::watch;
-use tracing::{debug, info};
+use restate_types::{PlainNodeId, Version, Versioned, flexbuffers_storage_encode_decode};
 
 #[test_log::test(restate_core::test)]
 async fn raft_metadata_cluster_smoke_test() -> googletest::Result<()> {
@@ -336,6 +344,358 @@ async fn raft_metadata_cluster_chaos_test() -> googletest::Result<()> {
 enum State {
     Write,
     Reconcile,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct SetValue {
+    version: Version,
+    elements: BTreeSet<u64>,
+}
+
+impl Default for SetValue {
+    fn default() -> Self {
+        Self {
+            version: Version::MIN,
+            elements: BTreeSet::new(),
+        }
+    }
+}
+
+impl SetValue {
+    fn next_version(mut self) -> Self {
+        self.version = self.version.next();
+        self
+    }
+}
+
+impl Versioned for SetValue {
+    fn version(&self) -> Version {
+        self.version
+    }
+}
+
+flexbuffers_storage_encode_decode!(SetValue);
+
+struct HistoryRecorder {
+    history: Mutex<History<u64>>,
+    index: AtomicUsize,
+    start_time: Instant,
+}
+
+impl HistoryRecorder {
+    fn new() -> Self {
+        Self {
+            history: Mutex::new(History::new()),
+            index: AtomicUsize::new(0),
+            start_time: Instant::now(),
+        }
+    }
+
+    fn next_index(&self) -> usize {
+        self.index.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn elapsed(&self) -> spectroscope::Timestamp {
+        self.start_time.elapsed().into()
+    }
+
+    fn add_invoke(&self, process: u64, element: u64) -> usize {
+        let idx = self.next_index();
+        let op = Op::add_invoke(idx, process, element).at(self.elapsed());
+        self.history.lock().push(op);
+        idx
+    }
+
+    fn add_ok(&self, process: u64, element: u64) {
+        let idx = self.next_index();
+        let op = Op::add_ok(idx, process, element).at(self.elapsed());
+        self.history.lock().push(op);
+    }
+
+    fn add_info(&self, process: u64, element: u64) {
+        let idx = self.next_index();
+        let op = Op::add_info(idx, process, element).at(self.elapsed());
+        self.history.lock().push(op);
+    }
+
+    fn read_invoke(&self, process: u64) -> usize {
+        let idx = self.next_index();
+        let op = Op::read_invoke(idx, process).at(self.elapsed());
+        self.history.lock().push(op);
+        idx
+    }
+
+    fn read_ok(&self, process: u64, elements: impl IntoIterator<Item = u64>) {
+        let idx = self.next_index();
+        let op = Op::read_ok(idx, process, elements).at(self.elapsed());
+        self.history.lock().push(op);
+    }
+
+    fn read_info(&self, process: u64) {
+        let idx = self.next_index();
+        let op = Op::read_info(idx, process).at(self.elapsed());
+        self.history.lock().push(op);
+    }
+
+    fn into_history(self) -> History<u64> {
+        self.history.into_inner()
+    }
+}
+
+async fn run_set_workload(
+    client: MetadataStoreClient,
+    key: ByteString,
+    recorder: Arc<HistoryRecorder>,
+    process_id: u64,
+    next_element: Arc<AtomicU64>,
+    cancel: CancellationToken,
+    success_tx: watch::Sender<u64>,
+) {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(process_id);
+
+    while !cancel.is_cancelled() {
+        let is_add: bool = rng.random_bool(0.2);
+
+        if is_add {
+            let element = next_element.fetch_add(1, Ordering::Relaxed);
+            recorder.add_invoke(process_id, element);
+
+            let result = client
+                .read_modify_write::<SetValue, _, _>(key.clone(), |value| {
+                    let mut set = value.map(|v| v.next_version()).unwrap_or_default();
+                    set.elements.insert(element);
+                    Ok::<_, Infallible>(set)
+                })
+                .await;
+
+            match result {
+                Ok(_) => {
+                    recorder.add_ok(process_id, element);
+                    success_tx.send_modify(|v| *v += 1);
+                }
+                Err(_) => recorder.add_info(process_id, element),
+            }
+        } else {
+            recorder.read_invoke(process_id);
+
+            let result = client.get::<SetValue>(key.clone()).await;
+
+            match result {
+                Ok(Some(value)) => {
+                    recorder.read_ok(process_id, value.elements);
+                    success_tx.send_modify(|v| *v += 1);
+                }
+                Ok(None) => {
+                    recorder.read_ok(process_id, std::iter::empty());
+                    success_tx.send_modify(|v| *v += 1);
+                }
+                Err(_) => recorder.read_info(process_id),
+            }
+        }
+    }
+}
+
+#[test_log::test(restate_core::test)]
+async fn raft_metadata_cluster_linearizability_test() -> googletest::Result<()> {
+    let num_nodes = 3;
+    let num_workers = 5;
+    let chaos_duration = Duration::from_secs(20);
+    let expected_recovery_duration = Duration::from_secs(10);
+    let mut base_config = Configuration::new_unix_sockets();
+    base_config.metadata_server.set_raft_options(RaftOptions {
+        raft_election_tick: NonZeroUsize::new(5).expect("5 to be non zero"),
+        raft_heartbeat_tick: NonZeroUsize::new(2).expect("2 to be non zero"),
+        ..RaftOptions::default()
+    });
+
+    let nodes = NodeSpec::new_test_nodes(
+        base_config,
+        BinarySource::CargoTest,
+        enum_set!(Role::MetadataServer),
+        num_nodes,
+        true,
+    );
+    let mut cluster = Cluster::builder()
+        .cluster_name("raft_metadata_cluster_linearizability_test")
+        .nodes(nodes)
+        .temp_base_dir("raft_metadata_cluster_linearizability_test")
+        .build()
+        .start()
+        .await?;
+
+    cluster.wait_healthy(Duration::from_secs(30)).await?;
+
+    let addresses: Vec<_> = cluster
+        .nodes
+        .iter()
+        .map(|node| node.advertised_address().clone())
+        .collect();
+
+    let mut configuration = Configuration::default();
+    configuration
+        .common
+        .set_cluster_name(cluster.cluster_name().to_owned());
+    set_current_config(configuration);
+
+    let recorder = Arc::new(HistoryRecorder::new());
+    let next_element = Arc::new(AtomicU64::new(0));
+    let workload_cancel = CancellationToken::new();
+    let key = ByteString::from_static("jepsen-set");
+
+    let (success_tx, success_rx) = watch::channel(0u64);
+
+    let mut workload_handles = Vec::new();
+    for process_id in 0..num_workers {
+        use rand::SeedableRng;
+        use rand::seq::SliceRandom;
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(process_id as u64);
+        let mut shuffled_addresses = addresses.clone();
+        shuffled_addresses.shuffle(&mut rng);
+
+        let metadata_store_client_options = MetadataClientOptions {
+            kind: MetadataClientKind::Replicated {
+                addresses: shuffled_addresses,
+            },
+            ..MetadataClientOptions::default()
+        };
+        let client = create_client(metadata_store_client_options)
+            .await
+            .expect("to not fail");
+
+        let key = key.clone();
+        let recorder = Arc::clone(&recorder);
+        let next_element = Arc::clone(&next_element);
+        let cancel = workload_cancel.clone();
+        let success_tx = success_tx.clone();
+
+        let handle =
+            TaskCenter::spawn_unmanaged(TaskKind::TestRunner, "set-workload", async move {
+                run_set_workload(
+                    client,
+                    key,
+                    recorder,
+                    process_id as u64,
+                    next_element,
+                    cancel,
+                    success_tx,
+                )
+                .await;
+                Ok::<_, anyhow::Error>(())
+            })?;
+        workload_handles.push(handle);
+    }
+
+    // Drop the sender so we can detect when all workers complete
+    drop(success_tx);
+
+    // Run chaos in background
+    let chaos_handle = TaskCenter::spawn_unmanaged(TaskKind::TestRunner, "chaos", async move {
+        async fn restart_node(
+            cluster: &mut StartedCluster,
+            mut success_rx: watch::Receiver<u64>,
+            expected_recovery_duration: Duration,
+        ) -> anyhow::Result<Infallible> {
+            loop {
+                let node = cluster
+                    .nodes
+                    .choose_mut(&mut rand::rng())
+                    .expect("at least one node being present");
+
+                node.restart(TerminationSignal::random()).await?;
+                success_rx.mark_unchanged();
+                cluster
+                    .wait_check_healthy(HealthCheck::MetadataServer, Duration::from_secs(10))
+                    .await?;
+                tokio::time::timeout(expected_recovery_duration, success_rx.changed())
+                    .await
+                    .map_err(|_| {
+                        anyhow!(
+                            "Failed to accept new operations within the expected recovery duration"
+                        )
+                    })??;
+            }
+        }
+
+        if let Some(result) = cancellation_token()
+            .run_until_cancelled(restart_node(
+                &mut cluster,
+                success_rx,
+                expected_recovery_duration,
+            ))
+            .await
+        {
+            result?;
+        }
+
+        Ok::<_, anyhow::Error>(cluster)
+    })?;
+
+    info!("Starting linearizability test with {} workers", num_workers);
+
+    tokio::time::sleep(chaos_duration).await;
+
+    workload_cancel.cancel();
+    for handle in workload_handles {
+        handle.await?.into_test_result()?;
+    }
+
+    chaos_handle.cancel();
+    let mut cluster = chaos_handle.await?.into_test_result()?;
+
+    info!(
+        "Test duration elapsed. Recorded {} operations.",
+        recorder.index.load(Ordering::Relaxed)
+    );
+
+    // Verify linearizability
+    let history = Arc::try_unwrap(recorder)
+        .map_err(|_| anyhow!("all workers should have completed"))
+        .into_test_result()?
+        .into_history();
+
+    let result = SetFullChecker::linearizable().check(&history);
+
+    info!(
+        "Linearizability check: {:?} (stable: {}, lost: {}, stale: {}, never-read: {})",
+        result.valid,
+        result.stable_count,
+        result.lost_count,
+        result.stale_count,
+        result.never_read_count
+    );
+
+    if !result.lost.is_empty() {
+        info!("Lost elements: {:?}", result.lost);
+    }
+    if !result.stale.is_empty() {
+        info!("Stale elements: {:?}", result.stale);
+    }
+
+    assert_eq!(
+        result.valid,
+        Validity::Valid,
+        "Linearizability violation: {} lost, {} stale. Lost: {:?}, Stale: {:?}",
+        result.lost_count,
+        result.stale_count,
+        result.lost,
+        result.stale
+    );
+
+    // Ensure we actually did some work
+    assert!(
+        result.stable_count > 0 || result.never_read_count > 0,
+        "No elements were added during the test"
+    );
+
+    info!(
+        "Linearizability verified: {} elements stable, {} never-read",
+        result.stable_count, result.never_read_count
+    );
+
+    cluster.graceful_shutdown(Duration::from_secs(3)).await?;
+
+    Ok(())
 }
 
 #[test_log::test(restate_core::test)]


### PR DESCRIPTION
Add a Jepsen-style metadata test based on the existing Raft replicated store chaos test, that verifies linearizability of metadata store operations. 

This is a port of Restate's [restate.jepsen.set-metadata-store](https://github.com/restatedev/jepsen/blob/c727249f3e4c79f517d481e362491b6b75d038f7/src/restate/jepsen/set_metadata_store.clj#L10) Jepsen workload to run in-tree.

It makes use of [spectroscope](https://crates.io/crates/spectroscope), a new Rust port of Jepsen's [set-full](https://jepsen-io.github.io/jepsen/jepsen.checker.html#var-set-full) lineariability checker.

The test:
- Runs 5 concurrent workers performing add/read operations
- Each worker has its own independent client with shuffled node addresses
- Records operation history with invoke/ok/info events
- Runs chaos (random node restarts) concurrently
- Uses the spectroscope checker to verify linearizability
