### PR TITLE
Retry editor on JSON parse error in `restate state edit`

### DIFF
--- a/cli/src/commands/state/edit.rs
+++ b/cli/src/commands/state/edit.rs
@@ -13,8 +13,8 @@ use cling::prelude::*;
 use comfy_table::{Cell, Table};
 use tempfile::tempdir;
 
-use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
-use restate_cli_util::{c_println, c_title};
+use restate_cli_util::ui::console::{StyledTable, confirm, confirm_or_exit};
+use restate_cli_util::{CliContext, c_eprintln, c_println, c_title};
 
 use crate::cli_env::CliEnv;
 use crate::commands::state::util::{
@@ -52,8 +52,20 @@ async fn edit(env: &CliEnv, opts: &Edit) -> Result<()> {
     let edit_file = tempdir.path().join(".restate_edit");
     let current_state_json = as_json(current_state, opts.binary)?;
     write_json_file(&edit_file, current_state_json)?;
-    env.open_default_editor(&edit_file)?;
-    let modified_state_json = read_json_file(&edit_file)?;
+    let modified_state_json = loop {
+        env.open_default_editor(&edit_file)?;
+        match read_json_file(&edit_file) {
+            Ok(json) => break json,
+            Err(err) => {
+                c_eprintln!("{:#}", err);
+                // In non-interactive mode (--yes / CI), retrying would loop forever
+                // since the editor can't fix the file without human input.
+                if CliContext::get().auto_confirm() || !confirm("Re-open editor to fix?") {
+                    return Err(err);
+                }
+            }
+        }
+    };
 
     //
     // confirm change

--- a/release-notes/unreleased/state-edit-retry-on-parse-error.md
+++ b/release-notes/unreleased/state-edit-retry-on-parse-error.md
@@ -1,0 +1,12 @@
+# CLI: Retry editor on JSON parse error in `restate state edit`
+
+## Improvement
+
+### What Changed
+
+`restate state edit` now re-opens the editor when the edited JSON fails to parse, instead of discarding your work.
+
+### Impact on Users
+
+- Interactive use: you'll see the parse error and a prompt to re-open the editor
+- Non-interactive use (`--yes` / CI): behavior is unchanged — the command fails immediately on invalid JSON


### PR DESCRIPTION
## Summary
- When `restate state edit` fails to parse JSON after the editor closes, show the error and prompt the user to re-open the editor to fix it, instead of bailing immediately
- In non-interactive mode (`--yes` / CI), the command fails immediately to avoid infinite retry loops

Fixes: https://github.com/restatedev/restate-cloud/issues/564

## Test plan
- [x] Manual: introduce a trailing comma in the editor, verify the error is shown and you're prompted to re-edit
- [x] Verify `--yes` mode bails immediately on parse error
- [x] `cargo check -p restate-cli`
- [x] `cargo fmt --check`
