### PR TITLE
[Futures-Util] Add monotonic_token and waiter_queue modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7173,6 +7173,7 @@ version = "1.6.2"
 dependencies = [
  "anyhow",
  "async-channel",
+ "criterion",
  "futures",
  "pin-project",
  "pin-project-lite",

--- a/crates/futures-util/Cargo.toml
+++ b/crates/futures-util/Cargo.toml
@@ -23,7 +23,12 @@ tracing = { workspace = true }
 [dev-dependencies]
 restate-test-util = { workspace = true }
 
+criterion = { workspace = true }
 test-log = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing = { workspace = true }
 tracing-test = { workspace = true }
+
+[[bench]]
+name = "waiter_queue"
+harness = false

--- a/crates/futures-util/benches/waiter_queue.rs
+++ b/crates/futures-util/benches/waiter_queue.rs
@@ -1,0 +1,502 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmarks comparing four WaiterQueue push/drain strategies:
+//!
+//! 1. **Naive unsorted:** `push` always appends. `drain_up_to` pops from the
+//!    front then uses a `remove(i)` loop for out-of-order stragglers —
+//!    O(k * remainder).
+//!
+//! 2. **Compact unsorted:** Same push, but the drain slow path uses a
+//!    single-pass swap-and-compact — O(remainder) regardless of match count.
+//!
+//! 3. **Adaptive sorted-on-demand (production):** Tracks `max_key`. In-order
+//!    pushes use `push_back`; out-of-order pushes use binary-search insert to
+//!    maintain sorted order. Drain is always a simple front-pop — no scan.
+//!    This is what [`WaiterQueue`] uses in production.
+//!
+//! 4. **Always sorted-insert:** Every `push` uses binary search + insert.
+//!    Drain is a simple front-pop.
+//!
+//! We benchmark realistic scenarios:
+//! - **All ordered:** Entries arrive in order (common case).
+//! - **Few out-of-order:** ~5% of entries are displaced (repair stores).
+//! - **Many out-of-order:** ~30% of entries are displaced (stress case).
+//! - **Push-only:** Measuring push throughput in isolation.
+
+use std::collections::VecDeque;
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use restate_futures_util::waiter_queue::WaiterQueue;
+
+// ---------------------------------------------------------------------------
+// Naive unsorted variant (old slow path with remove(i) — O(k * remainder))
+// ---------------------------------------------------------------------------
+
+struct NaiveUnsortedQueue<K, V> {
+    inner: VecDeque<(K, V)>,
+}
+
+impl<K, V> NaiveUnsortedQueue<K, V> {
+    fn new() -> Self {
+        Self {
+            inner: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, target: K, value: V) {
+        self.inner.push_back((target, value));
+    }
+}
+
+impl<K: Ord, V> NaiveUnsortedQueue<K, V> {
+    fn drain_up_to(&mut self, threshold: K, mut f: impl FnMut(V)) {
+        while let Some(entry) = self.inner.pop_front_if(|e| e.0 <= threshold) {
+            f(entry.1);
+        }
+        let mut i = 0;
+        while i < self.inner.len() {
+            if self.inner[i].0 <= threshold {
+                f(self.inner.remove(i).unwrap().1);
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compact unsorted variant (production — O(remainder) swap-and-compact)
+// ---------------------------------------------------------------------------
+
+struct CompactQueue<K, V> {
+    inner: VecDeque<(K, V)>,
+}
+
+impl<K, V> CompactQueue<K, V> {
+    fn new() -> Self {
+        Self {
+            inner: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, target: K, value: V) {
+        self.inner.push_back((target, value));
+    }
+}
+
+impl<K: Ord, V> CompactQueue<K, V> {
+    fn drain_up_to(&mut self, threshold: K, mut f: impl FnMut(V)) {
+        // Fast path: pop from front while resolved.
+        while let Some(entry) = self.inner.pop_front_if(|e| e.0 <= threshold) {
+            f(entry.1);
+        }
+        // Slow path: single-pass swap-compact.
+        let mut write = 0;
+        for read in 0..self.inner.len() {
+            if self.inner[read].0 <= threshold {
+                self.inner.swap(write, read);
+                write += 1;
+            }
+        }
+        for _ in 0..write {
+            f(self.inner.pop_front().unwrap().1);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sorted-insert variant (candidate)
+// ---------------------------------------------------------------------------
+
+struct SortedQueue<K, V> {
+    inner: VecDeque<(K, V)>,
+}
+
+impl<K, V> SortedQueue<K, V> {
+    fn new() -> Self {
+        Self {
+            inner: VecDeque::new(),
+        }
+    }
+}
+
+impl<K: Ord, V> SortedQueue<K, V> {
+    fn push(&mut self, target: K, value: V) {
+        // Binary search on VecDeque for the insertion point.
+        let pos = self.inner.partition_point(|e| e.0 <= target);
+        self.inner.insert(pos, (target, value));
+    }
+
+    fn drain_up_to(&mut self, threshold: K, mut f: impl FnMut(V)) {
+        // Everything is sorted, so just pop from front.
+        while let Some(entry) = self.inner.pop_front_if(|e| e.0 <= threshold) {
+            f(entry.1);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Generates a sequence of keys. `out_of_order_pct` controls how many entries
+/// are displaced backward by a random amount.
+fn generate_keys(n: usize, out_of_order_pct: f64) -> Vec<u64> {
+    // Deterministic "random" via simple LCG for reproducibility.
+    let mut rng_state: u64 = 0xDEAD_BEEF;
+    let mut next_rng = || -> u64 {
+        rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        rng_state >> 33
+    };
+
+    let mut keys = Vec::with_capacity(n);
+    for i in 0..n {
+        let base = (i as u64 + 1) * 10; // spread out so there's room to insert before
+        // Decide if this entry is out-of-order.
+        let is_ooo = (next_rng() % 1000) < (out_of_order_pct * 1000.0) as u64;
+        if is_ooo && base > 20 {
+            // Push it backward by some amount (simulates a repair store).
+            let displacement = (next_rng() % (base / 2)).max(1);
+            keys.push(base - displacement);
+        } else {
+            keys.push(base);
+        }
+    }
+    keys
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_push_and_drain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("waiter_queue/push_and_drain");
+
+    for &(label, ooo_pct) in &[
+        ("all_ordered", 0.0),
+        ("5pct_ooo", 0.05),
+        ("30pct_ooo", 0.30),
+    ] {
+        for &n in &[50, 200, 1000] {
+            let keys = generate_keys(n, ooo_pct);
+            // Drain threshold: drain roughly half the entries each round.
+            let threshold = keys.iter().copied().max().unwrap() / 2;
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("naive/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = NaiveUnsortedQueue::new();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("compact/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = CompactQueue::new();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("adaptive/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = WaiterQueue::default();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("sorted/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = SortedQueue::new();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_push_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("waiter_queue/push_only");
+
+    for &(label, ooo_pct) in &[("all_ordered", 0.0), ("5pct_ooo", 0.05)] {
+        for &n in &[50, 200, 1000] {
+            let keys = generate_keys(n, ooo_pct);
+
+            // Naive and compact have identical push — benchmark one as "unsorted".
+            group.bench_with_input(
+                BenchmarkId::new(format!("unsorted/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = CompactQueue::new();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        black_box(&q);
+                    });
+                },
+            );
+
+            // Adaptive has the same push_back but also tracks max_key/sorted.
+            group.bench_with_input(
+                BenchmarkId::new(format!("adaptive/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = WaiterQueue::default();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        black_box(&q);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("sorted/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = SortedQueue::new();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        black_box(&q);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_drain_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("waiter_queue/drain_only");
+
+    for &(label, ooo_pct) in &[
+        ("all_ordered", 0.0),
+        ("5pct_ooo", 0.05),
+        ("30pct_ooo", 0.30),
+    ] {
+        for &n in &[50, 200, 1000] {
+            let keys = generate_keys(n, ooo_pct);
+            let threshold = keys.iter().copied().max().unwrap() / 2;
+
+            // Pre-build unsorted queue (same data for naive and compact).
+            let mut unsorted_template = CompactQueue::new();
+            for &k in &keys {
+                unsorted_template.push(k, k);
+            }
+
+            // Pre-build sorted queue.
+            let mut sorted_template = SortedQueue::new();
+            for &k in &keys {
+                sorted_template.push(k, k);
+            }
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("naive/{label}"), n),
+                &unsorted_template.inner,
+                |b, template| {
+                    b.iter(|| {
+                        let mut q = NaiveUnsortedQueue {
+                            inner: template.clone(),
+                        };
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("compact/{label}"), n),
+                &unsorted_template.inner,
+                |b, template| {
+                    b.iter(|| {
+                        let mut q = CompactQueue {
+                            inner: template.clone(),
+                        };
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+
+            // Adaptive: build via push (which maintains the sorted invariant).
+            group.bench_with_input(
+                BenchmarkId::new(format!("adaptive/{label}"), n),
+                &keys,
+                |b, keys| {
+                    b.iter(|| {
+                        let mut q = WaiterQueue::default();
+                        for &k in keys {
+                            q.push(k, k);
+                        }
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("sorted/{label}"), n),
+                &sorted_template.inner,
+                |b, template| {
+                    b.iter(|| {
+                        let mut q = SortedQueue {
+                            inner: template.clone(),
+                        };
+                        q.drain_up_to(threshold, |v| {
+                            black_box(v);
+                        });
+                        black_box(&q);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// Simulates the real steady-state: interleaved pushes and drains,
+/// as the log-server worker would do (batch of pushes, then drain).
+fn bench_mixed_workload(c: &mut Criterion) {
+    let mut group = c.benchmark_group("waiter_queue/mixed_workload");
+
+    for &(label, ooo_pct) in &[("all_ordered", 0.0), ("5pct_ooo", 0.05)] {
+        let keys = generate_keys(500, ooo_pct);
+        // Simulate: push 50 entries, drain, push 50, drain, ...
+        let batch_size = 50;
+
+        group.bench_function(BenchmarkId::new(format!("naive/{label}"), 500), |b| {
+            b.iter(|| {
+                let mut q = NaiveUnsortedQueue::new();
+                for chunk in keys.chunks(batch_size) {
+                    for &k in chunk {
+                        q.push(k, k);
+                    }
+                    let threshold = *chunk.iter().max().unwrap();
+                    q.drain_up_to(threshold, |v| {
+                        black_box(v);
+                    });
+                }
+                black_box(&q);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new(format!("compact/{label}"), 500), |b| {
+            b.iter(|| {
+                let mut q = CompactQueue::new();
+                for chunk in keys.chunks(batch_size) {
+                    for &k in chunk {
+                        q.push(k, k);
+                    }
+                    let threshold = *chunk.iter().max().unwrap();
+                    q.drain_up_to(threshold, |v| {
+                        black_box(v);
+                    });
+                }
+                black_box(&q);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new(format!("adaptive/{label}"), 500), |b| {
+            b.iter(|| {
+                let mut q = WaiterQueue::default();
+                for chunk in keys.chunks(batch_size) {
+                    for &k in chunk {
+                        q.push(k, k);
+                    }
+                    let threshold = *chunk.iter().max().unwrap();
+                    q.drain_up_to(threshold, |v| {
+                        black_box(v);
+                    });
+                }
+                black_box(&q);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new(format!("sorted/{label}"), 500), |b| {
+            b.iter(|| {
+                let mut q = SortedQueue::new();
+                for chunk in keys.chunks(batch_size) {
+                    for &k in chunk {
+                        q.push(k, k);
+                    }
+                    let threshold = *chunk.iter().max().unwrap();
+                    q.drain_up_to(threshold, |v| {
+                        black_box(v);
+                    });
+                }
+                black_box(&q);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_push_and_drain, bench_push_only, bench_drain_only, bench_mixed_workload
+);
+criterion_main!(benches);

--- a/crates/futures-util/src/lib.rs
+++ b/crates/futures-util/src/lib.rs
@@ -10,6 +10,8 @@
 
 pub mod command;
 pub mod concurrency;
+pub mod monotonic_token;
 pub mod overdue;
 pub mod pipe;
 pub mod streams;
+pub mod waiter_queue;

--- a/crates/futures-util/src/monotonic_token.rs
+++ b/crates/futures-util/src/monotonic_token.rs
@@ -1,0 +1,606 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A monotonically increasing token system for tracking ordered completions.
+//!
+//! This module provides a lightweight mechanism for a producer to signal that
+//! it has finished processing a *prefix* of sequentially issued work items.
+//! The core abstraction is a [`Token<T>`], an opaque, ordered identifier
+//! drawn from a [`Tokens<T>`] generator.
+//!
+//! # Roles
+//!
+//! | Type | Role |
+//! |------|------|
+//! | [`TokenOwner<T>`] | Root owner. Creates [`Tokens`] generators and retires tokens. |
+//! | [`Tokens<T>`] | Generator. Produces new [`Token`]s and creates [`TokenListener`]s. |
+//! | [`TokenListener<T>`] | Observer. Asynchronously waits for tokens to be retired. |
+//!
+//! # Semantics
+//!
+//! Tokens are monotonically increasing integers (starting at 1). Calling
+//! [`retire_through(t)`](TokenOwner::retire_through) signals that all tokens
+//! `<= t` have been processed. Listeners waiting on any token in that prefix
+//! will be woken up.
+//!
+//! # Pitfalls
+//!
+//! There is no atomic "acquire token then submit work" primitive. This means
+//! the owner may retire *through* a token before the holder has submitted
+//! its work. Callers must handle this race in their protocol — for example,
+//! by checking the current `retired_through` value after submission and
+//! re-submitting or treating the work as already committed.
+//!
+//! Similarly, if a caller acquires a token via [`Tokens::next`] but never
+//! submits work for it, the token still occupies a position in the sequence.
+//! When the owner later retires *through* a higher token, the unused token
+//! is implicitly included. Always submit work for every token you acquire,
+//! or handle the gap explicitly in your protocol.
+//!
+//! # Notification model
+//!
+//! [`TokenListener::changed`] returns the latest retired token at the moment
+//! the listener wakes up. Multiple retirements between polls are *coalesced*:
+//! the listener sees only the highest value, not each intermediate step. This
+//! is intentional — it mirrors the behaviour of `tokio::sync::watch` and
+//! keeps the fast path allocation-free.
+//!
+//! # Type parameter `T`
+//!
+//! The phantom type parameter `T` prevents accidental mixing of tokens from
+//! unrelated systems. Define a zero-sized marker type per domain:
+//!
+//! ```ignore
+//! struct Commit;      // tokens for durable commits
+//! struct Compaction;  // tokens for compaction rounds
+//! ```
+//!
+//! # Memory ordering
+//!
+//! * [`Tokens::next`] uses `Relaxed` — it is a pure counter with no
+//!   data dependency.
+//! * [`TokenOwner::retire_through`] uses `Release` via `fetch_max` — it
+//!   publishes side-effects that happened before retirement and never moves
+//!   the value backward.
+//! * [`TokenListener::changed`] and [`TokenListener::retired_through`] use
+//!   `Acquire` — they synchronize with the `Release` `fetch_max` and
+//!   observe all preceding side-effects.
+//!
+//! # Example
+//!
+//! ```
+//! # async fn example() {
+//! use restate_futures_util::monotonic_token::TokenOwner;
+//!
+//! struct Flush;
+//!
+//! let owner = TokenOwner::<Flush>::new();
+//! let tokens = owner.new_tokens();
+//! let listener = tokens.new_listener();
+//!
+//! let t1 = tokens.next();
+//! let t2 = tokens.next();
+//!
+//! // Retire through t2 — both t1 and t2 are now considered processed.
+//! owner.retire_through(t2);
+//!
+//! // Listener sees t2 immediately (t1 is implicitly included).
+//! let seen = listener.changed(None).await;
+//! assert_eq!(seen, t2);
+//! # }
+//! ```
+
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
+use std::sync::{Arc, atomic};
+
+use tokio::sync::Notify;
+
+/// An opaque, ordered token drawn from a [`Tokens`] generator.
+///
+/// Tokens are [`Copy`], [`Ord`], and [`Eq`]. The phantom type `T` prevents
+/// accidental mixing of tokens from unrelated domains.
+pub struct Token<T>(NonZeroUsize, PhantomData<T>);
+
+impl<T> Clone for Token<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for Token<T> {}
+impl<T> Unpin for Token<T> {}
+
+// SAFETY: Token<T> is a plain NonZeroUsize + PhantomData<T>. The phantom type
+// parameter is a zero-sized marker with no data — Token is safe to send and
+// share across threads regardless of T.
+unsafe impl<T> Send for Token<T> {}
+unsafe impl<T> Sync for Token<T> {}
+
+impl<T> std::fmt::Debug for Token<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Token<{}>({})", std::any::type_name::<T>(), self.0)
+    }
+}
+
+impl<T> std::hash::Hash for Token<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> PartialOrd for Token<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for Token<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<T> PartialEq for Token<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T> Eq for Token<T> {}
+
+struct Inner {
+    next: AtomicUsize,
+    retired_through: AtomicUsize,
+    notify: Notify,
+}
+
+/// Root owner of a token sequence.
+///
+/// The owner has two responsibilities:
+/// 1. Create [`Tokens`] generators via [`new_tokens`](Self::new_tokens).
+/// 2. Signal completion of a prefix via
+///    [`retire_through`](Self::retire_through).
+///
+/// There should be exactly one `TokenOwner` per logical sequence. Multiple
+/// [`Tokens`] generators and [`TokenListener`]s may be created from it.
+pub struct TokenOwner<T> {
+    inner: Arc<Inner>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> TokenOwner<T> {
+    /// Creates a new token sequence. The first token produced by any generator
+    /// derived from this owner will have an internal value of 1.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                next: AtomicUsize::new(1),
+                retired_through: AtomicUsize::new(0),
+                notify: Notify::new(),
+            }),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a new [`Tokens`] generator that shares this owner's sequence.
+    pub fn new_tokens(&self) -> Tokens<T> {
+        Tokens {
+            inner: self.inner.clone(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Marks all tokens `<= through_token` as retired.
+    ///
+    /// This signals that the entire prefix up to and including `through_token`
+    /// has been processed and will not be processed again. All listeners whose
+    /// `last_seen` token is less than `through_token` will be woken.
+    ///
+    /// Retiring a token lower than a previously retired one is safe — the
+    /// internal value is updated via `fetch_max`, so it never goes backward.
+    pub fn retire_through(&self, through_token: Token<T>) {
+        self.inner
+            .retired_through
+            .fetch_max(through_token.0.get(), atomic::Ordering::Release);
+        self.inner.notify.notify_waiters();
+    }
+}
+
+impl<T> Default for TokenOwner<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A generator of monotonically increasing [`Token`]s.
+///
+/// Cloning a `Tokens` generator produces a handle to the *same* underlying
+/// sequence — tokens produced by either clone are globally ordered.
+///
+/// `Tokens::next` is thread-safe and lock-free.
+pub struct Tokens<T> {
+    inner: Arc<Inner>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Clone for Tokens<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Tokens<T> {
+    /// Produces the next token in the sequence.
+    ///
+    /// Tokens are guaranteed to be strictly increasing across all clones of
+    /// this generator.
+    pub fn next(&self) -> Token<T> {
+        // SAFETY: `next` is initialised to 1 and only incremented, so the
+        // value returned by `fetch_add` is always >= 1 (non-zero).
+        unsafe {
+            Token(
+                NonZeroUsize::new_unchecked(
+                    self.inner.next.fetch_add(1, atomic::Ordering::Relaxed),
+                ),
+                PhantomData,
+            )
+        }
+    }
+
+    /// Creates a new [`TokenListener`] that observes retirements on this
+    /// sequence.
+    pub fn new_listener(&self) -> TokenListener<T> {
+        TokenListener {
+            inner: self.inner.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// An observer that asynchronously waits for tokens to be retired.
+///
+/// Multiple listeners may exist for the same sequence; all are woken when the
+/// owner retires tokens.
+pub struct TokenListener<T> {
+    inner: Arc<Inner>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Clone for TokenListener<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> TokenListener<T> {
+    /// Returns the highest token retired so far, or `None` if no token has
+    /// been retired yet.
+    pub fn retired_through(&self) -> Option<Token<T>> {
+        let value = self.inner.retired_through.load(atomic::Ordering::Acquire);
+        NonZeroUsize::new(value).map(|t| Token(t, PhantomData))
+    }
+
+    /// Waits until a token strictly greater than `last_seen` has been retired.
+    ///
+    /// If `last_seen` is `None`, waits for the very first retirement or returns
+    /// the latest retired immediately if it was set.
+    ///
+    /// Returns the latest retired token at the time of wakeup. Due to
+    /// coalescing, this may be greater than the token that triggered the
+    /// wakeup.
+    pub async fn changed(&self, last_seen: Option<Token<T>>) -> Token<T> {
+        let threshold = last_seen.map_or(0, |t| t.0.get());
+        let mut notified = std::pin::pin!(self.inner.notify.notified());
+
+        loop {
+            // The `Notified` future is guaranteed to receive wakeups from
+            // `notify_waiters()` as soon as it has been created, even before
+            // being polled. So no `enable()` call is needed here — creation
+            // alone is sufficient to register the waiter.
+            let current = self.inner.retired_through.load(atomic::Ordering::Acquire);
+            if current > threshold {
+                // SAFETY: current > threshold >= 0, so current >= 1 (non-zero).
+                return Token(unsafe { NonZeroUsize::new_unchecked(current) }, PhantomData);
+            }
+
+            // Wait for the next notification, then re-create the future for
+            // the next loop iteration (`Notified` is fused — once completed it
+            // always returns `Ready` immediately).
+            notified.as_mut().await;
+            notified.set(self.inner.notify.notified());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Marker type for tests.
+    struct Test;
+
+    /// Polls a future once and returns whether it resolved.
+    fn poll_once<F: Future>(fut: Pin<&mut F>) -> Poll<F::Output> {
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        fut.poll(&mut cx)
+    }
+
+    #[tokio::test]
+    async fn generator_produces_monotonic_tokens() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let t1 = tokens.next();
+        let t2 = tokens.next();
+        let t3 = tokens.next();
+        assert!(t1 < t2);
+        assert!(t2 < t3);
+    }
+
+    #[tokio::test]
+    async fn changed_none_blocks_until_first_retirement() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        let t1 = tokens.next();
+
+        let mut fut = std::pin::pin!(listener.changed(None));
+        assert!(poll_once(fut.as_mut()).is_pending());
+
+        owner.retire_through(t1);
+        let result = fut.await;
+        assert_eq!(result, t1);
+    }
+
+    #[tokio::test]
+    async fn changed_resolves_immediately_if_already_retired() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        let t1 = tokens.next();
+        let t2 = tokens.next();
+
+        owner.retire_through(t2);
+
+        // changed(None) resolves immediately since there's already a retirement.
+        let result = listener.changed(None).await;
+        assert_eq!(result, t2);
+
+        // changed(Some(t1)) also resolves immediately since t2 > t1.
+        let result = listener.changed(Some(t1)).await;
+        assert_eq!(result, t2);
+
+        // changed(Some(t2)) blocks — nothing newer than t2 yet.
+        let mut fut = std::pin::pin!(listener.changed(Some(t2)));
+        assert!(poll_once(fut.as_mut()).is_pending());
+    }
+
+    #[tokio::test]
+    async fn changed_blocks_when_last_seen_equals_current() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        let t1 = tokens.next();
+        let t2 = tokens.next();
+        owner.retire_through(t1);
+
+        // t1 is NOT strictly greater than t1, so this blocks.
+        let mut fut = std::pin::pin!(listener.changed(Some(t1)));
+        assert!(poll_once(fut.as_mut()).is_pending());
+
+        owner.retire_through(t2);
+        let result = fut.await;
+        assert_eq!(result, t2);
+    }
+
+    #[tokio::test]
+    async fn coalesced_retirements() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        let t1 = tokens.next();
+        let t2 = tokens.next();
+        let t3 = tokens.next();
+
+        // Three rapid retirements coalesce — listener sees the latest.
+        owner.retire_through(t1);
+        owner.retire_through(t2);
+        owner.retire_through(t3);
+
+        let result = listener.changed(None).await;
+        assert_eq!(result, t3);
+    }
+
+    #[tokio::test]
+    async fn sequential_changed_calls_in_a_loop() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        let t1 = tokens.next();
+        let t2 = tokens.next();
+        let t3 = tokens.next();
+
+        // First iteration.
+        owner.retire_through(t1);
+        let seen = listener.changed(None).await;
+        assert_eq!(seen, t1);
+
+        // Second iteration: blocks until t2.
+        let task = tokio::spawn({
+            let listener = listener.clone();
+            async move { listener.changed(Some(t1)).await }
+        });
+        tokio::task::yield_now().await;
+        owner.retire_through(t2);
+        let seen = task.await.unwrap();
+        assert_eq!(seen, t2);
+
+        // Third iteration: retirement before changed call.
+        owner.retire_through(t3);
+        let seen = listener.changed(Some(t2)).await;
+        assert_eq!(seen, t3);
+    }
+
+    #[tokio::test]
+    async fn multiple_listeners_all_wake() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let l1 = tokens.new_listener();
+        let l2 = tokens.new_listener();
+
+        let t1 = tokens.next();
+
+        let task1 = tokio::spawn({
+            let l = l1.clone();
+            async move { l.changed(None).await }
+        });
+        let task2 = tokio::spawn({
+            let l = l2.clone();
+            async move { l.changed(None).await }
+        });
+
+        tokio::task::yield_now().await;
+        owner.retire_through(t1);
+
+        assert_eq!(task1.await.unwrap(), t1);
+        assert_eq!(task2.await.unwrap(), t1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_producer_consumer_no_missed_wakeup() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        const ITERATIONS: usize = 200;
+        let mut all_tokens = Vec::with_capacity(ITERATIONS);
+        for _ in 0..ITERATIONS {
+            all_tokens.push(tokens.next());
+        }
+        let last_token = *all_tokens.last().unwrap();
+
+        let producer = tokio::spawn({
+            let all_tokens = all_tokens.clone();
+            async move {
+                for token in all_tokens {
+                    owner.retire_through(token);
+                    if token.0.get() % 10 == 0 {
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        });
+
+        let consumer = tokio::spawn(async move {
+            let mut last_seen = None;
+            let mut wakeup_count = 0usize;
+            loop {
+                let token = listener.changed(last_seen).await;
+                wakeup_count += 1;
+                last_seen = Some(token);
+                if token >= last_token {
+                    break;
+                }
+            }
+            (last_seen.unwrap(), wakeup_count)
+        });
+
+        producer.await.unwrap();
+
+        let (final_token, wakeup_count) = tokio::time::timeout(Duration::from_secs(5), consumer)
+            .await
+            .expect("consumer should not deadlock")
+            .unwrap();
+
+        assert_eq!(final_token, last_token);
+        assert!(wakeup_count <= ITERATIONS);
+        assert!(wakeup_count >= 1);
+    }
+
+    #[tokio::test]
+    async fn retired_through_reflects_latest() {
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        assert_eq!(listener.retired_through(), None);
+
+        let t1 = tokens.next();
+        owner.retire_through(t1);
+        assert_eq!(listener.retired_through(), Some(t1));
+
+        let _t2 = tokens.next();
+        let t3 = tokens.next();
+        owner.retire_through(t3);
+        // Skipped _t2 is implicitly included in the retired prefix.
+        assert_eq!(listener.retired_through(), Some(t3));
+
+        let result = listener.changed(Some(t1)).await;
+        assert_eq!(result, t3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_busy_loop_after_wakeup() {
+        // With `start_paused = true`, time only advances when the runtime has
+        // no ready tasks (all are waiting on IO/timers). If `changed()` were
+        // busy-looping, the spawned task would run to completion despite no new
+        // retirement, and the assertion below would fail. If the implementation
+        // is correct, the task suspends on `Notify` and remains unfinished
+        // until we explicitly retire t2. A bug here would cause the test to
+        // hang indefinitely (timeout) or the `!task.is_finished()` assert to
+        // trip.
+        let owner = TokenOwner::<Test>::new();
+        let tokens = owner.new_tokens();
+        let listener = tokens.new_listener();
+
+        let t1 = tokens.next();
+        let t2 = tokens.next();
+
+        owner.retire_through(t1);
+        let seen = listener.changed(None).await;
+        assert_eq!(seen, t1);
+
+        let task = tokio::spawn({
+            let listener = listener.clone();
+            async move { listener.changed(Some(t1)).await }
+        });
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            !task.is_finished(),
+            "task completed without a new retirement — changed() is likely busy-looping"
+        );
+
+        owner.retire_through(t2);
+        let result = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("should resolve after retirement")
+            .unwrap();
+        assert_eq!(result, t2);
+    }
+}

--- a/crates/futures-util/src/waiter_queue.rs
+++ b/crates/futures-util/src/waiter_queue.rs
@@ -1,0 +1,319 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A queue of waiters that are drained when a monotonically advancing
+//! threshold is reached.
+//!
+//! [`WaiterQueue<K, V>`] stores `(key, value)` pairs where `K` is an ordered
+//! threshold (e.g. an offset, a [`Token`], a sequence number) and `V` is a
+//! payload to deliver when the threshold is met. Calling
+//! [`drain_up_to(threshold, f)`](WaiterQueue::drain_up_to) invokes `f` on
+//! every entry whose key `<= threshold`.
+//!
+//! # Ordering invariant
+//!
+//! The queue maintains entries in non-decreasing key order at all times.
+//! [`push`](WaiterQueue::push) appends to the back in the common case
+//! (monotonically non-decreasing keys), making it O(1) amortised.
+//!
+//! **Out-of-order pushes are expected to be rare** (e.g. repair stores,
+//! retries). When detected, `push` falls back to a binary-search + insert to
+//! restore sorted order — O(N) in the worst case, but negligible when
+//! amortised over many in-order pushes.
+//!
+//! Because the queue is always sorted, [`drain_up_to`](WaiterQueue::drain_up_to)
+//! is always a simple front-pop — **O(drained)** with no remainder scan.
+//!
+//! # Design decisions
+//!
+//! Several strategies were benchmarked (see `benches/waiter_queue.rs`):
+//!
+//! - **Always sorted-insert** uses binary search on every push, which is
+//!   3-10x slower overall because the O(N) shift cost dominates even when
+//!   entries are already in order.
+//!
+//! - **Unsorted push + scan-on-drain** keeps push O(1) but pays an
+//!   O(remainder) scan on every drain, even when the queue is perfectly
+//!   sorted.
+//!
+//! - **Adaptive sorted-on-demand** (chosen) tracks the maximum key pushed so
+//!   far. In-order pushes are a simple `push_back`. Out-of-order pushes use
+//!   binary-search insert to maintain sorted order. Drain is always a
+//!   front-pop with no scan.
+//!
+//! [`Token`]: crate::monotonic_token::Token
+
+use std::collections::VecDeque;
+
+/// A queue of in-flight waiters keyed by a monotonically advancing threshold.
+///
+/// `K` is the target key (must be [`Ord`] + [`Clone`]). `V` is the waiter
+/// payload.
+///
+/// Entries are maintained in non-decreasing key order. In-order pushes are
+/// O(1) amortised; out-of-order pushes (expected to be rare) use
+/// binary-search insert. Drain is always a simple front-pop.
+pub struct WaiterQueue<K, V> {
+    inner: VecDeque<Entry<K, V>>,
+    /// `None` when the queue is empty. Tracks the maximum key pushed so far
+    /// to distinguish in-order pushes (fast `push_back`) from out-of-order
+    /// pushes (binary-search `insert`).
+    max_key: Option<K>,
+}
+
+struct Entry<K, V> {
+    target: K,
+    value: V,
+}
+
+impl<K, V> Default for WaiterQueue<K, V> {
+    fn default() -> Self {
+        Self {
+            inner: VecDeque::new(),
+            max_key: None,
+        }
+    }
+}
+
+impl<K: Ord + Clone, V> WaiterQueue<K, V> {
+    /// Pushes a waiter that will be drained when the threshold reaches
+    /// `target`.
+    ///
+    /// When `target >= max_key` (the common case), the entry is appended to
+    /// the back in O(1) amortised. When `target < max_key` (out-of-order),
+    /// a binary-search insert maintains sorted order in O(N). Out-of-order
+    /// pushes are expected to be rare.
+    pub fn push(&mut self, target: K, value: V) {
+        let in_order = self.max_key.as_ref().is_none_or(|max| target >= *max);
+
+        if in_order {
+            self.max_key = Some(target.clone());
+            self.inner.push_back(Entry { target, value });
+        } else {
+            let pos = self.inner.partition_point(|e| e.target <= target);
+            self.inner.insert(pos, Entry { target, value });
+        }
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> + '_ {
+        self.inner.iter().map(|e| &e.target)
+    }
+
+    /// Drains all entries whose `target <= threshold` (inclusive), invoking `f`
+    /// on each drained value.
+    ///
+    /// Because entries are always in non-decreasing order, this is a simple
+    /// front-pop — O(drained).
+    pub fn drain_up_to(&mut self, threshold: K, mut f: impl FnMut(V)) {
+        while let Some(entry) = self.inner.pop_front_if(|e| e.target <= threshold) {
+            f(entry.value);
+        }
+        if self.inner.is_empty() {
+            self.max_key = None;
+        }
+    }
+
+    /// Drains **all** entries unconditionally, invoking `f` on each.
+    pub fn drain_all(&mut self, mut f: impl FnMut(V)) {
+        for entry in self.inner.drain(..) {
+            f(entry.value);
+        }
+        self.max_key = None;
+    }
+
+    /// Returns `true` if the queue contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the number of entries in the queue.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monotonic_token::TokenOwner;
+
+    struct Test;
+
+    #[test]
+    fn drain_ordered() {
+        let mut q = WaiterQueue::default();
+        q.push(5u64, "a");
+        q.push(10, "b");
+        q.push(15, "c");
+
+        let mut drained = Vec::new();
+        q.drain_up_to(10, |v| drained.push(v));
+        assert_eq!(drained, vec!["a", "b"]);
+        assert_eq!(q.len(), 1);
+
+        q.drain_up_to(20, |v| drained.push(v));
+        assert_eq!(drained, vec!["a", "b", "c"]);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn drain_inclusive() {
+        let mut q = WaiterQueue::default();
+        q.push(5u64, "x");
+        q.push(6, "y");
+
+        let mut drained = Vec::new();
+        q.drain_up_to(5, |v| drained.push(v));
+        assert_eq!(drained, vec!["x"]);
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn drain_out_of_order() {
+        let mut q = WaiterQueue::default();
+        q.push(5u64, "a");
+        q.push(10, "b");
+        // Out-of-order: inserted before "a" and "b" in sorted position.
+        q.push(3, "c");
+        q.push(15, "d");
+
+        let mut drained = Vec::new();
+        q.drain_up_to(10, |v| drained.push(v));
+        // Sorted insert places "c" before "a", so drain order is c, a, b.
+        assert_eq!(drained, vec!["c", "a", "b"]);
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn drain_all_entries() {
+        let mut q = WaiterQueue::default();
+        q.push(1u64, 10);
+        q.push(2, 20);
+        q.push(3, 30);
+
+        let mut sum = 0;
+        q.drain_all(|v| sum += v);
+        assert_eq!(sum, 60);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn empty_drain_is_noop() {
+        let mut q: WaiterQueue<u64, &str> = WaiterQueue::default();
+        let mut count = 0;
+        q.drain_up_to(100, |_| count += 1);
+        assert_eq!(count, 0);
+        q.drain_all(|_| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn token_keyed_drain() {
+        let owner = TokenOwner::<Test>::new();
+        let generator = owner.new_tokens();
+
+        let t1 = generator.next();
+        let t2 = generator.next();
+        let t3 = generator.next();
+
+        let mut q = WaiterQueue::default();
+        q.push(t1, "first");
+        q.push(t2, "second");
+        q.push(t3, "third");
+
+        let mut drained = Vec::new();
+        q.drain_up_to(t2, |v| drained.push(v));
+        assert_eq!(drained, vec!["first", "second"]);
+        assert_eq!(q.len(), 1);
+
+        q.drain_up_to(t3, |v| drained.push(v));
+        assert_eq!(drained, vec!["first", "second", "third"]);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn monotonic_pushes_and_partial_drain() {
+        let mut q = WaiterQueue::default();
+        for i in 0u64..100 {
+            q.push(i, i);
+        }
+
+        // Drain half.
+        let mut count = 0;
+        q.drain_up_to(49, |_| count += 1);
+        assert_eq!(count, 50);
+        assert_eq!(q.len(), 50);
+
+        // Continue pushing in order — should not regress.
+        q.push(100, 100);
+        q.push(101, 101);
+        assert_eq!(q.len(), 52);
+    }
+
+    #[test]
+    fn out_of_order_push_maintains_sort() {
+        let mut q = WaiterQueue::default();
+        q.push(10u64, "a");
+        q.push(20, "b");
+        q.push(5, "c"); // out-of-order — sorted insert
+        q.push(30, "d");
+
+        // Drain up to 20 — "c"(5), "a"(10), "b"(20) should all come out.
+        let mut drained = Vec::new();
+        q.drain_up_to(20, |v| drained.push(v));
+        assert_eq!(drained, vec!["c", "a", "b"]);
+        assert_eq!(q.len(), 1);
+
+        // New monotonic pushes continue normally.
+        q.push(40, "e");
+        q.push(50, "f");
+        assert_eq!(q.len(), 3);
+
+        q.drain_up_to(50, |v| drained.push(v));
+        assert_eq!(drained, vec!["c", "a", "b", "d", "e", "f"]);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn drain_all_clears_max_key() {
+        let mut q = WaiterQueue::default();
+        q.push(10u64, 1);
+        q.push(5, 2); // out-of-order
+
+        let mut sum = 0;
+        q.drain_all(|v| sum += v);
+        assert_eq!(sum, 3);
+        assert!(q.max_key.is_none());
+
+        // After drain_all, a push with any key should work without
+        // false out-of-order detection.
+        q.push(1, 100);
+        assert_eq!(q.max_key, Some(1));
+    }
+
+    #[test]
+    fn max_key_tracks_correctly() {
+        let mut q = WaiterQueue::default();
+        q.push(10u64, "a");
+        assert_eq!(q.max_key, Some(10));
+
+        q.push(20, "b");
+        assert_eq!(q.max_key, Some(20));
+
+        // Out-of-order push: max_key should not decrease.
+        q.push(5, "c");
+        assert_eq!(q.max_key, Some(20));
+
+        // Drain everything.
+        q.drain_up_to(20, |_| {});
+        assert!(q.is_empty());
+        assert!(q.max_key.is_none());
+    }
+}


### PR DESCRIPTION

Extract two generic, reusable utilities into restate-futures-util:

**monotonic_token**: A lightweight mechanism for a producer to signal
completion of a prefix of sequentially issued work items. Provides
Token<T>, TokenOwner<T>, Tokens<T>, and TokenListener<T> types with
a phantom type parameter to prevent mixing tokens from different domains.
Uses atomics (Relaxed/Release/Acquire) for lock-free operation — no
RwLock or watch overhead.

**waiter_queue**: A priority-drainable queue (WaiterQueue<K, V>) designed
for the common case where entries arrive in key-order. Uses an adaptive
strategy: push_back for in-order inserts (O(1)), binary-search insert for
out-of-order (rare). Drain is always a simple front-pop. Includes a
Criterion benchmark comparing four strategies (naive, compact,
adaptive, sorted-insert).

Both modules include comprehensive documentation and tests. Neither
references any specific use-case — they are general-purpose building
blocks.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4446).
* #4479
* #4476
* #4474
* #4473
* #4472
* #4471
* #4466
* #4460
* __->__ #4446