### PR TITLE
[Networking] Changes to push-back and swimlanes

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -65,8 +65,7 @@ impl<T: TransportConnect> Factory<T> {
         let data_request_pump = router_builder
             .register_buffered_service_with_pool(data_pool, BackPressureMode::PushBack);
         // Sequencer meta uses the default shared pool.
-        let info_request_pump =
-            router_builder.register_buffered_service(BackPressureMode::PushBack);
+        let info_request_pump = router_builder.register_buffered_service(BackPressureMode::Lossy);
 
         Self {
             networking,

--- a/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/read_path/read_stream_task.rs
@@ -571,7 +571,7 @@ impl ReadStreamTask {
         let maybe_records = networking
             .call_rpc(
                 server,
-                Swimlane::BifrostData,
+                Swimlane::BifrostReads,
                 request,
                 Some(self.my_params.loglet_id.into()),
                 Some(*options.log_server_rpc_timeout),

--- a/crates/core/protobuf/restate/network.proto
+++ b/crates/core/protobuf/restate/network.proto
@@ -23,8 +23,12 @@ enum Swimlane {
   GOSSIP = 1;
   // Fat pipe for streaming bifrost records
   BIFROST_DATA = 2;
-  // Fat pipe for ingress data communication with workers
+  // Fat pipe for ingress data communication with workers (data ingestion)
   INGRESS_DATA = 3;
+  /// Fat pipe for sending read requests and responses between bifrost nodes and log-servers
+  BIFROST_READS = 4;
+  /// Data pipe for performing remote datafusion scans
+  DATAFUSION = 5;
 }
 
 //

--- a/crates/log-server/src/network.rs
+++ b/crates/log-server/src/network.rs
@@ -61,7 +61,7 @@ impl RequestPump {
         let data_svc_rx =
             router_builder.register_service_with_pool(data_pool, BackPressureMode::PushBack);
         // Meta service uses the default shared memory pool.
-        let info_svc_rx = router_builder.register_service(BackPressureMode::PushBack);
+        let info_svc_rx = router_builder.register_service(BackPressureMode::Lossy);
 
         Self {
             data_svc_rx,

--- a/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
@@ -284,7 +284,7 @@ impl<T: TransportConnect> RemoteScannerService for RemoteScannerServiceProxy<T> 
     ) -> Result<RemoteScanner, DataFusionError> {
         let connection = self
             .networking
-            .get_connection(peer, Swimlane::default())
+            .get_connection(peer, Swimlane::Datafusion)
             .in_tc_as_task(
                 &self.task_center,
                 TaskKind::InPlace,

--- a/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_server.rs
@@ -45,7 +45,7 @@ impl RemoteQueryScannerServer {
         remote_scanner_manager: RemoteScannerManager,
         router_builder: &mut MessageRouterBuilder,
     ) -> Self {
-        let network_rx = router_builder.register_service(BackPressureMode::PushBack);
+        let network_rx = router_builder.register_service(BackPressureMode::Lossy);
 
         Self {
             query_context,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -250,7 +250,7 @@ where
         ingestion_client: IngestionClient<T, Envelope>,
     ) -> Self {
         let config = updateable_config.pinned();
-        let ppm_svc_rx = router_builder.register_service(BackPressureMode::PushBack);
+        let ppm_svc_rx = router_builder.register_service(BackPressureMode::Lossy);
 
         // NOTE: this is a shared pool for RPC requests from ingress and ingestion clients across all
         // partitions.


### PR DESCRIPTION

We want to keep push-back backpressure strictly to users of the data swimlanes (ingestion, and bifrost). Everything else should be lossy.

This also introduces two new swimlanes:
- BifrostReads: for log-server readers to use to reduce the latency of store responses being qeueued behind log-server read responses.
- Datafusion: for remote scanner queries where responses can be large.

Note that reads will go to the general swimlane as fallback if servers don't recognize the new swimlane (i.e. during upgrade).
