### PR TITLE
Add image.tag and image.digest support to Helm chart

### DIFF
--- a/charts/restate-helm/README.md
+++ b/charts/restate-helm/README.md
@@ -8,7 +8,49 @@ Helm chart for Restate as a single-node StatefulSet.
 helm install restate oci://ghcr.io/restatedev/restate-helm --namespace restate --create-namespace
 ```
 
-# Resources
+## Image Configuration
+
+By default, the chart uses the image version matching the chart version. You can override this using `image.tag` or pin to a specific digest using `image.digest`.
+
+### Using a specific tag
+
+```bash
+helm install restate oci://ghcr.io/restatedev/restate-helm \
+  --namespace restate --create-namespace \
+  --set image.tag=1.6.0
+```
+
+### Using a date-suffixed tag
+
+Restate publishes weekly refreshed images with security updates (e.g., `1.6.0-20260205`):
+
+```bash
+helm install restate oci://ghcr.io/restatedev/restate-helm \
+  --namespace restate --create-namespace \
+  --set image.tag=1.6.0-20260205
+```
+
+### Pinning to a specific digest
+
+For reproducible deployments or security compliance, you can pin to an exact image digest:
+
+```bash
+helm install restate oci://ghcr.io/restatedev/restate-helm \
+  --namespace restate --create-namespace \
+  --set image.digest=sha256:abc123...
+```
+
+### Using a different registry
+
+```bash
+helm install restate oci://ghcr.io/restatedev/restate-helm \
+  --namespace restate --create-namespace \
+  --set image.repository=ghcr.io/restatedev/restate \
+  --set image.tag=1.6.0
+```
+
+## Resources
+
 Restate's performance is strongly influenced by the CPU and memory available. You can vary the resources in your values file.
 The defaults are:
 
@@ -26,7 +68,7 @@ The environment variable `RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE` should be set under
 In the default helm values, this variable is set to `3Gi`.
 Under load, Restate will eventually use the entire RocksDB memory size offered to it.
 
-# Running a replicated cluster
+## Running a replicated cluster
 You can find example values for a 3-node replicated cluster in [replicated-values.yaml](./replicated-values.yaml).
 Please ensure you use a version of that file (based on the git tag of the repo) which matches the version of the helm chart you are deploying.
 

--- a/charts/restate-helm/templates/_helpers.tpl
+++ b/charts/restate-helm/templates/_helpers.tpl
@@ -10,13 +10,31 @@
 {{- define "restate.labels" -}}
 {{- include "restate.selectorLabels" . }}
 app.kubernetes.io/name: {{ include "restate.name" . }}
-app.kubernetes.io/version: {{ .Values.version | default .Chart.Version | quote }}
+app.kubernetes.io/version: {{ include "restate.tag" . | quote }}
 {{- end }}
 
 {{- define "restate.selectorLabels" -}}
 app: {{ include "restate.fullname" . }}
 {{- end }}
 
+{{/*
+Image tag to use. Prefers image.tag, falls back to version (deprecated), then Chart.Version.
+*/}}
 {{- define "restate.tag" -}}
-{{- .Values.version | default .Chart.Version }}
+{{- .Values.image.tag | default .Values.version | default .Chart.Version }}
+{{- end }}
+
+{{/*
+Full image reference. Uses digest if specified, otherwise uses tag.
+Note: If both image.digest and image.tag are specified, image.digest takes precedence.
+*/}}
+{{- define "restate.image" -}}
+{{- if and .Values.image.digest (not (hasPrefix "sha256:" .Values.image.digest)) -}}
+{{- fail "image.digest must start with 'sha256:'" -}}
+{{- end -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ include "restate.tag" . }}
+{{- end -}}
 {{- end }}

--- a/charts/restate-helm/templates/statefulset.yaml
+++ b/charts/restate-helm/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end}}
-          image: {{ .Values.image.repository }}:{{ include "restate.tag" . }}
+          image: {{ include "restate.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/restate-helm/values.yaml
+++ b/charts/restate-helm/values.yaml
@@ -1,10 +1,16 @@
 replicaCount: 1
 nameOverride: "restate"
+# DEPRECATED: Use image.tag instead. This field will be removed in a future release.
 version: ""
 
 image:
   repository: docker.restate.dev/restatedev/restate
   pullPolicy: IfNotPresent
+  # -- Image tag to use. Defaults to Chart.Version if not set.
+  # tag: ""
+  # -- Image digest to use (e.g., sha256:abc123...).
+  # If set, takes precedence over tag and version. Must start with 'sha256:'.
+  # digest: ""
 
 imagePullSecrets: []
 

--- a/release-notes/unreleased/helm-image-digest-support.md
+++ b/release-notes/unreleased/helm-image-digest-support.md
@@ -1,0 +1,58 @@
+# Release Notes: Helm chart image configuration improvements
+
+## Deprecation
+
+### What Changed
+
+The `version` field in the Helm chart values is now deprecated in favor of `image.tag`. A new `image.digest` field has been added to support pinning images by digest (SHA).
+
+### Why This Matters
+
+- **`image.tag`**: More conventional Helm naming, aligns with common chart patterns
+- **`image.digest`**: Enables pinning to specific image digests for reproducible deployments and security compliance
+
+### Migration Guidance
+
+**Old approach (deprecated):**
+```yaml
+version: "1.6.0"
+```
+
+**New approach:**
+```yaml
+image:
+  tag: "1.6.0"
+```
+
+**Using a digest:**
+```yaml
+image:
+  digest: "sha256:abc123..."
+```
+
+The `version` field continues to work for backward compatibility but will be removed in a future release. If both `image.tag` and `version` are set, `image.tag` takes precedence. If `image.digest` is set, it takes precedence over both `image.tag` and `version`. The `image.digest` value must start with `sha256:`.
+
+### Impact on Users
+
+- **Existing deployments using `version`**: Continue to work, but users should migrate to `image.tag`
+- **New deployments**: Should use `image.tag` or `image.digest`
+- **No breaking changes**: This is a backward-compatible change with a deprecation notice
+
+### Example Usage
+
+```bash
+# Use specific tag
+helm install restate ./charts/restate-helm --set image.tag=1.6.0
+
+# Use date-suffixed tag (from docker-refresh workflow)
+helm install restate ./charts/restate-helm --set image.tag=1.6.0-20260205
+
+# Pin to specific digest
+helm install restate ./charts/restate-helm \
+  --set image.digest=sha256:abc123def456...
+
+# Use different registry with digest
+helm install restate ./charts/restate-helm \
+  --set image.repository=ghcr.io/restatedev/restate \
+  --set image.digest=sha256:abc123def456...
+```


### PR DESCRIPTION
## Summary

- Add `image.tag` as the preferred way to specify image tag (deprecates `version`)
- Add `image.digest` to support pinning to specific image digests (SHA)
- Maintain backward compatibility with existing `version` field

## Motivation

Enable users to pin Helm chart deployments to specific image digests for:
- Reproducible deployments
- Security compliance requirements
- Using date-suffixed tags from the docker-refresh workflow (e.g., `1.6.0-20260205`)

## Changes

| File | Change |
|------|--------|
| `values.yaml` | Add `image.tag` and `image.digest` fields, deprecation notice for `version` |
| `_helpers.tpl` | Add `restate.image` helper, update `restate.tag` to prefer `image.tag` |
| `statefulset.yaml` | Use new `restate.image` helper |
| `release-notes/` | Add deprecation notice and migration guidance |

## Usage Examples

```bash
# Use specific tag (new preferred approach)
helm install restate ./charts/restate-helm --set image.tag=1.6.0

# Use date-suffixed tag from docker-refresh workflow
helm install restate ./charts/restate-helm --set image.tag=1.6.0-20260205

# Pin to specific digest
helm install restate ./charts/restate-helm \
  --set image.digest=sha256:abc123def456...

# Old approach still works (deprecated)
helm install restate ./charts/restate-helm --set version=1.6.0
```

## Backward Compatibility

The existing `version` field continues to work. Priority order:
1. `image.digest` (if set, uses `@digest` format)
2. `image.tag` (if set)
3. `version` (deprecated, fallback)
4. `Chart.Version` (default)