### PR TITLE
Move back to gha cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,6 @@ jobs:
         with:
           components: clippy
           rustflags: ""
-          cache: false
-
-      - name: Setup Rust Caching
-        uses: WarpBuilds/rust-cache@v2 # a fork of Swatinem/rust-cache@v2 that uses warpbuild cache
-        with:
-          cache-on-failure: "true"
 
       - name: Install cargo-hakari
         uses: taiki-e/install-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,14 +115,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # https://docs.warpbuild.com/cache/docker-layer-caching#step-1-set-up-docker-buildx-action
-          driver-opts: |
-            network=host
 
       - name: Cache sccache
         id: cache
-        uses: WarpBuilds/cache@v1
+        uses: actions/cache@v5
         with:
           path: sccache-cache
           key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
@@ -233,7 +229,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # on main, always push both platforms, otherwise use platform input
           platforms: ${{ github.ref == 'refs/heads/main' && 'linux/arm64,linux/amd64' || (inputs.platforms || 'linux/arm64,linux/amd64') }}
-          network: host
           build-args: |
             CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug || inputs.parca }}
             BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
@@ -241,9 +236,9 @@ jobs:
             RESTATE_FEATURES=${{ inputs.features || '' }}
           secrets: |
             parca=${{ secrets.PARCA_TOKEN }}
-          cache-from: type=gha,url=http://127.0.0.1:49160/,version=1
+          cache-from: type=gha
           # don't cache debug/parca builds, it's just too big
-          cache-to: ${{ (!inputs.debug && !inputs.parca) && 'type=gha,url=http://127.0.0.1:49160/,mode=max,version=1' || '' }}
+          cache-to: ${{ (!inputs.debug && !inputs.parca) && 'type=gha,mode=max' || '' }}
 
       - name: Upload docker image tar as artifact
         if: ${{ inputs.uploadImageAsTarball != '' }}

--- a/.github/workflows/hack-clippy.yml
+++ b/.github/workflows/hack-clippy.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   hack-clippy:
@@ -30,12 +30,6 @@ jobs:
         with:
           components: clippy
           rustflags: ""
-          cache: false
-
-      - name: Setup Rust Caching
-        uses: WarpBuilds/rust-cache@v2 # a fork of Swatinem/rust-cache@v2 that uses warpbuild cache
-        with:
-          cache-on-failure: "true"
 
       - name: Install cargo-hakari and cargo-hack
         uses: taiki-e/install-action@v2

--- a/docs/dev/build-and-ci.md
+++ b/docs/dev/build-and-ci.md
@@ -201,9 +201,9 @@ A **reusable workflow** called by this repo and many others in the restatedev or
 - `pushToDockerHub`: Push to Docker Hub in addition to GHCR
 
 **Build optimizations:**
-- Uses `sccache` with WarpBuild cache
+- Uses `sccache` with GHA cache
 - Multi-platform builds via Docker Buildx
-- Caches layers via WarpBuild's GHA cache proxy
+- Caches Docker layers to GHA cache
 
 ### Release Workflow (`release.yml`)
 
@@ -309,18 +309,12 @@ All CI jobs use [WarpBuild](https://warpbuild.com/) runners instead of GitHub-ho
 
 **Benefits:**
 - Larger machines at lower cost (up to 32x runners for release builds)
-- Unlimited build cache
 - Faster checkout and artifact operations
 
 **Runner naming:**
 - `warp-ubuntu-latest-x64-{2,4,16,32}x`: Linux x64 with N cores
 - `warp-ubuntu-latest-arm64-{2,4,32}x`: Linux ARM64
 - `warp-macos-latest-arm64-6x`: macOS ARM64
-
-**Cache integration:**
-- `WarpBuilds/rust-cache@v2`: Fork of Swatinem/rust-cache using WarpBuild cache
-- `WarpBuilds/cache@v1`: General-purpose cache action
-- Docker layer caching via GHA cache proxy (`cache-from: type=gha,url=http://127.0.0.1:49160/`)
 
 ## Analytics and Observability
 


### PR DESCRIPTION
github have beefed up their cache and increased the size limit, and warpbuild no longer recommend that you use their cache. Therefore we can revert all the warpbuild cache stuff we have