### PR TITLE
[Restate UI] Update to v0.1.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8318,8 +8318,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.43"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.43#4d1274b2aaa040a0a2a953a75009662972a05b73"
+version = "0.1.44"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.44#d51f2ffc70c9d5ae0577d9f3a52b6c4ba705b8eb"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.43", tag = "v0.1.43" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.44", tag = "v0.1.44" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.44
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.44/ui-v0.1.44.zip