### PR TITLE
Add as_str() method for zero-allocation short ID string conversion

### DIFF
--- a/crates/types/src/id_interning.rs
+++ b/crates/types/src/id_interning.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Compile-time generated string interning for ID types.
+//!
+//! This module provides zero-allocation string lookups for common ID types.
+//! IDs 0-1024 use compile-time generated strings, while IDs > 1024 fall back
+//! to a lazily-populated cache.
+
+use std::sync::{Mutex, OnceLock};
+
+include!(concat!(env!("OUT_DIR"), "/short_id_strings.rs"));
+
+/// Maximum ID with a pre-computed string (inclusive).
+const MAX_PRECOMPUTED_ID: u64 = 1024;
+
+/// Overflow storage for IDs > 1024 (extremely rare in practice).
+static OVERFLOW_ID_STRINGS: OnceLock<Mutex<Vec<&'static str>>> = OnceLock::new();
+static OVERFLOW_NODE_ID_STRINGS: OnceLock<Mutex<Vec<&'static str>>> = OnceLock::new();
+
+/// Returns a static string representation of the given numeric ID.
+/// Optimized for IDs 0-1024 (compile-time generated, single array lookup).
+#[inline]
+pub(crate) fn id_to_str(id: u64) -> &'static str {
+    if id <= MAX_PRECOMPUTED_ID {
+        // SAFETY: bounds check above, MAX_PRECOMPUTED_ID < SHORT_ID_STRINGS.len()
+        return SHORT_ID_STRINGS[id as usize];
+    }
+
+    // Cold path: IDs > 1024 (should be extremely rare)
+    overflow_id_lookup(id)
+}
+
+#[cold]
+#[inline(never)]
+fn overflow_id_lookup(id: u64) -> &'static str {
+    let overflow = OVERFLOW_ID_STRINGS.get_or_init(|| Mutex::new(Vec::new()));
+    let idx = (id - MAX_PRECOMPUTED_ID - 1) as usize;
+
+    let mut guard = overflow.lock().unwrap();
+
+    // Extend if necessary
+    if idx >= guard.len() {
+        guard.resize(idx + 1, "");
+    }
+
+    if guard[idx].is_empty() {
+        // Leak the string - this only happens once per ID
+        guard[idx] = id.to_string().leak();
+    }
+
+    guard[idx]
+}
+
+/// Returns a static N-prefixed string for the given node ID.
+/// Optimized for IDs 0-1024 (compile-time generated, single array lookup).
+#[inline]
+pub(crate) fn node_id_to_str(id: u32) -> &'static str {
+    if (id as u64) <= MAX_PRECOMPUTED_ID {
+        // SAFETY: bounds check above
+        return NODE_ID_STRINGS[id as usize];
+    }
+
+    // Cold path: IDs > 1024 (should be extremely rare)
+    overflow_node_id_lookup(id)
+}
+
+#[cold]
+#[inline(never)]
+fn overflow_node_id_lookup(id: u32) -> &'static str {
+    let overflow = OVERFLOW_NODE_ID_STRINGS.get_or_init(|| Mutex::new(Vec::new()));
+    let idx = (id as u64 - MAX_PRECOMPUTED_ID - 1) as usize;
+
+    let mut guard = overflow.lock().unwrap();
+
+    if idx >= guard.len() {
+        guard.resize(idx + 1, "");
+    }
+
+    if guard[idx].is_empty() {
+        guard[idx] = format!("N{id}").leak();
+    }
+
+    guard[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id_to_str() {
+        // Fast path
+        assert_eq!(id_to_str(0), "0");
+        assert_eq!(id_to_str(1), "1");
+        assert_eq!(id_to_str(1024), "1024");
+
+        // Overflow path
+        assert_eq!(id_to_str(1025), "1025");
+        assert_eq!(id_to_str(2000), "2000");
+    }
+
+    #[test]
+    fn test_node_id_to_str() {
+        // Fast path
+        assert_eq!(node_id_to_str(0), "N0");
+        assert_eq!(node_id_to_str(1), "N1");
+        assert_eq!(node_id_to_str(1024), "N1024");
+
+        // Overflow path
+        assert_eq!(node_id_to_str(1025), "N1025");
+        assert_eq!(node_id_to_str(2000), "N2000");
+    }
+}

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -96,8 +96,6 @@ impl From<LeaderEpoch> for crate::protobuf::common::LeaderEpoch {
     derive_more::From,
     derive_more::Into,
     derive_more::Add,
-    derive_more::Display,
-    derive_more::Debug,
     derive_more::FromStr,
     serde::Serialize,
     serde::Deserialize,
@@ -106,8 +104,19 @@ impl From<LeaderEpoch> for crate::protobuf::common::LeaderEpoch {
 )]
 #[repr(transparent)]
 #[serde(transparent)]
-#[debug("{}", _0)]
 pub struct PartitionId(u16);
+
+impl std::fmt::Debug for PartitionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for PartitionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 impl From<PartitionId> for u32 {
     fn from(value: PartitionId) -> Self {
@@ -134,6 +143,12 @@ impl PartitionId {
     #[inline]
     pub fn next(self) -> Self {
         Self(std::cmp::min(*Self::MAX, self.0.saturating_add(1)))
+    }
+
+    /// Returns a static string representation of this partition ID.
+    #[inline]
+    pub fn as_str(&self) -> &'static str {
+        crate::id_interning::id_to_str(self.0 as u64)
     }
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -11,6 +11,7 @@
 //! This crate contains the core types used by various Restate components.
 
 mod base62_util;
+mod id_interning;
 mod id_util;
 mod macros;
 mod node_id;

--- a/crates/types/src/logs/mod.rs
+++ b/crates/types/src/logs/mod.rs
@@ -40,16 +40,25 @@ pub use tail::*;
     Hash,
     Ord,
     PartialOrd,
-    derive_more::Debug,
-    derive_more::Display,
     derive_more::From,
     derive_more::Into,
     Serialize,
     Deserialize,
     BilrostNewType,
 )]
-#[debug("{}", _0)]
 pub struct LogId(u32);
+
+impl std::fmt::Debug for LogId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for LogId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 impl LogId {
     pub const MAX: LogId = LogId(u32::MAX);
@@ -65,6 +74,12 @@ impl LogId {
     /// should be read from the partition table.
     pub fn default_for_partition(value: PartitionId) -> Self {
         LogId(u32::from(*value))
+    }
+
+    /// Returns a static string representation of this log ID.
+    #[inline]
+    pub fn as_str(&self) -> &'static str {
+        crate::id_interning::id_to_str(self.0 as u64)
     }
 }
 

--- a/crates/types/src/node_id.rs
+++ b/crates/types/src/node_id.rs
@@ -166,8 +166,6 @@ impl From<u64> for GenerationalNodeId {
     Hash,
     derive_more::From,
     derive_more::Into,
-    derive_more::Display,
-    derive_more::Debug,
     serde::Serialize,
     serde::Deserialize,
     BilrostNewType,
@@ -176,9 +174,19 @@ impl From<u64> for GenerationalNodeId {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(transparent))]
 #[cfg_attr(feature = "utoipa-schema", derive(utoipa::ToSchema))]
-#[display("N{}", _0)]
-#[debug("N{}", _0)]
 pub struct PlainNodeId(u32);
+
+impl std::fmt::Debug for PlainNodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::fmt::Display for PlainNodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 impl FromStr for PlainNodeId {
     type Err = MalformedPlainNodeId;
@@ -326,6 +334,16 @@ impl PlainNodeId {
     pub fn next(mut self) -> Self {
         self.0 += 1;
         self
+    }
+
+    /// Returns a static string representation of this node ID.
+    ///
+    /// Format: "N{id}" (e.g., "N0", "N1", "N1024").
+    /// This is a zero-allocation operation for IDs 0-1024 (compile-time generated strings).
+    /// IDs beyond 1024 are lazily cached on first access.
+    #[inline]
+    pub fn as_str(&self) -> &'static str {
+        crate::id_interning::node_id_to_str(self.0)
     }
 }
 


### PR DESCRIPTION

Introduces the id_interning module providing compile-time generated strings
for PartitionId, LogId, and PlainNodeId types. This enables zero-allocation
string conversion for IDs 0-1024 via pre-generated static strings, with lazy
caching for overflow values.

New methods:
- PartitionId::as_str() -> &'static str
- LogId::as_str() -> &'static str
- PlainNodeId::as_str() -> &'static str

Debug and Display implementations for these types now use as_str() internally.
