### PR TITLE
Improve the datafusion explain output

### DIFF
--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -16,6 +16,7 @@ use anyhow::anyhow;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
+use datafusion::physical_plan::metrics::Time;
 use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 use datafusion::physical_plan::{PhysicalExpr, SendableRecordBatchStream};
 use tokio::sync::mpsc::Sender;
@@ -100,6 +101,7 @@ impl<S: StatusHandle + Send + Sync + Debug + Clone + 'static> ScanPartition for 
         _predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,
         limit: Option<usize>,
+        _elapsed_compute: Time,
     ) -> anyhow::Result<SendableRecordBatchStream> {
         let status = self.status_handle.clone();
         let partition_store_manager = self.partition_store_manager.clone();

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -18,6 +18,7 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::SendableRecordBatchStream;
 
 use datafusion::physical_plan::PhysicalExpr;
+use datafusion::physical_plan::metrics::Time;
 use restate_core::Metadata;
 use restate_core::partitions::PartitionRouting;
 use restate_types::NodeId;
@@ -184,6 +185,7 @@ impl ScanPartition for RemotePartitionsScanner {
         predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,
         limit: Option<usize>,
+        elapsed_compute: Time,
     ) -> anyhow::Result<SendableRecordBatchStream> {
         match self.manager.get_partition_target_node(partition_id)? {
             PartitionLocation::Local => {
@@ -197,6 +199,7 @@ impl ScanPartition for RemotePartitionsScanner {
                     predicate,
                     batch_size,
                     limit,
+                    elapsed_compute,
                 )?)
             }
             PartitionLocation::Remote { node_id } => Ok(remote_scan_as_datafusion_stream(

--- a/crates/storage-query-datafusion/src/scanner_task.rs
+++ b/crates/storage-query-datafusion/src/scanner_task.rs
@@ -16,6 +16,7 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
 use datafusion::physical_plan::PhysicalExpr;
+use datafusion::physical_plan::metrics::Time;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt as TokioStreamExt;
 use tracing::{debug, warn};
@@ -92,6 +93,7 @@ impl ScannerTask {
             request
                 .limit
                 .map(|limit| usize::try_from(limit).expect("limit to fit in a usize")),
+            Time::new(),
         )?;
 
         let (tx, rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
It makes it quite a bit easier to debug if you can see the filters and the projection

Also we can track metrics including io thread scan time for `explain analyze`

explain:
```
                                                           PartitionedExecutionPlan: scanner=RemotePartitionsScanner { manager:
                                                             RemoteScannerManager, table_name: "sys_invocation_status" }, partitions=1,
                                                             projection=[partition_key, uuid, modified_at], predicate=DynamicFilter [
                                                             empty ], schema=[partition_key:UInt64;N, uuid:FixedSizeBinary(16);N,
                                                             modified_at:Timestamp(ms, "+00:00");N]
```

explain tree:
```
                                             ┌─────────────┴─────────────┐
                                             │  PartitionedExecutionPlan │
                                             │    --------------------   │
                                             │       partitions: 1       │
                                             │                           │
                                             │         predicate:        │
                                             │  DynamicFilter [ empty ]  │
                                             │                           │
                                             │        projection:        │
                                             │   [partition_key, uuid,   │
                                             │        modified_at]       │
                                             │                           │
                                             │          scanner:         │
                                             │ RemotePartitionsScanner { │
                                             │          manager:         │
                                             │         RemoteScan        │
                                             │  nerManager, table_name:  │
                                             │  "sys_invocation_status"  │
                                             │              }            │
                                             └───────────────────────────┘
```

analyze:
```
                    PartitionedExecutionPlan: scanner=RemotePartitionsScanner { manager: RemoteScannerManager, table_name:
                    "sys_invocation_status" }, partitions=1, projection=[id, modified_at], predicate=true, metrics=[output_rows=1.00 K,
                    elapsed_compute=4.67ms, output_bytes=71.3 KB, output_batches=8]
```