### PR TITLE
[Restate UI] Update to v0.1.51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8298,8 +8298,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.50"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.50#d34123a470843d30bc1a660b549f34146005fea6"
+version = "0.1.51"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.51#2a4e47a4d981bbad8de82cb2beb79c117e972c45"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.50", tag = "v0.1.50" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.51", tag = "v0.1.51" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.51
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.51/ui-v0.1.51.zip