### PR TITLE
Fix stale reads from /output endpoint during partition reconfiguration

### DIFF
--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -46,7 +46,7 @@ use restate_timer::TokioClock;
 use restate_types::cluster::cluster_state::RunMode;
 use restate_types::config::Configuration;
 use restate_types::errors::GenericError;
-use restate_types::identifiers::{LeaderEpoch, PartitionLeaderEpoch};
+use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
 use restate_types::identifiers::{PartitionKey, PartitionProcessorRpcRequestId};
 use restate_types::logs::Keys;
 use restate_types::message::MessageIndex;
@@ -202,6 +202,10 @@ where
 
     pub(crate) fn is_leader(&self) -> bool {
         matches!(self.state, State::Leader(_))
+    }
+
+    pub(crate) fn partition_id(&self) -> PartitionId {
+        self.partition.partition_id
     }
 
     pub fn effective_mode(&self) -> RunMode {

--- a/crates/worker/src/partition/rpc/get_invocation_output.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_output.rs
@@ -134,6 +134,26 @@ where
                     .await;
             }
             GetInvocationOutputResponseMode::ReplyIfNotReady => {
+                // Reading invocation output from a non-leader partition processor can return
+                // stale results (e.g. NotFound for an invocation that exists on the leader)
+                // because the follower's local store may not have replayed all log entries yet.
+                // To prevent stale reads, we only serve this point-read from the leader whose
+                // store is authoritative. Non-leaders return NotLeader, which the ingress retry
+                // loop will retry until the request reaches the actual leader.
+                //
+                // TODO: We could relax the leadership requirement by implementing linearizable
+                // reads on followers using the wait_for_tail_then pattern: find the current log
+                // tail and wait until this replica has applied up to that point before serving the
+                // read. This would allow followers to serve reads and reduce load on the leader.
+                // An open question is how to handle partitioned followers that can no longer apply
+                // the latest records (e.g. due to network partitions) — they would need to time
+                // out and return an error rather than blocking indefinitely.
+                if !self.proposer.is_leader() {
+                    replier.send_result(Err(PartitionProcessorRpcError::NotLeader(
+                        self.proposer.partition_id(),
+                    )));
+                    return Ok(());
+                }
                 replier.send_result(
                     self.get_invocation_output(request_id, invocation_query)
                         .await

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -29,7 +29,9 @@ use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2::ReadJournalTable;
 use restate_storage_api::service_status_table::ReadVirtualObjectStatusTable;
-use restate_types::identifiers::{InvocationId, PartitionKey, PartitionProcessorRpcRequestId};
+use restate_types::identifiers::{
+    InvocationId, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
+};
 use restate_types::invocation::InvocationRequest;
 use restate_types::net::partition_processor::{
     AppendInvocationReplyOn, PartitionProcessorRpcError, PartitionProcessorRpcRequest,
@@ -61,6 +63,10 @@ pub(super) trait Actuator {
     fn notify_invoker_to_retry_now(&mut self, invocation_id: InvocationId);
 
     fn notify_invoker_to_pause(&mut self, invocation_id: InvocationId);
+
+    fn is_leader(&self) -> bool;
+
+    fn partition_id(&self) -> PartitionId;
 }
 
 impl<T, I> Actuator for LeadershipState<T, I>
@@ -120,6 +126,14 @@ where
             return;
         };
         let _ = invoker_handle.pause_invocation(partition_leader_epoch, invocation_id);
+    }
+
+    fn is_leader(&self) -> bool {
+        LeadershipState::is_leader(self)
+    }
+
+    fn partition_id(&self) -> PartitionId {
+        LeadershipState::partition_id(self)
     }
 }
 


### PR DESCRIPTION
Gate the ReplyIfNotReady point-read in GetInvocationOutput on leadership to prevent non-leader partition processors from serving stale data. A follower whose local store has not yet replayed all log entries could return NotFound (HTTP 404) for an invocation that actually exists on the leader. By returning NotLeader instead, the ingress retry loop retries the request until it reaches the actual leader.

Closes restatedev/restate#4513