### PR TITLE
[Restate UI] Update to v0.1.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8318,8 +8318,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.44"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.44#d51f2ffc70c9d5ae0577d9f3a52b6c4ba705b8eb"
+version = "0.1.45"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.45#56620917d08c558dbe329dfc1e22a5b54127d12a"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.44", tag = "v0.1.44" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.45", tag = "v0.1.45" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.45
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.45/ui-v0.1.45.zip