### PR TITLE
[LogServer] Move log server reads to the background

### DIFF
--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -56,7 +56,7 @@ tracing = { workspace = true }
 # which benefits importing libraries that don't need rocksdb.
 restate-bifrost = {path = ".", default-features = false, features = ["local-loglet"]}
 restate-core = { workspace = true, features = ["test-util"] }
-restate-log-server = { workspace = true }
+restate-log-server = { workspace = true, features = ["test-util"] }
 restate-rocksdb = { workspace = true }
 restate-serde-util = { workspace = true }
 restate-storage-api = { workspace = true }

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -290,15 +290,19 @@ impl<S: LogStore> LogletWorker<S> {
                 // seal to happen
                 let tail_watcher = self.loglet_state.get_local_tail_watch();
                 let global_tail = self.loglet_state.get_global_tail_tracker();
-                waiting_for_seal.spawn(Box::pin(async move {
-                    let seal_watcher = tail_watcher.wait_for_seal();
-                    if seal_watcher.await.is_ok() {
-                        let body = Sealed::new(*tail_watcher.get(), global_tail.get())
-                            .with_status(Status::Ok);
-                        // send the response over the network
-                        reciprocal.send(body);
-                    }
-                }));
+                waiting_for_seal
+                    .build_task()
+                    .name("loglet-wait-for-seal")
+                    .spawn(Box::pin(async move {
+                        let seal_watcher = tail_watcher.wait_for_seal();
+                        if seal_watcher.await.is_ok() {
+                            let body = Sealed::new(*tail_watcher.get(), global_tail.get())
+                                .with_status(Status::Ok);
+                            // send the response over the network
+                            reciprocal.send(body);
+                        }
+                    }))
+                    .unwrap();
                 let seal_token = self.process_seal(msg, sealing_in_progress).await;
                 if let Some(seal_token) = seal_token {
                     in_flight_seal.set(Some(seal_token).into());

--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -99,98 +99,100 @@ impl LogStore for RocksDbLogStore {
 
     async fn load_loglet_state(&self, loglet_id: LogletId) -> Result<LogletState, OperationError> {
         let start = Instant::now();
-        let metadata_cf = self.metadata_cf();
-        let data_cf = self.data_cf();
-        let keys = [
-            // keep byte-wise sorted
-            &MetadataKey::new(KeyPrefixKind::Sequencer, loglet_id).to_binary_array(),
-            &MetadataKey::new(KeyPrefixKind::TrimPoint, loglet_id).to_binary_array(),
-            &MetadataKey::new(KeyPrefixKind::Seal, loglet_id).to_binary_array(),
-        ];
-        let mut readopts = ReadOptions::default();
-        // no need to cache those metadata records since we won't read them again.
-        readopts.fill_cache(false);
-        let mut results = self.rocksdb.inner().as_raw_db().batched_multi_get_cf_opt(
-            &metadata_cf,
-            keys,
-            true,
-            &readopts,
-        );
-        debug_assert_eq!(3, results.len());
-        // If the key exists, it means a seal is set.
-        let is_sealed = results
-            .pop()
-            .unwrap()
-            .map_err(RocksDbLogStoreError::from)?
-            .is_some();
-        let trim_point = results
-            .pop()
-            .unwrap()
-            .map_err(RocksDbLogStoreError::from)?
-            .map(|raw_slice| LogletOffset::decode(raw_slice.as_ref()))
-            .unwrap_or(LogletOffset::INVALID);
-        let sequencer = results
-            .pop()
-            .unwrap()
-            .map_err(RocksDbLogStoreError::from)?
-            .map(|raw_slice| GenerationalNodeId::decode(raw_slice.as_ref()));
-
-        // Find the last locally committed offset
-        let oldest_key = DataRecordKey::new(loglet_id, LogletOffset::INVALID);
-        let max_legal_record = DataRecordKey::new(loglet_id, LogletOffset::MAX);
-        let upper_bound = DataRecordKey::exclusive_upper_bound(loglet_id);
-        readopts.fill_cache(false);
-        readopts.set_total_order_seek(false);
-        readopts.set_prefix_same_as_start(true);
-        readopts.set_iterate_lower_bound(oldest_key.to_binary_array());
-        // upper bound is exclusive
-        readopts.set_iterate_upper_bound(upper_bound);
-        let mut iterator = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(&data_cf, readopts);
-        // see to the max key that exists
-        iterator.seek_for_prev(max_legal_record.to_binary_array());
-        let mut local_tail = if iterator.valid() {
-            let decoded_key = DataRecordKey::from_slice(iterator.key().unwrap());
-            trace!(
-                %loglet_id,
-                elapsed = ?start.elapsed(),
-                "Found last record of loglet {} is {}",
-                decoded_key.loglet_id(),
-                decoded_key.offset(),
+        block_in_place(|| {
+            let metadata_cf = self.metadata_cf();
+            let data_cf = self.data_cf();
+            let keys = [
+                // keep byte-wise sorted
+                &MetadataKey::new(KeyPrefixKind::Sequencer, loglet_id).to_binary_array(),
+                &MetadataKey::new(KeyPrefixKind::TrimPoint, loglet_id).to_binary_array(),
+                &MetadataKey::new(KeyPrefixKind::Seal, loglet_id).to_binary_array(),
+            ];
+            let mut readopts = ReadOptions::default();
+            // no need to cache those metadata records since we won't read them again.
+            readopts.fill_cache(false);
+            let mut results = self.rocksdb.inner().as_raw_db().batched_multi_get_cf_opt(
+                &metadata_cf,
+                keys,
+                true,
+                &readopts,
             );
-            decoded_key.offset().next()
-        } else {
-            trace!(
+            debug_assert_eq!(3, results.len());
+            // If the key exists, it means a seal is set.
+            let is_sealed = results
+                .pop()
+                .unwrap()
+                .map_err(RocksDbLogStoreError::from)?
+                .is_some();
+            let trim_point = results
+                .pop()
+                .unwrap()
+                .map_err(RocksDbLogStoreError::from)?
+                .map(|raw_slice| LogletOffset::decode(raw_slice.as_ref()))
+                .unwrap_or(LogletOffset::INVALID);
+            let sequencer = results
+                .pop()
+                .unwrap()
+                .map_err(RocksDbLogStoreError::from)?
+                .map(|raw_slice| GenerationalNodeId::decode(raw_slice.as_ref()));
+
+            // Find the last locally committed offset
+            let oldest_key = DataRecordKey::new(loglet_id, LogletOffset::INVALID);
+            let max_legal_record = DataRecordKey::new(loglet_id, LogletOffset::MAX);
+            let upper_bound = DataRecordKey::exclusive_upper_bound(loglet_id);
+            readopts.fill_cache(false);
+            readopts.set_total_order_seek(false);
+            readopts.set_prefix_same_as_start(true);
+            readopts.set_iterate_lower_bound(oldest_key.to_binary_array());
+            // upper bound is exclusive
+            readopts.set_iterate_upper_bound(upper_bound);
+            let mut iterator = self
+                .rocksdb
+                .inner()
+                .as_raw_db()
+                .raw_iterator_cf_opt(&data_cf, readopts);
+            // see to the max key that exists
+            iterator.seek_for_prev(max_legal_record.to_binary_array());
+            let mut local_tail = if iterator.valid() {
+                let decoded_key = DataRecordKey::from_slice(iterator.key().unwrap());
+                trace!(
+                    %loglet_id,
+                    elapsed = ?start.elapsed(),
+                    "Found last record of loglet {} is {}",
+                    decoded_key.loglet_id(),
+                    decoded_key.offset(),
+                );
+                decoded_key.offset().next()
+            } else {
+                trace!(
                 %loglet_id,
                 elapsed = ?start.elapsed(),
                 "No data records for loglet {}", loglet_id);
-            LogletOffset::OLDEST
-        };
-        // If the loglet is trimmed (all records were removed) and we know the trim_point, then we
-        // use the trim_point.next() as the local_tail.
-        //
-        // Another way to describe this is `if trim_point >= local_tail` but at this stage, I
-        // prefer to be conservative and explicit to catch unintended corner cases.
-        if local_tail == LogletOffset::OLDEST && trim_point > LogletOffset::INVALID {
-            local_tail = trim_point.next();
-        }
+                LogletOffset::OLDEST
+            };
+            // If the loglet is trimmed (all records were removed) and we know the trim_point, then we
+            // use the trim_point.next() as the local_tail.
+            //
+            // Another way to describe this is `if trim_point >= local_tail` but at this stage, I
+            // prefer to be conservative and explicit to catch unintended corner cases.
+            if local_tail == LogletOffset::OLDEST && trim_point > LogletOffset::INVALID {
+                local_tail = trim_point.next();
+            }
 
-        // We can only trim records that are known to be globally committed, let's use that trim
-        // point to initialize our known_global_tail
-        let known_global_tail = trim_point.next();
+            // We can only trim records that are known to be globally committed, let's use that trim
+            // point to initialize our known_global_tail
+            let known_global_tail = trim_point.next();
 
-        // todo(asoli): Persist last_known_global_tail for more efficient tail repairs if the
-        // loglet is not trimmed.
-        Ok(LogletState::new(
-            sequencer,
-            local_tail,
-            is_sealed,
-            trim_point,
-            known_global_tail,
-        ))
+            // todo(asoli): Persist last_known_global_tail for more efficient tail repairs if the
+            // loglet is not trimmed.
+            Ok(LogletState::new(
+                sequencer,
+                local_tail,
+                is_sealed,
+                trim_point,
+                known_global_tail,
+            ))
+        })
     }
 
     async fn enqueue_store(
@@ -220,140 +222,141 @@ impl LogStore for RocksDbLogStore {
         msg: GetRecords,
         loglet_state: &LogletState,
     ) -> Result<Records, OperationError> {
-        let data_cf = self.data_cf();
-        let loglet_id = msg.header.loglet_id;
-        // The order of operations is important to remain correct.
-        // The scenario that we want to avoid is the silent data loss. Although the
-        // replicated-loglet reader can ensure contiguous offset range and detect trim-point
-        // detection errors or data loss, we try to structure this to reduce the possibilities for
-        // errors as much as possible.
-        //
-        // If we are reading beyond the tail, the first thing we do is to clip to the
-        // local_tail.
-        let local_tail = loglet_state.local_tail();
-        let trim_point = loglet_state.trim_point();
+        block_in_place(|| {
+            let data_cf = self.data_cf();
+            let loglet_id = msg.header.loglet_id;
+            // The order of operations is important to remain correct.
+            // The scenario that we want to avoid is the silent data loss. Although the
+            // replicated-loglet reader can ensure contiguous offset range and detect trim-point
+            // detection errors or data loss, we try to structure this to reduce the possibilities for
+            // errors as much as possible.
+            //
+            // If we are reading beyond the tail, the first thing we do is to clip to the
+            // local_tail.
+            let local_tail = loglet_state.local_tail();
+            let trim_point = loglet_state.trim_point();
 
-        let read_from = msg.from_offset.max(trim_point.next());
-        let read_to = msg.to_offset.min(local_tail.offset().prev());
+            let read_from = msg.from_offset.max(trim_point.next());
+            let read_to = msg.to_offset.min(local_tail.offset().prev());
 
-        let mut size_budget = msg.total_limit_in_bytes.unwrap_or(usize::MAX);
+            let mut size_budget = msg.total_limit_in_bytes.unwrap_or(usize::MAX);
 
-        // why +1? to have enough room for the initial trim_gap if we have one.
-        let mut records = Vec::with_capacity(
-            usize::try_from(read_to.saturating_sub(*read_from)).expect("no overflow") + 1,
-        );
+            // why +1? to have enough room for the initial trim_gap if we have one.
+            let mut records = Vec::with_capacity(
+                usize::try_from(read_to.saturating_sub(*read_from)).expect("no overflow") + 1,
+            );
 
-        // Issue a trim gap until the known head
-        if read_from > msg.from_offset {
-            records.push((
-                msg.from_offset,
-                MaybeRecord::TrimGap(Gap {
-                    to: read_from.prev_unchecked(),
-                }),
-            ));
-        }
-
-        // setup the iterator
-        let mut readopts = rocksdb::ReadOptions::default();
-        let oldest_key = DataRecordKey::new(loglet_id, read_from);
-        let upper_bound = DataRecordKey::exclusive_upper_bound(loglet_id);
-
-        // If we ever switch to using a tailing iterator, be aware that these can fail on
-        // encountering a `RangeDelete` tombstone. Doing so might also require us to
-        // set_ignore_range_deletions(true).
-        readopts.set_tailing(false);
-
-        readopts.set_prefix_same_as_start(true);
-        readopts.set_total_order_seek(false);
-        // don't fill up the cache as the reader we often don't read the same record multiple times
-        // from disk. It still can happen if multiple nodes are back-filling from disk, and in that
-        // case we'd still want to favor the most recent data.
-        readopts.fill_cache(false);
-        readopts.set_async_io(true);
-        let oldest_key_bytes = oldest_key.to_binary_array();
-        readopts.set_iterate_lower_bound(oldest_key_bytes);
-        readopts.set_iterate_upper_bound(upper_bound);
-        let mut iterator = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(&data_cf, readopts);
-
-        // read_pointer points to the next offset we should attempt to read (or expect to read)
-        let mut read_pointer = read_from;
-        iterator.seek(oldest_key_bytes);
-        let mut first_record_inserted = false;
-
-        while iterator.valid() && iterator.key().is_some() && read_pointer <= read_to {
-            let loaded_key = DataRecordKey::from_slice(iterator.key().expect("log record exists"));
-            let offset = loaded_key.offset();
-            // We found a record but it's beyond what we want to read
-            if offset > read_to {
-                // reset the pointer
-                read_pointer = read_to.next();
-                break;
+            // Issue a trim gap until the known head
+            if read_from > msg.from_offset {
+                records.push((
+                    msg.from_offset,
+                    MaybeRecord::TrimGap(Gap {
+                        to: read_from.prev_unchecked(),
+                    }),
+                ));
             }
 
-            if offset > read_pointer {
-                // we skipped records. Either because they got trimmed or we don't have copies for
-                // those offsets
-                let potentially_different_trim_point = loglet_state.trim_point();
-                if potentially_different_trim_point >= offset {
-                    // drop the set of accumulated records and start over with a a fresh trim-gap
-                    records.clear();
-                    records.push((
-                        msg.from_offset,
-                        MaybeRecord::TrimGap(Gap {
-                            to: potentially_different_trim_point,
-                        }),
-                    ));
-                    read_pointer = potentially_different_trim_point.next();
-                    iterator.seek(DataRecordKey::new(loglet_id, read_pointer).to_binary_array());
-                    continue;
-                }
-                // Another possibility is that we don't have a copy of that offset. In this case,
-                // it's safe to resume.
-            }
+            // setup the iterator
+            let mut readopts = rocksdb::ReadOptions::default();
+            let oldest_key = DataRecordKey::new(loglet_id, read_from);
+            let upper_bound = DataRecordKey::exclusive_upper_bound(loglet_id);
 
-            // Is this a filtered record?
-            let decoder = DataRecordDecoder::new(iterator.value().expect("log record exists"))
-                .map_err(RocksDbLogStoreError::from)?;
+            // If we ever switch to using a tailing iterator, be aware that these can fail on
+            // encountering a `RangeDelete` tombstone. Doing so might also require us to
+            // set_ignore_range_deletions(true).
+            readopts.set_tailing(false);
 
-            if !decoder.matches_key_query(&msg.filter) {
-                records.push((offset, MaybeRecord::FilteredGap(Gap { to: offset })));
-            } else {
-                if first_record_inserted && size_budget < decoder.size() {
-                    // we have reached the limit
-                    read_pointer = offset;
+            readopts.set_prefix_same_as_start(true);
+            readopts.set_total_order_seek(false);
+            // don't fill up the cache as the reader we often don't read the same record multiple times
+            // from disk. It still can happen if multiple nodes are back-filling from disk, and in that
+            // case we'd still want to favor the most recent data.
+            readopts.fill_cache(false);
+            readopts.set_async_io(true);
+            let oldest_key_bytes = oldest_key.to_binary_array();
+            readopts.set_iterate_lower_bound(oldest_key_bytes);
+            readopts.set_iterate_upper_bound(upper_bound);
+            let mut iterator = self
+                .rocksdb
+                .inner()
+                .as_raw_db()
+                .raw_iterator_cf_opt(&data_cf, readopts);
+
+            // read_pointer points to the next offset we should attempt to read (or expect to read)
+            let mut read_pointer = read_from;
+            iterator.seek(oldest_key_bytes);
+            let mut first_record_inserted = false;
+
+            while iterator.valid() && iterator.key().is_some() && read_pointer <= read_to {
+                let loaded_key =
+                    DataRecordKey::from_slice(iterator.key().expect("log record exists"));
+                let offset = loaded_key.offset();
+                // We found a record but it's beyond what we want to read
+                if offset > read_to {
+                    // reset the pointer
+                    read_pointer = read_to.next();
                     break;
                 }
-                first_record_inserted = true;
-                size_budget = size_budget.saturating_sub(decoder.size());
-                let data_record = decoder.decode().map_err(RocksDbLogStoreError::from)?;
-                records.push((offset, MaybeRecord::Data(data_record)));
+
+                if offset > read_pointer {
+                    // we skipped records. Either because they got trimmed or we don't have copies for
+                    // those offsets
+                    let potentially_different_trim_point = loglet_state.trim_point();
+                    if potentially_different_trim_point >= offset {
+                        // drop the set of accumulated records and start over with a a fresh trim-gap
+                        records.clear();
+                        records.push((
+                            msg.from_offset,
+                            MaybeRecord::TrimGap(Gap {
+                                to: potentially_different_trim_point,
+                            }),
+                        ));
+                        read_pointer = potentially_different_trim_point.next();
+                        iterator
+                            .seek(DataRecordKey::new(loglet_id, read_pointer).to_binary_array());
+                        continue;
+                    }
+                    // Another possibility is that we don't have a copy of that offset. In this case,
+                    // it's safe to resume.
+                }
+
+                // Is this a filtered record?
+                let decoder = DataRecordDecoder::new(iterator.value().expect("log record exists"))
+                    .map_err(RocksDbLogStoreError::from)?;
+
+                if !decoder.matches_key_query(&msg.filter) {
+                    records.push((offset, MaybeRecord::FilteredGap(Gap { to: offset })));
+                } else {
+                    if first_record_inserted && size_budget < decoder.size() {
+                        // we have reached the limit
+                        read_pointer = offset;
+                        break;
+                    }
+                    first_record_inserted = true;
+                    size_budget = size_budget.saturating_sub(decoder.size());
+                    let data_record = decoder.decode().map_err(RocksDbLogStoreError::from)?;
+                    records.push((offset, MaybeRecord::Data(data_record)));
+                }
+
+                read_pointer = offset.next();
+                if read_pointer > read_to {
+                    break;
+                }
+                iterator.next();
             }
 
-            read_pointer = offset.next();
-            if read_pointer > read_to {
-                break;
+            // we reached the end (or an error)
+            if let Err(e) = iterator.status() {
+                // whoa, we have I/O errors, we should switch into failsafe mode (todo)
+                self.health_status.update(LogServerStatus::Failsafe);
+                return Err(RocksDbLogStoreError::Rocksdb(e).into());
             }
-            iterator.next();
-            // Allow other tasks on this thread to run, but only if we have exhausted the coop
-            // budget.
-            tokio::task::consume_budget().await;
-        }
 
-        // we reached the end (or an error)
-        if let Err(e) = iterator.status() {
-            // whoa, we have I/O errors, we should switch into failsafe mode (todo)
-            self.health_status.update(LogServerStatus::Failsafe);
-            return Err(RocksDbLogStoreError::Rocksdb(e).into());
-        }
-
-        Ok(Records {
-            header: LogServerResponseHeader::new(local_tail, loglet_state.known_global_tail()),
-            next_offset: read_pointer,
-            records,
+            Ok(Records {
+                header: LogServerResponseHeader::new(local_tail, loglet_state.known_global_tail()),
+                next_offset: read_pointer,
+                records,
+            })
         })
     }
 
@@ -362,134 +365,145 @@ impl LogStore for RocksDbLogStore {
         msg: GetDigest,
         loglet_state: &LogletState,
     ) -> Result<Digest, OperationError> {
-        let data_cf = self.data_cf();
-        let loglet_id = msg.header.loglet_id;
-        // If we are reading beyond the tail, the first thing we do is to clip to the
-        // local_tail.
-        let local_tail = loglet_state.local_tail();
-        let trim_point = loglet_state.trim_point();
+        block_in_place(|| {
+            let data_cf = self.data_cf();
+            let loglet_id = msg.header.loglet_id;
+            // If we are reading beyond the tail, the first thing we do is to clip to the
+            // local_tail.
+            let local_tail = loglet_state.local_tail();
+            let trim_point = loglet_state.trim_point();
 
-        // inclusive
-        let read_from = msg.from_offset.max(trim_point.next());
-        let read_to = msg.to_offset.min(local_tail.offset().prev());
+            // inclusive
+            let read_from = msg.from_offset.max(trim_point.next());
+            let read_to = msg.to_offset.min(local_tail.offset().prev());
 
-        // allocate for near-worst-case.
-        let mut entries = Vec::with_capacity(
-            usize::try_from(read_to.saturating_sub(*read_from)).expect("no overflow") + 1,
-        );
+            // allocate for near-worst-case.
+            let mut entries = Vec::with_capacity(
+                usize::try_from(read_to.saturating_sub(*read_from)).expect("no overflow") + 1,
+            );
 
-        // Issue a trim gap until the known head
-        if read_from > msg.from_offset {
-            entries.push(DigestEntry {
-                from_offset: msg.from_offset,
-                to_offset: read_from.prev_unchecked(),
-                status: RecordStatus::Trimmed,
-            });
-        }
+            // Issue a trim gap until the known head
+            if read_from > msg.from_offset {
+                entries.push(DigestEntry {
+                    from_offset: msg.from_offset,
+                    to_offset: read_from.prev_unchecked(),
+                    status: RecordStatus::Trimmed,
+                });
+            }
 
-        // setup the iterator
-        let mut readopts = rocksdb::ReadOptions::default();
-        let oldest_key = DataRecordKey::new(loglet_id, read_from);
-        // the iterator has an exclusive upper bound
-        let upper_bound_bytes = if read_to == LogletOffset::MAX {
-            DataRecordKey::exclusive_upper_bound(loglet_id)
-        } else {
-            DataRecordKey::new(loglet_id, read_to.next()).to_binary_array()
-        };
+            // setup the iterator
+            let mut readopts = rocksdb::ReadOptions::default();
+            let oldest_key = DataRecordKey::new(loglet_id, read_from);
+            // the iterator has an exclusive upper bound
+            let upper_bound_bytes = if read_to == LogletOffset::MAX {
+                DataRecordKey::exclusive_upper_bound(loglet_id)
+            } else {
+                DataRecordKey::new(loglet_id, read_to.next()).to_binary_array()
+            };
 
-        // If we ever switch to using a tailing iterator, be aware that these can fail on
-        // encountering a `RangeDelete` tombstone. Doing so might also require us to
-        // set_ignore_range_deletions(true).
-        readopts.set_tailing(false);
+            // If we ever switch to using a tailing iterator, be aware that these can fail on
+            // encountering a `RangeDelete` tombstone. Doing so might also require us to
+            // set_ignore_range_deletions(true).
+            readopts.set_tailing(false);
 
-        readopts.set_prefix_same_as_start(true);
-        readopts.set_total_order_seek(false);
-        // don't fill up the cache as the reader might actually end up reading very few records and
-        // we don't want to evict more important records from the cache.
-        readopts.fill_cache(false);
-        readopts.set_async_io(true);
-        let oldest_key_bytes = oldest_key.to_binary_array();
-        readopts.set_iterate_lower_bound(oldest_key_bytes);
-        readopts.set_iterate_upper_bound(upper_bound_bytes);
-        let mut iterator = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(&data_cf, readopts);
+            readopts.set_prefix_same_as_start(true);
+            readopts.set_total_order_seek(false);
+            // don't fill up the cache as the reader might actually end up reading very few records and
+            // we don't want to evict more important records from the cache.
+            readopts.fill_cache(false);
+            readopts.set_async_io(true);
+            let oldest_key_bytes = oldest_key.to_binary_array();
+            readopts.set_iterate_lower_bound(oldest_key_bytes);
+            readopts.set_iterate_upper_bound(upper_bound_bytes);
+            let mut iterator = self
+                .rocksdb
+                .inner()
+                .as_raw_db()
+                .raw_iterator_cf_opt(&data_cf, readopts);
 
-        // read_pointer points to the next offset we should attempt to read (or expect to read)
-        let mut read_pointer = read_from;
-        iterator.seek(oldest_key_bytes);
+            // read_pointer points to the next offset we should attempt to read (or expect to read)
+            let mut read_pointer = read_from;
+            iterator.seek(oldest_key_bytes);
 
-        let mut current_open_entry: Option<DigestEntry> = None;
+            let mut current_open_entry: Option<DigestEntry> = None;
 
-        while iterator.valid() && iterator.key().is_some() && read_pointer <= read_to {
-            let loaded_key =
-                DataRecordKey::from_slice(&mut iterator.key().expect("log record exists"));
-            let offset = loaded_key.offset();
-            match offset.cmp(&read_pointer) {
-                Ordering::Greater => {
-                    // We found a record but it's beyond what we expect as next (local gap)
-                    // close the entry if we had one
-                    if let Some(open) = current_open_entry.take() {
-                        entries.push(open);
-                    }
-                    if offset > read_to {
-                        // we are done.
-                        break;
-                    }
+            while iterator.valid() && iterator.key().is_some() && read_pointer <= read_to {
+                let loaded_key =
+                    DataRecordKey::from_slice(&mut iterator.key().expect("log record exists"));
+                let offset = loaded_key.offset();
+                match offset.cmp(&read_pointer) {
+                    Ordering::Greater => {
+                        // We found a record but it's beyond what we expect as next (local gap)
+                        // close the entry if we had one
+                        if let Some(open) = current_open_entry.take() {
+                            entries.push(open);
+                        }
+                        if offset > read_to {
+                            // we are done.
+                            break;
+                        }
 
-                    // open a new entry
-                    current_open_entry = Some(DigestEntry {
-                        from_offset: offset,
-                        to_offset: offset,
-                        status: RecordStatus::Exists,
-                    });
-                    // reset the pointer
-                    read_pointer = offset.next();
-                }
-                Ordering::Equal => {
-                    if let Some(open) = current_open_entry.as_mut() {
-                        open.to_offset = read_pointer;
-                    } else {
                         // open a new entry
                         current_open_entry = Some(DigestEntry {
                             from_offset: offset,
                             to_offset: offset,
                             status: RecordStatus::Exists,
                         });
+                        // reset the pointer
+                        read_pointer = offset.next();
                     }
-                    read_pointer = read_pointer.next();
+                    Ordering::Equal => {
+                        if let Some(open) = current_open_entry.as_mut() {
+                            open.to_offset = read_pointer;
+                        } else {
+                            // open a new entry
+                            current_open_entry = Some(DigestEntry {
+                                from_offset: offset,
+                                to_offset: offset,
+                                status: RecordStatus::Exists,
+                            });
+                        }
+                        read_pointer = read_pointer.next();
+                    }
+                    Ordering::Less => {
+                        // offset < read_pointer?
+                        panic!("Bad logic, iterator is going backward!");
+                    }
                 }
-                Ordering::Less => {
-                    // offset < read_pointer?
-                    panic!("Bad logic, iterator is going backward!");
-                }
+                iterator.next();
             }
-            iterator.next();
-            // Allow other tasks on this thread to run, but only if we have exhausted the coop
-            // budget.
-            tokio::task::consume_budget().await;
-        }
 
-        // we reached the end due to an error
-        if read_pointer <= read_to
-            && let Err(e) = iterator.status()
-        {
-            // whoa, we have I/O errors, we should switch into failsafe mode (todo)
-            self.health_status.update(LogServerStatus::Failsafe);
-            return Err(RocksDbLogStoreError::Rocksdb(e).into());
-        }
+            // we reached the end due to an error
+            if read_pointer <= read_to
+                && let Err(e) = iterator.status()
+            {
+                // whoa, we have I/O errors, we should switch into failsafe mode (todo)
+                self.health_status.update(LogServerStatus::Failsafe);
+                return Err(RocksDbLogStoreError::Rocksdb(e).into());
+            }
 
-        if let Some(last) = current_open_entry.take() {
-            // close the last entry
-            entries.push(last);
-        }
+            if let Some(last) = current_open_entry.take() {
+                // close the last entry
+                entries.push(last);
+            }
 
-        Ok(Digest {
-            header: LogServerResponseHeader::new(local_tail, loglet_state.known_global_tail()),
-            entries,
+            Ok(Digest {
+                header: LogServerResponseHeader::new(local_tail, loglet_state.known_global_tail()),
+                entries,
+            })
         })
+    }
+}
+
+#[track_caller]
+pub fn block_in_place<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    if cfg!(any(test, feature = "test-util")) {
+        f()
+    } else {
+        tokio::task::block_in_place(f)
     }
 }
 


### PR DESCRIPTION

Reads on the default runtime may block the IO driver, let's move the worker to become a background worker on reads.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4394).
* #4395
* __->__ #4394