### PR TITLE
Add configurable eager state size limit to mitigate memory pressure

### DIFF
--- a/cli/src/commands/services/config/view.rs
+++ b/cli/src/commands/services/config/view.rs
@@ -154,6 +154,13 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
 
     let mut table = Table::new_styled();
     table.add_kv_row("Enable lazy state:", service.enable_lazy_state);
+    table.add_kv_row(
+        "Eager state size limit:",
+        service
+            .eager_state_size_limit
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "<UNSET>".to_string()),
+    );
     c_println!("{table}");
     c_tip!("{}", ENABLE_LAZY_STATE);
     c_println!();
@@ -199,6 +206,7 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
             || handler.inactivity_timeout.is_some()
             || handler.abort_timeout.is_some()
             || handler.enable_lazy_state.is_some()
+            || handler.eager_state_size_limit.is_some()
             || handler.public != service.public
             || !is_retry_policy_empty(&handler.retry_policy);
 
@@ -230,6 +238,10 @@ async fn view(env: &CliEnv, opts: &View) -> Result<()> {
 
             if let Some(enable_lazy_state) = handler.enable_lazy_state {
                 table.add_kv_row("  Enable lazy state:", enable_lazy_state);
+            }
+
+            if let Some(eager_state_size_limit) = handler.eager_state_size_limit {
+                table.add_kv_row("  Eager state size limit:", eager_state_size_limit);
             }
 
             if handler.public != service.public {

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -168,6 +168,7 @@ mod mocks {
                         inactivity_timeout: None,
                         abort_timeout: None,
                         enable_lazy_state: None,
+                        eager_state_size_limit: None,
                         public: true,
                         input_description: "any".to_string(),
                         output_description: "any".to_string(),
@@ -189,6 +190,7 @@ mod mocks {
                 inactivity_timeout: DEFAULT_INACTIVITY_TIMEOUT,
                 abort_timeout: DEFAULT_ABORT_TIMEOUT,
                 enable_lazy_state: false,
+                eager_state_size_limit: None,
                 retry_policy: Default::default(),
                 info: vec![],
             });

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -21,7 +21,7 @@ use std::task::{Context, Poll, ready};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use futures::{FutureExt, Stream};
+use futures::{FutureExt, Stream, StreamExt};
 use http::response::Parts as ResponseParts;
 use http::{HeaderName, HeaderValue, Response};
 use http_body::{Body, Frame};
@@ -29,9 +29,11 @@ use metrics::histogram;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::task::AbortOnDropHandle;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
-use restate_invoker_api::invocation_reader::{InvocationReader, InvocationReaderTransaction};
+use restate_invoker_api::invocation_reader::{
+    EagerState, InvocationReader, InvocationReaderTransaction,
+};
 use restate_invoker_api::{EntryEnricher, InvokeInputJournal};
 use restate_service_client::{Request, ResponseBody, ServiceClient, ServiceClientError};
 use restate_types::deployment::PinnedDeployment;
@@ -80,6 +82,58 @@ const SERVICE_PROTOCOL_VERSION_V6: HeaderValue =
 
 #[allow(clippy::declare_interior_mutable_const)]
 const X_RESTATE_SERVER: HeaderName = HeaderName::from_static("x-restate-server");
+
+/// Collects state entries from an [`EagerState`] stream, respecting an optional size limit.
+///
+/// Returns a tuple of `(is_partial, entries)` where:
+/// - `is_partial` is true if the state was already partial or if collection stopped due to size limit
+/// - `entries` contains the collected `(key, value)` pairs
+///
+/// TODO: It would be better to estimate state size before reading, so we can
+/// send no state entries directly instead of reading until we exceed the limit.
+async fn collect_eager_state<S, E>(
+    state: Option<EagerState<S>>,
+    size_limit: Option<usize>,
+) -> Result<(bool, Vec<(Bytes, Bytes)>), InvokerError>
+where
+    S: Stream<Item = Result<(Bytes, Bytes), E>> + Send,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let Some(state) = state else {
+        return Ok((true, Vec::new()));
+    };
+
+    let mut is_partial = state.is_partial();
+    let mut entries = Vec::new();
+    let mut total_size: usize = 0;
+
+    let mut stream = std::pin::pin!(state.into_inner());
+    while let Some(result) = stream.next().await {
+        let (key, value) = result.map_err(|e| InvokerError::StateReader(e.into()))?;
+        let entry_size = key.len() + value.len();
+
+        // Check if adding this entry would exceed the limit
+        if let Some(limit) = size_limit
+            && total_size.saturating_add(entry_size) > limit
+        {
+            // We've hit the limit - mark as partial and stop
+            debug!(
+                "Eager state size limit reached ({} bytes, limit: {} bytes), \
+                 sending partial state with {} entries",
+                total_size,
+                limit,
+                entries.len()
+            );
+            is_partial = true;
+            break;
+        }
+
+        total_size = total_size.saturating_add(entry_size);
+        entries.push((key, value));
+    }
+
+    Ok((is_partial, entries))
+}
 
 pub(super) struct InvocationTaskOutput {
     pub(super) partition: PartitionLeaderEpoch,
@@ -142,7 +196,7 @@ pub(super) struct InvocationTask<EE, DMR> {
     invocation_target: InvocationTarget,
     inactivity_timeout: Duration,
     abort_timeout: Duration,
-    disable_eager_state: bool,
+    eager_state_size_limit: Option<usize>,
     message_size_warning: NonZeroUsize,
     message_size_limit: NonZeroUsize,
     retry_count_since_last_stored_entry: u32,
@@ -202,7 +256,7 @@ where
         invocation_target: InvocationTarget,
         default_inactivity_timeout: Duration,
         default_abort_timeout: Duration,
-        disable_eager_state: bool,
+        eager_state_size_limit: Option<usize>,
         message_size_warning: NonZeroUsize,
         message_size_limit: NonZeroUsize,
         retry_count_since_last_stored_entry: u32,
@@ -219,7 +273,7 @@ where
             invocation_target,
             inactivity_timeout: default_inactivity_timeout,
             abort_timeout: default_abort_timeout,
-            disable_eager_state,
+            eager_state_size_limit,
             entry_enricher,
             schemas: deployment_metadata_resolver,
             invoker_tx,
@@ -378,10 +432,15 @@ where
             )));
         }
 
-        // Determine if we need to read state
+        // Resolve the effective eager state size limit:
+        // Per-handler/service override takes precedence over server-level config.
+        if let Some(limit) = invocation_attempt_options.eager_state_size_limit {
+            self.eager_state_size_limit = Some(limit);
+        }
+
+        // Determine if we need to read state (Some(0) means lazy state / no eager state)
         let keyed_service_id = if self.invocation_target.as_keyed_service_id().is_some()
-            && invocation_attempt_options.enable_lazy_state != Some(true)
-            && !self.disable_eager_state
+            && self.eager_state_size_limit != Some(0)
         {
             self.invocation_target.as_keyed_service_id()
         } else {

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use bytestring::ByteString;
-use futures::{Stream, StreamExt, TryStreamExt, stream};
+use futures::{Stream, StreamExt, stream};
 use gardal::futures::StreamExt as GardalStreamExt;
 use http::uri::PathAndQuery;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
@@ -64,7 +64,7 @@ use crate::error::{
 };
 use crate::invocation_task::{
     InvocationTask, InvocationTaskOutputInner, InvokerBodyStream, InvokerRequestStreamSender,
-    ResponseChunk, ResponseStream, TerminalLoopState, X_RESTATE_SERVER,
+    ResponseChunk, ResponseStream, TerminalLoopState, X_RESTATE_SERVER, collect_eager_state,
     invocation_id_to_header_value, service_protocol_version_to_header_value,
 };
 
@@ -535,19 +535,13 @@ where
         S: Stream<Item = Result<(Bytes, Bytes), E>> + Send,
         E: std::error::Error + Send + Sync + 'static,
     {
-        // Collect state if present, mapping to StateEntry while collecting
-        let (partial_state, state_map) = if let Some(state) = state {
-            let is_partial = state.is_partial();
-            let entries: Vec<StateEntry> = state
-                .into_inner()
-                .map_ok(|(key, value)| StateEntry { key, value })
-                .try_collect()
-                .await
-                .map_err(|e| InvokerError::StateReader(e.into()))?;
-            (is_partial, entries)
-        } else {
-            (true, Vec::new())
-        };
+        // Collect state entries with size limit
+        let (partial_state, raw_entries) =
+            collect_eager_state(state, self.invocation_task.eager_state_size_limit).await?;
+        let state_map: Vec<StateEntry> = raw_entries
+            .into_iter()
+            .map(|(key, value)| StateEntry { key, value })
+            .collect();
 
         // Send the invoke frame
         self.write(

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -145,7 +145,12 @@ where
                     invocation_target,
                     opts.inactivity_timeout.into(),
                     opts.abort_timeout.into(),
-                    opts.disable_eager_state,
+                    // Fuse disable_eager_state (deprecated) with eager_state_size_limit
+                    if opts.disable_eager_state {
+                        Some(0)
+                    } else {
+                        opts.eager_state_size_limit.map(|v| v.as_usize())
+                    },
                     opts.message_size_warning.as_non_zero_usize(),
                     opts.message_size_limit(),
                     retry_count_since_last_stored_entry,

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -307,7 +307,20 @@ pub struct InvokerOptions {
     /// Number of concurrent invocations that can be processed by the invoker.
     concurrent_invocations_limit: Option<NonZeroUsize>,
 
+    /// # Eager state size limit
+    ///
+    /// Maximum total size (in bytes) of state entries to send eagerly in the StartMessage.
+    /// When the total size of state entries exceeds this limit, only a partial state is sent
+    /// and the service will fetch remaining state lazily using GetEagerState commands.
+    ///
+    /// This helps reduce memory pressure on deployments for services with large state.
+    /// If unset, all state entries are sent eagerly (no limit).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eager_state_size_limit: Option<NonZeroByteCount>,
+
     // -- Private config options (not exposed in the schema)
+    /// Deprecated: Use `eager_state_size_limit` with a value of `0` instead.
+    /// When true, treated as `eager_state_size_limit = 0` (no eager state).
     #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub disable_eager_state: bool,
@@ -390,6 +403,7 @@ impl Default for InvokerOptions {
             message_size_limit: None,
             tmp_dir: None,
             concurrent_invocations_limit: Some(NonZeroUsize::new(1000).expect("is non zero")),
+            eager_state_size_limit: None,
             disable_eager_state: false,
             invocation_throttling: None,
             action_throttling: None,

--- a/crates/types/src/schema/invocation_target.rs
+++ b/crates/types/src/schema/invocation_target.rs
@@ -123,7 +123,10 @@ impl InvocationTargetMetadata {
 pub struct InvocationAttemptOptions {
     pub abort_timeout: Option<Duration>,
     pub inactivity_timeout: Option<Duration>,
-    pub enable_lazy_state: Option<bool>,
+    /// Maximum total size (in bytes) of state entries to send eagerly.
+    /// `Some(0)` means no eager state (equivalent to lazy state).
+    /// `None` means no per-handler override (use server default).
+    pub eager_state_size_limit: Option<usize>,
 }
 
 // --- Input rules

--- a/crates/types/src/schema/metadata/serde_hacks.rs
+++ b/crates/types/src/schema/metadata/serde_hacks.rs
@@ -79,6 +79,9 @@ mod v1_data_model {
 
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pub enable_lazy_state: Option<bool>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub eager_state_size_limit: Option<usize>,
     }
 
     impl MapAsVecItem for ServiceMetadata {
@@ -164,6 +167,9 @@ mod v1_data_model {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pub enable_lazy_state: Option<bool>,
 
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub eager_state_size_limit: Option<usize>,
+
         #[serde(default = "restate_serde_util::default::bool::<true>")]
         pub public: bool,
 
@@ -230,6 +236,8 @@ mod v1_data_model {
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pub enable_lazy_state: Option<bool>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub eager_state_size_limit: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub documentation: Option<String>,
         #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
         pub metadata: HashMap<String, String>,
@@ -250,6 +258,8 @@ mod v1_data_model {
         pub abort_timeout: Option<Duration>,
         #[serde(skip_serializing_if = "Option::is_none", default)]
         pub enable_lazy_state: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub eager_state_size_limit: Option<usize>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub documentation: Option<String>,
         #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -504,6 +514,7 @@ mod conversions {
                             abort_timeout: handler.abort_timeout,
                             documentation: handler.documentation,
                             enable_lazy_state: handler.enable_lazy_state,
+                            eager_state_size_limit: handler.eager_state_size_limit,
                             metadata: handler.metadata,
                             retry_policy_initial_interval: None,
                             retry_policy_exponentiation_factor: None,
@@ -528,6 +539,7 @@ mod conversions {
                         inactivity_timeout: service.inactivity_timeout,
                         abort_timeout: service.abort_timeout,
                         enable_lazy_state: service.enable_lazy_state,
+                        eager_state_size_limit: service.eager_state_size_limit,
                         retry_policy_initial_interval: None,
                         retry_policy_exponentiation_factor: None,
                         retry_policy_max_attempts: None,
@@ -616,6 +628,7 @@ mod conversions {
                                 inactivity_timeout: handler.inactivity_timeout,
                                 abort_timeout: handler.abort_timeout,
                                 enable_lazy_state: handler.enable_lazy_state,
+                                eager_state_size_limit: handler.eager_state_size_limit,
                                 public: handler.public.unwrap_or(service.public),
                                 input_description: handler.input_rules.to_string(),
                                 output_description: handler.output_rules.to_string(),
@@ -642,6 +655,7 @@ mod conversions {
                             inactivity_timeout: service.inactivity_timeout,
                             abort_timeout: service.abort_timeout,
                             enable_lazy_state: service.enable_lazy_state,
+                            eager_state_size_limit: service.eager_state_size_limit,
                         },
                     );
                     current_service_revision_to_deployment
@@ -723,6 +737,7 @@ mod conversions {
                                 inactivity_timeout: handler.inactivity_timeout,
                                 abort_timeout: handler.abort_timeout,
                                 enable_lazy_state: handler.enable_lazy_state,
+                                eager_state_size_limit: handler.eager_state_size_limit,
                                 documentation: handler.documentation.clone(),
                                 metadata: handler.metadata.clone(),
                             },
@@ -745,6 +760,7 @@ mod conversions {
                             inactivity_timeout: service.inactivity_timeout,
                             abort_timeout: service.abort_timeout,
                             enable_lazy_state: service.enable_lazy_state,
+                            eager_state_size_limit: service.eager_state_size_limit,
                             documentation: service.documentation.clone(),
                             metadata: service.metadata.clone(),
                         },
@@ -838,6 +854,7 @@ mod conversions {
                                     inactivity_timeout: None,
                                     abort_timeout: None,
                                     enable_lazy_state: None,
+                                    eager_state_size_limit: None,
                                     retry_policy_initial_interval: None,
                                     retry_policy_exponentiation_factor: None,
                                     retry_policy_max_attempts: None,
@@ -859,6 +876,7 @@ mod conversions {
                                             abort_timeout: None,
                                             documentation: None,
                                             enable_lazy_state: None,
+                                            eager_state_size_limit: None,
                                             metadata: Default::default(),
                                             retry_policy_initial_interval: None,
                                             retry_policy_exponentiation_factor: None,
@@ -884,6 +902,7 @@ mod conversions {
                                     inactivity_timeout: None,
                                     abort_timeout: None,
                                     enable_lazy_state: None,
+                                    eager_state_size_limit: None,
                                     retry_policy_initial_interval: None,
                                     retry_policy_exponentiation_factor: None,
                                     retry_policy_max_attempts: None,
@@ -908,6 +927,7 @@ mod conversions {
                                                 abort_timeout: None,
                                                 documentation: None,
                                                 enable_lazy_state: None,
+                                                eager_state_size_limit: None,
                                                 metadata: Default::default(),
                                                 retry_policy_initial_interval: None,
                                                 retry_policy_exponentiation_factor: None,
@@ -933,6 +953,7 @@ mod conversions {
                                                 abort_timeout: None,
                                                 documentation: None,
                                                 enable_lazy_state: None,
+                                                eager_state_size_limit: None,
                                                 metadata: Default::default(),
                                                 retry_policy_initial_interval: None,
                                                 retry_policy_exponentiation_factor: None,
@@ -973,6 +994,7 @@ mod conversions {
                                 inactivity_timeout: None,
                                 abort_timeout: None,
                                 enable_lazy_state: None,
+                                eager_state_size_limit: None,
                                 retry_policy_initial_interval: None,
                                 retry_policy_exponentiation_factor: None,
                                 retry_policy_max_attempts: None,
@@ -994,6 +1016,7 @@ mod conversions {
                                         abort_timeout: None,
                                         documentation: None,
                                         enable_lazy_state: None,
+                                        eager_state_size_limit: None,
                                         metadata: Default::default(),
                                         retry_policy_initial_interval: None,
                                         retry_policy_exponentiation_factor: None,
@@ -1116,6 +1139,7 @@ mod conversions {
                                         inactivity_timeout: None,
                                         abort_timeout: None,
                                         enable_lazy_state: None,
+                                        eager_state_size_limit: None,
                                         handlers: HashMap::from([(
                                             "greet".to_owned(),
                                             HandlerMetadata {
@@ -1127,6 +1151,7 @@ mod conversions {
                                                 abort_timeout: None,
                                                 documentation: None,
                                                 enable_lazy_state: None,
+                                                eager_state_size_limit: None,
                                                 public: true,
                                                 input_description: "".to_string(),
                                                 output_description: "".to_string(),
@@ -1153,6 +1178,7 @@ mod conversions {
                                         inactivity_timeout: None,
                                         abort_timeout: None,
                                         enable_lazy_state: None,
+                                        eager_state_size_limit: None,
                                         public: true,
                                         handlers: HashMap::from([
                                             (
@@ -1166,6 +1192,7 @@ mod conversions {
                                                     abort_timeout: None,
                                                     documentation: None,
                                                     enable_lazy_state: None,
+                                                    eager_state_size_limit: None,
                                                     public: true,
                                                     input_description: "".to_string(),
                                                     output_description: "".to_string(),
@@ -1188,6 +1215,7 @@ mod conversions {
                                                     abort_timeout: None,
                                                     documentation: None,
                                                     enable_lazy_state: None,
+                                                    eager_state_size_limit: None,
                                                     public: true,
                                                     input_description: "".to_string(),
                                                     output_description: "".to_string(),
@@ -1233,6 +1261,7 @@ mod conversions {
                                     inactivity_timeout: None,
                                     abort_timeout: None,
                                     enable_lazy_state: None,
+                                    eager_state_size_limit: None,
                                     handlers: HashMap::from([(
                                         "greet".to_owned(),
                                         HandlerMetadata {
@@ -1247,6 +1276,7 @@ mod conversions {
                                             abort_timeout: None,
                                             documentation: None,
                                             enable_lazy_state: None,
+                                            eager_state_size_limit: None,
                                             metadata: Default::default(),
                                             ty: None,
                                             output_json_schema: None,
@@ -1276,6 +1306,7 @@ mod conversions {
                             inactivity_timeout: None,
                             abort_timeout: None,
                             enable_lazy_state: None,
+                            eager_state_size_limit: None,
                             handlers: HashMap::from([(
                                 "greet".to_owned(),
                                 HandlerSchemas {
@@ -1294,6 +1325,7 @@ mod conversions {
                                     abort_timeout: None,
                                     documentation: None,
                                     enable_lazy_state: None,
+                                    eager_state_size_limit: None,
                                     metadata: Default::default(),
                                 },
                             )]),
@@ -1316,6 +1348,7 @@ mod conversions {
                             inactivity_timeout: None,
                             abort_timeout: None,
                             enable_lazy_state: None,
+                            eager_state_size_limit: None,
                             handlers: HashMap::from([
                                 (
                                     "greet".to_owned(),
@@ -1337,6 +1370,7 @@ mod conversions {
                                         abort_timeout: None,
                                         documentation: None,
                                         enable_lazy_state: None,
+                                        eager_state_size_limit: None,
                                         metadata: Default::default(),
                                     },
                                 ),
@@ -1360,6 +1394,7 @@ mod conversions {
                                         abort_timeout: None,
                                         documentation: None,
                                         enable_lazy_state: None,
+                                        eager_state_size_limit: None,
                                         metadata: Default::default(),
                                     },
                                 ),

--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -631,6 +631,7 @@ impl SchemaUpdater {
             inactivity_timeout,
             abort_timeout,
             enable_lazy_state: service.enable_lazy_state,
+            eager_state_size_limit: None,
             retry_policy_initial_interval,
             retry_policy_exponentiation_factor,
             retry_policy_max_attempts,
@@ -1128,6 +1129,7 @@ impl Handler {
             inactivity_timeout,
             abort_timeout,
             enable_lazy_state: handler.enable_lazy_state,
+            eager_state_size_limit: None,
             public: handler.ingress_private.map(bool::not),
             retry_policy_on_max_attempts,
         })

--- a/crates/types/src/schema/metadata/updater/tests.rs
+++ b/crates/types/src/schema/metadata/updater/tests.rs
@@ -2217,7 +2217,7 @@ mod endpoint_manifest_options_propagation {
             eq(InvocationAttemptOptions {
                 abort_timeout: Some(Duration::from_secs(120)),
                 inactivity_timeout: Some(Duration::from_secs(60)),
-                enable_lazy_state: None,
+                eager_state_size_limit: None,
             })
         )
     }
@@ -2242,7 +2242,7 @@ mod endpoint_manifest_options_propagation {
             eq(InvocationAttemptOptions {
                 abort_timeout: Some(Duration::from_secs(120)),
                 inactivity_timeout: Some(Duration::from_secs(30)),
-                enable_lazy_state: None,
+                eager_state_size_limit: None,
             })
         )
     }

--- a/crates/types/src/schema/service.rs
+++ b/crates/types/src/schema/service.rs
@@ -177,6 +177,14 @@ pub struct ServiceMetadata {
     #[serde(default = "restate_serde_util::default::bool::<false>")]
     pub enable_lazy_state: bool,
 
+    /// # Eager state size limit
+    ///
+    /// Maximum total size (in bytes) of state entries to send eagerly.
+    /// If set, it overrides the server-level `eager-state-size-limit` configuration.
+    /// A value of `0` is equivalent to enabling lazy state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eager_state_size_limit: Option<usize>,
+
     /// # Retry policy
     ///
     /// Retry policy applied to invocations of this service.
@@ -396,6 +404,14 @@ pub struct HandlerMetadata {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub enable_lazy_state: Option<bool>,
 
+    /// # Eager state size limit
+    ///
+    /// Maximum total size (in bytes) of state entries to send eagerly.
+    /// If set, it overrides the value set in the service.
+    /// A value of `0` is equivalent to enabling lazy state.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub eager_state_size_limit: Option<usize>,
+
     /// # Public
     ///
     /// If true, this handler can be invoked through the ingress.
@@ -557,6 +573,7 @@ pub mod test_util {
                                 inactivity_timeout: None,
                                 abort_timeout: None,
                                 enable_lazy_state: None,
+                                eager_state_size_limit: None,
                                 public: true,
                                 input_description: "any".to_string(),
                                 output_description: "any".to_string(),
@@ -580,6 +597,7 @@ pub mod test_util {
                 inactivity_timeout: DEFAULT_INACTIVITY_TIMEOUT,
                 abort_timeout: DEFAULT_ABORT_TIMEOUT,
                 enable_lazy_state: false,
+                eager_state_size_limit: None,
                 retry_policy: Default::default(),
                 info: vec![],
             }
@@ -606,6 +624,7 @@ pub mod test_util {
                                 inactivity_timeout: None,
                                 abort_timeout: None,
                                 enable_lazy_state: None,
+                                eager_state_size_limit: None,
                                 public: true,
                                 input_description: "any".to_string(),
                                 output_description: "any".to_string(),
@@ -629,6 +648,7 @@ pub mod test_util {
                 inactivity_timeout: DEFAULT_INACTIVITY_TIMEOUT,
                 abort_timeout: DEFAULT_ABORT_TIMEOUT,
                 enable_lazy_state: false,
+                eager_state_size_limit: None,
                 retry_policy: Default::default(),
                 info: vec![],
             }

--- a/release-notes/unreleased/4345-eager-state-size-limit.md
+++ b/release-notes/unreleased/4345-eager-state-size-limit.md
@@ -1,0 +1,53 @@
+# Release Notes for Issue #4345: Eager state size limit and internal unification
+
+## New Feature / Deprecation
+
+### What Changed
+
+1. **Eager state size limit**: Added a new configuration option `eager-state-size-limit` to limit the
+   amount of state sent eagerly to service endpoints in the StartMessage.
+
+2. **Internal unification of eager state controls**: The three independent eager-state controls
+   (`disable_eager_state`, `enable_lazy_state`, and `eager_state_size_limit`) have been unified
+   internally into a single `eager_state_size_limit` field that flows through the schema and invoker.
+
+3. **Deprecated `disable_eager_state`**: The private config option `disable_eager_state` is deprecated
+   in favor of setting `eager-state-size-limit` to `0`. Existing configs using `disable_eager_state: true`
+   continue to work and are internally treated as `eager_state_size_limit = 0`.
+
+4. **Schema-level `eager_state_size_limit`**: The new field is now part of the per-service and
+   per-handler schema metadata, laying the groundwork for future per-handler configuration via
+   the endpoint manifest and Admin API. Currently it is not user-configurable and defaults to `None`
+   (use server-level setting).
+
+### Why This Matters
+
+When eager state is enabled (the default for Virtual Objects and Workflows), the server sends all
+state entries to the service endpoint in the StartMessage. For services with large state, this forces
+the deployment to hold the entire state in memory, which can be problematic for the service endpoint.
+
+This new option allows operators to cap the eager state size. When exceeded, the server sends partial
+state and the service fetches remaining keys lazily on demand, reducing memory pressure on the
+deployment. As a side effect, this also reduces memory usage on the server side during state collection.
+
+### Configuration
+
+```toml
+[worker.invoker]
+# Maximum total size (in bytes) of state entries to send eagerly
+# When exceeded, partial state is sent and the service fetches remaining state lazily
+eager-state-size-limit = "10MB"
+```
+
+### Impact on Users
+
+- **Default behavior unchanged**: If unset, all state entries are sent eagerly (existing behavior)
+- **When limit is set**: Services with state exceeding the limit will receive partial state and
+  use `GetEagerState`/`GetEagerStateKeys` commands to fetch remaining keys lazily
+- **SDK compatibility**: All SDKs already support partial state - no changes required
+- **`disable_eager_state` users**: The option still works but is deprecated. Consider migrating to
+  `eager-state-size-limit = "0"` for the same behavior.
+
+### Related Issues
+
+- #4344 - Stream state entries to service endpoints (longer-term solution)


### PR DESCRIPTION
Add a new configuration option `eager-state-size-limit` to limit the amount
of state sent eagerly to service endpoints in the StartMessage. When the total
size of state entries exceeds this limit, the server sends partial state and
the service fetches remaining keys lazily on demand.

This helps reduce memory pressure on deployments for services with large state.
By default, no limit is set and all state entries are sent eagerly (existing
behavior unchanged).

Closes https://github.com/restatedev/restate/issues/4345