### PR TITLE
Add restate-memory crate with EstimatedMemorySize trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7552,6 +7552,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-memory"
+version = "1.6.1-dev"
+dependencies = [
+ "bytes",
+ "restate-workspace-hack",
+]
+
+[[package]]
 name = "restate-metadata-providers"
 version = "1.6.1-dev"
 dependencies = [
@@ -8221,6 +8229,7 @@ dependencies = [
  "restate-clock",
  "restate-encoding",
  "restate-errors",
+ "restate-memory",
  "restate-serde-util",
  "restate-test-util",
  "restate-time-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ restate-invoker-impl = { path = "crates/invoker-impl" }
 restate-local-cluster-runner = { path = "crates/local-cluster-runner" }
 restate-log-server = { path = "crates/log-server" }
 restate-log-server-grpc = { path = "crates/log-server-grpc" }
+restate-memory = { path = "crates/memory" }
 restate-metadata-providers = { path = "crates/metadata-providers" }
 restate-metadata-server = { path = "crates/metadata-server" }
 restate-metadata-server-grpc = { path = "crates/metadata-server-grpc" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,6 +22,7 @@ restate-workspace-hack = { workspace = true }
 
 restate-core-derive = { workspace = true, optional = true }
 restate-futures-util = { workspace = true }
+restate-memory = { workspace = true }
 restate-metadata-store = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }

--- a/crates/core/src/network/incoming.rs
+++ b/crates/core/src/network/incoming.rs
@@ -16,6 +16,7 @@ use tokio::sync::{oneshot, watch};
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use restate_memory::EstimatedMemorySize;
 use restate_types::GenerationalNodeId;
 use restate_types::net::codec::{WireDecode, WireEncode};
 use restate_types::net::{ProtocolVersion, Service, UnaryMessage, WatchResponse};
@@ -255,6 +256,27 @@ impl<S> Incoming<RawSvcRpc<S>> {
     }
 }
 
+impl EstimatedMemorySize for Incoming<RawRpc> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
+impl<S> EstimatedMemorySize for Incoming<RawSvcRpc<S>> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
+impl<S> EstimatedMemorySize for Incoming<Rpc<S>> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
 impl Incoming<RawRpc> {
     pub fn msg_type(&self) -> &str {
         &self.inner.msg_type
@@ -336,6 +358,27 @@ impl<S> Incoming<RawSvcUnary<S>> {
     }
 }
 
+impl EstimatedMemorySize for Incoming<RawUnary> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
+impl<S> EstimatedMemorySize for Incoming<RawSvcUnary<S>> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
+impl<S> EstimatedMemorySize for Incoming<Unary<S>> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
 impl Incoming<RawUnary> {
     pub fn msg_type(&self) -> &str {
         &self.inner.msg_type
@@ -404,6 +447,27 @@ impl<S: Service> Incoming<RawSvcUnary<S>> {
 impl Incoming<RawWatch> {
     pub fn msg_type(&self) -> &str {
         &self.inner.msg_type
+    }
+}
+
+impl EstimatedMemorySize for Incoming<RawWatch> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
+impl<S> EstimatedMemorySize for Incoming<RawSvcWatch<S>> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
+    }
+}
+
+impl<S> EstimatedMemorySize for Incoming<Watch<S>> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.inner.payload.estimated_memory_size()
     }
 }
 

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "restate-memory"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+bytes = { workspace = true }

--- a/crates/memory/src/footprint.rs
+++ b/crates/memory/src/footprint.rs
@@ -1,0 +1,239 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// A trait for types that can be significant contributors to memory usage.
+pub trait EstimatedMemorySize {
+    /// Estimated number of bytes to be used by this value in memory.
+    fn estimated_memory_size(&self) -> usize;
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for &T {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for &mut T {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl EstimatedMemorySize for () {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        0
+    }
+}
+
+impl<T: EstimatedMemorySize> EstimatedMemorySize for Option<T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.as_ref()
+            .map_or(0, EstimatedMemorySize::estimated_memory_size)
+    }
+}
+
+impl<T: EstimatedMemorySize> EstimatedMemorySize for Vec<T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.iter()
+            .map(EstimatedMemorySize::estimated_memory_size)
+            .sum()
+    }
+}
+
+impl<T: EstimatedMemorySize> EstimatedMemorySize for [T] {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.iter()
+            .map(EstimatedMemorySize::estimated_memory_size)
+            .sum()
+    }
+}
+
+impl EstimatedMemorySize for String {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl EstimatedMemorySize for bytes::Bytes {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl EstimatedMemorySize for bytes::BytesMut {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl EstimatedMemorySize for [u8] {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl EstimatedMemorySize for str {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for std::sync::Arc<T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for std::rc::Rc<T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for Box<T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for std::sync::MutexGuard<'_, T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for std::sync::RwLockReadGuard<'_, T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ?Sized> EstimatedMemorySize for std::sync::RwLockWriteGuard<'_, T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize> EstimatedMemorySize for std::cell::Ref<'_, T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize> EstimatedMemorySize for std::cell::RefMut<'_, T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self)
+    }
+}
+
+impl<T: EstimatedMemorySize + ToOwned + ?Sized> EstimatedMemorySize for std::borrow::Cow<'_, T> {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        T::estimated_memory_size(self.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::{Bytes, BytesMut};
+
+    #[test]
+    fn test_primitives() {
+        assert_eq!(().estimated_memory_size(), 0);
+
+        let slice: &[u8] = &[1, 2, 3, 4, 5];
+        assert_eq!(slice.estimated_memory_size(), 5);
+    }
+
+    #[test]
+    fn test_string_and_bytes() {
+        assert_eq!("hello".to_string().estimated_memory_size(), 5);
+        assert_eq!(Bytes::from_static(b"world").estimated_memory_size(), 5);
+        assert_eq!(BytesMut::from(&b"test"[..]).estimated_memory_size(), 4);
+    }
+
+    #[test]
+    fn test_option() {
+        let none: Option<String> = None;
+        assert_eq!(none.estimated_memory_size(), 0);
+
+        let some = Some("hello".to_string());
+        assert_eq!(some.estimated_memory_size(), 5);
+    }
+
+    #[test]
+    fn test_vec_and_slice() {
+        let vec: Vec<String> = vec!["hello".to_string(), "world".to_string()];
+        assert_eq!(vec.estimated_memory_size(), 10);
+
+        let slice: &[String] = &vec;
+        assert_eq!(slice.estimated_memory_size(), 10);
+    }
+
+    #[test]
+    #[allow(clippy::needless_borrow, clippy::unnecessary_mut_passed)]
+    fn test_references() {
+        // These explicit borrows are intentional - we're testing the
+        // EstimatedMemorySize implementations for &T and &mut T
+        let s = "hello".to_string();
+        assert_eq!((&s).estimated_memory_size(), 5);
+        assert_eq!((&&s).estimated_memory_size(), 5);
+
+        let mut s2 = "world".to_string();
+        assert_eq!((&mut s2).estimated_memory_size(), 5);
+    }
+
+    #[test]
+    fn test_smart_pointers() {
+        use std::borrow::Cow;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        // Box
+        let boxed = Box::new("hello".to_string());
+        assert_eq!(boxed.estimated_memory_size(), 5);
+
+        // Arc
+        let arc = Arc::new("world".to_string());
+        assert_eq!(arc.estimated_memory_size(), 5);
+
+        // Rc
+        let rc = Rc::new("test".to_string());
+        assert_eq!(rc.estimated_memory_size(), 4);
+
+        // Cow
+        let cow_borrowed: Cow<'_, str> = Cow::Borrowed("borrowed");
+        assert_eq!(cow_borrowed.estimated_memory_size(), 8);
+
+        let cow_owned: Cow<'_, str> = Cow::Owned("owned".to_string());
+        assert_eq!(cow_owned.estimated_memory_size(), 5);
+    }
+}

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Memory management utilities for Restate.
+mod footprint;
+
+pub use footprint::*;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -26,6 +26,7 @@ restate-base64-util = { workspace = true }
 restate-clock = { workspace = true, features = ["prost-types", "jiff", "hlc"] }
 restate-encoding = { workspace = true }
 restate-errors = { workspace = true }
+restate-memory = { workspace = true }
 restate-serde-util = { workspace = true }
 restate-test-util = { workspace = true, optional = true }
 restate-time-util = { workspace = true, features = ["serde", "serde_with"] }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -68,6 +68,11 @@ pub mod clock {
     pub use restate_clock::*;
 }
 
+// Re-export restate-memory crate for memory management utilities.
+pub mod memory {
+    pub use restate_memory::*;
+}
+
 // Re-export metrics' SharedString (Space-efficient Cow + RefCounted variant)
 pub type SharedString = metrics::SharedString;
 

--- a/crates/types/src/logs/record.rs
+++ b/crates/types/src/logs/record.rs
@@ -11,7 +11,9 @@
 use std::sync::Arc;
 
 use bytes::BytesMut;
+
 use restate_encoding::NetSerde;
+use restate_memory::EstimatedMemorySize;
 
 use crate::storage::{PolyBytes, StorageCodec, StorageDecode, StorageDecodeError, StorageEncode};
 use crate::time::NanosSinceEpoch;
@@ -129,6 +131,13 @@ impl Record {
             },
         };
         Ok(decoded)
+    }
+}
+
+impl EstimatedMemorySize for Record {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.body.estimated_memory_size()
     }
 }
 

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -15,6 +15,7 @@ use bitflags::bitflags;
 use prost_dto::{FromProst, IntoProst};
 
 use restate_encoding::{ArcedSlice, BilrostNewType, NetSerde};
+use restate_memory::EstimatedMemorySize;
 
 use super::{RpcResponse, ServiceTag};
 use crate::GenerationalNodeId;
@@ -310,6 +311,13 @@ impl From<Vec<Record>> for Payloads {
     }
 }
 
+impl EstimatedMemorySize for Payloads {
+    #[inline]
+    fn estimated_memory_size(&self) -> usize {
+        self.0.estimated_memory_size()
+    }
+}
+
 /// Store one or more records on a log-server
 #[derive(Debug, Clone, bilrost::Message, NetSerde)]
 pub struct Store {
@@ -353,6 +361,12 @@ impl Store {
             .iter()
             .map(|p| p.estimated_encode_size())
             .sum()
+    }
+}
+
+impl EstimatedMemorySize for Store {
+    fn estimated_memory_size(&self) -> usize {
+        self.payloads.estimated_memory_size()
     }
 }
 

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -19,6 +19,7 @@ use chrono::Utc;
 use downcast_rs::{DowncastSync, impl_downcast};
 
 use restate_encoding::{BilrostAs, NetSerde};
+use restate_memory::EstimatedMemorySize;
 
 use crate::errors::GenericError;
 use crate::journal_v2::raw::{RawEntry, RawEntryError, TryFromEntry};
@@ -221,8 +222,8 @@ impl Default for PolyBytes {
 // implement NetSerde for PolyBytes manually
 impl NetSerde for PolyBytes {}
 
-impl PolyBytes {
-    pub fn estimated_encode_size(&self) -> usize {
+impl EstimatedMemorySize for PolyBytes {
+    fn estimated_memory_size(&self) -> usize {
         match self {
             PolyBytes::Bytes(bytes) => bytes.len(),
             PolyBytes::Both(_, bytes) => bytes.len(),
@@ -233,6 +234,12 @@ impl PolyBytes {
                 2_048 // 2KiB
             }
         }
+    }
+}
+
+impl PolyBytes {
+    pub fn estimated_encode_size(&self) -> usize {
+        self.estimated_memory_size()
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION

Introduce a new restate-memory crate containing memory management utilities.
The crate provides EstimatedMemorySize trait for types that can be significant
contributors to memory usage.

Key features:
- EstimatedMemorySize trait with blanket impls for references (&T, &mut T)
- Impls for common types: String, Bytes, BytesMut, [u8], str, Vec<T>, [T]
- Impls for smart pointers: Arc<T>, Rc<T>, Box<T>, Cow<T>
- Impls for lock guards: MutexGuard, RwLockReadGuard, RwLockWriteGuard, Ref, RefMut
- Impl for Option<T>

The trait is re-exported through restate-types::memory for convenience.
Also implements EstimatedMemorySize for Record, Payloads, Store, and PolyBytes
in restate-types.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4336).
* #4356
* #4340
* __->__ #4336