### PR TITLE
[invoker] Replace manual slot bookkeeping with RAII ConcurrencySlot

### DIFF
--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -21,6 +21,8 @@ use restate_types::retries;
 use restate_types::schema::invocation_target::OnMaxAttempts;
 use restate_types::vqueue::VQueueId;
 
+use crate::quota::ConcurrencySlot;
+
 use super::*;
 
 /// Trait alias for types that can be used as retry timer keys.
@@ -49,6 +51,7 @@ pub(super) struct InvocationStateMachine<K: TimerKey = tokio_util::time::delay_q
     /// For more details of when we bump it, see [`InvokerError::should_bump_start_message_retry_count_since_last_stored_entry`].
     pub(super) start_message_retry_count_since_last_stored_command: u32,
     pub(super) requested_pause: bool,
+    _concurrency_slot: ConcurrencySlot,
 }
 
 /// This struct tracks which commands the invocation task generates,
@@ -199,6 +202,7 @@ impl<K: TimerKey> InvocationStateMachine<K> {
         invocation_target: InvocationTarget,
         retry_iter: retries::RetryIter<'static>,
         on_max_attempts: OnMaxAttempts,
+        concurrency_slot: ConcurrencySlot,
     ) -> InvocationStateMachine<K> {
         Self {
             qid,
@@ -213,6 +217,7 @@ impl<K: TimerKey> InvocationStateMachine<K> {
             },
             start_message_retry_count_since_last_stored_command: 0,
             requested_pause: false,
+            _concurrency_slot: concurrency_slot,
         }
     }
 
@@ -617,6 +622,7 @@ mod tests {
             InvocationTarget::mock_virtual_object(),
             RetryPolicy::fixed_delay(Duration::from_secs(1), Some(10)).into_iter(),
             OnMaxAttempts::Kill,
+            ConcurrencySlot::empty(),
         )
     }
 

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -609,6 +609,7 @@ where
                 .invocation_state_machine_manager
                 .partition_storage_reader(command.partition)
                 .expect("partition is registered");
+            let concurrency_slot = self.quota.acquire_slot();
             self.start_invocation_task(
                 options,
                 command.partition,
@@ -621,6 +622,7 @@ where
                     command.invocation_target,
                     retry_iter,
                     on_max_attempts,
+                    concurrency_slot,
                 ),
             )
         } else {
@@ -665,7 +667,7 @@ where
                 .invocation_state_machine_manager
                 .partition_storage_reader(partition)
                 .expect("partition is registered");
-            self.quota.reserve_slot();
+            let concurrency_slot = self.quota.acquire_slot();
             self.start_invocation_task(
                 options,
                 partition,
@@ -678,6 +680,7 @@ where
                     invocation_target,
                     retry_iter,
                     on_max_attempts,
+                    concurrency_slot,
                 ),
             )
         } else {
@@ -1031,10 +1034,7 @@ where
             trace!(
                 restate.invocation.target = %ism.invocation_target,
                 "Invocation task closed correctly");
-            if ism._permit.is_empty() {
-                // the permit is empty when we are using a real permit token (vqueues).
-                self.quota.unreserve_slot();
-            }
+
             self.status_store.on_end(&partition, &invocation_id);
             let _ = sender
                 .send(Box::new(Effect {
@@ -1067,7 +1067,6 @@ where
             .remove_invocation(partition, &invocation_id)
         {
             counter!(INVOKER_INVOCATION_TASKS, "status" => TASK_OP_SUSPENDED, "partition_id" => ID_LOOKUP.get(partition.0)).increment(1);
-            self.quota.unreserve_slot();
             self.status_store.on_end(&partition, &invocation_id);
 
             if ism.requested_pause {
@@ -1128,7 +1127,6 @@ where
         {
             counter!(INVOKER_INVOCATION_TASKS, "status" => TASK_OP_SUSPENDED, "partition_id" => ID_LOOKUP.get(partition.0))
                 .increment(1);
-            self.quota.unreserve_slot();
             self.status_store.on_end(&partition, &invocation_id);
 
             if ism.requested_pause {
@@ -1223,7 +1221,6 @@ where
                 "Aborting invocation"
             );
             ism.abort();
-            self.quota.unreserve_slot();
             self.status_store.on_end(&partition, &invocation_id);
         } else {
             trace!(
@@ -1333,7 +1330,6 @@ where
                     "Aborting invocation"
                 );
                 ism.abort();
-                self.quota.unreserve_slot();
                 self.status_store.on_end(&partition, &fid);
             }
         } else {
@@ -1479,7 +1475,6 @@ where
                     restate.invocation.target = %ism.invocation_target,
                     restate.deployment.id = %attempt_deployment_id,
                     "Error when executing the invocation, pausing the invocation.");
-                self.quota.unreserve_slot();
                 self.status_store.on_end(&partition, &invocation_id);
 
                 let journal_v2_related_command_type =
@@ -1541,7 +1536,6 @@ where
                     restate.invocation.target = %ism.invocation_target,
                     restate.deployment.id = %attempt_deployment_id,
                     "Error when executing the invocation, not going to retry.");
-                self.quota.unreserve_slot();
                 self.status_store.on_end(&partition, &invocation_id);
 
                 let _ = self
@@ -1686,7 +1680,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use crate::error::{InvokerError, SdkInvocationErrorV2};
-    use crate::quota::InvokerConcurrencyQuota;
+    use crate::quota::{ConcurrencySlot, InvokerConcurrencyQuota};
 
     // -- Mocks
 
@@ -2240,6 +2234,7 @@ mod tests {
             invocation_target.clone(),
             RetryPolicy::fixed_delay(Duration::from_millis(100), None).into_iter(),
             OnMaxAttempts::Kill,
+            ConcurrencySlot::empty(),
         );
         let (tx, _rx) = mpsc::unbounded_channel();
         ism.start(tokio::spawn(async {}).abort_handle(), tx);

--- a/crates/invoker-impl/src/metric_definitions.rs
+++ b/crates/invoker-impl/src/metric_definitions.rs
@@ -65,7 +65,8 @@ impl IdLookup {
 
 pub const INVOKER_ENQUEUE: &str = "restate.invoker.enqueue.total";
 pub const INVOKER_INVOCATION_TASKS: &str = "restate.invoker.invocation_tasks.total";
-pub const INVOKER_AVAILABLE_SLOTS: &str = "restate.invoker.available_slots";
+pub const INVOKER_CONCURRENCY_SLOTS_ACQUIRED: &str = "restate.invoker.concurrency_slots.acquired";
+pub const INVOKER_CONCURRENCY_SLOTS_RELEASED: &str = "restate.invoker.concurrency_slots.released";
 pub const INVOKER_CONCURRENCY_LIMIT: &str = "restate.invoker.concurrency_limit";
 pub const INVOKER_TASK_DURATION: &str = "restate.invoker.task_duration.seconds";
 
@@ -93,10 +94,16 @@ pub(crate) fn describe_metrics() {
         "Invocation task operation"
     );
 
-    describe_gauge!(
-        INVOKER_AVAILABLE_SLOTS,
+    describe_counter!(
+        INVOKER_CONCURRENCY_SLOTS_ACQUIRED,
         Unit::Count,
-        "Number of available slots to create new tasks"
+        "Number of concurrency slots acquired"
+    );
+
+    describe_counter!(
+        INVOKER_CONCURRENCY_SLOTS_RELEASED,
+        Unit::Count,
+        "Number of concurrency slots released"
     );
 
     describe_histogram!(

--- a/crates/invoker-impl/src/quota.rs
+++ b/crates/invoker-impl/src/quota.rs
@@ -8,95 +8,149 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
-use metrics::gauge;
+use metrics::{Counter, counter, gauge};
 
 use crate::{
     InvokerId,
-    metric_definitions::{ID_LOOKUP, INVOKER_AVAILABLE_SLOTS, INVOKER_CONCURRENCY_LIMIT},
+    metric_definitions::{
+        ID_LOOKUP, INVOKER_CONCURRENCY_LIMIT, INVOKER_CONCURRENCY_SLOTS_ACQUIRED,
+        INVOKER_CONCURRENCY_SLOTS_RELEASED,
+    },
 };
+
+/// Bundles the available-slots atomic with the released-slots counter
+/// so they can be passed around as a single unit.
+#[derive(Debug)]
+struct LimitedSlots {
+    available_slots: AtomicUsize,
+    released_counter: Counter,
+}
 
 #[derive(Debug)]
 enum InvokerConcurrencyQuotaInner {
     Unlimited,
-    Limited { available_slots: usize },
+    Limited {
+        slots: Arc<LimitedSlots>,
+        acquired_counter: Counter,
+    },
 }
 
 #[derive(Debug)]
 pub(super) struct InvokerConcurrencyQuota {
     inner: InvokerConcurrencyQuotaInner,
-    invoker_id: InvokerId,
 }
 
 impl InvokerConcurrencyQuota {
     pub(super) fn new(invoker_id: impl Into<InvokerId>, quota: Option<NonZeroUsize>) -> Self {
         let invoker_id = invoker_id.into();
+
         let inner = match quota {
             Some(available_slots) => {
                 gauge!(INVOKER_CONCURRENCY_LIMIT, "invoker_id" => ID_LOOKUP.get(invoker_id))
                     .set(available_slots.get() as f64);
-                gauge!(INVOKER_AVAILABLE_SLOTS, "invoker_id" => ID_LOOKUP.get(invoker_id))
-                    .set(available_slots.get() as f64);
+
+                let acquired_counter = counter!(INVOKER_CONCURRENCY_SLOTS_ACQUIRED, "invoker_id" => ID_LOOKUP.get(invoker_id));
+                let released_counter = counter!(INVOKER_CONCURRENCY_SLOTS_RELEASED, "invoker_id" => ID_LOOKUP.get(invoker_id));
+
                 InvokerConcurrencyQuotaInner::Limited {
-                    available_slots: available_slots.get(),
+                    slots: Arc::new(LimitedSlots {
+                        available_slots: AtomicUsize::new(available_slots.get()),
+                        released_counter,
+                    }),
+                    acquired_counter,
                 }
             }
             None => {
                 gauge!(INVOKER_CONCURRENCY_LIMIT, "invoker_id" => ID_LOOKUP.get(invoker_id))
                     .set(f64::INFINITY);
-                gauge!(INVOKER_AVAILABLE_SLOTS, "invoker_id" => ID_LOOKUP.get(invoker_id))
-                    .set(f64::INFINITY);
+
                 InvokerConcurrencyQuotaInner::Unlimited
             }
         };
 
-        Self { inner, invoker_id }
+        Self { inner }
     }
 
     pub(super) fn is_slot_available(&self) -> bool {
         match &self.inner {
             InvokerConcurrencyQuotaInner::Unlimited => true,
-            InvokerConcurrencyQuotaInner::Limited { available_slots } => *available_slots > 0,
-        }
-    }
-
-    pub(super) fn unreserve_slot(&mut self) {
-        match &mut self.inner {
-            InvokerConcurrencyQuotaInner::Unlimited => {}
-            InvokerConcurrencyQuotaInner::Limited { available_slots } => {
-                *available_slots += 1;
-                gauge!(
-                    INVOKER_AVAILABLE_SLOTS,
-                    "invoker_id" =>
-                    ID_LOOKUP.get(self.invoker_id)
-                )
-                .set(*available_slots as f64);
+            InvokerConcurrencyQuotaInner::Limited { slots, .. } => {
+                slots.available_slots.load(Ordering::Relaxed) > 0
             }
         }
     }
 
-    pub(super) fn reserve_slot(&mut self) {
+    /// Acquires a concurrency slot from the quota.
+    ///
+    /// # Panics
+    /// Panics if no slot is available. Callers must check [`is_slot_available`](Self::is_slot_available)
+    /// before calling this method.
+    pub(super) fn acquire_slot(&mut self) -> ConcurrencySlot {
         assert!(self.is_slot_available());
+
         match &mut self.inner {
-            InvokerConcurrencyQuotaInner::Unlimited => {}
-            InvokerConcurrencyQuotaInner::Limited { available_slots } => {
-                *available_slots -= 1;
-                gauge!(
-                    INVOKER_AVAILABLE_SLOTS,
-                    "invoker_id" =>
-                    ID_LOOKUP.get(self.invoker_id)
-                )
-                .set(*available_slots as f64);
+            InvokerConcurrencyQuotaInner::Unlimited => ConcurrencySlot { inner: None },
+            InvokerConcurrencyQuotaInner::Limited {
+                slots,
+                acquired_counter,
+            } => {
+                let prev = slots.available_slots.fetch_sub(1, Ordering::Relaxed);
+
+                // sanity check: This should never happen since we assert that a slot is available
+                // while holding an exclusive reference
+                assert!(prev != 0, "Called acquire_slot with no slots available");
+
+                acquired_counter.increment(1);
+                ConcurrencySlot {
+                    inner: Some(Arc::clone(slots)),
+                }
             }
         }
     }
 
     #[cfg(test)]
     pub(super) fn available_slots(&self) -> usize {
-        match self.inner {
+        match &self.inner {
             InvokerConcurrencyQuotaInner::Unlimited => usize::MAX,
-            InvokerConcurrencyQuotaInner::Limited { available_slots } => available_slots,
+            InvokerConcurrencyQuotaInner::Limited { slots, .. } => {
+                slots.available_slots.load(Ordering::Relaxed)
+            }
+        }
+    }
+}
+
+/// An acquired concurrency slot.
+///
+/// # Important
+/// Must only be dropped inside the Invoker's event loop. Slot availability
+/// drives the `select!` arms, and dropping a slot externally won't wake the
+/// loop to observe the change.
+#[derive(derive_more::Debug)]
+#[debug("ConcurrencySlot({})", inner.is_some())]
+pub struct ConcurrencySlot {
+    inner: Option<Arc<LimitedSlots>>,
+}
+
+impl ConcurrencySlot {
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        Self { inner: None }
+    }
+}
+
+impl Drop for ConcurrencySlot {
+    fn drop(&mut self) {
+        if let Some(store) = self.inner.take() {
+            store.released_counter.increment(1);
+            store.available_slots.fetch_add(1, Ordering::Relaxed);
         }
     }
 }

--- a/release-notes/unreleased/invoker-metrics.md
+++ b/release-notes/unreleased/invoker-metrics.md
@@ -1,0 +1,14 @@
+# Invoker metrics
+
+## Dropped metrics
+The following metric has been dropped:
+- `restate.invoker.available_slots`
+
+## Added metrics
+Two new counter metrics have been added as replacements:
+- `restate.invoker.concurrency_slots.acquired` (counter)
+- `restate.invoker.concurrency_slots.released` (counter)
+
+These counters make it easy to derive:
+- Rate of slot acquisition and release
+- Available slots: `restate.invoker.concurrency_limit - (restate.invoker.concurrency_slots.acquired - restate.invoker.concurrency_slots.released)`


### PR DESCRIPTION
[invoker] Replace manual slot bookkeeping with RAII ConcurrencySlot

## Summary
- Replaces the manual `reserve_slot()`/`unreserve_slot()` pattern with an RAII
  `ConcurrencySlot` that automatically releases the concurrency slot on drop,
  eliminating a class of bugs where slots could leak on missed release paths.
- Replaces the `restate.invoker.available_slots` gauge with two monotonic counters
  (`restate.invoker.concurrency_slots.acquired` / `.released`) that are more
  suitable for rate-based monitoring and accurate derived slot calculations.
## Breaking Changes
- Drops the `restate.invoker.available_slots` gauge metric. Users should derive
  available slots as: `concurrency_limit - (acquired - released)`.
