### PR TITLE
[Build Perf 1/N] derive_more and avoid unnecessary protoc rebuilds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ datafusion = { version = "52.1.0", default-features = false, features = [
 datafusion-functions-json = { version = "0.52.0" }
 datafusion-proto = { version = "52.1.0", default-features = false }
 derive_builder = "0.20.2"
-derive_more = { version = "2.1.1", features = ["full"] }
+derive_more = { version = "2.1.1", default-features = false }
 dialoguer = { version = "0.12.0" }
 downcast-rs = { version = "2.0.2" }
 enum-map = { version = "2.7.3" }

--- a/crates/admin-rest-model/Cargo.toml
+++ b/crates/admin-rest-model/Cargo.toml
@@ -19,7 +19,7 @@ restate-serde-util = { workspace = true }
 restate-time-util = { workspace = true, features = ["serde_with"] }
 
 bytes = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["try_from"] }
 http = { workspace = true }
 http-serde = { workspace = true }
 humantime = { workspace = true }

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -48,7 +48,7 @@ bytestring = { workspace = true }
 codederror = { workspace = true }
 datafusion = { workspace = true }
 derive_builder = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["deref", "from"] }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -36,7 +36,7 @@ bitflags = { workspace = true }
 bytes = { workspace = true }
 crossbeam-utils = { version = "0.8" }
 dashmap = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug", "display", "is_variant", "try_from"] }
 enum-map = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 googletest = { workspace = true, features = ["anyhow"], optional = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,7 +36,7 @@ axum = { workspace = true, default-features = false }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 dashmap = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug", "deref", "display", "from", "index", "index_mut", "into", "is_variant"] }
 prost-dto = { workspace = true }
 enum-map = { workspace = true }
 enumset = { workspace = true }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -14,6 +14,10 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=protobuf/");
+
     tonic_prost_build::configure()
         .bytes(".")
         .file_descriptor_set_path(out_dir.join("cluster_ctrl_svc_descriptor.bin"))

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -30,7 +30,7 @@ restate-wal-protocol = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["deref"] }
 futures = { workspace = true }
 metrics = { workspace = true }
 opentelemetry = { workspace = true }

--- a/crates/invoker-impl/Cargo.toml
+++ b/crates/invoker-impl/Cargo.toml
@@ -30,7 +30,7 @@ bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
 dashmap = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 futures = { workspace = true }
 gardal = { workspace = true , features = ["async"]}
 http = { workspace = true }

--- a/crates/local-cluster-runner/Cargo.toml
+++ b/crates/local-cluster-runner/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { workspace = true }
 arc-swap = { workspace = true }
 clap = { workspace = true }
 clap-verbosity-flag = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }
 futures = { workspace = true }
 enumset = { workspace = true }
 http = { workspace = true }

--- a/crates/log-server-grpc/build.rs
+++ b/crates/log-server-grpc/build.rs
@@ -14,6 +14,10 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=protobuf/");
+
     tonic_prost_build::configure()
         .bytes(".")
         .file_descriptor_set_path(out_dir.join("log_server_svc_descriptor.bin"))

--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -31,7 +31,7 @@ bitflags = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 codederror = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["from", "try_from"] }
 futures = { workspace = true }
 metrics = { workspace = true }
 rocksdb = { workspace = true }

--- a/crates/log-server/build.rs
+++ b/crates/log-server/build.rs
@@ -14,6 +14,10 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=protobuf/");
+
     tonic_prost_build::configure()
         .bytes(".")
         .file_descriptor_set_path(out_dir.join("log_server_svc_descriptor.bin"))

--- a/crates/metadata-providers/Cargo.toml
+++ b/crates/metadata-providers/Cargo.toml
@@ -66,7 +66,7 @@ serde = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 
 # Deps for replicated metadata client
-derive_more = { workspace = true, optional = true }
+derive_more = { workspace = true, optional = true, features = ["deref", "deref_mut", "from"] }
 indexmap = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }

--- a/crates/metadata-server-grpc/Cargo.toml
+++ b/crates/metadata-server-grpc/Cargo.toml
@@ -20,7 +20,7 @@ restate-types = { workspace = true }
 
 bytes = { workspace = true }
 bytestring = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }
 itertools = { workspace = true }
 prost = { workspace = true }
 prost-dto = { workspace = true }

--- a/crates/metadata-server-grpc/build.rs
+++ b/crates/metadata-server-grpc/build.rs
@@ -14,6 +14,10 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=proto/");
+
     tonic_prost_build::configure()
         .bytes(".")
         .file_descriptor_set_path(out_dir.join("metadata_server_svc.bin"))

--- a/crates/metadata-server/Cargo.toml
+++ b/crates/metadata-server/Cargo.toml
@@ -27,7 +27,7 @@ assert2 = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 flexbuffers = { workspace = true }
 futures = { workspace = true }
 metrics = { workspace = true }

--- a/crates/metadata-server/build.rs
+++ b/crates/metadata-server/build.rs
@@ -14,6 +14,10 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=proto/");
+
     tonic_prost_build::configure()
         .bytes(".")
         .file_descriptor_set_path(out_dir.join("metadata_server_network_svc.bin"))

--- a/crates/metadata-store/build.rs
+++ b/crates/metadata-store/build.rs
@@ -14,6 +14,10 @@ use std::path::PathBuf;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=protobuf/");
+
     tonic_prost_build::configure()
         .bytes(".")
         .file_descriptor_set_path(out_dir.join("metadata_proxy_svc_descriptor.bin"))

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -60,7 +60,7 @@ axum = { workspace = true }
 bytes = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 enumset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -29,7 +29,7 @@ bilrost = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["add", "deref", "display", "from", "from_str", "into"] }
 enum-map = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/rocksdb/Cargo.toml
+++ b/crates/rocksdb/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 codederror = { workspace = true }
 derive_builder = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["as_ref", "debug", "deref", "display", "from", "into"] }
 metrics = {workspace = true }
 parking_lot = { workspace = true }
 rocksdb = { workspace = true }

--- a/crates/service-protocol-v4/build.rs
+++ b/crates/service-protocol-v4/build.rs
@@ -17,6 +17,11 @@ use typify::{TypeSpace, TypeSpaceSettings};
 fn main() -> std::io::Result<()> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files, JSON schema, or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../service-protocol/dev/restate/service/protocol.proto");
+    println!("cargo:rerun-if-changed=../../service-protocol/endpoint_manifest_schema.json");
+
     prost_build::Config::new()
         .bytes(["."])
         .protoc_arg("--experimental_allow_proto3_optional")

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { workspace = true }
 bilrost = { workspace = true, features = ["smallvec"] }
 bytes = { workspace = true }
 bytestring = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["from", "into"] }
 futures = { workspace = true }
 opentelemetry = { workspace = true }
 prost = { workspace = true }

--- a/crates/storage-api/build.rs
+++ b/crates/storage-api/build.rs
@@ -9,6 +9,11 @@
 // by the Apache License, Version 2.0.
 
 fn main() -> std::io::Result<()> {
+    // Only re-run when proto files or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=proto/");
+    println!("cargo:rerun-if-changed=../../service-protocol/dev/restate/service/protocol.proto");
+
     prost_build::Config::new()
         .bytes(["."])
         // allow older protobuf compiler to be used

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -33,7 +33,7 @@ dashmap = { workspace = true }
 datafusion = { workspace = true }
 datafusion-functions-json = { workspace = true }
 datafusion-proto = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 enumset = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -48,7 +48,7 @@ clap = { workspace = true, features = ["std", "derive", "env"], optional = true 
 codederror = { workspace = true }
 dashmap = { workspace = true }
 derive_builder = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["add", "add_assign", "as_ref", "debug", "deref", "deref_mut", "display", "from", "from_str", "index", "into", "into_iterator", "is_variant", "try_unwrap"] }
 downcast-rs = { workspace = true }
 dyn-clone = { version = "1.0" }
 enum-map = { workspace = true }

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -17,6 +17,13 @@ use typify::{TypeSpace, TypeSpaceSettings};
 fn main() -> std::io::Result<()> {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // Only re-run when proto files, JSON schema, or this build script change
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=service-protocol-v3/");
+    println!("cargo:rerun-if-changed=../../service-protocol/dev/restate/service/discovery.proto");
+    println!("cargo:rerun-if-changed=../../service-protocol/endpoint_manifest_schema.json");
+    println!("cargo:rerun-if-changed=protobuf/");
+
     // Old service-protocol
     prost_build::Config::new()
         .bytes(["."])

--- a/crates/vqueues/Cargo.toml
+++ b/crates/vqueues/Cargo.toml
@@ -17,7 +17,7 @@ restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 
 bilrost = { workspace = true, features = ["smallvec"] }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug", "into_iterator", "is_variant"] }
 gardal = { workspace = true, features = ["tokio"] }
 hashbrown = { workspace = true  }
 metrics = { workspace = true }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -56,7 +56,7 @@ async-channel = { workspace = true }
 bytes = { workspace = true }
 bytestring = { workspace = true }
 codederror = { workspace = true }
-derive_more = { workspace = true }
+derive_more = { workspace = true, features = ["debug", "display", "from"] }
 enumset = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -47,6 +47,7 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
 dashmap = { version = "6", default-features = false, features = ["inline"] }
+derive_more = { version = "2", features = ["add", "add_assign", "as_ref", "debug", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "try_from", "try_unwrap"] }
 digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }
@@ -171,6 +172,8 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
 dashmap = { version = "6", default-features = false, features = ["inline"] }
+derive_more = { version = "2", features = ["add", "add_assign", "as_ref", "debug", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "try_from", "try_unwrap"] }
+derive_more-impl = { version = "2", features = ["add", "add_assign", "as_ref", "debug", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "try_from", "try_unwrap"] }
 digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1" }
 enum-map = { version = "2", default-features = false, features = ["serde"] }
@@ -268,7 +271,6 @@ zstd-sys = { version = "2", features = ["experimental", "std"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
-derive_more = { version = "2", features = ["full"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
@@ -287,8 +289,6 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unpref
 bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
-derive_more = { version = "2", features = ["full"] }
-derive_more-impl = { version = "2", features = ["add", "add_assign", "as_ref", "constructor", "debug", "deref", "deref_mut", "display", "eq", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "mul", "mul_assign", "not", "sum", "try_from", "try_into", "try_unwrap", "unwrap"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
@@ -307,7 +307,6 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unpref
 bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
-derive_more = { version = "2", features = ["full"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
@@ -325,8 +324,6 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unpref
 bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
-derive_more = { version = "2", features = ["full"] }
-derive_more-impl = { version = "2", features = ["add", "add_assign", "as_ref", "constructor", "debug", "deref", "deref_mut", "display", "eq", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "mul", "mul_assign", "not", "sum", "try_from", "try_into", "try_unwrap", "unwrap"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }


### PR DESCRIPTION

## Changes

1. **Minimize derive_more features**: Changed from `features = ["full"]` to
   `default-features = false` at the workspace level, with each of the 19
   consuming crates specifying only the derive features they actually use.
   This reduces compile time of the derive_more-impl proc-macro crate and
   prevents accidental feature creep.

2. **Add cargo:rerun-if-changed to 9 build.rs files**: The protobuf/typify
   build scripts (in types, core, service-protocol-v4, metadata-server,
   metadata-server-grpc, metadata-store, log-server, log-server-grpc,
   storage-api) previously had no rerun-if-changed directives, causing
   protoc to re-run on every build whenever any file in the crate changed.
   Now they only re-run when .proto files, JSON schemas, or build.rs itself
   changes.

## Measurements (median of 3 runs, clean target, `cargo build` default profile)

| Benchmark                      | Before  | After   | Delta   |
|--------------------------------|---------|---------|---------|
| No-op build                    |  0.90s  |  0.86s  |  -4%    |
| Touch types/src/lib.rs         | 42.13s  | 41.10s  |  -2%    |
| Touch core/src/lib.rs          | 25.21s  | 25.32s  |  ~same  |
| Touch server/src/main.rs       | 15.71s  | 14.70s  |  -6%    |
| derive_more-impl clean compile |  6.15s  |  5.36s  | -13%    |

The primary benefit is in clean/CI builds where derive_more-impl must be
compiled from scratch (-13%), and in avoiding unnecessary build script
re-runs during incremental development. The touch-types improvement (-2%)
is modest since the bottleneck is recompiling the crate graph, not the
build scripts. The touch-server improvement (-6%) reflects reduced linking
overhead from smaller derive_more output.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4441).
* #4444
* #4443
* #4442
* __->__ #4441