### PR TITLE
Reduce the in memory buffering between the service protocol runner and the hyper client

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -261,8 +261,10 @@ where
         invocation_id: &InvocationId,
         parent_span_context: &ServiceInvocationSpanContext,
     ) -> (InvokerRequestStreamSender, Request<InvokerBodyStream>) {
-        // Just an arbitrary buffering size
-        let (http_stream_tx, http_stream_rx) = mpsc::channel(10);
+        // Make this channel a rendezvous channel to avoid unnecessary buffering between the service
+        // protocol runner and the underlying hyper HTTP client. This helps with keeping the overall
+        // memory consumption per invocation in check.
+        let (http_stream_tx, http_stream_rx) = mpsc::channel(1);
         let req_body = InvokerBodyStream::new(ReceiverStream::new(http_stream_rx));
 
         let service_protocol_header_value =

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -288,8 +288,10 @@ where
         invocation_id: &InvocationId,
         parent_span_context: &ServiceInvocationSpanContext,
     ) -> (InvokerRequestStreamSender, Request<InvokerBodyStream>) {
-        // Just an arbitrary buffering size
-        let (http_stream_tx, http_stream_rx) = mpsc::channel(10);
+        // Make this channel a rendezvous channel to avoid unnecessary buffering between the service
+        // protocol runner and the underlying hyper HTTP client. This helps with keeping the overall
+        // memory consumption per invocation in check.
+        let (http_stream_tx, http_stream_rx) = mpsc::channel(1);
         let req_body = InvokerBodyStream::new(ReceiverStream::new(http_stream_rx));
 
         let service_protocol_header_value =


### PR DESCRIPTION
This commit sets the capacity of the in-memory channel used to communicate between the service protocol runner and the hyper client to 1 to avoid unnecessary buffering outside of the network buffers. This will help to keep the memory usage per invocation better in check.

This PR is the new incarnation of #4353.