### PR TITLE
Fix delete_journal using wrong scan prefix for jc index cleanup (#4519)

### DIFF
--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -57,6 +57,15 @@ pub(crate) mod fsm_variable {
     /// Stores the current and next partition configuration from the latest AnnounceLeader.
     /// *Since v1.6*
     pub(crate) const PARTITION_CONFIG_STATE: u64 = 7;
+
+    /// Set to 1 once the one-time cleanup of orphaned `jc` index entries has completed.
+    /// These orphans were caused by a bug in `delete_journal` that used the wrong scan
+    /// prefix when deleting `JournalCompletionIdToCommandIndex` entries.
+    ///
+    /// Can be removed in v1.8 once we are confident this cleanup has been executed on all
+    /// deployments.
+    /// *Since v1.6.3*
+    pub(crate) const JC_ORPHAN_CLEANUP_DONE: u64 = 8;
 }
 
 fn get<T: PartitionStoreProtobufValue, S: StorageAccess>(
@@ -122,6 +131,26 @@ pub(crate) async fn put_storage_version<S: StorageAccess>(
         partition_id,
         fsm_variable::STORAGE_VERSION,
         &SequenceNumber::from(last_executed_migration as u64),
+    )
+}
+
+pub(crate) fn is_jc_orphan_cleanup_done<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+) -> Result<bool> {
+    get::<SequenceNumber, _>(storage, partition_id, fsm_variable::JC_ORPHAN_CLEANUP_DONE)
+        .map(|opt| opt.is_some())
+}
+
+pub(crate) fn put_jc_orphan_cleanup_done<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+) -> Result<()> {
+    put(
+        storage,
+        partition_id,
+        fsm_variable::JC_ORPHAN_CLEANUP_DONE,
+        &SequenceNumber::from(1u64),
     )
 }
 

--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -224,10 +224,10 @@ fn delete_journal<S: StorageAccess>(
     let completion_id_to_command_index = JournalCompletionIdToCommandIndexKey::builder()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
-    let notification_id_index =
+    let completion_id_index =
         OwnedIterator::new(storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
             invocation_id.partition_key(),
-            notification_id_to_notification_index.clone(),
+            completion_id_to_command_index.clone(),
         ))?)
         .map(|(mut key, _)| {
             let journal_key = JournalCompletionIdToCommandIndexKey::deserialize_from(&mut key)?;
@@ -235,17 +235,106 @@ fn delete_journal<S: StorageAccess>(
             Ok(completion_id)
         })
         .collect::<Result<Vec<_>>>()?;
-    for notification_id in notification_id_index {
+    for completion_id in completion_id_index {
         storage.delete_key(
             &completion_id_to_command_index
                 .clone()
-                .completion_id(notification_id)
+                .completion_id(completion_id)
                 .into_complete()
                 .unwrap(),
         )?;
     }
 
     Ok(())
+}
+
+/// Scans for and removes orphaned `JournalCompletionIdToCommandIndex` (`jc`) entries.
+///
+/// A `jc` entry is orphaned if no corresponding `JournalKey` (`j2`) entries exist for that
+/// invocation, meaning the journal has already been deleted. These orphans were caused by a
+/// bug in `delete_journal` that used the wrong scan prefix when cleaning up `jc` entries.
+///
+/// Only the keys for a single invocation are held in memory at any time to avoid unbounded
+/// memory usage on large stores.
+///
+/// The `is_cancelled` predicate is checked when moving to a new invocation. If it returns
+/// `true`, the scan stops early and the returned `cancelled` flag is set to `true`.
+pub fn cleanup_orphaned_completion_id_index_entries(
+    storage: &mut PartitionStore,
+    is_cancelled: impl Fn() -> bool,
+) -> Result<OrphanCleanupResult> {
+    let _x = RocksDbPerfGuard::new("cleanup-orphaned-jc-entries");
+
+    let mut deleted_entries: usize = 0;
+    let mut affected_invocations: usize = 0;
+    let mut cancelled = false;
+
+    let scan_store = storage.clone();
+    let partition_key_range = scan_store.partition_key_range().clone();
+    let scan = TableScan::FullScanPartitionKeyRange::<JournalCompletionIdToCommandIndexKeyBuilder>(
+        partition_key_range,
+    );
+    let iter = OwnedIterator::new(scan_store.iterator_from(scan)?);
+
+    let mut current_invocation: Option<(PartitionKey, InvocationUuid, bool)> = None;
+
+    for (mut key_bytes, _) in iter {
+        let jc_key = JournalCompletionIdToCommandIndexKey::deserialize_from(&mut key_bytes)?;
+
+        let is_orphan = match &current_invocation {
+            Some((pk, uuid, orphan))
+                if *pk == jc_key.partition_key && *uuid == jc_key.invocation_uuid =>
+            {
+                // Same invocation as before -- reuse the cached result.
+                *orphan
+            }
+            _ => {
+                // Check cancellation at invocation boundaries.
+                if is_cancelled() {
+                    cancelled = true;
+                    break;
+                }
+                // New invocation -- check if its journal still exists.
+                let orphan =
+                    !has_journal_entries(storage, jc_key.partition_key, jc_key.invocation_uuid)?;
+                if orphan {
+                    affected_invocations += 1;
+                }
+                current_invocation = Some((jc_key.partition_key, jc_key.invocation_uuid, orphan));
+                orphan
+            }
+        };
+
+        if is_orphan {
+            storage.delete_key(&jc_key)?;
+            deleted_entries += 1;
+        }
+    }
+
+    Ok(OrphanCleanupResult {
+        deleted_entries,
+        affected_invocations,
+        cancelled,
+    })
+}
+
+pub struct OrphanCleanupResult {
+    pub deleted_entries: usize,
+    pub affected_invocations: usize,
+    pub cancelled: bool,
+}
+
+/// Returns true if any `j2` journal entries exist for the given invocation.
+fn has_journal_entries(
+    storage: &mut PartitionStore,
+    partition_key: PartitionKey,
+    invocation_uuid: InvocationUuid,
+) -> Result<bool> {
+    let prefix = JournalKey::builder()
+        .partition_key(partition_key)
+        .invocation_uuid(invocation_uuid);
+    let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(partition_key, prefix))?;
+    Ok(iter.item().is_some())
 }
 
 fn get_notifications_index<S: StorageAccess>(

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -39,6 +39,7 @@ pub mod vqueue_table;
 mod tests;
 
 pub use error::*;
+pub use journal_table_v2::{OrphanCleanupResult, cleanup_orphaned_completion_id_index_entries};
 pub use partition_db::PartitionDb;
 pub use partition_store::*;
 pub use partition_store_manager::*;

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -41,7 +41,10 @@ use restate_types::storage::StorageCodec;
 use restate_types::storage::StorageDecode;
 use restate_types::storage::StorageEncode;
 
-use crate::fsm_table::{get_locally_durable_lsn, get_storage_version, put_storage_version};
+use crate::fsm_table::{
+    get_locally_durable_lsn, get_storage_version, is_jc_orphan_cleanup_done,
+    put_jc_orphan_cleanup_done, put_storage_version,
+};
 use crate::keys::KeyKind;
 use crate::keys::TableKey;
 use crate::keys::TableKeyPrefix;
@@ -687,6 +690,17 @@ impl PartitionStore {
         self.db.partition()
     }
 
+    /// Returns `true` if the one-time cleanup of orphaned `jc` index entries has not yet been
+    /// performed on this partition store.
+    pub fn needs_jc_orphan_cleanup(&mut self) -> Result<bool> {
+        is_jc_orphan_cleanup_done(self, self.partition_id()).map(|done| !done)
+    }
+
+    /// Marks the one-time `jc` orphan cleanup as complete so it won't run again.
+    pub fn mark_jc_orphan_cleanup_done(&mut self) -> Result<()> {
+        put_jc_orphan_cleanup_done(self, self.partition_id())
+    }
+
     pub async fn verify_and_run_migrations(&mut self) -> Result<()> {
         // We assume the partition store to be empty if it does not contain any applied lsn. The
         // reason is that we always commit changes to the partition store via a transaction which
@@ -694,6 +708,9 @@ impl PartitionStore {
         let is_empty = self.get_applied_lsn().await?.is_none();
         if is_empty {
             put_storage_version(self, self.partition_id(), LATEST_VERSION as u16).await?;
+            // A fresh partition store cannot have orphaned jc index entries, so mark the
+            // cleanup as already done to avoid a needless scan on first startup.
+            put_jc_orphan_cleanup_done(self, self.partition_id())?;
             return Ok(());
         }
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -10,10 +10,10 @@
 
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use tokio::sync::watch;
-use tracing::info;
-use tracing::{error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use restate_bifrost::Bifrost;
 use restate_core::network::{ShardSender, TransportConnect};
@@ -175,7 +175,79 @@ where
                         return Ok(());
                     };
 
-                    let partition_store = partition_store?;
+                    let mut partition_store = partition_store?;
+
+                    // One-time background cleanup of orphaned jc index entries left behind
+                    // by a bug in delete_journal that used the wrong scan prefix.
+                    // Runs on a blocking thread so it doesn't starve the tokio runtime.
+                    // The child task is bound to the partition processor's lifecycle and
+                    // will be cancelled if the processor shuts down (e.g. due to trim gap).
+                    if partition_store.needs_jc_orphan_cleanup()? {
+                        let mut cleanup_store = partition_store.clone();
+                        let cleanup_partition_id = partition_store.partition_id();
+                        let cancel = cancellation_token();
+                        TaskCenter::spawn_child(
+                            TaskKind::Background,
+                            "jc-orphan-cleanup",
+                            async move {
+                                let result = tokio::task::spawn_blocking(move || {
+                                    let start = Instant::now();
+                                    let result = restate_partition_store::cleanup_orphaned_completion_id_index_entries(
+                                        &mut cleanup_store,
+                                        || cancel.is_cancelled(),
+                                    );
+                                    (result, cleanup_store, start.elapsed())
+                                }).await.expect("cleanup blocking task must not panic");
+
+                                let (result, mut cleanup_store, elapsed) = result;
+                                match result {
+                                    Ok(outcome) => {
+                                        if outcome.cancelled {
+                                            info!(
+                                                partition_id = %cleanup_partition_id,
+                                                deleted_entries = outcome.deleted_entries,
+                                                affected_invocations = outcome.affected_invocations,
+                                                ?elapsed,
+                                                "Orphaned jc index cleanup cancelled, \
+                                                 will retry on next startup"
+                                            );
+                                        } else if outcome.deleted_entries > 0 {
+                                            info!(
+                                                partition_id = %cleanup_partition_id,
+                                                deleted_entries = outcome.deleted_entries,
+                                                affected_invocations = outcome.affected_invocations,
+                                                ?elapsed,
+                                                "Cleaned up orphaned journal completion-id index entries"
+                                            );
+                                        } else {
+                                            debug!(
+                                                partition_id = %cleanup_partition_id,
+                                                ?elapsed,
+                                                "No orphaned journal completion-id index entries found"
+                                            );
+                                        }
+                                        if !outcome.cancelled && let Err(err) = cleanup_store.mark_jc_orphan_cleanup_done()
+                                            {
+                                                warn!(
+                                                    partition_id = %cleanup_partition_id,
+                                                    "Failed to mark jc orphan cleanup as done, \
+                                                     will retry on next startup: {err}"
+                                                );
+                                            }
+                                    }
+                                    Err(err) => {
+                                        warn!(
+                                            partition_id = %cleanup_partition_id,
+                                            ?elapsed,
+                                            "Failed to clean up orphaned journal completion-id \
+                                             index entries, will retry on next startup: {err}"
+                                        );
+                                    }
+                                }
+                                Ok(())
+                            },
+                        )?;
+                    }
 
                     let pp = pp_builder
                         .build(

--- a/release-notes/unreleased/4519-fix-orphaned-jc-index-entries.md
+++ b/release-notes/unreleased/4519-fix-orphaned-jc-index-entries.md
@@ -1,0 +1,29 @@
+# Release Notes for Issue #4519: Fix orphaned journal index entries
+
+## Bug Fix
+
+### What Changed
+
+Fixed a bug where journal index entries were not cleaned up when journals were deleted,
+causing them to accumulate over time and waste disk space.
+
+A one-time background cleanup task now runs automatically on partition processor startup
+to remove any orphaned entries that accumulated due to this bug. The cleanup runs in the
+partition processor runtime and does not block partition processing.
+
+### Impact on Users
+
+- **Existing deployments**: A background cleanup task runs automatically on the first
+  startup after upgrading. It scans for orphaned entries and deletes them without
+  blocking the partition processor. The cleanup is tracked per partition store and only
+  runs once. If interrupted (e.g., by a restart), it will retry on the next startup.
+- **New deployments**: No impact. The bug fix prevents orphaned entries from being
+  created in the first place.
+
+### Migration Guidance
+
+No action required. The cleanup happens automatically on upgrade.
+
+### Related Issues
+
+- Issue #4519


### PR DESCRIPTION
delete_journal used the notification-id prefix (jn) instead of the completion-id prefix (jc) when cleaning up JournalCompletionIdToCommandIndex entries, causing them to never be deleted when journals were purged.

Additionally, a non-blocking background cleanup task now runs on first startup after upgrade to remove any orphaned jc entries that accumulated due to this bug. The task streams entries one invocation at a time to avoid unbounded memory usage and is tracked via an FSM flag so it only runs once per partition store. Fresh partition stores are marked as already clean to skip the unnecessary scan.