### PR TITLE
[Networking] Do not spawn an RPC responder task if message_router dropped the message

### DIFF
--- a/crates/core/src/network/metric_definitions.rs
+++ b/crates/core/src/network/metric_definitions.rs
@@ -13,6 +13,8 @@ use metrics::{Unit, describe_counter, describe_histogram};
 pub const NETWORK_CONNECTION_CREATED: &str = "restate.network.connection_created.total";
 pub const NETWORK_CONNECTION_DROPPED: &str = "restate.network.connection_dropped.total";
 pub const NETWORK_MESSAGE_RECEIVED_BYTES: &str = "restate.network.message_received_bytes.total";
+pub const NETWORK_MESSAGE_RECEIVED_DROPPED_BYTES: &str =
+    "restate.network.message_received_dropped_bytes.total";
 
 pub const NETWORK_MESSAGE_PROCESSING_DURATION: &str =
     "restate.network.message_processing_duration.seconds";
@@ -31,7 +33,13 @@ pub fn describe_metrics() {
     describe_counter!(
         NETWORK_MESSAGE_RECEIVED_BYTES,
         Unit::Bytes,
-        "Number of bytes received by message name"
+        "Number of bytes received by service name"
+    );
+
+    describe_counter!(
+        NETWORK_MESSAGE_RECEIVED_DROPPED_BYTES,
+        Unit::Bytes,
+        "Number of bytes received and dropped/rejected by service name"
     );
 
     describe_histogram!(


### PR DESCRIPTION

This also adds a new metric/counter to count the bytes we dropped after receiving due to a lossy service.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4356).
* #4369
* #4368
* #4367
* #4339
* #4360
* __->__ #4356