### PR TITLE
Add udfs to the remote scanner server

### DIFF
--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -19,6 +19,7 @@ use tracing::warn;
 use datafusion::catalog::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
+use datafusion::execution::TaskContext;
 use datafusion::execution::context::SQLOptions;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -405,6 +406,10 @@ impl QueryContext {
         self.sql_options.verify_plan(&plan)?;
         let df = self.datafusion_context.execute_logical_plan(plan).await?;
         df.execute_stream().await
+    }
+
+    pub fn task_ctx(&self) -> Arc<TaskContext> {
+        self.datafusion_context.task_ctx()
     }
 }
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -196,8 +196,11 @@ where
         )
         .await?;
 
-        let datafusion_remote_scanner =
-            RemoteQueryScannerServer::new(remote_scanner_manager, router_builder);
+        let datafusion_remote_scanner = RemoteQueryScannerServer::new(
+            storage_query_context.clone(),
+            remote_scanner_manager,
+            router_builder,
+        );
 
         Ok(Self {
             storage_query_context,


### PR DESCRIPTION
The decode_expr takes a context for a reason; to look up udfs by name. We can't pushdown filters across the remote scanner if the server side doesn't have the udfs registered. In theory for backwards compatibility reasons we could just ignore parts of a conjunction that we can't parse, but this would be a little complicated and potentially error prone. I think its ok if, when adding a new udf, you can't use it in queries until the whole cluster is upgraded.

This pr fixes json filters, which in 1.6.0 couldn't be pushed through the remote scanner eg `Unable to create a scanner in partition 2:  This feature is not implemented: PhysicalExtensionCodec is not provided for scalar function json_as_text`