### PR TITLE
logserver-bench: add log-server RocksDB benchmark tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,6 @@ propose to write a micro-benchmark with Criterion to help guide the user's decis
 However, to make sure our priorities are clear. The priority should always for correctness before considering performance.
 
 Be extra careful when making changes to the latency critical paths of the system. Primarily, Bifrost, the networking layer, restate-core, the partition-processor state machine, and the invoker.
+
+# Benchmarking Tools
+- **`tools/logserver-bench`** — A standalone benchmark tool for the log-server's RocksDB storage layer. Use it to measure write throughput, mixed read/write/trim workloads, and to validate that log-server changes don't regress performance. See `tools/logserver-bench/README.md` for usage details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4763,6 +4763,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "logserver-bench"
+version = "1.6.2"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "clap",
+ "codederror",
+ "comfy-table",
+ "hdrhistogram",
+ "indexmap 2.13.0",
+ "libc",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "rand 0.9.2",
+ "restate-cli-util",
+ "restate-core",
+ "restate-errors",
+ "restate-log-server",
+ "restate-memory",
+ "restate-rocksdb",
+ "restate-serde-util",
+ "restate-time-util",
+ "restate-tracing-instrumentation",
+ "restate-types",
+ "restate-workspace-hack",
+ "rlimit",
+ "rust-rocksdb",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "lite",
     "benchmarks",
     "tools/bifrost-benchpress",
+    "tools/logserver-bench",
     "tools/mock-service-endpoint",
     "tools/restate-doctor",
     "tools/restatectl",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,7 +9,12 @@ publish = false
 
 [features]
 default = []
+# Lightweight feature that enables ServiceMessage::fake_rpc() and ShardSender::send()
+# without pulling in tokio/test-util or restate-types/test-util. Intended for
+# benchmark tooling that needs to inject messages into service workers directly.
+message-util = []
 test-util = [
+  "message-util",
   "restate-core-derive",
   "restate-metadata-store/test-util",
   "restate-types/test-util",

--- a/crates/core/src/network/incoming.rs
+++ b/crates/core/src/network/incoming.rs
@@ -293,7 +293,7 @@ impl<S: Service> Incoming<RawSvcRpc<S>> {
         }
     }
 
-    #[cfg(feature = "test-util")]
+    #[cfg(feature = "message-util")]
     pub(crate) fn into_raw_rpc(self) -> Incoming<RawRpc> {
         Incoming {
             protocol_version: self.protocol_version,
@@ -410,7 +410,7 @@ impl<S: Service> Incoming<RawSvcUnary<S>> {
         }
     }
 
-    #[cfg(feature = "test-util")]
+    #[cfg(feature = "message-util")]
     pub(crate) fn into_raw_unary(self) -> Incoming<RawUnary> {
         Incoming {
             protocol_version: self.protocol_version,
@@ -526,7 +526,7 @@ impl<S: Service> Incoming<RawSvcWatch<S>> {
         }
     }
 
-    #[cfg(feature = "test-util")]
+    #[cfg(feature = "message-util")]
     pub(crate) fn into_raw_watch(self) -> Incoming<RawWatch> {
         Incoming {
             protocol_version: self.protocol_version,

--- a/crates/core/src/network/message_router.rs
+++ b/crates/core/src/network/message_router.rs
@@ -639,8 +639,8 @@ pub enum ServiceMessage<S> {
 }
 
 impl<S: Service> ServiceMessage<S> {
-    // For testing
-    #[cfg(feature = "test-util")]
+    // For testing and benchmarking
+    #[cfg(feature = "message-util")]
     pub fn fake_rpc<M>(
         msg: M,
         sort_code: Option<u64>,

--- a/crates/core/src/network/message_router/sharded.rs
+++ b/crates/core/src/network/message_router/sharded.rs
@@ -207,9 +207,9 @@ impl<S: Service> ShardSender<S> {
 
     /// Sends a service message directly through this shard sender.
     ///
-    /// This is intended for use in tests where messages are sent directly to a
-    /// loglet worker without going through the full message router.
-    #[cfg(feature = "test-util")]
+    /// This is intended for use in tests and benchmarks where messages are sent
+    /// directly to a loglet worker without going through the full message router.
+    #[cfg(feature = "message-util")]
     pub fn send(&self, msg: super::ServiceMessage<S>) {
         use super::ServiceOp;
         let op = match msg {

--- a/crates/log-server/Cargo.toml
+++ b/crates/log-server/Cargo.toml
@@ -10,7 +10,10 @@ publish = false
 [features]
 default = []
 clients = []
-test-util = []
+# Expose internal modules (loglet_worker, logstore, metadata, rocksdb_logstore) for
+# benchmarking tools that drive the log-server directly without networking.
+expose-internals = []
+test-util = ["expose-internals"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }

--- a/crates/log-server/src/lib.rs
+++ b/crates/log-server/src/lib.rs
@@ -10,12 +10,24 @@
 
 mod error;
 mod grpc_svc_handler;
+#[cfg(feature = "expose-internals")]
+pub mod loglet_worker;
+#[cfg(not(feature = "expose-internals"))]
 mod loglet_worker;
+#[cfg(feature = "expose-internals")]
+pub mod logstore;
+#[cfg(not(feature = "expose-internals"))]
 mod logstore;
+#[cfg(feature = "expose-internals")]
+pub mod metadata;
+#[cfg(not(feature = "expose-internals"))]
 mod metadata;
 mod metric_definitions;
 mod network;
 pub mod protobuf;
+#[cfg(feature = "expose-internals")]
+pub mod rocksdb_logstore;
+#[cfg(not(feature = "expose-internals"))]
 mod rocksdb_logstore;
 mod service;
 

--- a/crates/log-server/src/loglet_worker.rs
+++ b/crates/log-server/src/loglet_worker.rs
@@ -45,11 +45,11 @@ impl LogletWorkerHandle {
         self.loglet_guard.cancel_and_wait().await
     }
 
-    pub(crate) fn data_tx(&self) -> ShardSender<LogServerDataService> {
+    pub fn data_tx(&self) -> ShardSender<LogServerDataService> {
         self.data_tx.clone()
     }
 
-    pub(crate) fn meta_tx(&self) -> ShardSender<LogServerMetaService> {
+    pub fn meta_tx(&self) -> ShardSender<LogServerMetaService> {
         self.meta_tx.clone()
     }
 }

--- a/tools/logserver-bench/Cargo.toml
+++ b/tools/logserver-bench/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "logserver-bench"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+restate-cli-util = { workspace = true }
+restate-core = { workspace = true, features = ["message-util"] }
+restate-errors = { workspace = true }
+restate-log-server = { workspace = true, features = ["expose-internals"] }
+restate-memory = { workspace = true }
+restate-rocksdb = { workspace = true }
+restate-serde-util = { workspace = true }
+restate-time-util = { workspace = true }
+restate-tracing-instrumentation = { workspace = true, features = ["rt-tokio"] }
+restate-types = { workspace = true, features = ["clap"] }
+
+anyhow = { workspace = true }
+axum = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive", "env", "color", "help", "wrap_help", "usage", "suggestions", "error-context", "std"] }
+codederror = { workspace = true }
+comfy-table = { workspace = true }
+hdrhistogram = { version = "7.5.4" }
+indexmap = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+rand = { workspace = true }
+rlimit = { workspace = true }
+rocksdb = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, features = ["unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/tools/logserver-bench/README.md
+++ b/tools/logserver-bench/README.md
@@ -1,0 +1,105 @@
+# Log-Server Bench
+
+A load-generation tool for benchmarking the Restate log-server's RocksDB storage layer in isolation. It drives configurable workloads (writes, reads, trims) through the `LogletWorker` pipeline using `ServiceMessage::fake_rpc()`, bypassing all networking.
+
+## Architecture
+
+The tool exercises the full write path: **LogletWorker -> LogStoreWriter batching -> WriteBatch -> RocksDB commit**, without spinning up a full Restate node or any networking stack. This makes it suitable for profiling and tuning RocksDB column family configurations.
+
+## Benchmarks
+
+### `write-throughput`
+
+Sequential write benchmark. Sends `Store` batches into one or more loglet workers and measures per-batch latency (HDR histogram) and aggregate throughput.
+
+### `mixed-workload`
+
+Duration-based concurrent workload. Spawns per-loglet writer, reader, and trimmer tasks that run simultaneously for a configurable duration. Writers send `Store` batches, readers issue `GetRecords` trailing behind the writer, and trimmers issue periodic `Trim` operations.
+
+### `generate-payload`
+
+Offline subcommand that pre-generates a deterministic payload file. The file can then be loaded via `--payload-file` on `write-throughput` or `mixed-workload` runs to:
+
+- **Eliminate RNG overhead** during the measured phase
+- **Ensure identical data** across repeated runs for fair A/B comparisons
+
+## How to run
+
+```sh
+# Basic write throughput test
+RUST_LOG=info cargo run --profile=bench --bin logserver-bench -- \
+    write-throughput --num-records 5000000 --records-per-batch 10 --payload-size 512
+
+# Mixed workload with reads and trims for 60 seconds
+RUST_LOG=info cargo run --profile=bench --bin logserver-bench -- \
+    mixed-workload --duration 60s --num-loglets 10 --enable-reads --enable-trims
+
+# With a custom RocksDB config
+RUST_LOG=info cargo run --profile=bench --bin logserver-bench -- \
+    --config-file=restate.toml --retain-test-dir \
+    write-throughput --num-records 10000000
+
+# Pre-generate a payload file, then use it
+cargo run --profile=bench --bin logserver-bench -- \
+    generate-payload --output payloads.bin \
+    --records-per-batch 10 --num-batches 2048 \
+    --payload-size 1KB --entropy 0.8 --seed 42
+
+RUST_LOG=info cargo run --profile=bench --bin logserver-bench -- \
+    write-throughput --num-records 5000000 --records-per-batch 10 \
+    --payload-file payloads.bin
+```
+
+## Observability
+
+### Prometheus metrics endpoint
+
+By default, an HTTP metrics server listens on port 9090. Point Prometheus/Grafana at `http://localhost:9090/metrics` to observe RocksDB internals in real time during a run:
+
+- Tickers: block cache hit/miss, compaction bytes, stall micros, WAL syncs
+- Histograms: db.write, db.get, wal.file.sync, sst.read/write latencies
+- CF properties: num-files-at-levelN, estimate-pending-compaction-bytes, is-write-stopped, live-sst-files-size, mem-table sizes
+- Write buffer manager usage and capacity
+
+Use `--metrics-port 0` to disable.
+
+### End-of-run summary
+
+At completion, the tool prints styled KV tables covering:
+- **Config & throughput** — records/s, batches/s, MB/s
+- **Latency** — HDR histogram percentiles (P50 through max)
+- **CPU** — user/system time, wall time, average utilisation
+- **Memory** — jemalloc allocated/active/resident/mapped/retained
+- **RocksDB** — write stalls, WAL syncs/bytes, flush/compaction I/O, block cache hit rate, LSM level file counts, live SST size, pending compaction, write buffer usage
+
+Use `--raw-rocksdb-stats` to additionally dump the full raw RocksDB statistics string.
+
+## Payload generation
+
+Payloads are pre-generated into a pool of batches and cycled through during the benchmark. This avoids allocation overhead in the hot path. There are two modes:
+
+### In-memory (default)
+
+When no `--payload-file` is specified, batches are generated in-memory from an RNG at startup:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--payload-size` | Body size per record (e.g. "512", "4KB", "1MiB") | 512 |
+| `--entropy` | 0.0 = all zeros (compressible), 1.0 = random (incompressible) | 1.0 |
+| `--key-style` | Record key type: `none`, `single`, `pair`, `range` | none |
+| `--seed` | PRNG seed for reproducible payloads | random |
+
+### From file (`--payload-file`)
+
+Pass `--payload-file path/to/payloads.bin` to load pre-generated batches from a file created by `generate-payload`. The tool validates that the file's `batch_size` matches `--records-per-batch` and errors out on mismatch. When loading from file, the `--payload-size`, `--entropy`, `--key-style`, and `--seed` flags on the benchmark subcommand are ignored (the file's parameters take precedence).
+
+The payload file uses a compact binary format with a 40-byte self-describing header (magic, version, payload size, key style, batch size, count, seed) followed by raw record data.
+
+## Tuning RocksDB
+
+RocksDB configuration is controlled through the standard Restate TOML config file (`--config-file`). The log-server uses two column families:
+
+- **`data`** — 85% of memory budget, 7 LSM levels, Zstd compression, prefix extractor (9 bytes)
+- **`metadata`** — 15% of memory budget, 3 LSM levels, merge operator for trim points
+
+Use `--retain-test-dir` (or `--base-dir`) to persist the RocksDB directory between runs for inspecting SST files or running follow-up experiments on existing data.

--- a/tools/logserver-bench/src/lib.rs
+++ b/tools/logserver-bench/src/lib.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+
+use restate_cli_util::CommonOpts;
+use restate_time_util::FriendlyDuration;
+use restate_types::config::CommonOptionCliOverride;
+
+pub mod metrics_server;
+pub mod mixed_workload;
+pub mod payload;
+pub mod report;
+pub mod write_throughput;
+
+#[derive(Clone, clap::Parser)]
+#[command(author, version, about = "Log-server RocksDB benchmark tool")]
+pub struct Arguments {
+    /// Set a configuration file to use for Restate.
+    #[arg(
+        short,
+        long = "config-file",
+        env = "RESTATE_CONFIG",
+        value_name = "FILE",
+        global = true
+    )]
+    pub config_file: Option<PathBuf>,
+
+    /// Print the full raw RocksDB statistics string at the end.
+    #[arg(long, global = true)]
+    pub raw_rocksdb_stats: bool,
+
+    /// Keep the data directory after the run (useful for inspecting RocksDB).
+    #[arg(long, global = true)]
+    pub retain_test_dir: bool,
+
+    /// Port for Prometheus metrics HTTP endpoint. Set to 0 to disable.
+    #[arg(long, global = true, default_value = "9090")]
+    pub metrics_port: u16,
+
+    /// Interval between periodic progress reports (e.g. "5s", "10s").
+    #[arg(long, global = true, default_value = "5s")]
+    pub report_interval: FriendlyDuration,
+
+    #[clap(flatten)]
+    pub common_opts: CommonOpts,
+
+    #[clap(flatten)]
+    pub opts_overrides: CommonOptionCliOverride,
+
+    /// Choose the benchmark to run.
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Clone, clap::Parser)]
+pub enum Command {
+    /// Sequential write throughput benchmark.
+    WriteThroughput(write_throughput::WriteThroughputOpts),
+    /// Concurrent write + read + trim workload.
+    MixedWorkload(mixed_workload::MixedWorkloadOpts),
+    /// Pre-generate a payload file for deterministic, zero-overhead benchmarks.
+    GeneratePayload(payload::GeneratePayloadOpts),
+}

--- a/tools/logserver-bench/src/main.rs
+++ b/tools/logserver-bench/src/main.rs
@@ -1,0 +1,206 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Parser;
+use codederror::CodedError;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tracing::info;
+
+use restate_cli_util::{CliContext, c_eprintln, c_println, c_tip, c_warn};
+use restate_core::task_center::TaskCenterMonitoring;
+use restate_core::{MetadataBuilder, TaskCenter, TaskCenterBuilder, TaskKind, task_center};
+use restate_errors::fmt::RestateCode;
+use restate_log_server::metadata::LogletStateMap;
+use restate_log_server::rocksdb_logstore::RocksDbLogStoreBuilder;
+use restate_rocksdb::RocksDbManager;
+use restate_tracing_instrumentation::init_tracing_and_logging;
+use restate_types::config::Configuration;
+use restate_types::config_loader::ConfigLoaderBuilder;
+
+use logserver_bench::{Arguments, Command, metrics_server, mixed_workload, write_throughput};
+
+// Configure jemalloc to mimic restate server
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+fn main() -> anyhow::Result<()> {
+    let mut cli_args = Arguments::parse();
+
+    // `generate-payload` is a pure offline command — no TaskCenter, RocksDB, or
+    // tracing needed. Handle it early and exit.
+    if let Command::GeneratePayload(ref opts) = cli_args.command {
+        CliContext::new(cli_args.common_opts.clone()).set_as_global();
+        return logserver_bench::payload::generate_payload_file(opts);
+    }
+
+    let user_provided_base_dir = cli_args.opts_overrides.base_dir.is_some();
+
+    // If no explicit --base-dir was provided, create a temporary directory.
+    // We hold `_temp_dir_guard` to keep the directory alive until the end of main.
+    // When `--retain-test-dir` is set, we `.keep()` the TempDir so it persists after exit.
+    let (_temp_dir_guard, base_dir): (Option<tempfile::TempDir>, PathBuf) =
+        if let Some(ref base_dir) = cli_args.opts_overrides.base_dir {
+            (None, base_dir.clone())
+        } else {
+            let temp = tempfile::TempDir::new().expect("failed to create temp dir");
+            let path = temp.path().to_path_buf();
+            cli_args.opts_overrides.base_dir = Some(path.clone());
+            if cli_args.retain_test_dir {
+                let _ = temp.keep();
+                (None, path)
+            } else {
+                (Some(temp), path)
+            }
+        };
+
+    if rlimit::increase_nofile_limit(u64::MAX).is_err() {
+        c_warn!("Failed to increase the number of open file descriptors limit.");
+    }
+
+    let config_path = cli_args
+        .config_file
+        .as_ref()
+        .map(|p| std::fs::canonicalize(p).expect("config-file path is valid"));
+
+    let config_loader = ConfigLoaderBuilder::default()
+        .load_env(true)
+        .path(config_path)
+        .cli_override(cli_args.opts_overrides.clone())
+        .build()
+        .unwrap();
+
+    let config = match config_loader.load_once() {
+        Ok(c) => c,
+        Err(e) => {
+            c_eprintln!("{}", e.decorate());
+            c_eprintln!("{:#?}", RestateCode::from_code(e.code()));
+            std::process::exit(1);
+        }
+    };
+
+    restate_types::config::set_current_config(config.clone());
+
+    let recorder = PrometheusBuilder::new().install_recorder().unwrap();
+    let (tc, log_store, state_map) = spawn_environment(Configuration::live());
+    let task_center = tc.clone();
+    let args = cli_args.clone();
+
+    tc.block_on(async move {
+        let tracing_guard = init_tracing_and_logging(&config.common, "logserver-bench")
+            .expect("failed to configure logging and tracing!");
+
+        // Initialize CLI context without tracing — we already have a tracing subscriber
+        // from init_tracing_and_logging above.
+        CliContext::new_without_tracing(args.common_opts.clone()).set_as_global();
+
+        // Start metrics HTTP server
+        metrics_server::start_metrics_server(args.metrics_port, recorder);
+
+        info!("Log-server benchmark environment ready");
+
+        // Run the benchmark as a spawned task so it executes on the tokio runtime
+        // worker pool rather than inline in block_on (which runs on the calling
+        // thread). This better reflects real-world scheduling behaviour.
+        let bench_handle =
+            TaskCenter::spawn_unmanaged(TaskKind::Disposable, "benchmark", async move {
+                match args.command {
+                    Command::WriteThroughput(ref opts) => {
+                        write_throughput::run(
+                            opts,
+                            log_store.clone(),
+                            &state_map,
+                            args.report_interval,
+                            args.raw_rocksdb_stats,
+                        )
+                        .await
+                    }
+                    Command::MixedWorkload(ref opts) => {
+                        mixed_workload::run(
+                            opts,
+                            log_store.clone(),
+                            &state_map,
+                            args.report_interval,
+                            args.raw_rocksdb_stats,
+                        )
+                        .await
+                    }
+                    Command::GeneratePayload(_) => {
+                        unreachable!("handled above before TaskCenter setup")
+                    }
+                }
+            })?;
+        bench_handle.await??;
+
+        // Record tokio runtime metrics
+        task_center.submit_metrics();
+
+        task_center.shutdown_node("completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+
+        let shutdown_tracing_with_timeout =
+            tokio::time::timeout(Duration::from_secs(10), tracing_guard.async_shutdown());
+        if shutdown_tracing_with_timeout.await.is_err() {
+            tracing::trace!("Failed to fully flush pending spans, terminating now.");
+        }
+        anyhow::Ok(())
+    })?;
+
+    if user_provided_base_dir || cli_args.retain_test_dir {
+        c_tip!("Keeping the base_dir in {}", base_dir.display());
+    } else {
+        c_println!("Removing test dir at {}", base_dir.display());
+    }
+
+    Ok(())
+}
+
+fn spawn_environment(
+    config: restate_types::live::Live<Configuration>,
+) -> (
+    task_center::Handle,
+    restate_log_server::rocksdb_logstore::RocksDbLogStore,
+    LogletStateMap,
+) {
+    let tc = TaskCenterBuilder::default()
+        .options(config.pinned().common.clone())
+        .build()
+        .expect("task_center builds")
+        .into_handle();
+
+    let (log_store, state_map) = tc.block_on(async move {
+        let metadata_builder = MetadataBuilder::default();
+        TaskCenter::try_set_global_metadata(metadata_builder.to_metadata());
+
+        RocksDbManager::init();
+
+        let builder = RocksDbLogStoreBuilder::create()
+            .await
+            .expect("Failed to create RocksDB log store");
+        let log_store = builder
+            .start(Default::default())
+            .await
+            .expect("Failed to start RocksDB log store");
+
+        let state_map = LogletStateMap::load_all(&log_store)
+            .await
+            .expect("Failed to load loglet state map");
+
+        (log_store, state_map)
+    });
+
+    (tc, log_store, state_map)
+}

--- a/tools/logserver-bench/src/metrics_server.rs
+++ b/tools/logserver-bench/src/metrics_server.rs
@@ -1,0 +1,405 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Lightweight Prometheus metrics HTTP server that exposes both standard metrics and
+//! RocksDB-specific statistics for real-time observability during benchmark runs.
+
+use std::fmt::Write;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::routing::get;
+use indexmap::IndexMap;
+use metrics_exporter_prometheus::PrometheusHandle;
+use metrics_exporter_prometheus::formatting;
+use rocksdb::statistics::{Histogram, Ticker};
+use tracing::info;
+
+use restate_rocksdb::{CfName, RocksDbManager};
+
+// Duplicated from crates/node/src/network_server/metrics.rs and prometheus_helpers.rs
+// to avoid pulling in the entire node crate. These could be extracted into a shared
+// crate in the future.
+
+const ROCKSDB_TICKERS: &[Ticker] = &[
+    Ticker::BlockCacheBytesRead,
+    Ticker::BlockCacheBytesWrite,
+    Ticker::BlockCacheHit,
+    Ticker::BlockCacheMiss,
+    Ticker::BloomFilterUseful,
+    Ticker::BytesRead,
+    Ticker::BytesWritten,
+    Ticker::CompactReadBytes,
+    Ticker::CompactWriteBytes,
+    Ticker::FlushWriteBytes,
+    Ticker::IterBytesRead,
+    Ticker::MemtableHit,
+    Ticker::MemtableMiss,
+    Ticker::NoIteratorCreated,
+    Ticker::NoIteratorDeleted,
+    Ticker::NumberDbNext,
+    Ticker::NumberDbSeek,
+    Ticker::NumberIterSkip,
+    Ticker::NumberKeysRead,
+    Ticker::NumberKeysUpdated,
+    Ticker::NumberKeysWritten,
+    Ticker::NumberOfReseeksInIteration,
+    Ticker::StallMicros,
+    Ticker::WalFileBytes,
+    Ticker::WalFileSynced,
+    Ticker::WriteWithWal,
+];
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum MetricUnit {
+    Micros,
+    Bytes,
+    Count,
+}
+
+impl MetricUnit {
+    fn normalize_value(self, value: f64) -> f64 {
+        match self {
+            MetricUnit::Micros => value / 1_000_000.0,
+            MetricUnit::Bytes | MetricUnit::Count => value,
+        }
+    }
+
+    fn normalized_unit(self) -> metrics::Unit {
+        match self {
+            MetricUnit::Micros => metrics::Unit::Seconds,
+            MetricUnit::Bytes => metrics::Unit::Bytes,
+            MetricUnit::Count => metrics::Unit::Count,
+        }
+    }
+}
+
+const ROCKSDB_HISTOGRAMS: &[(Histogram, &str, MetricUnit)] = &[
+    (Histogram::DbGet, "rocksdb.db.get", MetricUnit::Micros),
+    (
+        Histogram::DbMultiget,
+        "rocksdb.db.multiget",
+        MetricUnit::Micros,
+    ),
+    (Histogram::DbWrite, "rocksdb.db.write", MetricUnit::Micros),
+    (Histogram::DbSeek, "rocksdb.db.seek", MetricUnit::Micros),
+    (Histogram::FlushTime, "rocksdb.db.flush", MetricUnit::Micros),
+    (
+        Histogram::ReadBlockGetMicros,
+        "rocksdb.read.block.get",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::SstReadMicros,
+        "rocksdb.sst.read",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::SstWriteMicros,
+        "rocksdb.sst.write",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::WalFileSyncMicros,
+        "rocksdb.wal.file.sync",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::CompactionTime,
+        "rocksdb.compaction.times",
+        MetricUnit::Micros,
+    ),
+    (
+        Histogram::BytesPerWrite,
+        "rocksdb.bytes.per.write",
+        MetricUnit::Bytes,
+    ),
+    (
+        Histogram::BytesPerRead,
+        "rocksdb.bytes.per.read",
+        MetricUnit::Bytes,
+    ),
+];
+
+const ROCKSDB_DB_PROPERTIES: &[(&str, MetricUnit)] = &[
+    ("rocksdb.block-cache-capacity", MetricUnit::Bytes),
+    ("rocksdb.block-cache-usage", MetricUnit::Bytes),
+    ("rocksdb.block-cache-pinned-usage", MetricUnit::Bytes),
+    ("rocksdb.num-running-flushes", MetricUnit::Count),
+];
+
+const ROCKSDB_CF_PROPERTIES: &[(&str, MetricUnit)] = &[
+    ("rocksdb.num-immutable-mem-table", MetricUnit::Count),
+    ("rocksdb.mem-table-flush-pending", MetricUnit::Count),
+    ("rocksdb.is-write-stopped", MetricUnit::Count),
+    ("rocksdb.compaction-pending", MetricUnit::Count),
+    ("rocksdb.background-errors", MetricUnit::Count),
+    ("rocksdb.cur-size-active-mem-table", MetricUnit::Bytes),
+    ("rocksdb.cur-size-all-mem-tables", MetricUnit::Bytes),
+    ("rocksdb.size-all-mem-tables", MetricUnit::Bytes),
+    ("rocksdb.num-entries-active-mem-table", MetricUnit::Count),
+    ("rocksdb.num-entries-imm-mem-tables", MetricUnit::Count),
+    ("rocksdb.num-deletes-active-mem-table", MetricUnit::Count),
+    ("rocksdb.num-deletes-imm-mem-tables", MetricUnit::Count),
+    ("rocksdb.estimate-num-keys", MetricUnit::Count),
+    ("rocksdb.estimate-table-readers-mem", MetricUnit::Bytes),
+    ("rocksdb.num-live-versions", MetricUnit::Count),
+    ("rocksdb.estimate-live-data-size", MetricUnit::Bytes),
+    ("rocksdb.live-sst-files-size", MetricUnit::Bytes),
+    (
+        "rocksdb.estimate-pending-compaction-bytes",
+        MetricUnit::Bytes,
+    ),
+    ("rocksdb.num-running-compactions", MetricUnit::Count),
+    ("rocksdb.actual-delayed-write-rate", MetricUnit::Count),
+    ("rocksdb.num-files-at-level0", MetricUnit::Count),
+    ("rocksdb.num-files-at-level1", MetricUnit::Count),
+    ("rocksdb.num-files-at-level2", MetricUnit::Count),
+    ("rocksdb.num-files-at-level3", MetricUnit::Count),
+    ("rocksdb.num-files-at-level4", MetricUnit::Count),
+    ("rocksdb.num-files-at-level5", MetricUnit::Count),
+    ("rocksdb.num-files-at-level6", MetricUnit::Count),
+];
+
+#[derive(Clone)]
+struct MetricsState {
+    prometheus_handle: Arc<PrometheusHandle>,
+}
+
+pub fn start_metrics_server(port: u16, prometheus_handle: PrometheusHandle) {
+    if port == 0 {
+        return;
+    }
+    let state = MetricsState {
+        prometheus_handle: Arc::new(prometheus_handle),
+    };
+    let app = axum::Router::new()
+        .route("/metrics", get(render_metrics))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        let addr = SocketAddr::from(([0, 0, 0, 0], port));
+        let listener = match tokio::net::TcpListener::bind(addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                restate_cli_util::c_warn!("Failed to bind metrics server on port {port}: {e}");
+                return;
+            }
+        };
+        info!("Metrics server listening on http://{addr}/metrics");
+        if let Err(e) = axum::serve(listener, app).await {
+            restate_cli_util::c_error!("Metrics server error: {e}");
+        }
+    });
+}
+
+async fn render_metrics(State(state): State<MetricsState>) -> String {
+    let mut out = state.prometheus_handle.render();
+    append_rocksdb_metrics(&mut out);
+    out
+}
+
+fn append_rocksdb_metrics(out: &mut String) {
+    let manager = RocksDbManager::get();
+    let all_dbs = manager.get_all_dbs();
+    let default_cf = CfName::new("default");
+    let mut labels = IndexMap::new();
+
+    // Write buffer manager stats
+    format_property(
+        out,
+        &labels,
+        MetricUnit::Bytes,
+        "rocksdb.memory.write_buffer_manager_capacity",
+        manager.get_total_write_buffer_capacity(),
+    );
+    format_property(
+        out,
+        &labels,
+        MetricUnit::Bytes,
+        "rocksdb.memory.write_buffer_manager_usage",
+        manager.get_total_write_buffer_usage(),
+    );
+
+    for db in &all_dbs {
+        labels.insert("db".to_owned(), formatting::sanitize_label_value(db.name()));
+
+        // Tickers
+        for ticker in ROCKSDB_TICKERS {
+            format_ticker(out, db, &labels, *ticker);
+        }
+
+        // Histograms
+        for (histogram, name, unit) in ROCKSDB_HISTOGRAMS {
+            format_histogram(out, name, db.get_histogram_data(*histogram), *unit, &labels);
+        }
+
+        // Memory usage
+        if let Ok(memory) = manager.get_memory_usage_stats(&[]) {
+            format_property(
+                out,
+                &labels,
+                MetricUnit::Bytes,
+                "rocksdb.memory.approx-memtable",
+                memory.approximate_mem_table_total(),
+            );
+            format_property(
+                out,
+                &labels,
+                MetricUnit::Bytes,
+                "rocksdb.memory.approx-memtable-unflushed",
+                memory.approximate_mem_table_unflushed(),
+            );
+            format_property(
+                out,
+                &labels,
+                MetricUnit::Bytes,
+                "rocksdb.memory.approx-memtable-readers",
+                memory.approximate_mem_table_readers_total(),
+            );
+        }
+
+        // Per-DB properties
+        for (property, unit) in ROCKSDB_DB_PROPERTIES {
+            format_property(
+                out,
+                &labels,
+                *unit,
+                property,
+                db.inner()
+                    .get_property_int_cf(&default_cf, property)
+                    .unwrap_or_default()
+                    .unwrap_or_default(),
+            );
+        }
+
+        // Per-CF properties
+        for cf in &db.cfs() {
+            labels.insert("cf".to_owned(), formatting::sanitize_label_value(cf));
+            for (property, unit) in ROCKSDB_CF_PROPERTIES {
+                format_property(
+                    out,
+                    &labels,
+                    *unit,
+                    property,
+                    db.inner()
+                        .get_property_int_cf(cf, property)
+                        .unwrap_or_default()
+                        .unwrap_or_default(),
+                );
+            }
+        }
+    }
+}
+
+fn format_ticker(
+    out: &mut String,
+    db: &restate_rocksdb::RocksDb,
+    labels: &IndexMap<String, String>,
+    ticker: Ticker,
+) {
+    let name = format!(
+        "restate_{}",
+        formatting::sanitize_metric_name(ticker.name())
+    );
+    formatting::write_type_line(out, &name, None, Some("total"), "counter");
+    formatting::write_metric_line::<&str, u64>(
+        out,
+        &name,
+        Some("total"),
+        &metrics_exporter_prometheus::LabelSet::from_key_and_global(
+            &metrics::Key::from_static_name("x"),
+            labels,
+        ),
+        None,
+        db.get_ticker_count(ticker),
+        None,
+    );
+    let _ = writeln!(out);
+}
+
+fn format_property(
+    out: &mut String,
+    labels: &IndexMap<String, String>,
+    unit: MetricUnit,
+    property_name: &str,
+    value: u64,
+) {
+    let name = format!(
+        "restate_{}",
+        formatting::sanitize_metric_name(property_name),
+    );
+    formatting::write_type_line(out, &name, Some(unit.normalized_unit()), None, "gauge");
+    formatting::write_metric_line::<&str, u64>(
+        out,
+        &name,
+        None,
+        &metrics_exporter_prometheus::LabelSet::from_key_and_global(
+            &metrics::Key::from_static_name("x"),
+            labels,
+        ),
+        None,
+        value,
+        Some(unit.normalized_unit()),
+    );
+    let _ = writeln!(out);
+}
+
+fn format_histogram(
+    out: &mut String,
+    name: &str,
+    data: rocksdb::statistics::HistogramData,
+    unit: MetricUnit,
+    labels: &IndexMap<String, String>,
+) {
+    let name = format!("restate_{}", formatting::sanitize_metric_name(name));
+    formatting::write_type_line(out, &name, Some(unit.normalized_unit()), None, "summary");
+
+    let labels = metrics_exporter_prometheus::LabelSet::from_key_and_global(
+        &metrics::Key::from_static_name("x"),
+        labels,
+    );
+    for (quantile, value) in [
+        ("0.5", data.median()),
+        ("0.95", data.p95()),
+        ("0.99", data.p99()),
+        ("1.0", data.max()),
+    ] {
+        formatting::write_metric_line::<&str, f64>(
+            out,
+            &name,
+            None,
+            &labels,
+            Some(("quantile", quantile)),
+            unit.normalize_value(value),
+            Some(unit.normalized_unit()),
+        );
+    }
+    formatting::write_metric_line::<&str, f64>(
+        out,
+        &name,
+        Some("sum"),
+        &labels,
+        None,
+        unit.normalize_value(data.sum() as f64),
+        Some(unit.normalized_unit()),
+    );
+    formatting::write_metric_line::<&str, u64>(
+        out,
+        &name,
+        Some("count"),
+        &labels,
+        None,
+        data.count(),
+        Some(unit.normalized_unit()),
+    );
+    let _ = writeln!(out);
+}

--- a/tools/logserver-bench/src/mixed_workload.rs
+++ b/tools/logserver-bench/src/mixed_workload.rs
@@ -1,0 +1,366 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Mixed workload: concurrent writes, reads, and trims across multiple loglets.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use anyhow::Result;
+use hdrhistogram::Histogram;
+use tokio::sync::Barrier;
+use tracing::info;
+
+use restate_core::network::ServiceMessage;
+use restate_core::{TaskCenter, TaskKind};
+use restate_log_server::loglet_worker::{LogletWorker, LogletWorkerHandle};
+use restate_log_server::logstore::LogStore;
+use restate_log_server::metadata::LogletStateMap;
+use restate_time_util::FriendlyDuration;
+use restate_types::GenerationalNodeId;
+use restate_types::logs::{KeyFilter, LogletId, LogletOffset, Record, SequenceNumber};
+use restate_types::net::log_server::*;
+
+use crate::payload::{PayloadPool, PayloadSpec};
+use crate::report::{
+    BenchCounters, IntervalReporter, RunSummary, SystemSnapshot, print_read_summary, print_summary,
+};
+
+const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+const DB_NAME: &str = "log-server";
+const POOL_BATCHES: usize = 1024;
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct MixedWorkloadOpts {
+    /// Duration to run the workload (e.g. "60s", "5m").
+    #[arg(long, default_value = "60s")]
+    pub duration: FriendlyDuration,
+
+    /// Number of loglets.
+    #[arg(long, default_value = "10")]
+    pub num_loglets: u32,
+
+    /// Number of records per Store batch.
+    #[arg(long, default_value = "10")]
+    pub records_per_batch: usize,
+
+    /// Enable read tasks (one per loglet, reading behind the writer).
+    #[arg(long)]
+    pub enable_reads: bool,
+
+    /// How many records behind the writer the reader stays.
+    #[arg(long, default_value = "10000")]
+    pub read_lag: u64,
+
+    /// Enable periodic trim operations.
+    #[arg(long)]
+    pub enable_trims: bool,
+
+    /// Interval between trim operations.
+    #[arg(long, default_value = "10s")]
+    pub trim_interval: FriendlyDuration,
+
+    /// How many records behind the writer the trim point stays.
+    #[arg(long, default_value = "100000")]
+    pub trim_lag: u64,
+
+    /// Load payload from a pre-generated file (see `generate-payload` subcommand).
+    /// When set, --payload-size/--entropy/--key-style/--seed are ignored.
+    #[arg(long)]
+    pub payload_file: Option<PathBuf>,
+
+    #[clap(flatten)]
+    pub payload: PayloadSpec,
+}
+
+struct SharedState {
+    /// Per-loglet write offset (records written so far).
+    offsets: Vec<AtomicU64>,
+    stop: AtomicBool,
+}
+
+pub async fn run<S: LogStore + Sync>(
+    opts: &MixedWorkloadOpts,
+    log_store: S,
+    state_map: &LogletStateMap,
+    report_interval: FriendlyDuration,
+    raw_rocksdb_stats: bool,
+) -> Result<()> {
+    let records_per_batch = opts.records_per_batch.max(1);
+
+    // Create workers
+    let mut workers: Vec<LogletWorkerHandle> = Vec::with_capacity(opts.num_loglets as usize);
+    for i in 0..opts.num_loglets {
+        let loglet_id = LogletId::new_unchecked(u64::from(i) + 1);
+        let loglet_state = state_map.get_or_load(loglet_id, &log_store).await?;
+        let worker = LogletWorker::start(loglet_id, log_store.clone(), loglet_state)?;
+        workers.push(worker);
+    }
+
+    let shared = Arc::new(SharedState {
+        offsets: (0..opts.num_loglets).map(|_| AtomicU64::new(1)).collect(),
+        stop: AtomicBool::new(false),
+    });
+
+    info!(
+        duration = %opts.duration,
+        num_loglets = opts.num_loglets,
+        records_per_batch,
+        enable_reads = opts.enable_reads,
+        enable_trims = opts.enable_trims,
+        payload_size = %opts.payload.payload_size,
+        entropy = opts.payload.entropy,
+        "Starting mixed workload"
+    );
+
+    // We use a barrier to start all tasks simultaneously after setup.
+    let mut task_count = opts.num_loglets as usize; // writers
+    if opts.enable_reads {
+        task_count += opts.num_loglets as usize;
+    }
+    if opts.enable_trims {
+        task_count += opts.num_loglets as usize;
+    }
+    let barrier = Arc::new(Barrier::new(task_count + 1)); // +1 for the main task
+
+    // Set up reporting
+    let counters = BenchCounters::new();
+    let (reporter, latency_collector) =
+        IntervalReporter::new(report_interval, DB_NAME, counters.clone());
+    let latency_collector = Arc::new(latency_collector);
+    let reporter_handle = tokio::spawn(reporter.run());
+
+    let mut write_tasks = Vec::new();
+    let mut read_tasks = Vec::new();
+
+    // Spawn writer tasks
+    for (i, worker) in workers.iter().enumerate() {
+        let loglet_id = LogletId::new_unchecked(i as u64 + 1);
+        let shared = shared.clone();
+        let barrier = barrier.clone();
+        let payload_spec = opts.payload.clone();
+        let payload_file = opts.payload_file.clone();
+        let data_tx = worker.data_tx();
+        let counters = counters.clone();
+        let collector = latency_collector.clone();
+        let payload_size = opts.payload.payload_size.as_u64();
+
+        let handle =
+            TaskCenter::spawn_unmanaged(TaskKind::LogServerRole, "bench-writer", async move {
+                let mut pool = if let Some(ref path) = payload_file {
+                    PayloadPool::from_file(path, Some(records_per_batch))?
+                } else {
+                    PayloadPool::new(&payload_spec, records_per_batch, POOL_BATCHES)
+                };
+                let mut next_offset = LogletOffset::OLDEST;
+
+                barrier.wait().await;
+
+                while !shared.stop.load(Ordering::Relaxed) {
+                    let payloads: Arc<[Record]> = pool.next_batch();
+                    let batch_len = payloads.len() as u32;
+                    let store_msg = Store {
+                        header: LogServerRequestHeader::new(loglet_id, next_offset),
+                        timeout_at: None,
+                        sequencer: SEQUENCER,
+                        known_archived: LogletOffset::INVALID,
+                        first_offset: next_offset,
+                        flags: StoreFlags::empty(),
+                        payloads: payloads.into(),
+                    };
+                    let (msg, reply) = ServiceMessage::fake_rpc(
+                        store_msg,
+                        Some(loglet_id.into()),
+                        SEQUENCER,
+                        None,
+                    );
+
+                    let batch_start = std::time::Instant::now();
+                    data_tx.send(msg);
+                    let stored: Stored = reply.await?;
+                    collector.record(batch_start.elapsed().as_nanos() as u64);
+
+                    if stored.status != Status::Ok {
+                        anyhow::bail!("Store failed: {:?}", stored.status);
+                    }
+
+                    next_offset = next_offset + batch_len;
+                    shared.offsets[i].store(u64::from(next_offset), Ordering::Relaxed);
+
+                    // Update shared counters
+                    counters.ops.fetch_add(batch_len as u64, Ordering::Relaxed);
+                    counters
+                        .payload_bytes
+                        .fetch_add(batch_len as u64 * payload_size, Ordering::Relaxed);
+                }
+
+                let total_records = u64::from(next_offset) - 1;
+                Ok::<_, anyhow::Error>((loglet_id, total_records))
+            })?;
+        write_tasks.push(handle);
+    }
+
+    // Spawn reader tasks
+    if opts.enable_reads {
+        for (i, worker) in workers.iter().enumerate() {
+            let loglet_id = LogletId::new_unchecked(i as u64 + 1);
+            let shared = shared.clone();
+            let barrier = barrier.clone();
+            let read_lag = opts.read_lag;
+            let data_tx = worker.data_tx();
+
+            let handle =
+                TaskCenter::spawn_unmanaged(TaskKind::LogServerRole, "bench-reader", async move {
+                    let mut latencies = Histogram::<u64>::new(3)?;
+                    let mut read_offset = LogletOffset::OLDEST;
+                    let mut total_records_read: u64 = 0;
+
+                    barrier.wait().await;
+
+                    while !shared.stop.load(Ordering::Relaxed) {
+                        let writer_offset = shared.offsets[i].load(Ordering::Relaxed);
+                        let target = writer_offset.saturating_sub(read_lag);
+                        if u64::from(read_offset) >= target {
+                            tokio::task::yield_now().await;
+                            continue;
+                        }
+
+                        let to_raw = (u64::from(read_offset) + 1000)
+                            .min(target)
+                            .min(u32::MAX as u64) as u32;
+                        let get_msg = GetRecords {
+                            header: LogServerRequestHeader::new(loglet_id, read_offset),
+                            from_offset: read_offset,
+                            to_offset: LogletOffset::from(to_raw),
+                            total_limit_in_bytes: Some(64 * 1024),
+                            filter: KeyFilter::Any,
+                        };
+
+                        let (msg, reply) = ServiceMessage::fake_rpc(
+                            get_msg,
+                            Some(loglet_id.into()),
+                            SEQUENCER,
+                            None,
+                        );
+
+                        let read_start = std::time::Instant::now();
+                        data_tx.send(msg);
+                        let records: Records = reply.await?;
+                        latencies.record(read_start.elapsed().as_nanos() as u64)?;
+
+                        total_records_read += records.records.len() as u64;
+                        read_offset = records.next_offset;
+                    }
+
+                    Ok::<_, anyhow::Error>((total_records_read, latencies))
+                })?;
+            read_tasks.push(handle);
+        }
+    }
+
+    // Spawn trim tasks
+    if opts.enable_trims {
+        for (i, worker) in workers.iter().enumerate() {
+            let loglet_id = LogletId::new_unchecked(i as u64 + 1);
+            let shared = shared.clone();
+            let barrier = barrier.clone();
+            let trim_lag = opts.trim_lag;
+            let trim_interval = opts.trim_interval;
+            let info_tx = worker.meta_tx();
+
+            TaskCenter::spawn_unmanaged(TaskKind::LogServerRole, "bench-trimmer", async move {
+                barrier.wait().await;
+                while !shared.stop.load(Ordering::Relaxed) {
+                    tokio::time::sleep(*trim_interval).await;
+                    let writer_offset = shared.offsets[i].load(Ordering::Relaxed);
+                    let trim_to = writer_offset.saturating_sub(trim_lag);
+                    if trim_to <= 1 {
+                        continue;
+                    }
+                    let trim_offset = LogletOffset::from(trim_to.min(u32::MAX as u64) as u32);
+                    let trim_msg = Trim {
+                        header: LogServerRequestHeader::new(loglet_id, trim_offset),
+                        trim_point: trim_offset,
+                    };
+                    let (msg, reply) =
+                        ServiceMessage::fake_rpc(trim_msg, Some(loglet_id.into()), SEQUENCER, None);
+                    info_tx.send(msg);
+                    let _ = reply.await;
+                }
+                Ok::<_, anyhow::Error>(())
+            })?;
+        }
+    }
+
+    let start_snapshot = SystemSnapshot::capture(DB_NAME);
+
+    // Start all tasks
+    barrier.wait().await;
+    info!("All tasks started, running for {}", opts.duration);
+
+    // Wait for duration
+    tokio::time::sleep(*opts.duration).await;
+    shared.stop.store(true, Ordering::Relaxed);
+    info!("Duration elapsed, stopping tasks...");
+
+    // Stop reporter and collect combined histogram
+    drop(latency_collector);
+    reporter_handle.abort();
+    let combined = match reporter_handle.await {
+        Ok(h) => h,
+        Err(_) => Histogram::<u64>::new(3)?,
+    };
+
+    let end_snapshot = SystemSnapshot::capture(DB_NAME);
+
+    // Collect writer results
+    let mut total_write_records: u64 = 0;
+    for task in write_tasks {
+        let (_loglet_id, records) = task.await??;
+        total_write_records += records;
+    }
+    let total_batches = total_write_records / records_per_batch as u64;
+
+    print_summary(&RunSummary {
+        title: "Mixed Workload Results",
+        total_ops: total_write_records,
+        total_batches,
+        records_per_batch,
+        payload_size: opts.payload.payload_size,
+        entropy: opts.payload.entropy,
+        num_loglets: opts.num_loglets,
+        wall_time: opts.duration,
+        latencies: &combined,
+        start_snapshot: &start_snapshot,
+        end_snapshot: &end_snapshot,
+        db_name: DB_NAME,
+        raw_rocksdb_stats,
+    });
+
+    // Collect reader results
+    if opts.enable_reads {
+        let mut total_read_records: u64 = 0;
+        let mut combined_read_latencies = Histogram::<u64>::new(3)?;
+        for task in read_tasks {
+            let (records, latencies) = task.await??;
+            total_read_records += records;
+            combined_read_latencies.add(&latencies)?;
+        }
+        print_read_summary(&combined_read_latencies, total_read_records, opts.duration);
+    }
+
+    // Drain workers
+    for worker in workers {
+        worker.drain().await?;
+    }
+
+    Ok(())
+}

--- a/tools/logserver-bench/src/payload.rs
+++ b/tools/logserver-bench/src/payload.rs
@@ -1,0 +1,462 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Payload generation: in-memory pool or pre-generated file for deterministic, zero-overhead runs.
+//!
+//! # Payload file format
+//!
+//! A payload file stores pre-materialized record batches so that benchmark runs
+//! don't spend CPU on RNG during the measured phase and repeated runs use
+//! identical data.
+//!
+//! ```text
+//! ┌─────────────────── Header (fixed size) ──────────────────┐
+//! │ magic: [u8; 8]       "RSBENCH\0"                         │
+//! │ version: u32          1                                   │
+//! │ payload_size: u32     body size per record (bytes)        │
+//! │ key_style: u8         0=None, 1=Single, 2=Pair, 3=Range  │
+//! │ batch_size: u32       records per batch                   │
+//! │ num_batches: u32      total batches in file               │
+//! │ seed: u64             RNG seed used to generate           │
+//! │ _reserved: [u8; 7]    padding / future use                │
+//! └──────────────────────────────────────────────────────────┘
+//! ┌─────────────────── Body ─────────────────────────────────┐
+//! │ For each batch (num_batches times):                       │
+//! │   For each record (batch_size times):                     │
+//! │     keys:  encoded keys (size depends on key_style)       │
+//! │     body:  [u8; payload_size]                             │
+//! └──────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Keys encoding per style:
+//! - None:  0 bytes
+//! - Single: 8 bytes (u64 LE)
+//! - Pair:   16 bytes (2 × u64 LE)
+//! - Range:  16 bytes (lo u64 LE, hi u64 LE)
+
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use rand::rngs::StdRng;
+use rand::{Rng, RngCore, SeedableRng};
+
+use restate_cli_util::{c_println, c_success};
+use restate_serde_util::ByteCount;
+use restate_types::logs::{Keys, Record};
+use restate_types::storage::PolyBytes;
+use restate_types::time::NanosSinceEpoch;
+
+// ---------------------------------------------------------------------------
+// CLI types
+// ---------------------------------------------------------------------------
+
+/// Controls how record keys are generated.
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum KeyStyleArg {
+    /// No keys (Keys::None) — record matches all readers.
+    #[default]
+    None,
+    /// Single u64 key per record.
+    Single,
+    /// Pair of u64 keys per record.
+    Pair,
+    /// Inclusive range of u64 keys per record.
+    Range,
+}
+
+/// Specification for generating payloads with controlled characteristics.
+#[derive(Debug, Clone, clap::Args)]
+pub struct PayloadSpec {
+    /// Payload body size (e.g. "512", "4KB", "1MiB").
+    #[arg(long, default_value = "512")]
+    pub payload_size: ByteCount,
+
+    /// Entropy of the payload body (0.0 = all zeros / maximally compressible,
+    /// 1.0 = random bytes / incompressible).
+    #[arg(long, default_value = "1.0")]
+    pub entropy: f64,
+
+    /// Key style attached to each record.
+    #[arg(long, default_value = "none")]
+    pub key_style: KeyStyleArg,
+
+    /// Seed for deterministic payload generation.
+    /// If omitted, a random seed is used and printed at startup for reproducibility.
+    #[arg(long)]
+    pub seed: Option<u64>,
+}
+
+/// Options for the `generate-payload` subcommand.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct GeneratePayloadOpts {
+    /// Output file path.
+    #[arg(long, short)]
+    pub output: PathBuf,
+
+    /// Number of records per batch (should match --records-per-batch on the benchmark).
+    #[arg(long, default_value = "10")]
+    pub records_per_batch: usize,
+
+    /// Number of batches to generate.
+    #[arg(long, default_value = "1024")]
+    pub num_batches: usize,
+
+    #[clap(flatten)]
+    pub payload: PayloadSpec,
+}
+
+// ---------------------------------------------------------------------------
+// PayloadPool — unified in-memory pool from either RNG or file
+// ---------------------------------------------------------------------------
+
+/// Pre-generated pool of record batches that benchmark tasks cycle through.
+pub struct PayloadPool {
+    records: Vec<Arc<[Record]>>,
+    batch_size: usize,
+    index: usize,
+}
+
+impl PayloadPool {
+    /// Create a new pool by generating batches in-memory from the RNG.
+    pub fn new(spec: &PayloadSpec, batch_size: usize, pool_batches: usize) -> Self {
+        let seed = spec.seed.unwrap_or_else(|| rand::rng().random());
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let records: Vec<Arc<[Record]>> = (0..pool_batches)
+            .map(|_| {
+                let batch: Vec<Record> = (0..batch_size)
+                    .map(|_| generate_record(&mut rng, spec))
+                    .collect();
+                batch.into()
+            })
+            .collect();
+
+        Self {
+            records,
+            batch_size,
+            index: 0,
+        }
+    }
+
+    /// Load a pool from a previously generated payload file.
+    ///
+    /// The `expected_batch_size` is validated against the file header. Pass `None`
+    /// to accept whatever batch size the file was generated with.
+    pub fn from_file(path: &Path, expected_batch_size: Option<usize>) -> anyhow::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut reader = BufReader::new(file);
+
+        let header = FileHeader::read_from(&mut reader)?;
+        if let Some(expected) = expected_batch_size {
+            anyhow::ensure!(
+                header.batch_size as usize == expected,
+                "Payload file batch_size ({}) does not match --records-per-batch ({expected})",
+                header.batch_size,
+            );
+        }
+
+        let batch_size = header.batch_size as usize;
+        let payload_size = header.payload_size as usize;
+        let key_bytes = header.key_style.byte_size();
+
+        let mut records = Vec::with_capacity(header.num_batches as usize);
+        for _ in 0..header.num_batches {
+            let mut batch = Vec::with_capacity(batch_size);
+            for _ in 0..batch_size {
+                let keys = read_keys(&mut reader, header.key_style)?;
+                let mut body = vec![0u8; payload_size];
+                reader.read_exact(&mut body)?;
+                batch.push(Record::from_parts(
+                    NanosSinceEpoch::now(),
+                    keys,
+                    PolyBytes::Bytes(Bytes::from(body)),
+                ));
+            }
+            records.push(Arc::from(batch));
+        }
+
+        // Verify we consumed exactly the expected amount of data
+        let expected_body_bytes = header.num_batches as u64
+            * batch_size as u64
+            * (key_bytes as u64 + payload_size as u64);
+        let actual_file_size = std::fs::metadata(path)?.len();
+        let expected_total = FileHeader::SIZE as u64 + expected_body_bytes;
+        anyhow::ensure!(
+            actual_file_size == expected_total,
+            "Payload file size mismatch: expected {expected_total} bytes, got {actual_file_size}",
+        );
+
+        Ok(Self {
+            records,
+            batch_size,
+            index: 0,
+        })
+    }
+
+    /// Get the next batch of records, cycling through the pool.
+    pub fn next_batch(&mut self) -> Arc<[Record]> {
+        let batch = self.records[self.index].clone();
+        self.index = (self.index + 1) % self.records.len();
+        batch
+    }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload file generation (the `generate-payload` subcommand)
+// ---------------------------------------------------------------------------
+
+/// Generate a payload file from the given options. Does not require TaskCenter.
+pub fn generate_payload_file(opts: &GeneratePayloadOpts) -> anyhow::Result<()> {
+    let batch_size = opts.records_per_batch.max(1);
+    let seed = opts.payload.seed.unwrap_or_else(|| rand::rng().random());
+    let mut rng = StdRng::seed_from_u64(seed);
+    let key_style: FileKeyStyle = opts.payload.key_style.into();
+
+    let header = FileHeader {
+        payload_size: opts.payload.payload_size.as_usize() as u32,
+        key_style,
+        batch_size: batch_size as u32,
+        num_batches: opts.num_batches as u32,
+        seed,
+    };
+
+    let file = std::fs::File::create(&opts.output)?;
+    let mut writer = BufWriter::new(file);
+
+    header.write_to(&mut writer)?;
+
+    let payload_size = opts.payload.payload_size.as_usize();
+    let entropy = opts.payload.entropy;
+    let total_records = opts.num_batches * batch_size;
+
+    for _ in 0..opts.num_batches {
+        for _ in 0..batch_size {
+            let keys = generate_keys(&mut rng, opts.payload.key_style);
+            write_keys(&mut writer, &keys)?;
+            let body = generate_body(&mut rng, payload_size, entropy);
+            writer.write_all(&body)?;
+        }
+    }
+    writer.flush()?;
+
+    let file_size = std::fs::metadata(&opts.output)?.len();
+    c_success!(
+        "Generated {} records ({} batches × {}) to {}",
+        total_records,
+        opts.num_batches,
+        batch_size,
+        opts.output.display(),
+    );
+    c_println!(
+        "  payload={}, key_style={:?}, seed={seed}, file_size={}",
+        opts.payload.payload_size,
+        opts.payload.key_style,
+        ByteCount::<true>::new(file_size),
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Record generation helpers
+// ---------------------------------------------------------------------------
+
+fn generate_record(rng: &mut StdRng, spec: &PayloadSpec) -> Record {
+    let body = generate_body(rng, spec.payload_size.as_usize(), spec.entropy);
+    let keys = generate_keys(rng, spec.key_style);
+    Record::from_parts(NanosSinceEpoch::now(), keys, PolyBytes::Bytes(body))
+}
+
+fn generate_body(rng: &mut StdRng, size: usize, entropy: f64) -> Bytes {
+    let entropy = entropy.clamp(0.0, 1.0);
+    let mut buf = vec![0u8; size];
+    let random_bytes = (size as f64 * entropy).ceil() as usize;
+    if random_bytes > 0 {
+        rng.fill_bytes(&mut buf[..random_bytes.min(size)]);
+    }
+    Bytes::from(buf)
+}
+
+fn generate_keys(rng: &mut StdRng, style: KeyStyleArg) -> Keys {
+    match style {
+        KeyStyleArg::None => Keys::None,
+        KeyStyleArg::Single => Keys::Single(rng.random()),
+        KeyStyleArg::Pair => Keys::Pair(rng.random(), rng.random()),
+        KeyStyleArg::Range => {
+            let a: u64 = rng.random();
+            let b: u64 = rng.random();
+            Keys::RangeInclusive(a.min(b)..=a.max(b))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload file format
+// ---------------------------------------------------------------------------
+
+const MAGIC: [u8; 8] = *b"RSBENCH\0";
+const VERSION: u32 = 1;
+
+/// Key style tag stored in the file header (1 byte).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum FileKeyStyle {
+    None = 0,
+    Single = 1,
+    Pair = 2,
+    Range = 3,
+}
+
+impl FileKeyStyle {
+    fn from_u8(v: u8) -> anyhow::Result<Self> {
+        match v {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Single),
+            2 => Ok(Self::Pair),
+            3 => Ok(Self::Range),
+            _ => anyhow::bail!("Unknown key style tag: {v}"),
+        }
+    }
+
+    /// Number of bytes needed to encode keys of this style.
+    fn byte_size(self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Single => 8,
+            Self::Pair | Self::Range => 16,
+        }
+    }
+}
+
+impl From<KeyStyleArg> for FileKeyStyle {
+    fn from(k: KeyStyleArg) -> Self {
+        match k {
+            KeyStyleArg::None => Self::None,
+            KeyStyleArg::Single => Self::Single,
+            KeyStyleArg::Pair => Self::Pair,
+            KeyStyleArg::Range => Self::Range,
+        }
+    }
+}
+
+/// Fixed-size file header (40 bytes).
+struct FileHeader {
+    payload_size: u32,
+    key_style: FileKeyStyle,
+    batch_size: u32,
+    num_batches: u32,
+    seed: u64,
+}
+
+impl FileHeader {
+    /// Total header size in bytes.
+    const SIZE: usize = 8 + 4 + 4 + 1 + 4 + 4 + 8 + 7; // = 40
+
+    fn write_to<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        w.write_all(&MAGIC)?;
+        w.write_all(&VERSION.to_le_bytes())?;
+        w.write_all(&self.payload_size.to_le_bytes())?;
+        w.write_all(&[self.key_style as u8])?;
+        w.write_all(&self.batch_size.to_le_bytes())?;
+        w.write_all(&self.num_batches.to_le_bytes())?;
+        w.write_all(&self.seed.to_le_bytes())?;
+        w.write_all(&[0u8; 7])?; // reserved
+        Ok(())
+    }
+
+    fn read_from<R: Read>(r: &mut R) -> anyhow::Result<Self> {
+        let mut magic = [0u8; 8];
+        r.read_exact(&mut magic)?;
+        anyhow::ensure!(magic == MAGIC, "Not a valid payload file (bad magic)");
+
+        let mut buf4 = [0u8; 4];
+        r.read_exact(&mut buf4)?;
+        let version = u32::from_le_bytes(buf4);
+        anyhow::ensure!(
+            version == VERSION,
+            "Unsupported payload file version: {version}"
+        );
+
+        r.read_exact(&mut buf4)?;
+        let payload_size = u32::from_le_bytes(buf4);
+
+        let mut buf1 = [0u8; 1];
+        r.read_exact(&mut buf1)?;
+        let key_style = FileKeyStyle::from_u8(buf1[0])?;
+
+        r.read_exact(&mut buf4)?;
+        let batch_size = u32::from_le_bytes(buf4);
+
+        r.read_exact(&mut buf4)?;
+        let num_batches = u32::from_le_bytes(buf4);
+
+        let mut buf8 = [0u8; 8];
+        r.read_exact(&mut buf8)?;
+        let seed = u64::from_le_bytes(buf8);
+
+        let mut reserved = [0u8; 7];
+        r.read_exact(&mut reserved)?;
+
+        Ok(Self {
+            payload_size,
+            key_style,
+            batch_size,
+            num_batches,
+            seed,
+        })
+    }
+}
+
+fn write_keys<W: Write>(w: &mut W, keys: &Keys) -> std::io::Result<()> {
+    match keys {
+        Keys::None => {}
+        Keys::Single(k) => w.write_all(&k.to_le_bytes())?,
+        Keys::Pair(a, b) => {
+            w.write_all(&a.to_le_bytes())?;
+            w.write_all(&b.to_le_bytes())?;
+        }
+        Keys::RangeInclusive(r) => {
+            w.write_all(&r.start().to_le_bytes())?;
+            w.write_all(&r.end().to_le_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+fn read_keys<R: Read>(r: &mut R, style: FileKeyStyle) -> anyhow::Result<Keys> {
+    let mut buf8 = [0u8; 8];
+    match style {
+        FileKeyStyle::None => Ok(Keys::None),
+        FileKeyStyle::Single => {
+            r.read_exact(&mut buf8)?;
+            Ok(Keys::Single(u64::from_le_bytes(buf8)))
+        }
+        FileKeyStyle::Pair => {
+            r.read_exact(&mut buf8)?;
+            let a = u64::from_le_bytes(buf8);
+            r.read_exact(&mut buf8)?;
+            let b = u64::from_le_bytes(buf8);
+            Ok(Keys::Pair(a, b))
+        }
+        FileKeyStyle::Range => {
+            r.read_exact(&mut buf8)?;
+            let lo = u64::from_le_bytes(buf8);
+            r.read_exact(&mut buf8)?;
+            let hi = u64::from_le_bytes(buf8);
+            Ok(Keys::RangeInclusive(lo..=hi))
+        }
+    }
+}

--- a/tools/logserver-bench/src/report.rs
+++ b/tools/logserver-bench/src/report.rs
@@ -1,0 +1,723 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmark reporting: periodic interval lines, end-of-run summary, and system snapshot helpers.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use comfy_table::Table;
+use hdrhistogram::Histogram;
+use rocksdb::statistics::Ticker;
+
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::{Styled, StyledTable};
+use restate_cli_util::ui::stylesheet::Style;
+use restate_rocksdb::{DbName, RocksDbManager};
+use restate_serde_util::ByteCount;
+use restate_time_util::FriendlyDuration;
+
+// ---------------------------------------------------------------------------
+// Human-friendly formatting helpers
+// ---------------------------------------------------------------------------
+
+fn fmt_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Compact duration for table columns (fixed width-ish, no spaces).
+fn fmt_duration_short(d: Duration) -> String {
+    let nanos = d.as_nanos();
+    if nanos < 1_000 {
+        format!("{nanos}ns")
+    } else if nanos < 1_000_000 {
+        format!("{:.0}µs", nanos as f64 / 1_000.0)
+    } else if nanos < 1_000_000_000 {
+        format!("{:.1}ms", nanos as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2}s", nanos as f64 / 1_000_000_000.0)
+    }
+}
+
+fn friendly(d: Duration) -> FriendlyDuration {
+    FriendlyDuration::from(d)
+}
+
+fn bytes(b: u64) -> ByteCount {
+    ByteCount::<true>::new(b)
+}
+
+fn bytes_usize(b: usize) -> ByteCount {
+    ByteCount::<true>::new(b as u64)
+}
+
+// ---------------------------------------------------------------------------
+// CPU usage via getrusage (Unix only)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CpuUsage {
+    pub user_secs: f64,
+    pub system_secs: f64,
+}
+
+impl CpuUsage {
+    #[cfg(unix)]
+    pub fn now() -> Self {
+        unsafe {
+            let mut usage: libc::rusage = std::mem::zeroed();
+            libc::getrusage(libc::RUSAGE_SELF, &mut usage);
+            Self {
+                user_secs: usage.ru_utime.tv_sec as f64
+                    + usage.ru_utime.tv_usec as f64 / 1_000_000.0,
+                system_secs: usage.ru_stime.tv_sec as f64
+                    + usage.ru_stime.tv_usec as f64 / 1_000_000.0,
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    pub fn now() -> Self {
+        Self::default()
+    }
+
+    pub fn delta(&self, prev: &Self) -> Self {
+        Self {
+            user_secs: self.user_secs - prev.user_secs,
+            system_secs: self.system_secs - prev.system_secs,
+        }
+    }
+
+    pub fn total(&self) -> f64 {
+        self.user_secs + self.system_secs
+    }
+
+    fn as_friendly(&self) -> (FriendlyDuration, FriendlyDuration) {
+        (
+            FriendlyDuration::from(Duration::from_secs_f64(self.user_secs)),
+            FriendlyDuration::from(Duration::from_secs_f64(self.system_secs)),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Jemalloc stats
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct JemallocSnapshot {
+    pub allocated: usize,
+    pub active: usize,
+    pub resident: usize,
+    pub mapped: usize,
+    pub retained: usize,
+    pub metadata: usize,
+}
+
+impl JemallocSnapshot {
+    #[cfg(not(target_env = "msvc"))]
+    pub fn read() -> Self {
+        use tikv_jemalloc_ctl::{epoch, stats};
+        let _ = epoch::advance();
+        Self {
+            allocated: stats::allocated::read().unwrap_or(0),
+            active: stats::active::read().unwrap_or(0),
+            resident: stats::resident::read().unwrap_or(0),
+            mapped: stats::mapped::read().unwrap_or(0),
+            retained: stats::retained::read().unwrap_or(0),
+            metadata: stats::metadata::read().unwrap_or(0),
+        }
+    }
+
+    #[cfg(target_env = "msvc")]
+    pub fn read() -> Self {
+        Self::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RocksDB ticker snapshot (cumulative counters)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RocksDbTickers {
+    pub stall_micros: u64,
+    pub wal_synced: u64,
+    pub wal_bytes: u64,
+    pub flush_write_bytes: u64,
+    pub compact_read_bytes: u64,
+    pub compact_write_bytes: u64,
+    pub block_cache_hit: u64,
+    pub block_cache_miss: u64,
+    pub bytes_written: u64,
+    pub bytes_read: u64,
+}
+
+impl RocksDbTickers {
+    pub fn read(db_name: &str) -> Self {
+        let manager = RocksDbManager::get();
+        let Some(db) = manager.get_db(DbName::new(db_name)) else {
+            return Self::default();
+        };
+        Self {
+            stall_micros: db.get_ticker_count(Ticker::StallMicros),
+            wal_synced: db.get_ticker_count(Ticker::WalFileSynced),
+            wal_bytes: db.get_ticker_count(Ticker::WalFileBytes),
+            flush_write_bytes: db.get_ticker_count(Ticker::FlushWriteBytes),
+            compact_read_bytes: db.get_ticker_count(Ticker::CompactReadBytes),
+            compact_write_bytes: db.get_ticker_count(Ticker::CompactWriteBytes),
+            block_cache_hit: db.get_ticker_count(Ticker::BlockCacheHit),
+            block_cache_miss: db.get_ticker_count(Ticker::BlockCacheMiss),
+            bytes_written: db.get_ticker_count(Ticker::BytesWritten),
+            bytes_read: db.get_ticker_count(Ticker::BytesRead),
+        }
+    }
+
+    pub fn delta(&self, prev: &Self) -> Self {
+        Self {
+            stall_micros: self.stall_micros.saturating_sub(prev.stall_micros),
+            wal_synced: self.wal_synced.saturating_sub(prev.wal_synced),
+            wal_bytes: self.wal_bytes.saturating_sub(prev.wal_bytes),
+            flush_write_bytes: self
+                .flush_write_bytes
+                .saturating_sub(prev.flush_write_bytes),
+            compact_read_bytes: self
+                .compact_read_bytes
+                .saturating_sub(prev.compact_read_bytes),
+            compact_write_bytes: self
+                .compact_write_bytes
+                .saturating_sub(prev.compact_write_bytes),
+            block_cache_hit: self.block_cache_hit.saturating_sub(prev.block_cache_hit),
+            block_cache_miss: self.block_cache_miss.saturating_sub(prev.block_cache_miss),
+            bytes_written: self.bytes_written.saturating_sub(prev.bytes_written),
+            bytes_read: self.bytes_read.saturating_sub(prev.bytes_read),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Combined system snapshot at a point in time
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub struct SystemSnapshot {
+    pub cpu: CpuUsage,
+    pub jemalloc: JemallocSnapshot,
+    pub rocksdb: RocksDbTickers,
+}
+
+impl SystemSnapshot {
+    pub fn capture(db_name: &str) -> Self {
+        Self {
+            cpu: CpuUsage::now(),
+            jemalloc: JemallocSnapshot::read(),
+            rocksdb: RocksDbTickers::read(db_name),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared counters that benchmarks update, the reporter reads
+// ---------------------------------------------------------------------------
+
+/// Atomic counters that benchmark tasks update and the reporter reads.
+pub struct BenchCounters {
+    /// Total operations completed (cumulative).
+    pub ops: AtomicU64,
+    /// Total bytes of payload written (cumulative).
+    pub payload_bytes: AtomicU64,
+}
+
+impl BenchCounters {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            ops: AtomicU64::new(0),
+            payload_bytes: AtomicU64::new(0),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interval reporter — runs on a background task, prints periodic lines
+// ---------------------------------------------------------------------------
+
+/// Collects per-interval latencies from the benchmark tasks.
+/// The benchmark pushes individual latency samples; the reporter drains them each interval.
+pub struct LatencyCollector {
+    tx: tokio::sync::mpsc::UnboundedSender<u64>,
+}
+
+impl LatencyCollector {
+    pub fn record(&self, nanos: u64) {
+        // Best-effort; if the channel is full/closed, drop the sample.
+        let _ = self.tx.send(nanos);
+    }
+}
+
+pub struct IntervalReporter {
+    interval: FriendlyDuration,
+    db_name: String,
+    counters: Arc<BenchCounters>,
+    rx: tokio::sync::mpsc::UnboundedReceiver<u64>,
+}
+
+impl IntervalReporter {
+    /// Create the reporter and a latency collector that benchmark tasks use to submit samples.
+    pub fn new(
+        interval: FriendlyDuration,
+        db_name: &str,
+        counters: Arc<BenchCounters>,
+    ) -> (Self, LatencyCollector) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (
+            Self {
+                interval,
+                db_name: db_name.to_owned(),
+                counters,
+                rx,
+            },
+            LatencyCollector { tx },
+        )
+    }
+
+    /// Run the periodic reporter until the returned histogram sender is dropped.
+    /// Returns the combined histogram of all samples seen.
+    pub async fn run(mut self) -> Histogram<u64> {
+        let mut combined = Histogram::<u64>::new(3).unwrap();
+        let mut interval_hist = Histogram::<u64>::new(3).unwrap();
+        let mut prev_snap = SystemSnapshot::capture(&self.db_name);
+        let mut prev_ops: u64 = 0;
+        let mut prev_bytes: u64 = 0;
+        let start = Instant::now();
+
+        // Print header matching the fixed-width data columns below.
+        c_println!(
+            "{:>8} {:>9} {:>9} {:>8} {:>8} {:>8} {:>8} {:>5} {:>7} {:>7} {:>7}",
+            "ELAPSED",
+            "OPS",
+            "OPS/S",
+            "MB/S",
+            "P50",
+            "P99",
+            "P999",
+            "CPU%",
+            "STALLS",
+            "ALLOC",
+            "RSS",
+        );
+
+        let mut ticker = tokio::time::interval(*self.interval);
+        ticker.tick().await; // first tick is immediate
+
+        loop {
+            ticker.tick().await;
+            let wall = self.interval.as_secs_f64();
+            let elapsed = start.elapsed();
+
+            // Drain latency samples
+            interval_hist.reset();
+            while let Ok(nanos) = self.rx.try_recv() {
+                let _ = interval_hist.record(nanos);
+                let _ = combined.record(nanos);
+            }
+
+            // Read counters
+            let cur_ops = self.counters.ops.load(Ordering::Relaxed);
+            let cur_bytes = self.counters.payload_bytes.load(Ordering::Relaxed);
+            let delta_ops = cur_ops.saturating_sub(prev_ops);
+            let delta_bytes = cur_bytes.saturating_sub(prev_bytes);
+            prev_ops = cur_ops;
+            prev_bytes = cur_bytes;
+
+            // System snapshot
+            let snap = SystemSnapshot::capture(&self.db_name);
+            let cpu_delta = snap.cpu.delta(&prev_snap.cpu);
+            let stall_delta = snap
+                .rocksdb
+                .stall_micros
+                .saturating_sub(prev_snap.rocksdb.stall_micros);
+            prev_snap = snap;
+
+            let ops_per_sec = delta_ops as f64 / wall;
+            let mb_per_sec = delta_bytes as f64 / wall / 1_048_576.0;
+            let cpu_pct = if wall > 0.0 {
+                cpu_delta.total() / wall * 100.0
+            } else {
+                0.0
+            };
+
+            let p50 = if interval_hist.is_empty() {
+                "-".to_owned()
+            } else {
+                fmt_duration_short(Duration::from_nanos(
+                    interval_hist.value_at_percentile(50.0),
+                ))
+            };
+            let p99 = if interval_hist.is_empty() {
+                "-".to_owned()
+            } else {
+                fmt_duration_short(Duration::from_nanos(
+                    interval_hist.value_at_percentile(99.0),
+                ))
+            };
+            let p999 = if interval_hist.is_empty() {
+                "-".to_owned()
+            } else {
+                fmt_duration_short(Duration::from_nanos(
+                    interval_hist.value_at_percentile(99.9),
+                ))
+            };
+
+            let stall_str = if stall_delta == 0 {
+                "0".to_owned()
+            } else {
+                friendly(Duration::from_micros(stall_delta)).to_string()
+            };
+
+            c_println!(
+                "[{:>5.0}s] {:>9} {:>9.0} {:>8.1} {:>8} {:>8} {:>8} {:>4.0}% {:>7} {:>7} {:>7}",
+                elapsed.as_secs_f64(),
+                fmt_count(delta_ops),
+                ops_per_sec,
+                mb_per_sec,
+                p50,
+                p99,
+                p999,
+                cpu_pct,
+                stall_str,
+                bytes_usize(snap.jemalloc.allocated),
+                bytes_usize(snap.jemalloc.resident),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// End-of-run summary
+// ---------------------------------------------------------------------------
+
+pub struct RunSummary<'a> {
+    pub title: &'a str,
+    pub total_ops: u64,
+    pub total_batches: u64,
+    pub records_per_batch: usize,
+    pub payload_size: ByteCount,
+    pub entropy: f64,
+    pub num_loglets: u32,
+    pub wall_time: FriendlyDuration,
+    pub latencies: &'a Histogram<u64>,
+    pub start_snapshot: &'a SystemSnapshot,
+    pub end_snapshot: &'a SystemSnapshot,
+    pub db_name: &'a str,
+    pub raw_rocksdb_stats: bool,
+}
+
+pub fn print_summary(s: &RunSummary<'_>) {
+    let wall = s.wall_time.as_secs_f64();
+    let total_bytes = s.total_ops * s.payload_size.as_u64();
+
+    // --- Title ---
+    restate_cli_util::c_title!("📊", s.title);
+
+    // --- Config ---
+    {
+        let mut table = Table::new_styled();
+        table.add_kv_row(
+            "Config:",
+            format!(
+                "{} loglet{}, {} rec/batch, {} payload, entropy={:.2}",
+                s.num_loglets,
+                if s.num_loglets != 1 { "s" } else { "" },
+                s.records_per_batch,
+                s.payload_size,
+                s.entropy,
+            ),
+        );
+        table.add_kv_row(
+            "Total:",
+            format!(
+                "{} records ({} batches) in {}",
+                fmt_count(s.total_ops),
+                fmt_count(s.total_batches),
+                s.wall_time,
+            ),
+        );
+        table.add_kv_row(
+            "Throughput:",
+            format!(
+                "{:.0} records/s | {:.0} batches/s | {:.1} MB/s",
+                s.total_ops as f64 / wall,
+                s.total_batches as f64 / wall,
+                total_bytes as f64 / wall / 1_048_576.0,
+            ),
+        );
+        c_println!("{}", table);
+    }
+
+    // --- Latency ---
+    restate_cli_util::c_title!("⏱", "Latency (store batch)");
+    if !s.latencies.is_empty() {
+        let mut table = Table::new_styled();
+        for (label, pct) in [
+            ("p50", 50.0),
+            ("p90", 90.0),
+            ("p99", 99.0),
+            ("p99.9", 99.9),
+            ("p99.99", 99.99),
+            ("max", 100.0),
+        ] {
+            table.add_kv_row(
+                &format!("{label}:"),
+                friendly(Duration::from_nanos(s.latencies.value_at_percentile(pct))).to_string(),
+            );
+        }
+        table.add_kv_row("samples:", s.latencies.len().to_string());
+        c_println!("{}", table);
+    } else {
+        c_println!("  {}", Styled(Style::Notice, "(no samples)"));
+    }
+
+    // --- CPU ---
+    {
+        let cpu = s.end_snapshot.cpu.delta(&s.start_snapshot.cpu);
+        let (user, sys) = cpu.as_friendly();
+        restate_cli_util::c_title!("🖥", "CPU");
+        let mut table = Table::new_styled();
+        table.add_kv_row("User:", user.to_string());
+        table.add_kv_row("System:", sys.to_string());
+        table.add_kv_row("Wall:", s.wall_time.to_string());
+        if wall > 0.0 {
+            table.add_kv_row("Avg util:", format!("{:.1}%", cpu.total() / wall * 100.0));
+        }
+        c_println!("{}", table);
+    }
+
+    // --- Memory (jemalloc) ---
+    {
+        let je = &s.end_snapshot.jemalloc;
+        restate_cli_util::c_title!("🧠", "Memory (jemalloc)");
+        let mut table = Table::new_styled();
+        table.add_kv_row("Allocated:", bytes_usize(je.allocated).to_string());
+        table.add_kv_row("Active:", bytes_usize(je.active).to_string());
+        table.add_kv_row("Resident:", bytes_usize(je.resident).to_string());
+        table.add_kv_row("Mapped:", bytes_usize(je.mapped).to_string());
+        table.add_kv_row("Retained:", bytes_usize(je.retained).to_string());
+        c_println!("{}", table);
+    }
+
+    // --- RocksDB curated summary ---
+    {
+        let rocks = s.end_snapshot.rocksdb.delta(&s.start_snapshot.rocksdb);
+        restate_cli_util::c_title!("🪨", "RocksDB");
+        let mut table = Table::new_styled();
+        table.add_kv_row(
+            "Write stall:",
+            friendly(Duration::from_micros(rocks.stall_micros)).to_string(),
+        );
+        table.add_kv_row(
+            "WAL:",
+            format!(
+                "{} syncs, {} written",
+                fmt_count(rocks.wal_synced),
+                bytes(rocks.wal_bytes),
+            ),
+        );
+        table.add_kv_row(
+            "Flush:",
+            format!("{} written", bytes(rocks.flush_write_bytes)),
+        );
+        table.add_kv_row(
+            "Compaction:",
+            format!(
+                "read={} written={}",
+                bytes(rocks.compact_read_bytes),
+                bytes(rocks.compact_write_bytes),
+            ),
+        );
+
+        let cache_total = rocks.block_cache_hit + rocks.block_cache_miss;
+        if cache_total > 0 {
+            table.add_kv_row(
+                "Block cache:",
+                format!(
+                    "{:.1}% hit ({} / {})",
+                    rocks.block_cache_hit as f64 / cache_total as f64 * 100.0,
+                    fmt_count(rocks.block_cache_hit),
+                    fmt_count(cache_total),
+                ),
+            );
+        } else {
+            table.add_kv_row("Block cache:", "(no accesses)");
+        }
+        c_println!("{}", table);
+    }
+
+    // Memtable + LSM from properties
+    print_rocksdb_properties(s.db_name);
+
+    // Raw stats dump if requested
+    if s.raw_rocksdb_stats {
+        let manager = RocksDbManager::get();
+        if let Some(db) = manager.get_db(DbName::new(s.db_name))
+            && let Some(stats_str) = db.get_statistics_str()
+        {
+            c_println!();
+            c_println!("--- Raw RocksDB Statistics ---");
+            c_println!("{stats_str}");
+        }
+    }
+
+    c_println!();
+}
+
+fn print_rocksdb_properties(db_name: &str) {
+    let manager = RocksDbManager::get();
+    let Some(db) = manager.get_db(DbName::new(db_name)) else {
+        return;
+    };
+
+    let mut table = Table::new_styled();
+
+    // Memory from RocksDB's memory usage API
+    if let Ok(memory) = manager.get_memory_usage_stats(&[DbName::new(db_name)]) {
+        table.add_kv_row(
+            "Memtable:",
+            format!(
+                "active={} total={} unflushed={}",
+                bytes(memory.approximate_mem_table_total()),
+                bytes(
+                    memory.approximate_mem_table_total()
+                        + memory.approximate_mem_table_readers_total()
+                ),
+                bytes(memory.approximate_mem_table_unflushed()),
+            ),
+        );
+    }
+
+    let wb_usage = manager.get_total_write_buffer_usage();
+    let wb_cap = manager.get_total_write_buffer_capacity();
+    table.add_kv_row(
+        "Write buffer:",
+        format!(
+            "{}/{} ({:.0}%)",
+            bytes(wb_usage),
+            bytes(wb_cap),
+            if wb_cap > 0 {
+                wb_usage as f64 / wb_cap as f64 * 100.0
+            } else {
+                0.0
+            },
+        ),
+    );
+
+    // Per-CF LSM level file counts + aggregated SST/compaction stats
+    let cfs = db.cfs();
+    let mut total_live_sst: u64 = 0;
+    let mut total_pending: u64 = 0;
+
+    for cf in &cfs {
+        let mut lsm = String::new();
+        let mut has_files = false;
+        for level in 0..=6 {
+            let prop = format!("rocksdb.num-files-at-level{level}");
+            let count = db
+                .inner()
+                .get_property_int_cf(cf, &prop)
+                .unwrap_or_default()
+                .unwrap_or_default();
+            if count > 0 {
+                has_files = true;
+            }
+            if !lsm.is_empty() {
+                lsm.push(' ');
+            }
+            lsm.push_str(&format!("L{level}:{count}"));
+        }
+
+        // Only print CFs that have data
+        if has_files {
+            table.add_kv_row(&format!("LSM [{cf}]:"), lsm);
+        }
+
+        total_live_sst += db
+            .inner()
+            .get_property_int_cf(cf, "rocksdb.live-sst-files-size")
+            .unwrap_or_default()
+            .unwrap_or_default();
+        total_pending += db
+            .inner()
+            .get_property_int_cf(cf, "rocksdb.estimate-pending-compaction-bytes")
+            .unwrap_or_default()
+            .unwrap_or_default();
+    }
+
+    table.add_kv_row(
+        "Live SST:",
+        format!(
+            "{} (pending compaction: {})",
+            bytes(total_live_sst),
+            bytes(total_pending),
+        ),
+    );
+
+    c_println!("{}", table);
+}
+
+// ---------------------------------------------------------------------------
+// Mixed workload: read summary helper
+// ---------------------------------------------------------------------------
+
+pub fn print_read_summary(
+    latencies: &Histogram<u64>,
+    total_records_read: u64,
+    wall_time: FriendlyDuration,
+) {
+    let wall = wall_time.as_secs_f64();
+
+    restate_cli_util::c_title!("📖", "Reads");
+    {
+        let mut table = Table::new_styled();
+        table.add_kv_row(
+            "Total:",
+            format!(
+                "{} records, {:.0} records/s",
+                fmt_count(total_records_read),
+                total_records_read as f64 / wall,
+            ),
+        );
+        c_println!("{}", table);
+    }
+
+    if !latencies.is_empty() {
+        c_println!("Latency (read batch):");
+        let mut table = Table::new_styled();
+        for (label, pct) in [
+            ("p50", 50.0),
+            ("p90", 90.0),
+            ("p99", 99.0),
+            ("p99.9", 99.9),
+            ("max", 100.0),
+        ] {
+            table.add_kv_row(
+                &format!("{label}:"),
+                friendly(Duration::from_nanos(latencies.value_at_percentile(pct))).to_string(),
+            );
+        }
+        table.add_kv_row("samples:", latencies.len().to_string());
+        c_println!("{}", table);
+    }
+}

--- a/tools/logserver-bench/src/write_throughput.rs
+++ b/tools/logserver-bench/src/write_throughput.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Sequential write throughput benchmark.
+//!
+//! Drives Store messages into per-loglet workers and measures write latency and throughput.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use anyhow::Result;
+use tracing::info;
+
+use restate_core::network::ServiceMessage;
+use restate_log_server::loglet_worker::{LogletWorker, LogletWorkerHandle};
+use restate_log_server::logstore::LogStore;
+use restate_log_server::metadata::LogletStateMap;
+use restate_time_util::FriendlyDuration;
+use restate_types::GenerationalNodeId;
+use restate_types::logs::{LogletId, LogletOffset, Record, SequenceNumber};
+use restate_types::net::log_server::{LogServerRequestHeader, Status, Store, StoreFlags, Stored};
+
+use crate::payload::{PayloadPool, PayloadSpec};
+use crate::report::{BenchCounters, IntervalReporter, RunSummary, SystemSnapshot, print_summary};
+
+const SEQUENCER: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+const DB_NAME: &str = "log-server";
+/// Number of pre-generated payload batches to cycle through.
+const POOL_BATCHES: usize = 1024;
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct WriteThroughputOpts {
+    /// Total number of records to write. Mutually exclusive with --duration.
+    /// Defaults to 1,000,000 when neither --num-records nor --duration is given.
+    #[arg(long, conflicts_with = "duration")]
+    pub num_records: Option<u64>,
+
+    /// Run continuously for a duration (e.g. "5m", "1h"). Mutually exclusive with --num-records.
+    #[arg(long, conflicts_with = "num_records")]
+    pub duration: Option<FriendlyDuration>,
+
+    /// Number of records per Store message batch.
+    #[arg(long, default_value = "10")]
+    pub records_per_batch: usize,
+
+    /// Number of loglets to write to concurrently.
+    #[arg(long, default_value = "1")]
+    pub num_loglets: u32,
+
+    /// Number of records to write as warmup (not measured).
+    #[arg(long, default_value = "50000")]
+    pub warmup_records: u64,
+
+    /// Load payload from a pre-generated file (see `generate-payload` subcommand).
+    /// When set, --payload-size/--entropy/--key-style/--seed are ignored.
+    #[arg(long)]
+    pub payload_file: Option<PathBuf>,
+
+    #[clap(flatten)]
+    pub payload: PayloadSpec,
+}
+
+const DEFAULT_NUM_RECORDS: u64 = 1_000_000;
+
+struct LogletContext {
+    worker: LogletWorkerHandle,
+    loglet_id: LogletId,
+    next_offset: LogletOffset,
+}
+
+pub async fn run<S: LogStore + Sync>(
+    opts: &WriteThroughputOpts,
+    log_store: S,
+    state_map: &LogletStateMap,
+    report_interval: FriendlyDuration,
+    raw_rocksdb_stats: bool,
+) -> Result<()> {
+    let records_per_batch = opts.records_per_batch.max(1);
+    let mut pool = if let Some(ref path) = opts.payload_file {
+        PayloadPool::from_file(path, Some(records_per_batch))?
+    } else {
+        PayloadPool::new(&opts.payload, records_per_batch, POOL_BATCHES)
+    };
+
+    // Create loglet workers
+    let mut loglets: Vec<LogletContext> = Vec::with_capacity(opts.num_loglets as usize);
+    for i in 0..opts.num_loglets {
+        let loglet_id = LogletId::new_unchecked((i + 1) as u64);
+        let loglet_state = state_map.get_or_load(loglet_id, &log_store).await?;
+        let worker = LogletWorker::start(loglet_id, log_store.clone(), loglet_state)?;
+        loglets.push(LogletContext {
+            worker,
+            loglet_id,
+            next_offset: LogletOffset::OLDEST,
+        });
+    }
+
+    // Determine stop condition
+    let max_batches = if opts.duration.is_some() {
+        None
+    } else {
+        Some(opts.num_records.unwrap_or(DEFAULT_NUM_RECORDS) / records_per_batch as u64)
+    };
+
+    if let Some(max) = max_batches {
+        info!(
+            num_loglets = opts.num_loglets,
+            records_per_batch,
+            num_records = max * records_per_batch as u64,
+            payload_size = %opts.payload.payload_size,
+            entropy = opts.payload.entropy,
+            "Starting write throughput benchmark (record count mode)"
+        );
+    } else {
+        info!(
+            num_loglets = opts.num_loglets,
+            records_per_batch,
+            duration = %opts.duration.unwrap(),
+            payload_size = %opts.payload.payload_size,
+            entropy = opts.payload.entropy,
+            "Starting write throughput benchmark (duration mode)"
+        );
+    }
+
+    // Warmup phase
+    if opts.warmup_records > 0 {
+        info!(warmup_records = opts.warmup_records, "Warmup phase");
+        let warmup_batches = opts.warmup_records / records_per_batch as u64;
+        let num_loglets = loglets.len();
+        for batch_i in 0..warmup_batches {
+            let ctx = &mut loglets[batch_i as usize % num_loglets];
+            send_store_batch(ctx, &mut pool).await?;
+        }
+        info!("Warmup complete");
+    }
+
+    // Set up reporting
+    let counters = BenchCounters::new();
+    let (reporter, latency_collector) =
+        IntervalReporter::new(report_interval, DB_NAME, counters.clone());
+    let reporter_handle = tokio::spawn(reporter.run());
+
+    let start_snapshot = SystemSnapshot::capture(DB_NAME);
+    let num_loglets = loglets.len();
+    let payload_size = opts.payload.payload_size.as_u64();
+    let deadline = opts.duration.map(|d| Instant::now() + *d);
+
+    let start = Instant::now();
+    let mut batch_count: u64 = 0;
+    loop {
+        if let Some(max) = max_batches
+            && batch_count >= max
+        {
+            break;
+        }
+        if let Some(dl) = deadline
+            && Instant::now() >= dl
+        {
+            break;
+        }
+
+        let ctx = &mut loglets[batch_count as usize % num_loglets];
+        let batch_start = Instant::now();
+        send_store_batch(ctx, &mut pool).await?;
+        latency_collector.record(batch_start.elapsed().as_nanos() as u64);
+
+        batch_count += 1;
+        let completed_records = batch_count * records_per_batch as u64;
+        counters.ops.store(completed_records, Ordering::Relaxed);
+        counters
+            .payload_bytes
+            .store(completed_records * payload_size, Ordering::Relaxed);
+    }
+    let wall_time = start.elapsed();
+
+    // Stop reporter and collect combined histogram
+    drop(latency_collector);
+    reporter_handle.abort();
+    let combined = match reporter_handle.await {
+        Ok(h) => h,
+        Err(_) => hdrhistogram::Histogram::<u64>::new(3)?,
+    };
+
+    let end_snapshot = SystemSnapshot::capture(DB_NAME);
+    let total_records = batch_count * records_per_batch as u64;
+
+    print_summary(&RunSummary {
+        title: "Write Throughput Results",
+        total_ops: total_records,
+        total_batches: batch_count,
+        records_per_batch,
+        payload_size: opts.payload.payload_size,
+        entropy: opts.payload.entropy,
+        num_loglets: opts.num_loglets,
+        wall_time: wall_time.into(),
+        latencies: &combined,
+        start_snapshot: &start_snapshot,
+        end_snapshot: &end_snapshot,
+        db_name: DB_NAME,
+        raw_rocksdb_stats,
+    });
+
+    // Drain workers
+    for ctx in loglets {
+        ctx.worker.drain().await?;
+    }
+
+    Ok(())
+}
+
+async fn send_store_batch(ctx: &mut LogletContext, pool: &mut PayloadPool) -> Result<()> {
+    let payloads: Arc<[Record]> = pool.next_batch();
+    let batch_len = payloads.len() as u32;
+
+    let store_msg = Store {
+        header: LogServerRequestHeader::new(ctx.loglet_id, ctx.next_offset),
+        timeout_at: None,
+        sequencer: SEQUENCER,
+        known_archived: LogletOffset::INVALID,
+        first_offset: ctx.next_offset,
+        flags: StoreFlags::empty(),
+        payloads: payloads.into(),
+    };
+
+    let (msg, reply) =
+        ServiceMessage::fake_rpc(store_msg, Some(ctx.loglet_id.into()), SEQUENCER, None);
+    ctx.worker.data_tx().send(msg);
+    let stored: Stored = reply.await?;
+
+    anyhow::ensure!(
+        stored.status == Status::Ok,
+        "Store failed with status {:?}",
+        stored.status
+    );
+
+    ctx.next_offset = ctx.next_offset.checked_add(batch_len).unwrap().into();
+    Ok(())
+}


### PR DESCRIPTION

Standalone benchmarking tool for the log-server's RocksDB storage layer.
Drives configurable write, read, and trim workloads through the LogletWorker
pipeline using fake RPCs, completely bypassing networking.

Features:
- Two benchmark modes: sequential write-throughput and mixed (concurrent
  write + read + trim) workload
- Periodic progress reporting with latency percentiles, throughput, CPU,
  jemalloc, and RocksDB stall metrics
- End-of-run summary with detailed RocksDB statistics (WAL, flush,
  compaction, block cache, LSM levels)
- Prometheus metrics endpoint for real-time observability
- Configurable payload entropy, key styles, batch sizes, and loglet count

Uses restate-cli-util for styled CLI output (c_println!, c_title!, c_warn!,
styled KV tables) with proper color detection and broken-pipe safety. Adds
CliContext::new_without_tracing() to cli-util for tools that manage their own
tracing subscriber.

The benchmark workload runs as a spawned TaskCenter task (TaskKind::Disposable)
rather than inline in block_on, to match real-world tokio scheduling behaviour.
