### PR TITLE
[Restate UI] Update to v0.1.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,8 +8321,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.46"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.46#4b1297479e7da8af21194ecc8aeef2b9d383c386"
+version = "0.1.47"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.47#dbd8efa976590b9fc9d845ddf96e551a66af9e30"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.46", tag = "v0.1.46" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.47", tag = "v0.1.47" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.47
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.47/ui-v0.1.47.zip