### PR TITLE
Fix InvocationError metadata lost during protobuf deserialization of ResponseResult

### DIFF
--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -3575,10 +3575,16 @@ pub mod v1 {
                         let failure_message = Vec::<u8>::from(failure.failure_message);
                         let failure_message = String::from_utf8(failure_message)
                             .map_err(ConversionError::invalid_data)?;
-                        restate_types::invocation::ResponseResult::Failure(InvocationError::new(
-                            failure.failure_code,
-                            failure_message,
-                        ))
+                        restate_types::invocation::ResponseResult::Failure(
+                            InvocationError::new(failure.failure_code, failure_message)
+                                .with_metadata_vec(
+                                    failure
+                                        .failure_metadata
+                                        .into_iter()
+                                        .map(|m| (m.key, m.value))
+                                        .collect(),
+                                ),
+                        )
                     }
                 };
 


### PR DESCRIPTION
The TryFrom<ResponseResult> implementation for deserializing a ResponseResult from protobuf storage was constructing an InvocationError with only code and message, silently dropping the failure_metadata field. The serialization direction (From<ResponseResult>) correctly included failure_metadata, so metadata was written to storage but lost on read.

This surfaces in multi-node clusters when an idempotent invocation completes on one node and the result is later read back from storage on another. For example, in the threeNodes/UserErrors test: the ingress on N1 submits callTerminallyFailingCall, but partition 0 is reassigned to N3 mid-flight. N3 replays the log, completes the invocation, and persists the completed status (with metadata) to RocksDB. When N1's ingress retries (using the idempotency key), N3's partition processor finds InvocationStatus::Completed in storage and returns the stored response_result — which goes through the buggy TryFrom<ResponseResult> deserialization, stripping the metadata before it reaches the ingress.

This fixes #4508.