### PR TITLE
[Restate UI] Update to v0.1.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8320,8 +8320,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.47"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.47#dbd8efa976590b9fc9d845ddf96e551a66af9e30"
+version = "0.1.48"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.48#3101105ec6afe1cba9b6719273ad149c5b9ceb08"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.47", tag = "v0.1.47" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.48", tag = "v0.1.48" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.48
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.48/ui-v0.1.48.zip