### PR TITLE
Add leader/follower label to partition processor metrics

### DIFF
--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -15,6 +15,9 @@ use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 pub const TYPE_LABEL: &str = "type";
 pub const PARTITION_LABEL: &str = "partition";
 pub const REASON_LABEL: &str = "reason";
+pub const LEADER_LABEL: &str = "leader";
+pub const LEADER_LABEL_LEADER: &str = "1";
+pub const LEADER_LABEL_FOLLOWER: &str = "0";
 
 // contains `reason' label and `partition`labels:
 // - `version_barrier` indicates that the partition processor manager was unable to start

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -77,9 +77,9 @@ use restate_wal_protocol::{Command, Destination, Envelope, Header};
 
 use self::leadership::trim_queue::TrimQueue;
 use crate::metric_definitions::{
-    FLARE_REASON_VERSION_BARRIER, PARTITION_BLOCKED_FLARE, PARTITION_INGESTION_REQUEST_LEN,
-    PARTITION_INGESTION_REQUEST_SIZE, PARTITION_LABEL,
-    PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, REASON_LABEL,
+    FLARE_REASON_VERSION_BARRIER, LEADER_LABEL, LEADER_LABEL_FOLLOWER, LEADER_LABEL_LEADER,
+    PARTITION_BLOCKED_FLARE, PARTITION_INGESTION_REQUEST_LEN, PARTITION_INGESTION_REQUEST_SIZE,
+    PARTITION_LABEL, PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, REASON_LABEL,
 };
 use crate::partition::invoker_storage_reader::InvokerStorageReader;
 use crate::partition::leadership::LeadershipState;
@@ -485,10 +485,8 @@ where
         let mut live_schemas = Metadata::with_current(|m| m.updateable_schema());
 
         // Telemetry setup
-        let leader_record_write_to_read_latency =
-            histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, "leader" => "1");
-        let follower_record_write_to_read_latency =
-            histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, "leader" => "0");
+        let leader_record_write_to_read_latency = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, LEADER_LABEL => LEADER_LABEL_LEADER);
+        let follower_record_write_to_read_latency = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, LEADER_LABEL => LEADER_LABEL_FOLLOWER);
         // Start reading after the last applied lsn
 
         let mut record_stream = self.bifrost.create_reader(

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -120,7 +120,10 @@ use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{Command, vqueues};
 
 use self::utils::SpanExt;
-use crate::metric_definitions::{PARTITION_APPLY_COMMAND, USAGE_LEADER_JOURNAL_ENTRY_COUNT};
+use crate::metric_definitions::{
+    LEADER_LABEL, LEADER_LABEL_FOLLOWER, LEADER_LABEL_LEADER, PARTITION_APPLY_COMMAND,
+    USAGE_LEADER_JOURNAL_ENTRY_COUNT,
+};
 use crate::partition::state_machine::lifecycle::OnCancelCommand;
 use crate::partition::types::{InvokerEffect, InvokerEffectKind, OutboxMessageExt};
 
@@ -304,7 +307,7 @@ impl StateMachine {
             }
             .on_apply(command)
             .await;
-            histogram!(PARTITION_APPLY_COMMAND, "command" => command_type).record(start.elapsed());
+            histogram!(PARTITION_APPLY_COMMAND, "command" => command_type, LEADER_LABEL => if is_leader { LEADER_LABEL_LEADER } else { LEADER_LABEL_FOLLOWER }).record(start.elapsed());
             res
         }
         .instrument(span)


### PR DESCRIPTION
Add LEADER_LABEL constants to metric_definitions for discoverability and use them consistently in both PARTITION_APPLY_COMMAND and PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS metrics.

This fixes #4430.