### PR TITLE
[PartitionProcessor] PartitionProcessor uses the sharded service routing

### DIFF
--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -24,14 +24,14 @@ use anyhow::Context;
 use assert2::let_assert;
 use futures::{FutureExt, Stream, StreamExt};
 use metrics::{SharedString, gauge, histogram};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{Span, debug, error, info, instrument, trace, warn};
 
 use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{Bifrost, LogEntry, MaybeRecord};
 use restate_core::network::{
-    Incoming, Oneshot, Reciprocal, Rpc, ServiceMessage, TransportConnect, Verdict,
+    Incoming, Oneshot, Reciprocal, Rpc, ServiceMessage, ServiceStream, TransportConnect, Verdict,
 };
 use restate_core::{
     Metadata, ShutdownError, TaskCenter, TaskKind, cancellation_watcher, my_node_id,
@@ -119,7 +119,7 @@ pub(super) struct PartitionProcessorBuilder<InvokerInputSender> {
     status: PartitionProcessorStatus,
     invoker_tx: InvokerInputSender,
     target_leader_state_rx: watch::Receiver<TargetLeaderState>,
-    network_svc_rx: mpsc::Receiver<ServiceMessage<PartitionLeaderService>>,
+    network_svc_rx: ServiceStream<PartitionLeaderService>,
     status_watch_tx: watch::Sender<PartitionProcessorStatus>,
     invoker_capacity: InvokerCapacity,
 }
@@ -132,7 +132,7 @@ where
     pub(super) fn new(
         status: PartitionProcessorStatus,
         target_leader_state_rx: watch::Receiver<TargetLeaderState>,
-        network_svc_rx: mpsc::Receiver<ServiceMessage<PartitionLeaderService>>,
+        network_svc_rx: ServiceStream<PartitionLeaderService>,
         status_watch_tx: watch::Sender<PartitionProcessorStatus>,
         invoker_tx: InvokerInputSender,
         invoker_capacity: InvokerCapacity,
@@ -269,7 +269,7 @@ pub struct PartitionProcessor<T, InvokerSender> {
     state_machine: StateMachine,
     bifrost: Bifrost,
     target_leader_state_rx: watch::Receiver<TargetLeaderState>,
-    network_leader_svc_rx: mpsc::Receiver<ServiceMessage<PartitionLeaderService>>,
+    network_leader_svc_rx: ServiceStream<PartitionLeaderService>,
     status_watch_tx: watch::Sender<PartitionProcessorStatus>,
     status: PartitionProcessorStatus,
     replica_set_states: PartitionReplicaSetStates,
@@ -385,7 +385,7 @@ where
 
         // Drain leader network service
         self.network_leader_svc_rx.close();
-        while let Some(msg) = self.network_leader_svc_rx.recv().await {
+        while let Some(msg) = self.network_leader_svc_rx.next().await {
             // signals that we are not the leader anymore
             msg.fail(Verdict::SortCodeNotFound);
         }
@@ -544,7 +544,7 @@ where
                     self.leadership_state.maybe_step_down(new_state.current_leader_epoch, new_state.current_leader).await;
                     self.status.effective_mode = self.leadership_state.effective_mode();
                 }
-                Some(msg) = self.network_leader_svc_rx.recv() => {
+                Some(msg) = self.network_leader_svc_rx.next() => {
                     self.on_rpc(msg, &mut partition_store, live_schemas.live_load(), &last_applied_lsn_watch).await;
                 }
                 _ = status_update_timer.tick() => {

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -11,12 +11,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 use tracing::info;
 use tracing::{error, instrument, warn};
 
 use restate_bifrost::Bifrost;
-use restate_core::network::TransportConnect;
+use restate_core::network::{ShardSender, TransportConnect};
 use restate_core::{Metadata, RuntimeTaskHandle, TaskCenter, TaskKind, cancellation_token};
 use restate_ingestion_client::IngestionClient;
 use restate_invoker_api::capacity::InvokerCapacity;
@@ -127,9 +127,7 @@ where
         let status_reader = invoker.status_reader();
 
         let (control_tx, control_rx) = watch::channel(TargetLeaderState::Follower);
-        // todo(asoli): This channel should be replaced by a memory-aware channel to cap the
-        // budget per processor.
-        let (net_tx, net_rx) = mpsc::channel(128);
+        let (net_tx, net_rx) = ShardSender::new();
         let status = PartitionProcessorStatus::new();
         let (watch_tx, watch_rx) = watch::channel(status.clone());
 


### PR DESCRIPTION

This removes the bottleneck of moving leader service network requests through the partition processor manager and using the intermediate channels.

The partition processor manager loop is not entirely non-blocking.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4418).
* #4436
* #4429
* #4428
* #4424
* #4423
* #4422
* #4419
* __->__ #4418