### PR TITLE
[Restate UI] Update to v0.1.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8318,8 +8318,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.45"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.45#56620917d08c558dbe329dfc1e22a5b54127d12a"
+version = "0.1.46"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.46#4b1297479e7da8af21194ecc8aeef2b9d383c386"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.45", tag = "v0.1.45" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.46", tag = "v0.1.46" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.46
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.46/ui-v0.1.46.zip