### PR TITLE
chore: reduce buildup of test artefacts in CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
           name: local-cluster-runner
           path: ${{ runner.temp }}/lcr
 
+      - name: Clean up test artifacts before cache save
+        if: always()
+        run: rm -rf target/tests
+
   docker:
     name: Create docker image
     uses: ./.github/workflows/docker.yml


### PR DESCRIPTION
part of #4494 

we need to address the accumulation over time but this change should save a big chunk of disk space and buy us headroom for a while.