### PR TITLE
[Restate UI] Update to v0.1.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,8 +8364,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.39"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.39#9969761c659ab8809753e73decbfb94689dc770b"
+version = "0.1.40"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.40#79f7658b40f59a50605651cda7a00ef011ff3d28"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.39", tag = "v0.1.39" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.40", tag = "v0.1.40" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.40
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.40/ui-v0.1.40.zip