### PR TITLE
[Ingestion] Fix stale session handles causing permanent SessionClosed errors

### DIFF
--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -35,8 +35,8 @@ use crate::{
 /// Errors that can be observed when interacting with the ingestion facade.
 #[derive(Debug, thiserror::Error)]
 pub enum IngestionError {
-    #[error("Ingestion closed")]
-    Closed,
+    #[error("Ingestion client closed: {0}")]
+    Closed(&'static str),
     #[error(transparent)]
     PartitionTableError(#[from] PartitionTableError),
 }
@@ -207,9 +207,9 @@ impl Future for IngestFuture {
                         let record = record.take().unwrap();
                         handle
                             .ingest(permit, record)
-                            .map_err(|_| IngestionError::Closed)
+                            .map_err(|_| IngestionError::Closed("partition session closed"))
                     }
-                    Err(_) => Err(IngestionError::Closed),
+                    Err(_) => Err(IngestionError::Closed("permits semaphore closed")),
                 };
 
                 Poll::Ready(output)

--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -211,6 +211,7 @@ enum SessionState {
 
 /// Background task that drives the lifecycle of a single partition connection.
 pub struct PartitionSession<T> {
+    manager: Arc<SessionManagerInner<T>>,
     partition: PartitionId,
     partition_routing: PartitionRouting,
     networking: Networking<T>,
@@ -222,6 +223,7 @@ pub struct PartitionSession<T> {
 
 impl<T> PartitionSession<T> {
     fn new(
+        manager: Arc<SessionManagerInner<T>>,
         networking: Networking<T>,
         partition_routing: PartitionRouting,
         partition: PartitionId,
@@ -231,6 +233,7 @@ impl<T> PartitionSession<T> {
         let rx = UnboundedReceiverStream::new(rx);
 
         Self {
+            manager,
             partition,
             partition_routing,
             networking,
@@ -246,6 +249,12 @@ impl<T> PartitionSession<T> {
         SessionHandle {
             tx: self.tx.clone(),
         }
+    }
+}
+
+impl<T> Drop for PartitionSession<T> {
+    fn drop(&mut self) {
+        self.manager.handles.remove(&self.partition);
     }
 }
 
@@ -448,33 +457,36 @@ where
 {
     /// Gets or start a new session to partition with given partition id.
     /// It guarantees that only one session is started per partition id.
-    pub fn get(&self, id: PartitionId) -> SessionHandle {
+    pub fn get(self: &Arc<Self>, id: PartitionId) -> SessionHandle {
         self.handles
             .entry(id)
-            .or_insert_with(|| {
-                let session = PartitionSession::new(
-                    self.networking.clone(),
-                    self.partition_routing.clone(),
-                    id,
-                    self.opts.clone(),
-                );
-
-                let handle = session.handle();
-
-                let cancellation = self.cancellation.child_token();
-                let _ = TaskCenter::spawn(
-                    TaskKind::Background,
-                    "ingestion-partition-session",
-                    async move {
-                        session.start(cancellation).await;
-                        Ok(())
-                    },
-                );
-
-                handle
-            })
+            .or_insert_with(|| self.start_session(id))
             .value()
             .clone()
+    }
+
+    fn start_session(self: &Arc<Self>, id: PartitionId) -> SessionHandle {
+        let session = PartitionSession::new(
+            Arc::clone(self),
+            self.networking.clone(),
+            self.partition_routing.clone(),
+            id,
+            self.opts.clone(),
+        );
+
+        let handle = session.handle();
+
+        let cancellation = self.cancellation.child_token();
+        let _ = TaskCenter::spawn(
+            TaskKind::Background,
+            "ingestion-partition-session",
+            async move {
+                session.start(cancellation).await;
+                Ok(())
+            },
+        );
+
+        handle
     }
 }
 

--- a/crates/ingress-kafka/src/legacy/consumer_task.rs
+++ b/crates/ingress-kafka/src/legacy/consumer_task.rs
@@ -162,7 +162,7 @@ impl MessageSender {
             .dispatch_kafka_event(req)
             .instrument(ingress_span)
             .await
-            .map_err(|_| Error::IngestionClosed)?;
+            .map_err(|err| Error::IngestionClosed(err.into()))?;
         Ok(())
     }
 

--- a/crates/ingress-kafka/src/lib.rs
+++ b/crates/ingress-kafka/src/lib.rs
@@ -45,7 +45,7 @@ pub enum Error {
     #[error(transparent)]
     Kafka(#[from] KafkaError),
     #[error(
-        "error processing message subscription {subscription} topic {topic} partition {partition} offset {offset}: {cause}"
+        "Error processing message subscription {subscription} topic {topic} partition {partition} offset {offset}: {cause}"
     )]
     Event {
         subscription: String,
@@ -55,16 +55,16 @@ pub enum Error {
         #[source]
         cause: anyhow::Error,
     },
-    #[error("ingress stream is closed")]
-    IngestionClosed,
+    #[error("Ingress stream is closed: {0}")]
+    IngestionClosed(Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     PartitionTableError(#[from] PartitionTableError),
     #[error(
-        "received a message on the main partition queue for topic {0} partition {1} despite partitioned queues"
+        "Received a message on the main partition queue for topic {0} partition {1} despite partitioned queues"
     )]
     UnexpectedMainQueueMessage(String, i32),
     #[error(
-        "consumption task exited unexpectedly for subscription '{subscription}', topic: {topic} and partition: {partition}"
+        "Consumption task exited unexpectedly for subscription '{subscription}', topic: {topic} and partition: {partition}"
     )]
     UnexpectedConsumptionTaskExited {
         subscription: String,


### PR DESCRIPTION
[Ingestion] Fix stale session handles causing permanent SessionClosed errors

SessionManagerInner caches SessionHandles in a DashMap that is never
cleaned up. If a PartitionSession background task terminates (e.g. due
to ConnectError::Shutdown or cancellation), the cached handle becomes
permanently stale — every subsequent ingest() call for that partition
returns SessionClosed forever.

Fix this by checking if the cached handle is closed (via the underlying
mpsc sender) before returning it from SessionManagerInner::get(). When
a stale handle is detected, it is evicted from the cache and a fresh
session is started transparently.
