### PR TITLE
fix: deterministic monotonic timestamps for vqueue inbox ordering

### DIFF
--- a/crates/clock/src/unique_timestamp.rs
+++ b/crates/clock/src/unique_timestamp.rs
@@ -148,6 +148,34 @@ impl UniqueTimestamp {
         Self::from_parts_unchecked(unix_millis.as_u64() - RESTATE_EPOCH.as_u64(), 0)
     }
 
+    /// Advances this timestamp using a deterministic HLC-like algorithm driven by an
+    /// external millisecond clock source. Returns a new [`UniqueTimestamp`] that is
+    /// guaranteed to be strictly greater than `self`.
+    ///
+    /// If `unix_millis` advances past `self`'s physical component, the logical clock
+    /// resets to 0. Otherwise, the logical clock is incremented.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the logical clock overflows (more than [`LC_MAX`] increments within
+    /// the same millisecond, i.e. >4M records/ms).
+    pub fn next_from_millis(&self, unix_millis: MillisSinceEpoch) -> Self {
+        debug_assert!(
+            unix_millis.as_u64() >= RESTATE_EPOCH.as_u64(),
+            "HLC timestamps below Jan 01 2022 00:00:00 GMT+0000 are invalid"
+        );
+        let new_phy = unix_millis.as_u64() - RESTATE_EPOCH.as_u64();
+        let my_phy = self.physical_raw();
+
+        if new_phy > my_phy {
+            Self::from_parts_unchecked(new_phy, 0)
+        } else {
+            // Physical clock hasn't advanced (same millisecond or clock went backwards).
+            // Increment logical counter to maintain strict monotonicity.
+            Self::from_parts_unchecked(my_phy, self.logical_raw() + 1)
+        }
+    }
+
     pub const fn to_unix_millis(&self) -> MillisSinceEpoch {
         MillisSinceEpoch::new(self.physical_raw() + RESTATE_EPOCH.as_u64())
     }
@@ -306,5 +334,71 @@ mod tests {
         let unique = UniqueTimestamp::from_unix_millis_unchecked(ts);
 
         assert_eq!(unique.to_unix_millis(), ts);
+    }
+
+    #[test]
+    fn next_from_millis_advances_physical_clock() {
+        let ts1 = MillisSinceEpoch::new(1704067200120);
+        let ts2 = MillisSinceEpoch::new(1704067200130);
+
+        let a = UniqueTimestamp::MIN.next_from_millis(ts1);
+        let b = a.next_from_millis(ts2);
+
+        // Physical time advances, logical clock resets
+        assert_eq!(a.to_unix_millis(), ts1);
+        assert_eq!(a.logical_raw(), 0);
+        assert_eq!(b.to_unix_millis(), ts2);
+        assert_eq!(b.logical_raw(), 0);
+        assert!(b > a);
+    }
+
+    #[test]
+    fn next_from_millis_increments_logical_clock_within_same_ms() {
+        let ts = MillisSinceEpoch::new(1704067200120);
+
+        let a = UniqueTimestamp::MIN.next_from_millis(ts);
+        let b = a.next_from_millis(ts);
+        let c = b.next_from_millis(ts);
+
+        // Same millisecond → logical clock increments
+        assert_eq!(a.to_unix_millis(), ts);
+        assert_eq!(a.logical_raw(), 0);
+        assert_eq!(b.logical_raw(), 1);
+        assert_eq!(c.logical_raw(), 2);
+        assert!(a < b);
+        assert!(b < c);
+    }
+
+    #[test]
+    fn next_from_millis_handles_clock_going_backwards() {
+        let ts_later = MillisSinceEpoch::new(1704067200200);
+        let ts_earlier = MillisSinceEpoch::new(1704067200100);
+
+        let a = UniqueTimestamp::MIN.next_from_millis(ts_later);
+        let b = a.next_from_millis(ts_earlier);
+
+        // Clock went backwards — keeps the higher physical time and increments lc
+        assert_eq!(b.to_unix_millis(), ts_later);
+        assert_eq!(b.logical_raw(), 1);
+        assert!(b > a);
+    }
+
+    #[test]
+    fn next_from_millis_always_strictly_monotonic() {
+        let ts = MillisSinceEpoch::new(1704067200120);
+        let mut prev = UniqueTimestamp::MIN.next_from_millis(ts);
+
+        // Many records within the same millisecond
+        for _ in 0..1000 {
+            let next = prev.next_from_millis(ts);
+            assert!(next > prev, "{next:?} should be > {prev:?}");
+            prev = next;
+        }
+
+        // Advancing the clock resets and is still monotonic
+        let ts2 = MillisSinceEpoch::new(1704067200121);
+        let next = prev.next_from_millis(ts2);
+        assert!(next > prev, "{next:?} should be > {prev:?}");
+        assert_eq!(next.logical_raw(), 0);
     }
 }

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -14,6 +14,7 @@ use restate_storage_api::fsm_table::{
 };
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_types::SemanticRestateVersion;
+use restate_types::clock::UniqueTimestamp;
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
@@ -57,6 +58,13 @@ pub(crate) mod fsm_variable {
     /// Stores the current and next partition configuration from the latest AnnounceLeader.
     /// *Since v1.6*
     pub(crate) const PARTITION_CONFIG_STATE: u64 = 7;
+
+    /// The last deterministic monotonic timestamp emitted by the state machine, used to
+    /// ensure correct vqueue inbox ordering across crash recovery.
+    ///
+    /// TODO: This is a temporary workaround until <https://github.com/restatedev/restate/issues/4516>
+    ///  is resolved by storing a proper HLC timestamp in Bifrost `Record.created_at`.
+    pub(crate) const LAST_RECORD_UNIQUE_TS: u64 = 8;
 }
 
 fn get<T: PartitionStoreProtobufValue, S: StorageAccess>(
@@ -167,6 +175,15 @@ impl ReadFsmTable for PartitionStore {
         let key = create_key(self.partition_id(), fsm_variable::PARTITION_CONFIG_STATE);
         self.get_value_storage_codec(key)
     }
+
+    async fn get_last_record_unique_ts(&mut self) -> Result<Option<UniqueTimestamp>> {
+        get::<SequenceNumber, _>(
+            self,
+            self.partition_id(),
+            fsm_variable::LAST_RECORD_UNIQUE_TS,
+        )
+        .map(|opt| opt.and_then(|s| UniqueTimestamp::try_from(u64::from(s)).ok()))
+    }
 }
 
 impl WriteFsmTable for PartitionStoreTransaction<'_> {
@@ -223,5 +240,14 @@ impl WriteFsmTable for PartitionStoreTransaction<'_> {
     fn put_partition_config_state(&mut self, state: &CachedEpochMetadata) -> Result<()> {
         let key = create_key(self.partition_id(), fsm_variable::PARTITION_CONFIG_STATE);
         self.put_kv_storage_codec(key, state)
+    }
+
+    fn put_last_record_unique_ts(&mut self, ts: UniqueTimestamp) -> Result<()> {
+        put(
+            self,
+            self.partition_id(),
+            fsm_variable::LAST_RECORD_UNIQUE_TS,
+            &SequenceNumber::from(ts.as_u64()),
+        )
     }
 }

--- a/crates/storage-api/src/fsm_table/mod.rs
+++ b/crates/storage-api/src/fsm_table/mod.rs
@@ -12,6 +12,7 @@ use std::future::Future;
 
 use bytes::BytesMut;
 
+use restate_types::clock::UniqueTimestamp;
 use restate_types::identifiers::LeaderEpoch;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
@@ -48,6 +49,16 @@ pub trait ReadFsmTable {
     fn get_partition_config_state(
         &mut self,
     ) -> impl Future<Output = Result<Option<CachedEpochMetadata>>> + Send + '_;
+
+    /// Returns the last record's deterministic monotonic timestamp used for vqueue inbox
+    /// ordering. Returns `None` on first boot or upgrade from a version that didn't persist
+    /// this value.
+    ///
+    /// TODO: This is a temporary workaround until <https://github.com/restatedev/restate/issues/4516>
+    ///  is resolved by storing a proper HLC timestamp in Bifrost `Record.created_at`.
+    fn get_last_record_unique_ts(
+        &mut self,
+    ) -> impl Future<Output = Result<Option<UniqueTimestamp>>> + Send + '_;
 }
 
 pub trait WriteFsmTable {
@@ -64,6 +75,14 @@ pub trait WriteFsmTable {
     fn put_schema(&mut self, schema: &Schema) -> Result<()>;
 
     fn put_partition_config_state(&mut self, state: &CachedEpochMetadata) -> Result<()>;
+
+    /// Persists the last record's deterministic monotonic timestamp used for vqueue inbox
+    /// ordering. Must be persisted atomically with the record's effects to ensure correct
+    /// recovery after crashes.
+    ///
+    /// TODO: This is a temporary workaround until <https://github.com/restatedev/restate/issues/4516>
+    ///  is resolved by storing a proper HLC timestamp in Bifrost `Record.created_at`.
+    fn put_last_record_unique_ts(&mut self, ts: UniqueTimestamp) -> Result<()>;
 }
 
 #[derive(Debug, Clone, Copy, derive_more::From, derive_more::Into)]

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -237,6 +237,7 @@ where
         let outbox_head_seq_number = partition_store.get_outbox_head_seq_number().await?;
         let min_restate_version = partition_store.get_min_restate_version().await?;
         let schema = partition_store.get_schema().await?;
+        let last_record_unique_ts = partition_store.get_last_record_unique_ts().await?;
 
         if !SemanticRestateVersion::current().is_equal_or_newer_than(&min_restate_version) {
             gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL =>
@@ -257,6 +258,7 @@ where
             partition_store.partition_key_range().clone(),
             min_restate_version,
             schema,
+            last_record_unique_ts,
         );
 
         Ok(state_machine)
@@ -1009,6 +1011,9 @@ where
                         self.leadership_state.is_leader(),
                     )
                     .await?;
+                transaction
+                    .put_last_record_unique_ts(self.state_machine.last_record_unique_ts())
+                    .map_err(state_machine::Error::Storage)?;
             }
         } else {
             self.status.num_skipped_records += 1;

--- a/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
@@ -66,7 +66,8 @@ mod tests {
             None, /* outbox_head_seq_number */
             PartitionKey::MIN..=PartitionKey::MAX,
             SemanticRestateVersion::unknown().clone(),
-            Default::default(),
+            Default::default(), /* schema */
+            None,               /* last_record_unique_ts */
         );
         // this is fine as we are always above the unknown version (current > 0.0.0)
         let mut test_env = TestEnv::create_with_state_machine(state_machine).await;
@@ -108,7 +109,8 @@ mod tests {
             None, /* outbox_head_seq_number */
             PartitionKey::MIN..=PartitionKey::MAX,
             SemanticRestateVersion::unknown().clone(),
-            Default::default(),
+            Default::default(), /* schema */
+            None,               /* last_record_unique_ts */
         );
         // this is fine as we are always above the unknown version (current > 0.0.0)
         let mut test_env = TestEnv::create_with_state_machine(state_machine).await;

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -154,6 +154,15 @@ pub struct StateMachine {
     pub(crate) schema: Option<Schema>,
 
     pub(crate) partition_key_range: RangeInclusive<PartitionKey>,
+
+    /// A deterministic monotonic timestamp derived from each Bifrost record's wall-clock
+    /// timestamp. Uses an HLC-like algorithm: if consecutive records share the same millisecond,
+    /// the logical clock is incremented to preserve ordering. Persisted to the FSM table so
+    /// that crash recovery produces correctly ordered timestamps.
+    ///
+    /// TODO: This is a temporary workaround until <https://github.com/restatedev/restate/issues/4516>
+    ///  is resolved by storing a proper HLC timestamp in Bifrost `Record.created_at`.
+    last_record_unique_ts: UniqueTimestamp,
 }
 
 impl Debug for StateMachine {
@@ -239,6 +248,7 @@ impl StateMachine {
         partition_key_range: RangeInclusive<PartitionKey>,
         min_restate_version: SemanticRestateVersion,
         schema: Option<Schema>,
+        last_record_unique_ts: Option<UniqueTimestamp>,
     ) -> Self {
         Self {
             inbox_seq_number,
@@ -247,7 +257,13 @@ impl StateMachine {
             partition_key_range,
             min_restate_version,
             schema,
+            last_record_unique_ts: last_record_unique_ts.unwrap_or(UniqueTimestamp::MIN),
         }
+    }
+
+    /// Returns the last emitted deterministic monotonic timestamp.
+    pub fn last_record_unique_ts(&self) -> UniqueTimestamp {
+        self.last_record_unique_ts
     }
 }
 
@@ -255,6 +271,10 @@ pub(crate) struct StateMachineApplyContext<'a, S> {
     storage: &'a mut S,
     record_created_at: MillisSinceEpoch,
     record_lsn: Lsn,
+    /// A deterministic monotonic [`UniqueTimestamp`] derived from this record's wall-clock
+    /// timestamp. Guaranteed to be strictly greater than the timestamp of any previously
+    /// applied record, even when multiple records share the same millisecond.
+    record_unique_ts: UniqueTimestamp,
     action_collector: &'a mut ActionCollector,
     vqueues_cache: &'a mut VQueuesMetaMut,
     inbox_seq_number: &'a mut MessageIndex,
@@ -286,6 +306,14 @@ impl StateMachine {
         vqueues_cache: &mut VQueuesMetaMut,
         is_leader: bool,
     ) -> Result<(), Error> {
+        // Advance the deterministic monotonic timestamp using an HLC-like algorithm.
+        // If the current record's millisecond timestamp is ahead of the last emitted
+        // timestamp's physical component, use it with lc=0. Otherwise, increment the
+        // logical clock to maintain strict monotonicity across same-millisecond records.
+        self.last_record_unique_ts = self
+            .last_record_unique_ts
+            .next_from_millis(record_created_at);
+
         let span = utils::state_machine_apply_command_span(is_leader, &command);
         async {
             let start = Instant::now();
@@ -295,6 +323,7 @@ impl StateMachine {
                 storage: transaction,
                 record_created_at,
                 record_lsn,
+                record_unique_ts: self.last_record_unique_ts,
                 action_collector,
                 inbox_seq_number: &mut self.inbox_seq_number,
                 outbox_seq_number: &mut self.outbox_seq_number,
@@ -316,6 +345,15 @@ impl StateMachine {
 }
 
 impl<S> StateMachineApplyContext<'_, S> {
+    /// Returns a deterministic, monotonically increasing [`UniqueTimestamp`] for the current
+    /// Bifrost record. This is pre-computed using an HLC-like algorithm that guarantees
+    /// strict ordering across records, even when multiple records share the same millisecond
+    /// wall-clock timestamp. This is critical for deterministic FIFO ordering in vqueue
+    /// inboxes.
+    fn record_unique_ts(&self) -> UniqueTimestamp {
+        self.record_unique_ts
+    }
+
     async fn get_invocation_status(
         &mut self,
         invocation_id: &InvocationId,
@@ -475,6 +513,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     cmd.assignment.partition_key,
                     VQueueInstance::from_raw(cmd.assignment.instance),
                 );
+                let record_unique_ts = self.record_unique_ts();
                 let mut inbox = VQueues::new(
                     qid,
                     self.storage,
@@ -482,8 +521,6 @@ impl<S> StateMachineApplyContext<'_, S> {
                     self.is_leader.then_some(self.action_collector),
                 );
 
-                let record_unique_ts =
-                    UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
                 for entry in cmd.assignment.entries {
                     inbox.yield_running(record_unique_ts, entry.card).await?;
                 }
@@ -902,7 +939,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // todo(asoli): temporary until we move this to the invocation id creation site.
         let qid = Self::vqueue_id_from_invocation(&invocation_id, &metadata.invocation_target);
 
-        let record_unique_ts = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+        let record_unique_ts = self.record_unique_ts();
         let visible_at = VisibleAt::new(metadata.execution_time.unwrap_or(self.record_created_at));
 
         VQueues::new(
@@ -1828,8 +1865,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         )?;
 
         if Configuration::pinned().common.experimental_enable_vqueues {
-            let record_unique_ts =
-                UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+            let record_unique_ts = self.record_unique_ts();
             // Is this an invocation that has a vqueue inbox?
             if !VQueues::end_by_id(
                 self.storage,
@@ -1936,8 +1972,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         )?;
 
         if Configuration::pinned().common.experimental_enable_vqueues {
-            let record_unique_ts =
-                UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+            let record_unique_ts = self.record_unique_ts();
             // Is this an invocation that has a vqueue inbox?
             if !VQueues::end_by_id(
                 self.storage,
@@ -2780,8 +2815,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     .map_err(Error::Storage)?;
             }
 
-            let record_unique_ts =
-                UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+            let record_unique_ts = self.record_unique_ts();
 
             // we need to remove the invocation from the running list
             VQueues::end_by_id(
@@ -2870,7 +2904,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             VQueueInstance::from_raw(command.assignment.instance),
         );
 
-        let record_unique_ts = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+        let record_unique_ts = self.record_unique_ts();
         let updated_run_token_bucket_zero_time =
             command.meta_updates.updated_token_bucket_zero_time;
         for entry in command.assignment.entries {
@@ -5172,14 +5206,14 @@ impl<S> StateMachineApplyContext<'_, S> {
             );
         };
 
+        let now = self.record_unique_ts();
+
         let mut vqueue = VQueues::new(
             qid,
             self.storage,
             self.vqueues_cache,
             self.is_leader.then_some(self.action_collector),
         );
-
-        let now = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
 
         let should_release_concurrency_token = match cause {
             ParkCause::Suspend => {
@@ -5246,14 +5280,14 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         let qid = entry_state_header.vqueue_id();
 
+        let now = self.record_unique_ts();
+
         let mut vqueue = VQueues::new(
             qid,
             self.storage,
             self.vqueues_cache,
             self.is_leader.then_some(self.action_collector),
         );
-
-        let now = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
 
         match entry_state_header.stage() {
             Stage::Park => {
@@ -5338,7 +5372,7 @@ impl<S> StateMachineApplyContext<'_, S> {
     where
         S: WriteVQueueTable + ReadVQueueTable + WriteFsmTable,
     {
-        let now = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+        let now = self.record_unique_ts();
         let visible_at = VisibleAt::Now;
 
         let service_id = &state_mutation.service_id;

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -97,7 +97,8 @@ impl TestEnv {
             None, /* outbox_head_seq_number */
             PartitionKey::MIN..=PartitionKey::MAX,
             min_restate_version,
-            None,
+            None, /* schema */
+            None, /* last_record_unique_ts */
         ))
         .await
     }
@@ -1088,7 +1089,8 @@ async fn truncate_outbox_with_gap() -> Result<(), Error> {
         Some(outbox_head_index),
         PartitionKey::MIN..=PartitionKey::MAX,
         SemanticRestateVersion::unknown().clone(),
-        None,
+        None, /* schema */
+        None, /* last_record_unique_ts */
     ))
     .await;
 


### PR DESCRIPTION
The vqueue inbox ordering broke when multiple Bifrost records arrived within the same millisecond because UniqueTimestamp was constructed with logical clock = 0 via from_unix_millis_unchecked(), making same-ms entries indistinguishable. The tiebreaker then fell to random InvocationUuid bytes, producing non-deterministic FIFO violations.

Add an HLC-like counter to the partition state machine that generates strictly monotonic UniqueTimestamp values across records: if consecutive records share the same millisecond, the logical clock increments; otherwise it resets. The counter is persisted to the FSM table so that crash recovery continues from the correct state.

This is a temporary workaround until #4516 is resolved by storing a proper HLC timestamp in Bifrost Record.created_at.

Closes #4515