### PR TITLE
[Networking] Introduces sort-code-based sharded service routing

### DIFF
--- a/crates/core/src/network/error.rs
+++ b/crates/core/src/network/error.rs
@@ -58,6 +58,7 @@ impl From<RouterError> for rpc_reply::Status {
 /// to ensure that the handler adheres to the contract of the rpc protocol.
 ///
 /// The rest of the errors are emitted by the message routing infrastructure.
+#[derive(Debug, derive_more::Display)]
 pub enum Verdict {
     /// The target service is known but the message type is not recognized by the handler
     MessageUnrecognized,
@@ -88,6 +89,14 @@ impl From<Verdict> for watch_update::Start {
             Verdict::LoadShedding => Self::LoadShedding,
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ShardRegistrationError {
+    #[error("router error: {0}")]
+    Router(#[from] RouterError),
+    #[error("verdict: {0}")]
+    Verdict(Verdict),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/core/src/network/message_router/shard_map.rs
+++ b/crates/core/src/network/message_router/shard_map.rs
@@ -1,0 +1,543 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+use dashmap::DashMap;
+use tokio::sync::mpsc;
+
+use restate_types::net::ServiceTag;
+
+use super::RawSender;
+
+static EPOCH: AtomicU64 = const { AtomicU64::new(1) };
+
+type Epoch = u64;
+
+type Map = DashMap<(ServiceTag, u64), Value<RawSender>, ahash::RandomState>;
+
+#[derive(Clone, Default)]
+pub struct Shards {
+    items: Arc<Map>,
+}
+
+/// Held while registering a new network service shard.
+///
+/// While this token is held, other network messages requesting access to the same shard will wait
+/// until this token is dropped or `done()` is called.
+#[must_use]
+pub struct RegistrationToken {
+    key: (ServiceTag, u64),
+    epoch: Epoch,
+    map: Arc<Map>,
+    receiver: Option<mpsc::UnboundedReceiver<()>>,
+}
+
+impl RegistrationToken {
+    /// Marks the registration as done.
+    ///
+    /// This returns `true` if the registration was successful in the map. This
+    /// will return `false` if the map was updated by force-removing the entry.
+    pub fn done(mut self, sender: RawSender) -> bool {
+        if let Some(_receiver) = self.receiver.take()
+            && let dashmap::mapref::entry::Entry::Occupied(mut v) = self.map.entry(self.key)
+        {
+            match v.get() {
+                Value::Waiting(epoch, _) if *epoch == self.epoch => {
+                    v.insert(Value::Filled(sender));
+                    return true;
+                }
+                Value::Filled(existing) if existing.same_channel(&sender) => {
+                    // it's already registered
+                    return true;
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+}
+
+impl Drop for RegistrationToken {
+    fn drop(&mut self) {
+        if self.receiver.is_some() {
+            match self.map.entry(self.key) {
+                dashmap::mapref::entry::Entry::Occupied(v) => match v.get() {
+                    Value::Waiting(epoch, _) if *epoch == self.epoch => {
+                        let _ = v.remove();
+                    }
+                    _ => {}
+                },
+                dashmap::mapref::entry::Entry::Vacant(_) => {}
+            }
+        }
+    }
+}
+
+/// A token to wait for an on-going shard registration.
+///
+/// This token needs to be awaited by calling `join()`. Once join() returns, the shard
+/// state can be queried again.
+#[must_use]
+#[derive(Clone, Debug)]
+pub struct WaitToken(mpsc::UnboundedSender<()>);
+
+impl WaitToken {
+    /// Waits for the registration token to be dropped
+    pub async fn join(self) {
+        self.0.closed().await
+    }
+}
+
+pub enum MaybeValue {
+    Filled(RawSender),
+    Opening(WaitToken),
+    Register(RegistrationToken),
+}
+
+impl Shards {
+    pub fn maybe_register(&self, target: ServiceTag, sort_code: u64) -> MaybeValue {
+        match self.items.entry((target, sort_code)) {
+            dashmap::mapref::entry::Entry::Occupied(v) => match v.get() {
+                Value::Filled(v) => MaybeValue::Filled(v.clone()),
+                Value::Waiting(_, wait) => MaybeValue::Opening(wait.clone()),
+            },
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let epoch = EPOCH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let (sender, receiver) = mpsc::unbounded_channel();
+                entry.insert(Value::Waiting(epoch, WaitToken(sender)));
+                MaybeValue::Register(RegistrationToken {
+                    key: (target, sort_code),
+                    map: Arc::clone(&self.items),
+                    epoch,
+                    receiver: Some(receiver),
+                })
+            }
+        }
+    }
+
+    pub fn force_register(&self, target: ServiceTag, sort_code: u64, sender: RawSender) {
+        self.items
+            .insert((target, sort_code), Value::Filled(sender));
+    }
+
+    /// Remove an existing shard only if the sender matches the existing one
+    pub fn remove_if_matches(&self, target: ServiceTag, sort_code: u64, sender: &RawSender) {
+        if let dashmap::mapref::entry::Entry::Occupied(v) = self.items.entry((target, sort_code))
+            && let Value::Filled(existing) = v.get()
+            && existing.same_channel(sender)
+        {
+            v.remove();
+        }
+    }
+
+    /// Remove an existing shard
+    pub fn remove(&self, target: ServiceTag, sort_code: u64) -> Option<RawSender> {
+        let entry = self.items.remove(&(target, sort_code))?;
+        match entry {
+            (_, Value::Filled(value)) => Some(value),
+            (_, Value::Waiting(..)) => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Value<V> {
+    Waiting(Epoch, WaitToken),
+    Filled(V),
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_types::net::ServiceTag;
+
+    use super::*;
+
+    const SVC_A: ServiceTag = ServiceTag::LogServerDataService;
+    const SVC_B: ServiceTag = ServiceTag::LogServerMetaService;
+
+    /// Helper: creates a RawSender/receiver pair for testing.
+    fn raw_sender() -> (
+        super::super::RawSender,
+        tokio::sync::mpsc::UnboundedReceiver<super::super::ServiceOp>,
+    ) {
+        super::super::RawSender::test_channel()
+    }
+
+    #[test]
+    fn vacant_entry_returns_register_and_done_completes_it() {
+        // First call on a vacant entry must yield Register, calling done() fills the slot,
+        // and subsequent lookups must return Filled with the same channel.
+        let shards = Shards::default();
+        let (sender, _rx) = raw_sender();
+
+        let token = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        assert!(
+            token.done(sender.clone()),
+            "done() should succeed on matching epoch"
+        );
+
+        // Now the entry is filled — a second lookup must return the same sender.
+        match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Filled(s) => assert!(s.same_channel(&sender)),
+            other => panic!("expected Filled, got {}", variant_name(&other)),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn concurrent_lookup_returns_opening_and_join_resolves_on_done() {
+        // While a registration is in-flight (token exists, done() not called), concurrent
+        // callers must see Opening. WaitToken::join() must resolve once done() is called.
+        let shards = Shards::default();
+        let (sender, _rx) = raw_sender();
+
+        let token = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        // Second caller while first registration is in progress.
+        let wait = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Opening(w) => w,
+            other => panic!("expected Opening, got {}", variant_name(&other)),
+        };
+
+        // join() should not resolve yet.
+        let join_handle = tokio::spawn(async move { wait.join().await });
+        tokio::task::yield_now().await;
+        assert!(!join_handle.is_finished(), "join should still be pending");
+
+        // Complete registration.
+        assert!(token.done(sender));
+
+        // join() must now resolve.
+        tokio::time::timeout(std::time::Duration::from_millis(100), join_handle)
+            .await
+            .expect("join should resolve after done()")
+            .expect("task should not panic");
+    }
+
+    #[test]
+    fn drop_token_without_done_cleans_up_entry() {
+        // Dropping the RegistrationToken without calling done() must remove the
+        // Waiting entry from the map — this is the cancellation-safety guarantee.
+        let shards = Shards::default();
+
+        let token = match shards.maybe_register(SVC_A, 42) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+        // Drop without done().
+        drop(token);
+
+        // The slot should be vacant again — next lookup must yield Register.
+        match shards.maybe_register(SVC_A, 42) {
+            MaybeValue::Register(t) => drop(t.done(raw_sender().0)), // clean up
+            other => panic!(
+                "expected Register after cancelled registration, got {}",
+                variant_name(&other)
+            ),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drop_token_resolves_waiters() {
+        // When a RegistrationToken is dropped (cancelled), WaitToken::join() must resolve
+        // so that waiters can retry registration.
+        let shards = Shards::default();
+
+        let token = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        let wait = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Opening(w) => w,
+            other => panic!("expected Opening, got {}", variant_name(&other)),
+        };
+
+        let join_handle = tokio::spawn(async move { wait.join().await });
+
+        // Cancel registration by dropping the token.
+        drop(token);
+
+        // Waiter must unblock.
+        tokio::time::timeout(std::time::Duration::from_millis(100), join_handle)
+            .await
+            .expect("join should resolve after token drop")
+            .expect("task should not panic");
+    }
+
+    #[test]
+    fn force_register_overwrites_and_makes_token_done_fail() {
+        // force_register unconditionally fills the slot. If a RegistrationToken from
+        // a prior maybe_register exists, its done() must return false (epoch mismatch).
+        let shards = Shards::default();
+        let (force_sender, _rx1) = raw_sender();
+        let (token_sender, _rx2) = raw_sender();
+
+        let token = match shards.maybe_register(SVC_A, 7) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        // Force-register overwrites the Waiting entry.
+        shards.force_register(SVC_A, 7, force_sender.clone());
+
+        // The old token's done() should fail because the entry is now Filled
+        // with a different sender (epoch no longer matches).
+        assert!(
+            !token.done(token_sender),
+            "done() should fail after force_register with different sender"
+        );
+
+        // The force-registered sender should be what we get back.
+        match shards.maybe_register(SVC_A, 7) {
+            MaybeValue::Filled(s) => assert!(s.same_channel(&force_sender)),
+            other => panic!("expected Filled, got {}", variant_name(&other)),
+        }
+    }
+
+    #[test]
+    fn drop_token_after_force_register_does_not_remove_entry() {
+        // If force_register overwrote the Waiting entry, dropping the stale
+        // RegistrationToken must NOT remove the force-registered entry (epoch mismatch).
+        let shards = Shards::default();
+        let (force_sender, _rx) = raw_sender();
+
+        let token = match shards.maybe_register(SVC_A, 3) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        shards.force_register(SVC_A, 3, force_sender.clone());
+
+        // Drop the stale token — must not clobber the force-registered entry.
+        drop(token);
+
+        match shards.maybe_register(SVC_A, 3) {
+            MaybeValue::Filled(s) => assert!(s.same_channel(&force_sender)),
+            other => panic!(
+                "expected Filled to survive stale token drop, got {}",
+                variant_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn done_with_already_registered_same_sender_returns_true() {
+        // If force_register already filled the slot with the *same* sender that
+        // done() is called with, done() returns true (idempotent).
+        let shards = Shards::default();
+        let (sender, _rx) = raw_sender();
+
+        let token = match shards.maybe_register(SVC_A, 5) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        shards.force_register(SVC_A, 5, sender.clone());
+
+        // done() with the same channel should succeed because same_channel matches.
+        assert!(
+            token.done(sender),
+            "done() should return true for same channel"
+        );
+    }
+
+    #[test]
+    fn different_service_tags_are_independent() {
+        // Entries are keyed by (ServiceTag, sort_code). Two different service tags
+        // with the same sort_code must not interfere.
+        let shards = Shards::default();
+        let (sender_a, _rx_a) = raw_sender();
+        let (sender_b, _rx_b) = raw_sender();
+
+        // Register sort_code=1 under SVC_A
+        let token_a = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register for SVC_A, got {}", variant_name(&other)),
+        };
+        assert!(token_a.done(sender_a.clone()));
+
+        // Register sort_code=1 under SVC_B — must NOT return Filled from SVC_A.
+        let token_b = match shards.maybe_register(SVC_B, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register for SVC_B, got {}", variant_name(&other)),
+        };
+        assert!(token_b.done(sender_b.clone()));
+
+        // Each returns its own sender.
+        match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Filled(s) => assert!(s.same_channel(&sender_a)),
+            other => panic!("expected Filled(sender_a), got {}", variant_name(&other)),
+        }
+        match shards.maybe_register(SVC_B, 1) {
+            MaybeValue::Filled(s) => assert!(s.same_channel(&sender_b)),
+            other => panic!("expected Filled(sender_b), got {}", variant_name(&other)),
+        }
+    }
+
+    #[test]
+    fn remove_if_matches_only_removes_matching_sender() {
+        let shards = Shards::default();
+        let (sender_a, _rx_a) = raw_sender();
+        let (sender_b, _rx_b) = raw_sender();
+
+        shards.force_register(SVC_A, 1, sender_a.clone());
+
+        // Attempting to remove with a different sender should be a no-op.
+        shards.remove_if_matches(SVC_A, 1, &sender_b);
+        match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Filled(s) => assert!(
+                s.same_channel(&sender_a),
+                "entry should survive non-matching remove"
+            ),
+            other => panic!("expected Filled, got {}", variant_name(&other)),
+        }
+
+        // Removing with the matching sender should succeed.
+        shards.remove_if_matches(SVC_A, 1, &sender_a);
+        match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => drop(t), // clean up
+            other => panic!(
+                "expected Register after removal, got {}",
+                variant_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn remove_if_matches_ignores_waiting_entries() {
+        // remove_if_matches should not remove an entry that is in Waiting state.
+        let shards = Shards::default();
+        let (sender, _rx) = raw_sender();
+
+        let token = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+
+        // Entry is Waiting — remove_if_matches must be a no-op.
+        shards.remove_if_matches(SVC_A, 1, &sender);
+
+        // Entry should still be Opening for a concurrent caller.
+        match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Opening(_) => {} // expected
+            other => panic!(
+                "expected Opening (entry should survive), got {}",
+                variant_name(&other)
+            ),
+        }
+
+        drop(token); // clean up
+    }
+
+    #[test]
+    fn remove_returns_sender_for_filled_none_for_waiting_or_absent() {
+        let shards = Shards::default();
+        let (sender, _rx) = raw_sender();
+
+        // Absent entry.
+        assert!(shards.remove(SVC_A, 99).is_none());
+
+        // Waiting entry.
+        let token = match shards.maybe_register(SVC_A, 10) {
+            MaybeValue::Register(t) => t,
+            other => panic!("expected Register, got {}", variant_name(&other)),
+        };
+        assert!(
+            shards.remove(SVC_A, 10).is_none(),
+            "remove on Waiting should return None"
+        );
+        // Token's drop should not panic even though the entry was force-removed.
+        drop(token);
+
+        // Filled entry.
+        shards.force_register(SVC_A, 20, sender.clone());
+        let removed = shards.remove(SVC_A, 20);
+        assert!(removed.is_some());
+        assert!(removed.unwrap().same_channel(&sender));
+
+        // After removal, the slot is vacant.
+        match shards.maybe_register(SVC_A, 20) {
+            MaybeValue::Register(t) => drop(t),
+            other => panic!(
+                "expected Register after remove, got {}",
+                variant_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn force_register_then_remove_then_re_register() {
+        // Full lifecycle: register → remove → re-register with a different sender.
+        let shards = Shards::default();
+        let (sender1, _rx1) = raw_sender();
+        let (sender2, _rx2) = raw_sender();
+
+        shards.force_register(SVC_A, 1, sender1.clone());
+        shards.remove(SVC_A, 1);
+
+        let token = match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Register(t) => t,
+            other => panic!(
+                "expected Register after remove, got {}",
+                variant_name(&other)
+            ),
+        };
+        assert!(token.done(sender2.clone()));
+
+        match shards.maybe_register(SVC_A, 1) {
+            MaybeValue::Filled(s) => {
+                assert!(!s.same_channel(&sender1), "should not be the old sender");
+                assert!(s.same_channel(&sender2), "should be the new sender");
+            }
+            other => panic!("expected Filled, got {}", variant_name(&other)),
+        }
+    }
+
+    #[test]
+    fn multiple_sort_codes_same_service_are_independent() {
+        let shards = Shards::default();
+        let (sender1, _rx1) = raw_sender();
+        let (sender2, _rx2) = raw_sender();
+
+        shards.force_register(SVC_A, 100, sender1.clone());
+        shards.force_register(SVC_A, 200, sender2.clone());
+
+        // Removing sort_code=100 should not affect sort_code=200.
+        shards.remove(SVC_A, 100);
+
+        assert!(shards.remove(SVC_A, 100).is_none(), "already removed");
+        match shards.maybe_register(SVC_A, 200) {
+            MaybeValue::Filled(s) => assert!(s.same_channel(&sender2)),
+            other => panic!(
+                "expected Filled for sort_code=200, got {}",
+                variant_name(&other)
+            ),
+        }
+    }
+
+    /// Helper to name the MaybeValue variant for better assertion messages.
+    fn variant_name(v: &MaybeValue) -> &'static str {
+        match v {
+            MaybeValue::Filled(_) => "Filled",
+            MaybeValue::Opening(_) => "Opening",
+            MaybeValue::Register(_) => "Register",
+        }
+    }
+}

--- a/crates/core/src/network/message_router/sharded.rs
+++ b/crates/core/src/network/message_router/sharded.rs
@@ -1,0 +1,428 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Poll, ready};
+
+use futures::Stream;
+use metrics::{Counter, counter};
+use tokio::sync::{mpsc, oneshot};
+
+use restate_memory::{MemoryLease, MemoryPool};
+use restate_types::net::Service;
+
+use super::shard_map::Shards;
+use super::{BackPressureMode, RawSender, ServiceStream};
+use crate::network::metric_definitions::NETWORK_SERVICE_ACCEPTED_REQUEST_BYTES;
+use crate::network::{RouterError, ShardRegistrationError, Verdict};
+
+/// A handle to a sharded network service.
+///
+/// Sharded network services run independent shards for each 'sort-code'.
+///
+/// Owners of sharded services can create new shards via two mechanisms:
+///   1. Upon receiving a message with a sort-code that is not registered yet, the service
+///      owner will receive a [`ShardControlMessage::RegisterSortCode`] message on the [`ShardControlStream`]
+///      with the sort-code in question. The service owner can then do the necessary setup
+///      and return a [`ShardSender`] via [`ShardControlMessage::RegisterSortCode::decision`].
+///   2. By calling [`ControlServiceShards::force_register_sort_code`]. This will register a new
+///      shard immediately and unconditionally.
+pub struct Sharded<S> {
+    rx: ShardControlReceiver<S>,
+    shards: Shards,
+}
+
+impl<S: Service> Sharded<S> {
+    pub(crate) const fn new(rx: ShardControlReceiver<S>, shards: Shards) -> Self {
+        Self { rx, shards }
+    }
+
+    /// Starts accepting messages and returns the control handles.
+    ///
+    /// Returns a pair of:
+    /// - [`ShardControlStream`] — a stream of [`ShardControlMessage`] that the service owner
+    ///   polls to handle on-demand shard registration requests from the message router. Each
+    ///   message carries a sort-code and a [`ShardRegistrationDecision`] that the owner must
+    ///   resolve (accept or fail).
+    /// - [`ControlServiceShards`] — a handle for imperative shard management
+    ///   (force-register / unregister) outside the request-driven flow.
+    ///
+    /// After this call, the message router will begin routing incoming messages to
+    /// registered shards and will send registration requests for unknown sort-codes.
+    pub fn start(self) -> (ShardControlStream<S>, ControlServiceShards<S>) {
+        let Self { rx, shards } = self;
+        let stream = rx.start();
+
+        (stream, ControlServiceShards::new(shards))
+    }
+
+    /// Splits into the raw receiver and the shard control handle **without** starting.
+    ///
+    /// Use this when you need to defer calling
+    /// [`ShardControlReceiver::start`] (e.g. to pass the receiver to another task
+    /// that will start it later). Messages sent before `start()` is called will be
+    /// rejected with [`RouterError::ServiceNotReady`].
+    pub fn split(self) -> (ShardControlReceiver<S>, ControlServiceShards<S>) {
+        (self.rx, ControlServiceShards::new(self.shards))
+    }
+
+    /// Takes ownership of the inner value, replacing `self` with a closed default.
+    ///
+    /// The returned [`Sharded`] retains the original receiver and shard map.
+    /// `self` is left in a default (closed) state — any messages routed to it will
+    /// be rejected.
+    ///
+    /// This is useful when a component needs to move the receiver into a subtask
+    /// while keeping the field in the parent struct intact.
+    pub fn take(&mut self) -> Sharded<S> {
+        std::mem::take(self)
+    }
+}
+
+impl<S: Service> Default for Sharded<S> {
+    fn default() -> Self {
+        Self::new(ShardControlReceiver::default(), Shards::default())
+    }
+}
+
+/// A one-shot decision handle for an on-demand shard registration request.
+///
+/// The message router produces this handle when it encounters a sort-code that
+/// has no registered shard yet. The service owner must resolve it by calling
+/// either [`accept`](Self::accept) or [`fail`](Self::fail). Dropping the handle
+/// without calling either method is equivalent to a failure — the router will
+/// treat the registration as cancelled and may retry on the next message.
+pub struct ShardRegistrationDecision<S> {
+    inner: oneshot::Sender<Result<RawSender, ShardRegistrationError>>,
+    _phantom: PhantomData<S>,
+}
+
+impl<S: Service> ShardRegistrationDecision<S> {
+    pub(crate) const fn new(
+        inner: oneshot::Sender<Result<RawSender, ShardRegistrationError>>,
+    ) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Accepts the registration and provides a [`ShardSender`] that the router
+    /// will use to deliver subsequent messages with this sort-code.
+    pub fn accept(self, sender: ShardSender<S>) {
+        let _ = self.inner.send(Ok(sender.into_raw()));
+    }
+
+    /// Rejects the registration with a [`Verdict`].
+    ///
+    /// The verdict is propagated back to the caller:
+    /// - For RPC calls, it is sent as the reply status.
+    /// - For unary messages, it is translated into a routing error.
+    pub fn fail(self, verdict: Verdict) {
+        let _ = self
+            .inner
+            .send(Err(ShardRegistrationError::Verdict(verdict)));
+    }
+}
+
+/// Imperative shard management handle for a sharded service.
+///
+/// This is the counterpart to the request-driven [`ShardControlStream`]: while
+/// the stream lets the router ask the service to create shards on demand, this
+/// handle lets the service proactively register or unregister shards at any
+/// time (e.g. during startup to pre-warm known shards, or during shutdown to
+/// tear them down).
+///
+/// Obtained from [`Sharded::start`] or [`Sharded::split`].
+pub struct ControlServiceShards<S> {
+    shards: Shards,
+    _phantom: std::marker::PhantomData<S>,
+}
+
+impl<S: Service> ControlServiceShards<S> {
+    pub(crate) fn new(shards: Shards) -> Self {
+        Self {
+            shards,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn force_register_sort_code(&self, sort_code: u64, sender: ShardSender<S>) {
+        self.shards
+            .force_register(S::TAG, sort_code, sender.into_raw());
+    }
+
+    pub fn force_unregister_sort_code(&self, sort_code: u64) {
+        let _ = self.shards.remove(S::TAG, sort_code);
+    }
+}
+
+/// A typed sender for delivering messages to a single shard of a sharded service.
+///
+/// Created via [`ShardSender::new`], which returns a `(ShardSender, ServiceStream)`
+/// pair. The [`ServiceStream`] is the receiving end that the shard's worker task
+/// polls for incoming messages.
+///
+/// A `ShardSender` is handed to the router — either through
+/// [`ShardRegistrationDecision::accept`] (on-demand) or
+/// [`ControlServiceShards::force_register_sort_code`] (imperative) — so the
+/// router can deliver messages for the corresponding sort-code.
+///
+/// Cloning a `ShardSender` produces another handle to the **same** underlying
+/// channel.
+pub struct ShardSender<S> {
+    raw_sender: RawSender,
+    _phantom: PhantomData<S>,
+}
+
+impl<S: Service> ShardSender<S> {
+    pub fn new() -> (Self, ServiceStream<S>) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let raw_sender = RawSender(sender);
+        (
+            Self {
+                raw_sender,
+                _phantom: PhantomData,
+            },
+            ServiceStream {
+                inner: receiver,
+                _marker: std::marker::PhantomData,
+            },
+        )
+    }
+
+    pub(crate) fn into_raw(self) -> RawSender {
+        self.raw_sender
+    }
+
+    /// Sends a service message directly through this shard sender.
+    ///
+    /// This is intended for use in tests where messages are sent directly to a
+    /// loglet worker without going through the full message router.
+    #[cfg(feature = "test-util")]
+    pub fn send(&self, msg: super::ServiceMessage<S>) {
+        use super::ServiceOp;
+        let op = match msg {
+            super::ServiceMessage::Rpc(i) => ServiceOp::CallRpc(i.into_raw_rpc()),
+            super::ServiceMessage::Watch(i) => ServiceOp::Watch(i.into_raw_watch()),
+            super::ServiceMessage::Unary(i) => ServiceOp::Unary(i.into_raw_unary()),
+        };
+        let _ = self.raw_sender.send(op);
+    }
+}
+
+impl<S> Clone for ShardSender<S> {
+    fn clone(&self) -> Self {
+        Self {
+            raw_sender: self.raw_sender.clone(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<S> std::fmt::Debug for ShardSender<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShardSender").finish_non_exhaustive()
+    }
+}
+
+/// A stream of shard control messages for a sharded service.
+///
+/// The service owner polls this stream (typically inside a `tokio::select!`
+/// loop) to handle on-demand shard registration requests from the message
+/// router. Each item is a [`ShardControlMessage`] that must be resolved before
+/// the router can deliver messages for that sort-code.
+///
+/// The stream terminates (`None`) when the router side is dropped (e.g. during
+/// shutdown).
+pub struct ShardControlStream<S> {
+    inner: mpsc::UnboundedReceiver<ShardControlOp>,
+    _marker: std::marker::PhantomData<S>,
+}
+
+impl<S: Service> ShardControlStream<S> {
+    fn new(receiver: mpsc::UnboundedReceiver<ShardControlOp>) -> Self {
+        Self {
+            inner: receiver,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Closes the receiving end of the service handler
+    ///
+    /// This prevents any further messages from being sent on the inner channel while
+    /// still enabling the receiver to drain messages that are buffered.
+    ///
+    /// Peers that attempt to send RPC calls to this service will receive an error indicating that
+    /// this service has been stopped.
+    ///
+    /// To guarantee no messages are dropped, after calling `close()`, you must
+    /// receive all items from the stream until `None` is returned.
+    pub fn close(&mut self) {
+        self.inner.close();
+    }
+
+    /// Returns the number of messages in the queue.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if there are no messages in the queue.
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+}
+
+impl<S: Service> Stream for ShardControlStream<S> {
+    type Item = ShardControlMessage<S>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match ready!(self.inner.poll_recv(cx)) {
+            Some(op) => match op {
+                ShardControlOp::RegisterSortCode(sort_code, reply_port) => {
+                    Poll::Ready(Some(ShardControlMessage::RegisterSortCode {
+                        sort_code,
+                        decision: ShardRegistrationDecision::new(reply_port),
+                    }))
+                }
+            },
+            None => Poll::Ready(None),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.inner.len(), None)
+    }
+}
+
+/// A control message delivered on [`ShardControlStream`].
+#[derive(derive_more::Debug)]
+pub enum ShardControlMessage<S> {
+    /// The router received a message for an unregistered sort-code and is asking
+    /// the service owner to set up a shard for it. The owner must resolve the
+    /// [`decision`](ShardControlMessage::RegisterSortCode::decision) by calling
+    /// [`accept`](ShardRegistrationDecision::accept) or
+    /// [`fail`](ShardRegistrationDecision::fail).
+    RegisterSortCode {
+        sort_code: u64,
+        #[debug(skip)]
+        decision: ShardRegistrationDecision<S>,
+    },
+}
+
+pub struct ShardControlReceiver<S> {
+    receiver: mpsc::UnboundedReceiver<ShardControlOp>,
+    started: Arc<AtomicBool>,
+    _marker: std::marker::PhantomData<S>,
+}
+
+impl<S: Service> ShardControlReceiver<S> {
+    pub fn start(self) -> ShardControlStream<S> {
+        self.started.store(true, Ordering::Relaxed);
+        ShardControlStream::new(self.receiver)
+    }
+}
+
+// creates a default closed receiver
+impl<S: Service> Default for ShardControlReceiver<S> {
+    fn default() -> Self {
+        let (_tx, mut receiver) = mpsc::unbounded_channel();
+        receiver.close();
+        Self {
+            receiver,
+            started: Arc::new(AtomicBool::new(false)),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+pub(crate) struct ShardedSender {
+    control_sender: mpsc::UnboundedSender<ShardControlOp>,
+    started: Arc<AtomicBool>,
+    pool: MemoryPool,
+    backpressure: BackPressureMode,
+    bytes_accepted: Counter,
+}
+
+impl ShardedSender {
+    pub fn new<S: Service>(
+        pool: MemoryPool,
+        backpressure: BackPressureMode,
+    ) -> (Self, ShardControlReceiver<S>) {
+        let started = Arc::new(AtomicBool::new(false));
+        let (control_sender, receiver) = mpsc::unbounded_channel();
+        (
+            Self {
+                control_sender,
+                started: started.clone(),
+                pool,
+                backpressure,
+                bytes_accepted: counter!(NETWORK_SERVICE_ACCEPTED_REQUEST_BYTES, "target" => S::TAG.as_str_name()),
+            },
+            ShardControlReceiver {
+                receiver,
+                started,
+                _marker: std::marker::PhantomData,
+            },
+        )
+    }
+
+    pub fn increment_bytes_accepted(&self, payload_size: usize) {
+        self.bytes_accepted.increment(payload_size as u64);
+    }
+
+    pub async fn register_sort_code(
+        &self,
+        sort_code: u64,
+    ) -> Result<RawSender, ShardRegistrationError> {
+        let (reply_port, reply_rx) = oneshot::channel();
+        self.control_sender
+            .send(ShardControlOp::RegisterSortCode(sort_code, reply_port))
+            .map_err(|_| RouterError::ServiceStopped)?;
+        reply_rx
+            .await
+            .map_err(|_| ShardRegistrationError::Router(RouterError::ServiceStopped))?
+    }
+
+    pub async fn reserve(&self, payload_size: usize) -> Result<MemoryLease, RouterError> {
+        if !self.started.load(Ordering::Relaxed) {
+            return Err(RouterError::ServiceNotReady);
+        }
+
+        // Reserve memory based on backpressure mode
+        match self.backpressure {
+            BackPressureMode::PushBack => {
+                // Wait for memory to become available
+                Ok(self.pool.reserve(payload_size).await)
+            }
+            BackPressureMode::Lossy => {
+                // Try to reserve immediately, fail if no capacity
+                self.pool
+                    .try_reserve(payload_size)
+                    .ok_or(RouterError::CapacityExceeded)
+            }
+        }
+    }
+}
+
+/// Internal messages for shard control messages
+enum ShardControlOp {
+    RegisterSortCode(
+        u64,
+        oneshot::Sender<Result<RawSender, ShardRegistrationError>>,
+    ),
+}


### PR DESCRIPTION

The message router previously only supported mono (single-channel) service
sinks. This adds a sharded routing mode where each incoming message is
dispatched to an independent shard identified by its sort-code (u64).

Shards are created on demand: the first message targeting an unknown
sort-code sends a registration request on a control stream, giving the
service owner a chance to accept (returning a ShardSender) or reject
(returning a Verdict). Subsequent messages with the same sort-code are
delivered directly to the cached shard channel. Stale channels (closed
receivers) are detected on send failure, evicted, and re-registered
transparently.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4416).
* #4429
* #4428
* #4424
* #4423
* #4422
* #4419
* #4418
* #4417
* __->__ #4416