### PR TITLE
Use forked jemalloc pprof and disable parca-debuginfo stripping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost 0.14.1",
+ "prost",
  "prost-types",
  "tonic",
  "tonic-prost",
@@ -1655,7 +1655,7 @@ dependencies = [
  "humantime",
  "hyper-util",
  "parking_lot",
- "prost 0.14.1",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
@@ -2657,7 +2657,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-proto-common",
  "object_store 0.12.4",
- "prost 0.14.1",
+ "prost",
 ]
 
 [[package]]
@@ -2668,7 +2668,7 @@ checksum = "12a0cb3cce232a3de0d14ef44b58a6537aeb1362cfb6cf4d808691ddbb918956"
 dependencies = [
  "arrow",
  "datafusion-common",
- "prost 0.14.1",
+ "prost",
 ]
 
 [[package]]
@@ -3141,7 +3141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acfe553027cd07fc5fafa81a84f19a7a87eaffaccd2162b6db05e8d6ce98084"
 dependencies = [
  "http 1.4.0",
- "prost 0.14.1",
+ "prost",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4385,8 +4385,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 [[package]]
 name = "jemalloc_pprof"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ff642505c7ce8d31c0d43ec0e235c6fd4585d9b8172d8f9dd04d36590200b5"
+source = "git+https://github.com/restatedev/rust-jemalloc-pprof?branch=max-limit#f0ab24db48376cee26865ef076d1dc24d40e2fde"
 dependencies = [
  "anyhow",
  "libc",
@@ -4899,8 +4898,7 @@ dependencies = [
 [[package]]
 name = "mappings"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d277bb50d4508057e7bddd7fcd19ef4a4cc38051b6a5a36868d75ae2cbeb9"
+source = "git+https://github.com/restatedev/rust-jemalloc-pprof?branch=max-limit#f0ab24db48376cee26865ef076d1dc24d40e2fde"
 dependencies = [
  "anyhow",
  "libc",
@@ -5105,7 +5103,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
- "prost 0.14.1",
+ "prost",
  "restate-service-protocol-v4",
  "restate-types",
  "restate-workspace-hack",
@@ -5646,7 +5644,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.1",
+ "prost",
  "reqwest",
  "serde_json",
  "thiserror 2.0.17",
@@ -5665,7 +5663,7 @@ dependencies = [
  "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.1",
+ "prost",
  "serde",
  "serde_json",
  "tonic",
@@ -5975,8 +5973,7 @@ dependencies = [
 [[package]]
 name = "pprof_util"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4429d44e5e2c8a69399fc0070379201eed018e3df61e04eb7432811df073c224"
+source = "git+https://github.com/restatedev/rust-jemalloc-pprof?branch=max-limit#f0ab24db48376cee26865ef076d1dc24d40e2fde"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -5984,7 +5981,7 @@ dependencies = [
  "inferno 0.12.4",
  "num",
  "paste",
- "prost 0.13.4",
+ "prost",
 ]
 
 [[package]]
@@ -6134,22 +6131,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
-dependencies = [
- "bytes",
- "prost-derive 0.13.4",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive",
 ]
 
 [[package]]
@@ -6165,26 +6152,13 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost 0.14.1",
+ "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.114",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -6239,7 +6213,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
- "prost 0.14.1",
+ "prost",
 ]
 
 [[package]]
@@ -6979,7 +6953,7 @@ dependencies = [
  "paste",
  "pin-project",
  "pprof",
- "prost 0.14.1",
+ "prost",
  "rand 0.9.2",
  "restate-bifrost",
  "restate-clock",
@@ -7175,7 +7149,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pin-project-lite",
- "prost 0.14.1",
+ "prost",
  "prost-dto",
  "prost-types",
  "rand 0.9.2",
@@ -7560,7 +7534,7 @@ dependencies = [
  "futures",
  "googletest",
  "metrics",
- "prost 0.14.1",
+ "prost",
  "restate-bifrost",
  "restate-clock",
  "restate-core",
@@ -7586,7 +7560,7 @@ dependencies = [
 name = "restate-log-server-grpc"
 version = "1.6.1-dev"
 dependencies = [
- "prost 0.14.1",
+ "prost",
  "restate-types",
  "restate-workspace-hack",
  "tonic",
@@ -7645,7 +7619,7 @@ dependencies = [
  "futures",
  "googletest",
  "metrics",
- "prost 0.14.1",
+ "prost",
  "prost-dto",
  "protobuf",
  "raft",
@@ -7683,7 +7657,7 @@ dependencies = [
  "bytestring",
  "derive_more",
  "itertools 0.14.0",
- "prost 0.14.1",
+ "prost",
  "prost-dto",
  "restate-types",
  "restate-workspace-hack",
@@ -7704,7 +7678,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "metrics",
- "prost 0.14.1",
+ "prost",
  "restate-serde-util",
  "restate-time-util",
  "restate-types",
@@ -7819,7 +7793,7 @@ dependencies = [
  "object_store 0.13.0",
  "parking_lot",
  "paste",
- "prost 0.14.1",
+ "prost",
  "rand 0.9.2",
  "restate-clock",
  "restate-core",
@@ -7903,7 +7877,7 @@ dependencies = [
  "bytesize",
  "http 1.4.0",
  "http-serde",
- "prost 0.14.1",
+ "prost",
  "restate-workspace-hack",
  "schemars 1.2.0",
  "serde",
@@ -8015,7 +7989,7 @@ dependencies = [
  "http-body-util",
  "itertools 0.14.0",
  "paste",
- "prost 0.14.1",
+ "prost",
  "restate-errors",
  "restate-serde-util",
  "restate-service-client",
@@ -8043,7 +8017,7 @@ dependencies = [
  "jsonptr 0.7.1",
  "paste",
  "prettyplease",
- "prost 0.14.1",
+ "prost",
  "prost-build",
  "restate-errors",
  "restate-serde-util",
@@ -8069,7 +8043,7 @@ dependencies = [
  "derive_more",
  "futures",
  "opentelemetry",
- "prost 0.14.1",
+ "prost",
  "prost-build",
  "restate-clock",
  "restate-types",
@@ -8101,7 +8075,7 @@ dependencies = [
  "googletest",
  "itertools 0.14.0",
  "paste",
- "prost 0.14.1",
+ "prost",
  "restate-core",
  "restate-invoker-api",
  "restate-partition-store",
@@ -8128,7 +8102,7 @@ dependencies = [
  "bytestring",
  "googletest",
  "pretty_assertions",
- "prost 0.14.1",
+ "prost",
  "prost-types",
  "rand 0.9.2",
  "restate-workspace-hack",
@@ -8253,7 +8227,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "prettyplease",
- "prost 0.14.1",
+ "prost",
  "prost-build",
  "prost-dto",
  "prost-types",
@@ -8383,7 +8357,7 @@ dependencies = [
  "opentelemetry",
  "parking_lot",
  "pin-project",
- "prost 0.14.1",
+ "prost",
  "rand 0.9.2",
  "restate-bifrost",
  "restate-clock",
@@ -8488,7 +8462,6 @@ dependencies = [
  "idna",
  "indexmap 2.13.0",
  "ipnet",
- "itertools 0.13.0",
  "itertools 0.14.0",
  "jemalloc_pprof",
  "lexical-parse-float",
@@ -8514,7 +8487,7 @@ dependencies = [
  "pprof",
  "pprof_util",
  "proc-macro2",
- "prost 0.14.1",
+ "prost",
  "prost-build",
  "prost-types",
  "protobuf",
@@ -10114,7 +10087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost 0.14.1",
+ "prost",
  "tonic",
 ]
 
@@ -10140,7 +10113,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34da53e8387581d66db16ff01f98a70b426b091fdf76856e289d5c1bd386ed7b"
 dependencies = [
- "prost 0.14.1",
+ "prost",
  "prost-types",
  "tokio",
  "tokio-stream",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -80,7 +80,8 @@ tonic = { workspace = true, features = ["gzip", "zstd"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemalloc_pprof = { version = "0.8.1", default-features = false, features = ["symbolize"] }
+# forked version while we wait for an upstream release of https://github.com/polarsignals/rust-jemalloc-pprof/pull/31
+jemalloc_pprof = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["symbolize"] }
 tikv-jemalloc-ctl = { workspace = true }
 tikv-jemalloc-sys = { workspace = true }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,7 +96,7 @@ RUN --mount=type=secret,id=parca --mount=type=cache,target=/var/cache/sccache \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --add-gnu-debuglink=target/restate-server.debug target/restate-server && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restatectl && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate && \
-    parca-debuginfo upload --store-address=grpc.polarsignals.com:443 --bearer-token-file=/run/secrets/parca target/restate-server.debug && \
+    parca-debuginfo upload --store-address=grpc.polarsignals.com:443 --bearer-token-file=/run/secrets/parca --no-extract --type=debuginfo target/restate-server.debug && \
     rm target/restate-server.debug
 RUN cp docker/scripts/download-restate-debug-symbols.sh target/ && \
     sed -i"" "s/BUILD_ID/$($(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-readelf -n target/restate-server | awk '/Build/{print $3}')/g" target/download-restate-debug-symbols.sh

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -69,7 +69,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2" }
-itertools-582f2526e08bb6a0 = { package = "itertools", version = "0.14" }
+itertools = { version = "0.14" }
 lexical-parse-float = { version = "1", features = ["format"] }
 lexical-parse-integer = { version = "1", default-features = false, features = ["format", "std"] }
 lexical-util = { version = "1", default-features = false, features = ["format", "parse-floats", "parse-integers", "std", "write-floats", "write-integers"] }
@@ -192,7 +192,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 ipnet = { version = "2" }
-itertools-582f2526e08bb6a0 = { package = "itertools", version = "0.14" }
+itertools = { version = "0.14" }
 lexical-parse-float = { version = "1", features = ["format"] }
 lexical-parse-integer = { version = "1", default-features = false, features = ["format", "std"] }
 lexical-util = { version = "1", default-features = false, features = ["format", "parse-floats", "parse-integers", "std", "write-floats", "write-integers"] }
@@ -268,12 +268,13 @@ clap = { version = "4" }
 crossterm = { version = "0.29" }
 derive_more = { version = "2", features = ["full"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 nix = { version = "0.30", features = ["signal"] }
 num = { version = "0.4" }
-pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
+pprof_util = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph"] }
+prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.38", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
@@ -287,13 +288,13 @@ crossterm = { version = "0.29" }
 derive_more = { version = "2", features = ["full"] }
 derive_more-impl = { version = "2", features = ["add", "add_assign", "as_ref", "constructor", "debug", "deref", "deref_mut", "display", "eq", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "mul", "mul_assign", "not", "sum", "try_from", "try_into", "try_unwrap", "unwrap"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13" }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 nix = { version = "0.30", features = ["signal"] }
 num = { version = "0.4" }
-pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
+pprof_util = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph"] }
+prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.38", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
@@ -306,11 +307,12 @@ clap = { version = "4" }
 crossterm = { version = "0.29" }
 derive_more = { version = "2", features = ["full"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 nix = { version = "0.30", features = ["signal"] }
 num = { version = "0.4" }
-pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
+pprof_util = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph"] }
+prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.38", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
@@ -324,12 +326,12 @@ crossterm = { version = "0.29" }
 derive_more = { version = "2", features = ["full"] }
 derive_more-impl = { version = "2", features = ["add", "add_assign", "as_ref", "constructor", "debug", "deref", "deref_mut", "display", "eq", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "mul", "mul_assign", "not", "sum", "try_from", "try_into", "try_unwrap", "unwrap"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
-itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13" }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 nix = { version = "0.30", features = ["signal"] }
 num = { version = "0.4" }
-pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
+pprof_util = { git = "https://github.com/restatedev/rust-jemalloc-pprof", branch = "max-limit", default-features = false, features = ["flamegraph"] }
+prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.38", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }


### PR DESCRIPTION
1. By disabling parca-debuginfo's built in extraction mechanisms, we can allow pprof to parse its elf build id. With extraction this doesn't work. Without this change, pprof will only work if the symbols are provided directly `pprof ./restate-server.debug heap.pb.gz` and it does not work when they are found in a directory `PPROF_BINARY_PATH=. pprof ./heap.pb.gz`. With this change, either works.
2. via https://github.com/polarsignals/rust-jemalloc-pprof/pull/31 we can allow pprof to symbolize our heap profiles. Without that pr, the pprof has its mappings zeroed out, signifying that addresses are normalized, which pprof attempts to handle correctly but fails to do so.
