### PR TITLE
Disable incremental builds for CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         os: [warp-ubuntu-latest-x64-16x]
     env:
       RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: "0"
     steps:
       # Disabled as uring is not used in production yet.
       # - name: Install liburing


### PR DESCRIPTION
Disable incremental builds for CI runs

Summary:
This effectively reduces the amount of space used by the build
